### PR TITLE
chore(broker-core): do not expect stdin to be readable

### DIFF
--- a/broker-core/src/main/java/org/camunda/tngp/broker/StandaloneBroker.java
+++ b/broker-core/src/main/java/org/camunda/tngp/broker/StandaloneBroker.java
@@ -26,19 +26,22 @@ public class StandaloneBroker
             }
         });
 
+
         try (Scanner scanner = new Scanner(System.in))
         {
-            final String nextLine = scanner.nextLine();
-            if (nextLine.contains("exit")
+            while (scanner.hasNextLine())
+            {
+                final String nextLine = scanner.nextLine();
+                if (nextLine.contains("exit")
                     || nextLine.contains("close")
                     || nextLine.contains("quit")
                     || nextLine.contains("halt")
                     || nextLine.contains("shutdown")
                     || nextLine.contains("stop"))
-            {
-                System.exit(0);
+                {
+                    System.exit(0);
+                }
             }
-
         }
 
     }


### PR DESCRIPTION
If you want to run the broker unattended (in the background) it is better to accept that stdin is not readable.
