### PR TITLE
introduce isConnected()

### DIFF
--- a/client-java/src/main/java/io/zeebe/client/ZeebeClient.java
+++ b/client-java/src/main/java/io/zeebe/client/ZeebeClient.java
@@ -50,6 +50,12 @@ public interface ZeebeClient extends AutoCloseable
     void connect();
 
     /**
+     * Indicates current state of connection.
+     * @return <code>true</code> if connected
+     */
+    boolean isConnected();
+
+    /**
      * Disconnects the client from the configured broker. Not thread-safe.
      */
     void disconnect();

--- a/client-java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
+++ b/client-java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
@@ -155,6 +155,12 @@ public class ZeebeClientImpl implements ZeebeClient
     }
 
     @Override
+    public boolean isConnected()
+    {
+        return connected;
+    }
+
+    @Override
     public void disconnect()
     {
         if (connected)


### PR DESCRIPTION
Exposing the internal connection state is most useful to implement retry/failover strategies in java clients.