### PR TITLE
Make docker image k8s-ready

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM openjdk:8
 
 ARG DISTBALL
 
+ENV DEBUG=false
+ENV DEPLOY_ON_KUBERNETES=false
 ENV ZB_HOME=/usr/local/zeebe/
 
 COPY ${DISTBALL} ${ZB_HOME}
@@ -12,4 +14,7 @@ WORKDIR ${ZB_HOME}/bin
 EXPOSE 51016 51017 51015
 VOLUME ${ZB_HOME}/bin/data
 
-ENTRYPOINT ["./broker"]
+COPY docker-utils/startup.sh /usr/local/bin
+COPY docker-utils/zeebe.cfg.toml $ZB_HOME/conf/
+
+ENTRYPOINT ["/usr/local/bin/startup.sh"]

--- a/docker-utils/startup.sh
+++ b/docker-utils/startup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -xeu
+
+cfgHome=/usr/local/zeebe/conf/zeebe.cfg.toml
+cfgLog=/usr/local/zeebe/conf/log4j2.xml
+
+if [[ "$DEPLOY_ON_KUBERNETES" == "true" ]]; then
+
+    DNSNAME="${HOST}.${DNS}"
+
+    sed -i "s/@DNSNAME@/${DNSNAME}/g" $cfgHome
+
+    if [[ -n $INITIAL_CONTACT_POINT && ! $HOST =~ .*-0$ ]]; then
+        sed -i "s/@INITIAL_CONTACT_POINT@/initialContactPoints = \[\n\t\"${INITIAL_CONTACT_POINT}\"\n\]/g" $cfgHome
+    else
+        sed -i "s/@INITIAL_CONTACT_POINT@//g" $cfgHome
+    fi
+
+else
+
+    sed -i "s/@DNSNAME@/$(hostname --ip-address)/g" $cfgHome
+    sed -i "s/@INITIAL_CONTACT_POINT@//g" $cfgHome
+
+fi
+
+if [[ "$DEBUG" == "true" ]]; then
+    sed -i 's/<Logger name="io.zeebe" level="info"\/>/<Logger name="io.zeebe" level="debug"\/>/g' $cfgLog
+fi
+
+exec /usr/local/zeebe/bin/broker

--- a/docker-utils/zeebe.cfg.toml
+++ b/docker-utils/zeebe.cfg.toml
@@ -1,0 +1,54 @@
+# Default Zeebe Config File. Used if no config file is provided to the broker.
+
+# Networking configuration ----------------------------
+
+[network]
+host = "@DNSNAME@"
+sendBufferSize = 128
+
+[network.clientApi]
+port = 51015
+receiveBufferSize = 16
+controlMessageRequestTimeoutInMillis = 10000
+
+[network.managementApi]
+host = "@DNSNAME@"
+port = 51016
+receiveBufferSize = 16
+
+[network.replicationApi]
+host = "@DNSNAME@"
+port = 51017
+receiveBufferSize = 16
+
+[network.gossip]
+@INITIAL_CONTACT_POINT@
+peersStorageFile = "../data/gossip-state.data"
+
+[network.management]
+metaDirectory = "../data/meta"
+
+# System Configuration --------------------------------
+
+[threading]
+# numberOfThreads = 2
+maxIdleTimeMs = 10
+idleStrategy = "BACKOFF"
+
+[metrics]
+countersFileName = "../data/counters.data"
+
+# Log Configuration -----------------------------------
+
+[logs]
+defaultLogSegmentSize = 512
+logDirectories = [ "../data/logstreams" ]
+indexDirectory = "../data/index"
+
+[snapshot]
+snapshotDirectory = "../data/index/snapshots"
+
+# Topic Subscriptions ------------------------------------------
+
+[subscriptions]
+snapshotDirectory = "../data/snapshots/subscriptions"

--- a/docs/src/introduction/install.md
+++ b/docs/src/introduction/install.md
@@ -67,6 +67,22 @@ The Zeebe configuration is located under
 `/usr/local/zeebe/conf/zeebe.cfg.toml`. The logging configuration is located
 under `/usr/local/zeebe/conf/log4j2.xml`.
 
+The configuration of the docker image can be changed also using environment
+variables.
+
+Available environment variables:
+
+ - `DEBUG`
+
+If set to `true` enables the debug log.
+
+ - `DEPLOY_ON_KUBERNETES`
+
+If set to `true` applies some configuration changes in order to run zeebe
+in a kubernetes environment. Please note that the recommended method to
+run zeebe on kubernetes is using the
+[zeebe-operator](https://github.com/zeebe-io/zeebe-operator).
+
 ### Mac and Windows users
 
 **Note**: On systems which use a VM to run Docker containers like Mac and


### PR DESCRIPTION
Hey

I cleaned up the changes that we had to make to the zeebe image in order to let it run on k8s.

Basically a small script modifies the configuration file to specify the correct dns name and contact point when zeebe starts. All the modifications should be harmless for normal users running zeebe outside k8s since they are done only when the env variable `DEPLOY_ON_KUBERNETES` is set to true.

I also added another environment variable that enables the debug mode, since it's not possible to see when nodes are joining with the current level of logging ( `DEBUG` = true ).

Of course in the future we should make zeebe aware of env variables without editing config file with a script, but for now i think it can work :)

Please double-test! :) 

Cheers