### PR TITLE
chore(Dockerfile): switch to jre alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:8-jre-alpine
 
 ARG DISTBALL
 
@@ -8,7 +8,8 @@ ENV ZB_HOME=/usr/local/zeebe/ \
 
 COPY ${DISTBALL} ${ZB_HOME}
 
-RUN tar xfvz ${ZB_HOME}/*.tar.gz --strip 1 -C ${ZB_HOME} && rm ${ZB_HOME}/*.tar.gz
+RUN apk add --no-cache bash && \
+    tar xfvz ${ZB_HOME}/*.tar.gz --strip 1 -C ${ZB_HOME} && rm ${ZB_HOME}/*.tar.gz
 
 WORKDIR ${ZB_HOME}/bin
 EXPOSE 51016 51017 51015

--- a/docker/utils/startup.sh
+++ b/docker/utils/startup.sh
@@ -17,7 +17,7 @@ if [[ "$DEPLOY_ON_KUBERNETES" == "true" ]]; then
 
 else
 
-    sed -i "s/@DNSNAME@/$(hostname --ip-address)/g" $cfgHome
+    sed -i "s/@DNSNAME@/$(hostname -i)/g" $cfgHome
     sed -i "s/@INITIAL_CONTACT_POINT@//g" $cfgHome
 
 fi


### PR DESCRIPTION
- only jre is needed during runtime
- alpine image smaller then ubuntu
- reduces the image size from ~300MB to ~90MB