### PR TITLE
allow Broker creation with ConfigurationManager

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker-core/src/main/java/io/zeebe/broker/Broker.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 
 import io.zeebe.broker.clustering.ClusterComponent;
 import io.zeebe.broker.logstreams.LogStreamsComponent;
+import io.zeebe.broker.system.ConfigurationManager;
 import io.zeebe.broker.system.SystemComponent;
 import io.zeebe.broker.system.SystemContext;
 import io.zeebe.broker.task.TaskQueueComponent;
@@ -36,13 +37,22 @@ public class Broker implements AutoCloseable
 
     public Broker(String configFileLocation)
     {
-        brokerContext = new SystemContext(configFileLocation);
-        start();
+        this(new SystemContext(configFileLocation));
     }
 
     public Broker(InputStream configStream)
     {
-        brokerContext = new SystemContext(configStream);
+        this(new SystemContext(configStream));
+    }
+
+    public Broker(ConfigurationManager configurationManager)
+    {
+        this(new SystemContext(configurationManager));
+    }
+
+    public Broker(SystemContext brokerContext)
+    {
+        this.brokerContext = brokerContext;
         start();
     }
 

--- a/broker-core/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -46,7 +46,7 @@ public class SystemContext implements AutoCloseable
 
     protected final List<CompletableFuture<?>> requiredStartActions = new ArrayList<>();
 
-    protected SystemContext(ConfigurationManager configurationManager)
+    public SystemContext(ConfigurationManager configurationManager)
     {
         this.serviceContainer = new ServiceContainerImpl();
         this.configurationManager = configurationManager;


### PR DESCRIPTION
For the spring/spring-boot configuration, I need to be able to configure the broker without a toml file, since toml is one of the few formats spring-boot does not support. So I need a hook where I can create a broker with some kind of Pojo structure.

After analysing the code and talking to Daniel, I think that this PR comes up with a clean and elegant solution: I can start the broker using an instance of ConfigurationManager. I will create my own impl of ConfigurationManager in spring and use it only to map to configurationProperties read from yaml or cloud.