### PR TITLE
Remove withoutPayload method from Client API

### DIFF
--- a/client-java/src/main/java/io/zeebe/client/api/commands/CompleteJobCommandStep1.java
+++ b/client-java/src/main/java/io/zeebe/client/api/commands/CompleteJobCommandStep1.java
@@ -56,12 +56,4 @@ public interface CompleteJobCommandStep1 extends FinalCommandStep<JobEvent> {
    *     to the broker.
    */
   CompleteJobCommandStep1 payload(Object payload);
-
-  /**
-   * Complete the job without payload.
-   *
-   * @return the builder for this command. Call {@link #send()} to complete the command and send it
-   *     to the broker.
-   */
-  CompleteJobCommandStep1 withoutPayload();
 }

--- a/client-java/src/main/java/io/zeebe/client/impl/data/MsgpackPayloadModule.java
+++ b/client-java/src/main/java/io/zeebe/client/impl/data/MsgpackPayloadModule.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import io.zeebe.msgpack.spec.MsgPackHelper;
 import java.io.IOException;
 
 public class MsgpackPayloadModule extends SimpleModule {
@@ -49,8 +50,7 @@ public class MsgpackPayloadModule extends SimpleModule {
       final byte[] bytes = value.getMsgPack();
 
       if (bytes == null) {
-        // currently, the broker doesn't support null as payload
-        throw new IllegalArgumentException("can't serialize 'null' as payload");
+        gen.writeBinary(MsgPackHelper.EMTPY_OBJECT);
       } else {
         gen.writeBinary(value.getMsgPack());
       }

--- a/client-java/src/main/java/io/zeebe/client/impl/job/CompleteJobCommandImpl.java
+++ b/client-java/src/main/java/io/zeebe/client/impl/job/CompleteJobCommandImpl.java
@@ -64,12 +64,6 @@ public class CompleteJobCommandImpl extends CommandImpl<JobEvent>
   }
 
   @Override
-  public CompleteJobCommandStep1 withoutPayload() {
-    command.clearPayload();
-    return this;
-  }
-
-  @Override
   public RecordImpl getCommand() {
     return command;
   }

--- a/client-java/src/main/java/io/zeebe/client/impl/record/JobRecordImpl.java
+++ b/client-java/src/main/java/io/zeebe/client/impl/record/JobRecordImpl.java
@@ -41,6 +41,7 @@ public abstract class JobRecordImpl extends RecordImpl implements JobRecord {
 
   public JobRecordImpl(ZeebeObjectMapperImpl objectMapper, RecordType recordType) {
     super(objectMapper, recordType, ValueType.JOB);
+    this.payload = new PayloadField(objectMapper);
   }
 
   public JobRecordImpl(JobRecordImpl base, JobIntent intent) {
@@ -53,9 +54,7 @@ public abstract class JobRecordImpl extends RecordImpl implements JobRecord {
     this.retries = base.retries;
     this.type = base.type;
 
-    if (base.payload != null) {
-      this.payload = new PayloadField(base.payload);
-    }
+    this.payload = new PayloadField(base.payload);
   }
 
   @Override
@@ -112,62 +111,42 @@ public abstract class JobRecordImpl extends RecordImpl implements JobRecord {
 
   @JsonProperty("payload")
   public void setPayloadField(PayloadField payload) {
-    this.payload = payload;
+    if (payload != null) {
+      this.payload = payload;
+    }
   }
 
   @Override
   public String getPayload() {
-    if (payload == null) {
-      return null;
-    } else {
-      return payload.getAsJsonString();
-    }
+    return payload.getAsJsonString();
   }
 
   @JsonIgnore
   @Override
   public Map<String, Object> getPayloadAsMap() {
-    if (payload == null) {
-      return null;
-    } else {
-      return payload.getAsMap();
-    }
+    return payload.getAsMap();
   }
 
   @JsonIgnore
   @Override
   public <T> T getPayloadAsType(Class<T> payloadType) {
-    if (payload == null) {
-      return null;
-    } else {
-      return payload.getAsType(payloadType);
-    }
+    return payload.getAsType(payloadType);
   }
 
   public void setPayload(String jsonString) {
-    initializePayloadField();
     this.payload.setJson(jsonString);
   }
 
   public void setPayload(InputStream jsonStream) {
-    initializePayloadField();
     this.payload.setJson(jsonStream);
   }
 
   public void setPayload(Map<String, Object> payload) {
-    initializePayloadField();
     this.payload.setAsMap(payload);
   }
 
   public void setPayload(Object payload) {
-    initializePayloadField();
     this.payload.setAsObject(payload);
-  }
-
-  private void initializePayloadField() {
-    if (payload == null) {
-      payload = new PayloadField(objectMapper);
-    }
   }
 
   @Override

--- a/client-java/src/main/java/io/zeebe/client/impl/record/JobRecordImpl.java
+++ b/client-java/src/main/java/io/zeebe/client/impl/record/JobRecordImpl.java
@@ -170,12 +170,6 @@ public abstract class JobRecordImpl extends RecordImpl implements JobRecord {
     }
   }
 
-  public void clearPayload() {
-    // set field to null so that it is not serialized to Msgpack
-    // - currently, the broker doesn't support null as payload
-    payload = null;
-  }
-
   @Override
   public Integer getRetries() {
     return retries;

--- a/client-java/src/main/java/io/zeebe/client/impl/record/WorkflowInstanceRecordImpl.java
+++ b/client-java/src/main/java/io/zeebe/client/impl/record/WorkflowInstanceRecordImpl.java
@@ -38,6 +38,7 @@ public abstract class WorkflowInstanceRecordImpl extends RecordImpl
 
   public WorkflowInstanceRecordImpl(ZeebeObjectMapperImpl objectMapper, RecordType recordType) {
     super(objectMapper, recordType, ValueType.WORKFLOW_INSTANCE);
+    this.payload = new PayloadField(objectMapper);
   }
 
   public WorkflowInstanceRecordImpl(
@@ -50,9 +51,7 @@ public abstract class WorkflowInstanceRecordImpl extends RecordImpl
     this.workflowInstanceKey = base.getWorkflowInstanceKey();
     this.activityId = base.getActivityId();
 
-    if (base.payload != null) {
-      this.payload = new PayloadField(base.payload);
-    }
+    this.payload = new PayloadField(base.payload);
   }
 
   @Override
@@ -98,68 +97,42 @@ public abstract class WorkflowInstanceRecordImpl extends RecordImpl
 
   @JsonProperty("payload")
   public void setPayloadField(PayloadField payload) {
-    this.payload = payload;
+    if (payload != null) {
+      this.payload = payload;
+    }
   }
 
   @Override
   public String getPayload() {
-    if (payload == null) {
-      return null;
-    } else {
-      return payload.getAsJsonString();
-    }
+    return payload.getAsJsonString();
   }
 
   @JsonIgnore
   @Override
   public Map<String, Object> getPayloadAsMap() {
-    if (payload == null) {
-      return null;
-    } else {
-      return payload.getAsMap();
-    }
+    return payload.getAsMap();
   }
 
   @JsonIgnore
   @Override
   public <T> T getPayloadAsType(Class<T> payloadType) {
-    if (payload == null) {
-      return null;
-    } else {
-      return payload.getAsType(payloadType);
-    }
+    return payload.getAsType(payloadType);
   }
 
   public void setPayload(String jsonString) {
-    initializePayloadField();
     this.payload.setJson(jsonString);
   }
 
   public void setPayload(InputStream jsonStream) {
-    initializePayloadField();
     this.payload.setJson(jsonStream);
   }
 
   public void setPayload(Map<String, Object> payload) {
-    initializePayloadField();
     this.payload.setAsMap(payload);
   }
 
   public void setPayload(Object payload) {
-    initializePayloadField();
     this.payload.setAsObject(payload);
-  }
-
-  private void initializePayloadField() {
-    if (payload == null) {
-      payload = new PayloadField(objectMapper);
-    }
-  }
-
-  public void clearPayload() {
-    // set field to null so that it is not serialized to Msgpack
-    // - currently, the broker doesn't support null as payload
-    payload = null;
   }
 
   @Override

--- a/client-java/src/test/java/io/zeebe/client/data/ZeebeObjectMapperTest.java
+++ b/client-java/src/test/java/io/zeebe/client/data/ZeebeObjectMapperTest.java
@@ -106,7 +106,7 @@ public class ZeebeObjectMapperTest {
   public void shouldSerializeWorkflowInstanceRecordWithoutPayload() {
     // given
     final WorkflowInstanceEventImpl wfInstanceEvent = Events.exampleWorfklowInstance();
-    wfInstanceEvent.clearPayload();
+    wfInstanceEvent.setPayload((String) null);
 
     // when / then
     final String json = objectMapper.toJson(wfInstanceEvent);

--- a/client-java/src/test/java/io/zeebe/client/data/ZeebeObjectMapperTest.java
+++ b/client-java/src/test/java/io/zeebe/client/data/ZeebeObjectMapperTest.java
@@ -77,7 +77,7 @@ public class ZeebeObjectMapperTest {
   public void shouldSerializeJobRecordWithoutPayload() {
     // given
     final JobEventImpl jobEvent = Events.exampleJob();
-    jobEvent.clearPayload();
+    jobEvent.setPayload((String) null);
 
     // when / then
     final String json = objectMapper.toJson(jobEvent);

--- a/client-java/src/test/java/io/zeebe/client/job/CompleteJobTest.java
+++ b/client-java/src/test/java/io/zeebe/client/job/CompleteJobTest.java
@@ -26,6 +26,7 @@ import io.zeebe.client.impl.data.MsgPackConverter;
 import io.zeebe.client.impl.event.JobEventImpl;
 import io.zeebe.client.util.ClientRule;
 import io.zeebe.client.util.Events;
+import io.zeebe.msgpack.spec.MsgPackHelper;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.test.broker.protocol.brokerapi.ExecuteCommandRequest;
 import io.zeebe.test.broker.protocol.brokerapi.StubBrokerRule;
@@ -106,12 +107,12 @@ public class CompleteJobTest {
     final JobEventImpl baseEvent = Events.exampleJob();
 
     // when
-    clientRule.jobClient().newCompleteCommand(baseEvent).withoutPayload().send().join();
+    clientRule.jobClient().newCompleteCommand(baseEvent).payload((String) null).send().join();
 
     // then
     final ExecuteCommandRequest request = brokerRule.getReceivedCommandRequests().get(0);
 
-    assertThat(request.getCommand()).doesNotContainKey("payload");
+    assertThat(request.getCommand()).contains(entry("payload", MsgPackHelper.EMTPY_OBJECT));
   }
 
   @Test

--- a/client-java/src/test/java/io/zeebe/client/job/CreateJobTest.java
+++ b/client-java/src/test/java/io/zeebe/client/job/CreateJobTest.java
@@ -25,6 +25,7 @@ import io.zeebe.client.api.record.RecordMetadata;
 import io.zeebe.client.cmd.ClientException;
 import io.zeebe.client.impl.data.MsgPackConverter;
 import io.zeebe.client.util.ClientRule;
+import io.zeebe.msgpack.spec.MsgPackHelper;
 import io.zeebe.protocol.clientapi.ExecuteCommandRequestEncoder;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.protocol.intent.JobIntent;
@@ -133,7 +134,8 @@ public class CreateJobTest {
             entry("retries", CreateJobCommandStep1.DEFAULT_RETRIES),
             entry("type", "fooType"),
             entry("headers", Collections.emptyMap()),
-            entry("customHeaders", Collections.emptyMap()));
+            entry("customHeaders", Collections.emptyMap()),
+            entry("payload", MsgPackHelper.EMTPY_OBJECT));
   }
 
   @Test

--- a/client-java/src/test/java/io/zeebe/client/job/subscription/JobWorkerTest.java
+++ b/client-java/src/test/java/io/zeebe/client/job/subscription/JobWorkerTest.java
@@ -516,7 +516,7 @@ public class JobWorkerTest {
         .jobClient()
         .newWorker()
         .jobType("bar")
-        .handler((c, t) -> c.newCompleteCommand(t).withoutPayload().send().join())
+        .handler((c, t) -> c.newCompleteCommand(t).payload((String) null).send().join())
         .name("foo")
         .timeout(10000L)
         .open();
@@ -545,7 +545,7 @@ public class JobWorkerTest {
     assertThat(jobRequest.getCommand())
         .containsEntry("type", "bar")
         .containsEntry("worker", "foo")
-        .doesNotContainKey("payload");
+        .contains(entry("payload", io.zeebe.msgpack.spec.MsgPackHelper.EMTPY_OBJECT));
   }
 
   @Test

--- a/client-java/src/test/java/io/zeebe/client/workflow/CreateWorkflowInstanceTest.java
+++ b/client-java/src/test/java/io/zeebe/client/workflow/CreateWorkflowInstanceTest.java
@@ -26,6 +26,7 @@ import io.zeebe.client.cmd.ClientCommandRejectedException;
 import io.zeebe.client.cmd.ClientException;
 import io.zeebe.client.impl.data.MsgPackConverter;
 import io.zeebe.client.util.ClientRule;
+import io.zeebe.msgpack.spec.MsgPackHelper;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import io.zeebe.test.broker.protocol.brokerapi.ExecuteCommandRequest;
@@ -89,14 +90,15 @@ public class CreateWorkflowInstanceTest {
             entry("bpmnProcessId", "foo"),
             entry("version", CreateWorkflowInstanceCommandStep1.LATEST_VERSION),
             entry("workflowKey", -1),
-            entry("workflowInstanceKey", -1));
+            entry("workflowInstanceKey", -1),
+            entry("payload", MsgPackHelper.EMTPY_OBJECT));
 
     assertThat(workflowInstance.getState()).isEqualTo(WorkflowInstanceState.CREATED);
     assertThat(workflowInstance.getBpmnProcessId()).isEqualTo("foo");
     assertThat(workflowInstance.getVersion()).isEqualTo(1);
     assertThat(workflowInstance.getWorkflowInstanceKey()).isEqualTo(1);
-    assertThat(workflowInstance.getPayload()).isNull();
-    assertThat(workflowInstance.getPayloadAsMap()).isNull();
+    assertThat(workflowInstance.getPayload()).isEqualTo("{}");
+    assertThat(workflowInstance.getPayloadAsMap()).isEmpty();
     assertThat(workflowInstance.getMetadata().getSourceRecordPosition()).isEqualTo(1);
   }
 
@@ -175,7 +177,8 @@ public class CreateWorkflowInstanceTest {
             entry("bpmnProcessId", "foo"),
             entry("version", 2),
             entry("workflowKey", -1),
-            entry("workflowInstanceKey", -1));
+            entry("workflowInstanceKey", -1),
+            entry("payload", MsgPackHelper.EMTPY_OBJECT));
 
     assertThat(workflowInstance.getBpmnProcessId()).isEqualTo("foo");
     assertThat(workflowInstance.getVersion()).isEqualTo(2);
@@ -205,7 +208,10 @@ public class CreateWorkflowInstanceTest {
     final ExecuteCommandRequest commandRequest = brokerRule.getReceivedCommandRequests().get(0);
     assertThat(commandRequest.getCommand())
         .containsOnly(
-            entry("version", -1), entry("workflowKey", 2), entry("workflowInstanceKey", -1));
+            entry("version", -1),
+            entry("workflowKey", 2),
+            entry("workflowInstanceKey", -1),
+            entry("payload", MsgPackHelper.EMTPY_OBJECT));
 
     assertThat(workflowInstance.getWorkflowKey()).isEqualTo(2);
     assertThat(workflowInstance.getWorkflowInstanceKey()).isEqualTo(1);

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/BrokerLeaderChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/BrokerLeaderChangeTest.java
@@ -32,6 +32,7 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
 
 public class BrokerLeaderChangeTest {
+  public static final String NULL_PAYLOAD = null;
   public static final String JOB_TYPE = "testTask";
 
   public AutoCloseableRule closeables = new AutoCloseableRule();
@@ -84,7 +85,7 @@ public class BrokerLeaderChangeTest {
                           .handler(
                               (client, job) -> {
                                 if (job.getMetadata().getKey() == eventKey) {
-                                  client.newCompleteCommand(job).withoutPayload().send();
+                                  client.newCompleteCommand(job).payload(NULL_PAYLOAD).send();
                                 }
                               })
                           .open())

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/incident/IncidentTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/incident/IncidentTest.java
@@ -161,7 +161,7 @@ public class IncidentTest {
       if (failJob) {
         throw new RuntimeException("expected failure");
       } else {
-        client.newCompleteCommand(job).withoutPayload().send().join();
+        client.newCompleteCommand(job).payload((String) null).send().join();
       }
     }
   }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/job/JobWorkerTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/job/JobWorkerTest.java
@@ -15,9 +15,7 @@
  */
 package io.zeebe.broker.it.job;
 
-import static io.zeebe.broker.it.util.TopicEventRecorder.jobCommand;
-import static io.zeebe.broker.it.util.TopicEventRecorder.jobRetries;
-import static io.zeebe.broker.it.util.TopicEventRecorder.state;
+import static io.zeebe.broker.it.util.TopicEventRecorder.*;
 import static io.zeebe.test.util.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -47,6 +45,8 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
 
 public class JobWorkerTest {
+  public static final String NULL_PAYLOAD = null;
+
   public EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule();
 
   public ClientRule clientRule = new ClientRule();
@@ -250,7 +250,7 @@ public class JobWorkerTest {
             (c, j) -> {
               throw new RuntimeException("expected failure");
             },
-            (c, j) -> c.newCompleteCommand(j).withoutPayload().send().join());
+            (c, j) -> c.newCompleteCommand(j).payload(NULL_PAYLOAD).send().join());
 
     // when
     jobClient
@@ -311,7 +311,7 @@ public class JobWorkerTest {
             (c, j) -> {
               throw new RuntimeException("expected failure");
             },
-            (c, j) -> c.newCompleteCommand(j).withoutPayload().send().join());
+            (c, j) -> c.newCompleteCommand(j).payload(NULL_PAYLOAD).send().join());
 
     jobClient
         .newWorker()
@@ -374,7 +374,8 @@ public class JobWorkerTest {
   public void shouldGiveJobToSingleSubscription() {
     // given
     final RecordingJobHandler jobHandler =
-        new RecordingJobHandler((c, t) -> c.newCompleteCommand(t).withoutPayload().send().join());
+        new RecordingJobHandler(
+            (c, t) -> c.newCompleteCommand(t).payload(NULL_PAYLOAD).send().join());
 
     jobClient
         .newWorker()

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRecoveryTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRecoveryTest.java
@@ -54,6 +54,8 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
 
 public class BrokerRecoveryTest {
+  private static final String NULL_PAYLOAD = null;
+
   private static final WorkflowDefinition WORKFLOW =
       Bpmn.createExecutableWorkflow("process")
           .startEvent("start")
@@ -140,7 +142,7 @@ public class BrokerRecoveryTest {
         .getJobClient()
         .newWorker()
         .jobType("foo")
-        .handler((client, job) -> client.newCompleteCommand(job).withoutPayload().send())
+        .handler((client, job) -> client.newCompleteCommand(job).payload(NULL_PAYLOAD).send())
         .open();
 
     // then
@@ -205,7 +207,7 @@ public class BrokerRecoveryTest {
         .getJobClient()
         .newWorker()
         .jobType("foo")
-        .handler((client, job) -> client.newCompleteCommand(job).withoutPayload().send())
+        .handler((client, job) -> client.newCompleteCommand(job).payload(NULL_PAYLOAD).send())
         .open();
 
     waitUntil(() -> eventRecorder.getJobEvents(JobState.CREATED).size() > 1);
@@ -217,7 +219,7 @@ public class BrokerRecoveryTest {
         .getJobClient()
         .newWorker()
         .jobType("bar")
-        .handler((client, job) -> client.newCompleteCommand(job).withoutPayload().send())
+        .handler((client, job) -> client.newCompleteCommand(job).payload(NULL_PAYLOAD).send())
         .open();
 
     // then
@@ -288,7 +290,7 @@ public class BrokerRecoveryTest {
         .getJobClient()
         .newWorker()
         .jobType("foo")
-        .handler((client, job) -> client.newCompleteCommand(job).withoutPayload().send())
+        .handler((client, job) -> client.newCompleteCommand(job).payload(NULL_PAYLOAD).send())
         .open();
 
     // then

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRestartTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRestartTest.java
@@ -27,12 +27,7 @@ import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.api.commands.BrokerInfo;
 import io.zeebe.client.api.commands.PartitionInfo;
 import io.zeebe.client.api.commands.Topology;
-import io.zeebe.client.api.events.DeploymentEvent;
-import io.zeebe.client.api.events.IncidentState;
-import io.zeebe.client.api.events.JobEvent;
-import io.zeebe.client.api.events.JobState;
-import io.zeebe.client.api.events.WorkflowInstanceEvent;
-import io.zeebe.client.api.events.WorkflowInstanceState;
+import io.zeebe.client.api.events.*;
 import io.zeebe.client.api.subscription.JobWorker;
 import io.zeebe.client.cmd.ClientCommandRejectedException;
 import io.zeebe.model.bpmn.Bpmn;
@@ -74,6 +69,7 @@ public class BrokerRestartTest {
           .serviceTask("task", t -> t.taskType("test").input("$.foo", "$.foo"))
           .endEvent("end")
           .done();
+  public static final String NULL_PAYLOAD = null;
 
   public EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule();
 
@@ -139,7 +135,7 @@ public class BrokerRestartTest {
         .getJobClient()
         .newWorker()
         .jobType("foo")
-        .handler((client, job) -> client.newCompleteCommand(job).withoutPayload().send())
+        .handler((client, job) -> client.newCompleteCommand(job).payload(NULL_PAYLOAD).send())
         .open();
 
     // then
@@ -204,7 +200,7 @@ public class BrokerRestartTest {
         .getJobClient()
         .newWorker()
         .jobType("foo")
-        .handler((client, job) -> client.newCompleteCommand(job).withoutPayload().send())
+        .handler((client, job) -> client.newCompleteCommand(job).payload(NULL_PAYLOAD).send())
         .open();
 
     waitUntil(() -> eventRecorder.getJobEvents(JobState.CREATED).size() > 1);
@@ -216,7 +212,7 @@ public class BrokerRestartTest {
         .getJobClient()
         .newWorker()
         .jobType("bar")
-        .handler((client, job) -> client.newCompleteCommand(job).withoutPayload().send())
+        .handler((client, job) -> client.newCompleteCommand(job).payload(NULL_PAYLOAD).send())
         .open();
 
     // then
@@ -287,7 +283,7 @@ public class BrokerRestartTest {
         .getJobClient()
         .newWorker()
         .jobType("foo")
-        .handler((client, job) -> client.newCompleteCommand(job).withoutPayload().send())
+        .handler((client, job) -> client.newCompleteCommand(job).payload(NULL_PAYLOAD).send())
         .open();
 
     // then

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/YamlWorkflowTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/YamlWorkflowTest.java
@@ -92,7 +92,7 @@ public class YamlWorkflowTest {
         .getJobClient()
         .newWorker()
         .jobType("foo")
-        .handler((client, job) -> client.newCompleteCommand(job).withoutPayload().send())
+        .handler((client, job) -> client.newCompleteCommand(job).payload((String) null).send())
         .open();
 
     // then

--- a/samples/src/main/java/io/zeebe/example/job/JobWorkerCreator.java
+++ b/samples/src/main/java/io/zeebe/example/job/JobWorkerCreator.java
@@ -68,7 +68,7 @@ public class JobWorkerCreator {
               job.getHeaders(),
               job.getPayload()));
 
-      client.newCompleteCommand(job).withoutPayload().send().join();
+      client.newCompleteCommand(job).payload((String) null).send().join();
     }
   }
 

--- a/test/src/test/java/io/zeebe/test/WorkflowTest.java
+++ b/test/src/test/java/io/zeebe/test/WorkflowTest.java
@@ -58,7 +58,7 @@ public class WorkflowTest {
         .jobClient()
         .newWorker()
         .jobType("task")
-        .handler((c, j) -> c.newCompleteCommand(j).withoutPayload().send().join())
+        .handler((c, j) -> c.newCompleteCommand(j).payload((String) null).send().join())
         .name("test")
         .open();
 


### PR DESCRIPTION
Removes the withoutPayload from the client api and uses instead the payload with a null value.

fixes zeebe-io/zeebe#947