### PR TITLE
Release sockets after broker shutdown

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -26,6 +26,8 @@ import io.zeebe.util.metrics.MetricsManager;
 import io.zeebe.util.sched.ActorScheduler;
 import io.zeebe.util.sched.clock.ActorClock;
 import io.zeebe.util.sched.future.ActorFuture;
+import java.io.Closeable;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Paths;
 import java.util.*;
@@ -44,11 +46,13 @@ public class SystemContext implements AutoCloseable {
   protected final BrokerCfg brokerCfg;
 
   protected final List<ActorFuture<?>> requiredStartActions = new ArrayList<>();
+  private final List<Closeable> closeablesToReleaseResources = new ArrayList<>();
 
   protected Map<String, String> diagnosticContext;
   protected ActorScheduler scheduler;
 
   private MetricsManager metricsManager;
+  private int closeTimeout;
 
   public SystemContext(String configFileLocation, String basePath, ActorClock clock) {
     if (!Paths.get(configFileLocation).isAbsolute()) {
@@ -90,6 +94,8 @@ public class SystemContext implements AutoCloseable {
     this.scheduler.start();
 
     initBrokerInfoMetric();
+
+    setCloseTimeout(CLOSE_TIMEOUT);
   }
 
   private MetricsManager initMetricsManager(String brokerId) {
@@ -171,14 +177,23 @@ public class SystemContext implements AutoCloseable {
     LOG.info("Closing...");
 
     try {
-      serviceContainer.close(CLOSE_TIMEOUT, TimeUnit.SECONDS);
+      serviceContainer.close(getCloseTimeout(), TimeUnit.SECONDS);
     } catch (TimeoutException e) {
       LOG.error("Failed to close broker within {} seconds.", CLOSE_TIMEOUT, e);
     } catch (ExecutionException | InterruptedException e) {
       LOG.error("Exception while closing broker", e);
     } finally {
+
+      for (Closeable delegate : closeablesToReleaseResources) {
+        try {
+          delegate.close();
+        } catch (IOException ioe) {
+          LOG.error("Exception while releasing resources", ioe);
+        }
+      }
+
       try {
-        scheduler.stop().get(CLOSE_TIMEOUT, TimeUnit.SECONDS);
+        scheduler.stop().get(getCloseTimeout(), TimeUnit.SECONDS);
       } catch (TimeoutException e) {
         LOG.error("Failed to close scheduler within {} seconds", CLOSE_TIMEOUT, e);
       } catch (ExecutionException | InterruptedException e) {
@@ -195,7 +210,20 @@ public class SystemContext implements AutoCloseable {
     requiredStartActions.add(future);
   }
 
+  public void addResourceReleasingDelegate(Closeable delegate) {
+    closeablesToReleaseResources.add(delegate);
+  }
+
   public Map<String, String> getDiagnosticContext() {
     return diagnosticContext;
+  }
+
+  public int getCloseTimeout() {
+    return closeTimeout;
+  }
+
+  public void setCloseTimeout(int closeTimeout) {
+    this.closeTimeout = closeTimeout;
+    scheduler.setBlockingTasksShutdownTime(closeTimeout);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/transport/BufferingServerTransportService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/transport/BufferingServerTransportService.java
@@ -19,12 +19,16 @@ package io.zeebe.broker.transport;
 
 import io.zeebe.broker.Loggers;
 import io.zeebe.dispatcher.Dispatcher;
-import io.zeebe.servicecontainer.*;
+import io.zeebe.servicecontainer.Injector;
+import io.zeebe.servicecontainer.Service;
+import io.zeebe.servicecontainer.ServiceStartContext;
+import io.zeebe.servicecontainer.ServiceStopContext;
 import io.zeebe.transport.BufferingServerTransport;
 import io.zeebe.transport.Transports;
 import io.zeebe.transport.impl.memory.NonBlockingMemoryPool;
 import io.zeebe.util.ByteValue;
 import io.zeebe.util.sched.ActorScheduler;
+import java.io.Closeable;
 import java.net.InetSocketAddress;
 import org.slf4j.Logger;
 
@@ -74,5 +78,13 @@ public class BufferingServerTransportService implements Service<BufferingServerT
 
   public Injector<Dispatcher> getReceiveBufferInjector() {
     return receiveBufferInjector;
+  }
+
+  public Closeable getReleasingResourcesDelegate() {
+    return () -> {
+      if (serverTransport != null) {
+        serverTransport.releaseResources();
+      }
+    };
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/transport/ServerTransportService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/transport/ServerTransportService.java
@@ -17,11 +17,15 @@
  */
 package io.zeebe.broker.transport;
 
-import io.zeebe.servicecontainer.*;
+import io.zeebe.servicecontainer.Injector;
+import io.zeebe.servicecontainer.Service;
+import io.zeebe.servicecontainer.ServiceStartContext;
+import io.zeebe.servicecontainer.ServiceStopContext;
 import io.zeebe.transport.*;
 import io.zeebe.transport.impl.memory.NonBlockingMemoryPool;
 import io.zeebe.util.ByteValue;
 import io.zeebe.util.sched.ActorScheduler;
+import java.io.Closeable;
 import java.net.InetSocketAddress;
 import org.slf4j.Logger;
 
@@ -69,6 +73,14 @@ public class ServerTransportService implements Service<ServerTransport> {
   @Override
   public ServerTransport get() {
     return serverTransport;
+  }
+
+  public Closeable getReleasingResourcesDelegate() {
+    return () -> {
+      if (serverTransport != null) {
+        serverTransport.releaseResources();
+      }
+    };
   }
 
   public Injector<ServerRequestHandler> getRequestHandlerInjector() {

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/shutdown/BrokerShutdownTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/shutdown/BrokerShutdownTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -61,7 +62,7 @@ public class BrokerShutdownTest {
   @Test
   public void shouldReleaseSockets() {
     // given
-    broker.getBrokerContext().setCloseTimeout(1);
+    broker.getBrokerContext().setCloseTimeout(Duration.ofSeconds(1));
 
     // when
     broker.close();

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/shutdown/BrokerShutdownTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/shutdown/BrokerShutdownTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.broker.it.shutdown;
+
+import io.zeebe.broker.Broker;
+import io.zeebe.broker.it.EmbeddedBrokerRule;
+import io.zeebe.broker.system.configuration.NetworkCfg;
+import io.zeebe.broker.transport.TransportServiceNames;
+import io.zeebe.client.api.events.*;
+import io.zeebe.servicecontainer.*;
+import io.zeebe.transport.SocketAddress;
+import io.zeebe.transport.impl.ServerSocketBinding;
+import io.zeebe.util.sched.future.CompletableActorFuture;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.assertj.core.util.Files;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class BrokerShutdownTest {
+
+  private static final ServiceName<Void> BLOCK_BROKER_SERVICE_NAME =
+      ServiceName.newServiceName("blockService", Void.class);
+
+  @Rule public ExpectedException exception = ExpectedException.none();
+
+  @Test
+  public void shouldReleaseSockets() {
+    // given
+    final Broker broker = startBrokerWithBlockingService();
+    broker.getBrokerContext().setCloseTimeout(1);
+
+    // when
+    broker.close();
+
+    // then
+    final NetworkCfg networkCfg = broker.getBrokerContext().getBrokerConfiguration().getNetwork();
+
+    tryToBindSocketAddress(networkCfg.getManagement().toSocketAddress());
+    tryToBindSocketAddress(networkCfg.getReplication().toSocketAddress());
+    tryToBindSocketAddress(networkCfg.getClient().toSocketAddress());
+  }
+
+  private void tryToBindSocketAddress(SocketAddress socketAddress) {
+    final InetSocketAddress replicationSocket = socketAddress.toInetSocketAddress();
+    final ServerSocketBinding binding = new ServerSocketBinding(replicationSocket);
+    binding.doBind();
+    binding.close();
+  }
+
+  private Broker startBrokerWithBlockingService() {
+    final File brokerBase = Files.newTemporaryFolder();
+
+    final Broker broker;
+    try (InputStream configStream =
+        EmbeddedBrokerRule.class.getResourceAsStream("/zeebe.default.cfg.toml")) {
+      broker = new Broker(configStream, brokerBase.getAbsolutePath(), null);
+    } catch (final IOException e) {
+      throw new RuntimeException("Unable to open configuration", e);
+    }
+
+    final ServiceContainer serviceContainer = broker.getBrokerContext().getServiceContainer();
+
+    try {
+      // blocks on shutdown
+      serviceContainer
+          .createService(BLOCK_BROKER_SERVICE_NAME, new BlockingService())
+          .dependency(
+              TransportServiceNames.bufferingServerTransport(
+                  TransportServiceNames.MANAGEMENT_API_SERVER_NAME))
+          .dependency(
+              TransportServiceNames.serverTransport(TransportServiceNames.CLIENT_API_SERVER_NAME))
+          .dependency(
+              TransportServiceNames.serverTransport(
+                  TransportServiceNames.REPLICATION_API_SERVER_NAME))
+          .install()
+          .get(25, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RuntimeException(
+          "System patition not installed into the container withing 25 seconds.");
+    }
+    return broker;
+  }
+
+  private class BlockingService implements Service<Void> {
+    @Override
+    public void start(ServiceStartContext startContext) {}
+
+    @Override
+    public void stop(ServiceStopContext stopContext) {
+      final CompletableActorFuture<Void> neverCompletingFuture = new CompletableActorFuture<>();
+      stopContext.async(neverCompletingFuture);
+    }
+
+    @Override
+    public Void get() {
+      return null;
+    }
+  }
+}

--- a/transport/src/main/java/io/zeebe/transport/ServerTransport.java
+++ b/transport/src/main/java/io/zeebe/transport/ServerTransport.java
@@ -62,4 +62,8 @@ public class ServerTransport implements AutoCloseable {
   public void close() {
     closeAsync().join();
   }
+
+  public void releaseResources() {
+    transportActorContext.getConductor().close().join();
+  }
 }

--- a/transport/src/main/java/io/zeebe/transport/impl/ServerSocketBinding.java
+++ b/transport/src/main/java/io/zeebe/transport/impl/ServerSocketBinding.java
@@ -95,6 +95,10 @@ public class ServerSocketBinding {
     } catch (Exception e) {
       LOG.debug("Failed to close selectors", e);
     }
+    releaseMedia();
+  }
+
+  public void releaseMedia() {
     try {
       media.close();
     } catch (IOException e) {

--- a/util/src/main/java/io/zeebe/util/sched/ActorExecutor.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorExecutor.java
@@ -31,7 +31,7 @@ public class ActorExecutor {
   private final ActorThreadGroup ioBoundThreads;
   private final ThreadPoolExecutor blockingTasksRunner;
   private final MetricsManager metricsManager;
-  private final Duration blockingTasksShutdownTime;
+  private Duration blockingTasksShutdownTime;
 
   public ActorExecutor(ActorSchedulerBuilder builder) {
     this.ioBoundThreads = builder.getIoBoundActorThreads();
@@ -110,5 +110,13 @@ public class ActorExecutor {
 
   public ActorThreadGroup getIoBoundThreads() {
     return ioBoundThreads;
+  }
+
+  public Duration getBlockingTasksShutdownTime() {
+    return blockingTasksShutdownTime;
+  }
+
+  public void setBlockingTasksShutdownTime(Duration duration) {
+    blockingTasksShutdownTime = duration;
   }
 }

--- a/util/src/main/java/io/zeebe/util/sched/ActorScheduler.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorScheduler.java
@@ -136,8 +136,8 @@ public class ActorScheduler {
     }
   }
 
-  public void setBlockingTasksShutdownTime(int seconds) {
-    actorTaskExecutor.setBlockingTasksShutdownTime(Duration.ofSeconds(seconds));
+  public void setBlockingTasksShutdownTime(Duration shutdownTime) {
+    actorTaskExecutor.setBlockingTasksShutdownTime(shutdownTime);
   }
 
   public static ActorSchedulerBuilder newActorScheduler() {

--- a/util/src/main/java/io/zeebe/util/sched/ActorScheduler.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorScheduler.java
@@ -136,6 +136,10 @@ public class ActorScheduler {
     }
   }
 
+  public void setBlockingTasksShutdownTime(int seconds) {
+    actorTaskExecutor.setBlockingTasksShutdownTime(Duration.ofSeconds(seconds));
+  }
+
   public static ActorSchedulerBuilder newActorScheduler() {
     return new ActorSchedulerBuilder();
   }


### PR DESCRIPTION
Closes the Conductors even if service container close fails.
On setup, close delegates are collected, which are executed after service container closing.
These delegates should release resources (like socket bindings).

If the ServerTransport is already closed, during service container closing, this is not a problem since the close is then ignored. If transport is not closed, then the delegates will release the necessary resources.
We need to stop the scheduler afterwards.

fixes zeebe-io/zeebe#965
