### PR TITLE
Fix race condition in stream ctrl tests

### DIFF
--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
@@ -96,4 +96,8 @@ public class RecordingStreamProcessor implements StreamProcessor {
   public EventProcessor getEventProcessorSpy() {
     return eventProcessor;
   }
+
+  public StreamProcessorContext getContext() {
+    return context;
+  }
 }

--- a/logstreams/src/test/resources/log4j2-test.xml
+++ b/logstreams/src/test/resources/log4j2-test.xml
@@ -3,7 +3,7 @@
 
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n"/>
     </Console>
   </Appenders>
 


### PR DESCRIPTION
As described mock or spy changes should be done in actor thread

 closes zeebe-io/zeebe#973
