### PR TITLE
Add git pre-commit script to check formatting and style

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# 1. get all added (A), copied (C) and modified (M) java files which are staged
+# 2. get the first part of the path which we assume is a maven module
+# 3. join the maven modules to build
+modules=$(git diff --staged --diff-filter=ACM --name-only \*.java | cut -d / -f 1 | sort -u | paste -d , -s)
+
+# If any maven module was changed check if the license headers, foramt and style is correct
+if [ -n "${modules}" ]; then
+    echo "Checking license header, code format and style for maven modules '${modules}'"
+    # some JVM options to reduce JVM startup time, should be fine as the maven process is only shortliving
+    export MAVEN_OPTS="-client -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xverify:none"
+
+    # run maven in offline mode, quiet (only errors) and with a thread per core
+    # specify checkstyle xml based on the multi module project root directory (requires maven 3.3.1+)
+    mvn -o -q -T 1C -pl ${modules} com.mycila:license-maven-plugin:check com.coveo:fmt-maven-plugin:check checkstyle:check -Dcheckstyle.config.location='${maven.multiModuleProjectDirectory}/build-tools/src/main/resources/check/.checkstyle.xml'
+fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 // vim: set filetype=groovy:
 
 def jdkVersion = 'jdk-8-latest'
-def mavenVersion = 'maven-3.3-latest'
+def mavenVersion = 'maven-3.5-latest'
 def mavenSettingsConfig = 'camunda-maven-settings'
 
 def joinJmhResults = '''\
@@ -22,7 +22,7 @@ pipeline {
         stage('Install') {
             steps {
                 withMaven(jdk: jdkVersion, maven: mavenVersion, mavenSettingsConfig: mavenSettingsConfig) {
-                    sh 'mvn -B clean com.mycila:license-maven-plugin:check install -DskipTests'
+                    sh 'mvn -B clean com.mycila:license-maven-plugin:check com.coveo:fmt-maven-plugin:check install -DskipTests'
                 }
             }
         }

--- a/githooks-plugin/pom.xml
+++ b/githooks-plugin/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Zeebe Git Hooks Maven Plugin</name>
+  <artifactId>zb-githooks-plugin</artifactId>
+  <version>0.11.0-SNAPSHOT</version>
+  <packaging>maven-plugin</packaging>
+
+  <parent>
+    <artifactId>zb-bom</artifactId>
+    <groupId>io.zeebe</groupId>
+    <version>0.11.0-SNAPSHOT</version>
+    <relativePath>../bom</relativePath>
+  </parent>
+
+  <properties>
+    <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <!-- disable jdk8 javadoc checks on release build -->
+    <additionalparam>-Xdoclint:none</additionalparam>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>3.2</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.2</version>
+        <configuration>
+          <goalPrefix>zb-githooks</goalPrefix>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+        </configuration>
+        <executions>
+          <execution>
+            <id>mojo-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>help-goal</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/githooks-plugin/src/main/java/io/zeebe/SetupMojo.java
+++ b/githooks-plugin/src/main/java/io/zeebe/SetupMojo.java
@@ -1,0 +1,126 @@
+package io.zeebe;
+
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+@Mojo(name = "setup", defaultPhase = LifecyclePhase.INITIALIZE)
+public class SetupMojo extends AbstractMojo {
+
+  private static final Charset CHARSET = StandardCharsets.UTF_8;
+  private static final String LINE_SEPARATOR = System.lineSeparator();
+
+  private static final String SHEBANG = "#!/bin/sh" + LINE_SEPARATOR;
+  private static final String PRE_COMMIT_SCRIPT = ".githooks/pre-commit" + LINE_SEPARATOR;
+
+  @Parameter(
+      defaultValue = "${maven.multiModuleProjectDirectory}",
+      property = "rootDir",
+      required = true)
+  private File rootDir;
+
+  public void execute() throws MojoExecutionException {
+    ensureGitHooksDirExists();
+    ensurePreCommitFileExists();
+    ensurePreCommitFilePermissions();
+    ensurePreCommitScript();
+  }
+
+  private void ensureGitHooksDirExists() throws MojoExecutionException {
+    final Path gitHooksDir = getGitHooksDir();
+    final File file = gitHooksDir.toFile();
+    if (file.isDirectory()) {
+      getLog().debug("Git hooks directory " + file.getAbsolutePath() + " exist");
+    } else {
+      if (file.exists()) {
+        throw new MojoExecutionException(
+            "Git hooks directory " + file.getAbsolutePath() + " exists but is not directory");
+      } else {
+        if (file.mkdirs()) {
+          getLog().info("Created git hooks directory " + file.getAbsolutePath());
+        } else {
+          throw new MojoExecutionException(
+              "Failed to create git hooks directory " + file.getAbsolutePath());
+        }
+      }
+    }
+  }
+
+  private void ensurePreCommitFileExists() throws MojoExecutionException {
+    final Path preCommitFile = getPreCommitFile();
+    final File file = preCommitFile.toFile();
+    if (file.isFile()) {
+      getLog().debug("Pre-commit hook " + file.getAbsolutePath() + " file exist");
+    } else {
+      if (file.exists()) {
+        throw new MojoExecutionException(
+            "Pre-commit hook file " + file.getAbsolutePath() + " exists but is not a file");
+      } else {
+        try {
+          Files.write(preCommitFile, SHEBANG.getBytes(CHARSET), CREATE);
+          getLog().info("Created pre-commit hook file " + file.getAbsolutePath());
+        } catch (final IOException e) {
+          throw new MojoExecutionException(
+              "Failed to create pre-commit hook file " + file.getAbsolutePath(), e);
+        }
+      }
+    }
+  }
+
+  private void ensurePreCommitFilePermissions() throws MojoExecutionException {
+    final Path preCommitFile = getPreCommitFile();
+    try {
+      final Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rwxrwxrwx");
+      if (!Files.getPosixFilePermissions(preCommitFile).equals(permissions)) {
+        Files.setPosixFilePermissions(preCommitFile, permissions);
+        getLog()
+            .info(
+                "Set file permissions for pre-commit hook file " + preCommitFile.toAbsolutePath());
+      }
+    } catch (final UnsupportedOperationException e) {
+      getLog().debug("Skip setting file permissions as it is not supported on this system", e);
+    } catch (final IOException e) {
+      throw new MojoExecutionException(
+          "Failed to set file permissions for pre-commit hook file "
+              + preCommitFile.toAbsolutePath(),
+          e);
+    }
+  }
+
+  private void ensurePreCommitScript() throws MojoExecutionException {
+    final Path preCommitFile = getPreCommitFile();
+    try {
+      final String preCommitFileContent = new String(Files.readAllBytes(preCommitFile), CHARSET);
+      if (!preCommitFileContent.contains(PRE_COMMIT_SCRIPT)) {
+        Files.write(preCommitFile, PRE_COMMIT_SCRIPT.getBytes(CHARSET), APPEND);
+        getLog().info("Added pre-commit script to file " + preCommitFile.toAbsolutePath());
+      }
+    } catch (final IOException e) {
+      throw new MojoExecutionException(
+          "Failed to read content of pre-commit file " + preCommitFile.toAbsolutePath());
+    }
+  }
+
+  private Path getGitHooksDir() {
+    return Paths.get(rootDir.getAbsolutePath(), ".git", "hooks");
+  }
+
+  private Path getPreCommitFile() {
+    return getGitHooksDir().resolve("pre-commit");
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -53,7 +53,7 @@
     <plugin.version.scala>3.2.1</plugin.version.scala>
     <plugin.version.antrun>1.8</plugin.version.antrun>
     <plugin.version.versions>2.5</plugin.version.versions>
-    <plugin.version.fmt>2.5.0</plugin.version.fmt>
+    <plugin.version.fmt>2.5.1</plugin.version.fmt>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
@@ -38,6 +39,25 @@
     <module>json-el</module>
     <module>json-path</module>
     <module>build-tools</module>
+    <module>githooks-plugin</module>
   </modules>
+
+  <build>
+    <plugins>
+      <!-- Zeebe githooks plugin -->
+      <plugin>
+        <groupId>io.zeebe</groupId>
+        <artifactId>zb-githooks-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>setup</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -20,10 +20,6 @@ import static io.zeebe.broker.logstreams.LogStreamServiceNames.snapshotStorageSe
 import static io.zeebe.logstreams.impl.service.LogStreamServiceNames.logBlockIndexWriterService;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
-
 import io.zeebe.broker.Broker;
 import io.zeebe.broker.clustering.base.snapshots.SnapshotReplicationService;
 import io.zeebe.broker.it.ClientRule;
@@ -37,6 +33,9 @@ import io.zeebe.servicecontainer.*;
 import io.zeebe.test.util.AutoCloseableRule;
 import io.zeebe.test.util.TestUtil;
 import io.zeebe.transport.SocketAddress;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;


### PR DESCRIPTION
This adds a small maven plugin `github-hooks` which installs and updates a git pre-commit script in the `initialize` phase of the zeebe-root module. After that on every commit which changed java files a minimal maven run is executed to validate the license header, code format and style.
