### PR TITLE
Send repeatedly sync requests via gossip

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/Topology.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/Topology.java
@@ -22,7 +22,10 @@ import io.zeebe.broker.clustering.base.topology.TopologyDto.BrokerDto;
 import io.zeebe.raft.state.RaftState;
 import io.zeebe.transport.SocketAddress;
 import io.zeebe.util.buffer.BufferUtil;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.Int2ObjectHashMap;
@@ -108,13 +111,13 @@ public class Topology implements ReadableTopology {
     return new ArrayList<>(partitions.values());
   }
 
-  public void addMember(NodeInfo member) {
-    // replace member if present
+  public boolean addMember(NodeInfo member) {
+
     if (!members.contains(member)) {
       LOG.debug("Adding {} to list of known members", member);
-
-      members.add(member);
+      return members.add(member);
     }
+    return false;
   }
 
   public void removeMember(NodeInfo member) {

--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/TopologyManagerImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/TopologyManagerImpl.java
@@ -170,8 +170,10 @@ public class TopologyManagerImpl extends Actor implements TopologyManager, RaftS
             readSocketAddress(offset, payloadCopy, replicationApi);
 
             final NodeInfo newMember = new NodeInfo(clientApi, managementApi, replicationApi);
-            topology.addMember(newMember);
-            notifyMemberAdded(newMember);
+            final boolean memberAdded = topology.addMember(newMember);
+            if (memberAdded) {
+              notifyMemberAdded(newMember);
+            }
           });
     }
   }

--- a/dist/src/main/config/zeebe.cfg.toml
+++ b/dist/src/main/config/zeebe.cfg.toml
@@ -203,6 +203,7 @@ replicationFactor = 1
 # probeIndirectTimeout = "1s"
 # suspicionMultiplier = 5
 # syncTimeout = "3s"
+# syncInterval = "15s"
 # joinTimeout = "1s"
 # joinInterval = "5s"
 # leaveTimeout = "1s"

--- a/gossip/src/main/java/io/zeebe/gossip/GossipConfiguration.java
+++ b/gossip/src/main/java/io/zeebe/gossip/GossipConfiguration.java
@@ -30,6 +30,7 @@ public class GossipConfiguration {
   private int suspicionMultiplier = 5;
 
   private String syncTimeout = "3s";
+  private String syncInterval = "15s";
 
   private String joinTimeout = "1s";
   private String joinInterval = "1s";
@@ -147,6 +148,20 @@ public class GossipConfiguration {
 
   public Duration getSyncTimeoutDuration() {
     return DurationUtil.parse(syncTimeout);
+  }
+
+  /** The interval on which the sync requests are send. */
+  public String getSyncInterval() {
+    return syncInterval;
+  }
+
+  public Duration getSyncIntervalDuration() {
+    return DurationUtil.parse(syncInterval);
+  }
+
+  public GossipConfiguration setSyncInterval(String syncInterval) {
+    this.syncInterval = syncInterval;
+    return this;
   }
 
   /** The timeout of a sync request. */

--- a/gossip/src/main/java/io/zeebe/gossip/failuredetection/SyncController.java
+++ b/gossip/src/main/java/io/zeebe/gossip/failuredetection/SyncController.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.gossip.failuredetection;
+
+import io.zeebe.gossip.GossipConfiguration;
+import io.zeebe.gossip.GossipContext;
+import io.zeebe.gossip.Loggers;
+import io.zeebe.gossip.membership.Member;
+import io.zeebe.gossip.membership.MembershipList;
+import io.zeebe.gossip.membership.RoundRobinMemberIterator;
+import io.zeebe.gossip.protocol.GossipEvent;
+import io.zeebe.gossip.protocol.GossipEventSender;
+import io.zeebe.transport.ClientResponse;
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.future.ActorFuture;
+import org.agrona.DirectBuffer;
+import org.slf4j.Logger;
+
+public class SyncController {
+  private static final Logger LOG = Loggers.GOSSIP_LOGGER;
+
+  private final RoundRobinMemberIterator memberIterator;
+  private final GossipEventSender gossipEventSender;
+  private final GossipEvent syncResponse;
+  private final ActorControl actor;
+  private final GossipConfiguration configuration;
+
+  public SyncController(GossipContext context, ActorControl actorControl) {
+    configuration = context.getConfiguration();
+
+    actor = actorControl;
+    final MembershipList membershipList = context.getMembershipList();
+    this.memberIterator = new RoundRobinMemberIterator(membershipList);
+
+    this.gossipEventSender = context.getGossipEventSender();
+    this.syncResponse = context.getGossipEventFactory().createSyncResponse();
+  }
+
+  public void setupSyncRepetition() {
+    actor.runAtFixedRate(
+        configuration.getSyncIntervalDuration(),
+        () -> {
+          if (memberIterator.hasNext()) {
+            final Member nextMember = memberIterator.next();
+            LOG.debug("Send sync request to '{}'.", nextMember.getAddress());
+
+            final ActorFuture<ClientResponse> requestFuture =
+                gossipEventSender.sendSyncRequest(
+                    nextMember.getAddress(), configuration.getSyncTimeoutDuration());
+
+            actor.runOnCompletion(
+                requestFuture,
+                (request, failure) -> {
+                  if (failure == null) {
+                    LOG.debug("Received SYNC response.");
+                    final DirectBuffer response = request.getResponseBuffer();
+                    syncResponse.wrap(response, 0, response.capacity());
+                  } else {
+                    LOG.debug(
+                        "Failed to receive SYNC response from '{}'. Try again in {}",
+                        nextMember.getAddress(),
+                        configuration.getSyncIntervalDuration());
+                  }
+                });
+          }
+        });
+  }
+}


### PR DESCRIPTION
Gossip nodes are sending repeatedly sync requests in round-robin fashion to other members.
Sync interval is per default 15 seconds, but can be configured.

closes #1011 
