### PR TITLE
refactor(broker): make TypedRecordProcessor a single-method interface

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/clustering/orchestration/topic/TopicCreationService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/orchestration/topic/TopicCreationService.java
@@ -312,7 +312,9 @@ public class TopicCreationService extends Actor
   }
 
   private void writeEvent(final long key, final TopicIntent intent, final TopicRecord topicEvent) {
-    if (streamWriter.writeFollowUpEvent(key, intent, topicEvent) >= 0) {
+    streamWriter.writeFollowUpEvent(key, intent, topicEvent);
+
+    if (streamWriter.flush() >= 0) {
       actor.done();
     } else {
       actor.yield();

--- a/broker-core/src/main/java/io/zeebe/broker/event/processor/SubscribeProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/event/processor/SubscribeProcessor.java
@@ -18,7 +18,7 @@
 package io.zeebe.broker.event.processor;
 
 import io.zeebe.logstreams.impl.service.StreamProcessorService;
-import io.zeebe.logstreams.log.LogStreamWriter;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.logstreams.processor.EventLifecycleContext;
 import io.zeebe.logstreams.processor.EventProcessor;
@@ -81,7 +81,7 @@ public class SubscribeProcessor implements EventProcessor {
   }
 
   @Override
-  public long writeEvent(LogStreamWriter writer) {
+  public long writeEvent(LogStreamRecordWriter writer) {
     return state.writeEvent(writer);
   }
 
@@ -103,7 +103,7 @@ public class SubscribeProcessor implements EventProcessor {
     }
 
     @Override
-    public long writeEvent(LogStreamWriter writer) {
+    public long writeEvent(LogStreamRecordWriter writer) {
       // in the future, we can write a SUBSCRIBE_FAILED event here,
       // but at the moment that would make no difference for the user
       return 0L;
@@ -181,7 +181,7 @@ public class SubscribeProcessor implements EventProcessor {
     }
 
     @Override
-    public long writeEvent(LogStreamWriter writer) {
+    public long writeEvent(LogStreamRecordWriter writer) {
       metadata.protocolVersion(Protocol.PROTOCOL_VERSION).intent(SubscriberIntent.SUBSCRIBED);
 
       subscriberEvent.setStartPosition(processor.getStartPosition());

--- a/broker-core/src/main/java/io/zeebe/broker/event/processor/TopicSubscriptionManagementProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/event/processor/TopicSubscriptionManagementProcessor.java
@@ -266,7 +266,7 @@ public class TopicSubscriptionManagementProcessor implements StreamProcessor {
 
   protected class AckProcessor implements EventProcessor {
     @Override
-    public long writeEvent(LogStreamWriter writer) {
+    public long writeEvent(LogStreamRecordWriter writer) {
       metadata
           .recordType(RecordType.EVENT)
           .valueType(ValueType.SUBSCRIPTION)
@@ -341,7 +341,7 @@ public class TopicSubscriptionManagementProcessor implements StreamProcessor {
     }
 
     @Override
-    public long writeEvent(LogStreamWriter writer) {
+    public long writeEvent(LogStreamRecordWriter writer) {
       final DirectBuffer openedSubscriptionName = subscriberEvent.getName();
 
       subscriptionEvent.reset();

--- a/broker-core/src/main/java/io/zeebe/broker/incident/processor/IncidentStreamProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/incident/processor/IncidentStreamProcessor.java
@@ -26,6 +26,7 @@ import io.zeebe.broker.logstreams.processor.CommandProcessor;
 import io.zeebe.broker.logstreams.processor.TypedEventStreamProcessorBuilder;
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedRecordProcessor;
+import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
 import io.zeebe.broker.logstreams.processor.TypedStreamEnvironment;
 import io.zeebe.broker.logstreams.processor.TypedStreamProcessor;
 import io.zeebe.broker.logstreams.processor.TypedStreamReader;
@@ -64,16 +65,15 @@ public class IncidentStreamProcessor {
     builder =
         builder
             .onCommand(ValueType.INCIDENT, IncidentIntent.CREATE, new CreateIncidentProcessor())
-            .onCommand(
-                ValueType.INCIDENT, IncidentIntent.RESOLVE, new ResolveIncidentProcessor(env))
+            .onCommand(ValueType.INCIDENT, IncidentIntent.RESOLVE, new ResolveIncidentProcessor())
             .onEvent(
                 ValueType.INCIDENT, IncidentIntent.RESOLVE_FAILED, new ResolveFailedProcessor())
-            .onCommand(ValueType.INCIDENT, IncidentIntent.DELETE, new DeleteIncidentProcessor(env));
+            .onCommand(ValueType.INCIDENT, IncidentIntent.DELETE, new DeleteIncidentProcessor());
 
     // workflow instance events
     final ActivityRewrittenProcessor activityRewrittenProcessor = new ActivityRewrittenProcessor();
     final ActivityIncidentResolvedProcessor activityIncidentResolvedProcessor =
-        new ActivityIncidentResolvedProcessor(env);
+        new ActivityIncidentResolvedProcessor();
 
     builder =
         builder
@@ -112,7 +112,7 @@ public class IncidentStreamProcessor {
 
     // job events
     final JobIncidentResolvedProcessor jobIncidentResolvedProcessor =
-        new JobIncidentResolvedProcessor(env);
+        new JobIncidentResolvedProcessor();
 
     builder =
         builder
@@ -124,29 +124,24 @@ public class IncidentStreamProcessor {
   }
 
   private final class CreateIncidentProcessor implements CommandProcessor<IncidentRecord> {
-    private boolean isJobIncident;
 
     @Override
     public CommandResult onCommand(
         TypedRecord<IncidentRecord> command, CommandControl commandControl) {
       final IncidentRecord incidentEvent = command.getValue();
 
-      isJobIncident = incidentEvent.getJobKey() > 0;
+      final boolean isJobIncident = incidentEvent.getJobKey() > 0;
 
       if (isJobIncident) {
-        if (failedJobMap.get(incidentEvent.getJobKey(), -1L) == NON_PERSISTENT_INCIDENT) {
-          return commandControl.accept(IncidentIntent.CREATED);
-        } else {
+        if (failedJobMap.get(incidentEvent.getJobKey(), -1L) != NON_PERSISTENT_INCIDENT) {
           return commandControl.reject(RejectionType.NOT_APPLICABLE, "Job is not failed");
         }
-      } else {
-        return commandControl.accept(IncidentIntent.CREATED);
-      }
-    }
 
-    @Override
-    public void updateStateOnAccept(TypedRecord<IncidentRecord> command) {
-      final IncidentRecord incidentEvent = command.getValue();
+        failedJobMap.put(incidentEvent.getJobKey(), command.getKey());
+      } else {
+        activityInstanceMap.put(incidentEvent.getActivityInstanceKey(), command.getKey());
+      }
+
       incidentMap
           .newIncident(command.getKey())
           .setState(STATE_CREATED)
@@ -154,25 +149,22 @@ public class IncidentStreamProcessor {
           .setFailureEventPosition(incidentEvent.getFailureEventPosition())
           .write();
 
-      if (isJobIncident) {
-        failedJobMap.put(incidentEvent.getJobKey(), command.getKey());
-      } else {
-        activityInstanceMap.put(incidentEvent.getActivityInstanceKey(), command.getKey());
-      }
+      return commandControl.accept(IncidentIntent.CREATED);
     }
   }
 
   private final class PayloadUpdatedProcessor
       implements TypedRecordProcessor<WorkflowInstanceRecord> {
-    private boolean isResolving;
-    private long incidentKey;
+
     private final IncidentRecord incidentEvent = new IncidentRecord();
 
     @Override
-    public void processRecord(TypedRecord<WorkflowInstanceRecord> event) {
-      isResolving = false;
+    public void processRecord(
+        TypedRecord<WorkflowInstanceRecord> event,
+        TypedResponseWriter responseWriter,
+        TypedStreamWriter streamWriter) {
 
-      incidentKey = activityInstanceMap.get(event.getKey(), -1L);
+      final long incidentKey = activityInstanceMap.get(event.getKey(), -1L);
 
       if (incidentKey > 0 && incidentMap.wrapIncidentKey(incidentKey).getState() == STATE_CREATED) {
         final WorkflowInstanceRecord workflowInstanceEvent = event.getValue();
@@ -183,96 +175,65 @@ public class IncidentStreamProcessor {
             .setActivityInstanceKey(event.getKey())
             .setPayload(workflowInstanceEvent.getPayload());
 
-        isResolving = true;
+        streamWriter.writeFollowUpCommand(incidentKey, IncidentIntent.RESOLVE, incidentEvent);
       }
-    }
-
-    @Override
-    public long writeRecord(TypedRecord<WorkflowInstanceRecord> event, TypedStreamWriter writer) {
-      return isResolving
-          ? writer.writeFollowUpCommand(incidentKey, IncidentIntent.RESOLVE, incidentEvent)
-          : 0L;
     }
   }
 
   private final class ResolveIncidentProcessor implements TypedRecordProcessor<IncidentRecord> {
-    private final TypedStreamEnvironment environment;
     private TypedStreamReader reader;
 
-    private boolean resolving;
     private TypedRecord<WorkflowInstanceRecord> failureEvent;
     private long incidentKey;
 
-    ResolveIncidentProcessor(TypedStreamEnvironment environment) {
-      this.environment = environment;
-    }
-
     @Override
     public void onOpen(TypedStreamProcessor streamProcessor) {
-      reader = environment.getStreamReader();
+      reader = streamProcessor.getEnvironment().getStreamReader();
     }
 
     @Override
-    public void processRecord(TypedRecord<IncidentRecord> command) {
-      resolving = false;
+    public void processRecord(
+        TypedRecord<IncidentRecord> command,
+        TypedResponseWriter responseWriter,
+        TypedStreamWriter streamWriter) {
 
       incidentKey = command.getKey();
       incidentMap.wrapIncidentKey(incidentKey);
 
-      resolving = incidentMap.getState() == STATE_CREATED;
-
-      if (resolving) {
+      if (incidentMap.getState() == STATE_CREATED) {
         // re-write the failure event with new payload
         failureEvent =
             reader.readValue(incidentMap.getFailureEventPosition(), WorkflowInstanceRecord.class);
         failureEvent.getValue().setPayload(command.getValue().getPayload());
-      }
-    }
 
-    @Override
-    public long writeRecord(TypedRecord<IncidentRecord> command, TypedStreamWriter writer) {
-      final long position;
+        streamWriter.writeFollowUpEvent(
+            failureEvent.getKey(),
+            failureEvent.getMetadata().getIntent(),
+            failureEvent.getValue(),
+            this::setIncidentKey);
 
-      if (resolving) {
-        position =
-            writer.writeFollowUpEvent(
-                failureEvent.getKey(),
-                failureEvent.getMetadata().getIntent(),
-                failureEvent.getValue(),
-                this::setIncidentKey);
+        incidentMap.setState(STATE_RESOLVING).write();
       } else {
-        position =
-            writer.writeRejection(
-                command, RejectionType.NOT_APPLICABLE, "Incident is not in state CREATED");
+        streamWriter.writeRejection(
+            command, RejectionType.NOT_APPLICABLE, "Incident is not in state CREATED");
       }
-      return position;
     }
 
     private void setIncidentKey(RecordMetadata metadata) {
       metadata.incidentKey(incidentKey);
     }
-
-    @Override
-    public void updateState(TypedRecord<IncidentRecord> command) {
-      if (resolving) {
-        incidentMap.setState(STATE_RESOLVING).write();
-      }
-    }
   }
 
   private final class ResolveFailedProcessor implements TypedRecordProcessor<IncidentRecord> {
-    private boolean isFailed;
 
     @Override
-    public void processRecord(TypedRecord<IncidentRecord> event) {
+    public void processRecord(
+        TypedRecord<IncidentRecord> event,
+        TypedResponseWriter responseWriter,
+        TypedStreamWriter streamWriter) {
       incidentMap.wrapIncidentKey(event.getKey());
 
-      isFailed = incidentMap.getState() == STATE_RESOLVING;
-    }
-
-    @Override
-    public void updateState(TypedRecord<IncidentRecord> event) {
-      if (isFailed) {
+      if (incidentMap.getState() == STATE_RESOLVING) {
         incidentMap.setState(STATE_CREATED).write();
       }
     }
@@ -280,60 +241,45 @@ public class IncidentStreamProcessor {
 
   private final class DeleteIncidentProcessor implements TypedRecordProcessor<IncidentRecord> {
     private TypedStreamReader reader;
-    private final TypedStreamEnvironment environment;
-
-    private boolean isDeleted;
-    private TypedRecord<IncidentRecord> incidentToWrite;
-
-    DeleteIncidentProcessor(TypedStreamEnvironment environment) {
-      this.environment = environment;
-    }
 
     @Override
     public void onOpen(TypedStreamProcessor streamProcessor) {
-      reader = environment.getStreamReader();
+      reader = streamProcessor.getEnvironment().getStreamReader();
     }
 
     @Override
-    public void processRecord(TypedRecord<IncidentRecord> command) {
-      isDeleted = false;
+    public void processRecord(
+        TypedRecord<IncidentRecord> command,
+        TypedResponseWriter responseWriter,
+        TypedStreamWriter streamWriter) {
 
       incidentMap.wrapIncidentKey(command.getKey());
 
       final long incidentEventPosition = incidentMap.getIncidentEventPosition();
-      isDeleted = incidentEventPosition > 0;
 
-      if (isDeleted) {
+      if (incidentEventPosition > 0) {
         final TypedRecord<IncidentRecord> priorIncidentEvent =
             reader.readValue(incidentEventPosition, IncidentRecord.class);
 
-        incidentToWrite = priorIncidentEvent;
-      }
-    }
+        streamWriter.writeFollowUpEvent(
+            priorIncidentEvent.getKey(), IncidentIntent.DELETED, priorIncidentEvent.getValue());
 
-    @Override
-    public long writeRecord(TypedRecord<IncidentRecord> command, TypedStreamWriter writer) {
-      if (isDeleted) {
-        return writer.writeFollowUpEvent(
-            incidentToWrite.getKey(), IncidentIntent.DELETED, incidentToWrite.getValue());
-      } else {
-        return writer.writeRejection(
-            command, RejectionType.NOT_APPLICABLE, "Incident does not exist");
-      }
-    }
-
-    @Override
-    public void updateState(TypedRecord<IncidentRecord> command) {
-      if (isDeleted) {
         incidentMap.remove(command.getKey());
+      } else {
+        streamWriter.writeRejection(
+            command, RejectionType.NOT_APPLICABLE, "Incident does not exist");
       }
     }
   }
 
   private final class ActivityRewrittenProcessor
       implements TypedRecordProcessor<WorkflowInstanceRecord> {
+
     @Override
-    public void updateState(TypedRecord<WorkflowInstanceRecord> record) {
+    public void processRecord(
+        TypedRecord<WorkflowInstanceRecord> record,
+        TypedResponseWriter responseWriter,
+        TypedStreamWriter streamWriter) {
       final long incidentKey = record.getMetadata().getIncidentKey();
       if (incidentKey > 0) {
         resolvingEvents.put(record.getPosition(), incidentKey);
@@ -343,25 +289,18 @@ public class IncidentStreamProcessor {
 
   private final class ActivityIncidentResolvedProcessor
       implements TypedRecordProcessor<WorkflowInstanceRecord> {
-    private final TypedStreamEnvironment environment;
     private TypedStreamReader reader;
-
-    private boolean isResolved;
-    private TypedRecord<IncidentRecord> incidentEvent;
-
-    ActivityIncidentResolvedProcessor(TypedStreamEnvironment environment) {
-      this.environment = environment;
-    }
 
     @Override
     public void onOpen(TypedStreamProcessor streamProcessor) {
-      reader = environment.getStreamReader();
+      reader = streamProcessor.getEnvironment().getStreamReader();
     }
 
     @Override
-    public void processRecord(TypedRecord<WorkflowInstanceRecord> event) {
-      isResolved = false;
-      incidentEvent = null;
+    public void processRecord(
+        TypedRecord<WorkflowInstanceRecord> event,
+        TypedResponseWriter responseWriter,
+        TypedStreamWriter streamWriter) {
 
       final long incidentKey = resolvingEvents.get(event.getSourcePosition(), -1);
       if (incidentKey > 0) {
@@ -370,29 +309,18 @@ public class IncidentStreamProcessor {
         if (incidentMap.getState() == STATE_RESOLVING) {
           // incident is resolved when read next activity lifecycle event
           final long incidentPosition = incidentMap.getIncidentEventPosition();
-          incidentEvent = reader.readValue(incidentPosition, IncidentRecord.class);
+          final TypedRecord<IncidentRecord> incidentEvent =
+              reader.readValue(incidentPosition, IncidentRecord.class);
 
-          isResolved = true;
+          streamWriter.writeFollowUpEvent(
+              incidentEvent.getKey(), IncidentIntent.RESOLVED, incidentEvent.getValue());
+
+          incidentMap.remove(incidentEvent.getKey());
+          activityInstanceMap.remove(incidentEvent.getValue().getActivityInstanceKey(), -1L);
+          resolvingEvents.remove(event.getSourcePosition(), -1);
         } else {
           throw new IllegalStateException("inconsistent incident map");
         }
-      }
-    }
-
-    @Override
-    public long writeRecord(TypedRecord<WorkflowInstanceRecord> event, TypedStreamWriter writer) {
-      return isResolved
-          ? writer.writeFollowUpEvent(
-              incidentEvent.getKey(), IncidentIntent.RESOLVED, incidentEvent.getValue())
-          : 0L;
-    }
-
-    @Override
-    public void updateState(TypedRecord<WorkflowInstanceRecord> event) {
-      if (isResolved) {
-        incidentMap.remove(incidentEvent.getKey());
-        activityInstanceMap.remove(incidentEvent.getValue().getActivityInstanceKey(), -1L);
-        resolvingEvents.remove(event.getSourcePosition(), -1);
       }
     }
   }
@@ -401,39 +329,24 @@ public class IncidentStreamProcessor {
       implements TypedRecordProcessor<WorkflowInstanceRecord> {
     private final IncidentRecord incidentEvent = new IncidentRecord();
 
-    private boolean isTerminated;
-    private long incidentKey;
-
     @Override
-    public void processRecord(TypedRecord<WorkflowInstanceRecord> event) {
-      isTerminated = false;
-
-      incidentKey = activityInstanceMap.get(event.getKey(), -1L);
+    public void processRecord(
+        TypedRecord<WorkflowInstanceRecord> event,
+        TypedResponseWriter responseWriter,
+        TypedStreamWriter streamWriter) {
+      final long incidentKey = activityInstanceMap.get(event.getKey(), -1L);
 
       if (incidentKey > 0) {
         incidentMap.wrapIncidentKey(incidentKey);
 
         if (incidentMap.getState() == STATE_CREATED || incidentMap.getState() == STATE_RESOLVING) {
-          isTerminated = true;
+          streamWriter.writeFollowUpCommand(incidentKey, IncidentIntent.DELETE, incidentEvent);
+
+          incidentMap.setState(STATE_DELETING).write();
+          activityInstanceMap.remove(event.getKey(), -1L);
         } else {
           throw new IllegalStateException("inconsistent incident map");
         }
-      }
-    }
-
-    @Override
-    public long writeRecord(TypedRecord<WorkflowInstanceRecord> event, TypedStreamWriter writer) {
-
-      return isTerminated
-          ? writer.writeFollowUpCommand(incidentKey, IncidentIntent.DELETE, incidentEvent)
-          : 0L;
-    }
-
-    @Override
-    public void updateState(TypedRecord<WorkflowInstanceRecord> event) {
-      if (isTerminated) {
-        incidentMap.setState(STATE_DELETING).write();
-        activityInstanceMap.remove(event.getKey(), -1L);
       }
     }
   }
@@ -441,16 +354,15 @@ public class IncidentStreamProcessor {
   private final class JobFailedProcessor implements TypedRecordProcessor<JobRecord> {
     private final IncidentRecord incidentEvent = new IncidentRecord();
 
-    private boolean hasRetries;
-    private boolean isResolvingIncident;
-
     @Override
-    public void processRecord(TypedRecord<JobRecord> event) {
-      final JobRecord value = event.getValue();
-      hasRetries = value.getRetries() > 0;
-      isResolvingIncident = event.getMetadata().hasIncidentKey();
+    public void processRecord(
+        TypedRecord<JobRecord> event,
+        TypedResponseWriter responseWriter,
+        TypedStreamWriter streamWriter) {
 
-      if (!hasRetries) {
+      final JobRecord value = event.getValue();
+
+      if (value.getRetries() <= 0) {
         final JobHeaders jobHeaders = value.headers();
 
         incidentEvent.reset();
@@ -463,46 +375,26 @@ public class IncidentStreamProcessor {
             .setActivityId(jobHeaders.getActivityId())
             .setActivityInstanceKey(jobHeaders.getActivityInstanceKey())
             .setJobKey(event.getKey());
-      }
-    }
 
-    @Override
-    public long writeRecord(TypedRecord<JobRecord> event, TypedStreamWriter writer) {
-      if (hasRetries) {
-        return 0L;
-      } else {
-        if (!isResolvingIncident) {
-          return writer.writeNewCommand(IncidentIntent.CREATE, incidentEvent);
+        failedJobMap.put(event.getKey(), NON_PERSISTENT_INCIDENT);
+
+        if (!event.getMetadata().hasIncidentKey()) {
+          streamWriter.writeNewCommand(IncidentIntent.CREATE, incidentEvent);
         } else {
-          return writer.writeFollowUpEvent(
+          streamWriter.writeFollowUpEvent(
               event.getMetadata().getIncidentKey(), IncidentIntent.RESOLVE_FAILED, incidentEvent);
         }
-      }
-    }
-
-    @Override
-    public void updateState(TypedRecord<JobRecord> event) {
-      if (!hasRetries) {
-        failedJobMap.put(event.getKey(), NON_PERSISTENT_INCIDENT);
       }
     }
   }
 
   private final class JobIncidentResolvedProcessor implements TypedRecordProcessor<JobRecord> {
-    private final TypedStreamEnvironment environment;
 
     private TypedStreamReader reader;
-    private boolean isResolved;
-    private TypedRecord<IncidentRecord> persistedIncident;
-    private boolean isTransientIncident;
-
-    JobIncidentResolvedProcessor(TypedStreamEnvironment environment) {
-      this.environment = environment;
-    }
 
     @Override
     public void onOpen(TypedStreamProcessor streamProcessor) {
-      reader = environment.getStreamReader();
+      reader = streamProcessor.getEnvironment().getStreamReader();
     }
 
     @Override
@@ -511,40 +403,27 @@ public class IncidentStreamProcessor {
     }
 
     @Override
-    public void processRecord(TypedRecord<JobRecord> event) {
-      isResolved = false;
-      isTransientIncident = false;
+    public void processRecord(
+        TypedRecord<JobRecord> event,
+        TypedResponseWriter responseWriter,
+        TypedStreamWriter streamWriter) {
 
       final long incidentKey = failedJobMap.get(event.getKey(), -1L);
-      persistedIncident = null;
 
       if (incidentKey > 0) {
         incidentMap.wrapIncidentKey(incidentKey);
 
         if (incidentMap.getState() == STATE_CREATED) {
-          persistedIncident =
+          final TypedRecord<IncidentRecord> persistedIncident =
               reader.readValue(incidentMap.getIncidentEventPosition(), IncidentRecord.class);
 
-          isResolved = true;
+          streamWriter.writeFollowUpCommand(
+              persistedIncident.getKey(), IncidentIntent.DELETE, persistedIncident.getValue());
+          failedJobMap.remove(event.getKey(), -1L);
         } else {
           throw new IllegalStateException("inconsistent incident map");
         }
       } else if (incidentKey == NON_PERSISTENT_INCIDENT) {
-        isTransientIncident = true;
-      }
-    }
-
-    @Override
-    public long writeRecord(TypedRecord<JobRecord> event, TypedStreamWriter writer) {
-      return isResolved
-          ? writer.writeFollowUpCommand(
-              persistedIncident.getKey(), IncidentIntent.DELETE, persistedIncident.getValue())
-          : 0L;
-    }
-
-    @Override
-    public void updateState(TypedRecord<JobRecord> event) {
-      if (isResolved || isTransientIncident) {
         failedJobMap.remove(event.getKey(), -1L);
       }
     }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/CommandProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/CommandProcessor.java
@@ -29,10 +29,6 @@ public interface CommandProcessor<T extends UnpackedObject> {
 
   CommandResult onCommand(TypedRecord<T> command, CommandControl commandControl);
 
-  default void updateStateOnAccept(TypedRecord<T> command) {};
-
-  default void updateStateOnReject(TypedRecord<T> command) {};
-
   interface CommandControl {
     CommandResult accept(Intent newState);
 

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/SideEffectProducer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/SideEffectProducer.java
@@ -17,27 +17,12 @@
  */
 package io.zeebe.broker.logstreams.processor;
 
-import io.zeebe.protocol.clientapi.RejectionType;
-import io.zeebe.protocol.intent.Intent;
-import org.agrona.DirectBuffer;
-
-public interface TypedResponseWriter {
-
-  /** @return true if successful */
-  void writeRejection(TypedRecord<?> record, RejectionType type, String reason);
-
-  /** @return true if successful */
-  void writeRejection(TypedRecord<?> record, RejectionType type, DirectBuffer reason);
+@FunctionalInterface
+public interface SideEffectProducer {
 
   /**
-   * Writes the given record as response.
-   *
-   * @return true if successful
-   */
-  void writeRecord(Intent intent, TypedRecord<?> record);
-
-  /**
-   * Submits the response to transport.
+   * Applies the side effect. Called by the stream processor in the appropriate stage in the record
+   * processing lifecycle.
    *
    * @return false in case of backpressure, else true
    */

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedBatchWriter.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedBatchWriter.java
@@ -33,7 +33,4 @@ public interface TypedBatchWriter {
 
   TypedBatchWriter addFollowUpEvent(
       long key, Intent intent, UnpackedObject value, Consumer<RecordMetadata> metadata);
-
-  /** @return position of new event, negative value on failure */
-  long write();
 }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedEventStreamProcessorBuilder.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedEventStreamProcessorBuilder.java
@@ -153,37 +153,15 @@ public class TypedEventStreamProcessorBuilder {
     }
 
     @Override
-    public void processRecord(TypedRecord<T> record) {
+    public void processRecord(
+        TypedRecord<T> record,
+        TypedResponseWriter responseWriter,
+        TypedStreamWriter streamWriter,
+        Consumer<SideEffectProducer> sideEffect,
+        EventLifecycleContext ctx) {
       selectedProcessor = dispatcher.apply(record);
       if (selectedProcessor != null) {
-        selectedProcessor.processRecord(record);
-      }
-    }
-
-    @Override
-    public void processRecord(TypedRecord<T> record, EventLifecycleContext ctx) {
-      selectedProcessor = dispatcher.apply(record);
-      if (selectedProcessor != null) {
-        selectedProcessor.processRecord(record, ctx);
-      }
-    }
-
-    @Override
-    public boolean executeSideEffects(TypedRecord<T> record, TypedResponseWriter responseWriter) {
-      return selectedProcessor != null
-          ? selectedProcessor.executeSideEffects(record, responseWriter)
-          : true;
-    }
-
-    @Override
-    public long writeRecord(TypedRecord<T> record, TypedStreamWriter writer) {
-      return selectedProcessor != null ? selectedProcessor.writeRecord(record, writer) : 0L;
-    }
-
-    @Override
-    public void updateState(TypedRecord<T> record) {
-      if (selectedProcessor != null) {
-        selectedProcessor.updateState(record);
+        selectedProcessor.processRecord(record, responseWriter, streamWriter, sideEffect, ctx);
       }
     }
   }
@@ -197,7 +175,8 @@ public class TypedEventStreamProcessorBuilder {
     }
 
     @Override
-    public void processRecord(TypedRecord<T> record) {
+    public void processRecord(
+        TypedRecord<T> record, TypedResponseWriter responseWriter, TypedStreamWriter streamWriter) {
       consumer.accept(record.getValue());
     }
   }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedRecordProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedRecordProcessor.java
@@ -18,29 +18,37 @@
 package io.zeebe.broker.logstreams.processor;
 
 import io.zeebe.logstreams.processor.EventLifecycleContext;
-import io.zeebe.logstreams.processor.EventProcessor;
 import io.zeebe.msgpack.UnpackedObject;
+import java.util.function.Consumer;
 
 public interface TypedRecordProcessor<T extends UnpackedObject>
     extends StreamProcessorLifecycleAware {
-  /** @see EventProcessor#processEvent() */
-  default void processRecord(TypedRecord<T> record) {}
 
-  /** @see EventProcessor#processEvent() */
-  default void processRecord(TypedRecord<T> record, EventLifecycleContext ctx) {
-    processRecord(record);
+  /**
+   * @see #processRecord(TypedRecord, TypedResponseWriter, TypedStreamWriter, Consumer,
+   *     EventLifecycleContext)
+   */
+  default void processRecord(
+      TypedRecord<T> record, TypedResponseWriter responseWriter, TypedStreamWriter streamWriter) {}
+
+  /**
+   * @param record
+   * @param responseWriter the default side effect that can be used for sending responses. {@link
+   *     TypedResponseWriter#flush()} must not be called in this method.
+   * @param streamWriter
+   * @param sideEffect consumer to replace the default side effect (response writer). Can be used to
+   *     implement other types of side effects or composite side effects. If a composite side effect
+   *     involving the response writer is used, {@link TypedResponseWriter#flush()} must be called
+   *     in the {@link SideEffectProducer} implementation.
+   * @param ctx use {@link EventLifecycleContext#async(io.zeebe.util.sched.future.ActorFuture)} to
+   *     submit an asynchronous invocation that processing the record depends on.
+   */
+  default void processRecord(
+      TypedRecord<T> record,
+      TypedResponseWriter responseWriter,
+      TypedStreamWriter streamWriter,
+      Consumer<SideEffectProducer> sideEffect,
+      EventLifecycleContext ctx) {
+    processRecord(record, responseWriter, streamWriter);
   }
-
-  /** @see EventProcessor#executeSideEffects() */
-  default boolean executeSideEffects(TypedRecord<T> record, TypedResponseWriter responseWriter) {
-    return true;
-  }
-
-  /** @see EventProcessor#writeEvent(io.zeebe.logstreams.log.LogStreamWriter) */
-  default long writeRecord(TypedRecord<T> record, TypedStreamWriter writer) {
-    return 0;
-  }
-
-  /** @see EventProcessor#updateState() */
-  default void updateState(TypedRecord<T> record) {}
 }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamWriter.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamWriter.java
@@ -25,35 +25,37 @@ import java.util.function.Consumer;
 
 public interface TypedStreamWriter {
   /** @return position of new event, negative value on failure */
-  long writeRejection(
+  void writeRejection(
       TypedRecord<? extends UnpackedObject> command, RejectionType type, String reason);
 
   /** @return position of new event, negative value on failure */
-  long writeRejection(
+  void writeRejection(
       TypedRecord<? extends UnpackedObject> command,
       RejectionType type,
       String reason,
       Consumer<RecordMetadata> metadata);
 
   /** @return position of new event, negative value on failure */
-  long writeNewCommand(Intent intent, UnpackedObject value);
+  void writeNewCommand(Intent intent, UnpackedObject value);
 
   /** @return position of new event, negative value on failure */
-  long writeFollowUpCommand(long key, Intent intent, UnpackedObject value);
+  void writeFollowUpCommand(long key, Intent intent, UnpackedObject value);
 
   /** @return position of new event, negative value on failure */
-  long writeFollowUpCommand(
+  void writeFollowUpCommand(
       long key, Intent intent, UnpackedObject value, Consumer<RecordMetadata> metadata);
 
   /** @return position of new event, negative value on failure */
-  long writeNewEvent(Intent intent, UnpackedObject value);
+  void writeNewEvent(Intent intent, UnpackedObject value);
 
   /** @return position of new event, negative value on failure */
-  long writeFollowUpEvent(long key, Intent intent, UnpackedObject value);
+  void writeFollowUpEvent(long key, Intent intent, UnpackedObject value);
 
   /** @return position of new event, negative value on failure */
-  long writeFollowUpEvent(
+  void writeFollowUpEvent(
       long key, Intent intent, UnpackedObject value, Consumer<RecordMetadata> metadata);
 
   TypedBatchWriter newBatch();
+
+  long flush();
 }

--- a/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/DeploymentCreatedEventProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/DeploymentCreatedEventProcessor.java
@@ -33,15 +33,18 @@ public class DeploymentCreatedEventProcessor implements TypedRecordProcessor<Dep
   }
 
   @Override
-  public boolean executeSideEffects(
-      TypedRecord<DeploymentRecord> event, TypedResponseWriter responseWriter) {
-    return responseWriter.writeRecordUnchanged(event);
+  public void processRecord(
+      TypedRecord<DeploymentRecord> event,
+      TypedResponseWriter responseWriter,
+      TypedStreamWriter streamWriter) {
+
+    responseWriter.writeRecord(event.getMetadata().getIntent(), event);
+
+    addWorkflowsToIndex(event);
   }
 
-  @Override
-  public void updateState(TypedRecord<DeploymentRecord> event) {
+  private void addWorkflowsToIndex(TypedRecord<DeploymentRecord> event) {
     final DeploymentRecord deploymentEvent = event.getValue();
-
     final ValueArray<DeployedWorkflow> deployedWorkflows = deploymentEvent.deployedWorkflows();
 
     final String topicName = BufferUtil.bufferAsString(deploymentEvent.getTopicName());

--- a/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/DeploymentRejectedEventProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/DeploymentRejectedEventProcessor.java
@@ -20,12 +20,17 @@ package io.zeebe.broker.system.workflow.repository.processor;
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedRecordProcessor;
 import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
+import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
 import io.zeebe.broker.system.workflow.repository.data.DeploymentRecord;
 
 public class DeploymentRejectedEventProcessor implements TypedRecordProcessor<DeploymentRecord> {
+
   @Override
-  public boolean executeSideEffects(
-      TypedRecord<DeploymentRecord> event, TypedResponseWriter responseWriter) {
-    return responseWriter.writeRecordUnchanged(event);
+  public void processRecord(
+      TypedRecord<DeploymentRecord> record,
+      TypedResponseWriter responseWriter,
+      TypedStreamWriter streamWriter) {
+    responseWriter.writeRejection(
+        record, record.getMetadata().getRejectionType(), record.getMetadata().getRejectionReason());
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/DeploymentTopicCreatingEventProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/DeploymentTopicCreatingEventProcessor.java
@@ -20,6 +20,8 @@ package io.zeebe.broker.system.workflow.repository.processor;
 import io.zeebe.broker.clustering.orchestration.topic.TopicRecord;
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedRecordProcessor;
+import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
+import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
 import io.zeebe.broker.system.workflow.repository.processor.state.WorkflowRepositoryIndex;
 import io.zeebe.util.buffer.BufferUtil;
 
@@ -31,7 +33,10 @@ public class DeploymentTopicCreatingEventProcessor implements TypedRecordProcess
   }
 
   @Override
-  public void updateState(TypedRecord<TopicRecord> event) {
-    index.addTopic(BufferUtil.bufferAsString(event.getValue().getName()));
+  public void processRecord(
+      TypedRecord<TopicRecord> record,
+      TypedResponseWriter responseWriter,
+      TypedStreamWriter streamWriter) {
+    index.addTopic(BufferUtil.bufferAsString(record.getValue().getName()));
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/transport/clientapi/ClientApiMessageHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/transport/clientapi/ClientApiMessageHandler.java
@@ -28,7 +28,7 @@ import io.zeebe.broker.transport.controlmessage.ControlMessageRequestHeaderDescr
 import io.zeebe.broker.workflow.data.WorkflowInstanceRecord;
 import io.zeebe.dispatcher.ClaimedFragment;
 import io.zeebe.dispatcher.Dispatcher;
-import io.zeebe.logstreams.log.LogStreamWriter;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.logstreams.log.LogStreamWriterImpl;
 import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.Protocol;
@@ -63,7 +63,7 @@ public class ClientApiMessageHandler implements ServerMessageHandler, ServerRequ
 
   protected final Int2ObjectHashMap<Partition> leaderPartitions = new Int2ObjectHashMap<>();
   protected final RecordMetadata eventMetadata = new RecordMetadata();
-  protected final LogStreamWriter logStreamWriter = new LogStreamWriterImpl();
+  protected final LogStreamRecordWriter logStreamWriter = new LogStreamWriterImpl();
 
   protected final ErrorResponseWriter errorResponseWriter = new ErrorResponseWriter();
   protected final Dispatcher controlMessageDispatcher;

--- a/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessorTest.java
@@ -127,8 +127,12 @@ public class TypedStreamProcessorTest {
   protected static class BatchProcessor implements TypedRecordProcessor<TopicRecord> {
 
     @Override
-    public long writeRecord(TypedRecord<TopicRecord> event, TypedStreamWriter writer) {
-      return writer.newBatch().addNewEvent(TopicIntent.CREATED, event.getValue()).write();
+    public void processRecord(
+        TypedRecord<TopicRecord> record,
+        TypedResponseWriter responseWriter,
+        TypedStreamWriter streamWriter) {
+      streamWriter.newBatch().addNewEvent(TopicIntent.CREATED, record.getValue());
+      streamWriter.flush();
     }
   }
 }

--- a/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
@@ -32,7 +32,7 @@ import io.zeebe.logstreams.impl.service.StreamProcessorService;
 import io.zeebe.logstreams.log.BufferedLogStreamReader;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
-import io.zeebe.logstreams.log.LogStreamWriter;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.logstreams.log.LogStreamWriterImpl;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.logstreams.processor.*;
@@ -371,7 +371,7 @@ public class TestStreams {
         }
 
         @Override
-        public long writeEvent(LogStreamWriter writer) {
+        public long writeEvent(LogStreamRecordWriter writer) {
           return actualProcessor != null ? actualProcessor.writeEvent(writer) : 0;
         }
 
@@ -446,7 +446,7 @@ public class TestStreams {
     }
 
     public long write() {
-      final LogStreamWriter writer = new LogStreamWriterImpl(logStream);
+      final LogStreamRecordWriter writer = new LogStreamWriterImpl(logStream);
 
       if (key >= 0) {
         writer.key(key);

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/DisabledLogStreamWriter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/DisabledLogStreamWriter.java
@@ -18,58 +18,58 @@ package io.zeebe.logstreams.log;
 import io.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 
-public class DisabledLogStreamWriter implements LogStreamWriter {
+public class DisabledLogStreamWriter implements LogStreamRecordWriter {
 
   @Override
   public void wrap(LogStream log) {}
 
   @Override
-  public LogStreamWriter positionAsKey() {
+  public LogStreamRecordWriter positionAsKey() {
     return this;
   }
 
   @Override
-  public LogStreamWriter key(long key) {
+  public LogStreamRecordWriter key(long key) {
     return this;
   }
 
   @Override
-  public LogStreamWriter sourceRecordPosition(long position) {
+  public LogStreamRecordWriter sourceRecordPosition(long position) {
     return this;
   }
 
   @Override
-  public LogStreamWriter producerId(int producerId) {
+  public LogStreamRecordWriter producerId(int producerId) {
     return this;
   }
 
   @Override
-  public LogStreamWriter metadata(DirectBuffer buffer, int offset, int length) {
+  public LogStreamRecordWriter metadata(DirectBuffer buffer, int offset, int length) {
     return this;
   }
 
   @Override
-  public LogStreamWriter metadata(DirectBuffer buffer) {
+  public LogStreamRecordWriter metadata(DirectBuffer buffer) {
     return this;
   }
 
   @Override
-  public LogStreamWriter metadataWriter(BufferWriter writer) {
+  public LogStreamRecordWriter metadataWriter(BufferWriter writer) {
     return this;
   }
 
   @Override
-  public LogStreamWriter value(DirectBuffer value, int valueOffset, int valueLength) {
+  public LogStreamRecordWriter value(DirectBuffer value, int valueOffset, int valueLength) {
     return this;
   }
 
   @Override
-  public LogStreamWriter value(DirectBuffer value) {
+  public LogStreamRecordWriter value(DirectBuffer value) {
     return this;
   }
 
   @Override
-  public LogStreamWriter valueWriter(BufferWriter writer) {
+  public LogStreamRecordWriter valueWriter(BufferWriter writer) {
     return this;
   }
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamBatchWriter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamBatchWriter.java
@@ -24,7 +24,7 @@ import org.agrona.DirectBuffer;
  *
  * <p>Note that the log entry data is buffered until {@link #tryWrite()} is called.
  */
-public interface LogStreamBatchWriter {
+public interface LogStreamBatchWriter extends LogStreamWriter {
   /** Builder to add a log entry to the batch. */
   interface LogEntryBuilder {
     /** Use the log entry position as key. */
@@ -66,14 +66,6 @@ public interface LogStreamBatchWriter {
 
   /** Returns the builder to add a new log entry to the batch. */
   LogEntryBuilder event();
-
-  /**
-   * Attempts to write the batch to the underlying buffer.
-   *
-   * @return the position of the last written log entry, or a negative value if fails to claim the
-   *     batch
-   */
-  long tryWrite();
 
   /** Discard all non-written batch data. */
   void reset();

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamRecordWriter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamRecordWriter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.log;
+
+import io.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public interface LogStreamRecordWriter extends LogStreamWriter {
+
+  void wrap(LogStream log);
+
+  LogStreamRecordWriter positionAsKey();
+
+  LogStreamRecordWriter key(long key);
+
+  LogStreamRecordWriter sourceRecordPosition(long position);
+
+  LogStreamRecordWriter producerId(int producerId);
+
+  LogStreamRecordWriter metadata(DirectBuffer buffer, int offset, int length);
+
+  LogStreamRecordWriter metadata(DirectBuffer buffer);
+
+  LogStreamRecordWriter metadataWriter(BufferWriter writer);
+
+  LogStreamRecordWriter value(DirectBuffer value, int valueOffset, int valueLength);
+
+  LogStreamRecordWriter value(DirectBuffer value);
+
+  LogStreamRecordWriter valueWriter(BufferWriter writer);
+
+  void reset();
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamWriter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamWriter.java
@@ -15,34 +15,7 @@
  */
 package io.zeebe.logstreams.log;
 
-import io.zeebe.util.buffer.BufferWriter;
-import org.agrona.DirectBuffer;
-
 public interface LogStreamWriter {
-
-  void wrap(LogStream log);
-
-  LogStreamWriter positionAsKey();
-
-  LogStreamWriter key(long key);
-
-  LogStreamWriter sourceRecordPosition(long position);
-
-  LogStreamWriter producerId(int producerId);
-
-  LogStreamWriter metadata(DirectBuffer buffer, int offset, int length);
-
-  LogStreamWriter metadata(DirectBuffer buffer);
-
-  LogStreamWriter metadataWriter(BufferWriter writer);
-
-  LogStreamWriter value(DirectBuffer value, int valueOffset, int valueLength);
-
-  LogStreamWriter value(DirectBuffer value);
-
-  LogStreamWriter valueWriter(BufferWriter writer);
-
-  void reset();
 
   /**
    * Attempts to write the event to the underlying stream.

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamWriterImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamWriterImpl.java
@@ -30,7 +30,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.LangUtil;
 import org.agrona.MutableDirectBuffer;
 
-public class LogStreamWriterImpl implements LogStreamWriter {
+public class LogStreamWriterImpl implements LogStreamRecordWriter {
   protected final DirectBufferWriter metadataWriterInstance = new DirectBufferWriter();
   protected final DirectBufferWriter bufferWriterInstance = new DirectBufferWriter();
   protected final ClaimedFragment claimedFragment = new ClaimedFragment();
@@ -62,57 +62,57 @@ public class LogStreamWriterImpl implements LogStreamWriter {
   }
 
   @Override
-  public LogStreamWriter positionAsKey() {
+  public LogStreamRecordWriter positionAsKey() {
     positionAsKey = true;
     return this;
   }
 
   @Override
-  public LogStreamWriter key(long key) {
+  public LogStreamRecordWriter key(long key) {
     this.key = key;
     return this;
   }
 
-  public LogStreamWriter sourceRecordPosition(long position) {
+  public LogStreamRecordWriter sourceRecordPosition(long position) {
     this.sourceRecordPosition = position;
     return this;
   }
 
   @Override
-  public LogStreamWriter producerId(int producerId) {
+  public LogStreamRecordWriter producerId(int producerId) {
     this.producerId = producerId;
     return this;
   }
 
   @Override
-  public LogStreamWriter metadata(DirectBuffer buffer, int offset, int length) {
+  public LogStreamRecordWriter metadata(DirectBuffer buffer, int offset, int length) {
     metadataWriterInstance.wrap(buffer, offset, length);
     return this;
   }
 
   @Override
-  public LogStreamWriter metadata(DirectBuffer buffer) {
+  public LogStreamRecordWriter metadata(DirectBuffer buffer) {
     return metadata(buffer, 0, buffer.capacity());
   }
 
   @Override
-  public LogStreamWriter metadataWriter(BufferWriter writer) {
+  public LogStreamRecordWriter metadataWriter(BufferWriter writer) {
     this.metadataWriter = writer;
     return this;
   }
 
   @Override
-  public LogStreamWriter value(DirectBuffer value, int valueOffset, int valueLength) {
+  public LogStreamRecordWriter value(DirectBuffer value, int valueOffset, int valueLength) {
     return valueWriter(bufferWriterInstance.wrap(value, valueOffset, valueLength));
   }
 
   @Override
-  public LogStreamWriter value(DirectBuffer value) {
+  public LogStreamRecordWriter value(DirectBuffer value) {
     return value(value, 0, value.capacity());
   }
 
   @Override
-  public LogStreamWriter valueWriter(BufferWriter writer) {
+  public LogStreamRecordWriter valueWriter(BufferWriter writer) {
     this.valueWriter = writer;
     return this;
   }

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/EventProcessor.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/EventProcessor.java
@@ -15,7 +15,7 @@
  */
 package io.zeebe.logstreams.processor;
 
-import io.zeebe.logstreams.log.LogStreamWriter;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
 
 /** Process an event from a log stream. An implementation may be specified for one type of event. */
 public interface EventProcessor {
@@ -47,7 +47,7 @@ public interface EventProcessor {
    *     <li>zero, if no event was written, or
    *     <li>a negate value, if the write operation fails.
    */
-  default long writeEvent(LogStreamWriter writer) {
+  default long writeEvent(LogStreamRecordWriter writer) {
     return 0;
   }
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorBuilder.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorBuilder.java
@@ -39,7 +39,7 @@ public class StreamProcessorBuilder {
   protected SnapshotStorage snapshotStorage;
 
   protected LogStreamReader logStreamReader;
-  protected LogStreamWriter logStreamWriter;
+  protected LogStreamRecordWriter logStreamWriter;
 
   protected EventFilter eventFilter;
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorContext.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorContext.java
@@ -31,7 +31,7 @@ public class StreamProcessorContext {
   protected LogStream logStream;
 
   protected LogStreamReader logStreamReader;
-  protected LogStreamWriter logStreamWriter;
+  protected LogStreamRecordWriter logStreamWriter;
 
   protected Duration snapshotPeriod;
   protected SnapshotStorage snapshotStorage;
@@ -92,11 +92,11 @@ public class StreamProcessorContext {
     return logStreamReader;
   }
 
-  public LogStreamWriter getLogStreamWriter() {
+  public LogStreamRecordWriter getLogStreamWriter() {
     return logStreamWriter;
   }
 
-  public void setLogStreamWriter(LogStreamWriter logStreamWriter) {
+  public void setLogStreamWriter(LogStreamRecordWriter logStreamWriter) {
     this.logStreamWriter = logStreamWriter;
   }
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
@@ -18,7 +18,7 @@ package io.zeebe.logstreams.processor;
 import io.zeebe.logstreams.impl.Loggers;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
-import io.zeebe.logstreams.log.LogStreamWriter;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.logstreams.spi.ReadableSnapshot;
 import io.zeebe.logstreams.spi.SnapshotStorage;
@@ -49,7 +49,7 @@ public class StreamProcessorController extends Actor {
   private final StreamProcessorContext streamProcessorContext;
 
   private final LogStreamReader logStreamReader;
-  private final LogStreamWriter logStreamWriter;
+  private final LogStreamRecordWriter logStreamWriter;
 
   private final SnapshotStorage snapshotStorage;
   private final Duration snapshotPeriod;

--- a/logstreams/src/test/java/io/zeebe/logstreams/fs/snapshot/FsTemporarySnapshotWriterTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/fs/snapshot/FsTemporarySnapshotWriterTest.java
@@ -19,7 +19,11 @@ import static io.zeebe.util.StringUtil.getBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.zeebe.logstreams.impl.snapshot.fs.*;
+import io.zeebe.logstreams.impl.snapshot.fs.FsReadableSnapshot;
+import io.zeebe.logstreams.impl.snapshot.fs.FsSnapshotStorage;
+import io.zeebe.logstreams.impl.snapshot.fs.FsSnapshotStorageConfiguration;
+import io.zeebe.logstreams.impl.snapshot.fs.FsSnapshotWriter;
+import io.zeebe.logstreams.impl.snapshot.fs.FsTemporarySnapshotWriter;
 import java.io.File;
 import java.nio.file.Files;
 import java.security.MessageDigest;

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamWriterTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamWriterTest.java
@@ -52,7 +52,7 @@ public class LogStreamWriterTest {
           .around(writerRule)
           .around(readerRule);
 
-  private LogStreamWriter writer;
+  private LogStreamRecordWriter writer;
 
   @Before
   public void setUp() {

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.*;
 
 import io.zeebe.logstreams.LogStreams;
 import io.zeebe.logstreams.impl.service.StreamProcessorService;
-import io.zeebe.logstreams.log.LogStreamWriter;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.logstreams.spi.ReadableSnapshot;
 import io.zeebe.logstreams.util.LogStreamReaderRule;
@@ -350,7 +350,7 @@ public class StreamProcessorControllerTest {
             when(eventProcessor.writeEvent(any()))
                 .thenAnswer(
                     inv -> {
-                      final LogStreamWriter writer = inv.getArgument(0);
+                      final LogStreamRecordWriter writer = inv.getArgument(0);
 
                       final long position =
                           writer.key(2L).metadata(wrapString("META")).value(EVENT_2).tryWrite();
@@ -617,7 +617,7 @@ public class StreamProcessorControllerTest {
             when(eventProcessor.writeEvent(any()))
                 .thenAnswer(
                     inv -> {
-                      final LogStreamWriter writer = inv.getArgument(0);
+                      final LogStreamRecordWriter writer = inv.getArgument(0);
 
                       return writer.key(2L).metadata(wrapString("META")).value(EVENT_2).tryWrite();
                     }));

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorReprocessingTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorReprocessingTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.*;
 
 import io.zeebe.logstreams.LogStreams;
 import io.zeebe.logstreams.impl.service.StreamProcessorService;
-import io.zeebe.logstreams.log.LogStreamWriter;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.logstreams.util.LogStreamRule;
 import io.zeebe.logstreams.util.LogStreamWriterRule;
@@ -490,7 +490,7 @@ public class StreamProcessorReprocessingTest {
     return writeEventWith(w -> {});
   }
 
-  private long writeEventWith(final Consumer<LogStreamWriter> wr) {
+  private long writeEventWith(final Consumer<LogStreamRecordWriter> wr) {
     return writer.writeEvent(
         w -> {
           w.positionAsKey().value(EVENT);

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamWriterRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamWriterRule.java
@@ -25,7 +25,7 @@ public class LogStreamWriterRule extends ExternalResource {
   private LogStreamRule logStreamRule;
 
   private LogStream logStream;
-  private LogStreamWriter logStreamWriter;
+  private LogStreamRecordWriter logStreamWriter;
 
   public LogStreamWriterRule(final LogStreamRule logStreamRule) {
     this.logStreamRule = logStreamRule;
@@ -76,7 +76,7 @@ public class LogStreamWriterRule extends ExternalResource {
     return writeEvent(w -> w.positionAsKey().value(event), commit);
   }
 
-  public long writeEvent(final Consumer<LogStreamWriter> writer, final boolean commit) {
+  public long writeEvent(final Consumer<LogStreamRecordWriter> writer, final boolean commit) {
     final long position = writeEventInternal(writer);
 
     waitForPositionToBeAppended(position);
@@ -88,7 +88,7 @@ public class LogStreamWriterRule extends ExternalResource {
     return position;
   }
 
-  private long writeEventInternal(final Consumer<LogStreamWriter> writer) {
+  private long writeEventInternal(final Consumer<LogStreamRecordWriter> writer) {
     long position;
     do {
       position = tryWrite(writer);
@@ -105,7 +105,7 @@ public class LogStreamWriterRule extends ExternalResource {
     return tryWrite(w -> w.key(key).value(value));
   }
 
-  public long tryWrite(final Consumer<LogStreamWriter> writer) {
+  public long tryWrite(final Consumer<LogStreamRecordWriter> writer) {
     writer.accept(logStreamWriter);
 
     return logStreamWriter.tryWrite();

--- a/raft/src/main/java/io/zeebe/raft/event/InitialEvent.java
+++ b/raft/src/main/java/io/zeebe/raft/event/InitialEvent.java
@@ -15,7 +15,7 @@
  */
 package io.zeebe.raft.event;
 
-import io.zeebe.logstreams.log.LogStreamWriter;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.logstreams.log.LogStreamWriterImpl;
 import io.zeebe.msgpack.spec.MsgPackHelper;
 import io.zeebe.protocol.clientapi.ValueType;
@@ -27,7 +27,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 public class InitialEvent {
   private static final DirectBuffer EMPTY_OBJECT = new UnsafeBuffer(MsgPackHelper.EMTPY_OBJECT);
 
-  public final LogStreamWriter logStreamWriter = new LogStreamWriterImpl();
+  public final LogStreamRecordWriter logStreamWriter = new LogStreamWriterImpl();
   public final RecordMetadata metadata = new RecordMetadata();
 
   public InitialEvent reset() {

--- a/raft/src/main/java/io/zeebe/raft/event/RaftEvent.java
+++ b/raft/src/main/java/io/zeebe/raft/event/RaftEvent.java
@@ -15,7 +15,7 @@
  */
 package io.zeebe.raft.event;
 
-import io.zeebe.logstreams.log.LogStreamWriter;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.logstreams.log.LogStreamWriterImpl;
 import io.zeebe.msgpack.value.ValueArray;
 import io.zeebe.protocol.clientapi.RecordType;
@@ -27,7 +27,7 @@ import io.zeebe.raft.RaftMember;
 import java.util.List;
 
 public class RaftEvent {
-  public final LogStreamWriter logStreamWriter = new LogStreamWriterImpl();
+  public final LogStreamRecordWriter logStreamWriter = new LogStreamWriterImpl();
   public final RecordMetadata metadata = new RecordMetadata();
   public final RaftConfigurationEvent configuration = new RaftConfigurationEvent();
 

--- a/raft/src/test/java/io/zeebe/raft/ThroughputTest.java
+++ b/raft/src/test/java/io/zeebe/raft/ThroughputTest.java
@@ -37,7 +37,7 @@ public class ThroughputTest {
     final BenchmarkContext ctx = new BenchmarkContext();
     ctx.setUp();
 
-    final LogStreamWriter writer = ctx.writer;
+    final LogStreamRecordWriter writer = ctx.writer;
     final LogStream logStream = ctx.leader.getLogStream();
     final LongRingBuffer uncommitedPositions = new LongRingBuffer(10 * 1024);
 
@@ -71,7 +71,7 @@ public class ThroughputTest {
     final ThroughPutTestRaft raft3 =
         new ThroughPutTestRaft(new SocketAddress("localhost", 51017), raft1);
 
-    final LogStreamWriter writer = new LogStreamWriterImpl();
+    final LogStreamRecordWriter writer = new LogStreamWriterImpl();
 
     Raft leader;
 


### PR DESCRIPTION
- merges `#processRecord`, `#writeEvents`, `#executeSideEffects` and
  `#updateState` into one method #processRecord
- rewrites side effects and event emission into a two-step process:
  events are staged in the `#processRecord` invocation and then
  transparently flushed in the stream processor's `#writeEvents` phase
- leaves the `StreamProcessor`/`EventProcessor` interfaces as is, as
  `TopicSubscriptionManagementProcessor` works better with these
  interfaces as they are now; we can make that step once topic
  subscriptions are removed

closes #1047
