### PR TITLE
feat(broker): a message can be published idempotent

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/MessageRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/MessageRecord.java
@@ -26,10 +26,15 @@ public class MessageRecord extends UnpackedObject {
 
   private final StringProperty nameProp = new StringProperty("name");
   private final StringProperty correlationKeyProp = new StringProperty("correlationKey");
+
   private final DocumentProperty payloadProp = new DocumentProperty("payload");
+  private final StringProperty messageIdProp = new StringProperty("messageId", "");
 
   public MessageRecord() {
-    this.declareProperty(nameProp).declareProperty(correlationKeyProp).declareProperty(payloadProp);
+    this.declareProperty(nameProp)
+        .declareProperty(correlationKeyProp)
+        .declareProperty(payloadProp)
+        .declareProperty(messageIdProp);
   }
 
   public DirectBuffer getName() {
@@ -42,5 +47,13 @@ public class MessageRecord extends UnpackedObject {
 
   public DirectBuffer getPayload() {
     return payloadProp.getValue();
+  }
+
+  public boolean hasMessageId() {
+    return messageIdProp.getValue().capacity() > 0;
+  }
+
+  public DirectBuffer getMessageId() {
+    return messageIdProp.getValue();
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageDataStore.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageDataStore.java
@@ -32,6 +32,18 @@ public class MessageDataStore extends JsonSnapshotSupport<MessageData> {
     getData().messages.add(message);
   }
 
+  public boolean hasMessage(MessageEntry message) {
+    return getData()
+        .messages
+        .stream()
+        .anyMatch(
+            m ->
+                m.getId() != null
+                    && m.getId().equals(message.getId())
+                    && m.getName().equals(message.getName())
+                    && m.getCorrelationKey().equals(message.getCorrelationKey()));
+  }
+
   public static class MessageData {
 
     private List<MessageEntry> messages = new ArrayList<>();
@@ -41,11 +53,13 @@ public class MessageDataStore extends JsonSnapshotSupport<MessageData> {
     private final String name;
     private final String correlationKey;
     private final byte[] payload;
+    private final String id;
 
-    public MessageEntry(String name, String correlationKey, byte[] payload) {
+    public MessageEntry(String name, String correlationKey, byte[] payload, String id) {
       this.name = name;
       this.correlationKey = correlationKey;
       this.payload = payload;
+      this.id = id;
     }
 
     public String getName() {
@@ -58,6 +72,10 @@ public class MessageDataStore extends JsonSnapshotSupport<MessageData> {
 
     public byte[] getPayload() {
       return payload;
+    }
+
+    public String getId() {
+      return id;
     }
   }
 }


### PR DESCRIPTION
* new field 'messageId' in message record
* reject message if another message with the same id, name and
correlation-key is already published

closes #1012 
