### PR TITLE
feat(bpmn-model): support intermediate catch event and receive task

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/BpmnConstants.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/BpmnConstants.java
@@ -275,6 +275,8 @@ public final class BpmnConstants {
   public static final String ZEEBE_ELEMENT_TASK_HEADERS = "taskHeaders";
   public static final String ZEEBE_ELEMENT_TASK_HEADER = "header";
 
+  public static final String ZEEBE_ELEMENT_SUBSCRIPTION = "subscription";
+
   // attributes //////////////////////////////////////
 
   /** XSI attributes * */
@@ -404,4 +406,6 @@ public final class BpmnConstants {
   public static final String ZEEBE_ATTRIBUTES_TASK_RETRIES = "retries";
   public static final String ZEEBE_ATTRIBUTE_TASK_HEADER_KEY = "key";
   public static final String ZEEBE_ATTRIBUTE_TASK_HEADER_VALUE = "value";
+
+  public static final String ZEEBE_ATTRIBUTE_CORRELATION_KEY = "correlationKey";
 }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/BpmnMessageEventBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/BpmnMessageEventBuilder.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.builder;
+
+import io.zeebe.model.bpmn.impl.instance.ExtensionElementsImpl;
+import io.zeebe.model.bpmn.impl.instance.MessageImpl;
+import io.zeebe.model.bpmn.impl.metadata.SubscriptionImpl;
+import java.util.List;
+
+public class BpmnMessageEventBuilder {
+
+  private final List<MessageImpl> messages;
+
+  private String name = "";
+  private String correlationKey = "";
+
+  public BpmnMessageEventBuilder(List<MessageImpl> messages) {
+    this.messages = messages;
+  }
+
+  public MessageImpl done() {
+    return messages
+        .stream()
+        .filter(
+            msg ->
+                msg.getName().equals(name)
+                    && msg.getSubscription().getCorrelationKey().equals(correlationKey))
+        .findFirst()
+        .orElseGet(this::createMessage);
+  }
+
+  private MessageImpl createMessage() {
+    final MessageImpl message = new MessageImpl();
+    messages.add(message);
+
+    message.setId("message-" + messages.size());
+    message.setName(name);
+
+    final ExtensionElementsImpl extensionElements = new ExtensionElementsImpl();
+    final SubscriptionImpl subscription = new SubscriptionImpl();
+    subscription.setCorrelationKey(correlationKey);
+
+    extensionElements.setSubscription(subscription);
+    message.setExtensionElements(extensionElements);
+
+    return message;
+  }
+
+  public BpmnMessageEventBuilder messageName(String messageName) {
+    this.name = messageName;
+    return this;
+  }
+
+  public BpmnMessageEventBuilder correlationKey(String correlationKey) {
+    this.correlationKey = correlationKey;
+    return this;
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/DefinitionsImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/DefinitionsImpl.java
@@ -18,8 +18,14 @@ package io.zeebe.model.bpmn.impl.instance;
 import io.zeebe.model.bpmn.BpmnConstants;
 import io.zeebe.model.bpmn.instance.Workflow;
 import io.zeebe.model.bpmn.instance.WorkflowDefinition;
-import java.util.*;
-import javax.xml.bind.annotation.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 import org.agrona.DirectBuffer;
 
 @XmlRootElement(name = BpmnConstants.BPMN_ELEMENT_DEFINITIONS, namespace = BpmnConstants.BPMN20_NS)
@@ -27,6 +33,7 @@ public class DefinitionsImpl extends BaseElement implements WorkflowDefinition {
   private String targetNamespace = "http://zeebe.io/model/bpmn";
 
   private List<ProcessImpl> processes = new ArrayList<>();
+  private List<MessageImpl> messages = new ArrayList<>();
 
   private Map<DirectBuffer, Workflow> workflowsById = new HashMap<>();
 
@@ -37,6 +44,15 @@ public class DefinitionsImpl extends BaseElement implements WorkflowDefinition {
 
   public List<ProcessImpl> getProcesses() {
     return processes;
+  }
+
+  @XmlElement(name = BpmnConstants.BPMN_ELEMENT_MESSAGE, namespace = BpmnConstants.BPMN20_NS)
+  public void setMessages(List<MessageImpl> messages) {
+    this.messages = messages;
+  }
+
+  public List<MessageImpl> getMessages() {
+    return messages;
   }
 
   public String getTargetNamespace() {

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/ExtensionElementsImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/ExtensionElementsImpl.java
@@ -16,13 +16,17 @@
 package io.zeebe.model.bpmn.impl.instance;
 
 import io.zeebe.model.bpmn.BpmnConstants;
-import io.zeebe.model.bpmn.impl.metadata.*;
+import io.zeebe.model.bpmn.impl.metadata.InputOutputMappingImpl;
+import io.zeebe.model.bpmn.impl.metadata.SubscriptionImpl;
+import io.zeebe.model.bpmn.impl.metadata.TaskDefinitionImpl;
+import io.zeebe.model.bpmn.impl.metadata.TaskHeadersImpl;
 import javax.xml.bind.annotation.XmlElement;
 
 public class ExtensionElementsImpl {
   private TaskDefinitionImpl taskDefinition;
   private TaskHeadersImpl taskHeaders;
   private InputOutputMappingImpl inputOutputMapping;
+  private SubscriptionImpl subscription;
 
   @XmlElement(
       name = BpmnConstants.ZEEBE_ELEMENT_TASK_DEFINITION,
@@ -51,5 +55,14 @@ public class ExtensionElementsImpl {
 
   public InputOutputMappingImpl getInputOutputMapping() {
     return inputOutputMapping;
+  }
+
+  public SubscriptionImpl getSubscription() {
+    return subscription;
+  }
+
+  @XmlElement(name = BpmnConstants.ZEEBE_ELEMENT_SUBSCRIPTION, namespace = BpmnConstants.ZEEBE_NS)
+  public void setSubscription(SubscriptionImpl subscription) {
+    this.subscription = subscription;
   }
 }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/IntermediateCatchEventImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/IntermediateCatchEventImpl.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.impl.instance;
+
+import io.zeebe.model.bpmn.BpmnConstants;
+import io.zeebe.model.bpmn.instance.IntermediateMessageCatchEvent;
+import io.zeebe.model.bpmn.instance.MessageSubscription;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+public class IntermediateCatchEventImpl extends FlowNodeImpl
+    implements IntermediateMessageCatchEvent {
+
+  private MessageEventDefinitionImpl messageEventDefinition;
+
+  private MessageSubscription messageSubscription;
+
+  @XmlElement(
+      name = BpmnConstants.BPMN_ELEMENT_MESSAGE_EVENT_DEFINITION,
+      namespace = BpmnConstants.BPMN20_NS)
+  public void setMessageEventDefinition(MessageEventDefinitionImpl messageEventDefinition) {
+    this.messageEventDefinition = messageEventDefinition;
+  }
+
+  public MessageEventDefinitionImpl getMessageEventDefinition() {
+    return messageEventDefinition;
+  }
+
+  @Override
+  public MessageSubscription getMessageSubscription() {
+    return messageSubscription;
+  }
+
+  @XmlTransient
+  public void setMessageSubscription(MessageSubscription messageSubscription) {
+    this.messageSubscription = messageSubscription;
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/MessageEventDefinitionImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/MessageEventDefinitionImpl.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.impl.instance;
+
+import io.zeebe.model.bpmn.BpmnConstants;
+import javax.xml.bind.annotation.XmlAttribute;
+
+public class MessageEventDefinitionImpl extends FlowNodeImpl {
+
+  private String messageRef;
+
+  public String getMessageRef() {
+    return messageRef;
+  }
+
+  @XmlAttribute(name = BpmnConstants.BPMN_ATTRIBUTE_MESSAGE_REF)
+  public void setMessageRef(String messageRef) {
+    this.messageRef = messageRef;
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/MessageImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/MessageImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.impl.instance;
+
+import io.zeebe.model.bpmn.impl.metadata.SubscriptionImpl;
+
+public class MessageImpl extends FlowElementImpl {
+
+  public SubscriptionImpl getSubscription() {
+    return getExtensionElements() != null ? getExtensionElements().getSubscription() : null;
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/ProcessImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/ProcessImpl.java
@@ -16,9 +16,16 @@
 package io.zeebe.model.bpmn.impl.instance;
 
 import io.zeebe.model.bpmn.BpmnConstants;
-import io.zeebe.model.bpmn.instance.*;
-import java.util.*;
-import javax.xml.bind.annotation.*;
+import io.zeebe.model.bpmn.instance.FlowElement;
+import io.zeebe.model.bpmn.instance.StartEvent;
+import io.zeebe.model.bpmn.instance.Workflow;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlTransient;
 import org.agrona.DirectBuffer;
 
 public class ProcessImpl extends FlowElementImpl implements Workflow {
@@ -29,6 +36,8 @@ public class ProcessImpl extends FlowElementImpl implements Workflow {
   private List<EndEventImpl> endEvents = new ArrayList<>();
   private List<ServiceTaskImpl> serviceTasks = new ArrayList<>();
   private List<ExclusiveGatewayImpl> exclusiveGateways = new ArrayList<>();
+  private List<IntermediateCatchEventImpl> intermediateCatchEvents = new ArrayList<>();
+  private List<ReceiveTaskImpl> receiveTasks = new ArrayList<>();
 
   private StartEvent initialStartEvent;
   private final List<FlowElement> flowElements = new ArrayList<>();
@@ -89,6 +98,26 @@ public class ProcessImpl extends FlowElementImpl implements Workflow {
 
   public List<ExclusiveGatewayImpl> getExclusiveGateways() {
     return exclusiveGateways;
+  }
+
+  @XmlElement(
+      name = BpmnConstants.BPMN_ELEMENT_INTERMEDIATE_CATCH_EVENT,
+      namespace = BpmnConstants.BPMN20_NS)
+  public void setIntermediateCatchEvents(List<IntermediateCatchEventImpl> intermediateCatchEvents) {
+    this.intermediateCatchEvents = intermediateCatchEvents;
+  }
+
+  public List<IntermediateCatchEventImpl> getIntermediateCatchEvents() {
+    return intermediateCatchEvents;
+  }
+
+  @XmlElement(name = BpmnConstants.BPMN_ELEMENT_RECEIVE_TASK, namespace = BpmnConstants.BPMN20_NS)
+  public void setReceiveTasks(List<ReceiveTaskImpl> receiveTasks) {
+    this.receiveTasks = receiveTasks;
+  }
+
+  public List<ReceiveTaskImpl> getReceiveTasks() {
+    return receiveTasks;
   }
 
   @Override

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/ReceiveTaskImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/ReceiveTaskImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.impl.instance;
+
+import io.zeebe.model.bpmn.BpmnConstants;
+import io.zeebe.model.bpmn.instance.MessageSubscription;
+import io.zeebe.model.bpmn.instance.ReceiveTask;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlTransient;
+
+public class ReceiveTaskImpl extends FlowNodeImpl implements ReceiveTask {
+
+  private MessageSubscription messageSubscription;
+
+  private String messageRef;
+
+  public String getMessageRef() {
+    return messageRef;
+  }
+
+  @XmlAttribute(name = BpmnConstants.BPMN_ATTRIBUTE_MESSAGE_REF)
+  public void setMessageRef(String messageRef) {
+    this.messageRef = messageRef;
+  }
+
+  @Override
+  public MessageSubscription getMessageSubscription() {
+    return messageSubscription;
+  }
+
+  @XmlTransient
+  public void setMessageSubscription(MessageSubscription messageSubscription) {
+    this.messageSubscription = messageSubscription;
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/metadata/MessageSubscriptionImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/metadata/MessageSubscriptionImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.impl.metadata;
+
+import io.zeebe.model.bpmn.instance.MessageSubscription;
+import io.zeebe.msgpack.jsonpath.JsonPathQuery;
+
+public class MessageSubscriptionImpl implements MessageSubscription {
+
+  private final String messageName;
+  private final JsonPathQuery correlationKey;
+
+  public MessageSubscriptionImpl(String messageName, JsonPathQuery correlationKey) {
+    this.messageName = messageName;
+    this.correlationKey = correlationKey;
+  }
+
+  @Override
+  public String getMessageName() {
+    return messageName;
+  }
+
+  @Override
+  public JsonPathQuery getCorrelationKey() {
+    return correlationKey;
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/metadata/SubscriptionImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/metadata/SubscriptionImpl.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.impl.metadata;
+
+import io.zeebe.model.bpmn.BpmnConstants;
+import javax.xml.bind.annotation.XmlAttribute;
+
+public class SubscriptionImpl {
+
+  private String correlationKey;
+
+  public String getCorrelationKey() {
+    return correlationKey;
+  }
+
+  @XmlAttribute(name = BpmnConstants.ZEEBE_ATTRIBUTE_CORRELATION_KEY)
+  public void setCorrelationKey(String correlationKey) {
+    this.correlationKey = correlationKey;
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/transformation/nodes/IntermediateCatchEventTransformer.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/transformation/nodes/IntermediateCatchEventTransformer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.impl.transformation.nodes;
+
+import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.zeebe.model.bpmn.impl.error.ErrorCollector;
+import io.zeebe.model.bpmn.impl.instance.IntermediateCatchEventImpl;
+import io.zeebe.model.bpmn.impl.instance.MessageEventDefinitionImpl;
+import io.zeebe.model.bpmn.impl.instance.MessageImpl;
+import io.zeebe.model.bpmn.impl.metadata.MessageSubscriptionImpl;
+import io.zeebe.model.bpmn.impl.metadata.SubscriptionImpl;
+import io.zeebe.msgpack.jsonpath.JsonPathQuery;
+import io.zeebe.msgpack.jsonpath.JsonPathQueryCompiler;
+import java.util.List;
+import java.util.Map;
+
+public class IntermediateCatchEventTransformer {
+
+  public void transform(
+      ErrorCollector errorCollector,
+      List<IntermediateCatchEventImpl> events,
+      Map<String, MessageImpl> messagesById) {
+
+    for (IntermediateCatchEventImpl event : events) {
+
+      final MessageEventDefinitionImpl messageEventDefinition = event.getMessageEventDefinition();
+      if (messageEventDefinition != null) {
+
+        final String messageRef = messageEventDefinition.getMessageRef();
+        final MessageImpl message = messagesById.get(messageRef);
+        final String messageName = message.getName();
+
+        final JsonPathQuery query = createCorrelationKeyQuery(errorCollector, message);
+
+        event.setMessageSubscription(new MessageSubscriptionImpl(messageName, query));
+      }
+    }
+  }
+
+  private JsonPathQuery createCorrelationKeyQuery(
+      ErrorCollector errorCollector, final MessageImpl message) {
+
+    final SubscriptionImpl subscription = message.getSubscription();
+    final String correlationKey = subscription.getCorrelationKey();
+
+    final JsonPathQueryCompiler compiler = new JsonPathQueryCompiler();
+    final JsonPathQuery query = compiler.compile(correlationKey);
+
+    if (!query.isValid()) {
+      errorCollector.addError(
+          message,
+          String.format(
+              "JSON path query '%s' is not valid! Reason: %s",
+              bufferAsString(query.getExpression()), query.getErrorReason()));
+    }
+
+    return query;
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/transformation/nodes/ReceiveTaskTransformer.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/transformation/nodes/ReceiveTaskTransformer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.impl.transformation.nodes;
+
+import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.zeebe.model.bpmn.impl.error.ErrorCollector;
+import io.zeebe.model.bpmn.impl.instance.MessageImpl;
+import io.zeebe.model.bpmn.impl.instance.ReceiveTaskImpl;
+import io.zeebe.model.bpmn.impl.metadata.MessageSubscriptionImpl;
+import io.zeebe.model.bpmn.impl.metadata.SubscriptionImpl;
+import io.zeebe.msgpack.jsonpath.JsonPathQuery;
+import io.zeebe.msgpack.jsonpath.JsonPathQueryCompiler;
+import java.util.List;
+import java.util.Map;
+
+public class ReceiveTaskTransformer {
+
+  public void transform(
+      ErrorCollector errorCollector,
+      List<ReceiveTaskImpl> receiveTasks,
+      Map<String, MessageImpl> messagesById) {
+
+    for (ReceiveTaskImpl receiveTask : receiveTasks) {
+
+      final String messageRef = receiveTask.getMessageRef();
+      if (messageRef != null) {
+        final MessageImpl message = messagesById.get(messageRef);
+        final String messageName = message.getName();
+
+        final JsonPathQuery query = createCorrelationKeyQuery(errorCollector, message);
+
+        receiveTask.setMessageSubscription(new MessageSubscriptionImpl(messageName, query));
+      }
+    }
+  }
+
+  private JsonPathQuery createCorrelationKeyQuery(
+      ErrorCollector errorCollector, final MessageImpl message) {
+
+    final SubscriptionImpl subscription = message.getSubscription();
+    final String correlationKey = subscription.getCorrelationKey();
+
+    final JsonPathQueryCompiler compiler = new JsonPathQueryCompiler();
+    final JsonPathQuery query = compiler.compile(correlationKey);
+
+    if (!query.isValid()) {
+      errorCollector.addError(
+          message,
+          String.format(
+              "JSON path query '%s' is not valid! Reason: %s",
+              bufferAsString(query.getExpression()), query.getErrorReason()));
+    }
+
+    return query;
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/validation/BpmnValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/validation/BpmnValidator.java
@@ -18,8 +18,11 @@ package io.zeebe.model.bpmn.impl.validation;
 import io.zeebe.model.bpmn.impl.error.ErrorCollector;
 import io.zeebe.model.bpmn.impl.error.InvalidModelException;
 import io.zeebe.model.bpmn.impl.instance.DefinitionsImpl;
+import io.zeebe.model.bpmn.impl.instance.MessageImpl;
 import io.zeebe.model.bpmn.impl.instance.ProcessImpl;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class BpmnValidator {
@@ -40,11 +43,20 @@ public class BpmnValidator {
           definition, "BPMN model must contain at least one executable process.");
     }
 
+    final Map<String, MessageImpl> messages = getMessagesById(definition);
+
     for (ProcessImpl executableProcess : executableProcesses) {
-      processValidator.validate(validationResult, executableProcess);
+      processValidator.validate(validationResult, executableProcess, messages);
     }
 
     reportExsitingErrorsOrWarnings(validationResult);
+  }
+
+  private Map<String, MessageImpl> getMessagesById(DefinitionsImpl definition) {
+    return definition
+        .getMessages()
+        .stream()
+        .collect(Collectors.toMap(MessageImpl::getId, Function.identity()));
   }
 
   public void reportExsitingErrorsOrWarnings(ErrorCollector validationResult) {

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/validation/nodes/IntermediateCatchEventValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/validation/nodes/IntermediateCatchEventValidator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.impl.validation.nodes;
+
+import io.zeebe.model.bpmn.impl.error.ErrorCollector;
+import io.zeebe.model.bpmn.impl.instance.IntermediateCatchEventImpl;
+import io.zeebe.model.bpmn.impl.instance.MessageEventDefinitionImpl;
+import io.zeebe.model.bpmn.impl.instance.MessageImpl;
+import io.zeebe.model.bpmn.impl.metadata.SubscriptionImpl;
+import java.util.Map;
+
+public class IntermediateCatchEventValidator {
+  public void validate(
+      ErrorCollector validationResult,
+      IntermediateCatchEventImpl event,
+      Map<String, MessageImpl> messages) {
+
+    final MessageEventDefinitionImpl messageEventDefinition = event.getMessageEventDefinition();
+    if (messageEventDefinition == null) {
+      validationResult.addError(
+          event, "A intermediate catch event must have a message event definition.");
+      return;
+    }
+
+    final String messageRef = messageEventDefinition.getMessageRef();
+    final MessageImpl message = messages.get(messageRef);
+    if (message == null) {
+      validationResult.addError(
+          message, String.format("No message found with id '%s'", messageRef));
+      return;
+    }
+
+    final String messageName = message.getName();
+    if (messageName == null || messageName.isEmpty()) {
+      validationResult.addError(message, "A message must have a name.");
+      return;
+    }
+
+    final SubscriptionImpl subscription = message.getSubscription();
+    if (subscription == null) {
+      validationResult.addError(message, "A message must have a subscription element.");
+      return;
+    }
+
+    final String correlationKey = subscription.getCorrelationKey();
+    if (correlationKey == null || correlationKey.isEmpty()) {
+      validationResult.addError(message, "A subscription must have a correlation-key.");
+      return;
+    }
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/validation/nodes/ReceiveTaskValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/validation/nodes/ReceiveTaskValidator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.impl.validation.nodes;
+
+import io.zeebe.model.bpmn.impl.error.ErrorCollector;
+import io.zeebe.model.bpmn.impl.instance.MessageImpl;
+import io.zeebe.model.bpmn.impl.instance.ReceiveTaskImpl;
+import io.zeebe.model.bpmn.impl.metadata.SubscriptionImpl;
+import java.util.Map;
+
+public class ReceiveTaskValidator {
+  public void validate(
+      ErrorCollector validationResult,
+      ReceiveTaskImpl receiveTask,
+      Map<String, MessageImpl> messages) {
+
+    final String messageRef = receiveTask.getMessageRef();
+    if (messageRef == null) {
+      validationResult.addError(receiveTask, "A receive task must have a message reference.");
+      return;
+    }
+
+    final MessageImpl message = messages.get(messageRef);
+    if (message == null) {
+      validationResult.addError(
+          message, String.format("No message found with id '%s'", messageRef));
+      return;
+    }
+
+    final String messageName = message.getName();
+    if (messageName == null || messageName.isEmpty()) {
+      validationResult.addError(message, "A message must have a name.");
+      return;
+    }
+
+    final SubscriptionImpl subscription = message.getSubscription();
+    if (subscription == null) {
+      validationResult.addError(message, "A message must have a subscription element.");
+      return;
+    }
+
+    final String correlationKey = subscription.getCorrelationKey();
+    if (correlationKey == null || correlationKey.isEmpty()) {
+      validationResult.addError(message, "A subscription must have a correlation-key.");
+      return;
+    }
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/IntermediateMessageCatchEvent.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/IntermediateMessageCatchEvent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.instance;
+
+public interface IntermediateMessageCatchEvent extends FlowNode {
+
+  MessageSubscription getMessageSubscription();
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/MessageSubscription.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/MessageSubscription.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.instance;
+
+import io.zeebe.msgpack.jsonpath.JsonPathQuery;
+
+public interface MessageSubscription {
+
+  String getMessageName();
+
+  JsonPathQuery getCorrelationKey();
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/ReceiveTask.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/ReceiveTask.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.instance;
+
+public interface ReceiveTask extends FlowNode {
+
+  MessageSubscription getMessageSubscription();
+}

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/BpmnValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/BpmnValidationTest.java
@@ -240,4 +240,44 @@ public class BpmnValidationTest {
     // when
     Bpmn.readFromXmlFile(bpmnFile);
   }
+
+  @Test
+  public void testMissingMessageName() {
+    // expect
+    expectedException.expect(InvalidModelException.class);
+    expectedException.expectMessage("A message must have a name.");
+
+    // when
+    Bpmn.createExecutableWorkflow("process")
+        .startEvent()
+        .intermediateCatchEvent("catch-event", m -> m.correlationKey("$.orderId"))
+        .done();
+  }
+
+  @Test
+  public void testMissingMessageCorrelationKey() {
+    // expect
+    expectedException.expect(InvalidModelException.class);
+    expectedException.expectMessage("A subscription must have a correlation-key.");
+
+    // when
+    Bpmn.createExecutableWorkflow("process")
+        .startEvent()
+        .intermediateCatchEvent("catch-event", m -> m.messageName("order canceled"))
+        .done();
+  }
+
+  @Test
+  public void testInvalidMessageCorrelationKey() {
+    // expect
+    expectedException.expect(InvalidModelException.class);
+    expectedException.expectMessage("JSON path query 'foo' is not valid");
+
+    // when
+    Bpmn.createExecutableWorkflow("process")
+        .startEvent()
+        .intermediateCatchEvent(
+            "catch-event", m -> m.messageName("order canceled").correlationKey("foo"))
+        .done();
+  }
 }

--- a/bpmn-model/src/test/resources/workflow-intermediate-message-catch-event.bpmn
+++ b/bpmn-model/src/test/resources/workflow-intermediate-message-catch-event.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1mjeu96" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.16.0">
+  <bpmn:process id="workflow" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1vyky7m</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1vyky7m" sourceRef="StartEvent_1" targetRef="catch-event" />
+    <bpmn:intermediateCatchEvent id="catch-event">
+      <bpmn:incoming>SequenceFlow_1vyky7m</bpmn:incoming>
+      <bpmn:messageEventDefinition messageRef="Message_10q8g29" />
+    </bpmn:intermediateCatchEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_10q8g29" name="order canceled">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="$.orderId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="workflow">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1vyky7m_di" bpmnElement="SequenceFlow_1vyky7m">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="259" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_09dk09l_di" bpmnElement="catch-event">
+        <dc:Bounds x="259" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpmn-model/src/test/resources/workflow-receive-task.bpmn
+++ b/bpmn-model/src/test/resources/workflow-receive-task.bpmn
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1mjeu96" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.16.0">
+  <bpmn:process id="workflow" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1vyky7m</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1vyky7m" sourceRef="StartEvent_1" targetRef="receive-task" />
+    <bpmn:receiveTask id="receive-task" messageRef="Message_10q8g29">
+      <bpmn:incoming>SequenceFlow_1vyky7m</bpmn:incoming>
+    </bpmn:receiveTask>
+  </bpmn:process>
+  <bpmn:message id="Message_10q8g29" name="order canceled">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="$.orderId" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="workflow">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1vyky7m_di" bpmnElement="SequenceFlow_1vyky7m">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="259" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_09dk09l_di" bpmnElement="receive-task">
+        <dc:Bounds x="259" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
* parse BPMN with intermediate message catch event and receive task
* extend the BPMN model builder

closes #1013 
