### PR TITLE
chore(broker-tests): make CreateWorkflowInstanceTest stable

### DIFF
--- a/broker-core/src/test/java/io/zeebe/broker/workflow/CreateWorkflowInstanceTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/CreateWorkflowInstanceTest.java
@@ -560,7 +560,7 @@ public class CreateWorkflowInstanceTest {
     final int partitions = 3;
 
     apiRule.createTopic("test", partitions);
-    final List<Integer> partitionIds = apiRule.getPartitionsFromTopology("test");
+    final List<Integer> partitionIds = apiRule.getPartitionIds("test");
 
     final WorkflowDefinition definition =
         Bpmn.createExecutableWorkflow("process").startEvent().endEvent().done();


### PR DESCRIPTION
- test no longer relies on topology request

Avoids topology request in test, which seemed shaky. Uses partitions request instead.

closes #1059
