### PR TITLE
Wait for expected block index size before writing snapshot

### DIFF
--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogBlockIndexWriterTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogBlockIndexWriterTest.java
@@ -214,6 +214,8 @@ public class LogBlockIndexWriterTest {
     writer.writeEvents(2, EVENT_1, true);
     writer.writeEvents(2, EVENT_2, true);
 
+    waitUntil(() -> blockIndex.size() == 2);
+
     logStreamRule.getClock().addTime(SNAPSHOT_INTERVAL);
     waitUntil(() -> getSnapshotCount() > 0);
 


### PR DESCRIPTION
As the block index is updated asynchronously we have to wait for the desired state before the snapshot is written.

closes #1058
