### PR TITLE
Change zeebe ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache bash && \
     tar xfvz ${ZB_HOME}/*.tar.gz --strip 1 -C ${ZB_HOME}/ && rm ${ZB_HOME}/*.tar.gz
 
 WORKDIR ${ZB_HOME}
-EXPOSE 51016 51017 51015
+EXPOSE 26500 26501 26502 26503 26504
 VOLUME ${ZB_HOME}/data
 
 COPY docker/utils/startup.sh /usr/local/bin

--- a/broker-client/src/main/java/io/zeebe/broker/client/ZeebeClientBuilder.java
+++ b/broker-client/src/main/java/io/zeebe/broker/client/ZeebeClientBuilder.java
@@ -32,7 +32,7 @@ public interface ZeebeClientBuilder {
 
   /**
    * @param contactPoint the IP socket address of a broker that the client can initially connect to.
-   *     Must be in format <code>host:port</code>. The default value is <code>127.0.0.1:51015</code>
+   *     Must be in format <code>host:port</code>. The default value is <code>127.0.0.1:26501</code>
    *     .
    */
   ZeebeClientBuilder brokerContactPoint(String contactPoint);

--- a/broker-client/src/main/java/io/zeebe/broker/client/impl/ZeebeClientBuilderImpl.java
+++ b/broker-client/src/main/java/io/zeebe/broker/client/impl/ZeebeClientBuilderImpl.java
@@ -30,7 +30,7 @@ import java.time.Duration;
 import java.util.Properties;
 
 public class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientConfiguration {
-  private String brokerContactPoint = "127.0.0.1:51015";
+  private String brokerContactPoint = "127.0.0.1:26501";
   private Duration requestTimeout = Duration.ofSeconds(15);
   private Duration requestBlocktime = Duration.ofSeconds(15);
   private int sendBufferSize = 2;

--- a/broker-client/src/test/java/io/zeebe/broker/client/cluster/RequestTopologyTest.java
+++ b/broker-client/src/test/java/io/zeebe/broker/client/cluster/RequestTopologyTest.java
@@ -44,13 +44,13 @@ public class RequestTopologyTest {
   @Test
   public void shouldRequestTopics() {
     // given
-    final Map<String, Object> broker1 = buildBroker("0.0.0.0", 51015);
+    final Map<String, Object> broker1 = buildBroker("0.0.0.0", 26501);
     broker1.put(
         "partitions",
         Arrays.asList(
             buildPartition(0, "system", "LEADER"), buildPartition(1, "my-topic", "FOLLOWER")));
 
-    final Map<String, Object> broker2 = buildBroker("0.0.0.0", 41015);
+    final Map<String, Object> broker2 = buildBroker("0.0.0.0", 26511);
     broker2.put(
         "partitions",
         Arrays.asList(
@@ -76,7 +76,7 @@ public class RequestTopologyTest {
     assertThat(returnedBrokers).hasSize(2);
     assertThat(returnedBrokers)
         .extracting(BrokerInfo::getAddress)
-        .contains("0.0.0.0:51015", "0.0.0.0:41015");
+        .contains("0.0.0.0:26501", "0.0.0.0:26511");
 
     assertThat(returnedBrokers.get(0).getPartitions())
         .hasSize(2)

--- a/broker-client/src/test/java/io/zeebe/broker/client/event/PartitionedTopicSubscriptionTest.java
+++ b/broker-client/src/test/java/io/zeebe/broker/client/event/PartitionedTopicSubscriptionTest.java
@@ -56,8 +56,8 @@ public class PartitionedTopicSubscriptionTest {
   public static final int PARTITION_2 = 2;
 
   public ClientRule clientRule = new ClientRule();
-  public StubBrokerRule broker1 = new StubBrokerRule("localhost", 51015);
-  public StubBrokerRule broker2 = new StubBrokerRule("localhost", 51016);
+  public StubBrokerRule broker1 = new StubBrokerRule("localhost", 26501);
+  public StubBrokerRule broker2 = new StubBrokerRule("localhost", 26502);
 
   protected ZeebeClient client;
 

--- a/broker-client/src/test/java/io/zeebe/broker/client/job/subscription/PartitionedJobSubscriptionTest.java
+++ b/broker-client/src/test/java/io/zeebe/broker/client/job/subscription/PartitionedJobSubscriptionTest.java
@@ -48,8 +48,8 @@ public class PartitionedJobSubscriptionTest {
   public static final String JOB_TYPE = "foo";
 
   public ClientRule clientRule = new ClientRule();
-  public StubBrokerRule broker1 = new StubBrokerRule("localhost", 51015);
-  public StubBrokerRule broker2 = new StubBrokerRule("localhost", 51016);
+  public StubBrokerRule broker1 = new StubBrokerRule("localhost", 26501);
+  public StubBrokerRule broker2 = new StubBrokerRule("localhost", 26502);
 
   protected ZeebeClient client;
 

--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/SocketBindingClientApiCfg.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/SocketBindingClientApiCfg.java
@@ -19,7 +19,7 @@ package io.zeebe.broker.system.configuration;
 
 public class SocketBindingClientApiCfg extends SocketBindingCfg {
 
-  public static final int DEFAULT_PORT = 51015;
+  public static final int DEFAULT_PORT = 26501;
   private String controlMessageBufferSize = "8M";
 
   public SocketBindingClientApiCfg() {

--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/SocketBindingManagementCfg.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/SocketBindingManagementCfg.java
@@ -19,7 +19,7 @@ package io.zeebe.broker.system.configuration;
 
 public class SocketBindingManagementCfg extends SocketBindingCfg {
 
-  public static final int DEFAULT_PORT = 51016;
+  public static final int DEFAULT_PORT = 26502;
   private String receiveBufferSize = "8M";
 
   public SocketBindingManagementCfg() {

--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/SocketBindingReplicationCfg.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/SocketBindingReplicationCfg.java
@@ -19,7 +19,7 @@ package io.zeebe.broker.system.configuration;
 
 public class SocketBindingReplicationCfg extends SocketBindingCfg {
 
-  public static final int DEFAULT_PORT = 51017;
+  public static final int DEFAULT_PORT = 26503;
 
   public SocketBindingReplicationCfg() {
     port = DEFAULT_PORT;

--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/SocketBindingSubscriptionCfg.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/SocketBindingSubscriptionCfg.java
@@ -20,7 +20,7 @@ package io.zeebe.broker.system.configuration;
 public class SocketBindingSubscriptionCfg extends SocketBindingCfg {
   private String receiveBufferSize = "8M";
 
-  public static final int DEFAULT_PORT = 51018;
+  public static final int DEFAULT_PORT = 26504;
 
   public SocketBindingSubscriptionCfg() {
     port = DEFAULT_PORT;

--- a/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/api/client/GetWorkflowControlRequest.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/api/client/GetWorkflowControlRequest.java
@@ -18,7 +18,9 @@
 package io.zeebe.broker.system.workflow.repository.api.client;
 
 import io.zeebe.msgpack.UnpackedObject;
-import io.zeebe.msgpack.property.*;
+import io.zeebe.msgpack.property.IntegerProperty;
+import io.zeebe.msgpack.property.LongProperty;
+import io.zeebe.msgpack.property.StringProperty;
 import org.agrona.DirectBuffer;
 
 public class GetWorkflowControlRequest extends UnpackedObject {

--- a/broker-core/src/test/java/io/zeebe/broker/clustering/base/snapshots/SnapshotReplicationServiceTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/clustering/base/snapshots/SnapshotReplicationServiceTest.java
@@ -429,7 +429,7 @@ public class SnapshotReplicationServiceTest {
   }
 
   private NodeInfo createLeaderNodeInfo() {
-    return createNodeInfo("0.0.0.0", 51015);
+    return createNodeInfo("0.0.0.0", 26501);
   }
 
   private NodeInfo createNodeInfo(final String host, final int port) {

--- a/broker-core/src/test/java/io/zeebe/broker/topic/CreateTopicTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/topic/CreateTopicTest.java
@@ -50,7 +50,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 
 public class CreateTopicTest {
-  protected static final SocketAddress BROKER_MGMT_ADDRESS = new SocketAddress("localhost", 51016);
+  protected static final SocketAddress BROKER_MGMT_ADDRESS = new SocketAddress("localhost", 26502);
   public EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule();
 
   public ClientApiRule apiRule = new ClientApiRule();

--- a/dist/src/main/config/zeebe.cfg.toml
+++ b/dist/src/main/config/zeebe.cfg.toml
@@ -82,7 +82,7 @@ replicationFactor = 1
 #
 # The offset will be added to the second last position of the port, as Zeebe
 # requires multiple ports. As example a portOffset of 5 will increment all ports
-# by 50, i.e. 51015 will become 51065 and so on.
+# by 50, i.e. 26500 will become 26550 and so on.
 #
 # This setting can also be overridden using the environment variable ZEEBE_PORT_OFFSET.
 # portOffset = 0
@@ -98,7 +98,7 @@ replicationFactor = 1
 # host = "localhost"
 #
 # The port the client api binds to
-# port = 51015
+# port = 26501
 #
 # Overrides the size of the buffer used for buffering outgoing messages to
 # clients
@@ -114,7 +114,7 @@ replicationFactor = 1
 # host = "localhost"
 #
 # Sets the port the management api binds to
-# port = 51016
+# port = 26502
 #
 # Overrides the size of the buffer to be used for buffering outgoing messages to
 # other brokers through the management protocols
@@ -129,7 +129,7 @@ replicationFactor = 1
 # host = "localhost"
 #
 # Sets the port the replication api binds to
-# port = 51017
+# port = 26503
 #
 # Sets the buffer size used for buffering outgoing raft (replication) messages
 # sendBufferSize = "16M"
@@ -140,7 +140,7 @@ replicationFactor = 1
 # host = "localhost"
 #
 # Sets the port the subscription api binds to
-# port = 51018
+# port = 26504
 #
 # Overrides the size of the buffer to be used for buffering outgoing messages to
 # other brokers through the subscription protocols
@@ -187,7 +187,7 @@ replicationFactor = 1
 # The contact points of the management api must be specified.
 # The format is [HOST:PORT]
 # Example:
-# initialContactPoints = [ "192.168.1.22:51016", "192.168.1.32:51016" ]
+# initialContactPoints = [ "192.168.1.22:26502", "192.168.1.32:26502" ]
 #
 # Default is empty list:
 # initialContactPoints = []

--- a/docker/compose/docker-compose.yaml
+++ b/docker/compose/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     broker-1:
         image: camunda/zeebe:${ZEEBE_VERSION:-latest}
         ports:
-            - 51015:51015
+            - 26500:26500
         environment:
             - ZEEBE_LOG_LEVEL=${ZEEBE_LOG_LEVEL:-debug}
             - BOOTSTRAP=3
@@ -20,10 +20,10 @@ services:
     broker-2:
         image: camunda/zeebe:${ZEEBE_VERSION:-latest}
         ports:
-            - 51016:51015
+            - 26510:26500
         environment:
             - ZEEBE_LOG_LEVEL=${ZEEBE_LOG_LEVEL:-debug}
-            - INITIAL_CONTACT_POINT=broker-1:51016
+            - INITIAL_CONTACT_POINT=broker-1:26502
             - BOOTSTRAP=0
         volumes:
             - broker_2:/usr/local/zeebe/data
@@ -31,10 +31,10 @@ services:
     broker-3:
         image: camunda/zeebe:${ZEEBE_VERSION:-latest}
         ports:
-            - 51017:51015
+            - 26520:26500
         environment:
             - ZEEBE_LOG_LEVEL=${ZEEBE_LOG_LEVEL:-debug}
-            - INITIAL_CONTACT_POINT=broker-1:51016
+            - INITIAL_CONTACT_POINT=broker-1:26502
             - BOOTSTRAP=0
         volumes:
             - broker_3:/usr/local/zeebe/data

--- a/docs/src/basics/clustering.md
+++ b/docs/src/basics/clustering.md
@@ -13,7 +13,7 @@ The cluster is bootstrapped using a set of well-known bootstrap brokers, to whic
 
 ```toml
 [network.gossip]
-initialContactPoints = [ "node1.mycluster.loc:51016" ]
+initialContactPoints = [ "node1.mycluster.loc:26502" ]
 ```
 
 When a broker is connected to the cluster for the first time, it fetches the topology from the initial contact points and then starts gossiping with the other brokers. Brokers keep cluster topology locally across restarts.

--- a/docs/src/go-client/get-started.md
+++ b/docs/src/go-client/get-started.md
@@ -74,7 +74,7 @@ import (
 	"github.com/zeebe-io/zbc-go/zbc"
 )
 
-const BrokerAddr = "0.0.0.0:51015"
+const BrokerAddr = "0.0.0.0:26500"
 
 var errClientStartFailed = errors.New("cannot start client")
 
@@ -104,8 +104,8 @@ You should see similar output:
 ```json
 {
     "AddrByPartitionID": {
-        "0": "0.0.0.0:51015",
-        "1": "0.0.0.0:51015"
+        "0": "0.0.0.0:26500",
+        "1": "0.0.0.0:26500"
     },
     "PartitionIDByTopicName": {
         "default-topic": [
@@ -118,7 +118,7 @@ You should see similar output:
     "Brokers": [
         {
             "Host": "0.0.0.0",
-            "Port": 51015,
+            "Port": 26500,
             "Partitions": [
                 {
                     "State": "LEADER",
@@ -169,7 +169,7 @@ import (
 )
 
 const topicName = "default-topic"
-const brokerAddr = "0.0.0.0:51015"
+const brokerAddr = "0.0.0.0:26500"
 
 var errClientStartFailed = errors.New("cannot start client")
 var errWorkflowDeploymentFailed = errors.New("creating new workflow deployment failed")
@@ -238,7 +238,7 @@ import (
 )
 
 const topicName = "default-topic"
-const brokerAddr = "0.0.0.0:51015"
+const brokerAddr = "0.0.0.0:26500"
 
 var errClientStartFailed = errors.New("cannot start client")
 
@@ -319,7 +319,7 @@ import (
 )
 
 const topicName = "default-topic"
-const brokerAddr = "0.0.0.0:51015"
+const brokerAddr = "0.0.0.0:26500"
 
 var errClientStartFailed = errors.New("cannot start client")
 
@@ -467,7 +467,7 @@ import (
 )
 
 const topicName = "default-topic"
-const brokerAddr = "0.0.0.0:51015"
+const brokerAddr = "0.0.0.0:26500"
 
 var errClientStartFailed = errors.New("cannot start client")
 

--- a/docs/src/introduction/install.md
+++ b/docs/src/introduction/install.md
@@ -36,9 +36,9 @@ Once the Zeebe broker has started, it should produce the following output:
 10:49:52.342 [] [main] INFO  io.zeebe.broker.system - Scheduler configuration: Threads{cpu-bound: 2, io-bound: 2}.
 10:49:52.383 [] [main] INFO  io.zeebe.broker.system - Version: X.Y.Z
 10:49:52.430 [] [main] INFO  io.zeebe.broker.clustering - Starting standalone broker.
-10:49:52.435 [service-controller] [0.0.0.0:51015-zb-actors-1] INFO  io.zeebe.broker.transport - Bound managementApi.server to /0.0.0.0:51016
-10:49:52.460 [service-controller] [0.0.0.0:51015-zb-actors-1] INFO  io.zeebe.transport - Bound clientApi.server to /0.0.0.0:51015
-10:49:52.460 [service-controller] [0.0.0.0:51015-zb-actors-1] INFO  io.zeebe.transport - Bound replicationApi.server to /0.0.0.0:51017
+10:49:52.435 [service-controller] [0.0.0.0:26500-zb-actors-1] INFO  io.zeebe.broker.transport - Bound managementApi.server to /0.0.0.0:26502
+10:49:52.460 [service-controller] [0.0.0.0:26500-zb-actors-1] INFO  io.zeebe.transport - Bound clientApi.server to /0.0.0.0:26501
+10:49:52.460 [service-controller] [0.0.0.0:26500-zb-actors-1] INFO  io.zeebe.transport - Bound replicationApi.server to /0.0.0.0:26503
 ```
 
 ## Using Docker
@@ -46,14 +46,14 @@ Once the Zeebe broker has started, it should produce the following output:
 You can run Zeebe with Docker:
 
 ```bash
-docker run --name zeebe -p 51015:51015 camunda/zeebe:latest
+docker run --name zeebe -p 26500:26500 camunda/zeebe:latest
 ```
 
 ### Exposed Ports
 
-- `51015`: Client API
-- `51016`: Management API for broker to broker communcation
-- `51017`: Replication API for broker to broker replication
+- `26500`: Client API
+- `26502`: Management API for broker to broker communcation
+- `26503`: Replication API for broker to broker replication
 
 ### Volumes
 
@@ -131,7 +131,7 @@ eval $(docker-machine env zeebe)
 Then run Zeebe:
 
 ```
-docker run --rm -p 51015:51015 -p 51016:51016 -p 51017:51017 camunda/zeebe:latest
+docker run --rm -p 26500:26500 camunda/zeebe:latest
 ```
 
 To get the ip of Zeebe:
@@ -144,5 +144,5 @@ docker-machine ip zeebe
 
 Verify that you can connect to Zeebe:
 ```
-telnet 192.168.99.100 51015
+telnet 192.168.99.100 26500
 ```

--- a/docs/src/introduction/quickstart.md
+++ b/docs/src/introduction/quickstart.md
@@ -56,13 +56,13 @@ cd bin/
 09:04:17.776 [] [main] INFO  io.zeebe.broker.system - Scheduler configuration: Threads{cpu-bound: 2, io-bound: 2}.
 09:04:17.815 [] [main] INFO  io.zeebe.broker.system - Version: X.Y.Z
 09:04:17.861 [] [main] INFO  io.zeebe.broker.clustering - Starting standalone broker.
-09:04:17.865 [service-controller] [0.0.0.0:51015-zb-actors-1] INFO  io.zeebe.broker.transport - Bound managementApi.server to /0.0.0.0:51016
-09:04:17.887 [service-controller] [0.0.0.0:51015-zb-actors-0] INFO  io.zeebe.transport - Bound clientApi.server to /0.0.0.0:51015
-09:04:17.888 [service-controller] [0.0.0.0:51015-zb-actors-0] INFO  io.zeebe.transport - Bound replicationApi.server to /0.0.0.0:51017
-09:04:17.911 [io.zeebe.broker.clustering.base.bootstrap.BootstrapSystemTopic] [0.0.0.0:51015-zb-actors-1] INFO  io.zeebe.broker.clustering - Boostrapping internal system topic 'internal-system' with replication factor 1.
-09:04:18.065 [service-controller] [0.0.0.0:51015-zb-actors-0] INFO  io.zeebe.raft - Created raft internal-system-0 with configuration RaftConfiguration{heartbeatInterval='250ms', electionInterval='1s', leaveTimeout='1s'}
-09:04:18.069 [io.zeebe.broker.clustering.base.bootstrap.BootstrapSystemTopic] [0.0.0.0:51015-zb-actors-0] INFO  io.zeebe.broker.clustering - Bootstrapping default topics [TopicCfg{name='default-topic', partitions=1, replicationFactor=1}]
-09:04:18.122 [internal-system-0] [0.0.0.0:51015-zb-actors-1] INFO  io.zeebe.raft - Joined raft in term 0
+09:04:17.865 [service-controller] [0.0.0.0:26500-zb-actors-1] INFO  io.zeebe.broker.transport - Bound managementApi.server to /0.0.0.0:26502
+09:04:17.887 [service-controller] [0.0.0.0:26500-zb-actors-0] INFO  io.zeebe.transport - Bound clientApi.server to /0.0.0.0:26500
+09:04:17.888 [service-controller] [0.0.0.0:26500-zb-actors-0] INFO  io.zeebe.transport - Bound replicationApi.server to /0.0.0.0:26503
+09:04:17.911 [io.zeebe.broker.clustering.base.bootstrap.BootstrapSystemTopic] [0.0.0.0:26500-zb-actors-1] INFO  io.zeebe.broker.clustering - Boostrapping internal system topic 'internal-system' with replication factor 1.
+09:04:18.065 [service-controller] [0.0.0.0:26500-zb-actors-0] INFO  io.zeebe.raft - Created raft internal-system-0 with configuration RaftConfiguration{heartbeatInterval='250ms', electionInterval='1s', leaveTimeout='1s'}
+09:04:18.069 [io.zeebe.broker.clustering.base.bootstrap.BootstrapSystemTopic] [0.0.0.0:26500-zb-actors-0] INFO  io.zeebe.broker.clustering - Bootstrapping default topics [TopicCfg{name='default-topic', partitions=1, replicationFactor=1}]
+09:04:18.122 [internal-system-0] [0.0.0.0:26500-zb-actors-1] INFO  io.zeebe.raft - Joined raft in term 0
 ```
 
 You will see some output which contains the version of the broker, or different
@@ -114,11 +114,11 @@ We can now see our new topic in the topology of the Zeebe broker.
 +-----------------+--------------+----------------+---------+
 |   TOPIC NAME    | PARTITION ID | BROKER ADDRESS |  STATE  |
 +-----------------+--------------+----------------+---------+
-| internal-system |            0 | 0.0.0.0:51015  | LEADER  |
+| internal-system |            0 | 0.0.0.0:26500  | LEADER  |
 +-----------------+--------------+----------------+---------+
-| default-topic   |            1 | 0.0.0.0:51015  | LEADER  |
+| default-topic   |            1 | 0.0.0.0:26500  | LEADER  |
 +-----------------+--------------+----------------+---------+
-| quickstart      |            2 | 0.0.0.0:51015  | LEADER  |
+| quickstart      |            2 | 0.0.0.0:26500  | LEADER  |
 +-----------------+--------------+----------------+---------+
 ```
 

--- a/docs/src/java-client-examples/cluster-topology-request.md
+++ b/docs/src/java-client-examples/cluster-topology-request.md
@@ -9,7 +9,7 @@ Shows which broker is leader and follower for which partition. Particularly usef
 
 ## Prerequisites
 
-1. Running Zeebe broker with endpoint `localhost:51015` (default)
+1. Running Zeebe broker with endpoint `localhost:26500` (default)
 
 ## TopologyViewer.java
 

--- a/docs/src/java-client-examples/data-pojo.md
+++ b/docs/src/java-client-examples/data-pojo.md
@@ -6,7 +6,7 @@
 
 ## Prerequisites
 
-1. Running Zeebe broker with endpoint `localhost:51015` (default)
+1. Running Zeebe broker with endpoint `localhost:26500` (default)
 1. Run the [Deploy a Workflow example](java-client-examples/workflow-deploy.html)
 
 ## HandlePayloadAsPojo.java

--- a/docs/src/java-client-examples/job-worker-open.md
+++ b/docs/src/java-client-examples/job-worker-open.md
@@ -6,7 +6,7 @@
 
 ## Prerequisites
 
-1. Running Zeebe broker with endpoint `localhost:51015` (default)
+1. Running Zeebe broker with endpoint `localhost:26500` (default)
 1. Run the [Deploy a Workflow example](java-client-examples/workflow-deploy.html)
 1. Run the [Create a Workflow Instance example](java-client-examples/workflow-instance-create.html) a couple of times
 

--- a/docs/src/java-client-examples/topic-create.md
+++ b/docs/src/java-client-examples/topic-create.md
@@ -7,7 +7,7 @@
 
 ## Prerequisites
 
-1. Running Zeebe broker with endpoint `localhost:51015` (default)
+1. Running Zeebe broker with endpoint `localhost:26500` (default)
 
 ## TopicCreator.java
 

--- a/docs/src/java-client-examples/topic-subscription-open.md
+++ b/docs/src/java-client-examples/topic-subscription-open.md
@@ -6,7 +6,7 @@
 
 ## Prerequisites
 
-1. Running Zeebe broker with endpoint `localhost:51015` (default)
+1. Running Zeebe broker with endpoint `localhost:26500` (default)
 
 ## TopicSubscriber.java
 

--- a/docs/src/java-client-examples/workflow-deploy.md
+++ b/docs/src/java-client-examples/workflow-deploy.md
@@ -7,7 +7,7 @@
 
 ## Prerequisites
 
-1. Running Zeebe broker with endpoint `localhost:51015` (default)
+1. Running Zeebe broker with endpoint `localhost:26500` (default)
 
 ## WorkflowDeployer.java
 

--- a/docs/src/java-client-examples/workflow-deployment-request.md
+++ b/docs/src/java-client-examples/workflow-deployment-request.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-1. Running Zeebe broker with endpoint `localhost:51015` (default)
+1. Running Zeebe broker with endpoint `localhost:26500` (default)
 1. Make sure a couple of workflows are deployed, e.g. run the [Deploy a Workflow example](java-client-examples/workflow-deploy.html) multiple times to create multiple workflow versions.
 
 ## DeploymentViewer.java

--- a/docs/src/java-client-examples/workflow-instance-create-nonblocking.md
+++ b/docs/src/java-client-examples/workflow-instance-create-nonblocking.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-1. Running Zeebe broker with endpoint `localhost:51015` (default)
+1. Running Zeebe broker with endpoint `localhost:26500` (default)
 1. Run the [Deploy a Workflow example](java-client-examples/workflow-deploy.html)
 
 ## NonBlockingWorkflowInstanceCreator.java

--- a/docs/src/java-client-examples/workflow-instance-create.md
+++ b/docs/src/java-client-examples/workflow-instance-create.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-1. Running Zeebe broker with endpoint `localhost:51015` (default)
+1. Running Zeebe broker with endpoint `localhost:26500` (default)
 1. Run the [Deploy a Workflow example](java-client-examples/workflow-deploy.html)
 
 ## WorkflowInstanceCreator.java

--- a/docs/src/java-client/get-started.md
+++ b/docs/src/java-client/get-started.md
@@ -85,7 +85,7 @@ public class Application
     {
         final Properties clientProperties = new Properties();
         // change the contact point if needed
-        clientProperties.put(ClientProperties.BROKER_CONTACTPOINT, "127.0.0.1:51015");
+        clientProperties.put(ClientProperties.BROKER_CONTACTPOINT, "127.0.0.1:26500");
 
         final ZeebeClient client = ZeebeClient.newClientBuilder()
             .withProperties(clientProperties)
@@ -322,7 +322,7 @@ public class Application
     public static void main(String[] args)
     {
         // after the workflow is deployed
-        
+
         final Map<String, Object> data = new HashMap<>();
         data.put("orderId", 31243);
         data.put("orderItems", Arrays.asList(435, 182, 376));

--- a/docs/src/java-client/setup.md
+++ b/docs/src/java-client/setup.md
@@ -25,7 +25,7 @@ In Java code, instantiate the client as follows:
 
 ```java
 ZeebeClient client = ZeebeClient.newClientBuilder()
-  .brokerContactPoint("127.0.0.1:51015")
+  .brokerContactPoint("127.0.0.1:26500")
   .build();
 ```
 

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -18,10 +18,10 @@ The details of the format can be read in the [Prometheus documentation][prom-for
 **Example:**
 
 ```
-zb_storage_fs_total_bytes{cluster="zeebe",node="localhost:51015",partition="0",topic="internal-system"} 4192 1522124395234
+zb_storage_fs_total_bytes{cluster="zeebe",node="localhost:26500",partition="0",topic="internal-system"} 4192 1522124395234
 ```
 
-The record above descibes that the total size on bytes of partition `0` of topic `internal-system` on node `localhost:51015` in cluster `zeebe` is `4192`. The last number is a unix epoch timestamp.
+The record above descibes that the total size on bytes of partition `0` of topic `internal-system` on node `localhost:26500` in cluster `zeebe` is `4192`. The last number is a unix epoch timestamp.
 
 ## Configuring Metrics
 

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/brokerapi/StubBrokerRule.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/brokerapi/StubBrokerRule.java
@@ -67,7 +67,7 @@ public class StubBrokerRule extends ExternalResource {
   protected AtomicReference<Topology> currentTopology = new AtomicReference<>();
 
   public StubBrokerRule() {
-    this("127.0.0.1", 51015);
+    this("127.0.0.1", 26501);
   }
 
   public StubBrokerRule(String host, int port) {

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/ClientApiRule.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/ClientApiRule.java
@@ -56,7 +56,7 @@ public class ClientApiRule extends ExternalResource {
   }
 
   public ClientApiRule(boolean usesDefaultTopic) {
-    this("localhost", 51015, usesDefaultTopic);
+    this("localhost", 26501, usesDefaultTopic);
   }
 
   public ClientApiRule(String host, int port, boolean usesDefaultTopic) {

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/managementApi/ManagementApiRule.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/managementApi/ManagementApiRule.java
@@ -39,7 +39,7 @@ public class ManagementApiRule extends ExternalResource {
   private ActorScheduler scheduler;
 
   public ManagementApiRule() {
-    this("localhost", 51016);
+    this("localhost", 26502);
   }
 
   public ManagementApiRule(String host, int port) {

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -53,16 +53,16 @@ public class ClusteringRule extends ExternalResource {
   public static final int SYSTEM_TOPIC_REPLICATION_FACTOR = 3;
 
   public static final String BROKER_1_TOML = "zeebe.cluster.1.cfg.toml";
-  public static final SocketAddress BROKER_1_CLIENT_ADDRESS = new SocketAddress("0.0.0.0", 51015);
+  public static final SocketAddress BROKER_1_CLIENT_ADDRESS = new SocketAddress("0.0.0.0", 26501);
 
   public static final String BROKER_2_TOML = "zeebe.cluster.2.cfg.toml";
-  public static final SocketAddress BROKER_2_CLIENT_ADDRESS = new SocketAddress("0.0.0.0", 41015);
+  public static final SocketAddress BROKER_2_CLIENT_ADDRESS = new SocketAddress("0.0.0.0", 26511);
 
   public static final String BROKER_3_TOML = "zeebe.cluster.3.cfg.toml";
-  public static final SocketAddress BROKER_3_CLIENT_ADDRESS = new SocketAddress("0.0.0.0", 31015);
+  public static final SocketAddress BROKER_3_CLIENT_ADDRESS = new SocketAddress("0.0.0.0", 26521);
 
   public static final String BROKER_4_TOML = "zeebe.cluster.4.cfg.toml";
-  public static final SocketAddress BROKER_4_CLIENT_ADDRESS = new SocketAddress("0.0.0.0", 21015);
+  public static final SocketAddress BROKER_4_CLIENT_ADDRESS = new SocketAddress("0.0.0.0", 26531);
 
   private SocketAddress[] brokerAddresses =
       new SocketAddress[] {

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerReprocessingTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerReprocessingTest.java
@@ -526,7 +526,7 @@ public class BrokerReprocessingTest {
     assertThat(raftAfterRestart.getState()).isEqualTo(RaftState.LEADER);
     assertThat(raftAfterRestart.getTerm()).isGreaterThanOrEqualTo(9);
     assertThat(raftAfterRestart.getMemberSize()).isEqualTo(0);
-    assertThat(raftAfterRestart.getVotedFor()).isEqualTo(new SocketAddress("0.0.0.0", 51017));
+    assertThat(raftAfterRestart.getVotedFor()).isEqualTo(new SocketAddress("0.0.0.0", 26503));
   }
 
   @Test

--- a/qa/integration-tests/src/test/resources/zeebe.cluster.1.cfg.toml
+++ b/qa/integration-tests/src/test/resources/zeebe.cluster.1.cfg.toml
@@ -2,17 +2,5 @@
 
 bootstrap = 3
 
-[network.client]
-port = 51015
-
-[network.management]
-port = 51016
-
-[network.replication]
-port = 51017
-
-[network.subscription]
-port = 51018
-
 [cluster]
 initialContactPoints = []

--- a/qa/integration-tests/src/test/resources/zeebe.cluster.2.cfg.toml
+++ b/qa/integration-tests/src/test/resources/zeebe.cluster.2.cfg.toml
@@ -1,16 +1,7 @@
 # Broker 2
 
-[network.client]
-port = 41015
-
-[network.management]
-port = 41016
-
-[network.replication]
-port = 41017
-
-[network.subscription]
-port = 41018
+[network]
+portOffset = 1
 
 [cluster]
-initialContactPoints = [ "localhost:51016" ]
+initialContactPoints = [ "localhost:26502" ]

--- a/qa/integration-tests/src/test/resources/zeebe.cluster.3.cfg.toml
+++ b/qa/integration-tests/src/test/resources/zeebe.cluster.3.cfg.toml
@@ -1,16 +1,7 @@
 # Broker 3
 
-[network.client]
-port = 31015
-
-[network.management]
-port = 31016
-
-[network.replication]
-port = 31017
-
-[network.subscription]
-port = 31018
+[network]
+portOffset = 2
 
 [cluster]
-initialContactPoints = [ "localhost:51016" ]
+initialContactPoints = [ "localhost:26502" ]

--- a/qa/integration-tests/src/test/resources/zeebe.cluster.4.cfg.toml
+++ b/qa/integration-tests/src/test/resources/zeebe.cluster.4.cfg.toml
@@ -1,16 +1,7 @@
 # Broker 4
 
-[network.client]
-port = 21015
-
-[network.management]
-port = 21016
-
-[network.replication]
-port = 21017
-
-[network.subscription]
-port = 21018
+[network]
+portOffset = 3
 
 [cluster]
-initialContactPoints = [ "localhost:41016" ]
+initialContactPoints = [ "localhost:26512" ]

--- a/qa/integration-tests/src/test/resources/zeebe.cluster.defaultTopics.1.cfg.toml
+++ b/qa/integration-tests/src/test/resources/zeebe.cluster.defaultTopics.1.cfg.toml
@@ -8,17 +8,5 @@ name = "default-topic-1"
 partitions = 2
 replicationFactor = 2
 
-[network.client]
-port = 51015
-
-[network.management]
-port = 51016
-
-[network.replication]
-port = 51017
-
-[network.subscription]
-port = 51018
-
 [cluster]
 initialContactPoints = []

--- a/qa/integration-tests/src/test/resources/zeebe.cluster.defaultTopics.2.cfg.toml
+++ b/qa/integration-tests/src/test/resources/zeebe.cluster.defaultTopics.2.cfg.toml
@@ -7,17 +7,8 @@ name = "default-topic-2"
 partitions = 1
 replicationFactor = 1
 
-[network.client]
-port = 41015
-
-[network.management]
-port = 41016
-
-[network.replication]
-port = 41017
-
-[network.subscription]
-port = 41018
+[network]
+portOffset = 1
 
 [cluster]
-initialContactPoints = [ "localhost:51016" ]
+initialContactPoints = [ "localhost:26502" ]

--- a/qa/integration-tests/src/test/resources/zeebe.cluster.moreDefaultTopics.cfg.toml
+++ b/qa/integration-tests/src/test/resources/zeebe.cluster.moreDefaultTopics.cfg.toml
@@ -23,17 +23,5 @@ name = "thisTopic"
 partitions = 4
 replicationFactor = 1
 
-[network.client]
-port = 51015
-
-[network.management]
-port = 51016
-
-[network.replication]
-port = 51017
-
-[network.subscription]
-port = 51018
-
 [cluster]
 initialContactPoints = []

--- a/qa/integration-tests/src/test/resources/zeebe.cluster.snapshotReplication.1.cfg.toml
+++ b/qa/integration-tests/src/test/resources/zeebe.cluster.snapshotReplication.1.cfg.toml
@@ -3,18 +3,6 @@
 
 bootstrap = 3
 
-[network.client]
-port = 51015
-
-[network.management]
-port = 51016
-
-[network.replication]
-port = 51017
-
-[network.subscription]
-port = 51018
-
 [data]
 snapshotPeriod = "15m"
 snapshotReplicationPeriod = "5ms"

--- a/qa/integration-tests/src/test/resources/zeebe.cluster.snapshotReplication.2.cfg.toml
+++ b/qa/integration-tests/src/test/resources/zeebe.cluster.snapshotReplication.2.cfg.toml
@@ -1,20 +1,11 @@
 # Broker 2
 
-[network.client]
-port = 41015
-
-[network.management]
-port = 41016
-
-[network.replication]
-port = 41017
-
-[network.subscription]
-port = 41018
+[network]
+portOffset = 1
 
 [data]
 snapshotPeriod = "15m"
 snapshotReplicationPeriod = "5ms"
 
 [cluster]
-initialContactPoints = [ "localhost:51016" ]
+initialContactPoints = [ "localhost:26502" ]

--- a/qa/integration-tests/src/test/resources/zeebe.cluster.snapshotReplication.3.cfg.toml
+++ b/qa/integration-tests/src/test/resources/zeebe.cluster.snapshotReplication.3.cfg.toml
@@ -1,20 +1,11 @@
 # Broker 3
 
-[network.client]
-port = 31015
-
-[network.management]
-port = 31016
-
-[network.replication]
-port = 31017
-
-[network.subscription]
-port = 31018
+[network]
+portOffset = 2
 
 [data]
 snapshotPeriod = "15m"
 snapshotReplicationPeriod = "5ms"
 
 [cluster]
-initialContactPoints = [ "localhost:51016" ]
+initialContactPoints = [ "localhost:26502" ]

--- a/samples/src/main/java/io/zeebe/example/cluster/TopologyViewer.java
+++ b/samples/src/main/java/io/zeebe/example/cluster/TopologyViewer.java
@@ -22,7 +22,7 @@ import io.zeebe.broker.client.api.commands.Topology;
 public class TopologyViewer {
 
   public static void main(final String[] args) {
-    final String broker = "127.0.0.1:51015";
+    final String broker = "127.0.0.1:26501";
 
     final ZeebeClientBuilder builder = ZeebeClient.newClientBuilder().brokerContactPoint(broker);
 

--- a/samples/src/main/java/io/zeebe/example/data/HandlePayloadAsPojo.java
+++ b/samples/src/main/java/io/zeebe/example/data/HandlePayloadAsPojo.java
@@ -25,7 +25,7 @@ import java.util.Scanner;
 
 public class HandlePayloadAsPojo {
   public static void main(String[] args) {
-    final String broker = "127.0.0.1:51015";
+    final String broker = "127.0.0.1:26501";
     final String topic = "default-topic";
 
     final ZeebeClientBuilder builder = ZeebeClient.newClientBuilder().brokerContactPoint(broker);

--- a/samples/src/main/java/io/zeebe/example/job/JobWorkerCreator.java
+++ b/samples/src/main/java/io/zeebe/example/job/JobWorkerCreator.java
@@ -26,7 +26,7 @@ import java.util.Scanner;
 
 public class JobWorkerCreator {
   public static void main(String[] args) {
-    final String broker = "127.0.0.1:51015";
+    final String broker = "127.0.0.1:26501";
     final String topic = "default-topic";
 
     final String jobType = "foo";

--- a/samples/src/main/java/io/zeebe/example/topic/TopicCreator.java
+++ b/samples/src/main/java/io/zeebe/example/topic/TopicCreator.java
@@ -22,7 +22,7 @@ import io.zeebe.broker.client.api.events.TopicEvent;
 public class TopicCreator {
 
   public static void main(final String[] args) {
-    final String broker = "localhost:51015";
+    final String broker = "localhost:26501";
     final String topic = "test";
     final int partitions = 1;
     final int replicationFactor = 1;

--- a/samples/src/main/java/io/zeebe/example/topic/TopicSubscriber.java
+++ b/samples/src/main/java/io/zeebe/example/topic/TopicSubscriber.java
@@ -25,7 +25,7 @@ import java.util.Scanner;
 public class TopicSubscriber {
 
   public static void main(String[] args) {
-    final String broker = "127.0.0.1:51015";
+    final String broker = "127.0.0.1:26501";
     final String topic = "default-topic";
 
     final ZeebeClientBuilder builder = ZeebeClient.newClientBuilder().brokerContactPoint(broker);

--- a/samples/src/main/java/io/zeebe/example/workflow/DeploymentViewer.java
+++ b/samples/src/main/java/io/zeebe/example/workflow/DeploymentViewer.java
@@ -25,7 +25,7 @@ public class DeploymentViewer {
 
   public static void main(final String[] args) {
 
-    final String broker = "localhost:51015";
+    final String broker = "localhost:26501";
 
     final ZeebeClientBuilder clientBuilder =
         ZeebeClient.newClientBuilder().brokerContactPoint(broker);

--- a/samples/src/main/java/io/zeebe/example/workflow/NonBlockingWorkflowInstanceCreator.java
+++ b/samples/src/main/java/io/zeebe/example/workflow/NonBlockingWorkflowInstanceCreator.java
@@ -23,7 +23,7 @@ import io.zeebe.broker.client.api.events.WorkflowInstanceEvent;
 
 public class NonBlockingWorkflowInstanceCreator {
   public static void main(String[] args) {
-    final String broker = "127.0.0.1:51015";
+    final String broker = "127.0.0.1:26501";
     final String topic = "default-topic";
     final int numberOfInstances = 100_000;
     final String bpmnProcessId = "demoProcess";

--- a/samples/src/main/java/io/zeebe/example/workflow/WorkflowDeployer.java
+++ b/samples/src/main/java/io/zeebe/example/workflow/WorkflowDeployer.java
@@ -23,7 +23,7 @@ import io.zeebe.broker.client.api.events.DeploymentEvent;
 public class WorkflowDeployer {
 
   public static void main(String[] args) {
-    final String broker = "localhost:51015";
+    final String broker = "localhost:26501";
     final String topic = "default-topic";
 
     final ZeebeClientBuilder clientBuilder =

--- a/samples/src/main/java/io/zeebe/example/workflow/WorkflowInstanceCreator.java
+++ b/samples/src/main/java/io/zeebe/example/workflow/WorkflowInstanceCreator.java
@@ -23,7 +23,7 @@ import io.zeebe.broker.client.api.events.WorkflowInstanceEvent;
 public class WorkflowInstanceCreator {
 
   public static void main(String[] args) {
-    final String broker = "127.0.0.1:51015";
+    final String broker = "127.0.0.1:26501";
     final String topic = "default-topic";
 
     final String bpmnProcessId = "demoProcess";


### PR DESCRIPTION
 * changed 51015 to 26501: Broker Client API
 * changed 51016 to 26502: Management API
 * changed 51017 to 26503: Replication API
 * changed 51018 to 26504: Subscription API

 also ports which started with 41*, 31*, etc are use now the port offset
 (+10 to the default port)

 closes zeebe-io/zeebe#1074
