### PR TITLE
ci(surefire):  rerun flaky tests up to 3 times before failing the build

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -256,6 +256,7 @@
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            <rerunFailingTestsCount>3</rerunFailingTestsCount>
             <properties>
               <property>
                 <name>listener</name>


### PR DESCRIPTION
The test suite has some flaky tests which reduces the value of the CI as the developer has to analyse the build log and decide whether a failed test is a real problem or flaky test. To reduce this we will now rerun failing tests up to 3 times before failing the build.

closes #1138 
