### PR TITLE
Run maven module tests ins parallel on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
                 stage('Tests') {
                     steps {
                         withMaven(jdk: jdkVersion, maven: mavenVersion, mavenSettingsConfig: mavenSettingsConfig) {
-                            sh 'mvn -B -T 1C verify -P skip-unstable-ci'
+                            sh 'mvn -B -T 2 verify -P skip-unstable-ci'
                         }
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,7 @@ pipeline {
         }
 
         stage('Verify') {
+            failFast true
             parallel {
                 stage('Tests') {
                     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
                 stage('Tests') {
                     steps {
                         withMaven(jdk: jdkVersion, maven: mavenVersion, mavenSettingsConfig: mavenSettingsConfig) {
-                            sh 'mvn -B verify -P skip-unstable-ci'
+                            sh 'mvn -B -T 1C verify -P skip-unstable-ci'
                         }
                     }
                     post {

--- a/gossip/src/test/java/io/zeebe/gossip/CustomEventTest.java
+++ b/gossip/src/test/java/io/zeebe/gossip/CustomEventTest.java
@@ -43,9 +43,9 @@ public class CustomEventTest {
 
   private static final GossipConfiguration CONFIGURATION = new GossipConfiguration();
 
-  private GossipRule gossip1 = new GossipRule("localhost:8001");
-  private GossipRule gossip2 = new GossipRule("localhost:8002");
-  private GossipRule gossip3 = new GossipRule("localhost:8003");
+  private GossipRule gossip1 = new GossipRule(1);
+  private GossipRule gossip2 = new GossipRule(2);
+  private GossipRule gossip3 = new GossipRule(3);
 
   @Rule
   public GossipClusterRule cluster =

--- a/gossip/src/test/java/io/zeebe/gossip/GossipFailureDetectionTest.java
+++ b/gossip/src/test/java/io/zeebe/gossip/GossipFailureDetectionTest.java
@@ -31,9 +31,9 @@ public class GossipFailureDetectionTest {
   private static final GossipConfiguration CONFIGURATION =
       new GossipConfiguration().setSuspicionMultiplier(10);
 
-  private GossipRule gossip1 = new GossipRule("localhost:8001");
-  private GossipRule gossip2 = new GossipRule("localhost:8002");
-  private GossipRule gossip3 = new GossipRule("localhost:8003");
+  private GossipRule gossip1 = new GossipRule(1);
+  private GossipRule gossip2 = new GossipRule(2);
+  private GossipRule gossip3 = new GossipRule(3);
 
   @Rule
   public GossipClusterRule cluster =

--- a/gossip/src/test/java/io/zeebe/gossip/GossipJoinTest.java
+++ b/gossip/src/test/java/io/zeebe/gossip/GossipJoinTest.java
@@ -30,9 +30,9 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 public class GossipJoinTest {
-  private GossipRule gossip1 = new GossipRule("localhost:8001");
-  private GossipRule gossip2 = new GossipRule("localhost:8002");
-  private GossipRule gossip3 = new GossipRule("localhost:8003");
+  private GossipRule gossip1 = new GossipRule(1);
+  private GossipRule gossip2 = new GossipRule(2);
+  private GossipRule gossip3 = new GossipRule(3);
 
   @Rule public GossipClusterRule cluster = new GossipClusterRule(gossip1, gossip2, gossip3);
 

--- a/gossip/src/test/java/io/zeebe/gossip/GossipLeaveTest.java
+++ b/gossip/src/test/java/io/zeebe/gossip/GossipLeaveTest.java
@@ -27,9 +27,9 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 public class GossipLeaveTest {
-  private GossipRule gossip1 = new GossipRule("localhost:8001");
-  private GossipRule gossip2 = new GossipRule("localhost:8002");
-  private GossipRule gossip3 = new GossipRule("localhost:8003");
+  private GossipRule gossip1 = new GossipRule(1);
+  private GossipRule gossip2 = new GossipRule(2);
+  private GossipRule gossip3 = new GossipRule(3);
 
   @Rule public GossipClusterRule cluster = new GossipClusterRule(gossip1, gossip2, gossip3);
 

--- a/gossip/src/test/java/io/zeebe/gossip/SyncRequestHandlerTest.java
+++ b/gossip/src/test/java/io/zeebe/gossip/SyncRequestHandlerTest.java
@@ -42,9 +42,9 @@ public class SyncRequestHandlerTest {
 
   private static final GossipConfiguration CONFIGURATION = new GossipConfiguration();
 
-  private GossipRule gossip1 = new GossipRule("localhost:8001");
-  private GossipRule gossip2 = new GossipRule("localhost:8002");
-  private GossipRule gossip3 = new GossipRule("localhost:8003");
+  private GossipRule gossip1 = new GossipRule(1);
+  private GossipRule gossip2 = new GossipRule(2);
+  private GossipRule gossip3 = new GossipRule(3);
 
   @Rule
   public GossipClusterRule cluster =

--- a/gossip/src/test/java/io/zeebe/gossip/util/GossipRule.java
+++ b/gossip/src/test/java/io/zeebe/gossip/util/GossipRule.java
@@ -71,6 +71,10 @@ import org.junit.rules.ExternalResource;
 import org.mockito.ArgumentMatcher;
 
 public class GossipRule extends ExternalResource {
+
+  public static final String DEFAULT_HOST = "localhost";
+  public static final int DEFAULT_PORT = 8000;
+
   private final SocketAddress socketAddress;
   private final String memberId;
 
@@ -89,9 +93,17 @@ public class GossipRule extends ExternalResource {
   private LocalMembershipListener localMembershipListener;
   private ReceivedEventsCollector receivedEventsCollector = new ReceivedEventsCollector();
 
-  public GossipRule(final String address) {
-    this.socketAddress = SocketAddress.from(address);
-    this.memberId = address;
+  public GossipRule(final int portOffset) {
+    this(DEFAULT_HOST, DEFAULT_PORT + portOffset);
+  }
+
+  public GossipRule(final String host, final int port) {
+    this(new SocketAddress(host, port));
+  }
+
+  public GossipRule(final SocketAddress socketAddress) {
+    this.socketAddress = socketAddress;
+    this.memberId = socketAddress.toString();
   }
 
   public void init(ActorScheduler actorScheduler, GossipConfiguration configuration) {

--- a/raft/src/test/java/io/zeebe/raft/RaftFiveNodesTest.java
+++ b/raft/src/test/java/io/zeebe/raft/RaftFiveNodesTest.java
@@ -31,15 +31,11 @@ public class RaftFiveNodesTest {
   public ActorSchedulerRule actorScheduler = new ActorSchedulerRule();
   public ServiceContainerRule serviceContainerRule = new ServiceContainerRule(actorScheduler);
 
-  public RaftRule raft1 = new RaftRule(serviceContainerRule, "localhost", 8001, "default", 0);
-  public RaftRule raft2 =
-      new RaftRule(serviceContainerRule, "localhost", 8002, "default", 0, raft1);
-  public RaftRule raft3 =
-      new RaftRule(serviceContainerRule, "localhost", 8003, "default", 0, raft2);
-  public RaftRule raft4 =
-      new RaftRule(serviceContainerRule, "localhost", 8004, "default", 0, raft2, raft3);
-  public RaftRule raft5 =
-      new RaftRule(serviceContainerRule, "localhost", 8005, "default", 0, raft3);
+  public RaftRule raft1 = new RaftRule(serviceContainerRule, 1, "default", 0);
+  public RaftRule raft2 = new RaftRule(serviceContainerRule, 2, "default", 0, raft1);
+  public RaftRule raft3 = new RaftRule(serviceContainerRule, 3, "default", 0, raft2);
+  public RaftRule raft4 = new RaftRule(serviceContainerRule, 4, "default", 0, raft2, raft3);
+  public RaftRule raft5 = new RaftRule(serviceContainerRule, 5, "default", 0, raft3);
 
   @Rule
   public RaftClusterRule cluster =

--- a/raft/src/test/java/io/zeebe/raft/RaftJoinServiceTest.java
+++ b/raft/src/test/java/io/zeebe/raft/RaftJoinServiceTest.java
@@ -29,9 +29,8 @@ public class RaftJoinServiceTest {
   public ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
   public ServiceContainerRule serviceContainerRule = new ServiceContainerRule(actorSchedulerRule);
 
-  public RaftRule raft1 = new RaftRule(serviceContainerRule, "localhost", 8001, "default", 0);
-  public RaftRule raft2 =
-      new RaftRule(serviceContainerRule, "localhost", 8002, "default", 0, raft1);
+  public RaftRule raft1 = new RaftRule(serviceContainerRule, 1, "default", 0);
+  public RaftRule raft2 = new RaftRule(serviceContainerRule, 2, "default", 0, raft1);
 
   // Do not add raft 1 to cluster rule so raft 2 is never able to join
   @Rule

--- a/raft/src/test/java/io/zeebe/raft/RaftPersistentStorageTest.java
+++ b/raft/src/test/java/io/zeebe/raft/RaftPersistentStorageTest.java
@@ -29,8 +29,8 @@ public class RaftPersistentStorageTest {
   public ActorSchedulerRule actorScheduler = new ActorSchedulerRule();
   public ServiceContainerRule serviceContainer = new ServiceContainerRule(actorScheduler);
 
-  public RaftRule raft1 = new RaftRule(serviceContainer, "localhost", 8001, "default", 0);
-  public RaftRule raft2 = new RaftRule(serviceContainer, "localhost", 8002, "default", 0, raft1);
+  public RaftRule raft1 = new RaftRule(serviceContainer, 1, "default", 0);
+  public RaftRule raft2 = new RaftRule(serviceContainer, 2, "default", 0, raft1);
 
   @Rule
   public RaftClusterRule cluster =

--- a/raft/src/test/java/io/zeebe/raft/RaftSingleNodeTest.java
+++ b/raft/src/test/java/io/zeebe/raft/RaftSingleNodeTest.java
@@ -32,7 +32,7 @@ public class RaftSingleNodeTest {
 
   public ServiceContainerRule serviceContainer = new ServiceContainerRule(actorScheduler);
 
-  public RaftRule raft1 = new RaftRule(serviceContainer, "localhost", 8001, "default", 0);
+  public RaftRule raft1 = new RaftRule(serviceContainer, 1, "default", 0);
 
   @Rule
   public RaftClusterRule cluster = new RaftClusterRule(actorScheduler, serviceContainer, raft1);

--- a/raft/src/test/java/io/zeebe/raft/RaftThreeNodesTest.java
+++ b/raft/src/test/java/io/zeebe/raft/RaftThreeNodesTest.java
@@ -32,9 +32,9 @@ public class RaftThreeNodesTest {
   public ActorSchedulerRule actorScheduler = new ActorSchedulerRule();
   public ServiceContainerRule serviceContainer = new ServiceContainerRule(actorScheduler);
 
-  public RaftRule raft1 = new RaftRule(serviceContainer, "localhost", 8001, "default", 0);
-  public RaftRule raft2 = new RaftRule(serviceContainer, "localhost", 8002, "default", 0, raft1);
-  public RaftRule raft3 = new RaftRule(serviceContainer, "localhost", 8003, "default", 0, raft1);
+  public RaftRule raft1 = new RaftRule(serviceContainer, 1, "default", 0);
+  public RaftRule raft2 = new RaftRule(serviceContainer, 2, "default", 0, raft1);
+  public RaftRule raft3 = new RaftRule(serviceContainer, 3, "default", 0, raft1);
 
   @Rule
   public RaftClusterRule cluster =

--- a/raft/src/test/java/io/zeebe/raft/RaftTwoNodesTest.java
+++ b/raft/src/test/java/io/zeebe/raft/RaftTwoNodesTest.java
@@ -31,9 +31,8 @@ public class RaftTwoNodesTest {
   public ActorSchedulerRule actorScheduler = new ActorSchedulerRule();
   public ServiceContainerRule serviceContainerRule = new ServiceContainerRule(actorScheduler);
 
-  public RaftRule raft1 = new RaftRule(serviceContainerRule, "localhost", 8001, "default", 0);
-  public RaftRule raft2 =
-      new RaftRule(serviceContainerRule, "localhost", 8002, "default", 0, raft1);
+  public RaftRule raft1 = new RaftRule(serviceContainerRule, 1, "default", 0);
+  public RaftRule raft2 = new RaftRule(serviceContainerRule, 2, "default", 0, raft1);
 
   @Rule
   public RaftClusterRule cluster =

--- a/raft/src/test/java/io/zeebe/raft/protocol/RaftProtocolMessageTest.java
+++ b/raft/src/test/java/io/zeebe/raft/protocol/RaftProtocolMessageTest.java
@@ -37,9 +37,8 @@ public class RaftProtocolMessageTest {
   public static ActorSchedulerRule actorScheduler = new ActorSchedulerRule();
   public static ServiceContainerRule serviceContainer = new ServiceContainerRule(actorScheduler);
 
-  public static RaftRule raft1 = new RaftRule(serviceContainer, "localhost", 8001, "test", 123);
-  public static RaftRule raft2 =
-      new RaftRule(serviceContainer, "localhost", 8002, "test", 123, raft1);
+  public static RaftRule raft1 = new RaftRule(serviceContainer, 1, "test", 123);
+  public static RaftRule raft2 = new RaftRule(serviceContainer, 2, "test", 123, raft1);
 
   @ClassRule
   public static RaftClusterRule cluster =

--- a/raft/src/test/java/io/zeebe/raft/util/RaftRule.java
+++ b/raft/src/test/java/io/zeebe/raft/util/RaftRule.java
@@ -83,6 +83,10 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 public class RaftRule extends ExternalResource implements RaftStateListener {
+
+  public static final String DEFAULT_HOST = "localhost";
+  public static final int DEFAULT_PORT = 9000;
+
   public static final FragmentHandler NOOP_FRAGMENT_HANDLER =
       (buffer, offset, length, streamId, isMarkedFailed) -> FragmentHandler.CONSUME_FRAGMENT_RESULT;
 
@@ -113,6 +117,21 @@ public class RaftRule extends ExternalResource implements RaftStateListener {
   protected final List<RaftState> raftStateChanges = new ArrayList<>();
   protected Set<Integer> interrupedStreams = Collections.synchronizedSet(new HashSet<>());
   private ServiceName<Raft> raftServiceName;
+
+  public RaftRule(
+      final ServiceContainerRule serviceContainerRule,
+      final int portOffset,
+      final String topicName,
+      final int partition,
+      final RaftRule... members) {
+    this(
+        serviceContainerRule,
+        DEFAULT_HOST,
+        DEFAULT_PORT + portOffset,
+        topicName,
+        partition,
+        members);
+  }
 
   public RaftRule(
       final ServiceContainerRule serviceContainerRule,

--- a/test/src/test/java/io/zeebe/test/WorkflowTest.java
+++ b/test/src/test/java/io/zeebe/test/WorkflowTest.java
@@ -15,14 +15,29 @@
  */
 package io.zeebe.test;
 
+import static io.zeebe.test.EmbeddedBrokerRule.DEFAULT_CONFIG_SUPPLIER;
+
+import io.zeebe.broker.client.ClientProperties;
 import io.zeebe.broker.client.ZeebeClient;
 import io.zeebe.broker.client.api.events.WorkflowInstanceEvent;
+import io.zeebe.broker.system.configuration.SocketBindingClientApiCfg;
+import java.util.Properties;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class WorkflowTest {
-  @Rule public final ZeebeTestRule testRule = new ZeebeTestRule();
+  @Rule
+  public final ZeebeTestRule testRule =
+      new ZeebeTestRule(
+          DEFAULT_CONFIG_SUPPLIER,
+          () -> {
+            final Properties properties = new Properties();
+            properties.setProperty(
+                ClientProperties.BROKER_CONTACTPOINT,
+                "localhost:" + (SocketBindingClientApiCfg.DEFAULT_PORT + 200));
+            return properties;
+          });
 
   private ZeebeClient client;
   private String topic;

--- a/test/src/test/resources/zeebe.default.cfg.toml
+++ b/test/src/test/resources/zeebe.default.cfg.toml
@@ -1,3 +1,6 @@
 # Default configuration for integration tests 
 
 bootstrap = 1
+
+[network]
+portOffset = 20


### PR DESCRIPTION
This will run the test phase on Jenkins with 2 threads for maven module builds. It adjusts all maven modules which can be run in parallel, i.e. raft vs gossip and IT vs zeebe-test, to use different ports.

There is no real time gain here as the JMH tests takes longer then the test suite. The gain on the test suite is around 4min based on latest Jenkins runs without additional load, i.e. other parallel builds. And there are some disadvantages and possible pit falls. First the Jenkins log becomes even more unreadable as now maven module outputs interfere. Secondly more critical this can lead to an over subscription on threads vs cores if multiple Jenkins builds run on the same machine. Currently the CI machines have 4 cores and if two modules already spawn 2 actor schedulers the machine is saturated.

I'm personally not sure if we should merge this.

closes #943 
