### PR TITLE
ci(jenkins): only run JMH on develop and master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
 
         stage('Verify') {
             parallel {
-                stage('Tests') {
+                stage('1 - Java Tests') {
                     steps {
                         withMaven(jdk: jdkVersion, maven: mavenVersion, mavenSettingsConfig: mavenSettingsConfig) {
                             sh 'mvn -B verify -P skip-unstable-ci'
@@ -42,7 +42,9 @@ pipeline {
                     }
                 }
 
-                stage('JMH') {
+                stage('2 - JMH') {
+                    // delete this line to also run JMH on feature branch
+                    when { anyOf { branch 'master'; branch 'develop' } }
                     agent { node { label 'ubuntu-large' } }
 
                     steps {


### PR DESCRIPTION
- reduces test duration of feature branches
- reduces bors merge duration
- show performance impact of PRs and Releases on the respective branches
- number parallel stages to enforce ordering in Blue Ocean view
- **note**: skipping a parallel stage in Blue Ocean triggers a bug where
  log will not be show until the stage finished https://issues.jenkins-ci.org/browse/JENKINS-48879

closes #1143
