### PR TITLE
feat(bpmn-model): validate supported elements and event definitions

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/EndEventValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/EndEventValidator.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.validation.zeebe;
+
+import io.zeebe.model.bpmn.instance.EndEvent;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class EndEventValidator implements ModelElementValidator<EndEvent> {
+
+  @Override
+  public Class<EndEvent> getElementType() {
+    return EndEvent.class;
+  }
+
+  @Override
+  public void validate(EndEvent element, ValidationResultCollector validationResultCollector) {
+    if (!element.getEventDefinitions().isEmpty()) {
+      validationResultCollector.addError(0, "Must be a none end event");
+    }
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.validation.zeebe;
+
+import io.zeebe.model.bpmn.instance.EventDefinition;
+import io.zeebe.model.bpmn.instance.MessageEventDefinition;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class EventDefinitionValidator implements ModelElementValidator<EventDefinition> {
+
+  @Override
+  public Class<EventDefinition> getElementType() {
+    return EventDefinition.class;
+  }
+
+  @Override
+  public void validate(
+      EventDefinition element, ValidationResultCollector validationResultCollector) {
+    if (!(element instanceof MessageEventDefinition)) {
+      validationResultCollector.addError(0, "Event definition of this type is not supported");
+    }
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.validation.zeebe;
+
+import io.zeebe.model.bpmn.instance.EndEvent;
+import io.zeebe.model.bpmn.instance.ExclusiveGateway;
+import io.zeebe.model.bpmn.instance.FlowElement;
+import io.zeebe.model.bpmn.instance.IntermediateCatchEvent;
+import io.zeebe.model.bpmn.instance.ReceiveTask;
+import io.zeebe.model.bpmn.instance.SequenceFlow;
+import io.zeebe.model.bpmn.instance.ServiceTask;
+import io.zeebe.model.bpmn.instance.StartEvent;
+import io.zeebe.model.bpmn.instance.SubProcess;
+import java.util.HashSet;
+import java.util.Set;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class FlowElementValidator implements ModelElementValidator<FlowElement> {
+
+  private static final Set<Class<?>> SUPPORTED_ELEMENT_TYPES = new HashSet<>();
+
+  static {
+    SUPPORTED_ELEMENT_TYPES.add(EndEvent.class);
+    SUPPORTED_ELEMENT_TYPES.add(ExclusiveGateway.class);
+    SUPPORTED_ELEMENT_TYPES.add(IntermediateCatchEvent.class);
+    SUPPORTED_ELEMENT_TYPES.add(ReceiveTask.class);
+    SUPPORTED_ELEMENT_TYPES.add(SequenceFlow.class);
+    SUPPORTED_ELEMENT_TYPES.add(ServiceTask.class);
+    SUPPORTED_ELEMENT_TYPES.add(StartEvent.class);
+    SUPPORTED_ELEMENT_TYPES.add(SubProcess.class);
+  }
+
+  @Override
+  public Class<FlowElement> getElementType() {
+    return FlowElement.class;
+  }
+
+  @Override
+  public void validate(FlowElement element, ValidationResultCollector validationResultCollector) {
+    final Class<?> elementType = element.getElementType().getInstanceType();
+
+    if (!SUPPORTED_ELEMENT_TYPES.contains(elementType)) {
+      validationResultCollector.addError(0, "Elements of this type are not supported");
+    }
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/StartEventValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/StartEventValidator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.validation.zeebe;
+
+import io.zeebe.model.bpmn.instance.StartEvent;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class StartEventValidator implements ModelElementValidator<StartEvent> {
+  @Override
+  public Class<StartEvent> getElementType() {
+    return StartEvent.class;
+  }
+
+  @Override
+  public void validate(StartEvent element, ValidationResultCollector validationResultCollector) {
+    if (!element.getEventDefinitions().isEmpty()) {
+      validationResultCollector.addError(0, "Must be a none start event");
+    }
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -25,14 +25,18 @@ public class ZeebeDesignTimeValidators {
 
   static {
     VALIDATORS = new ArrayList<>();
+    VALIDATORS.add(new DefinitionsValidator());
+    VALIDATORS.add(new EndEventValidator());
+    VALIDATORS.add(new EventDefinitionValidator());
+    VALIDATORS.add(new ExclusiveGatewayValidator());
+    VALIDATORS.add(new FlowElementValidator());
+    VALIDATORS.add(new MessageValidator());
     VALIDATORS.add(new ProcessValidator());
     VALIDATORS.add(new ServiceTaskValidator());
+    VALIDATORS.add(new SequenceFlowValidator());
+    VALIDATORS.add(new StartEventValidator());
     VALIDATORS.add(new ZeebeTaskDefinitionValidator());
     VALIDATORS.add(new ZeebeIoMappingValidator());
-    VALIDATORS.add(new ExclusiveGatewayValidator());
-    VALIDATORS.add(new SequenceFlowValidator());
-    VALIDATORS.add(new MessageValidator());
     VALIDATORS.add(new ZeebeSubscriptionValidator());
-    VALIDATORS.add(new DefinitionsValidator());
   }
 }


### PR DESCRIPTION
- includes sub process already for #1118

closes #1127
