### PR TITLE
Move surefire retries to profile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
                 stage('1 - Java Tests') {
                     steps {
                         withMaven(jdk: jdkVersion, maven: mavenVersion, mavenSettingsConfig: mavenSettingsConfig) {
-                            sh 'mvn -B -T 2 verify -P skip-unstable-ci'
+                            sh 'mvn -B -T 2 verify -P skip-unstable-ci,retry-tests'
                         }
                     }
                     post {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -295,7 +295,6 @@
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
-            <rerunFailingTestsCount>3</rerunFailingTestsCount>
             <properties>
               <property>
                 <name>listener</name>
@@ -553,6 +552,20 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <excludedGroups>io.zeebe.UnstableCI</excludedGroups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>retry-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <rerunFailingTestsCount>3</rerunFailingTestsCount>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
- default surefire will not retry failed tests
- retries can be enabled using the profile retry-tests
- Jenkins uses the profile to retry flaky tests automatically


closes #1167
