### PR TITLE
Exporter user API

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -161,6 +161,12 @@
         <artifactId>zeebe-gateway</artifactId>
         <version>${project.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>io.zeebe</groupId>
+        <artifactId>zb-exporter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/exporter/pom.xml
+++ b/exporter/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <name>Zeebe Exporter</name>
+  <artifactId>zb-exporter</artifactId>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>io.zeebe</groupId>
+    <artifactId>zb-parent</artifactId>
+    <version>0.12.0-SNAPSHOT</version>
+    <relativePath>../parent</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zb-protocol</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>
+

--- a/exporter/src/main/java/io/zeebe/exporter/context/Configuration.java
+++ b/exporter/src/main/java/io/zeebe/exporter/context/Configuration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.context;
+
+import java.util.Map;
+
+/** Encapsulates the configuration of the exporter. */
+public interface Configuration {
+  /** @return the configured ID of the exporter */
+  String getId();
+
+  /** @return raw map of the parsed arguments from the configuration file */
+  Map<String, Object> getArguments();
+
+  /**
+   * Helper method to instantiate an object of type {@link T} based on the map of arguments (see
+   * {@link Configuration#getArguments()}.
+   *
+   * <p>Will map argument keys to field names; if no field is present for a key, it will be ignored.
+   * If no key is present for a field, it will also be ignored (and retain its initial value).
+   *
+   * @param configClass class to instantiate
+   * @return instantiated configuration class
+   */
+  <T> T instantiate(Class<T> configClass);
+}

--- a/exporter/src/main/java/io/zeebe/exporter/context/Context.java
+++ b/exporter/src/main/java/io/zeebe/exporter/context/Context.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.context;
+
+import org.slf4j.Logger;
+
+/** Encapsulates context associated with the exporter on open. */
+public interface Context {
+  /** @return pre-configured logger for this exporter */
+  Logger getLogger();
+
+  /** @return configuration for this exporter */
+  Configuration getConfiguration();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/context/Controller.java
+++ b/exporter/src/main/java/io/zeebe/exporter/context/Controller.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.context;
+
+import java.time.Duration;
+
+/** Controls various aspect of the exporting process. */
+public interface Controller {
+  /**
+   * Signals to the broker that the exporter has successfully exported all records up to and
+   * including the record at {@param position}.
+   *
+   * @param position the latest successfully exported record position
+   */
+  void updateLastExportedRecordPosition(long position);
+
+  /**
+   * Schedules a {@param task} to be ran after {@param delay} has expired.
+   *
+   * @param delay time to wait until the task is ran
+   * @param task the task to run
+   */
+  void scheduleTask(Duration delay, Runnable task);
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/Record.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/Record.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record;
+
+/** Represents a record published to the log stream. */
+public interface Record<T extends RecordValue> {
+
+  /**
+   * Retrieves relevant metadata of the record, such as the type of the value ({@link
+   * io.zeebe.protocol.clientapi.ValueType}), the type of record ({@link
+   * io.zeebe.protocol.clientapi.RecordType}), etc.
+   *
+   * @return record metadata
+   */
+  RecordMetadata getMetadata();
+
+  /**
+   * Returns the raw value of the record, which should implement one of the interfaces in the {@link
+   * io.zeebe.exporter.record.value} package.
+   *
+   * <p>The record value is essentially the record specific data, e.g. for a workflow instance
+   * creation event, it would contain information relevant to the workflow instance being created.
+   *
+   * @return record value
+   */
+  T getValue();
+
+  /** @return a JSON marshaled representation of this record */
+  String toJson();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/RecordMetadata.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/RecordMetadata.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record;
+
+import io.zeebe.protocol.clientapi.RecordType;
+import io.zeebe.protocol.clientapi.RejectionType;
+import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.intent.Intent;
+import java.time.Instant;
+
+/** Encapsulates metadata information shared by all records. */
+public interface RecordMetadata {
+  /**
+   * Retrieves the key of the record.
+   *
+   * <p>Multiple records can have the same key if they belongs to the same logical entity. Keys are
+   * unique for the combination of topic, partition and record type.
+   *
+   * @return the key of the record
+   */
+  long getKey();
+
+  /** @return the intent of the record */
+  Intent getIntent();
+
+  /** @return the partition ID on which the record was published */
+  int getPartitionId();
+
+  /**
+   * Retrieves the position of the record. Positions are locally unique to the partition, and
+   * monotonically increasing. Records are then ordered on the partition by their positions, i.e.
+   * lower position means the record was published earlier.
+   *
+   * @return position the record
+   */
+  long getPosition();
+
+  /** @return the type of the record (event, command or command rejection) */
+  RecordType getRecordType();
+
+  /**
+   * @return the type of rejection if {@link #getRecordType()} returns {@link
+   *     io.zeebe.protocol.clientapi.RecordType#COMMAND_REJECTION} or else <code>null</code>.
+   */
+  RejectionType getRejectionType();
+
+  /**
+   * @return the reason why a command was rejected if {@link #getRecordType()} returns {@link
+   *     io.zeebe.protocol.clientapi.RecordType#COMMAND_REJECTION} or else <code>null</code>.
+   */
+  String getRejectionReason();
+
+  /**
+   * Returns the position of the source record. The source record denotes the record which caused
+   * the current record. It can be unset (meaning there is no source record), at which point the
+   * position returned here will be -1. Anything >= 0 implies a source record.
+   *
+   * @return position of the source record
+   */
+  long getSourceRecordPosition();
+
+  /**
+   * Returns the instant at which the record was published on the partition.
+   *
+   * @return timestamp of the event
+   */
+  Instant getTimestamp();
+
+  /** @return the type of the record (e.g. job, workflow, workflow instance, etc.) */
+  ValueType getValueType();
+
+  /** @return a JSON marshaled representation of the record metadata */
+  String toJson();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/RecordValue.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/RecordValue.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record;
+
+public interface RecordValue {
+  /** @return a JSON marshaled representation of the record value */
+  String toJson();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/RecordValueWithPayload.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/RecordValueWithPayload.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record;
+
+import java.util.Map;
+
+/** Shared behaviour for all record values containing a payload document. */
+public interface RecordValueWithPayload extends RecordValue {
+  /** @return JSON-formatted payload */
+  String getPayload();
+
+  /** @return de-serialized payload as map */
+  Map<String, Object> getPayloadAsMap();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/DeploymentRecordValue.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/DeploymentRecordValue.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value;
+
+import io.zeebe.exporter.record.RecordValue;
+import io.zeebe.exporter.record.value.deployment.DeployedWorkflow;
+import io.zeebe.exporter.record.value.deployment.DeploymentResource;
+import java.util.List;
+
+/**
+ * Represents a single deployment event or command.
+ *
+ * <p>See {@link io.zeebe.protocol.intent.DeploymentIntent} for intents.
+ */
+public interface DeploymentRecordValue extends RecordValue {
+  /** @return the name of the topic to deploy to */
+  String getDeploymentTopic();
+
+  /** @return the resources to deploy */
+  List<DeploymentResource> getResources();
+
+  List<DeployedWorkflow> getDeployedWorkflows();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/IdRecordValue.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/IdRecordValue.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value;
+
+import io.zeebe.exporter.record.RecordValue;
+
+/**
+ * Represents an ID generation event or command.
+ *
+ * <p>See {@link io.zeebe.protocol.intent.IdIntent} for intents.
+ */
+public interface IdRecordValue extends RecordValue {
+  /** @return the generated ID */
+  int getId();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/IncidentRecordValue.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/IncidentRecordValue.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value;
+
+import io.zeebe.exporter.record.RecordValueWithPayload;
+
+/**
+ * Represents a workflow incident.
+ *
+ * <p>See {@link io.zeebe.protocol.intent.IncidentIntent} for intents.
+ */
+public interface IncidentRecordValue extends RecordValueWithPayload {
+  /** @return the type of error this incident is caused by. */
+  String getErrorType();
+
+  /** @return the description of the error this incident is caused by. */
+  String getErrorMessage();
+
+  /**
+   * @return the BPMN process id this incident belongs to. Can be <code>null</code> if the incident
+   *     belongs to no workflow instance.
+   */
+  String getBpmnProcessId();
+
+  /**
+   * @return the key of the workflow instance this incident belongs to. Can be <code>null</code> if
+   *     the incident belongs to no workflow instance.
+   */
+  long getWorkflowInstanceKey();
+
+  /**
+   * @return the id of the activity this incident belongs to. Can be <code>null</code> if the
+   *     incident belongs to no activity or workflow instance.
+   */
+  String getActivityId();
+
+  /**
+   * @return the key of the activity instance this incident belongs to. Can be <code>null</code> if
+   *     the incident belongs to no activity or workflow instance.
+   */
+  long getActivityInstanceKey();
+
+  /**
+   * @return the key of the job this incident belongs to. Can be <code>null</code> if the incident
+   *     belongs to no task.
+   */
+  long getJobKey();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/JobRecordValue.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/JobRecordValue.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value;
+
+import io.zeebe.exporter.record.RecordValueWithPayload;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Represents a job related event or command.
+ *
+ * <p>See {@link io.zeebe.protocol.intent.JobIntent} for intents.
+ */
+public interface JobRecordValue extends RecordValueWithPayload {
+  /** @return the type of the job */
+  String getType();
+
+  /**
+   * @return broker-defined headers associated with this job. For example, if this job is created in
+   *     the context of workflow instance, the header provide context information on which activity
+   *     is executed, etc.
+   */
+  Map<String, Object> getHeaders();
+
+  /** @return user-defined headers associated with this job */
+  Map<String, Object> getCustomHeaders();
+
+  /** @return the assigned worker to complete the job */
+  String getWorker();
+
+  /** @return remaining retries */
+  int getRetries();
+
+  /**
+   * @return the time until when the job is exclusively assigned to this worker. If the deadline is
+   *     exceeded, it can happen that the job is handed to another worker and the work is performed
+   *     twice.
+   */
+  Instant getDeadline();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/MessageRecordValue.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/MessageRecordValue.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value;
+
+import io.zeebe.exporter.record.RecordValueWithPayload;
+
+/**
+ * Represents a message event or command.
+ *
+ * <p>See {@link io.zeebe.protocol.intent.MessageIntent} for intents.
+ */
+public interface MessageRecordValue extends RecordValueWithPayload {
+  /** @return the name of the message */
+  String getName();
+
+  /** @return the correlation key of the message */
+  String getCorrelationKey();
+
+  /**
+   * The ID of a message is an optional field which is used to make messages unique and prevent
+   * publishing the same message twice during its lifetime.
+   *
+   * @return the id of the message
+   */
+  String getMessageId();
+
+  /** @return the time to live of the message */
+  long getTimeToLive();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/MessageSubscriptionRecordValue.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/MessageSubscriptionRecordValue.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value;
+
+import io.zeebe.exporter.record.RecordValue;
+
+/**
+ * Represents a message correlation subscription event or command.
+ *
+ * <p>See {@link io.zeebe.protocol.intent.MessageSubscriptionIntent} for intents.
+ */
+public interface MessageSubscriptionRecordValue extends RecordValue {
+  /** @return the partition ID on which the workflow instance exists */
+  int getWorkflowInstancePartitionId();
+
+  /** @return the workflow instance key tied to the subscription */
+  long getWorkflowInstanceKey();
+
+  /** @return the activity instance key tied to the subscription */
+  long getActivityInstanceKey();
+
+  /** @return the name of the message */
+  String getMessageName();
+
+  /** @return the correlation key */
+  String getCorrelationKey();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/RaftRecordValue.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/RaftRecordValue.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value;
+
+import io.zeebe.exporter.record.RecordValue;
+import io.zeebe.exporter.record.value.raft.RaftMember;
+import java.util.List;
+
+/**
+ * Represents a raft event or command.
+ *
+ * <p>See {@link io.zeebe.protocol.intent.RaftIntent} for intents.
+ */
+public interface RaftRecordValue extends RecordValue {
+  /** @return the list of members of this raft */
+  List<RaftMember> getMembers();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/TopicRecordValue.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/TopicRecordValue.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value;
+
+import io.zeebe.exporter.record.RecordValue;
+import java.util.List;
+
+/**
+ * Represents a topic command or event, e.g. topic creation.
+ *
+ * <p>See {@link io.zeebe.protocol.intent.TopicIntent} for intents.
+ */
+public interface TopicRecordValue extends RecordValue {
+  /** @return the topic name */
+  String getName();
+
+  /** @return the number of partition for this topic */
+  int getPartitionCount();
+
+  /** @return the replication factor of this topic */
+  int getReplicationFactor();
+
+  /** @return the list of partition IDs associated to this topic */
+  List<Integer> getPartitionIds();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/WorkflowInstanceRecordValue.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/WorkflowInstanceRecordValue.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value;
+
+import io.zeebe.exporter.record.RecordValueWithPayload;
+
+/**
+ * Represents a workflow instance related command or event.
+ *
+ * <p>See {@link io.zeebe.protocol.intent.WorkflowInstanceIntent} for intents.
+ */
+public interface WorkflowInstanceRecordValue extends RecordValueWithPayload {
+  /** @return the BPMN process id this workflow instance belongs to. */
+  String getBpmnProcessId();
+
+  /** @return the version of the deployed workflow this instance belongs to. */
+  int getVersion();
+
+  /** @return the key of the deployed workflow this instance belongs to. */
+  long getWorkflowKey();
+
+  /** @return the key of the workflow instance */
+  long getWorkflowInstanceKey();
+
+  /**
+   * @return the id of the current activity, or empty if the event does not belong to an activity.
+   */
+  String getActivityId();
+
+  /**
+   * @return the key of the activity instance that is the flow scope of this flow element instance;
+   *     -1 for records of the workflow instance itself.
+   */
+  long getScopeInstanceKey();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/WorkflowInstanceSubscriptionRecordValue.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/WorkflowInstanceSubscriptionRecordValue.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value;
+
+import io.zeebe.exporter.record.RecordValueWithPayload;
+
+/**
+ * Represents a workflow instance subscription command or event.
+ *
+ * <p>See {@link io.zeebe.protocol.intent.WorkflowInstanceSubscriptionIntent} for intents.
+ */
+public interface WorkflowInstanceSubscriptionRecordValue extends RecordValueWithPayload {
+  /** @return the workflow instance key */
+  long getWorkflowInstanceKey();
+
+  /** @return the activity instance key */
+  long getActivityInstanceKey();
+
+  /** @return the message name */
+  String getMessageName();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/deployment/DeployedWorkflow.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/deployment/DeployedWorkflow.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value.deployment;
+
+/** Represents a deployed workflow. */
+public interface DeployedWorkflow {
+  /** @return the bpmn process ID of this workflow */
+  String getBpmnProcessId();
+
+  /** @return the version of this workflow */
+  int getVersion();
+
+  /** @return the key of this workflow */
+  String getWorkflowKey();
+
+  /** @return the name of the resource through which this workflow was deployed */
+  String getResourceName();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/deployment/DeploymentResource.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/deployment/DeploymentResource.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value.deployment;
+
+/** Represents a single deployment resource. */
+public interface DeploymentResource {
+  /** @return the resource contents */
+  byte[] getResource();
+
+  /** @return the type of the resource */
+  DeploymentResourceType getResourceType();
+
+  /** @return the name of the resource */
+  String getResourceName();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/deployment/DeploymentResourceType.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/deployment/DeploymentResourceType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value.deployment;
+
+/** Lists the different types of deploy-able resources */
+public enum DeploymentResourceType {
+  /**
+   * Implies the resource blob is a BPMN XML document.
+   *
+   * @see <a href="https://docs.zeebe.io/bpmn-workflows/README.html">
+   *     https://docs.zeebe.io/bpmn-workflows/README.html</a>
+   */
+  BPMN_XML,
+  /**
+   * Implies the resource blob is a YAML document. See {@see
+   * @see <a href="https://docs.zeebe.io/yaml-workflows/README.html">
+   *   https://docs.zeebe.io/yaml-workflows/README.html</a>
+   */
+  YAML_WORKFLOW;
+}

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/raft/RaftMember.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/raft/RaftMember.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value.raft;
+
+/** Represents a single Raft member. */
+public interface RaftMember {
+  /** @return the host of the bound address */
+  String getHost();
+
+  /** @return the port of the bound address */
+  int getPort();
+}

--- a/exporter/src/main/java/io/zeebe/exporter/spi/Exporter.java
+++ b/exporter/src/main/java/io/zeebe/exporter/spi/Exporter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.spi;
+
+import io.zeebe.exporter.context.Context;
+import io.zeebe.exporter.context.Controller;
+import io.zeebe.exporter.record.Record;
+
+/**
+ * Minimal interface to be implemented by concrete exporters.
+ *
+ * <p>A concrete implementation should always provide a default, no-arguments constructor. It is not
+ * recommended to do anything in the constructor, but rather use the provided callbacks for
+ * configuration, setup, resource allocation, etc.
+ */
+public interface Exporter {
+  /**
+   * Use the provided configuration at this point to configure your exporter.
+   *
+   * <p>This method is called in two difference contexts: 1. right before opening the exporter, to
+   * configure the exporter 2. at startup, to allow validation of the exporter configuration.
+   *
+   * <p>To fail-fast at startup time (e.g. database endpoint is missing), for now you must throw an
+   * exception.
+   *
+   * <p>Note that the instance configured at startup will be discarded immediately.
+   *
+   * @param context the exporter context
+   */
+  default void configure(Context context) {}
+
+  /**
+   * Hook to perform any setup for a given exporter. This method is the first method called during
+   * the lifecycle of an exporter, and should be use to create, allocate or configure resources.
+   * After this is called, records will be published to this exporter.
+   *
+   * @param controller specific controller for this exporter
+   */
+  default void open(Controller controller) {}
+
+  /**
+   * Hook to perform any tear down. This is method is called exactly once at the end of the
+   * lifecycle of an exporter, and should be used to close and free any remaining resources.
+   */
+  default void close() {}
+
+  /**
+   * Called at least once for every record to be exporter. Once a record is guaranteed to have been
+   * exported, implementations should call {@link Controller#updateLastExportedRecordPosition(long)}
+   * to signal that this record should not be received here ever again.
+   *
+   * <p>Should the export method throw an unexpected {@link RuntimeException}, the method will be
+   * called indefinitely until it terminates without any exception. It is up to the implementation
+   * to handle errors properly, to implement retry strategies, etc.
+   *
+   * @param record the record to export
+   */
+  void export(Record record);
+}

--- a/exporter/src/test/resources/log4j2-test.xml
+++ b/exporter/src/test/resources/log4j2-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.zeebe" level="debug"/>
+
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <module>gateway-protocol</module>
     <module>gateway</module>
     <module>clients/java</module>
+    <module>exporter</module>
   </modules>
 
   <build>


### PR DESCRIPTION
Implements initial exporter API.

Some things to note:

1. The `Record` interface is closer to what we deal with in the broker, i.e. a pair of `RecordMetadata` and `RecordValue`, as opposed to the client's interface (a concrete `Record`, e.g. `WorkflowInstanceRecord`, with a metadata field).
1. All record values have been defined again (for the nth time), which I'm not happy about, and it makes sense to eventually consolidate those (or at least a base from which we extend in different scopes). Perhaps in the protocol module? Just a thought.
1. I split part of the context object into `Configuration` and `Controller`, configuration being an object to deal with the given exporter configuration, and controller dealing with exporter position, scheduling, etc. `Controller` is admittedly not a great name, but I couldn't think of a better one, so I'm very open to suggestions :sweat_smile: 
1. I tried to document all interfaces/fields to the best of my knowledge, but it's very likely I missed something or misunderstood it, or some of the things are ambiguous, so please correct me.
1. I didn't build any quality of life features yet (i.e. filtering records, a typed-processor kind of logic, batching, etc.), instead I focused on providing all the building blocks so we can eventually build those. That way we can have exporters working and integrated and then we can start iterating and improving things. This is why the test package is already there (as I assumed we will add tests) but is empty, since it was easy to just copy the structure of other modules

closes #1169 