### PR TITLE
feat(broker-core): push deployment to remaining partitions

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/Loggers.java
+++ b/broker-core/src/main/java/io/zeebe/broker/Loggers.java
@@ -27,4 +27,6 @@ public class Loggers {
   public static final Logger SYSTEM_LOGGER = new ZbLogger("io.zeebe.broker.system");
   public static final Logger TRANSPORT_LOGGER = new ZbLogger("io.zeebe.broker.transport");
   public static final Logger STREAM_PROCESSING = new ZbLogger("io.zeebe.broker.streamProcessing");
+  public static final Logger WORKFLOW_REPOSITORY_LOGGER =
+      new ZbLogger("io.zeebe.broker.workflow.repository");
 }

--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/TopologyPartitionListenerImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/TopologyPartitionListenerImpl.java
@@ -1,0 +1,85 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.clustering.base.topology;
+
+import io.zeebe.protocol.Protocol;
+import io.zeebe.transport.SocketAddress;
+import io.zeebe.util.sched.ActorCondition;
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.channel.ActorConditions;
+import org.agrona.collections.Int2ObjectHashMap;
+
+public class TopologyPartitionListenerImpl implements TopologyPartitionListener {
+
+  private final Int2ObjectHashMap<NodeInfo> partitionLeaders = new Int2ObjectHashMap<>();
+  private volatile SocketAddress systemPartitionLeader;
+  private final ActorControl actor;
+  private final ActorConditions conditions = new ActorConditions();
+
+  public TopologyPartitionListenerImpl(ActorControl actor) {
+    this.actor = actor;
+  }
+
+  @Override
+  public void onPartitionUpdated(PartitionInfo partitionInfo, NodeInfo member) {
+    if (member.getLeaders().contains(partitionInfo)) {
+      actor.submit(
+          () -> {
+            if (partitionInfo.getPartitionId() == Protocol.SYSTEM_PARTITION) {
+              updateSystemPartitionLeader(member);
+            } else {
+              updatePartitionLeader(partitionInfo, member);
+            }
+            conditions.signalConsumers();
+          });
+    }
+  }
+
+  private void updateSystemPartitionLeader(NodeInfo member) {
+    final SocketAddress currentLeader = systemPartitionLeader;
+
+    final SocketAddress managementApiAddress = member.getManagementApiAddress();
+    if (currentLeader == null || !currentLeader.equals(managementApiAddress)) {
+      systemPartitionLeader = managementApiAddress;
+    }
+  }
+
+  private void updatePartitionLeader(PartitionInfo partitionInfo, NodeInfo member) {
+    final NodeInfo currentLeader = partitionLeaders.get(partitionInfo.getPartitionId());
+
+    if (currentLeader == null || !currentLeader.equals(member)) {
+      partitionLeaders.put(partitionInfo.getPartitionId(), member);
+    }
+  }
+
+  public Int2ObjectHashMap<NodeInfo> getPartitionLeaders() {
+    return partitionLeaders;
+  }
+
+  public SocketAddress getSystemPartitionLeader() {
+    return systemPartitionLeader;
+  }
+
+  public void addCondition(ActorCondition condition) {
+    conditions.registerConsumer(condition);
+  }
+
+  public void removeCondition(ActorCondition condition) {
+    conditions.removeConsumer(condition);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionCommandSender.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionCommandSender.java
@@ -18,11 +18,9 @@
 package io.zeebe.broker.subscription.command;
 
 import io.zeebe.broker.clustering.base.topology.NodeInfo;
-import io.zeebe.broker.clustering.base.topology.PartitionInfo;
-import io.zeebe.broker.clustering.base.topology.TopologyPartitionListener;
+import io.zeebe.broker.clustering.base.topology.TopologyPartitionListenerImpl;
 import io.zeebe.broker.system.management.topics.FetchCreatedTopicsRequest;
 import io.zeebe.broker.system.management.topics.FetchCreatedTopicsResponse;
-import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.impl.SubscriptionUtil;
 import io.zeebe.transport.ClientResponse;
 import io.zeebe.transport.ClientTransport;
@@ -38,7 +36,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.collections.IntArrayList;
 
-public class SubscriptionCommandSender implements TopologyPartitionListener {
+public class SubscriptionCommandSender {
 
   private final FetchCreatedTopicsRequest fetchCreatedTopicsRequest =
       new FetchCreatedTopicsRequest();
@@ -55,8 +53,7 @@ public class SubscriptionCommandSender implements TopologyPartitionListener {
 
   private final TransportMessage subscriptionMessage = new TransportMessage();
 
-  private final Int2ObjectHashMap<RemoteAddress> partitionLeaders = new Int2ObjectHashMap<>();
-  private volatile RemoteAddress systemPartitionLeader;
+  private final TopologyPartitionListenerImpl partitionListener;
 
   private final ActorControl actor;
   private final ClientTransport managementClient;
@@ -78,6 +75,8 @@ public class SubscriptionCommandSender implements TopologyPartitionListener {
     this.subscriptionClient = subscriptionClient;
     this.topicName = topicName;
     this.partitionId = partitionId;
+
+    this.partitionListener = new TopologyPartitionListenerImpl(actor);
   }
 
   public boolean openMessageSubscription(
@@ -99,7 +98,7 @@ public class SubscriptionCommandSender implements TopologyPartitionListener {
     openMessageSubscriptionCommand.getMessageName().wrap(messageName);
     openMessageSubscriptionCommand.getCorrelationKey().wrap(correlationKey);
 
-    return sendSubscriptipnCommand(subscriptionPartitionId, openMessageSubscriptionCommand);
+    return sendSubscriptionCommand(subscriptionPartitionId, openMessageSubscriptionCommand);
   }
 
   private int getSubscriptionPartitionId(DirectBuffer correlationKey) {
@@ -123,20 +122,24 @@ public class SubscriptionCommandSender implements TopologyPartitionListener {
     correlateWorkflowInstanceSubscriptionCommand.getPayload().wrap(payload);
     subscriptionMessage.writer(correlateWorkflowInstanceSubscriptionCommand);
 
-    return sendSubscriptipnCommand(
+    return sendSubscriptionCommand(
         workflowInstancePartitionId, correlateWorkflowInstanceSubscriptionCommand);
   }
 
-  private boolean sendSubscriptipnCommand(
+  private boolean sendSubscriptionCommand(
       final int receiverPartitionId, final BufferWriter command) {
 
-    final RemoteAddress partitionLeader = partitionLeaders.get(receiverPartitionId);
+    final Int2ObjectHashMap<NodeInfo> partitionLeaders = partitionListener.getPartitionLeaders();
+    final NodeInfo partitionLeader = partitionLeaders.get(receiverPartitionId);
     if (partitionLeader == null) {
       // retry when no leader is known
       return false;
     }
 
-    subscriptionMessage.remoteAddress(partitionLeader);
+    final SocketAddress subscriptionApiAddress = partitionLeader.getSubscriptionApiAddress();
+    final RemoteAddress remoteAddress =
+        subscriptionClient.registerRemoteAddress(subscriptionApiAddress);
+    subscriptionMessage.remoteAddress(remoteAddress);
     subscriptionMessage.writer(command);
 
     return subscriptionClient.getOutput().sendMessage(subscriptionMessage);
@@ -165,10 +168,14 @@ public class SubscriptionCommandSender implements TopologyPartitionListener {
   }
 
   private ActorFuture<ClientResponse> sendFetchCreatedTopicsRequest() {
+    final SocketAddress systemPartitionLeader = partitionListener.getSystemPartitionLeader();
+    final RemoteAddress remoteAddress =
+        managementClient.registerRemoteAddress(systemPartitionLeader);
+
     return managementClient
         .getOutput()
         .sendRequestWithRetry(
-            () -> systemPartitionLeader,
+            () -> remoteAddress,
             b -> !fetchCreatedTopicsResponse.tryWrap(b),
             fetchCreatedTopicsRequest,
             Duration.ofSeconds(15));
@@ -186,39 +193,7 @@ public class SubscriptionCommandSender implements TopologyPartitionListener {
             });
   }
 
-  @Override
-  public void onPartitionUpdated(PartitionInfo partitionInfo, NodeInfo member) {
-
-    if (member.getLeaders().contains(partitionInfo)) {
-
-      if (partitionInfo.getPartitionId() == Protocol.SYSTEM_PARTITION) {
-        updateSystemPartitionLeader(member);
-      } else {
-        updatePartitionLeader(partitionInfo, member);
-      }
-    }
-  }
-
-  private void updateSystemPartitionLeader(NodeInfo member) {
-    final RemoteAddress currentLeader = systemPartitionLeader;
-
-    final SocketAddress managementApiAddress = member.getManagementApiAddress();
-    if (currentLeader == null || !currentLeader.getAddress().equals(managementApiAddress)) {
-      systemPartitionLeader = managementClient.registerRemoteAddress(managementApiAddress);
-    }
-  }
-
-  private void updatePartitionLeader(PartitionInfo partitionInfo, NodeInfo member) {
-    actor.submit(
-        () -> {
-          final RemoteAddress currentLeader = partitionLeaders.get(partitionInfo.getPartitionId());
-
-          final SocketAddress subscriptionApiAddress = member.getSubscriptionApiAddress();
-          if (currentLeader == null || !currentLeader.getAddress().equals(subscriptionApiAddress)) {
-            final RemoteAddress newLeader =
-                subscriptionClient.registerRemoteAddress(subscriptionApiAddress);
-            partitionLeaders.put(partitionInfo.getPartitionId(), newLeader);
-          }
-        });
+  public TopologyPartitionListenerImpl getPartitionListener() {
+    return partitionListener;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/MessageService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/MessageService.java
@@ -113,7 +113,7 @@ public class MessageService implements Service<MessageService> {
                         stream.getPartitionId());
                 getTopologyManagerInjector()
                     .getValue()
-                    .addTopologyPartitionListener(subscriptionCommandSender);
+                    .addTopologyPartitionListener(subscriptionCommandSender.getPartitionListener());
 
                 publishMessageProcessor.setSubscriptionCommandSender(subscriptionCommandSender);
                 openMessageSubscriptionProcessor.setSubscriptionCommandSender(

--- a/broker-core/src/main/java/io/zeebe/broker/system/SystemComponent.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/SystemComponent.java
@@ -19,6 +19,7 @@ package io.zeebe.broker.system;
 
 import static io.zeebe.broker.clustering.base.ClusterBaseLayerServiceNames.LEADER_PARTITION_GROUP_NAME;
 import static io.zeebe.broker.clustering.base.ClusterBaseLayerServiceNames.LEADER_PARTITION_SYSTEM_GROUP_NAME;
+import static io.zeebe.broker.clustering.base.ClusterBaseLayerServiceNames.TOPOLOGY_MANAGER_SERVICE;
 import static io.zeebe.broker.clustering.orchestration.ClusterOrchestrationLayerServiceNames.KNOWN_TOPICS_SERVICE_NAME;
 import static io.zeebe.broker.logstreams.LogStreamServiceNames.STREAM_PROCESSOR_SERVICE_FACTORY;
 import static io.zeebe.broker.system.SystemServiceNames.DEPLOYMENT_MANAGER_SERVICE;
@@ -26,8 +27,10 @@ import static io.zeebe.broker.system.SystemServiceNames.FETCH_CREATED_TOPIC_HAND
 import static io.zeebe.broker.system.SystemServiceNames.LEADER_MANAGEMENT_REQUEST_HANDLER;
 import static io.zeebe.broker.system.SystemServiceNames.METRICS_FILE_WRITER;
 import static io.zeebe.broker.transport.TransportServiceNames.CLIENT_API_SERVER_NAME;
+import static io.zeebe.broker.transport.TransportServiceNames.MANAGEMENT_API_CLIENT_NAME;
 import static io.zeebe.broker.transport.TransportServiceNames.MANAGEMENT_API_SERVER_NAME;
 import static io.zeebe.broker.transport.TransportServiceNames.bufferingServerTransport;
+import static io.zeebe.broker.transport.TransportServiceNames.clientTransport;
 import static io.zeebe.broker.transport.TransportServiceNames.serverTransport;
 
 import io.zeebe.broker.system.management.LeaderManagementRequestHandler;
@@ -38,6 +41,7 @@ import io.zeebe.broker.transport.TransportServiceNames;
 import io.zeebe.servicecontainer.ServiceContainer;
 
 public class SystemComponent implements Component {
+
   @Override
   public void init(SystemContext context) {
     final ServiceContainer serviceContainer = context.getServiceContainer();
@@ -53,6 +57,8 @@ public class SystemComponent implements Component {
         .dependency(
             bufferingServerTransport(MANAGEMENT_API_SERVER_NAME),
             requestHandlerService.getManagementApiServerTransportInjector())
+        .groupReference(
+            LEADER_PARTITION_GROUP_NAME, requestHandlerService.getLeaderPartitionsGroupReference())
         .install();
 
     final DeploymentManager deploymentManagerService = new DeploymentManager();
@@ -70,6 +76,10 @@ public class SystemComponent implements Component {
         .dependency(
             TransportServiceNames.CONTROL_MESSAGE_HANDLER_MANAGER,
             deploymentManagerService.getControlMessageHandlerManagerServiceInjector())
+        .dependency(TOPOLOGY_MANAGER_SERVICE, deploymentManagerService.getTopologyManagerInjector())
+        .dependency(
+            clientTransport(MANAGEMENT_API_CLIENT_NAME),
+            deploymentManagerService.getManagementApiClientInjector())
         .groupReference(
             LEADER_PARTITION_GROUP_NAME, deploymentManagerService.getPartitionsGroupReference())
         .install();

--- a/broker-core/src/main/java/io/zeebe/broker/system/SystemServiceNames.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/SystemServiceNames.java
@@ -20,6 +20,7 @@ package io.zeebe.broker.system;
 import io.zeebe.broker.system.management.LeaderManagementRequestHandler;
 import io.zeebe.broker.system.management.topics.FetchCreatedTopicsRequestHandlerService;
 import io.zeebe.broker.system.metrics.MetricsFileWriter;
+import io.zeebe.broker.system.workflow.repository.api.management.PushDeploymentRequestHandler;
 import io.zeebe.broker.system.workflow.repository.service.DeploymentManager;
 import io.zeebe.broker.system.workflow.repository.service.WorkflowRepositoryService;
 import io.zeebe.servicecontainer.ServiceName;
@@ -45,4 +46,8 @@ public class SystemServiceNames {
   public static final ServiceName<WorkflowRepositoryService> REPOSITORY_SERVICE =
       ServiceName.newServiceName(
           "broker.deployment.workflowRepositoryService", WorkflowRepositoryService.class);
+
+  public static final ServiceName<PushDeploymentRequestHandler> PUSH_DEPLOYMENT_REQUEST_HANDLER =
+      ServiceName.newServiceName(
+          "broker.system.deployment.push.requestHandler", PushDeploymentRequestHandler.class);
 }

--- a/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/api/management/PushDeploymentRequest.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/api/management/PushDeploymentRequest.java
@@ -1,0 +1,111 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.system.workflow.repository.api.management;
+
+import static io.zeebe.clustering.management.PushDeploymentRequestDecoder.deploymentHeaderLength;
+
+import io.zeebe.broker.util.SbeBufferWriterReader;
+import io.zeebe.clustering.management.PushDeploymentRequestDecoder;
+import io.zeebe.clustering.management.PushDeploymentRequestEncoder;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public class PushDeploymentRequest
+    extends SbeBufferWriterReader<PushDeploymentRequestEncoder, PushDeploymentRequestDecoder> {
+
+  private final PushDeploymentRequestEncoder bodyEncoder = new PushDeploymentRequestEncoder();
+  private final PushDeploymentRequestDecoder bodyDecoder = new PushDeploymentRequestDecoder();
+
+  private int partitionId = PushDeploymentRequestEncoder.partitionIdNullValue();
+  private long deploymentKey = PushDeploymentRequestEncoder.deploymentKeyNullValue();
+  private final DirectBuffer deployment = new UnsafeBuffer(0, 0);
+
+  public PushDeploymentRequest partitionId(int partitionId) {
+    this.partitionId = partitionId;
+    return this;
+  }
+
+  public int partitionId() {
+    return this.partitionId;
+  }
+
+  public PushDeploymentRequest deploymentKey(long deploymentKey) {
+    this.deploymentKey = deploymentKey;
+    return this;
+  }
+
+  public long deploymentKey() {
+    return this.deploymentKey;
+  }
+
+  public PushDeploymentRequest deployment(DirectBuffer directBuffer) {
+    deployment.wrap(directBuffer);
+    return this;
+  }
+
+  public DirectBuffer deployment() {
+    return this.deployment;
+  }
+
+  @Override
+  protected PushDeploymentRequestEncoder getBodyEncoder() {
+    return bodyEncoder;
+  }
+
+  @Override
+  protected PushDeploymentRequestDecoder getBodyDecoder() {
+    return bodyDecoder;
+  }
+
+  @Override
+  public void wrap(DirectBuffer buffer, int offset, int length) {
+    super.wrap(buffer, offset, length);
+
+    partitionId = bodyDecoder.partitionId();
+    deploymentKey = bodyDecoder.deploymentKey();
+
+    deployment.wrap(
+        buffer, bodyDecoder.limit() + deploymentHeaderLength(), bodyDecoder.deploymentLength());
+  }
+
+  @Override
+  public int getLength() {
+    return super.getLength()
+        + PushDeploymentRequestEncoder.deploymentHeaderLength()
+        + deployment.capacity();
+  }
+
+  @Override
+  public void write(MutableDirectBuffer buffer, int offset) {
+    super.write(buffer, offset);
+
+    bodyEncoder
+        .partitionId(partitionId)
+        .deploymentKey(deploymentKey)
+        .putDeployment(deployment, 0, deployment.capacity());
+  }
+
+  public void reset() {
+    super.reset();
+
+    partitionId = PushDeploymentRequestEncoder.partitionIdNullValue();
+    deploymentKey = PushDeploymentRequestEncoder.deploymentKeyNullValue();
+    deployment.wrap(0, 0);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/api/management/PushDeploymentRequestHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/api/management/PushDeploymentRequestHandler.java
@@ -1,0 +1,157 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.system.workflow.repository.api.management;
+
+import io.zeebe.broker.Loggers;
+import io.zeebe.broker.clustering.base.partitions.Partition;
+import io.zeebe.broker.system.workflow.repository.data.DeploymentRecord;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.zeebe.logstreams.log.LogStreamWriterImpl;
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.protocol.clientapi.RecordType;
+import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.impl.RecordMetadata;
+import io.zeebe.protocol.intent.DeploymentIntent;
+import io.zeebe.protocol.intent.Intent;
+import io.zeebe.transport.RemoteAddress;
+import io.zeebe.transport.ServerOutput;
+import io.zeebe.transport.ServerResponse;
+import io.zeebe.util.sched.ActorControl;
+import org.agrona.DirectBuffer;
+import org.agrona.collections.Int2ObjectHashMap;
+import org.slf4j.Logger;
+
+public class PushDeploymentRequestHandler {
+
+  private static final Logger LOG = Loggers.WORKFLOW_REPOSITORY_LOGGER;
+
+  private final LogStreamRecordWriter logStreamWriter = new LogStreamWriterImpl();
+  private final RecordMetadata recordMetadata = new RecordMetadata();
+
+  private final Int2ObjectHashMap<Partition> leaderPartitions;
+  private final ActorControl actor;
+
+  public PushDeploymentRequestHandler(
+      Int2ObjectHashMap<Partition> leaderPartitions, ActorControl actor) {
+    this.leaderPartitions = leaderPartitions;
+    this.actor = actor;
+  }
+
+  public boolean onPushDeploymentRequest(
+      ServerOutput output,
+      RemoteAddress remoteAddress,
+      DirectBuffer buffer,
+      int offset,
+      int length,
+      long requestId) {
+
+    final PushDeploymentRequest pushDeploymentRequest = new PushDeploymentRequest();
+    pushDeploymentRequest.wrap(buffer, offset, length);
+    final long deploymentKey = pushDeploymentRequest.deploymentKey();
+    final int partitionId = pushDeploymentRequest.partitionId();
+    final DirectBuffer deployment = pushDeploymentRequest.deployment();
+
+    LOG.debug("Got deployment push request for deployment {}.", deploymentKey);
+
+    final Partition partition = leaderPartitions.get(partitionId);
+    if (partition != null) {
+      LOG.trace("Leader for partition {}, handle deployment.", partitionId);
+      handlePushDeploymentRequest(
+          output, remoteAddress, requestId, deployment, deploymentKey, partitionId);
+
+    } else {
+      LOG.debug("Not leader for partition {}", partitionId);
+      return false;
+    }
+
+    return true;
+  }
+
+  private void handlePushDeploymentRequest(
+      ServerOutput output,
+      RemoteAddress remoteAddress,
+      long requestId,
+      DirectBuffer deployment,
+      long deploymentKey,
+      int partitionId) {
+
+    final DeploymentRecord deploymentRecord = new DeploymentRecord();
+    deploymentRecord.wrap(deployment);
+
+    actor.runUntilDone(
+        () -> {
+          final Partition partition = leaderPartitions.get(partitionId);
+          if (partition == null) {
+            LOG.debug("Leader change on partition {}, ignore push deployment request", partitionId);
+            actor.done();
+            return;
+          }
+
+          final boolean success =
+              writeDeploymentCreated(partition, deploymentKey, deploymentRecord);
+          if (success) {
+            LOG.debug("Deployment CREATED Event was written on partition {}", partitionId);
+            actor.done();
+
+            sendResponse(output, remoteAddress, requestId, deploymentKey, partitionId);
+          } else {
+            actor.yield();
+          }
+        });
+  }
+
+  private void sendResponse(
+      ServerOutput output,
+      RemoteAddress remoteAddress,
+      long requestId,
+      long deploymentKey,
+      int partitionId) {
+
+    final PushDeploymentResponse pushResponse = new PushDeploymentResponse();
+    pushResponse.deploymentKey(deploymentKey);
+    pushResponse.partitionId(partitionId);
+
+    final ServerResponse serverResponse =
+        new ServerResponse().writer(pushResponse).requestId(requestId).remoteAddress(remoteAddress);
+
+    actor.runUntilDone(
+        () -> {
+          if (output.sendResponse(serverResponse)) {
+            actor.done();
+            LOG.trace("Send response back to partition 1.");
+          } else {
+            actor.yield();
+          }
+        });
+  }
+
+  private boolean writeDeploymentCreated(Partition partition, long key, UnpackedObject event) {
+    final RecordType recordType = RecordType.EVENT;
+    final ValueType valueType = ValueType.DEPLOYMENT;
+    final Intent intent = DeploymentIntent.CREATED;
+
+    logStreamWriter.wrap(partition.getLogStream());
+
+    recordMetadata.reset().recordType(recordType).valueType(valueType).intent(intent);
+
+    final long position =
+        logStreamWriter.key(key).metadataWriter(recordMetadata).valueWriter(event).tryWrite();
+
+    return position > 0;
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/api/management/PushDeploymentResponse.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/api/management/PushDeploymentResponse.java
@@ -1,0 +1,85 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.system.workflow.repository.api.management;
+
+import io.zeebe.broker.util.SbeBufferWriterReader;
+import io.zeebe.clustering.management.PushDeploymentRequestEncoder;
+import io.zeebe.clustering.management.PushDeploymentResponseDecoder;
+import io.zeebe.clustering.management.PushDeploymentResponseEncoder;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class PushDeploymentResponse
+    extends SbeBufferWriterReader<PushDeploymentResponseEncoder, PushDeploymentResponseDecoder> {
+
+  private final PushDeploymentResponseEncoder bodyEncoder = new PushDeploymentResponseEncoder();
+  private final PushDeploymentResponseDecoder bodyDecoder = new PushDeploymentResponseDecoder();
+
+  private int partitionId = PushDeploymentResponseEncoder.partitionIdNullValue();
+  private long deploymentKey = PushDeploymentResponseEncoder.deploymentKeyNullValue();
+
+  public PushDeploymentResponse partitionId(int partitionId) {
+    this.partitionId = partitionId;
+    return this;
+  }
+
+  public int partitionId() {
+    return this.partitionId;
+  }
+
+  public PushDeploymentResponse deploymentKey(long deploymentKey) {
+    this.deploymentKey = deploymentKey;
+    return this;
+  }
+
+  public long deploymentKey() {
+    return this.deploymentKey;
+  }
+
+  @Override
+  protected PushDeploymentResponseEncoder getBodyEncoder() {
+    return bodyEncoder;
+  }
+
+  @Override
+  protected PushDeploymentResponseDecoder getBodyDecoder() {
+    return bodyDecoder;
+  }
+
+  @Override
+  public void wrap(DirectBuffer buffer, int offset, int length) {
+    super.wrap(buffer, offset, length);
+
+    partitionId = bodyDecoder.partitionId();
+    deploymentKey = bodyDecoder.deploymentKey();
+  }
+
+  @Override
+  public void write(MutableDirectBuffer buffer, int offset) {
+    super.write(buffer, offset);
+
+    bodyEncoder.partitionId(partitionId).deploymentKey(deploymentKey);
+  }
+
+  public void reset() {
+    super.reset();
+
+    partitionId = PushDeploymentResponseEncoder.partitionIdNullValue();
+    deploymentKey = PushDeploymentRequestEncoder.deploymentKeyNullValue();
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/DeploymentCreatedEventProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/DeploymentCreatedEventProcessor.java
@@ -17,6 +17,7 @@
  */
 package io.zeebe.broker.system.workflow.repository.processor;
 
+import io.zeebe.broker.Loggers;
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedRecordProcessor;
 import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
@@ -40,9 +41,6 @@ public class DeploymentCreatedEventProcessor implements TypedRecordProcessor<Dep
       TypedRecord<DeploymentRecord> event,
       TypedResponseWriter responseWriter,
       TypedStreamWriter streamWriter) {
-
-    responseWriter.writeEvent(event);
-
     addWorkflowsToIndex(event);
   }
 
@@ -58,7 +56,10 @@ public class DeploymentCreatedEventProcessor implements TypedRecordProcessor<Dep
               .setEventPosition(event.getPosition())
               .setVersion(deployedWorkflow.getVersion())
               .setResourceName(BufferUtil.bufferAsString(deployedWorkflow.getResourceName()));
-
+      Loggers.WORKFLOW_REPOSITORY_LOGGER.trace(
+          "Workflow {} with version {} added",
+          workflowMetadata.getBpmnProcessId(),
+          workflowMetadata.getVersion());
       repositoryIndex.add(workflowMetadata);
     }
   }

--- a/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/DeploymentDistributor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/DeploymentDistributor.java
@@ -1,0 +1,256 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.system.workflow.repository.processor;
+
+import static io.zeebe.protocol.Protocol.DEFAULT_TOPIC;
+
+import io.zeebe.broker.Loggers;
+import io.zeebe.broker.clustering.base.topology.NodeInfo;
+import io.zeebe.broker.clustering.base.topology.TopologyPartitionListenerImpl;
+import io.zeebe.broker.system.management.topics.FetchCreatedTopicsRequest;
+import io.zeebe.broker.system.management.topics.FetchCreatedTopicsResponse;
+import io.zeebe.broker.system.workflow.repository.api.management.PushDeploymentRequest;
+import io.zeebe.broker.system.workflow.repository.api.management.PushDeploymentResponse;
+import io.zeebe.protocol.Protocol;
+import io.zeebe.transport.ClientResponse;
+import io.zeebe.transport.ClientTransport;
+import io.zeebe.transport.RemoteAddress;
+import io.zeebe.transport.SocketAddress;
+import io.zeebe.util.sched.ActorCondition;
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
+import java.time.Duration;
+import org.agrona.DirectBuffer;
+import org.agrona.collections.Int2ObjectHashMap;
+import org.agrona.collections.IntArrayList;
+import org.agrona.collections.Long2ObjectHashMap;
+import org.slf4j.Logger;
+
+public class DeploymentDistributor {
+
+  private static final Logger LOG = Loggers.WORKFLOW_REPOSITORY_LOGGER;
+  public static final Duration PUSH_REQUEST_TIMEOUT = Duration.ofSeconds(15);
+  public static final Duration PARTITION_LEADER_RESOLVE_RETRY = Duration.ofMillis(100);
+  public static final Duration FETCH_TOPICS_TIMEOUT = Duration.ofSeconds(15);
+
+  private final PushDeploymentRequest pushDeploymentRequest = new PushDeploymentRequest();
+  private final PushDeploymentResponse pushDeploymentResponse = new PushDeploymentResponse();
+
+  private final FetchCreatedTopicsRequest fetchCreatedTopicsRequest =
+      new FetchCreatedTopicsRequest();
+  private final FetchCreatedTopicsResponse fetchCreatedTopicsResponse =
+      new FetchCreatedTopicsResponse();
+
+  private final Long2ObjectHashMap<PendingDeploymentDistribution> pendingDistributions =
+      new Long2ObjectHashMap<>();
+  private final ActorFuture<Void> partitionsResolved = new CompletableActorFuture<>();
+
+  private final ClientTransport managementApi;
+  private final TopologyPartitionListenerImpl partitionListener;
+  private final ActorControl actor;
+  private final ActorCondition updatePartition;
+
+  private IntArrayList remainingPartitions;
+
+  public DeploymentDistributor(
+      ClientTransport managementApi,
+      TopologyPartitionListenerImpl partitionListener,
+      ActorControl actor) {
+    this.managementApi = managementApi;
+    this.partitionListener = partitionListener;
+    this.actor = actor;
+    this.updatePartition = actor.onCondition("updatePartition", this::fetchTopics);
+  }
+
+  public ActorFuture<Void> pushDeployment(long key, long position, DirectBuffer buffer) {
+    final ActorFuture<Void> pushedFuture = new CompletableActorFuture<>();
+
+    final PendingDeploymentDistribution pendingDeploymentDistribution =
+        new PendingDeploymentDistribution(buffer, position, pushedFuture);
+    pendingDistributions.put(key, pendingDeploymentDistribution);
+
+    if (!partitionsResolved.isDone()) {
+      final SocketAddress systemPartitionLeader = partitionListener.getSystemPartitionLeader();
+      if (systemPartitionLeader == null) {
+        partitionListener.addCondition(updatePartition);
+      } else {
+        fetchTopics();
+      }
+    }
+
+    actor.runOnCompletion(
+        partitionsResolved,
+        (v, failure) -> {
+          pushDeploymentToPartitions(key);
+        });
+
+    return pushedFuture;
+  }
+
+  public PendingDeploymentDistribution removePendingDeployment(long key) {
+    return pendingDistributions.remove(key);
+  }
+
+  private void pushDeploymentToPartitions(long key) {
+    if (!remainingPartitions.isEmpty()) {
+      deployOnMultiplePartitions(key);
+    } else {
+      LOG.trace("No other partitions to distribute deployment.");
+      LOG.trace("Deployment finished.");
+      pendingDistributions.get(key).complete();
+    }
+  }
+
+  private void deployOnMultiplePartitions(long key) {
+    LOG.trace("Distribute deployment to other partitions.");
+
+    final Int2ObjectHashMap<NodeInfo> partitionLeaders = partitionListener.getPartitionLeaders();
+    if (partitionLeaders.size() - 1 == remainingPartitions.size()) {
+      distributeDeployment(key);
+    } else {
+      LOG.trace("Not enough leaders");
+      delayedRetry(key);
+    }
+  }
+
+  private void delayedRetry(long key) {
+    actor.runDelayed(
+        PARTITION_LEADER_RESOLVE_RETRY,
+        () -> {
+          LOG.trace("Retry partition leader resolving");
+          deployOnMultiplePartitions(key);
+        });
+  }
+
+  private void distributeDeployment(long key) {
+    final Int2ObjectHashMap<NodeInfo> partitionLeaders = partitionListener.getPartitionLeaders();
+
+    final PendingDeploymentDistribution pendingDeploymentDistribution =
+        pendingDistributions.get(key);
+    final DirectBuffer directBuffer = pendingDeploymentDistribution.getDeployment();
+    pendingDeploymentDistribution.setDistributionCount(remainingPartitions.size());
+
+    pushDeploymentRequest.reset();
+    pushDeploymentRequest.deployment(directBuffer).deploymentKey(key);
+
+    for (int partition : remainingPartitions) {
+      final NodeInfo leader = partitionLeaders.get(partition);
+      final SocketAddress managementApiAddress = leader.getManagementApiAddress();
+      pushDeploymentToPartition(managementApiAddress, partition);
+    }
+  }
+
+  private void pushDeploymentToPartition(SocketAddress partitionLeader, int partition) {
+    final RemoteAddress remoteAddress = managementApi.registerRemoteAddress(partitionLeader);
+
+    pushDeploymentRequest.partitionId(partition);
+    final ActorFuture<ClientResponse> pushResponseFuture =
+        managementApi
+            .getOutput()
+            .sendRequestWithRetry(
+                () -> remoteAddress,
+                (response) -> !pushDeploymentResponse.tryWrap(response),
+                pushDeploymentRequest,
+                PUSH_REQUEST_TIMEOUT);
+
+    LOG.debug("Deployment pushed to partition {}.", partition);
+    actor.runOnCompletion(
+        pushResponseFuture,
+        (response, throwable) -> {
+          if (throwable == null) {
+            handlePushResponse(response);
+          } else {
+            LOG.error(
+                "Error on pushing deployment to partition {}. Retry request. ",
+                partition,
+                throwable);
+            // TODO maybe need to request new partition leader ?
+            pushDeploymentToPartition(partitionLeader, partition);
+          }
+        });
+  }
+
+  private void handlePushResponse(ClientResponse response) {
+    pushDeploymentResponse.wrap(response.getResponseBuffer());
+    final long deploymentKey = pushDeploymentResponse.deploymentKey();
+    final PendingDeploymentDistribution pendingDeploymentDistribution =
+        pendingDistributions.get(deploymentKey);
+
+    final long remainingPartitions = pendingDeploymentDistribution.decrementCount();
+    if (remainingPartitions == 0) {
+      LOG.debug("Deployment pushed to all partitions successfully.");
+      pendingDeploymentDistribution.complete();
+    } else {
+      LOG.trace(
+          "Deployment was pushed to partition {} successfully.",
+          pushDeploymentResponse.partitionId());
+    }
+  }
+
+  ////////////////////////////////////////////////
+  //////////// topics / partition ids
+  ////////////////////////////////////////////////
+
+  private void fetchTopics() {
+    final SocketAddress systemPartitionLeader = partitionListener.getSystemPartitionLeader();
+    if (systemPartitionLeader != null) {
+      partitionListener.removeCondition(updatePartition);
+
+      final RemoteAddress remoteAddress =
+          managementApi.registerRemoteAddress(systemPartitionLeader);
+
+      final ActorFuture<ClientResponse> future =
+          managementApi
+              .getOutput()
+              .sendRequestWithRetry(
+                  () -> remoteAddress,
+                  b -> !fetchCreatedTopicsResponse.tryWrap(b),
+                  fetchCreatedTopicsRequest,
+                  FETCH_TOPICS_TIMEOUT);
+
+      actor.runOnCompletion(
+          future,
+          (response, failure) -> {
+            if (failure == null) {
+              handleFetchCreatedTopicsResponse(response.getResponseBuffer());
+            } else {
+              LOG.debug("Problem on fetching topics", failure);
+            }
+          });
+    }
+  }
+
+  private void handleFetchCreatedTopicsResponse(DirectBuffer response) {
+    fetchCreatedTopicsResponse.wrap(response);
+    fetchCreatedTopicsResponse
+        .getTopics()
+        .forEach(
+            topic -> {
+              if (topic.getTopicName().equals(DEFAULT_TOPIC)) {
+                remainingPartitions = topic.getPartitionIds();
+                remainingPartitions.removeInt(
+                    Protocol.DEPLOYMENT_PARTITION); // no need to send push to him self
+              }
+            });
+
+    if (!partitionsResolved.isDone()) {
+      partitionsResolved.complete(null);
+    }
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/DeploymentTransformer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/DeploymentTransformer.java
@@ -1,0 +1,170 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.system.workflow.repository.processor;
+
+import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.zeebe.broker.system.workflow.repository.data.DeploymentRecord;
+import io.zeebe.broker.system.workflow.repository.data.DeploymentResource;
+import io.zeebe.broker.system.workflow.repository.data.ResourceType;
+import io.zeebe.broker.system.workflow.repository.processor.state.WorkflowRepositoryIndex;
+import io.zeebe.broker.workflow.model.yaml.BpmnYamlParser;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.instance.Process;
+import io.zeebe.protocol.clientapi.RejectionType;
+import io.zeebe.util.buffer.BufferUtil;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collection;
+import java.util.Iterator;
+import org.agrona.DirectBuffer;
+import org.agrona.io.DirectBufferInputStream;
+
+public class DeploymentTransformer {
+
+  private final BpmnValidator validator = new BpmnValidator();
+  private final BpmnYamlParser yamlParser = new BpmnYamlParser();
+  private final WorkflowRepositoryIndex index;
+
+  // internal changes during processing
+  private RejectionType rejectionType;
+  private String rejectionReason;
+
+  public DeploymentTransformer(WorkflowRepositoryIndex index) {
+    this.index = index;
+  }
+
+  public boolean transform(final DeploymentRecord deploymentEvent) {
+    final StringBuilder validationErrors = new StringBuilder();
+    boolean success = true;
+    final Iterator<DeploymentResource> resourceIterator = deploymentEvent.resources().iterator();
+    if (!resourceIterator.hasNext()) {
+      validationErrors.append("Deployment doesn't contain a resource to deploy");
+      success = false;
+    } else {
+      while (resourceIterator.hasNext()) {
+        final DeploymentResource deploymentResource = resourceIterator.next();
+        success = transformResource(deploymentEvent, validationErrors, deploymentResource);
+      }
+    }
+
+    if (!success) {
+      rejectionType = RejectionType.BAD_VALUE;
+      rejectionReason = validationErrors.toString();
+    }
+
+    return success;
+  }
+
+  private boolean transformResource(
+      DeploymentRecord deploymentEvent,
+      StringBuilder validationErrors,
+      DeploymentResource deploymentResource) {
+    boolean success = true;
+    try {
+      final BpmnModelInstance definition = readWorkflowDefinition(deploymentResource);
+      final String validationError = validator.validate(definition);
+
+      if (validationError == null) {
+        transformWorkflowResource(deploymentEvent, deploymentResource, definition);
+      } else {
+        validationErrors.append(
+            String.format(
+                "Resource '%s':\n", bufferAsString(deploymentResource.getResourceName())));
+        validationErrors.append(validationError);
+        success = false;
+      }
+    } catch (Exception e) {
+      validationErrors.append(
+          String.format(
+              "Failed to deploy resource '%s':\n",
+              bufferAsString(deploymentResource.getResourceName())));
+      validationErrors.append(generateErrorMessage(e));
+      success = false;
+    }
+    return success;
+  }
+
+  private void transformWorkflowResource(
+      DeploymentRecord deploymentEvent,
+      DeploymentResource deploymentResource,
+      BpmnModelInstance definition) {
+    final Collection<Process> processes =
+        definition.getDefinitions().getChildElementsByType(Process.class);
+
+    for (Process workflow : processes) {
+      if (workflow.isExecutable()) {
+        final String bpmnProcessId = workflow.getId();
+        final long key = index.getNextKey();
+        final int version = index.getNextVersion(bpmnProcessId);
+
+        deploymentEvent
+            .deployedWorkflows()
+            .add()
+            .setBpmnProcessId(BufferUtil.wrapString(workflow.getId()))
+            .setVersion(version)
+            .setKey(key)
+            .setResourceName(deploymentResource.getResourceName());
+      }
+    }
+
+    transformYamlWorkflowResource(deploymentResource, definition);
+  }
+
+  private BpmnModelInstance readWorkflowDefinition(DeploymentResource deploymentResource) {
+    final DirectBuffer resource = deploymentResource.getResource();
+    final DirectBufferInputStream resourceStream = new DirectBufferInputStream(resource);
+
+    switch (deploymentResource.getResourceType()) {
+      case YAML_WORKFLOW:
+        return yamlParser.readFromStream(resourceStream);
+      case BPMN_XML:
+      default:
+        return Bpmn.readModelFromStream(resourceStream);
+    }
+  }
+
+  private void transformYamlWorkflowResource(
+      final DeploymentResource deploymentResource, final BpmnModelInstance definition) {
+    if (deploymentResource.getResourceType() != ResourceType.BPMN_XML) {
+      final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+      Bpmn.writeModelToStream(outStream, definition);
+
+      final DirectBuffer bpmnXml = BufferUtil.wrapArray(outStream.toByteArray());
+      deploymentResource.setResource(bpmnXml);
+    }
+  }
+
+  private String generateErrorMessage(final Exception e) {
+    final StringWriter stacktraceWriter = new StringWriter();
+
+    e.printStackTrace(new PrintWriter(stacktraceWriter));
+
+    return stacktraceWriter.toString();
+  }
+
+  public RejectionType getRejectionType() {
+    return rejectionType;
+  }
+
+  public String getRejectionReason() {
+    return rejectionReason;
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/PendingDeploymentDistribution.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/PendingDeploymentDistribution.java
@@ -1,0 +1,60 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.system.workflow.repository.processor;
+
+import io.zeebe.util.sched.future.ActorFuture;
+import org.agrona.DirectBuffer;
+
+public class PendingDeploymentDistribution {
+  private final DirectBuffer deployment;
+  private final long sourcePosition;
+  private final ActorFuture<Void> pushFuture;
+
+  private long distributionCount;
+
+  public PendingDeploymentDistribution(
+      DirectBuffer deployment, long sourcePosition, ActorFuture<Void> pushFuture) {
+    this.deployment = deployment;
+    this.sourcePosition = sourcePosition;
+    this.pushFuture = pushFuture;
+  }
+
+  public void setDistributionCount(long distributionCount) {
+    this.distributionCount = distributionCount;
+  }
+
+  public long decrementCount() {
+    return --distributionCount;
+  }
+
+  public void complete() {
+    pushFuture.complete(null);
+  }
+
+  public DirectBuffer getDeployment() {
+    return deployment;
+  }
+
+  public long getSourcePosition() {
+    return sourcePosition;
+  }
+
+  public ActorFuture<Void> getPushFuture() {
+    return pushFuture;
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/map/WorkflowCache.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/map/WorkflowCache.java
@@ -19,6 +19,7 @@ package io.zeebe.broker.workflow.map;
 
 import static io.zeebe.protocol.Protocol.DEPLOYMENT_PARTITION;
 
+import io.zeebe.broker.Loggers;
 import io.zeebe.broker.clustering.base.topology.NodeInfo;
 import io.zeebe.broker.clustering.base.topology.PartitionInfo;
 import io.zeebe.broker.clustering.base.topology.TopologyManager;
@@ -181,6 +182,7 @@ public class WorkflowCache implements TopologyPartitionListener {
 
       if (now - latest.getFetched() > LATEST_VERSION_REFRESH_INTERVAL) {
         // refresh latest version
+        Loggers.WORKFLOW_REPOSITORY_LOGGER.debug("fetch latest version");
         return null;
       }
     }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessor.java
@@ -202,7 +202,7 @@ public class WorkflowInstanceStreamProcessor implements StreamProcessorLifecycle
             subscriptionApiClient,
             topicName,
             logStream.getPartitionId());
-    topologyManager.addTopologyPartitionListener(subscriptionCommandSender);
+    topologyManager.addTopologyPartitionListener(subscriptionCommandSender.getPartitionListener());
 
     workflowInstanceEventCreate =
         metricsManager

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/catchevent/SubscribeMessageHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/catchevent/SubscribeMessageHandler.java
@@ -70,7 +70,7 @@ public class SubscribeMessageHandler
             subscriptionClient,
             BufferUtil.bufferAsString(logStream.getTopicName()),
             logStream.getPartitionId());
-    topologyManager.addTopologyPartitionListener(subscriptionCommandSender);
+    topologyManager.addTopologyPartitionListener(subscriptionCommandSender.getPartitionListener());
   }
 
   @Override

--- a/broker-core/src/main/resources/management-schema.xml
+++ b/broker-core/src/main/resources/management-schema.xml
@@ -101,6 +101,11 @@
     <data name="data" id="0" type="blob"/>
   </sbe:message>
 
+  <sbe:message name="ErrorResponse" id="10">
+    <field name="code" id="1" type="errorResponseCode"/>
+    <data name="data" id="2" type="varDataEncoding"/>
+  </sbe:message>
+
   <sbe:message name="FetchCreatedTopicsRequest" id="11">
   </sbe:message>
 
@@ -113,9 +118,15 @@
     </group>
   </sbe:message>
 
-  <sbe:message name="ErrorResponse" id="10">
-    <field name="code" id="1" type="errorResponseCode"/>
-    <data name="data" id="2" type="varDataEncoding"/>
+  <sbe:message name="PushDeploymentRequest" id="13">
+    <field name="partitionId" id="0" type="uint16"/>
+    <field name="deploymentKey" id="1" type="uint64"/>
+    <data name="deployment" id="2" type="varDataEncoding"/>
+  </sbe:message>
+
+  <sbe:message name="PushDeploymentResponse" id="14">
+    <field name="partitionId" id="0" type="uint16"/>
+    <field name="deploymentKey" id="1" type="uint64"/>
   </sbe:message>
 
 </sbe:messageSchema>

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/CreateDeploymentMultiplePartitionsTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/CreateDeploymentMultiplePartitionsTest.java
@@ -1,0 +1,296 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow;
+
+import static io.zeebe.protocol.Protocol.DEFAULT_TOPIC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
+import io.zeebe.broker.system.workflow.repository.data.ResourceType;
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.broker.workflow.data.WorkflowInstanceRecord;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.clientapi.RecordType;
+import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.intent.DeploymentIntent;
+import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
+import io.zeebe.test.broker.protocol.clientapi.ExecuteCommandResponse;
+import io.zeebe.test.broker.protocol.clientapi.SubscribedRecord;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class CreateDeploymentMultiplePartitionsTest {
+
+  private static final BpmnModelInstance WORKFLOW =
+      Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
+
+  private static final BpmnModelInstance WORKFLOW_2 =
+      Bpmn.createExecutableProcess("process2").startEvent().endEvent().done();
+
+  public static final int PARTITION_ID = 1;
+  public static final int PARTITION_COUNT = 3;
+
+  public EmbeddedBrokerRule brokerRule =
+      new EmbeddedBrokerRule("zeebe.unit-test.increased.partitions.cfg.toml");
+
+  public ClientApiRule apiRule = new ClientApiRule();
+
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(apiRule);
+
+  @Test
+  public void shouldCreateDeploymentOnAllPartitions() throws Exception {
+    // when
+    final ExecuteCommandResponse resp =
+        apiRule
+            .createCmdRequest()
+            .partitionId(1)
+            .type(ValueType.DEPLOYMENT, DeploymentIntent.CREATE)
+            .command()
+            .put("topicName", DEFAULT_TOPIC)
+            .put(
+                "resources",
+                Collections.singletonList(deploymentResource(bpmnXml(WORKFLOW), "process.bpmn")))
+            .done()
+            .sendAndAwait();
+
+    // then
+    assertThat(resp.key()).isGreaterThanOrEqualTo(0L);
+    assertThat(resp.position()).isGreaterThanOrEqualTo(0L);
+    assertThat(resp.partitionId()).isEqualTo(PARTITION_ID);
+
+    assertThat(resp.recordType()).isEqualTo(RecordType.EVENT);
+    assertThat(resp.intent()).isEqualTo(DeploymentIntent.CREATED);
+
+    assertCreatedDeploymentEventOnPartition(1, resp.key());
+    assertCreatedDeploymentEventOnPartition(2, resp.key());
+    assertCreatedDeploymentEventOnPartition(3, resp.key());
+  }
+
+  @Test
+  public void shouldCreateDeploymentWithYamlResourcesOnAllPartitions() throws Exception {
+    // given
+    final Path yamlFile =
+        Paths.get(getClass().getResource("/workflows/simple-workflow.yaml").toURI());
+    final byte[] yamlWorkflow = Files.readAllBytes(yamlFile);
+
+    // when
+    final ExecuteCommandResponse resp =
+        apiRule
+            .topic()
+            .deployWithResponse(
+                yamlWorkflow, ResourceType.YAML_WORKFLOW.name(), "simple-workflow.yaml");
+
+    // then
+    assertThat(resp.key()).isGreaterThanOrEqualTo(0L);
+    assertThat(resp.position()).isGreaterThanOrEqualTo(0L);
+    assertThat(resp.partitionId()).isEqualTo(PARTITION_ID);
+
+    assertThat(resp.recordType()).isEqualTo(RecordType.EVENT);
+    assertThat(resp.intent()).isEqualTo(DeploymentIntent.CREATED);
+
+    final Map<String, Object> resources = deploymentResource(yamlWorkflow, "simple-workflow.yaml");
+    resources.put("resourceType", ResourceType.YAML_WORKFLOW.name());
+
+    for (int i = 1; i < PARTITION_COUNT + 1; i++) {
+      assertCreatedDeploymentEventResources(
+          i,
+          resp.key(),
+          (deploymentCreatedEvent) -> {
+            final Map<String, Object> map =
+                (Map<String, Object>)
+                    ((List) deploymentCreatedEvent.value().get("resources")).get(0);
+            assertThat(map).contains(entry("resourceType", ResourceType.YAML_WORKFLOW.name()));
+
+            final List<Map<String, Object>> deployedWorkflows =
+                (List<Map<String, Object>>) deploymentCreatedEvent.value().get("deployedWorkflows");
+            assertThat(deployedWorkflows).hasSize(1);
+            assertThat(deployedWorkflows.get(0))
+                .containsExactly(
+                    entry("bpmnProcessId", "yaml-workflow"),
+                    entry("version", 1L),
+                    entry("workflowKey", 1L),
+                    entry("resourceName", "simple-workflow.yaml"));
+          });
+    }
+  }
+
+  @Test
+  public void shouldCreateDeploymentResourceWithMultipleWorkflows() {
+    // given
+    final List<Map<String, Object>> resources = new ArrayList<>();
+    resources.add(deploymentResource(bpmnXml(WORKFLOW), "process.bpmn"));
+    resources.add(deploymentResource(bpmnXml(WORKFLOW_2), "process2.bpmn"));
+
+    // when
+    final ExecuteCommandResponse resp =
+        apiRule
+            .createCmdRequest()
+            .partitionId(1)
+            .type(ValueType.DEPLOYMENT, DeploymentIntent.CREATE)
+            .command()
+            .put("topicName", DEFAULT_TOPIC)
+            .put("resources", resources)
+            .done()
+            .sendAndAwait();
+
+    // then
+    assertThat(resp.recordType()).isEqualTo(RecordType.EVENT);
+    assertThat(resp.intent()).isEqualTo(DeploymentIntent.CREATED);
+
+    for (int i = 1; i < PARTITION_COUNT + 1; i++) {
+      assertCreatedDeploymentEventResources(
+          i,
+          resp.key(),
+          (createdDeployment) -> {
+            final List<Map<String, Object>> deployedWorkflows =
+                Arrays.asList(
+                    getDeployedWorkflow(createdDeployment, 0),
+                    getDeployedWorkflow(createdDeployment, 1));
+            assertThat(deployedWorkflows)
+                .extracting(s -> s.get(WorkflowInstanceRecord.PROP_WORKFLOW_BPMN_PROCESS_ID))
+                .contains("process", "process2");
+          });
+    }
+  }
+
+  @Test
+  public void shouldIncrementWorkflowVersions() {
+    // given
+
+    // when
+    final ExecuteCommandResponse d1 = apiRule.topic().deployWithResponse(WORKFLOW);
+    final ExecuteCommandResponse d2 = apiRule.topic().deployWithResponse(WORKFLOW);
+
+    // then
+    final Map<String, Object> workflow1 = getDeployedWorkflow(d1, 0);
+    assertThat(workflow1.get("version")).isEqualTo(1L);
+
+    for (int i = 1; i < PARTITION_COUNT + 1; i++) {
+      assertCreatedDeploymentEventResources(
+          i,
+          d1.key(),
+          createdDeployment -> {
+            assertThat(getDeployedWorkflow(createdDeployment, 0).get("version")).isEqualTo(1L);
+          });
+    }
+
+    final Map<String, Object> workflow2 = getDeployedWorkflow(d2, 0);
+    assertThat(workflow2.get("version")).isEqualTo(2L);
+
+    for (int i = 1; i < PARTITION_COUNT + 1; i++) {
+      assertCreatedDeploymentEventResources(
+          i,
+          d2.key(),
+          createdDeployment -> {
+            assertThat(getDeployedWorkflow(createdDeployment, 0).get("version")).isEqualTo(2L);
+          });
+    }
+  }
+
+  private Map<String, Object> deploymentResource(final byte[] resource, String name) {
+    final Map<String, Object> deploymentResource = new HashMap<>();
+    deploymentResource.put("resource", resource);
+    deploymentResource.put("resourceType", ResourceType.BPMN_XML);
+    deploymentResource.put("resourceName", name);
+
+    return deploymentResource;
+  }
+
+  private byte[] bpmnXml(final BpmnModelInstance definition) {
+    final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+    Bpmn.writeModelToStream(outStream, definition);
+    return outStream.toByteArray();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> getDeployedWorkflow(final ExecuteCommandResponse d1, int offset) {
+    final List<Map<String, Object>> d1Workflows =
+        (List<Map<String, Object>>) d1.getValue().get("deployedWorkflows");
+    return d1Workflows.get(offset);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> getDeployedWorkflow(final SubscribedRecord record, int offset) {
+    final List<Map<String, Object>> d1Workflows =
+        (List<Map<String, Object>>) record.value().get("deployedWorkflows");
+    return d1Workflows.get(offset);
+  }
+
+  private void assertCreatedDeploymentEventOnPartition(int expectedPartition, long expectedKey) {
+    assertCreatedDeploymentEventResources(
+        expectedPartition,
+        expectedKey,
+        (deploymentCreatedEvent) -> {
+          assertThat(deploymentCreatedEvent.key()).isEqualTo(expectedKey);
+          assertThat(deploymentCreatedEvent.partitionId()).isEqualTo(expectedPartition);
+
+          final Map<String, Object> resources =
+              deploymentResource(bpmnXml(WORKFLOW), "process.bpmn");
+          resources.put("resourceType", "BPMN_XML");
+
+          final Map<String, Object> map =
+              (Map<String, Object>) ((List) deploymentCreatedEvent.value().get("resources")).get(0);
+          assertThat(map).contains(entry("resource", resources.get("resource")));
+          assertThat(map).contains(entry("resourceType", resources.get("resourceType")));
+
+          final List<Map<String, Object>> deployedWorkflows =
+              (List<Map<String, Object>>) deploymentCreatedEvent.value().get("deployedWorkflows");
+          assertThat(deployedWorkflows).hasSize(1);
+          assertThat(deployedWorkflows.get(0))
+              .containsExactly(
+                  entry("bpmnProcessId", "process"),
+                  entry("version", 1L),
+                  entry("workflowKey", 1L),
+                  entry("resourceName", "process.bpmn"));
+        });
+  }
+
+  private void assertCreatedDeploymentEventResources(
+      int expectedPartition, long expectedKey, Consumer<SubscribedRecord> deploymentAssert) {
+    final SubscribedRecord deploymentCreatedEvent =
+        apiRule
+            .topic(expectedPartition)
+            .receiveRecords()
+            .skipUntil(r -> r.valueType() == ValueType.DEPLOYMENT)
+            .filter(
+                r ->
+                    r.valueType() == ValueType.DEPLOYMENT
+                        && r.intent() == DeploymentIntent.CREATED
+                        && r.key() == expectedKey)
+            .findFirst()
+            .get();
+
+    assertThat(deploymentCreatedEvent.key()).isEqualTo(expectedKey);
+    assertThat(deploymentCreatedEvent.partitionId()).isEqualTo(expectedPartition);
+
+    deploymentAssert.accept(deploymentCreatedEvent);
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/CreateWorkflowInstanceTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/CreateWorkflowInstanceTest.java
@@ -561,7 +561,7 @@ public class CreateWorkflowInstanceTest {
   }
 
   @Test
-  public void shouldCreateWorkflowInstanceOnAllPartitions() {
+  public void shouldCreateWorkflowInstanceOnAllPartitions() throws Exception {
     // given
     final int partitions = 3;
 

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/WorkflowInstanceFunctionalTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/WorkflowInstanceFunctionalTest.java
@@ -619,6 +619,7 @@ public class WorkflowInstanceFunctionalTest {
             .done()
             .sendAndAwait();
 
+    testClient.receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentResp.key());
     assertThat(deploymentResp.intent()).isEqualTo(DeploymentIntent.CREATED);
 
     final long workflowInstanceKey = testClient.createWorkflowInstance("yaml-workflow");
@@ -648,7 +649,7 @@ public class WorkflowInstanceFunctionalTest {
     // given
     // make a couple of deployments to ensure that the deployment stream processor will need some
     // time for reprocessing
-    final int numDeployments = 100;
+    final int numDeployments = 25;
     for (int i = 0; i < numDeployments; i++) {
       testClient.deploy(
           Bpmn.createExecutableProcess("process")

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/ClientApiRule.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/ClientApiRule.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.agrona.DirectBuffer;
+import org.agrona.collections.Int2ObjectHashMap;
 import org.junit.rules.ExternalResource;
 
 public class ClientApiRule extends ExternalResource {
@@ -125,12 +126,17 @@ public class ClientApiRule extends ExternalResource {
     return (int) incomingMessageCollector.getNumMessagesFulfilling(this::isSubscribedEvent);
   }
 
+  private Int2ObjectHashMap<TestTopicClient> testTopicClients = new Int2ObjectHashMap<>();
+
   public TestTopicClient topic() {
     return topic(defaultPartitionId);
   }
 
   public TestTopicClient topic(final int partitionId) {
-    return new TestTopicClient(this, partitionId);
+    if (!testTopicClients.containsKey(partitionId)) {
+      testTopicClients.put(partitionId, new TestTopicClient(this, partitionId));
+    }
+    return testTopicClients.get(partitionId);
   }
 
   public ExecuteCommandRequest openTopicSubscription(final String name, final long startPosition) {

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/SubscribedRecordStream.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/SubscribedRecordStream.java
@@ -47,6 +47,10 @@ public class SubscribedRecordStream extends StreamWrapper<SubscribedRecord> {
     return recordsOfValueType(ValueType.WORKFLOW_INSTANCE);
   }
 
+  public SubscribedRecordStream ofTypeDeployment() {
+    return recordsOfValueType(ValueType.DEPLOYMENT);
+  }
+
   public SubscribedRecordStream ofTypeJob() {
     return recordsOfValueType(ValueType.JOB);
   }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/DeploymentClusteredTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/DeploymentClusteredTest.java
@@ -89,13 +89,16 @@ public class DeploymentClusteredTest {
     // given
 
     // when
-    client
-        .topicClient()
-        .workflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW, "workflow.bpmn")
-        .send()
-        .join();
+    final DeploymentEvent deploymentEvent =
+        client
+            .topicClient()
+            .workflowClient()
+            .newDeployCommand()
+            .addWorkflowModel(WORKFLOW, "workflow.bpmn")
+            .send()
+            .join();
+
+    clientRule.waitUntilDeploymentIsDone(deploymentEvent.getKey());
 
     // then
     for (int p = 0; p < PARTITION_COUNT; p++) {
@@ -132,6 +135,7 @@ public class DeploymentClusteredTest {
             .join();
 
     assertThat(deploymentEvent.getDeployedWorkflows().size()).isEqualTo(1);
+    clientRule.waitUntilDeploymentIsDone(deploymentEvent.getKey());
   }
 
   @Test
@@ -140,13 +144,16 @@ public class DeploymentClusteredTest {
     // given
 
     clusteringRule.stopBroker(ClusteringRule.BROKER_3_CLIENT_ADDRESS);
-    client
-        .topicClient()
-        .workflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW, "workflow.bpmn")
-        .send()
-        .join();
+    final DeploymentEvent deploymentEvent =
+        client
+            .topicClient()
+            .workflowClient()
+            .newDeployCommand()
+            .addWorkflowModel(WORKFLOW, "workflow.bpmn")
+            .send()
+            .join();
+
+    clientRule.waitUntilDeploymentIsDone(deploymentEvent.getKey());
 
     // when
     clusteringRule.restartBroker(ClusteringRule.BROKER_3_CLIENT_ADDRESS);
@@ -201,6 +208,7 @@ public class DeploymentClusteredTest {
             .join();
 
     assertThat(deploymentEvent.getDeployedWorkflows().size()).isEqualTo(1);
+    clientRule.waitUntilDeploymentIsDone(deploymentEvent.getKey());
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerReprocessingTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerReprocessingTest.java
@@ -130,12 +130,7 @@ public class BrokerReprocessingTest {
   @Test
   public void shouldCreateWorkflowInstanceAfterRestart() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW, "workflow.bpmn")
-        .send()
-        .join();
+    deploy(WORKFLOW, "workflow.bpmn");
 
     // when
     reprocessingTrigger.accept(this);
@@ -155,12 +150,7 @@ public class BrokerReprocessingTest {
   @Test
   public void shouldContinueWorkflowInstanceAtTaskAfterRestart() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW, "workflow.bpmn")
-        .send()
-        .join();
+    deploy(WORKFLOW, "workflow.bpmn");
 
     clientRule
         .getWorkflowClient()
@@ -191,12 +181,7 @@ public class BrokerReprocessingTest {
   @Test
   public void shouldContinueWorkflowInstanceWithLockedTaskAfterRestart() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW, "workflow.bpmn")
-        .send()
-        .join();
+    deploy(WORKFLOW, "workflow.bpmn");
 
     clientRule
         .getWorkflowClient()
@@ -227,12 +212,7 @@ public class BrokerReprocessingTest {
   @Test
   public void shouldContinueWorkflowInstanceAtSecondTaskAfterRestart() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW_TWO_TASKS, "two-tasks.bpmn")
-        .send()
-        .join();
+    deploy(WORKFLOW_TWO_TASKS, "two-tasks.bpmn");
 
     clientRule
         .getWorkflowClient()
@@ -270,12 +250,7 @@ public class BrokerReprocessingTest {
   @Test
   public void shouldDeployNewWorkflowVersionAfterRestart() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW, "workflow.bpmn")
-        .send()
-        .join();
+    deploy(WORKFLOW, "workflow.bpmn");
 
     // when
     reprocessingTrigger.accept(this);
@@ -418,12 +393,7 @@ public class BrokerReprocessingTest {
   @Test
   public void shouldResolveIncidentAfterRestart() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW_INCIDENT, "incident.bpmn")
-        .send()
-        .join();
+    deploy(WORKFLOW_INCIDENT, "incident.bpmn");
 
     clientRule
         .getWorkflowClient()
@@ -456,12 +426,7 @@ public class BrokerReprocessingTest {
   @Test
   public void shouldResolveFailedIncidentAfterRestart() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW_INCIDENT, "incident.bpmn")
-        .send()
-        .join();
+    deploy(WORKFLOW_INCIDENT, "incident.bpmn");
 
     clientRule
         .getWorkflowClient()
@@ -530,12 +495,7 @@ public class BrokerReprocessingTest {
   @Test
   public void shouldAssignUniqueWorkflowInstanceKeyAfterRestart() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW, "workflow.bpmn")
-        .send()
-        .join();
+    deploy(WORKFLOW, "workflow.bpmn");
 
     final long workflowInstance1Key = startWorkflowInstance("process").getKey();
 
@@ -551,12 +511,7 @@ public class BrokerReprocessingTest {
   @Test
   public void shouldAssignUniqueJobKeyAfterRestart() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW, "workflow.bpmn")
-        .send()
-        .join();
+    deploy(WORKFLOW, "workflow.bpmn");
 
     final Supplier<JobEvent> jobCreator =
         () -> clientRule.getJobClient().newCreateCommand().jobType("foo").send().join();
@@ -575,12 +530,7 @@ public class BrokerReprocessingTest {
   @Test
   public void shouldAssignUniqueIncidentKeyAfterRestart() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW_INCIDENT, "incident.bpmn")
-        .send()
-        .join();
+    deploy(WORKFLOW_INCIDENT, "incident.bpmn");
 
     startWorkflowInstance("process");
 
@@ -694,5 +644,17 @@ public class BrokerReprocessingTest {
 
     brokerRule.startBroker();
     eventRecorder.startRecordingEvents();
+  }
+
+  private void deploy(BpmnModelInstance workflowTwoTasks, String s) {
+    final DeploymentEvent deploymentEvent =
+        clientRule
+            .getWorkflowClient()
+            .newDeployCommand()
+            .addWorkflowModel(workflowTwoTasks, s)
+            .send()
+            .join();
+
+    clientRule.waitUntilDeploymentIsDone(deploymentEvent.getKey());
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/CancelWorkflowInstanceTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/CancelWorkflowInstanceTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.zeebe.broker.it.ClientRule;
 import io.zeebe.broker.it.EmbeddedBrokerRule;
 import io.zeebe.broker.it.util.TopicEventRecorder;
+import io.zeebe.gateway.api.events.DeploymentEvent;
 import io.zeebe.gateway.api.events.JobEvent;
 import io.zeebe.gateway.api.events.JobState;
 import io.zeebe.gateway.api.events.WorkflowInstanceEvent;
@@ -56,12 +57,15 @@ public class CancelWorkflowInstanceTest {
 
   @Before
   public void init() {
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW, "workflow.bpmn")
-        .send()
-        .join();
+    final DeploymentEvent deploymentEvent =
+        clientRule
+            .getWorkflowClient()
+            .newDeployCommand()
+            .addWorkflowModel(WORKFLOW, "workflow.bpmn")
+            .send()
+            .join();
+
+    clientRule.waitUntilDeploymentIsDone(deploymentEvent.getKey());
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/CreateWorkflowInstanceTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/CreateWorkflowInstanceTest.java
@@ -61,13 +61,17 @@ public class CreateWorkflowInstanceTest {
             .send()
             .join();
 
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(
-            Bpmn.createExecutableProcess("anId").startEvent().endEvent().done(), "workflow.bpmn")
-        .send()
-        .join();
+    final DeploymentEvent secondDeployment =
+        clientRule
+            .getWorkflowClient()
+            .newDeployCommand()
+            .addWorkflowModel(
+                Bpmn.createExecutableProcess("anId").startEvent().endEvent().done(),
+                "workflow.bpmn")
+            .send()
+            .join();
+
+    clientRule.waitUntilDeploymentIsDone(secondDeployment.getKey());
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/ExclusiveGatewayTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/ExclusiveGatewayTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.zeebe.broker.it.ClientRule;
 import io.zeebe.broker.it.EmbeddedBrokerRule;
 import io.zeebe.broker.it.util.TopicEventRecorder;
+import io.zeebe.gateway.api.events.DeploymentEvent;
 import io.zeebe.gateway.api.events.WorkflowInstanceEvent;
 import io.zeebe.gateway.api.events.WorkflowInstanceState;
 import io.zeebe.model.bpmn.Bpmn;
@@ -52,12 +53,7 @@ public class ExclusiveGatewayTest {
             .endEvent("b")
             .done();
 
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(workflowDefinition, "workflow.bpmn")
-        .send()
-        .join();
+    deploy(workflowDefinition);
 
     // when
     clientRule
@@ -90,12 +86,7 @@ public class ExclusiveGatewayTest {
             .endEvent("b")
             .done();
 
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(workflowDefinition, "workflow.bpmn")
-        .send()
-        .join();
+    deploy(workflowDefinition);
 
     // when
     clientRule
@@ -130,12 +121,7 @@ public class ExclusiveGatewayTest {
             .connectTo("inc")
             .done();
 
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(workflowDefinition, "workflow.bpmn")
-        .send()
-        .join();
+    deploy(workflowDefinition);
 
     // when
     clientRule
@@ -168,5 +154,17 @@ public class ExclusiveGatewayTest {
     final WorkflowInstanceEvent event =
         eventRecorder.getElementInState("workflow", WorkflowInstanceState.ELEMENT_COMPLETED);
     assertThat(event.getPayload()).isEqualTo("{\"count\":6}");
+  }
+
+  private void deploy(BpmnModelInstance workflowDefinition) {
+    final DeploymentEvent deploymentEvent =
+        clientRule
+            .getWorkflowClient()
+            .newDeployCommand()
+            .addWorkflowModel(workflowDefinition, "workflow.bpmn")
+            .send()
+            .join();
+
+    clientRule.waitUntilDeploymentIsDone(deploymentEvent.getKey());
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/IntermediateCatchEventTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/IntermediateCatchEventTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.entry;
 import io.zeebe.broker.it.ClientRule;
 import io.zeebe.broker.it.EmbeddedBrokerRule;
 import io.zeebe.broker.it.util.TopicEventRecorder;
+import io.zeebe.gateway.api.events.DeploymentEvent;
 import io.zeebe.gateway.api.events.WorkflowInstanceEvent;
 import io.zeebe.gateway.api.events.WorkflowInstanceState;
 import io.zeebe.model.bpmn.Bpmn;
@@ -52,12 +53,15 @@ public class IntermediateCatchEventTest {
 
   @Before
   public void init() {
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW, "wf.bpmn")
-        .send()
-        .join();
+    final DeploymentEvent deploymentEvent =
+        clientRule
+            .getWorkflowClient()
+            .newDeployCommand()
+            .addWorkflowModel(WORKFLOW, "wf.bpmn")
+            .send()
+            .join();
+
+    clientRule.waitUntilDeploymentIsDone(deploymentEvent.getKey());
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/PublishMessageTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/PublishMessageTest.java
@@ -26,6 +26,7 @@ import io.zeebe.broker.it.EmbeddedBrokerRule;
 import io.zeebe.broker.it.util.TopicEventRecorder;
 import io.zeebe.gateway.api.ZeebeFuture;
 import io.zeebe.gateway.api.clients.WorkflowClient;
+import io.zeebe.gateway.api.events.DeploymentEvent;
 import io.zeebe.gateway.api.events.MessageEvent;
 import io.zeebe.gateway.api.events.WorkflowInstanceEvent;
 import io.zeebe.gateway.api.events.WorkflowInstanceState;
@@ -68,7 +69,10 @@ public class PublishMessageTest {
 
     workflowClient = clientRule.getClient().topicClient().workflowClient();
 
-    workflowClient.newDeployCommand().addWorkflowModel(WORKFLOW, "wf.bpmn").send().join();
+    final DeploymentEvent deploymentEvent =
+        workflowClient.newDeployCommand().addWorkflowModel(WORKFLOW, "wf.bpmn").send().join();
+
+    clientRule.waitUntilDeploymentIsDone(deploymentEvent.getKey());
 
     eventRecorder.startRecordingEvents();
   }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/ServiceTaskTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/ServiceTaskTest.java
@@ -23,11 +23,13 @@ import io.zeebe.broker.it.ClientRule;
 import io.zeebe.broker.it.EmbeddedBrokerRule;
 import io.zeebe.broker.it.util.RecordingJobHandler;
 import io.zeebe.broker.it.util.TopicEventRecorder;
+import io.zeebe.gateway.api.events.DeploymentEvent;
 import io.zeebe.gateway.api.events.JobEvent;
 import io.zeebe.gateway.api.events.JobState;
 import io.zeebe.gateway.api.events.WorkflowInstanceEvent;
 import io.zeebe.gateway.api.events.WorkflowInstanceState;
 import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Rule;
@@ -50,18 +52,13 @@ public class ServiceTaskTest {
   @Test
   public void shouldCreateWorkflowInstanceWithServiceTask() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(
-            Bpmn.createExecutableProcess("process")
-                .startEvent("start")
-                .serviceTask("task", t -> t.zeebeTaskType("foo"))
-                .endEvent("end")
-                .done(),
-            "workflow.bpmn")
-        .send()
-        .join();
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask("task", t -> t.zeebeTaskType("foo"))
+            .endEvent("end")
+            .done();
+    deploy(modelInstance);
 
     // when
     final WorkflowInstanceEvent workflowInstance =
@@ -84,24 +81,18 @@ public class ServiceTaskTest {
     final Map<String, String> customHeaders = new HashMap<>();
     customHeaders.put("cust1", "a");
     customHeaders.put("cust2", "b");
-
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(
-            Bpmn.createExecutableProcess("process")
-                .startEvent("start")
-                .serviceTask(
-                    "task",
-                    t ->
-                        t.zeebeTaskType("foo")
-                            .zeebeTaskHeader("cust1", "a")
-                            .zeebeTaskHeader("cust2", "b"))
-                .endEvent("end")
-                .done(),
-            "workflow.bpmn")
-        .send()
-        .join();
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeTaskType("foo")
+                        .zeebeTaskHeader("cust1", "a")
+                        .zeebeTaskHeader("cust2", "b"))
+            .endEvent("end")
+            .done();
+    deploy(modelInstance);
 
     final WorkflowInstanceEvent workflowInstance =
         clientRule
@@ -141,18 +132,14 @@ public class ServiceTaskTest {
   @Test
   public void shouldCompleteServiceTask() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(
-            Bpmn.createExecutableProcess("process")
-                .startEvent("start")
-                .serviceTask("task", t -> t.zeebeTaskType("foo"))
-                .endEvent("end")
-                .done(),
-            "workflow.bpmn")
-        .send()
-        .join();
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask("task", t -> t.zeebeTaskType("foo"))
+            .endEvent("end")
+            .done();
+
+    deploy(modelInstance);
 
     clientRule
         .getWorkflowClient()
@@ -179,18 +166,13 @@ public class ServiceTaskTest {
   @Test
   public void shouldMapPayloadIntoTask() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(
-            Bpmn.createExecutableProcess("process")
-                .startEvent("start")
-                .serviceTask("task", t -> t.zeebeTaskType("foo").zeebeInput("$.foo", "$.bar"))
-                .endEvent("end")
-                .done(),
-            "workflow.bpmn")
-        .send()
-        .join();
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask("task", t -> t.zeebeTaskType("foo").zeebeInput("$.foo", "$.bar"))
+            .endEvent("end")
+            .done();
+    deploy(modelInstance);
 
     clientRule
         .getWorkflowClient()
@@ -216,18 +198,13 @@ public class ServiceTaskTest {
   @Test
   public void shouldMapPayloadFromTask() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(
-            Bpmn.createExecutableProcess("process")
-                .startEvent("start")
-                .serviceTask("task", t -> t.zeebeTaskType("foo").zeebeOutput("$.foo", "$.bar"))
-                .endEvent("end")
-                .done(),
-            "workflow.bpmn")
-        .send()
-        .join();
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask("task", t -> t.zeebeTaskType("foo").zeebeOutput("$.foo", "$.bar"))
+            .endEvent("end")
+            .done();
+    deploy(modelInstance);
 
     clientRule
         .getWorkflowClient()
@@ -257,23 +234,18 @@ public class ServiceTaskTest {
   @Test
   public void shouldModifyPayloadInTask() {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(
-            Bpmn.createExecutableProcess("process")
-                .startEvent("start")
-                .serviceTask(
-                    "task",
-                    t ->
-                        t.zeebeTaskType("foo")
-                            .zeebeInput("$.foo", "$.foo")
-                            .zeebeOutput("$.foo", "$.foo"))
-                .endEvent("end")
-                .done(),
-            "workflow.bpmn")
-        .send()
-        .join();
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeTaskType("foo")
+                        .zeebeInput("$.foo", "$.foo")
+                        .zeebeOutput("$.foo", "$.foo"))
+            .endEvent("end")
+            .done();
+    deploy(modelInstance);
 
     clientRule
         .getWorkflowClient()
@@ -308,23 +280,18 @@ public class ServiceTaskTest {
   @Test
   public void shouldCompleteTasksFromMultipleProcesses() throws InterruptedException {
     // given
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(
-            Bpmn.createExecutableProcess("process")
-                .startEvent("start")
-                .serviceTask(
-                    "task",
-                    t ->
-                        t.zeebeTaskType("foo")
-                            .zeebeInput("$.foo", "$.foo")
-                            .zeebeOutput("$.foo", "$.foo"))
-                .endEvent("end")
-                .done(),
-            "workflow.bpmn")
-        .send()
-        .join();
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeTaskType("foo")
+                        .zeebeInput("$.foo", "$.foo")
+                        .zeebeOutput("$.foo", "$.foo"))
+            .endEvent("end")
+            .done();
+    deploy(modelInstance);
 
     // when
     final int instances = 10;
@@ -354,5 +321,17 @@ public class ServiceTaskTest {
                     .getElementsInState("process", WorkflowInstanceState.ELEMENT_COMPLETED)
                     .size()
                 == instances);
+  }
+
+  private DeploymentEvent deploy(BpmnModelInstance modelInstance) {
+    final DeploymentEvent deploymentEvent =
+        clientRule
+            .getWorkflowClient()
+            .newDeployCommand()
+            .addWorkflowModel(modelInstance, "workflow.bpmn")
+            .send()
+            .join();
+    clientRule.waitUntilDeploymentIsDone(deploymentEvent.getKey());
+    return deploymentEvent;
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/UpdatePayloadTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/UpdatePayloadTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.entry;
 import io.zeebe.broker.it.ClientRule;
 import io.zeebe.broker.it.EmbeddedBrokerRule;
 import io.zeebe.broker.it.util.TopicEventRecorder;
+import io.zeebe.gateway.api.events.DeploymentEvent;
 import io.zeebe.gateway.api.events.WorkflowInstanceEvent;
 import io.zeebe.gateway.api.events.WorkflowInstanceState;
 import io.zeebe.gateway.cmd.BrokerErrorException;
@@ -58,12 +59,15 @@ public class UpdatePayloadTest {
 
   @Before
   public void init() {
-    clientRule
-        .getWorkflowClient()
-        .newDeployCommand()
-        .addWorkflowModel(WORKFLOW, "workflow.bpmn")
-        .send()
-        .join();
+    final DeploymentEvent deploymentEvent =
+        clientRule
+            .getWorkflowClient()
+            .newDeployCommand()
+            .addWorkflowModel(WORKFLOW, "workflow.bpmn")
+            .send()
+            .join();
+
+    clientRule.waitUntilDeploymentIsDone(deploymentEvent.getKey());
 
     clientRule
         .getWorkflowClient()

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/WorkflowRepositoryTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/WorkflowRepositoryTest.java
@@ -85,6 +85,8 @@ public class WorkflowRepositoryTest {
             .send()
             .join();
 
+    clientRule.waitUntilDeploymentIsDone(thirdDeployment.getKey());
+
     deployedWorkflows.addAll(firstDeployment.getDeployedWorkflows());
     deployedWorkflows.addAll(secondDeployment.getDeployedWorkflows());
     deployedWorkflows.addAll(thirdDeployment.getDeployedWorkflows());


### PR DESCRIPTION
  * introduce new push request / response
  * on processing create deployment command,
  the deployment is distributed to remaining partitions
  * partition ids and corresponding leaders have to been resolved
  * push request handler writes deployment created event to
  corresponding partition
  * created deployment processor simply adds workflow to index
  * deployment of multiple workflows per deployment is possible again
  * tests need to wait until deployment created event is written to
  partition one - this event is only written, if deployment is
  distributed to all other partitions


closes #1116 
