### PR TITLE
Create exporters based on configuration

### DIFF
--- a/broker-core/pom.xml
+++ b/broker-core/pom.xml
@@ -19,7 +19,7 @@
   </properties>
 
   <dependencies>
-     <dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
@@ -73,10 +73,15 @@
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-gateway</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zb-msgpack-json-el</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zb-exporter</artifactId>
     </dependency>
 
     <dependency>

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/context/ExporterConfiguration.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/context/ExporterConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.context;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import io.zeebe.exporter.context.Configuration;
+import java.util.Map;
+
+public class ExporterConfiguration implements Configuration {
+  private static final Gson CONFIG_INSTANTIATOR = new GsonBuilder().create();
+
+  private final String id;
+  private final Map<String, Object> arguments;
+
+  private JsonElement intermediateConfiguration;
+
+  public ExporterConfiguration(final String id, final Map<String, Object> arguments) {
+    this.id = id;
+    this.arguments = arguments;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public Map<String, Object> getArguments() {
+    return arguments;
+  }
+
+  @Override
+  public <T> T instantiate(Class<T> configClass) {
+    return CONFIG_INSTANTIATOR.fromJson(getIntermediateConfiguration(), configClass);
+  }
+
+  private JsonElement getIntermediateConfiguration() {
+    if (intermediateConfiguration == null) {
+      intermediateConfiguration = CONFIG_INSTANTIATOR.toJsonTree(arguments);
+    }
+
+    return intermediateConfiguration;
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/context/ExporterContext.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/context/ExporterContext.java
@@ -15,18 +15,28 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.zeebe.broker;
+package io.zeebe.broker.exporter.context;
 
-import io.zeebe.util.ZbLogger;
+import io.zeebe.exporter.context.Configuration;
+import io.zeebe.exporter.context.Context;
 import org.slf4j.Logger;
 
-public class Loggers {
-  public static final Logger CLUSTERING_LOGGER = new ZbLogger("io.zeebe.broker.clustering");
-  public static final Logger SERVICES_LOGGER = new ZbLogger("io.zeebe.broker.services");
-  public static final Logger SYSTEM_LOGGER = new ZbLogger("io.zeebe.broker.system");
-  public static final Logger TRANSPORT_LOGGER = new ZbLogger("io.zeebe.broker.transport");
-  public static final Logger STREAM_PROCESSING = new ZbLogger("io.zeebe.broker.streamProcessing");
-  public static final Logger WORKFLOW_REPOSITORY_LOGGER =
-      new ZbLogger("io.zeebe.broker.workflow.repository");
-  public static final Logger EXPORTER_LOGGER = new ZbLogger("io.zeebe.broker.exporter");
+public class ExporterContext implements Context {
+  private final Logger logger;
+  private final Configuration configuration;
+
+  public ExporterContext(final Logger logger, final Configuration configuration) {
+    this.logger = logger;
+    this.configuration = configuration;
+  }
+
+  @Override
+  public Logger getLogger() {
+    return logger;
+  }
+
+  @Override
+  public Configuration getConfiguration() {
+    return configuration;
+  }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/jar/ExporterJarClassLoader.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/jar/ExporterJarClassLoader.java
@@ -1,0 +1,87 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.jar;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+
+/**
+ * Provides a class loader which isolates external exporters from other exporters, while exposing
+ * our own code to ensure versions match at runtime.
+ */
+public class ExporterJarClassLoader extends URLClassLoader {
+  public static final String JAVA_PACKAGE_PREFIX = "java.";
+  public static final String JAR_URL_FORMAT = "jar:%s!/";
+
+  /** lists of packages from broker base that are exposed at runtime to the external exporters */
+  public static final String[] EXPOSED_PACKAGE_PREFIXES =
+      new String[] {"io.zeebe.exporter.", "org.slf4j.", "org.apache.logging.log4j."};
+
+  public ExporterJarClassLoader(URL[] urls) {
+    super(urls);
+  }
+
+  public static ExporterJarClassLoader ofPath(final Path jarPath) throws ExporterJarLoadException {
+    final URL jarUrl;
+
+    try {
+      final String expandedPath = jarPath.toUri().toURL().toString();
+      jarUrl = new URL(String.format(JAR_URL_FORMAT, expandedPath));
+    } catch (final MalformedURLException e) {
+      throw new ExporterJarLoadException(jarPath, "bad JAR url", e);
+    }
+
+    return new ExporterJarClassLoader(new URL[] {jarUrl});
+  }
+
+  @Override
+  public Class<?> loadClass(String name) throws ClassNotFoundException {
+    synchronized (getClassLoadingLock(name)) {
+      if (name.startsWith(JAVA_PACKAGE_PREFIX)) {
+        return findSystemClass(name);
+      }
+
+      if (isProvidedByBroker(name)) {
+        return getSystemClassLoader().loadClass(name);
+      }
+
+      Class<?> clazz = findLoadedClass(name);
+      if (clazz == null) {
+        try {
+          clazz = findClass(name);
+        } catch (final ClassNotFoundException ex) {
+          clazz = super.loadClass(name);
+        }
+      }
+
+      return clazz;
+    }
+  }
+
+  private boolean isProvidedByBroker(final String name) {
+    for (final String prefix : EXPOSED_PACKAGE_PREFIXES) {
+      if (name.startsWith(prefix)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/jar/ExporterJarLoadException.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/jar/ExporterJarLoadException.java
@@ -1,0 +1,34 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.jar;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class ExporterJarLoadException extends IOException {
+  private static final String MESSAGE_FORMAT = "Cannot load JAR at [%s]: %s";
+  private static final long serialVersionUID = 1655276726721040696L;
+
+  public ExporterJarLoadException(final Path jarPath, final String reason) {
+    super(String.format(MESSAGE_FORMAT, jarPath, reason));
+  }
+
+  public ExporterJarLoadException(final Path jarPath, final String reason, final Throwable cause) {
+    super(String.format(MESSAGE_FORMAT, jarPath, reason), cause);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/jar/ExporterJarRepository.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/jar/ExporterJarRepository.java
@@ -1,0 +1,91 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.jar;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Maintains a map of all loaded exporter JARs and their corresponding class loaders for quick
+ * reuse.
+ */
+public class ExporterJarRepository {
+  public static final String JAR_EXTENSION = ".jar";
+
+  private final Map<Path, ExporterJarClassLoader> loadedJars;
+
+  public ExporterJarRepository() {
+    this(new HashMap<>());
+  }
+
+  public ExporterJarRepository(final Map<Path, ExporterJarClassLoader> loadedJars) {
+    this.loadedJars = loadedJars;
+  }
+
+  public Map<Path, ExporterJarClassLoader> getJars() {
+    return Collections.unmodifiableMap(loadedJars);
+  }
+
+  public ExporterJarClassLoader remove(final String jarPath) {
+    return remove(Paths.get(jarPath));
+  }
+
+  public ExporterJarClassLoader remove(final Path jarPath) {
+    return loadedJars.remove(jarPath);
+  }
+
+  public ExporterJarClassLoader load(final String jarPath) throws ExporterJarLoadException {
+    return load(Paths.get(jarPath));
+  }
+
+  public ExporterJarClassLoader load(final Path jarPath) throws ExporterJarLoadException {
+    ExporterJarClassLoader classLoader = loadedJars.get(jarPath);
+
+    if (classLoader == null) {
+      verifyJarPath(jarPath);
+
+      classLoader = ExporterJarClassLoader.ofPath(jarPath);
+      loadedJars.put(jarPath, classLoader);
+    }
+
+    return classLoader;
+  }
+
+  /**
+   * Verifies that the given path points to an existing, readable JAR file. Does not perform more
+   * complex validation such as checking it is a valid JAR, verifying its signature, etc.
+   *
+   * @param path path to verify
+   * @throws ExporterJarLoadException if it is not a JAR, not readable, or does not exist
+   */
+  private void verifyJarPath(final Path path) throws ExporterJarLoadException {
+    final File jarFile = path.toFile();
+
+    if (!jarFile.getName().endsWith(JAR_EXTENSION)) {
+      throw new ExporterJarLoadException(path, "is not a JAR");
+    }
+
+    if (!jarFile.canRead()) {
+      throw new ExporterJarLoadException(path, "is not readable");
+    }
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/repo/ExporterDescriptor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/repo/ExporterDescriptor.java
@@ -1,0 +1,47 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.repo;
+
+import io.zeebe.broker.exporter.context.ExporterConfiguration;
+import io.zeebe.exporter.spi.Exporter;
+import java.util.Map;
+
+public class ExporterDescriptor {
+  private final ExporterConfiguration configuration;
+  private final Class<? extends Exporter> exporterClass;
+
+  public ExporterDescriptor(
+      final String id,
+      final Class<? extends Exporter> exporterClass,
+      final Map<String, Object> args) {
+    this.exporterClass = exporterClass;
+    this.configuration = new ExporterConfiguration(id, args);
+  }
+
+  public Exporter newInstance() throws IllegalAccessException, InstantiationException {
+    return exporterClass.newInstance();
+  }
+
+  public ExporterConfiguration getConfiguration() {
+    return configuration;
+  }
+
+  public String getId() {
+    return configuration.getId();
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/repo/ExporterLoadException.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/repo/ExporterLoadException.java
@@ -1,0 +1,31 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.repo;
+
+public class ExporterLoadException extends Exception {
+  private static final long serialVersionUID = -9192947670450762759L;
+  private static final String MESSAGE_FORMAT = "Cannot load exporter [%s]: %s";
+
+  public ExporterLoadException(final String id, final String reason) {
+    super(String.format(MESSAGE_FORMAT, id, reason));
+  }
+
+  public ExporterLoadException(final String id, final String reason, final Throwable cause) {
+    super(String.format(MESSAGE_FORMAT, id, reason), cause);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/repo/ExporterRepository.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/repo/ExporterRepository.java
@@ -1,0 +1,107 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.repo;
+
+import io.zeebe.broker.Loggers;
+import io.zeebe.broker.exporter.context.ExporterContext;
+import io.zeebe.broker.exporter.jar.ExporterJarLoadException;
+import io.zeebe.broker.exporter.jar.ExporterJarRepository;
+import io.zeebe.broker.system.configuration.ExporterCfg;
+import io.zeebe.exporter.spi.Exporter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+
+public class ExporterRepository {
+  private static final Logger LOG = Loggers.EXPORTER_LOGGER;
+  private final ExporterJarRepository jarRepository;
+  private final Map<String, ExporterDescriptor> exporters;
+
+  public ExporterRepository() {
+    this(new HashMap<>(), new ExporterJarRepository());
+  }
+
+  public ExporterRepository(
+      final Map<String, ExporterDescriptor> exporters, final ExporterJarRepository jarRepository) {
+    this.exporters = exporters;
+    this.jarRepository = jarRepository;
+  }
+
+  public Map<String, ExporterDescriptor> getExporters() {
+    return Collections.unmodifiableMap(exporters);
+  }
+
+  public ExporterDescriptor load(final String id, final Class<? extends Exporter> exporterClass)
+      throws ExporterLoadException {
+    return load(id, exporterClass, null);
+  }
+
+  public ExporterDescriptor load(
+      final String id,
+      final Class<? extends Exporter> exporterClass,
+      final Map<String, Object> args)
+      throws ExporterLoadException {
+    ExporterDescriptor descriptor = exporters.get(id);
+
+    if (descriptor == null) {
+      descriptor = new ExporterDescriptor(id, exporterClass, args);
+      validate(descriptor);
+
+      exporters.put(id, descriptor);
+    }
+
+    return descriptor;
+  }
+
+  public ExporterDescriptor load(final ExporterCfg config)
+      throws ExporterLoadException, ExporterJarLoadException {
+    final String id = config.getId();
+    final ClassLoader classLoader;
+    final Class<? extends Exporter> exporterClass;
+
+    if (exporters.containsKey(id)) {
+      return exporters.get(id);
+    }
+
+    if (!config.isExternal()) {
+      classLoader = getClass().getClassLoader();
+    } else {
+      classLoader = jarRepository.load(config.getJarPath());
+    }
+
+    try {
+      final Class<?> specifiedClass = classLoader.loadClass(config.getClassName());
+      exporterClass = specifiedClass.asSubclass(Exporter.class);
+    } catch (ClassNotFoundException | ClassCastException e) {
+      throw new ExporterLoadException(id, "cannot load specified class", e);
+    }
+
+    return load(id, exporterClass, config.getArgs());
+  }
+
+  private void validate(final ExporterDescriptor descriptor) throws ExporterLoadException {
+    try {
+      final Exporter instance = descriptor.newInstance();
+      final ExporterContext context = new ExporterContext(LOG, descriptor.getConfiguration());
+      instance.configure(context);
+    } catch (final Exception ex) {
+      throw new ExporterLoadException(descriptor.getId(), "failed validation", ex);
+    }
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
@@ -33,6 +33,7 @@ public class BrokerCfg {
   private GossipConfiguration gossip = new GossipConfiguration();
   private RaftConfiguration raft = new RaftConfiguration();
   private List<TopicCfg> topics = new ArrayList<>();
+  private List<ExporterCfg> exporters = new ArrayList<>();
 
   public void init(String brokerBase) {
     init(brokerBase, new Environment());
@@ -44,6 +45,7 @@ public class BrokerCfg {
     threads.init(this, brokerBase, environment);
     metrics.init(this, brokerBase, environment);
     data.init(this, brokerBase, environment);
+    exporters.forEach(e -> e.init(this, brokerBase, environment));
   }
 
   public int getBootstrap() {
@@ -116,5 +118,13 @@ public class BrokerCfg {
 
   public void setTopics(List<TopicCfg> topics) {
     this.topics = topics;
+  }
+
+  public List<ExporterCfg> getExporters() {
+    return exporters;
+  }
+
+  public void setExporters(List<ExporterCfg> exporters) {
+    this.exporters = exporters;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/ExporterCfg.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/ExporterCfg.java
@@ -1,0 +1,89 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.system.configuration;
+
+import java.util.Map;
+
+/**
+ * Exporter component configuration. To be expanded eventually to allow enabling/disabling
+ * exporters, and other general configuration.
+ */
+public class ExporterCfg implements ConfigurationEntry {
+  /** locally unique ID of the exporter */
+  private String id;
+
+  /**
+   * path to the JAR file containing the exporter class
+   *
+   * <p>optional field: if missing, will lookup the class in the zeebe classpath
+   */
+  private String jarPath;
+
+  /** fully qualified class name pointing to the class implementing the exporter interface */
+  private String className;
+
+  /** map of arguments to use when instantiating the exporter */
+  private Map<String, Object> args;
+
+  @Override
+  public void init(BrokerCfg globalConfig, String brokerBase, Environment environment) {
+    if (isExternal()) {
+      jarPath = ConfigurationUtil.toAbsolutePath(jarPath, brokerBase);
+    }
+  }
+
+  public boolean isExternal() {
+    return !isEmpty(jarPath);
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getJarPath() {
+    return jarPath;
+  }
+
+  public void setJarPath(String jarPath) {
+    this.jarPath = jarPath;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  public void setClassName(String className) {
+    this.className = className;
+  }
+
+  public Map<String, Object> getArgs() {
+    return args;
+  }
+
+  public void setArgs(Map<String, Object> args) {
+    this.args = args;
+  }
+
+  private boolean isEmpty(final String value) {
+    return value == null || value.isEmpty();
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/jar/ExporterJarClassLoaderTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/jar/ExporterJarClassLoaderTest.java
@@ -1,0 +1,105 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.jar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.exporter.util.JarCreatorRule;
+import io.zeebe.broker.exporter.util.TestJarExporter;
+import io.zeebe.exporter.spi.Exporter;
+import java.io.File;
+import org.apache.logging.log4j.LogManager;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+
+public class ExporterJarClassLoaderTest {
+  private TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private JarCreatorRule jarCreator = new JarCreatorRule(temporaryFolder);
+
+  @Rule public RuleChain chain = RuleChain.outerRule(temporaryFolder).around(jarCreator);
+
+  @Test
+  public void shouldLoadClassesPackagedInJar() throws Exception {
+    final Class exportedClass = TestJarExporter.class;
+    final File jarFile = jarCreator.create(exportedClass);
+    final ExporterJarClassLoader classLoader = ExporterJarClassLoader.ofPath(jarFile.toPath());
+
+    // when
+    final Class<?> loadedClass = classLoader.loadClass(exportedClass.getCanonicalName());
+
+    // then
+    assertThat(loadedClass).isNotEqualTo(exportedClass);
+    assertThat(loadedClass.getDeclaredField("FOO").get(loadedClass)).isEqualTo(TestJarExporter.FOO);
+    assertThat(loadedClass.newInstance()).isInstanceOf(Exporter.class);
+  }
+
+  @Test
+  public void shouldLoadSystemClassesFromSystemClassLoader() throws Exception {
+    final Class exportedClass = TestJarExporter.class;
+    final File jarFile = jarCreator.create(exportedClass);
+    final ExporterJarClassLoader classLoader = ExporterJarClassLoader.ofPath(jarFile.toPath());
+
+    // when
+    final Class loadedClass = classLoader.loadClass(String.class.getCanonicalName());
+
+    // then
+    assertThat(loadedClass).isEqualTo(String.class);
+  }
+
+  @Test
+  public void shouldLoadZbExporterClassesFromSystemClassLoader() throws Exception {
+    final Class exportedClass = TestJarExporter.class;
+    final File jarFile = jarCreator.create(exportedClass);
+    final ExporterJarClassLoader classLoader = ExporterJarClassLoader.ofPath(jarFile.toPath());
+
+    // when
+    final Class loadedClass = classLoader.loadClass(Exporter.class.getCanonicalName());
+
+    // then
+    assertThat(loadedClass).isEqualTo(Exporter.class);
+  }
+
+  @Test
+  public void shouldLoadSL4JClassesFromSystemClassLoader() throws Exception {
+    final Class exportedClass = TestJarExporter.class;
+    final File jarFile = jarCreator.create(exportedClass);
+    final ExporterJarClassLoader classLoader = ExporterJarClassLoader.ofPath(jarFile.toPath());
+
+    // when
+    final Class loadedClass = classLoader.loadClass(Logger.class.getCanonicalName());
+
+    // then
+    assertThat(loadedClass).isEqualTo(Logger.class);
+  }
+
+  @Test
+  public void shouldLoadLog4JClassesFromSystemClassLoader() throws Exception {
+    final Class exportedClass = TestJarExporter.class;
+    final File jarFile = jarCreator.create(exportedClass);
+    final ExporterJarClassLoader classLoader = ExporterJarClassLoader.ofPath(jarFile.toPath());
+
+    // when
+    final Class loadedClass = classLoader.loadClass(LogManager.class.getCanonicalName());
+
+    // then
+    assertThat(loadedClass).isEqualTo(LogManager.class);
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/jar/ExporterJarRepositoryTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/jar/ExporterJarRepositoryTest.java
@@ -1,0 +1,105 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.jar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assume.assumeTrue;
+
+import io.zeebe.broker.exporter.util.JarCreatorRule;
+import io.zeebe.broker.exporter.util.TestJarExporter;
+import java.io.File;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+
+public class ExporterJarRepositoryTest {
+  private TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private JarCreatorRule jarCreator = new JarCreatorRule(temporaryFolder);
+
+  @Rule public RuleChain chain = RuleChain.outerRule(temporaryFolder).around(jarCreator);
+
+  private final ExporterJarRepository jarRepository = new ExporterJarRepository();
+
+  @Test
+  public void shouldThrowExceptionOnLoadIfNotAJar() throws IOException {
+    // given
+    final File fake = temporaryFolder.newFile("fake-file");
+
+    // then
+    assertThatThrownBy(() -> jarRepository.load(fake.getAbsolutePath()))
+        .isInstanceOf(ExporterJarLoadException.class);
+  }
+
+  @Test
+  public void shouldThrowExceptionOnLoadIfNotReadable() throws Exception {
+    // given
+    assumeTrue(!System.getProperty("os.name").startsWith("Windows"));
+    final File dummy = temporaryFolder.newFile("unreadable.jar");
+
+    // when
+    dummy.setReadable(false);
+
+    // then
+    // System.out.println("was set = " + isSet);
+    assertThatThrownBy(() -> jarRepository.load(dummy.getAbsolutePath()))
+        .isInstanceOf(ExporterJarLoadException.class);
+  }
+
+  @Test
+  public void shouldThrowExceptionIfJarMissing() throws IOException {
+    // given
+    final File dummy = temporaryFolder.newFile("missing.jar");
+
+    // when
+    dummy.delete();
+
+    // then
+    assertThatThrownBy(() -> jarRepository.load(dummy.getAbsolutePath()))
+        .isInstanceOf(ExporterJarLoadException.class);
+  }
+
+  @Test
+  public void shouldLoadClassLoaderForJar() throws IOException {
+    // given
+    final File dummy = temporaryFolder.newFile("readable.jar");
+
+    // when
+    dummy.setReadable(true);
+
+    // then
+    assertThat(jarRepository.load(dummy.getAbsolutePath()))
+        .isInstanceOf(ExporterJarClassLoader.class);
+  }
+
+  @Test
+  public void shouldLoadClassLoaderCorrectlyOnlyOnce() throws Exception {
+    // given
+    final Class exportedClass = TestJarExporter.class;
+    final File jarFile = jarCreator.create(exportedClass);
+
+    // when
+    final ExporterJarClassLoader classLoader = jarRepository.load(jarFile.toPath());
+
+    // then
+    assertThat(classLoader.loadClass(exportedClass.getCanonicalName())).isNotEqualTo(exportedClass);
+    assertThat(jarRepository.load(jarFile.toPath())).isEqualTo(classLoader);
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/repo/ExporterRepositoryTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/repo/ExporterRepositoryTest.java
@@ -1,0 +1,169 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.repo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.zeebe.broker.exporter.jar.ExporterJarLoadException;
+import io.zeebe.broker.exporter.util.ControlledTestExporter;
+import io.zeebe.broker.exporter.util.JarCreatorRule;
+import io.zeebe.broker.exporter.util.TestJarExporter;
+import io.zeebe.broker.system.configuration.ExporterCfg;
+import io.zeebe.exporter.context.Context;
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.spi.Exporter;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+
+public class ExporterRepositoryTest {
+  private TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private JarCreatorRule jarCreator = new JarCreatorRule(temporaryFolder);
+
+  @Rule public RuleChain chain = RuleChain.outerRule(temporaryFolder).around(jarCreator);
+
+  private ExporterRepository repository = new ExporterRepository();
+
+  @Test
+  public void shouldCacheDescriptorOnceLoaded() throws ExporterLoadException {
+    // given
+    final String id = "myExporter";
+    final Class<? extends Exporter> exporterClass = TestJarExporter.class;
+
+    // when
+    final ExporterDescriptor descriptor = repository.load(id, exporterClass, null);
+
+    // then
+    assertThat(descriptor).isNotNull();
+    assertThat(repository.load(id, exporterClass)).isSameAs(descriptor);
+  }
+
+  @Test
+  public void shouldFailToLoadIfExporterInvalid() {
+    // given
+    final String id = "exporter";
+    final Class<? extends Exporter> exporterClass = InvalidExporter.class;
+
+    // then
+    assertThatThrownBy(() -> repository.load(id, exporterClass))
+        .isInstanceOf(ExporterLoadException.class)
+        .hasCauseInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void shouldLoadInternalExporter()
+      throws ExporterLoadException, ExporterJarLoadException, InstantiationException,
+          IllegalAccessException {
+    // given
+    final ExporterCfg config = new ExporterCfg();
+    config.setClassName(ControlledTestExporter.class.getCanonicalName());
+    config.setId("controlled");
+    config.setJarPath(null);
+
+    // when
+    final ExporterDescriptor descriptor = repository.load(config);
+
+    // then
+    assertThat(config.isExternal()).isFalse();
+    assertThat(descriptor.newInstance()).isInstanceOf(ControlledTestExporter.class);
+  }
+
+  @Test
+  public void shouldLoadExternalExporter() throws Exception {
+    // given
+    final Class<? extends Exporter> exportedClass = TestJarExporter.class;
+    final File jarFile = jarCreator.create(exportedClass);
+    final ExporterCfg config = new ExporterCfg();
+    final Map<String, Object> args = new HashMap<>();
+
+    // when
+    config.setClassName(exportedClass.getCanonicalName());
+    config.setId("exported");
+    config.setJarPath(jarFile.getAbsolutePath());
+    config.setArgs(args);
+
+    args.put("foo", 1);
+    args.put("bar", false);
+
+    // when
+    final ExporterDescriptor descriptor = repository.load(config);
+
+    // then
+    assertThat(config.isExternal()).isTrue();
+    assertThat(descriptor.getConfiguration().getArguments()).isEqualTo(config.getArgs());
+    assertThat(descriptor.getConfiguration().getId()).isEqualTo(config.getId());
+    assertThat(descriptor.newInstance().getClass().getCanonicalName())
+        .isEqualTo(exportedClass.getCanonicalName());
+  }
+
+  @Test
+  public void shouldFailToLoadNonExporterClasses() throws IOException {
+    // given
+    final Class exportedClass = ExporterRepository.class;
+    final File jarFile = jarCreator.create(exportedClass);
+    final ExporterCfg config = new ExporterCfg();
+    final Map<String, Object> args = new HashMap<>();
+
+    // when
+    config.setClassName(exportedClass.getCanonicalName());
+    config.setId("exported");
+    config.setJarPath(jarFile.getAbsolutePath());
+    config.setArgs(args);
+
+    // then
+    assertThatThrownBy(() -> repository.load(config))
+        .isInstanceOf(ExporterLoadException.class)
+        .hasCauseInstanceOf(ClassCastException.class);
+  }
+
+  @Test
+  public void shouldFailToLoadNonExistingClass() throws IOException {
+    // given
+    final Class exportedClass = ExporterRepository.class;
+    final File jarFile = jarCreator.create(exportedClass);
+    final ExporterCfg config = new ExporterCfg();
+    final Map<String, Object> args = new HashMap<>();
+
+    // when
+    config.setClassName("xyz.i.dont.Exist");
+    config.setId("exported");
+    config.setJarPath(jarFile.getAbsolutePath());
+    config.setArgs(args);
+
+    // then
+    assertThatThrownBy(() -> repository.load(config))
+        .isInstanceOf(ExporterLoadException.class)
+        .hasCauseInstanceOf(ClassNotFoundException.class);
+  }
+
+  static class InvalidExporter implements Exporter {
+    @Override
+    public void configure(Context context) {
+      throw new IllegalStateException("what");
+    }
+
+    @Override
+    public void export(Record record) {}
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/util/ControlledTestExporter.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/util/ControlledTestExporter.java
@@ -1,0 +1,109 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.util;
+
+import io.zeebe.exporter.context.Context;
+import io.zeebe.exporter.context.Controller;
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.spi.Exporter;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class ControlledTestExporter implements Exporter {
+  private Function<Context, Boolean> onValidate;
+  private Consumer<Context> onConfigure;
+  private Consumer<Controller> onOpen;
+  private Runnable onClose;
+  private Consumer<Record> onExport;
+
+  private Context context;
+  private Controller controller;
+
+  public ControlledTestExporter onValidate(final Function<Context, Boolean> callback) {
+    onValidate = callback;
+    return this;
+  }
+
+  public ControlledTestExporter onConfigure(final Consumer<Context> callback) {
+    onConfigure = callback;
+    return this;
+  }
+
+  public ControlledTestExporter onOpen(final Consumer<Controller> callback) {
+    onOpen = callback;
+    return this;
+  }
+
+  public ControlledTestExporter onClose(final Runnable callback) {
+    onClose = callback;
+    return this;
+  }
+
+  public ControlledTestExporter onExport(final Consumer<Record> callback) {
+    onExport = callback;
+    return this;
+  }
+
+  public Context getContext() {
+    return context;
+  }
+
+  public void setContext(final Context context) {
+    this.context = context;
+  }
+
+  public Controller getController() {
+    return controller;
+  }
+
+  public void setController(final Controller controller) {
+    this.controller = controller;
+  }
+
+  @Override
+  public void configure(final Context context) {
+    this.context = context;
+
+    if (onConfigure != null) {
+      onConfigure.accept(context);
+    }
+  }
+
+  @Override
+  public void open(final Controller controller) {
+    this.controller = controller;
+
+    if (onOpen != null) {
+      onOpen.accept(controller);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (onClose != null) {
+      onClose.run();
+    }
+  }
+
+  @Override
+  public void export(final Record record) {
+    if (onExport != null) {
+      onExport.accept(record);
+    }
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/util/JarCreatorRule.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/util/JarCreatorRule.java
@@ -1,0 +1,101 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.util;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.jar.Attributes.Name;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
+
+/** obviously not thread safe, strictly for testing */
+public class JarCreatorRule extends ExternalResource {
+  private static final Manifest DEFAULT_MANIFEST;
+
+  static {
+    DEFAULT_MANIFEST = new Manifest();
+    DEFAULT_MANIFEST.getMainAttributes().put(Name.MANIFEST_VERSION, "1.0");
+  }
+
+  private final TemporaryFolder temporaryFolder;
+
+  public JarCreatorRule(final TemporaryFolder temporaryFolder) {
+    this.temporaryFolder = temporaryFolder;
+  }
+
+  public File create(final String path, final Manifest manifest, Class compiledClass)
+      throws IOException {
+    final byte[] buffer = new byte[1024];
+    final File jarFile = new File(temporaryFolder.getRoot(), path);
+
+    try (JarOutputStream out = new JarOutputStream(new FileOutputStream(jarFile), manifest)) {
+      add(out, compiledClass, buffer);
+    }
+
+    return jarFile;
+  }
+
+  public File create(final String path, Class compiledClass) throws IOException {
+    return create(path, DEFAULT_MANIFEST, compiledClass);
+  }
+
+  public File create(Class compiledClass) throws IOException {
+    final File tempFile = File.createTempFile("exporter-", ".jar");
+    tempFile.renameTo(new File(temporaryFolder.getRoot(), tempFile.getName()));
+    return create(tempFile.getName(), compiledClass);
+  }
+
+  private void add(final JarOutputStream out, final Class compiledClass, final byte[] buffer)
+      throws IOException {
+    final String name = compiledClass.getCanonicalName().replace(".", "/") + ".class";
+    final String path = compiledClass.getClassLoader().getResource(name).getFile();
+    final String[] folders = name.split("/");
+
+    preparePackage(out, folders);
+    writeClassFile(out, buffer, name, path);
+  }
+
+  private void writeClassFile(JarOutputStream out, byte[] buffer, String name, String path)
+      throws IOException {
+    out.putNextEntry(new JarEntry(name));
+    final File classFile = new File(path);
+
+    try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(classFile))) {
+      int bytesRead = -1;
+
+      while ((bytesRead = in.read(buffer)) != -1) {
+        out.write(buffer, 0, bytesRead);
+      }
+    }
+  }
+
+  private void preparePackage(JarOutputStream out, String[] folders) throws IOException {
+    String entryName = "";
+    for (int i = 0; i < folders.length - 1; i++) {
+      entryName += folders[i] + "/";
+      out.putNextEntry(new JarEntry(entryName));
+      out.closeEntry();
+    }
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/util/TestJarExporter.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/util/TestJarExporter.java
@@ -1,0 +1,29 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.util;
+
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.spi.Exporter;
+
+/** Simple exported meant to be embedded into a JAR for testing */
+public class TestJarExporter implements Exporter {
+  public static final String FOO = "bar";
+
+  @Override
+  public void export(Record record) {}
+}

--- a/dist/src/main/config/zeebe.cfg.toml
+++ b/dist/src/main/config/zeebe.cfg.toml
@@ -252,3 +252,33 @@ replicationFactor = 1
 # heartbeatInterval = "250ms"
 # electionInterval = "1s"
 # leaveTimeout = "1s"
+
+# Configure exporters below; note that configuration parsing conventions do not apply to exporter
+# arguments, which will be parsed as normal TOML.
+#
+# Each exporter should be configured following this template:
+#
+# id:
+#   property should be unique in this configuration file, as it will server as the exporter
+#   ID for loading/unloading.
+# jarPath:
+#   path to the JAR file containing the exporter class. JARs are only loaded once, so you can define
+#   two exporters that point to the same JAR, with the same class or a different one, and use args
+#   to parametrize its instantiation.
+# className:
+#   entry point of the exporter, a class which *must* extend the io.zeebe.exporter.Exporter
+#   interface.
+#
+# A nested table as [exporters.args] will allow you to inject arbitrary arguments into your
+# class through the use of annotations.
+#
+# An example configuration for a MongoDB exporter:
+#
+# [[exporters]]
+# id = "MongoDB"
+# jarPath = "exporters/myExporter.jar"
+# className = "me.mustermann.mongodb.MongoDbExporter"
+#   [exporters.args]
+#   host = "localhost"
+#   port = 21707
+#

--- a/exporter/src/main/java/io/zeebe/exporter/spi/Exporter.java
+++ b/exporter/src/main/java/io/zeebe/exporter/spi/Exporter.java
@@ -68,5 +68,5 @@ public interface Exporter {
    *
    * @param record the record to export
    */
-  void export(Record record);
+  void export(final Record record);
 }


### PR DESCRIPTION
Added all necessary components to:

1. Load exporters, both internal (compiled with broker), and external (through a JAR)
1. Configure exporters (parses config, creates configuration object, etc.)
1. Allow exporter to validate its config and fail early

### Note

It doesn't do much, I know, it's not ideal since it seems unused (so e.g. the caching in the repository seems weird), but it will make sense with further issues (see #1171 and #1173).

Blocked by #1180  and closes #1170 