### PR TITLE
fix(broker-core): fix reprcoessing of deployments

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/state/DeploymentsStateController.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/workflow/repository/processor/state/DeploymentsStateController.java
@@ -1,0 +1,104 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.system.workflow.repository.processor.state;
+
+import io.zeebe.broker.system.workflow.repository.processor.PendingDeploymentDistribution;
+import io.zeebe.broker.util.KeyStateController;
+import java.nio.ByteOrder;
+import java.util.function.BiConsumer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.rocksdb.RocksIterator;
+
+public class DeploymentsStateController extends KeyStateController {
+
+  private final PendingDeploymentDistribution pendingDeploymentDistribution;
+  private final UnsafeBuffer buffer;
+
+  public DeploymentsStateController() {
+    pendingDeploymentDistribution = new PendingDeploymentDistribution(new UnsafeBuffer(0, 0), -1);
+    buffer = new UnsafeBuffer(0, 0);
+  }
+
+  public void putPendingDeployment(
+      long key, PendingDeploymentDistribution pendingDeploymentDistribution) {
+    ensureIsOpened("putPendingDeployment");
+
+    final int length = pendingDeploymentDistribution.getLength();
+    final byte[] bytes = new byte[length];
+    buffer.wrap(bytes);
+    pendingDeploymentDistribution.write(buffer, 0);
+
+    put(key, bytes);
+  }
+
+  private PendingDeploymentDistribution getPending(long key) {
+    final byte[] bytes = get(key);
+    PendingDeploymentDistribution pending = null;
+    if (bytes != null) {
+      buffer.wrap(bytes);
+      pendingDeploymentDistribution.wrap(buffer, 0, bytes.length);
+      pending = pendingDeploymentDistribution;
+    }
+
+    return pending;
+  }
+
+  public PendingDeploymentDistribution getPendingDeployment(long key) {
+    ensureIsOpened("getPendingDeployment");
+    return getPending(key);
+  }
+
+  public PendingDeploymentDistribution removePendingDeployment(long key) {
+    ensureIsOpened("removePendingDeployment");
+
+    final PendingDeploymentDistribution pending = getPending(key);
+    if (pending != null) {
+      delete(key);
+    }
+
+    return pending;
+  }
+
+  public void foreach(BiConsumer<Long, PendingDeploymentDistribution> consumer) {
+    ensureIsOpened("foreach");
+
+    try (final RocksIterator rocksIterator = getDb().newIterator()) {
+      rocksIterator.seekToFirst();
+
+      final UnsafeBuffer latestKeyBuffer = new UnsafeBuffer(KeyStateController.LATEST_KEY_BUFFER);
+      final UnsafeBuffer readBuffer = new UnsafeBuffer();
+      while (rocksIterator.isValid()) {
+
+        final byte[] keyBytes = rocksIterator.key();
+        readBuffer.wrap(keyBytes);
+
+        if (!latestKeyBuffer.equals(readBuffer)) {
+          final long longKey = readBuffer.getLong(0, ByteOrder.LITTLE_ENDIAN);
+
+          final byte[] valueBytes = rocksIterator.value();
+          readBuffer.wrap(valueBytes);
+
+          pendingDeploymentDistribution.wrap(readBuffer, 0, valueBytes.length);
+
+          consumer.accept(longKey, pendingDeploymentDistribution);
+        }
+        rocksIterator.next();
+      }
+    }
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/util/KeyStateController.java
+++ b/broker-core/src/main/java/io/zeebe/broker/util/KeyStateController.java
@@ -1,0 +1,65 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.util;
+
+import static io.zeebe.util.StringUtil.getBytes;
+
+import io.zeebe.logstreams.state.StateController;
+import java.io.File;
+import java.nio.ByteOrder;
+import java.util.concurrent.atomic.AtomicReference;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.rocksdb.RocksDB;
+
+public class KeyStateController extends StateController {
+  public static final byte[] LATEST_KEY_BUFFER = getBytes("latestKey");
+  private final MutableDirectBuffer dbLongBuffer = new UnsafeBuffer(new byte[Long.BYTES]);
+  private AtomicReference<Runnable> onOpenCallback = new AtomicReference<>();
+
+  public void addOnOpenCallback(Runnable runnable) {
+    final Runnable existingCallback = onOpenCallback.get();
+    onOpenCallback.compareAndSet(existingCallback, runnable);
+  }
+
+  @Override
+  public RocksDB open(File dbDirectory, boolean reopen) throws Exception {
+    final RocksDB rocksDB = super.open(dbDirectory, reopen);
+    if (isOpened()) {
+      onOpenCallback.get().run();
+    }
+    return rocksDB;
+  }
+
+  public long getLatestKey() {
+    ensureIsOpened("recoverLatestKey");
+
+    long latestKey = Long.MIN_VALUE;
+    if (tryGet(LATEST_KEY_BUFFER, dbLongBuffer.byteArray())) {
+      latestKey = dbLongBuffer.getLong(0, ByteOrder.LITTLE_ENDIAN);
+    }
+    return latestKey;
+  }
+
+  public void putLatestKey(long key) {
+    ensureIsOpened("putLatestKey");
+
+    dbLongBuffer.putLong(0, key, ByteOrder.LITTLE_ENDIAN);
+    put(LATEST_KEY_BUFFER, dbLongBuffer.byteArray());
+  }
+}

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/ClientRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/ClientRule.java
@@ -107,7 +107,6 @@ public class ClientRule extends ExternalResource {
         .name("deployment-await")
         .recordHandler(
             record -> {
-              System.out.println("search record");
               if (record.getMetadata().getPartitionId() == 1
                   && record.getMetadata().getValueType() == ValueType.DEPLOYMENT
                   && record.getMetadata().getIntent().equals(DeploymentIntent.CREATED.name())


### PR DESCRIPTION
 * add pending deployments to state
 * uses rocks db as store
 * pending deployments are re-distributed at `onOpen` callback
 * push deployments outside of side effects
 * fix key generation on deployments with rocks db
 * introduce new controller abstraction for keys
 * key generator uses controller to store the keys
 * ignore the broker reprocessing tests for now, since they failing due to concurrent reprocessing #1207 


closes #1172 
