### PR TITLE
feat(exporters): adds stream processor to export records

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/clustering/orchestration/topic/TopicRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/orchestration/topic/TopicRecord.java
@@ -43,20 +43,23 @@ public class TopicRecord extends UnpackedObject {
     return name.getValue();
   }
 
-  public void setName(DirectBuffer name) {
+  public TopicRecord setName(DirectBuffer name) {
     this.name.setValue(name);
+    return this;
   }
 
   public int getPartitions() {
     return partitions.getValue();
   }
 
-  public void setPartitions(int partitions) {
+  public TopicRecord setPartitions(int partitions) {
     this.partitions.setValue(partitions);
+    return this;
   }
 
-  public void setReplicationFactor(int replicationFactor) {
+  public TopicRecord setReplicationFactor(int replicationFactor) {
     this.replicationFactor.setValue(replicationFactor);
+    return this;
   }
 
   public int getReplicationFactor() {

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/ExporterException.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/ExporterException.java
@@ -15,25 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.zeebe.broker.clustering.orchestration.id;
+package io.zeebe.broker.exporter;
 
-import io.zeebe.msgpack.UnpackedObject;
-import io.zeebe.msgpack.property.IntegerProperty;
+public class ExporterException extends RuntimeException {
+  private static final long serialVersionUID = 9144017472787012481L;
 
-public class IdRecord extends UnpackedObject {
-
-  private final IntegerProperty id = new IntegerProperty("id");
-
-  public IdRecord() {
-    this.declareProperty(id);
-  }
-
-  public Integer getId() {
-    return id.getValue();
-  }
-
-  public IdRecord setId(final int id) {
-    this.id.setValue(id);
-    return this;
+  public ExporterException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/RecordImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/RecordImpl.java
@@ -1,0 +1,144 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record;
+
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.record.RecordMetadata;
+import io.zeebe.exporter.record.RecordValue;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import io.zeebe.logstreams.log.LoggedEvent;
+import java.time.Instant;
+
+public class RecordImpl<T extends RecordValue> implements Record<T> {
+  private final long key;
+  private final long position;
+  private final Instant timestamp;
+  private final int raftTerm;
+  private final int producerId;
+  private final long sourceRecordPosition;
+
+  private final RecordMetadata metadata;
+  private final T value;
+
+  private final ZeebeObjectMapperImpl objectMapper;
+
+  public RecordImpl(
+      ZeebeObjectMapperImpl objectMapper,
+      long key,
+      long position,
+      Instant timestamp,
+      int raftTerm,
+      int producerId,
+      long sourceRecordPosition,
+      RecordMetadata metadata,
+      T value) {
+    this.objectMapper = objectMapper;
+    this.key = key;
+    this.position = position;
+    this.timestamp = timestamp;
+    this.raftTerm = raftTerm;
+    this.producerId = producerId;
+    this.sourceRecordPosition = sourceRecordPosition;
+    this.metadata = metadata;
+    this.value = value;
+  }
+
+  public static <U extends RecordValue> RecordImpl<U> ofLoggedEvent(
+      final ZeebeObjectMapperImpl objectMapper,
+      final LoggedEvent event,
+      final RecordMetadataImpl metadata,
+      final U value) {
+    return new RecordImpl<>(
+        objectMapper,
+        event.getKey(),
+        event.getPosition(),
+        Instant.ofEpochMilli(event.getTimestamp()),
+        event.getRaftTerm(),
+        event.getProducerId(),
+        event.getSourceEventPosition(),
+        metadata,
+        value);
+  }
+
+  @Override
+  public long getKey() {
+    return key;
+  }
+
+  @Override
+  public long getPosition() {
+    return position;
+  }
+
+  @Override
+  public Instant getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public int getRaftTerm() {
+    return raftTerm;
+  }
+
+  @Override
+  public int getProducerId() {
+    return producerId;
+  }
+
+  @Override
+  public long getSourceRecordPosition() {
+    return sourceRecordPosition;
+  }
+
+  @Override
+  public RecordMetadata getMetadata() {
+    return metadata;
+  }
+
+  @Override
+  public T getValue() {
+    return value;
+  }
+
+  @Override
+  public String toJson() {
+    return objectMapper.toJson(this);
+  }
+
+  @Override
+  public String toString() {
+    return "RecordImpl{"
+        + "key="
+        + key
+        + ", position="
+        + position
+        + ", timestamp="
+        + timestamp
+        + ", raftTerm="
+        + raftTerm
+        + ", producerId="
+        + producerId
+        + ", sourceRecordPosition="
+        + sourceRecordPosition
+        + ", metadata="
+        + metadata
+        + ", value="
+        + value
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/RecordMetadataImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/RecordMetadataImpl.java
@@ -1,0 +1,112 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import io.zeebe.exporter.record.RecordMetadata;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import io.zeebe.protocol.clientapi.RecordType;
+import io.zeebe.protocol.clientapi.RejectionType;
+import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.intent.Intent;
+
+@JsonAutoDetect(fieldVisibility = Visibility.NONE, getterVisibility = Visibility.PUBLIC_ONLY)
+@JsonInclude(Include.NON_NULL)
+public class RecordMetadataImpl implements RecordMetadata {
+  private final ZeebeObjectMapperImpl objectMapper;
+  private final int partitionId;
+  private final Intent intent;
+  private final RecordType recordType;
+  private final RejectionType rejectionType;
+  private final String rejectionReason;
+  private final ValueType valueType;
+
+  public RecordMetadataImpl(
+      ZeebeObjectMapperImpl objectMapper,
+      int partitionId,
+      Intent intent,
+      RecordType recordType,
+      RejectionType rejectionType,
+      String rejectionReason,
+      ValueType valueType) {
+    this.objectMapper = objectMapper;
+    this.partitionId = partitionId;
+    this.intent = intent;
+    this.recordType = recordType;
+    this.rejectionType = rejectionType;
+    this.rejectionReason = rejectionReason;
+    this.valueType = valueType;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public Intent getIntent() {
+    return intent;
+  }
+
+  @Override
+  public RecordType getRecordType() {
+    return recordType;
+  }
+
+  @Override
+  public RejectionType getRejectionType() {
+    return rejectionType;
+  }
+
+  @Override
+  public String getRejectionReason() {
+    return rejectionReason;
+  }
+
+  @Override
+  public ValueType getValueType() {
+    return valueType;
+  }
+
+  @Override
+  public String toJson() {
+    return objectMapper.toJson(this);
+  }
+
+  @Override
+  public String toString() {
+    return "RecordMetadataImpl{"
+        + "partitionId="
+        + partitionId
+        + ", intent="
+        + intent
+        + ", recordType="
+        + recordType
+        + ", rejectionType="
+        + rejectionType
+        + ", rejectionReason='"
+        + rejectionReason
+        + '\''
+        + ", valueType="
+        + valueType
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/RecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/RecordValueImpl.java
@@ -15,25 +15,20 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.zeebe.broker.clustering.orchestration.id;
+package io.zeebe.broker.exporter.record;
 
-import io.zeebe.msgpack.UnpackedObject;
-import io.zeebe.msgpack.property.IntegerProperty;
+import io.zeebe.exporter.record.RecordValue;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
 
-public class IdRecord extends UnpackedObject {
+public abstract class RecordValueImpl implements RecordValue {
+  protected final ZeebeObjectMapperImpl objectMapper;
 
-  private final IntegerProperty id = new IntegerProperty("id");
-
-  public IdRecord() {
-    this.declareProperty(id);
+  public RecordValueImpl(ZeebeObjectMapperImpl objectMapper) {
+    this.objectMapper = objectMapper;
   }
 
-  public Integer getId() {
-    return id.getValue();
-  }
-
-  public IdRecord setId(final int id) {
-    this.id.setValue(id);
-    return this;
+  @Override
+  public String toJson() {
+    return objectMapper.toJson(this);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/RecordValueWithPayloadImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/RecordValueWithPayloadImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record;
+
+import io.zeebe.exporter.record.RecordValueWithPayload;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import java.util.Map;
+import java.util.Objects;
+
+public abstract class RecordValueWithPayloadImpl extends RecordValueImpl
+    implements RecordValueWithPayload {
+  protected final String payload;
+
+  public RecordValueWithPayloadImpl(
+      final ZeebeObjectMapperImpl objectMapper, final String payload) {
+    super(objectMapper);
+    this.payload = payload;
+  }
+
+  @Override
+  public String getPayload() {
+    return payload;
+  }
+
+  @Override
+  public Map<String, Object> getPayloadAsMap() {
+    return objectMapper.fromJsonAsMap(payload);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RecordValueWithPayloadImpl that = (RecordValueWithPayloadImpl) o;
+    return Objects.equals(payload, that.payload);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(payload);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/DeploymentRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/DeploymentRecordValueImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value;
+
+import io.zeebe.broker.exporter.record.RecordValueImpl;
+import io.zeebe.exporter.record.value.DeploymentRecordValue;
+import io.zeebe.exporter.record.value.deployment.DeployedWorkflow;
+import io.zeebe.exporter.record.value.deployment.DeploymentResource;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import java.util.List;
+import java.util.Objects;
+
+public class DeploymentRecordValueImpl extends RecordValueImpl implements DeploymentRecordValue {
+  private List<DeployedWorkflow> deployedWorkflows;
+  private List<DeploymentResource> resources;
+
+  public DeploymentRecordValueImpl(
+      ZeebeObjectMapperImpl objectMapper,
+      List<DeployedWorkflow> deployedWorkflows,
+      List<DeploymentResource> resources) {
+    super(objectMapper);
+    this.deployedWorkflows = deployedWorkflows;
+    this.resources = resources;
+  }
+
+  @Override
+  public List<DeployedWorkflow> getDeployedWorkflows() {
+    return deployedWorkflows;
+  }
+
+  @Override
+  public List<DeploymentResource> getResources() {
+    return resources;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DeploymentRecordValueImpl that = (DeploymentRecordValueImpl) o;
+    return Objects.equals(deployedWorkflows, that.deployedWorkflows)
+        && Objects.equals(resources, that.resources);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(deployedWorkflows, resources);
+  }
+
+  @Override
+  public String toString() {
+    return "DeploymentRecordValueImpl{"
+        + "deployedWorkflows="
+        + deployedWorkflows
+        + ", resources="
+        + resources
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/IdRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/IdRecordValueImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value;
+
+import io.zeebe.broker.exporter.record.RecordValueImpl;
+import io.zeebe.exporter.record.value.IdRecordValue;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import java.util.Objects;
+
+public class IdRecordValueImpl extends RecordValueImpl implements IdRecordValue {
+  private final int id;
+
+  public IdRecordValueImpl(final ZeebeObjectMapperImpl objectMapper, final int id) {
+    super(objectMapper);
+    this.id = id;
+  }
+
+  @Override
+  public int getId() {
+    return id;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IdRecordValueImpl that = (IdRecordValueImpl) o;
+    return id == that.id;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+
+  @Override
+  public String toString() {
+    return "IdRecordValueImpl{" + "id=" + id + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/IncidentRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/IncidentRecordValueImpl.java
@@ -1,0 +1,150 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value;
+
+import io.zeebe.broker.exporter.record.RecordValueWithPayloadImpl;
+import io.zeebe.exporter.record.value.IncidentRecordValue;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import java.util.Objects;
+
+public class IncidentRecordValueImpl extends RecordValueWithPayloadImpl
+    implements IncidentRecordValue {
+  private final String errorType;
+  private final String errorMessage;
+  private final String bpmnProcessId;
+  private final String activityId;
+  private final long workflowInstanceKey;
+  private final long activityInstanceKey;
+  private final long jobKey;
+
+  public IncidentRecordValueImpl(
+      final ZeebeObjectMapperImpl objectMapper,
+      final String payload,
+      final String errorType,
+      final String errorMessage,
+      final String bpmnProcessId,
+      final String activityId,
+      final long workflowInstanceKey,
+      final long activityInstanceKey,
+      final long jobKey) {
+    super(objectMapper, payload);
+    this.errorType = errorType;
+    this.errorMessage = errorMessage;
+    this.bpmnProcessId = bpmnProcessId;
+    this.activityId = activityId;
+    this.workflowInstanceKey = workflowInstanceKey;
+    this.activityInstanceKey = activityInstanceKey;
+    this.jobKey = jobKey;
+  }
+
+  @Override
+  public String getErrorType() {
+    return errorType;
+  }
+
+  @Override
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  @Override
+  public String getActivityId() {
+    return activityId;
+  }
+
+  @Override
+  public long getWorkflowInstanceKey() {
+    return workflowInstanceKey;
+  }
+
+  @Override
+  public long getActivityInstanceKey() {
+    return activityInstanceKey;
+  }
+
+  @Override
+  public long getJobKey() {
+    return jobKey;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final IncidentRecordValueImpl that = (IncidentRecordValueImpl) o;
+    return workflowInstanceKey == that.workflowInstanceKey
+        && activityInstanceKey == that.activityInstanceKey
+        && jobKey == that.jobKey
+        && Objects.equals(errorType, that.errorType)
+        && Objects.equals(errorMessage, that.errorMessage)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(activityId, that.activityId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(),
+        errorType,
+        errorMessage,
+        bpmnProcessId,
+        activityId,
+        workflowInstanceKey,
+        activityInstanceKey,
+        jobKey);
+  }
+
+  @Override
+  public String toString() {
+    return "IncidentRecordValueImpl{"
+        + "errorType='"
+        + errorType
+        + '\''
+        + ", errorMessage='"
+        + errorMessage
+        + '\''
+        + ", bpmnProcessId='"
+        + bpmnProcessId
+        + '\''
+        + ", activityId='"
+        + activityId
+        + '\''
+        + ", workflowInstanceKey="
+        + workflowInstanceKey
+        + ", activityInstanceKey="
+        + activityInstanceKey
+        + ", jobKey="
+        + jobKey
+        + ", payload='"
+        + payload
+        + '\''
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/JobRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/JobRecordValueImpl.java
@@ -1,0 +1,132 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value;
+
+import io.zeebe.broker.exporter.record.RecordValueWithPayloadImpl;
+import io.zeebe.broker.exporter.record.value.job.HeadersImpl;
+import io.zeebe.exporter.record.value.JobRecordValue;
+import io.zeebe.exporter.record.value.job.Headers;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements JobRecordValue {
+  private final String type;
+  private final String worker;
+  private final Instant deadline;
+  private final HeadersImpl headers;
+  private final Map<String, Object> customHeaders;
+  private final int retries;
+
+  public JobRecordValueImpl(
+      final ZeebeObjectMapperImpl objectMapper,
+      final String payload,
+      final String type,
+      final String worker,
+      final Instant deadline,
+      final HeadersImpl headers,
+      final Map<String, Object> customHeaders,
+      final int retries) {
+    super(objectMapper, payload);
+    this.type = type;
+    this.worker = worker;
+    this.deadline = deadline;
+    this.headers = headers;
+    this.customHeaders = customHeaders;
+    this.retries = retries;
+  }
+
+  @Override
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public Headers getHeaders() {
+    return headers;
+  }
+
+  @Override
+  public Map<String, Object> getCustomHeaders() {
+    return customHeaders;
+  }
+
+  @Override
+  public String getWorker() {
+    return worker;
+  }
+
+  @Override
+  public int getRetries() {
+    return retries;
+  }
+
+  @Override
+  public Instant getDeadline() {
+    return deadline;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final JobRecordValueImpl that = (JobRecordValueImpl) o;
+    return retries == that.retries
+        && Objects.equals(type, that.type)
+        && Objects.equals(worker, that.worker)
+        && Objects.equals(deadline, that.deadline)
+        && Objects.equals(headers, that.headers)
+        && Objects.equals(customHeaders, that.customHeaders);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), type, worker, deadline, headers, customHeaders, retries);
+  }
+
+  @Override
+  public String toString() {
+    return "JobRecordValueImpl{"
+        + "type='"
+        + type
+        + '\''
+        + ", worker='"
+        + worker
+        + '\''
+        + ", deadline="
+        + deadline
+        + ", headers="
+        + headers
+        + ", customHeaders="
+        + customHeaders
+        + ", retries="
+        + retries
+        + ", payload='"
+        + payload
+        + '\''
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/MessageRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/MessageRecordValueImpl.java
@@ -1,0 +1,108 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value;
+
+import io.zeebe.broker.exporter.record.RecordValueWithPayloadImpl;
+import io.zeebe.exporter.record.value.MessageRecordValue;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import java.util.Objects;
+
+public class MessageRecordValueImpl extends RecordValueWithPayloadImpl
+    implements MessageRecordValue {
+  private final String name;
+  private final String messageId;
+  private final String correlationKey;
+  private final long timeToLive;
+
+  public MessageRecordValueImpl(
+      final ZeebeObjectMapperImpl objectMapper,
+      final String payload,
+      final String name,
+      final String messageId,
+      final String correlationKey,
+      final long timeToLive) {
+    super(objectMapper, payload);
+    this.name = name;
+    this.messageId = messageId;
+    this.correlationKey = correlationKey;
+    this.timeToLive = timeToLive;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getMessageId() {
+    return messageId;
+  }
+
+  @Override
+  public String getCorrelationKey() {
+    return correlationKey;
+  }
+
+  @Override
+  public long getTimeToLive() {
+    return timeToLive;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final MessageRecordValueImpl that = (MessageRecordValueImpl) o;
+    return timeToLive == that.timeToLive
+        && Objects.equals(name, that.name)
+        && Objects.equals(messageId, that.messageId)
+        && Objects.equals(correlationKey, that.correlationKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), name, messageId, correlationKey, timeToLive);
+  }
+
+  @Override
+  public String toString() {
+    return "MessageRecordValueImpl{"
+        + "name='"
+        + name
+        + '\''
+        + ", messageId='"
+        + messageId
+        + '\''
+        + ", correlationKey='"
+        + correlationKey
+        + '\''
+        + ", timeToLive="
+        + timeToLive
+        + ", payload='"
+        + payload
+        + '\''
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/MessageSubscriptionRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/MessageSubscriptionRecordValueImpl.java
@@ -1,0 +1,116 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value;
+
+import io.zeebe.broker.exporter.record.RecordValueImpl;
+import io.zeebe.exporter.record.value.MessageSubscriptionRecordValue;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import java.util.Objects;
+
+public class MessageSubscriptionRecordValueImpl extends RecordValueImpl
+    implements MessageSubscriptionRecordValue {
+  private final String messageName;
+  private final String correlationKey;
+  private final int workflowInstancePartitionId;
+  private final long workflowInstanceKey;
+  private final long activityInstanceKey;
+
+  public MessageSubscriptionRecordValueImpl(
+      final ZeebeObjectMapperImpl objectMapper,
+      final String messageName,
+      final String correlationKey,
+      final int workflowInstancePartitionId,
+      final long workflowInstanceKey,
+      final long activityInstanceKey) {
+    super(objectMapper);
+    this.messageName = messageName;
+    this.correlationKey = correlationKey;
+    this.workflowInstancePartitionId = workflowInstancePartitionId;
+    this.workflowInstanceKey = workflowInstanceKey;
+    this.activityInstanceKey = activityInstanceKey;
+  }
+
+  @Override
+  public String getMessageName() {
+    return messageName;
+  }
+
+  @Override
+  public String getCorrelationKey() {
+    return correlationKey;
+  }
+
+  @Override
+  public int getWorkflowInstancePartitionId() {
+    return workflowInstancePartitionId;
+  }
+
+  @Override
+  public long getWorkflowInstanceKey() {
+    return workflowInstanceKey;
+  }
+
+  @Override
+  public long getActivityInstanceKey() {
+    return activityInstanceKey;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MessageSubscriptionRecordValueImpl that = (MessageSubscriptionRecordValueImpl) o;
+    return workflowInstancePartitionId == that.workflowInstancePartitionId
+        && workflowInstanceKey == that.workflowInstanceKey
+        && activityInstanceKey == that.activityInstanceKey
+        && Objects.equals(messageName, that.messageName)
+        && Objects.equals(correlationKey, that.correlationKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        messageName,
+        correlationKey,
+        workflowInstancePartitionId,
+        workflowInstanceKey,
+        activityInstanceKey);
+  }
+
+  @Override
+  public String toString() {
+    return "MessageSubscriptionRecordValueImpl{"
+        + "messageName='"
+        + messageName
+        + '\''
+        + ", correlationKey='"
+        + correlationKey
+        + '\''
+        + ", workflowInstancePartitionId="
+        + workflowInstancePartitionId
+        + ", workflowInstanceKey="
+        + workflowInstanceKey
+        + ", activityInstanceKey="
+        + activityInstanceKey
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/RaftRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/RaftRecordValueImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value;
+
+import io.zeebe.broker.exporter.record.RecordValueImpl;
+import io.zeebe.exporter.record.value.RaftRecordValue;
+import io.zeebe.exporter.record.value.raft.RaftMember;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import java.util.List;
+import java.util.Objects;
+
+public class RaftRecordValueImpl extends RecordValueImpl implements RaftRecordValue {
+  private final List<RaftMember> members;
+
+  public RaftRecordValueImpl(
+      final ZeebeObjectMapperImpl objectMapper, final List<RaftMember> members) {
+    super(objectMapper);
+    this.members = members;
+  }
+
+  @Override
+  public List<RaftMember> getMembers() {
+    return members;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RaftRecordValueImpl that = (RaftRecordValueImpl) o;
+    return Objects.equals(members, that.members);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(members);
+  }
+
+  @Override
+  public String toString() {
+    return "RaftRecordValueImpl{" + "members=" + members + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/TopicRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/TopicRecordValueImpl.java
@@ -1,0 +1,99 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value;
+
+import io.zeebe.broker.exporter.record.RecordValueImpl;
+import io.zeebe.exporter.record.value.TopicRecordValue;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import java.util.List;
+import java.util.Objects;
+
+public class TopicRecordValueImpl extends RecordValueImpl implements TopicRecordValue {
+  private final String name;
+  private final List<Integer> partitionIds;
+  private final int partitionCount;
+  private final int replicationFactor;
+
+  public TopicRecordValueImpl(
+      final ZeebeObjectMapperImpl objectMapper,
+      final String name,
+      final List<Integer> partitionIds,
+      final int partitionCount,
+      final int replicationFactor) {
+    super(objectMapper);
+    this.name = name;
+    this.partitionIds = partitionIds;
+    this.partitionCount = partitionCount;
+    this.replicationFactor = replicationFactor;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public List<Integer> getPartitionIds() {
+    return partitionIds;
+  }
+
+  @Override
+  public int getPartitionCount() {
+    return partitionCount;
+  }
+
+  @Override
+  public int getReplicationFactor() {
+    return replicationFactor;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TopicRecordValueImpl that = (TopicRecordValueImpl) o;
+    return partitionCount == that.partitionCount
+        && replicationFactor == that.replicationFactor
+        && Objects.equals(name, that.name)
+        && Objects.equals(partitionIds, that.partitionIds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, partitionIds, partitionCount, replicationFactor);
+  }
+
+  @Override
+  public String toString() {
+    return "TopicRecordValueImpl{"
+        + "name='"
+        + name
+        + '\''
+        + ", partitionIds="
+        + partitionIds
+        + ", partitionCount="
+        + partitionCount
+        + ", replicationFactor="
+        + replicationFactor
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/WorkflowInstanceRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/WorkflowInstanceRecordValueImpl.java
@@ -1,0 +1,136 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value;
+
+import io.zeebe.broker.exporter.record.RecordValueWithPayloadImpl;
+import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import java.util.Objects;
+
+public class WorkflowInstanceRecordValueImpl extends RecordValueWithPayloadImpl
+    implements WorkflowInstanceRecordValue {
+  private final String bpmnProcessId;
+  private final String activityId;
+  private final int version;
+  private final long workflowKey;
+  private final long workflowInstanceKey;
+  private final long scopeInstanceKey;
+
+  public WorkflowInstanceRecordValueImpl(
+      final ZeebeObjectMapperImpl objectMapper,
+      final String payload,
+      final String bpmnProcessId,
+      final String activityId,
+      final int version,
+      final long workflowKey,
+      final long workflowInstanceKey,
+      final long scopeInstanceKey) {
+    super(objectMapper, payload);
+    this.bpmnProcessId = bpmnProcessId;
+    this.activityId = activityId;
+    this.version = version;
+    this.workflowKey = workflowKey;
+    this.workflowInstanceKey = workflowInstanceKey;
+    this.scopeInstanceKey = scopeInstanceKey;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  @Override
+  public String getActivityId() {
+    return activityId;
+  }
+
+  @Override
+  public int getVersion() {
+    return version;
+  }
+
+  @Override
+  public long getWorkflowKey() {
+    return workflowKey;
+  }
+
+  @Override
+  public long getWorkflowInstanceKey() {
+    return workflowInstanceKey;
+  }
+
+  @Override
+  public long getScopeInstanceKey() {
+    return scopeInstanceKey;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final WorkflowInstanceRecordValueImpl that = (WorkflowInstanceRecordValueImpl) o;
+    return version == that.version
+        && workflowKey == that.workflowKey
+        && workflowInstanceKey == that.workflowInstanceKey
+        && scopeInstanceKey == that.scopeInstanceKey
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(activityId, that.activityId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(),
+        bpmnProcessId,
+        activityId,
+        version,
+        workflowKey,
+        workflowInstanceKey,
+        scopeInstanceKey);
+  }
+
+  @Override
+  public String toString() {
+    return "WorkflowInstanceRecordValueImpl{"
+        + "bpmnProcessId='"
+        + bpmnProcessId
+        + '\''
+        + ", activityId='"
+        + activityId
+        + '\''
+        + ", version="
+        + version
+        + ", workflowKey="
+        + workflowKey
+        + ", workflowInstanceKey="
+        + workflowInstanceKey
+        + ", scopeInstanceKey="
+        + scopeInstanceKey
+        + ", payload='"
+        + payload
+        + '\''
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/WorkflowInstanceSubscriptionRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/WorkflowInstanceSubscriptionRecordValueImpl.java
@@ -1,0 +1,96 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value;
+
+import io.zeebe.broker.exporter.record.RecordValueWithPayloadImpl;
+import io.zeebe.exporter.record.value.WorkflowInstanceSubscriptionRecordValue;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import java.util.Objects;
+
+public class WorkflowInstanceSubscriptionRecordValueImpl extends RecordValueWithPayloadImpl
+    implements WorkflowInstanceSubscriptionRecordValue {
+  private final String messageName;
+  private final long workflowInstanceKey;
+  private final long activityInstanceKey;
+
+  public WorkflowInstanceSubscriptionRecordValueImpl(
+      final ZeebeObjectMapperImpl objectMapper,
+      final String payload,
+      final String messageName,
+      final long workflowInstanceKey,
+      final long activityInstanceKey) {
+    super(objectMapper, payload);
+    this.messageName = messageName;
+    this.workflowInstanceKey = workflowInstanceKey;
+    this.activityInstanceKey = activityInstanceKey;
+  }
+
+  @Override
+  public String getMessageName() {
+    return messageName;
+  }
+
+  @Override
+  public long getWorkflowInstanceKey() {
+    return workflowInstanceKey;
+  }
+
+  @Override
+  public long getActivityInstanceKey() {
+    return activityInstanceKey;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final WorkflowInstanceSubscriptionRecordValueImpl that =
+        (WorkflowInstanceSubscriptionRecordValueImpl) o;
+    return workflowInstanceKey == that.workflowInstanceKey
+        && activityInstanceKey == that.activityInstanceKey
+        && Objects.equals(messageName, that.messageName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), messageName, workflowInstanceKey, activityInstanceKey);
+  }
+
+  @Override
+  public String toString() {
+    return "WorkflowInstanceSubscriptionRecordValueImpl{"
+        + "messageName='"
+        + messageName
+        + '\''
+        + ", workflowInstanceKey="
+        + workflowInstanceKey
+        + ", activityInstanceKey="
+        + activityInstanceKey
+        + ", payload='"
+        + payload
+        + '\''
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/deployment/DeployedWorkflowImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/deployment/DeployedWorkflowImpl.java
@@ -1,0 +1,92 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value.deployment;
+
+import io.zeebe.exporter.record.value.deployment.DeployedWorkflow;
+import java.util.Objects;
+
+public class DeployedWorkflowImpl implements DeployedWorkflow {
+  private final String bpmnProcessId;
+  private final String resourceName;
+  private final long workflowKey;
+  private final int version;
+
+  public DeployedWorkflowImpl(
+      String bpmnProcessId, String resourceName, long workflowKey, int version) {
+    this.bpmnProcessId = bpmnProcessId;
+    this.resourceName = resourceName;
+    this.workflowKey = workflowKey;
+    this.version = version;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  @Override
+  public String getResourceName() {
+    return resourceName;
+  }
+
+  @Override
+  public long getWorkflowKey() {
+    return workflowKey;
+  }
+
+  @Override
+  public int getVersion() {
+    return version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DeployedWorkflowImpl that = (DeployedWorkflowImpl) o;
+    return workflowKey == that.workflowKey
+        && version == that.version
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(resourceName, that.resourceName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(bpmnProcessId, resourceName, workflowKey, version);
+  }
+
+  @Override
+  public String toString() {
+    return "DeployedWorkflowImpl{"
+        + "bpmnProcessId='"
+        + bpmnProcessId
+        + '\''
+        + ", resourceName='"
+        + resourceName
+        + '\''
+        + ", workflowKey="
+        + workflowKey
+        + ", version="
+        + version
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/deployment/DeploymentResourceImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/deployment/DeploymentResourceImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value.deployment;
+
+import io.zeebe.exporter.record.value.deployment.DeploymentResource;
+import io.zeebe.exporter.record.value.deployment.ResourceType;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class DeploymentResourceImpl implements DeploymentResource {
+  private final byte[] resource;
+  private final ResourceType resourceType;
+  private final String resourceName;
+
+  public DeploymentResourceImpl(byte[] resource, ResourceType resourceType, String resourceName) {
+    this.resource = resource;
+    this.resourceType = resourceType;
+    this.resourceName = resourceName;
+  }
+
+  @Override
+  public byte[] getResource() {
+    return resource;
+  }
+
+  @Override
+  public ResourceType getResourceType() {
+    return resourceType;
+  }
+
+  @Override
+  public String getResourceName() {
+    return resourceName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DeploymentResourceImpl that = (DeploymentResourceImpl) o;
+    return Arrays.equals(resource, that.resource)
+        && resourceType == that.resourceType
+        && Objects.equals(resourceName, that.resourceName);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(resourceType, resourceName);
+    result = 31 * result + Arrays.hashCode(resource);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "DeploymentResourceImpl{"
+        + "resource="
+        + Arrays.toString(resource)
+        + ", resourceType="
+        + resourceType
+        + ", resourceName='"
+        + resourceName
+        + '\''
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/job/HeadersImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/job/HeadersImpl.java
@@ -1,0 +1,123 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value.job;
+
+import io.zeebe.exporter.record.value.job.Headers;
+import java.util.Objects;
+
+public class HeadersImpl implements Headers {
+  private final String bpmnProcessId;
+  private final String activityId;
+  private final long activityInstanceKey;
+  private final long workflowInstanceKey;
+  private final long workflowKey;
+  private final int workflowDefinitionVersion;
+
+  public HeadersImpl(
+      final String bpmnProcessId,
+      final String activityId,
+      final long activityInstanceKey,
+      final long workflowInstanceKey,
+      final long workflowKey,
+      final int workflowDefinitionVersion) {
+    this.bpmnProcessId = bpmnProcessId;
+    this.activityId = activityId;
+    this.activityInstanceKey = activityInstanceKey;
+    this.workflowInstanceKey = workflowInstanceKey;
+    this.workflowKey = workflowKey;
+    this.workflowDefinitionVersion = workflowDefinitionVersion;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  @Override
+  public String getActivityId() {
+    return activityId;
+  }
+
+  @Override
+  public long getActivityInstanceKey() {
+    return activityInstanceKey;
+  }
+
+  @Override
+  public long getWorkflowInstanceKey() {
+    return workflowInstanceKey;
+  }
+
+  @Override
+  public long getWorkflowKey() {
+    return workflowKey;
+  }
+
+  @Override
+  public int getWorkflowDefinitionVersion() {
+    return workflowDefinitionVersion;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final HeadersImpl headers = (HeadersImpl) o;
+    return activityInstanceKey == headers.activityInstanceKey
+        && workflowInstanceKey == headers.workflowInstanceKey
+        && workflowKey == headers.workflowKey
+        && workflowDefinitionVersion == headers.workflowDefinitionVersion
+        && Objects.equals(bpmnProcessId, headers.bpmnProcessId)
+        && Objects.equals(activityId, headers.activityId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        bpmnProcessId,
+        activityId,
+        activityInstanceKey,
+        workflowInstanceKey,
+        workflowKey,
+        workflowDefinitionVersion);
+  }
+
+  @Override
+  public String toString() {
+    return "HeadersImpl{"
+        + "bpmnProcessId='"
+        + bpmnProcessId
+        + '\''
+        + ", activityId='"
+        + activityId
+        + '\''
+        + ", activityInstanceKey="
+        + activityInstanceKey
+        + ", workflowInstanceKey="
+        + workflowInstanceKey
+        + ", workflowKey="
+        + workflowKey
+        + ", workflowDefinitionVersion="
+        + workflowDefinitionVersion
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/raft/RaftMemberImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/raft/RaftMemberImpl.java
@@ -15,25 +15,42 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.zeebe.broker.clustering.orchestration.id;
+package io.zeebe.broker.exporter.record.value.raft;
 
-import io.zeebe.msgpack.UnpackedObject;
-import io.zeebe.msgpack.property.IntegerProperty;
+import io.zeebe.exporter.record.value.raft.RaftMember;
+import java.util.Objects;
 
-public class IdRecord extends UnpackedObject {
+public class RaftMemberImpl implements RaftMember {
+  private final int nodeId;
 
-  private final IntegerProperty id = new IntegerProperty("id");
-
-  public IdRecord() {
-    this.declareProperty(id);
+  public RaftMemberImpl(final int nodeId) {
+    this.nodeId = nodeId;
   }
 
-  public Integer getId() {
-    return id.getValue();
+  @Override
+  public int getNodeId() {
+    return nodeId;
   }
 
-  public IdRecord setId(final int id) {
-    this.id.setValue(id);
-    return this;
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RaftMemberImpl that = (RaftMemberImpl) o;
+    return nodeId == that.nodeId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(nodeId);
+  }
+
+  @Override
+  public String toString() {
+    return "RaftMemberImpl{" + "nodeId=" + nodeId + '}';
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/repo/ExporterDescriptor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/repo/ExporterDescriptor.java
@@ -33,8 +33,12 @@ public class ExporterDescriptor {
     this.configuration = new ExporterConfiguration(id, args);
   }
 
-  public Exporter newInstance() throws IllegalAccessException, InstantiationException {
-    return exporterClass.newInstance();
+  public Exporter newInstance() throws ExporterInstantiationException {
+    try {
+      return exporterClass.newInstance();
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new ExporterInstantiationException(getId(), e);
+    }
   }
 
   public ExporterConfiguration getConfiguration() {

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/repo/ExporterInstantiationException.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/repo/ExporterInstantiationException.java
@@ -15,25 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.zeebe.broker.clustering.orchestration.id;
+package io.zeebe.broker.exporter.repo;
 
-import io.zeebe.msgpack.UnpackedObject;
-import io.zeebe.msgpack.property.IntegerProperty;
+public class ExporterInstantiationException extends RuntimeException {
+  private static final long serialVersionUID = -7231999951981994615L;
+  private static final String MESSAGE_FORMAT = "Cannot instantiate exporter [%s]";
 
-public class IdRecord extends UnpackedObject {
-
-  private final IntegerProperty id = new IntegerProperty("id");
-
-  public IdRecord() {
-    this.declareProperty(id);
-  }
-
-  public Integer getId() {
-    return id.getValue();
-  }
-
-  public IdRecord setId(final int id) {
-    this.id.setValue(id);
-    return this;
+  public ExporterInstantiationException(final String id, Throwable cause) {
+    super(String.format(MESSAGE_FORMAT, id), cause);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecord.java
@@ -1,0 +1,100 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.stream;
+
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.msgpack.property.ArrayProperty;
+import io.zeebe.msgpack.property.LongProperty;
+import io.zeebe.msgpack.property.StringProperty;
+import io.zeebe.msgpack.value.ValueArray;
+import java.util.Objects;
+import org.agrona.DirectBuffer;
+
+public class ExporterRecord extends UnpackedObject {
+  public static final long POSITION_UNKNOWN = -1L;
+  public static final String ID_UNKNOWN = "";
+
+  private ArrayProperty<ExporterPosition> positionsProperty =
+      new ArrayProperty<>("positions", new ExporterPosition());
+
+  public ExporterRecord() {
+    this.declareProperty(positionsProperty);
+  }
+
+  public ValueArray<ExporterPosition> getPositions() {
+    return positionsProperty;
+  }
+
+  public static class ExporterPosition extends UnpackedObject {
+    private StringProperty idProperty = new StringProperty("id", ID_UNKNOWN);
+    private LongProperty positionProperty = new LongProperty("position", POSITION_UNKNOWN);
+
+    public ExporterPosition() {
+      this.declareProperty(idProperty);
+      this.declareProperty(positionProperty);
+    }
+
+    public DirectBuffer getId() {
+      return idProperty.getValue();
+    }
+
+    public ExporterPosition setId(final String id) {
+      idProperty.setValue(id);
+      return this;
+    }
+
+    public ExporterPosition setId(final DirectBuffer id) {
+      idProperty.setValue(id);
+      return this;
+    }
+
+    public ExporterPosition setId(final DirectBuffer id, int offset, int length) {
+      idProperty.setValue(id, offset, length);
+      return this;
+    }
+
+    public long getPosition() {
+      return positionProperty.getValue();
+    }
+
+    public ExporterPosition setPosition(final long position) {
+      positionProperty.setValue(position);
+      return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+
+      if (!(o instanceof ExporterPosition)) {
+        return false;
+      }
+
+      final ExporterPosition that = (ExporterPosition) o;
+      return Objects.equals(getId(), that.getId())
+          && Objects.equals(getPosition(), that.getPosition());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getId(), getPosition());
+    }
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
@@ -1,0 +1,333 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.stream;
+
+import io.zeebe.broker.clustering.orchestration.id.IdRecord;
+import io.zeebe.broker.clustering.orchestration.topic.TopicRecord;
+import io.zeebe.broker.exporter.record.RecordImpl;
+import io.zeebe.broker.exporter.record.value.DeploymentRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.IdRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.IncidentRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.JobRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.MessageRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.MessageSubscriptionRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.RaftRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.TopicRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.WorkflowInstanceRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.WorkflowInstanceSubscriptionRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.deployment.DeployedWorkflowImpl;
+import io.zeebe.broker.exporter.record.value.deployment.DeploymentResourceImpl;
+import io.zeebe.broker.exporter.record.value.job.HeadersImpl;
+import io.zeebe.broker.exporter.record.value.raft.RaftMemberImpl;
+import io.zeebe.broker.incident.data.IncidentRecord;
+import io.zeebe.broker.job.data.JobHeaders;
+import io.zeebe.broker.job.data.JobRecord;
+import io.zeebe.broker.subscription.message.data.MessageRecord;
+import io.zeebe.broker.subscription.message.data.MessageSubscriptionRecord;
+import io.zeebe.broker.subscription.message.data.WorkflowInstanceSubscriptionRecord;
+import io.zeebe.broker.system.workflow.repository.data.DeploymentRecord;
+import io.zeebe.broker.workflow.data.WorkflowInstanceRecord;
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.record.RecordMetadata;
+import io.zeebe.exporter.record.RecordValue;
+import io.zeebe.exporter.record.value.DeploymentRecordValue;
+import io.zeebe.exporter.record.value.IdRecordValue;
+import io.zeebe.exporter.record.value.IncidentRecordValue;
+import io.zeebe.exporter.record.value.JobRecordValue;
+import io.zeebe.exporter.record.value.MessageRecordValue;
+import io.zeebe.exporter.record.value.MessageSubscriptionRecordValue;
+import io.zeebe.exporter.record.value.RaftRecordValue;
+import io.zeebe.exporter.record.value.TopicRecordValue;
+import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.exporter.record.value.WorkflowInstanceSubscriptionRecordValue;
+import io.zeebe.exporter.record.value.deployment.DeployedWorkflow;
+import io.zeebe.exporter.record.value.deployment.DeploymentResource;
+import io.zeebe.exporter.record.value.deployment.ResourceType;
+import io.zeebe.exporter.record.value.raft.RaftMember;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.msgpack.value.IntegerValue;
+import io.zeebe.raft.event.RaftConfigurationEvent;
+import io.zeebe.raft.event.RaftConfigurationEventMember;
+import io.zeebe.util.buffer.BufferUtil;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.agrona.DirectBuffer;
+import org.agrona.io.DirectBufferInputStream;
+
+public class ExporterRecordMapper {
+  private final DirectBufferInputStream serderInputStream = new DirectBufferInputStream();
+  private final ZeebeObjectMapperImpl objectMapper;
+
+  public ExporterRecordMapper(final ZeebeObjectMapperImpl objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public Record map(final LoggedEvent event, final RecordMetadata metadata) {
+    final Function<LoggedEvent, ? extends RecordValue> valueSupplier;
+
+    switch (metadata.getValueType()) {
+      case DEPLOYMENT:
+        valueSupplier = this::ofDeploymentRecord;
+        break;
+      case ID:
+        valueSupplier = this::ofIdRecord;
+        break;
+      case INCIDENT:
+        valueSupplier = this::ofIncidentRecord;
+        break;
+      case JOB:
+        valueSupplier = this::ofJobRecord;
+        break;
+      case MESSAGE:
+        valueSupplier = this::ofMessageRecord;
+        break;
+      case MESSAGE_SUBSCRIPTION:
+        valueSupplier = this::ofMessageSubscriptionRecord;
+        break;
+      case RAFT:
+        valueSupplier = this::ofRaftRecord;
+        break;
+      case TOPIC:
+        valueSupplier = this::ofTopicRecord;
+        break;
+      case WORKFLOW_INSTANCE:
+        valueSupplier = this::ofWorkflowInstanceRecord;
+        break;
+      case WORKFLOW_INSTANCE_SUBSCRIPTION:
+        valueSupplier = this::ofWorkflowInstanceSubscriptionRecord;
+        break;
+      default:
+        return null;
+    }
+
+    return newRecord(event, metadata, valueSupplier);
+  }
+
+  private <T extends RecordValue> RecordImpl<T> newRecord(
+      final LoggedEvent event,
+      final RecordMetadata metadata,
+      final Function<LoggedEvent, T> valueSupplier) {
+    return new RecordImpl<>(
+        objectMapper,
+        event.getKey(),
+        event.getPosition(),
+        Instant.ofEpochMilli(event.getTimestamp()),
+        event.getRaftTerm(),
+        event.getProducerId(),
+        event.getSourceEventPosition(),
+        metadata,
+        valueSupplier.apply(event));
+  }
+
+  // VALUE SUPPLIERS
+
+  private IdRecordValue ofIdRecord(final LoggedEvent event) {
+    final IdRecord record = new IdRecord();
+    event.readValue(record);
+
+    return new IdRecordValueImpl(objectMapper, record.getId());
+  }
+
+  private RaftRecordValue ofRaftRecord(final LoggedEvent event) {
+    final RaftConfigurationEvent record = new RaftConfigurationEvent();
+    event.readValue(record);
+
+    final List<RaftMember> members = new ArrayList<>();
+    for (final RaftConfigurationEventMember member : record.members()) {
+      members.add(new RaftMemberImpl(member.getNodeId()));
+    }
+
+    return new RaftRecordValueImpl(objectMapper, members);
+  }
+
+  private JobRecordValue ofJobRecord(final LoggedEvent event) {
+    final JobRecord record = new JobRecord();
+    event.readValue(record);
+
+    final JobHeaders jobHeaders = record.headers();
+    final HeadersImpl headers =
+        new HeadersImpl(
+            asString(jobHeaders.getBpmnProcessId()),
+            asString(jobHeaders.getActivityId()),
+            jobHeaders.getActivityInstanceKey(),
+            jobHeaders.getWorkflowInstanceKey(),
+            jobHeaders.getWorkflowKey(),
+            jobHeaders.getWorkflowDefinitionVersion());
+
+    return new JobRecordValueImpl(
+        objectMapper,
+        asJson(record.getPayload()),
+        asString(record.getType()),
+        asString(record.getWorker()),
+        Instant.ofEpochMilli(record.getDeadline()),
+        headers,
+        asMsgPackMap(record.getCustomHeaders()),
+        record.getRetries());
+  }
+
+  private DeploymentRecordValue ofDeploymentRecord(final LoggedEvent event) {
+    final List<DeployedWorkflow> deployedWorkflows = new ArrayList<>();
+    final List<DeploymentResource> resources = new ArrayList<>();
+    final DeploymentRecord record = new DeploymentRecord();
+
+    event.readValue(record);
+
+    for (final io.zeebe.broker.system.workflow.repository.data.DeployedWorkflow workflow :
+        record.deployedWorkflows()) {
+      deployedWorkflows.add(
+          new DeployedWorkflowImpl(
+              asString(workflow.getBpmnProcessId()),
+              asString(workflow.getResourceName()),
+              workflow.getKey(),
+              workflow.getVersion()));
+    }
+
+    for (final io.zeebe.broker.system.workflow.repository.data.DeploymentResource resource :
+        record.resources()) {
+      resources.add(
+          new DeploymentResourceImpl(
+              asByteArray(resource.getResource()),
+              asResourceType(resource.getResourceType()),
+              asString(resource.getResourceName())));
+    }
+
+    return new DeploymentRecordValueImpl(objectMapper, deployedWorkflows, resources);
+  }
+
+  private IncidentRecordValue ofIncidentRecord(final LoggedEvent event) {
+    final IncidentRecord record = new IncidentRecord();
+    event.readValue(record);
+
+    return new IncidentRecordValueImpl(
+        objectMapper,
+        asJson(record.getPayload()),
+        record.getErrorType().name(),
+        asString(record.getErrorMessage()),
+        asString(record.getBpmnProcessId()),
+        asString(record.getActivityId()),
+        record.getWorkflowInstanceKey(),
+        record.getActivityInstanceKey(),
+        record.getJobKey());
+  }
+
+  private MessageRecordValue ofMessageRecord(final LoggedEvent event) {
+    final MessageRecord record = new MessageRecord();
+    event.readValue(record);
+
+    return new MessageRecordValueImpl(
+        objectMapper,
+        asJson(record.getPayload()),
+        asString(record.getName()),
+        asString(record.getMessageId()),
+        asString(record.getCorrelationKey()),
+        record.getTimeToLive());
+  }
+
+  private MessageSubscriptionRecordValue ofMessageSubscriptionRecord(final LoggedEvent event) {
+    final MessageSubscriptionRecord record = new MessageSubscriptionRecord();
+    event.readValue(record);
+
+    return new MessageSubscriptionRecordValueImpl(
+        objectMapper,
+        asString(record.getMessageName()),
+        asString(record.getCorrelationKey()),
+        record.getWorkflowInstancePartitionId(),
+        record.getWorkflowInstanceKey(),
+        record.getActivityInstanceKey());
+  }
+
+  private TopicRecordValue ofTopicRecord(final LoggedEvent event) {
+    final TopicRecord record = new TopicRecord();
+    event.readValue(record);
+
+    final List<Integer> partitionIds = new ArrayList<>();
+    for (final IntegerValue partitionId : record.getPartitionIds()) {
+      partitionIds.add(partitionId.getValue());
+    }
+
+    return new TopicRecordValueImpl(
+        objectMapper,
+        asString(record.getName()),
+        partitionIds,
+        record.getPartitions(),
+        record.getReplicationFactor());
+  }
+
+  private WorkflowInstanceRecordValue ofWorkflowInstanceRecord(final LoggedEvent event) {
+    final WorkflowInstanceRecord record = new WorkflowInstanceRecord();
+    event.readValue(record);
+
+    return new WorkflowInstanceRecordValueImpl(
+        objectMapper,
+        asJson(record.getPayload()),
+        asString(record.getBpmnProcessId()),
+        asString(record.getActivityId()),
+        record.getVersion(),
+        record.getWorkflowKey(),
+        record.getWorkflowInstanceKey(),
+        record.getScopeInstanceKey());
+  }
+
+  private WorkflowInstanceSubscriptionRecordValue ofWorkflowInstanceSubscriptionRecord(
+      final LoggedEvent event) {
+    final WorkflowInstanceSubscriptionRecord record = new WorkflowInstanceSubscriptionRecord();
+    event.readValue(record);
+
+    return new WorkflowInstanceSubscriptionRecordValueImpl(
+        objectMapper,
+        asJson(record.getPayload()),
+        asString(record.getMessageName()),
+        record.getWorkflowInstanceKey(),
+        record.getActivityInstanceKey());
+  }
+
+  // UTILS
+
+  private byte[] asByteArray(final DirectBuffer buffer) {
+    return BufferUtil.bufferAsArray(buffer);
+  }
+
+  private String asString(final DirectBuffer buffer) {
+    return BufferUtil.bufferAsString(buffer);
+  }
+
+  private Map<String, Object> asMsgPackMap(final DirectBuffer msgPackEncoded) {
+    serderInputStream.wrap(msgPackEncoded);
+    return objectMapper.fromMsgpackAsMap(serderInputStream);
+  }
+
+  private String asJson(final DirectBuffer msgPackEncoded) {
+    serderInputStream.wrap(msgPackEncoded);
+    return objectMapper.getMsgPackConverter().convertToJson(serderInputStream);
+  }
+
+  private ResourceType asResourceType(
+      io.zeebe.broker.system.workflow.repository.data.ResourceType resourceType) {
+    switch (resourceType) {
+      case BPMN_XML:
+        return ResourceType.BPMN_XML;
+      case YAML_WORKFLOW:
+        return ResourceType.YAML_WORKFLOW;
+    }
+    throw new IllegalArgumentException("Provided resource type does not exist " + resourceType);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessor.java
@@ -1,0 +1,266 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.stream;
+
+import io.zeebe.broker.exporter.context.ExporterContext;
+import io.zeebe.broker.exporter.record.RecordMetadataImpl;
+import io.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.zeebe.broker.exporter.stream.ExporterRecord.ExporterPosition;
+import io.zeebe.broker.logstreams.processor.NoopSnapshotSupport;
+import io.zeebe.exporter.context.Controller;
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.spi.Exporter;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import io.zeebe.logstreams.log.LogStreamReader;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.logstreams.processor.EventProcessor;
+import io.zeebe.logstreams.processor.StreamProcessor;
+import io.zeebe.logstreams.processor.StreamProcessorContext;
+import io.zeebe.logstreams.spi.SnapshotSupport;
+import io.zeebe.logstreams.state.StateController;
+import io.zeebe.protocol.clientapi.RecordType;
+import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.impl.RecordMetadata;
+import io.zeebe.protocol.intent.ExporterIntent;
+import io.zeebe.util.buffer.BufferUtil;
+import io.zeebe.util.sched.ActorControl;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.LoggerFactory;
+
+public class ExporterStreamProcessor implements StreamProcessor {
+  private static final SnapshotSupport NONE = new NoopSnapshotSupport();
+
+  private final RecordMetadata rawMetadata = new RecordMetadata();
+  private final List<ExporterContainer> containers;
+  private final int partitionId;
+
+  private final ExporterStreamProcessorState state = new ExporterStreamProcessorState();
+  private final RecordExporter recordExporter = new RecordExporter();
+  private final ExporterRecordProcessor exporterRecordProcessor = new ExporterRecordProcessor();
+
+  private ActorControl actorControl;
+  private LogStreamReader logStreamReader;
+
+  public ExporterStreamProcessor(
+      final int partitionId, final List<ExporterDescriptor> descriptors) {
+    this.partitionId = partitionId;
+
+    this.containers = new ArrayList<>(descriptors.size());
+    for (final ExporterDescriptor descriptor : descriptors) {
+      this.containers.add(new ExporterContainer(descriptor));
+    }
+  }
+
+  @Override
+  public SnapshotSupport getStateResource() {
+    return NONE;
+  }
+
+  @Override
+  public StateController getStateController() {
+    return state;
+  }
+
+  @Override
+  public EventProcessor onEvent(LoggedEvent event) {
+    final EventProcessor processor;
+    event.readMetadata(rawMetadata);
+
+    if (rawMetadata.getValueType() == ValueType.EXPORTER) {
+      exporterRecordProcessor.wrap(event);
+      processor = exporterRecordProcessor;
+    } else {
+      recordExporter.wrap(event);
+      processor = recordExporter;
+    }
+
+    return processor;
+  }
+
+  @Override
+  public void onOpen(StreamProcessorContext context) {
+    logStreamReader = context.getLogStreamReader();
+    actorControl = context.getActorControl();
+
+    for (final ExporterContainer container : containers) {
+      container.exporter.configure(container.context);
+    }
+  }
+
+  @Override
+  public void onRecovered() {
+    long lowestPosition = -1;
+
+    for (final ExporterContainer container : containers) {
+      container.exporter.open(container);
+      container.position = state.getPosition(container.getId());
+
+      if (lowestPosition == -1 || lowestPosition > container.position) {
+        lowestPosition = container.position;
+      }
+    }
+
+    // in case the lowest known position is not found, start from the
+    // beginning again
+    if (lowestPosition <= 0 || !logStreamReader.seek(lowestPosition)) {
+      logStreamReader.seekToFirstEvent();
+    } else {
+      if (logStreamReader.hasNext()) {
+        logStreamReader.seek(lowestPosition + 1);
+      }
+    }
+  }
+
+  @Override
+  public void onClose() {
+    for (final ExporterContainer container : containers) {
+      try {
+        container.exporter.close();
+      } catch (final Exception e) {
+        container.context.getLogger().error("Error on close", e);
+      }
+    }
+
+    state.close();
+  }
+
+  private boolean shouldCommitPositions() {
+    return false;
+  }
+
+  private class ExporterContainer implements Controller {
+    private static final String LOGGER_NAME_FORMAT = "exporter-%s";
+
+    private final ExporterContext context;
+    private final Exporter exporter;
+    private long position;
+
+    ExporterContainer(ExporterDescriptor descriptor) {
+      context =
+          new ExporterContext(
+              LoggerFactory.getLogger(String.format(LOGGER_NAME_FORMAT, descriptor.getId())),
+              descriptor.getConfiguration());
+      exporter = descriptor.newInstance();
+    }
+
+    @Override
+    public void updateLastExportedRecordPosition(final long position) {
+      actorControl.run(
+          () -> {
+            state.setPosition(getId(), position);
+            this.position = position;
+          });
+    }
+
+    @Override
+    public void scheduleTask(final Duration delay, final Runnable task) {
+      actorControl.runDelayed(delay, task);
+    }
+
+    private String getId() {
+      return context.getConfiguration().getId();
+    }
+  }
+
+  private class ExporterRecordProcessor implements EventProcessor {
+    private final ExporterRecord record = new ExporterRecord();
+
+    public void wrap(final LoggedEvent event) {
+      event.readValue(record);
+    }
+
+    @Override
+    public void updateState() {
+      for (final ExporterPosition position : record.getPositions()) {
+        state.setPositionIfGreater(position.getId(), position.getPosition());
+      }
+    }
+  }
+
+  private class RecordExporter implements EventProcessor {
+    private final ZeebeObjectMapperImpl objectMapper = new ZeebeObjectMapperImpl();
+    private ExporterRecordMapper recordMapper = new ExporterRecordMapper(objectMapper);
+    private Record record;
+    private boolean shouldExecuteSideEffects;
+    private int exporterIndex;
+
+    void wrap(LoggedEvent rawEvent) {
+      final RecordMetadataImpl metadata =
+          new RecordMetadataImpl(
+              objectMapper,
+              partitionId,
+              rawMetadata.getIntent(),
+              rawMetadata.getRecordType(),
+              rawMetadata.getRejectionType(),
+              BufferUtil.bufferAsString(rawMetadata.getRejectionReason()),
+              rawMetadata.getValueType());
+
+      record = recordMapper.map(rawEvent, metadata);
+      exporterIndex = 0;
+      shouldExecuteSideEffects = record != null;
+    }
+
+    @Override
+    public boolean executeSideEffects() {
+      if (!shouldExecuteSideEffects) {
+        return true;
+      }
+
+      final int exportersCount = containers.size();
+
+      // current error handling strategy is simply to repeat forever until the record can be
+      // successfully exported.
+      while (exporterIndex < exportersCount) {
+        final ExporterContainer container = containers.get(exporterIndex);
+
+        try {
+          if (container.position < record.getPosition()) {
+            container.exporter.export(record);
+          }
+
+          exporterIndex++;
+        } catch (final Exception ex) {
+          container.context.getLogger().error("Error exporting record {}", record, ex);
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    @Override
+    public long writeEvent(LogStreamRecordWriter writer) {
+      if (shouldCommitPositions()) {
+        final ExporterRecord record = state.newExporterRecord();
+
+        rawMetadata
+            .reset()
+            .recordType(RecordType.EVENT)
+            .valueType(ValueType.EXPORTER)
+            .intent(ExporterIntent.EXPORTED);
+
+        return writer.positionAsKey().valueWriter(record).metadataWriter(rawMetadata).tryWrite();
+      }
+
+      return 0;
+    }
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessorState.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessorState.java
@@ -1,0 +1,132 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.stream;
+
+import static io.zeebe.util.StringUtil.getBytes;
+
+import io.zeebe.broker.exporter.stream.ExporterRecord.ExporterPosition;
+import io.zeebe.logstreams.state.StateController;
+import io.zeebe.util.LangUtil;
+import io.zeebe.util.buffer.BufferUtil;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.agrona.DirectBuffer;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+
+public class ExporterStreamProcessorState extends StateController {
+  private final ByteBuffer longBuffer = ByteBuffer.allocate(Long.BYTES);
+
+  public void setPosition(final String exporterId, final long position) {
+    setPosition(toByteArray(exporterId), position);
+  }
+
+  public void setPosition(final DirectBuffer exporterId, final long position) {
+    setPosition(toByteArray(exporterId), position);
+  }
+
+  public void setPosition(final byte[] exporterId, final long position) {
+    final byte[] value = ofLong(longBuffer, position);
+
+    try {
+      getDb().put(exporterId, value);
+    } catch (RocksDBException e) {
+      LangUtil.rethrowUnchecked(e);
+    }
+  }
+
+  public void setPositionIfGreater(final String exporterId, final long position) {
+    setPositionIfGreater(toByteArray(exporterId), position);
+  }
+
+  public void setPositionIfGreater(final DirectBuffer exporterId, final long position) {
+    setPositionIfGreater(toByteArray(exporterId), position);
+  }
+
+  public void setPositionIfGreater(final byte[] exporterId, final long position) {
+    final byte[] value = ofLong(longBuffer, position);
+
+    try {
+      getDb().merge(exporterId, value);
+    } catch (final RocksDBException e) {
+      LangUtil.rethrowUnchecked(e);
+    }
+  }
+
+  public long getPosition(final String exporterId) {
+    return getPosition(BufferUtil.wrapString(exporterId));
+  }
+
+  public long getPosition(final DirectBuffer exporterId) {
+    return getPosition(toByteArray(exporterId));
+  }
+
+  public long getPosition(final byte[] exporterId) {
+    long position = ExporterRecord.POSITION_UNKNOWN;
+
+    try {
+      final int bytesRead = getDb().get(exporterId, longBuffer.array());
+      if (bytesRead == Long.BYTES) {
+        position = toLong(longBuffer);
+      }
+    } catch (RocksDBException e) {
+      LangUtil.rethrowUnchecked(e);
+    }
+
+    return position;
+  }
+
+  public ExporterRecord newExporterRecord() {
+    final ExporterRecord record = new ExporterRecord();
+
+    try (final RocksIterator iterator = getDb().newIterator()) {
+      for (iterator.seekToFirst(); iterator.isValid(); iterator.next()) {
+        final ExporterPosition position = record.getPositions().add();
+        final long value = toLong(ByteBuffer.wrap(iterator.value()));
+
+        position.setId(BufferUtil.wrapArray(iterator.key()));
+        position.setPosition(value);
+      }
+    }
+
+    return record;
+  }
+
+  private byte[] ofLong(final ByteBuffer buffer, final long value) {
+    buffer.order(ByteOrder.LITTLE_ENDIAN).putLong(0, value);
+    return buffer.array();
+  }
+
+  private long toLong(final ByteBuffer buffer) {
+    return buffer.order(ByteOrder.LITTLE_ENDIAN).getLong(0);
+  }
+
+  @Override
+  protected Options createOptions() {
+    return super.createOptions().setMergeOperatorName("max");
+  }
+
+  private byte[] toByteArray(final DirectBuffer value) {
+    return BufferUtil.bufferAsArray(value);
+  }
+
+  private byte[] toByteArray(final String value) {
+    return getBytes(value);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/NoopEventProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/NoopEventProcessor.java
@@ -15,25 +15,27 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.zeebe.broker.clustering.orchestration.id;
+package io.zeebe.broker.logstreams.processor;
 
-import io.zeebe.msgpack.UnpackedObject;
-import io.zeebe.msgpack.property.IntegerProperty;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.zeebe.logstreams.processor.EventLifecycleContext;
+import io.zeebe.logstreams.processor.EventProcessor;
 
-public class IdRecord extends UnpackedObject {
+public class NoopEventProcessor implements EventProcessor {
 
-  private final IntegerProperty id = new IntegerProperty("id");
+  @Override
+  public void processEvent(EventLifecycleContext ctx) {}
 
-  public IdRecord() {
-    this.declareProperty(id);
+  @Override
+  public boolean executeSideEffects() {
+    return true;
   }
 
-  public Integer getId() {
-    return id.getValue();
+  @Override
+  public long writeEvent(LogStreamRecordWriter writer) {
+    return 0;
   }
 
-  public IdRecord setId(final int id) {
-    this.id.setValue(id);
-    return this;
-  }
+  @Override
+  public void updateState() {}
 }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamEnvironment.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamEnvironment.java
@@ -19,6 +19,7 @@ package io.zeebe.broker.logstreams.processor;
 
 import io.zeebe.broker.clustering.orchestration.id.IdRecord;
 import io.zeebe.broker.clustering.orchestration.topic.TopicRecord;
+import io.zeebe.broker.exporter.stream.ExporterRecord;
 import io.zeebe.broker.incident.data.IncidentRecord;
 import io.zeebe.broker.job.data.JobRecord;
 import io.zeebe.broker.subscription.message.data.MessageRecord;
@@ -49,6 +50,7 @@ public class TypedStreamEnvironment {
     EVENT_REGISTRY.put(ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionRecord.class);
     EVENT_REGISTRY.put(
         ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION, WorkflowInstanceSubscriptionRecord.class);
+    EVENT_REGISTRY.put(ValueType.EXPORTER, ExporterRecord.class);
   }
 
   private TypedStreamReader reader;

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessorStateTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessorStateTest.java
@@ -1,0 +1,160 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.stream;
+
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.exporter.stream.ExporterRecord.ExporterPosition;
+import io.zeebe.test.util.AutoCloseableRule;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.agrona.DirectBuffer;
+import org.assertj.core.api.Condition;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+
+public class ExporterStreamProcessorStateTest {
+  private final AutoCloseableRule autoCloseableRule = new AutoCloseableRule();
+  private final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private final ExporterStreamProcessorState state = new ExporterStreamProcessorState();
+
+  @Rule
+  public final RuleChain chain = RuleChain.outerRule(temporaryFolder).around(autoCloseableRule);
+
+  @Before
+  public void setup() throws Exception {
+    final File dbDirectory = temporaryFolder.newFolder();
+    state.open(dbDirectory, false);
+    autoCloseableRule.manage(state);
+  }
+
+  @Test
+  public void shouldSetPositionForNewExporter() {
+    // given
+    final String id = "exporter";
+    final long position = 123;
+
+    // when
+    state.setPosition(id, position);
+
+    // then
+    assertThat(state.getPosition(id)).isEqualTo(position);
+  }
+
+  @Test
+  public void shouldOverwritePositionOfExporter() {
+    // given
+    final String id = "exporter";
+    final long firstPosition = 123;
+    final long secondPosition = 2034;
+
+    // when
+    state.setPosition(id, firstPosition);
+    state.setPosition(id, secondPosition);
+
+    // then
+    assertThat(state.getPosition(id)).isEqualTo(secondPosition);
+  }
+
+  @Test
+  public void shouldReturnUnknownPositionForUnknownExporter() {
+    // given
+    final String id = "exporter";
+
+    // when
+    final long position = state.getPosition(id);
+
+    // then
+    assertThat(position).isEqualTo(ExporterRecord.POSITION_UNKNOWN);
+  }
+
+  @Test
+  public void shouldSetPositionSinceSomethingIsGreaterThanNothing() {
+    // given
+    final String id = "exporter";
+    final long position = 12312;
+
+    // when
+    state.setPositionIfGreater(id, position);
+
+    // then
+    assertThat(state.getPosition(id)).isEqualTo(position);
+  }
+
+  @Test
+  public void shouldNotSetPositionIfLowerThanExisting() {
+    // given
+    final String id = "exporter";
+    final long position = 12313;
+
+    // when
+    state.setPosition(id, position);
+    state.setPositionIfGreater(id, position - 1);
+
+    // then
+    assertThat(state.getPosition(id)).isEqualTo(position);
+  }
+
+  @Test
+  public void shouldSetPositionIfGreaterThanExisting() {
+    // given
+    final String id = "exporter";
+    final long position = 123;
+
+    // when
+    state.setPosition(id, position - 1);
+    state.setPositionIfGreater(id, position);
+
+    // then
+    assertThat(state.getPosition(id)).isEqualTo(position);
+  }
+
+  @Test
+  public void shouldWriteOutRecordOfAllExportersAndTheirPositions() {
+    // given
+    final Map<DirectBuffer, Long> positions = new HashMap<>();
+
+    positions.put(wrapString("exporter1"), 123L);
+    positions.put(wrapString("exporter2"), 2L);
+    positions.put(wrapString("exporter3"), 12034L);
+    positions.put(wrapString("exporter4"), Long.MAX_VALUE);
+
+    for (final Entry<DirectBuffer, Long> entry : positions.entrySet()) {
+      state.setPosition(entry.getKey(), entry.getValue());
+    }
+
+    // when
+    final ExporterRecord record = state.newExporterRecord();
+
+    // then
+    for (final Entry<DirectBuffer, Long> entry : positions.entrySet()) {
+      final ExporterPosition expected = new ExporterPosition();
+      expected.setPosition(entry.getValue());
+      expected.setId(entry.getKey());
+
+      assertThat(record.getPositions())
+          .haveExactly(1, new Condition<>(r -> r.equals(expected), expected.toString()));
+    }
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessorTest.java
@@ -1,0 +1,754 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.stream;
+
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import io.zeebe.broker.clustering.orchestration.id.IdRecord;
+import io.zeebe.broker.clustering.orchestration.topic.TopicRecord;
+import io.zeebe.broker.exporter.record.value.DeploymentRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.IdRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.IncidentRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.JobRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.MessageRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.MessageSubscriptionRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.RaftRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.TopicRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.WorkflowInstanceRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.WorkflowInstanceSubscriptionRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.deployment.DeployedWorkflowImpl;
+import io.zeebe.broker.exporter.record.value.deployment.DeploymentResourceImpl;
+import io.zeebe.broker.exporter.record.value.job.HeadersImpl;
+import io.zeebe.broker.exporter.record.value.raft.RaftMemberImpl;
+import io.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.zeebe.broker.exporter.stream.ExporterRecord.ExporterPosition;
+import io.zeebe.broker.exporter.util.ControlledTestExporter;
+import io.zeebe.broker.exporter.util.PojoConfigurationExporter;
+import io.zeebe.broker.exporter.util.PojoConfigurationExporter.PojoExporterConfiguration;
+import io.zeebe.broker.incident.data.ErrorType;
+import io.zeebe.broker.incident.data.IncidentRecord;
+import io.zeebe.broker.job.data.JobRecord;
+import io.zeebe.broker.subscription.message.data.MessageRecord;
+import io.zeebe.broker.subscription.message.data.MessageSubscriptionRecord;
+import io.zeebe.broker.subscription.message.data.WorkflowInstanceSubscriptionRecord;
+import io.zeebe.broker.system.workflow.repository.data.DeploymentRecord;
+import io.zeebe.broker.system.workflow.repository.data.ResourceType;
+import io.zeebe.broker.topic.StreamProcessorControl;
+import io.zeebe.broker.util.StreamProcessorRule;
+import io.zeebe.broker.workflow.data.WorkflowInstanceRecord;
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.record.RecordMetadata;
+import io.zeebe.exporter.record.RecordValue;
+import io.zeebe.exporter.record.value.DeploymentRecordValue;
+import io.zeebe.exporter.record.value.IdRecordValue;
+import io.zeebe.exporter.record.value.IncidentRecordValue;
+import io.zeebe.exporter.record.value.JobRecordValue;
+import io.zeebe.exporter.record.value.MessageRecordValue;
+import io.zeebe.exporter.record.value.MessageSubscriptionRecordValue;
+import io.zeebe.exporter.record.value.RaftRecordValue;
+import io.zeebe.exporter.record.value.TopicRecordValue;
+import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.exporter.record.value.WorkflowInstanceSubscriptionRecordValue;
+import io.zeebe.gateway.impl.data.ZeebeObjectMapperImpl;
+import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.protocol.intent.DeploymentIntent;
+import io.zeebe.protocol.intent.ExporterIntent;
+import io.zeebe.protocol.intent.IdIntent;
+import io.zeebe.protocol.intent.IncidentIntent;
+import io.zeebe.protocol.intent.Intent;
+import io.zeebe.protocol.intent.JobIntent;
+import io.zeebe.protocol.intent.MessageIntent;
+import io.zeebe.protocol.intent.MessageSubscriptionIntent;
+import io.zeebe.protocol.intent.RaftIntent;
+import io.zeebe.protocol.intent.TopicIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceSubscriptionIntent;
+import io.zeebe.raft.event.RaftConfigurationEvent;
+import io.zeebe.test.util.TestUtil;
+import io.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ExporterStreamProcessorTest {
+  private static final int PARTITION_ID = 1;
+  private static final ZeebeObjectMapperImpl OBJECT_MAPPER = new ZeebeObjectMapperImpl();
+  private static final Map<String, Object> PAYLOAD = Collections.singletonMap("foo", "bar");
+  private static final String PAYLOAD_JSON = OBJECT_MAPPER.toJson(PAYLOAD);
+  private static final DirectBuffer PAYLOAD_MSGPACK =
+      new UnsafeBuffer(OBJECT_MAPPER.toMsgpack(PAYLOAD));
+  private static final Map<String, Object> CUSTOM_HEADERS =
+      Collections.singletonMap("workerVersion", 42);
+  private static final DirectBuffer CUSTOM_HEADERS_MSGPACK =
+      new UnsafeBuffer(OBJECT_MAPPER.toMsgpack(CUSTOM_HEADERS));
+
+  @Rule public StreamProcessorRule rule = new StreamProcessorRule();
+
+  private List<ControlledTestExporter> exporters;
+
+  @Test
+  public void shouldConfigureAllExportersProperlyOnStart() {
+    // given
+    final Map[] arguments = new Map[] {newConfig("foo", "bar"), newConfig("bar", "foo")};
+    final List<ExporterDescriptor> descriptors = createMockedExporters(arguments);
+    final ExporterStreamProcessor processor =
+        new ExporterStreamProcessor(PARTITION_ID, descriptors);
+
+    // when
+    final StreamProcessorControl control = rule.initStreamProcessor(e -> processor);
+    control.start();
+
+    // then
+    for (int i = 0; i < exporters.size(); i++) {
+      assertThat(exporters.get(i).getContext().getConfiguration().getId())
+          .isEqualTo(descriptors.get(i).getId());
+      assertThat(exporters.get(i).getContext().getConfiguration().getArguments())
+          .isEqualTo(arguments[i]);
+      assertThat(exporters.get(i).getContext().getLogger()).isNotNull();
+      assertThat(exporters.get(i).getController()).isNotNull();
+    }
+  }
+
+  @Test
+  public void shouldInstantiateConfigurationClass() {
+    // given
+    final String foo = "bar";
+    final int x = 123;
+    final String bar = "baz";
+    final double y = 32.12;
+
+    final Map<String, Object> nested = new HashMap<>();
+    nested.put("bar", bar);
+    nested.put("y", y);
+
+    final Map<String, Object> arguments = new HashMap<>();
+    arguments.put("foo", foo);
+    arguments.put("x", x);
+    arguments.put("nested", nested);
+
+    final ExporterDescriptor descriptor =
+        new ExporterDescriptor(
+            "instantiateConfiguration", PojoConfigurationExporter.class, arguments);
+
+    final ExporterStreamProcessor processor =
+        new ExporterStreamProcessor(PARTITION_ID, Collections.singletonList(descriptor));
+
+    rule.runStreamProcessor(e -> processor);
+
+    // then
+    final PojoExporterConfiguration configuration = PojoConfigurationExporter.configuration;
+
+    assertThat(configuration.foo).isEqualTo(foo);
+    assertThat(configuration.x).isEqualTo(x);
+    assertThat(configuration.nested.bar).isEqualTo(bar);
+    assertThat(configuration.nested.y).isEqualTo(y);
+  }
+
+  @Test
+  public void shouldCloseAllExportersOnClose() {
+    // given
+    final boolean[] closedExporters = new boolean[] {false, false};
+    final ExporterStreamProcessor processor = createStreamProcessor(closedExporters.length);
+
+    exporters.get(0).onClose(() -> closedExporters[0] = true);
+    exporters.get(1).onClose(() -> closedExporters[1] = true);
+
+    // when
+    final StreamProcessorControl control = rule.initStreamProcessor(e -> processor);
+    control.start();
+
+    // then
+    for (int i = 0; i < exporters.size(); i++) {
+      assertThat(closedExporters[i]).isFalse();
+    }
+
+    // when
+    control.close();
+
+    // then
+    for (int i = 0; i < exporters.size(); i++) {
+      assertThat(closedExporters[i]).isTrue();
+    }
+  }
+
+  @Test
+  public void shouldRestartEachExporterFromCorrectPosition() {
+    // given
+    final ExporterStreamProcessor processor = createStreamProcessor(2);
+
+    // when
+    final StreamProcessorControl control = rule.initStreamProcessor(e -> processor);
+    final long lowestPosition = writeEvent();
+    final long highestPosition = writeEvent();
+
+    control.blockAfterEvent(e -> e.getPosition() == highestPosition);
+    control.start();
+    TestUtil.waitUntil(control::isBlocked);
+    control.unblock();
+
+    // then
+    TestUtil.waitUntil(() -> exporters.get(0).getExportedRecords().size() == 2);
+    TestUtil.waitUntil(() -> exporters.get(1).getExportedRecords().size() == 2);
+
+    // when
+    exporters.get(0).getController().updateLastExportedRecordPosition(highestPosition);
+    exporters.get(1).getController().updateLastExportedRecordPosition(lowestPosition);
+    control.close();
+    control.blockAfterEvent(e -> e.getPosition() == highestPosition);
+    control.start();
+    TestUtil.waitUntil(control::isBlocked);
+
+    // then
+    // should have reprocessed no events
+    assertThat(exporters.get(0).getExportedRecords()).hasSize(2);
+    assertThat(exporters.get(0).getExportedRecords().get(0).getPosition())
+        .isEqualTo(lowestPosition);
+    assertThat(exporters.get(0).getExportedRecords().get(1).getPosition())
+        .isEqualTo(highestPosition);
+
+    // should have reprocessed the last event twice
+    assertThat(exporters.get(1).getExportedRecords()).hasSize(3);
+    assertThat(exporters.get(1).getExportedRecords().get(0).getPosition())
+        .isEqualTo(lowestPosition);
+    assertThat(exporters.get(1).getExportedRecords().get(1).getPosition())
+        .isEqualTo(highestPosition);
+    assertThat(exporters.get(1).getExportedRecords().get(2).getPosition())
+        .isEqualTo(highestPosition);
+  }
+
+  @Test
+  public void shouldRecoverPositionsFromLogStream() {
+    // given
+    final List<ExporterDescriptor> descriptors = createMockedExporters(1);
+    final ExporterStreamProcessor processor =
+        new ExporterStreamProcessor(PARTITION_ID, descriptors);
+    final ExporterStreamProcessorState state =
+        (ExporterStreamProcessorState) processor.getStateController();
+
+    // when
+    final StreamProcessorControl control = rule.initStreamProcessor(e -> processor);
+    final long lowestPosition = writeEvent();
+    final long latestPosition = writeExporterEvent(descriptors.get(0).getId(), lowestPosition);
+
+    control.blockAfterEvent(e -> e.getPosition() == latestPosition);
+    control.start();
+    TestUtil.waitUntil(control::isBlocked);
+
+    // then
+    assertThat(state.getPosition(descriptors.get(0).getId())).isEqualTo(lowestPosition);
+  }
+
+  @Test
+  public void shouldRetryExportingOnException() {
+    final ExporterStreamProcessor processor = createStreamProcessor(3);
+
+    final AtomicLong failCount = new AtomicLong(3);
+    exporters
+        .get(1)
+        .onExport(
+            e -> {
+              if (failCount.getAndDecrement() > 0) {
+                throw new RuntimeException("Export failed (expected)");
+              }
+            });
+
+    // when
+    final StreamProcessorControl control = rule.initStreamProcessor(e -> processor);
+    final long lowestPosition = writeEvent();
+    final long highestPosition = writeEvent();
+
+    control.blockAfterEvent(e -> e.getPosition() == highestPosition);
+    control.start();
+    TestUtil.waitUntil(control::isBlocked);
+
+    // then
+    for (final ControlledTestExporter exporter : exporters) {
+      assertThat(exporter.getExportedRecords())
+          .extracting("position")
+          .containsExactly(lowestPosition, highestPosition);
+    }
+  }
+
+  @Test
+  public void shouldExecuteScheduledTask() throws InterruptedException {
+    // given
+    final ExporterStreamProcessor processor = createStreamProcessor(1);
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final Duration delay = Duration.ofSeconds(10);
+
+    final ControlledTestExporter controlledTestExporter = exporters.get(0);
+    controlledTestExporter.onExport(
+        r -> controlledTestExporter.getController().scheduleTask(delay, latch::countDown));
+
+    final long position = writeEvent();
+
+    final StreamProcessorControl control = rule.initStreamProcessor(e -> processor);
+    control.blockAfterEvent(e -> e.getPosition() == position);
+    control.start();
+    TestUtil.waitUntil(control::isBlocked);
+
+    // when
+    rule.getClock().addTime(delay.plusSeconds(10));
+    final boolean wasExecuted = latch.await(1, TimeUnit.SECONDS);
+
+    // then
+    assertThat(wasExecuted).isTrue();
+  }
+
+  @Test
+  public void shouldNotExportExporterRecords() {
+    // given
+    final List<ExporterDescriptor> descriptors = createMockedExporters(1);
+    final ExporterStreamProcessor processor =
+        new ExporterStreamProcessor(PARTITION_ID, descriptors);
+
+    // when
+    final StreamProcessorControl control = rule.initStreamProcessor(e -> processor);
+    final long lowestPosition = writeEvent();
+    final long latestPosition = writeExporterEvent(descriptors.get(0).getId(), lowestPosition);
+
+    control.blockAfterEvent(e -> e.getPosition() == latestPosition);
+    control.start();
+    TestUtil.waitUntil(control::isBlocked);
+
+    // then
+    assertThat(exporters.get(0).getExportedRecords()).hasSize(1);
+    assertThat(exporters.get(0).getExportedRecords().get(0).getPosition())
+        .isEqualTo(lowestPosition);
+  }
+
+  @Test
+  public void shouldExportIdEvent() {
+    // given
+    final int id = 1;
+
+    final IdRecord record = new IdRecord().setId(id);
+    final IdRecordValue expectedRecordValue = new IdRecordValueImpl(OBJECT_MAPPER, id);
+
+    // then
+    assertRecordExported(IdIntent.GENERATED, record, expectedRecordValue);
+  }
+
+  @Test
+  public void shouldExportDeploymentEvent() {
+    // given
+    final String resourceName = "resource";
+    final ResourceType resourceType = ResourceType.BPMN_XML;
+    final DirectBuffer resource = wrapString("contents");
+    final String bpmnProcessId = "testProcess";
+    final long workflowKey = 123;
+    final int workflowVersion = 12;
+
+    final DeploymentRecord record = new DeploymentRecord();
+    record
+        .resources()
+        .add()
+        .setResourceName(wrapString(resourceName))
+        .setResourceType(resourceType)
+        .setResource(resource);
+    record
+        .deployedWorkflows()
+        .add()
+        .setBpmnProcessId(wrapString(bpmnProcessId))
+        .setKey(workflowKey)
+        .setResourceName(wrapString(resourceName))
+        .setVersion(workflowVersion);
+
+    final DeploymentRecordValue expectedRecordValue =
+        new DeploymentRecordValueImpl(
+            OBJECT_MAPPER,
+            Collections.singletonList(
+                new DeployedWorkflowImpl(
+                    bpmnProcessId, resourceName, workflowKey, workflowVersion)),
+            Collections.singletonList(
+                new DeploymentResourceImpl(
+                    BufferUtil.bufferAsArray(resource),
+                    io.zeebe.exporter.record.value.deployment.ResourceType.BPMN_XML,
+                    resourceName)));
+
+    // then
+    assertRecordExported(DeploymentIntent.CREATE, record, expectedRecordValue);
+  }
+
+  @Test
+  public void shouldExportIncidentRecord() {
+    // given
+    final long activityInstanceKey = 34;
+    final long workflowInstanceKey = 10;
+    final long failureEventPosition = 12;
+    final String activityId = "activity";
+    final String bpmnProcessId = "process";
+    final String errorMessage = "error";
+    final ErrorType errorType = ErrorType.IO_MAPPING_ERROR;
+    final long jobKey = 123;
+
+    final IncidentRecord record =
+        new IncidentRecord()
+            .setActivityInstanceKey(activityInstanceKey)
+            .setWorkflowInstanceKey(workflowInstanceKey)
+            .setFailureEventPosition(failureEventPosition)
+            .setActivityId(wrapString(activityId))
+            .setBpmnProcessId(wrapString(bpmnProcessId))
+            .setErrorMessage(errorMessage)
+            .setErrorType(errorType)
+            .setJobKey(jobKey)
+            .setPayload(PAYLOAD_MSGPACK);
+
+    final IncidentRecordValue recordValue =
+        new IncidentRecordValueImpl(
+            OBJECT_MAPPER,
+            PAYLOAD_JSON,
+            errorType.name(),
+            errorMessage,
+            bpmnProcessId,
+            activityId,
+            workflowInstanceKey,
+            activityInstanceKey,
+            jobKey);
+
+    // then
+    assertRecordExported(IncidentIntent.CREATED, record, recordValue);
+  }
+
+  @Test
+  public void shouldExportJobRecord() {
+    // given
+    final String worker = "myWorker";
+    final String type = "myType";
+    final int retries = 12;
+    final int deadline = 13;
+
+    final String bpmnProcessId = "test-process";
+    final int workflowKey = 13;
+    final int workflowDefinitionVersion = 12;
+    final int workflowInstanceKey = 1234;
+    final String activityId = "activity";
+    final int activityInstanceKey = 123;
+
+    final JobRecord record =
+        new JobRecord()
+            .setWorker(wrapString(worker))
+            .setType(wrapString(type))
+            .setPayload(PAYLOAD_MSGPACK)
+            .setRetries(retries)
+            .setDeadline(deadline);
+    record
+        .headers()
+        .setBpmnProcessId(wrapString(bpmnProcessId))
+        .setWorkflowKey(workflowKey)
+        .setWorkflowDefinitionVersion(workflowDefinitionVersion)
+        .setWorkflowInstanceKey(workflowInstanceKey)
+        .setActivityId(wrapString(activityId))
+        .setActivityInstanceKey(activityInstanceKey);
+
+    record.setCustomHeaders(CUSTOM_HEADERS_MSGPACK);
+
+    final JobRecordValue recordValue =
+        new JobRecordValueImpl(
+            OBJECT_MAPPER,
+            PAYLOAD_JSON,
+            type,
+            worker,
+            Instant.ofEpochMilli(deadline),
+            new HeadersImpl(
+                bpmnProcessId,
+                activityId,
+                activityInstanceKey,
+                workflowInstanceKey,
+                workflowKey,
+                workflowDefinitionVersion),
+            CUSTOM_HEADERS,
+            retries);
+
+    // then
+    assertRecordExported(JobIntent.CREATED, record, recordValue);
+  }
+
+  @Test
+  public void shouldExportMessageRecord() {
+    // given
+    final String correlationKey = "test-key";
+    final String messageName = "test-message";
+    final long timeToLive = 12;
+    final String messageId = "test-id";
+
+    final MessageRecord record =
+        new MessageRecord()
+            .setCorrelationKey(wrapString(correlationKey))
+            .setName(wrapString(messageName))
+            .setPayload(PAYLOAD_MSGPACK)
+            .setTimeToLive(timeToLive)
+            .setMessageId(wrapString(messageId));
+
+    final MessageRecordValue recordValue =
+        new MessageRecordValueImpl(
+            OBJECT_MAPPER, PAYLOAD_JSON, messageName, messageId, correlationKey, timeToLive);
+
+    // then
+    assertRecordExported(MessageIntent.PUBLISHED, record, recordValue);
+  }
+
+  @Test
+  public void shouldExportMessageSubscriptionRecord() {
+    // given
+    final long activityInstanceKey = 1L;
+    final String messageName = "name";
+    final long workflowInstanceKey = 1L;
+    final int workflowInstancePartitionId = 1;
+    final String correlationKey = "key";
+
+    final MessageSubscriptionRecord record =
+        new MessageSubscriptionRecord()
+            .setActivityInstanceKey(activityInstanceKey)
+            .setMessageName(wrapString(messageName))
+            .setWorkflowInstanceKey(workflowInstanceKey)
+            .setWorkflowInstancePartitionId(workflowInstancePartitionId)
+            .setCorrelationKey(wrapString(correlationKey));
+
+    final MessageSubscriptionRecordValue recordValue =
+        new MessageSubscriptionRecordValueImpl(
+            OBJECT_MAPPER,
+            messageName,
+            correlationKey,
+            workflowInstancePartitionId,
+            workflowInstanceKey,
+            activityInstanceKey);
+
+    // then
+    assertRecordExported(MessageSubscriptionIntent.CORRELATE, record, recordValue);
+  }
+
+  @Test
+  public void shouldExportRaftRecord() {
+    // given
+    final List<Integer> nodeIds = IntStream.of(4).boxed().collect(Collectors.toList());
+
+    final RaftConfigurationEvent record = new RaftConfigurationEvent();
+    nodeIds.forEach(i -> record.members().add().setNodeId(i));
+
+    final RaftRecordValue recordValue =
+        new RaftRecordValueImpl(
+            OBJECT_MAPPER, nodeIds.stream().map(RaftMemberImpl::new).collect(Collectors.toList()));
+
+    // then
+    assertRecordExported(RaftIntent.MEMBER_ADDED, record, recordValue);
+  }
+
+  @Test
+  public void shouldExportTopicRecord() {
+    // given
+    final String topic = "test-topic";
+    final int partitions = 12;
+    final int replicationFactor = 34;
+    final List<Integer> partitionIds =
+        IntStream.of(partitions).boxed().collect(Collectors.toList());
+
+    final TopicRecord record =
+        new TopicRecord()
+            .setName(wrapString(topic))
+            .setPartitions(partitions)
+            .setReplicationFactor(replicationFactor);
+    partitionIds.forEach(i -> record.getPartitionIds().add().setValue(i));
+
+    final TopicRecordValue recordValue =
+        new TopicRecordValueImpl(OBJECT_MAPPER, topic, partitionIds, partitions, replicationFactor);
+
+    // then
+    assertRecordExported(TopicIntent.CREATED, record, recordValue);
+  }
+
+  @Test
+  public void shouldExportWorkflowInstanceRecord() {
+    // given
+    final String bpmnProcessId = "test-process";
+    final int workflowKey = 13;
+    final int version = 12;
+    final int workflowInstanceKey = 1234;
+    final String activityId = "activity";
+    final int scopeInstanceKey = 123;
+
+    final WorkflowInstanceRecord record =
+        new WorkflowInstanceRecord()
+            .setActivityId(activityId)
+            .setPayload(PAYLOAD_MSGPACK)
+            .setBpmnProcessId(wrapString(bpmnProcessId))
+            .setVersion(version)
+            .setWorkflowKey(workflowKey)
+            .setWorkflowInstanceKey(workflowInstanceKey)
+            .setScopeInstanceKey(scopeInstanceKey);
+
+    final WorkflowInstanceRecordValue recordValue =
+        new WorkflowInstanceRecordValueImpl(
+            OBJECT_MAPPER,
+            PAYLOAD_JSON,
+            bpmnProcessId,
+            activityId,
+            version,
+            workflowKey,
+            workflowInstanceKey,
+            scopeInstanceKey);
+
+    // then
+    assertRecordExported(WorkflowInstanceIntent.CREATED, record, recordValue);
+  }
+
+  @Test
+  public void shouldExportWorkflowInstanceSubscriptionRecord() {
+    // given
+    final long activityInstanceKey = 123;
+    final String messageName = "test-message";
+    final int subscriptionPartitionId = 2;
+    final long workflowInstanceKey = 1345;
+
+    final WorkflowInstanceSubscriptionRecord record =
+        new WorkflowInstanceSubscriptionRecord()
+            .setActivityInstanceKey(activityInstanceKey)
+            .setMessageName(wrapString(messageName))
+            .setSubscriptionPartitionId(subscriptionPartitionId)
+            .setWorkflowInstanceKey(workflowInstanceKey)
+            .setPayload(PAYLOAD_MSGPACK);
+
+    final WorkflowInstanceSubscriptionRecordValue recordValue =
+        new WorkflowInstanceSubscriptionRecordValueImpl(
+            OBJECT_MAPPER, PAYLOAD_JSON, messageName, workflowInstanceKey, activityInstanceKey);
+
+    // then
+    assertRecordExported(WorkflowInstanceSubscriptionIntent.OPENED, record, recordValue);
+  }
+
+  private ExporterStreamProcessor createStreamProcessor(final int count) {
+    return new ExporterStreamProcessor(PARTITION_ID, createMockedExporters(count));
+  }
+
+  private List<ExporterDescriptor> createMockedExporters(final int count) {
+    return createMockedExporters(count, new Map[0]);
+  }
+
+  private List<ExporterDescriptor> createMockedExporters(final Map... arguments) {
+    return createMockedExporters(arguments.length, arguments);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<ExporterDescriptor> createMockedExporters(final int count, final Map[] arguments) {
+    final List<ExporterDescriptor> descriptors = new ArrayList<>(count);
+    exporters = new ArrayList<>(count);
+
+    for (int i = 0; i < count; i++) {
+      final Map args = arguments.length > 0 ? arguments[i] : null;
+      final ControlledTestExporter exporter = spy(new ControlledTestExporter());
+      final ExporterDescriptor descriptor =
+          spy(new ExporterDescriptor(String.valueOf(i), exporter.getClass(), args));
+      doAnswer(c -> exporter).when(descriptor).newInstance();
+
+      exporters.add(exporter);
+      descriptors.add(descriptor);
+    }
+
+    return descriptors;
+  }
+
+  private long writeEvent() {
+    final IdRecord event = new IdRecord();
+    event.setId(0);
+    return rule.writeEvent(IdIntent.GENERATED, event);
+  }
+
+  private long writeExporterEvent(final String id, final long position) {
+    final ExporterRecord event = new ExporterRecord();
+    final ExporterPosition exporterPosition = event.getPositions().add();
+    exporterPosition.setId(id);
+    exporterPosition.setPosition(position);
+
+    return rule.writeEvent(ExporterIntent.EXPORTED, event);
+  }
+
+  private Map<String, Object> newConfig(final String... pairs) {
+    final Map<String, Object> config = new HashMap<>();
+
+    for (int i = 0; i < pairs.length; i += 2) {
+      config.put(pairs[i], pairs[i + 1]);
+    }
+
+    return config;
+  }
+
+  private void assertRecordExported(
+      final Intent intent, final UnpackedObject record, final RecordValue expectedRecordValue) {
+    // setup stream processor
+    final StreamProcessorControl control = rule.initStreamProcessor(e -> createStreamProcessor(1));
+
+    // write event
+    final long position = rule.writeEvent(intent, record);
+
+    // wait for event
+    control.blockAfterEvent(e -> e.getPosition() == position);
+    control.start();
+    TestUtil.waitUntil(control::isBlocked);
+
+    // assert exported record
+    final List<Record> exportedRecords = exporters.get(0).getExportedRecords();
+    assertThat(exportedRecords).hasSize(1);
+
+    final Record exportedRecord = exportedRecords.get(0);
+    final LoggedEvent loggedEvent = rule.events().withPosition(position);
+    assertMetadata(exportedRecord, loggedEvent);
+    assertThat(exportedRecord.getValue()).isEqualTo(expectedRecordValue);
+  }
+
+  private void assertMetadata(final Record actualRecord, final LoggedEvent expectedLoggedEvent) {
+    assertThat(actualRecord.getPosition()).isEqualTo(expectedLoggedEvent.getPosition());
+    assertThat(actualRecord.getRaftTerm()).isEqualTo(expectedLoggedEvent.getRaftTerm());
+    assertThat(actualRecord.getSourceRecordPosition())
+        .isEqualTo(expectedLoggedEvent.getSourceEventPosition());
+    assertThat(actualRecord.getProducerId()).isEqualTo(expectedLoggedEvent.getProducerId());
+    assertThat(actualRecord.getKey()).isEqualTo(expectedLoggedEvent.getKey());
+    assertThat(actualRecord.getTimestamp())
+        .isEqualTo(Instant.ofEpochMilli(expectedLoggedEvent.getTimestamp()));
+
+    final RecordMetadata actualMetadata = actualRecord.getMetadata();
+    final io.zeebe.protocol.impl.RecordMetadata expectedMetadata =
+        new io.zeebe.protocol.impl.RecordMetadata();
+    expectedLoggedEvent.readMetadata(expectedMetadata);
+
+    assertThat(actualMetadata.getIntent()).isEqualTo(expectedMetadata.getIntent());
+    assertThat(actualMetadata.getPartitionId()).isEqualTo(PARTITION_ID);
+    assertThat(actualMetadata.getRecordType()).isEqualTo(expectedMetadata.getRecordType());
+    assertThat(actualMetadata.getRejectionType()).isEqualTo(expectedMetadata.getRejectionType());
+    assertThat(actualMetadata.getRejectionReason())
+        .isEqualTo(BufferUtil.bufferAsString(expectedMetadata.getRejectionReason()));
+    assertThat(actualMetadata.getValueType()).isEqualTo(expectedMetadata.getValueType());
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/util/PojoConfigurationExporter.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/util/PojoConfigurationExporter.java
@@ -1,0 +1,51 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.util;
+
+import io.zeebe.exporter.context.Context;
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.spi.Exporter;
+
+public class PojoConfigurationExporter implements Exporter {
+
+  public static PojoExporterConfiguration configuration;
+
+  @Override
+  public void configure(Context context) {
+    configuration = context.getConfiguration().instantiate(PojoExporterConfiguration.class);
+  }
+
+  public PojoExporterConfiguration getConfiguration() {
+    return configuration;
+  }
+
+  @Override
+  public void export(Record record) {}
+
+  public class PojoExporterConfiguration {
+
+    public String foo;
+    public int x;
+    public PojoExporterConfigurationPart nested;
+  }
+
+  public class PojoExporterConfigurationPart {
+    public String bar;
+    public double y;
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/util/RecordStream.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/RecordStream.java
@@ -43,6 +43,12 @@ public class RecordStream extends StreamWrapper<LoggedEvent> {
     return new RecordStream(filter(r -> Records.hasIntent(r, intent)));
   }
 
+  public LoggedEvent withPosition(long position) {
+    return filter(e -> e.getPosition() == position)
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("No event found with position " + position));
+  }
+
   public TypedRecordStream<JobRecord> onlyJobRecords() {
     return new TypedRecordStream<>(
         filter(Records::isJobRecord).map(e -> CopiedTypedEvent.toTypedEvent(e, JobRecord.class)));

--- a/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
@@ -19,7 +19,9 @@ package io.zeebe.broker.util;
 
 import static io.zeebe.test.util.TestUtil.doRepeatedly;
 
+import io.zeebe.broker.clustering.orchestration.id.IdRecord;
 import io.zeebe.broker.clustering.orchestration.topic.TopicRecord;
+import io.zeebe.broker.exporter.stream.ExporterRecord;
 import io.zeebe.broker.incident.data.IncidentRecord;
 import io.zeebe.broker.job.data.JobRecord;
 import io.zeebe.broker.logstreams.processor.TypedRecord;
@@ -57,6 +59,7 @@ import io.zeebe.protocol.clientapi.RecordType;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.protocol.impl.RecordMetadata;
 import io.zeebe.protocol.intent.Intent;
+import io.zeebe.raft.event.RaftConfigurationEvent;
 import io.zeebe.servicecontainer.ServiceContainer;
 import io.zeebe.test.util.AutoCloseableRule;
 import io.zeebe.util.LangUtil;
@@ -87,6 +90,9 @@ public class TestStreams {
     VALUE_TYPES.put(MessageSubscriptionRecord.class, ValueType.MESSAGE_SUBSCRIPTION);
     VALUE_TYPES.put(
         WorkflowInstanceSubscriptionRecord.class, ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION);
+    VALUE_TYPES.put(IdRecord.class, ValueType.ID);
+    VALUE_TYPES.put(ExporterRecord.class, ValueType.EXPORTER);
+    VALUE_TYPES.put(RaftConfigurationEvent.class, ValueType.RAFT);
 
     VALUE_TYPES.put(UnpackedObject.class, ValueType.NOOP);
   }
@@ -481,6 +487,11 @@ public class TestStreams {
     public void onOpen(StreamProcessorContext context) {
       this.context = context;
       wrappedProcessor.onOpen(this.context);
+    }
+
+    @Override
+    public void onRecovered() {
+      wrappedProcessor.onRecovered();
     }
 
     @Override

--- a/exporter/src/main/java/io/zeebe/exporter/record/Record.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/Record.java
@@ -15,8 +15,50 @@
  */
 package io.zeebe.exporter.record;
 
+import java.time.Instant;
+
 /** Represents a record published to the log stream. */
 public interface Record<T extends RecordValue> {
+  /**
+   * Retrieves the position of the record. Positions are locally unique to the partition, and
+   * monotonically increasing. Records are then ordered on the partition by their positions, i.e.
+   * lower position means the record was published earlier.
+   *
+   * @return position the record
+   */
+  long getPosition();
+
+  /** @return the raft term this event was committed in */
+  int getRaftTerm();
+
+  /**
+   * Returns the position of the source record. The source record denotes the record which caused
+   * the current record. It can be unset (meaning there is no source record), at which point the
+   * position returned here will be -1. Anything >= 0 implies a source record.
+   *
+   * @return position of the source record
+   */
+  long getSourceRecordPosition();
+
+  /** @return the id of the producer which produced this event */
+  int getProducerId();
+
+  /**
+   * Retrieves the key of the record.
+   *
+   * <p>Multiple records can have the same key if they belongs to the same logical entity. Keys are
+   * unique for the combination of topic, partition and record type.
+   *
+   * @return the key of the record
+   */
+  long getKey();
+
+  /**
+   * Returns the instant at which the record was published on the partition.
+   *
+   * @return timestamp of the event
+   */
+  Instant getTimestamp();
 
   /**
    * Retrieves relevant metadata of the record, such as the type of the value ({@link

--- a/exporter/src/main/java/io/zeebe/exporter/record/RecordMetadata.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/RecordMetadata.java
@@ -19,34 +19,14 @@ import io.zeebe.protocol.clientapi.RecordType;
 import io.zeebe.protocol.clientapi.RejectionType;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.protocol.intent.Intent;
-import java.time.Instant;
 
 /** Encapsulates metadata information shared by all records. */
 public interface RecordMetadata {
-  /**
-   * Retrieves the key of the record.
-   *
-   * <p>Multiple records can have the same key if they belongs to the same logical entity. Keys are
-   * unique for the combination of topic, partition and record type.
-   *
-   * @return the key of the record
-   */
-  long getKey();
-
   /** @return the intent of the record */
   Intent getIntent();
 
   /** @return the partition ID on which the record was published */
   int getPartitionId();
-
-  /**
-   * Retrieves the position of the record. Positions are locally unique to the partition, and
-   * monotonically increasing. Records are then ordered on the partition by their positions, i.e.
-   * lower position means the record was published earlier.
-   *
-   * @return position the record
-   */
-  long getPosition();
 
   /** @return the type of the record (event, command or command rejection) */
   RecordType getRecordType();
@@ -62,22 +42,6 @@ public interface RecordMetadata {
    *     io.zeebe.protocol.clientapi.RecordType#COMMAND_REJECTION} or else <code>null</code>.
    */
   String getRejectionReason();
-
-  /**
-   * Returns the position of the source record. The source record denotes the record which caused
-   * the current record. It can be unset (meaning there is no source record), at which point the
-   * position returned here will be -1. Anything >= 0 implies a source record.
-   *
-   * @return position of the source record
-   */
-  long getSourceRecordPosition();
-
-  /**
-   * Returns the instant at which the record was published on the partition.
-   *
-   * @return timestamp of the event
-   */
-  Instant getTimestamp();
 
   /** @return the type of the record (e.g. job, workflow, workflow instance, etc.) */
   ValueType getValueType();

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/DeploymentRecordValue.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/DeploymentRecordValue.java
@@ -26,9 +26,6 @@ import java.util.List;
  * <p>See {@link io.zeebe.protocol.intent.DeploymentIntent} for intents.
  */
 public interface DeploymentRecordValue extends RecordValue {
-  /** @return the name of the topic to deploy to */
-  String getDeploymentTopic();
-
   /** @return the resources to deploy */
   List<DeploymentResource> getResources();
 

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/JobRecordValue.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/JobRecordValue.java
@@ -16,6 +16,7 @@
 package io.zeebe.exporter.record.value;
 
 import io.zeebe.exporter.record.RecordValueWithPayload;
+import io.zeebe.exporter.record.value.job.Headers;
 import java.time.Instant;
 import java.util.Map;
 
@@ -33,7 +34,7 @@ public interface JobRecordValue extends RecordValueWithPayload {
    *     the context of workflow instance, the header provide context information on which activity
    *     is executed, etc.
    */
-  Map<String, Object> getHeaders();
+  Headers getHeaders();
 
   /** @return user-defined headers associated with this job */
   Map<String, Object> getCustomHeaders();

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/deployment/DeployedWorkflow.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/deployment/DeployedWorkflow.java
@@ -24,7 +24,7 @@ public interface DeployedWorkflow {
   int getVersion();
 
   /** @return the key of this workflow */
-  String getWorkflowKey();
+  long getWorkflowKey();
 
   /** @return the name of the resource through which this workflow was deployed */
   String getResourceName();

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/deployment/DeploymentResource.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/deployment/DeploymentResource.java
@@ -21,7 +21,7 @@ public interface DeploymentResource {
   byte[] getResource();
 
   /** @return the type of the resource */
-  DeploymentResourceType getResourceType();
+  ResourceType getResourceType();
 
   /** @return the name of the resource */
   String getResourceName();

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/deployment/ResourceType.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/deployment/ResourceType.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.exporter.record.value.raft;
+package io.zeebe.exporter.record.value.deployment;
 
-/** Represents a single Raft member. */
-public interface RaftMember {
-  /** @return the node id of the member */
-  int getNodeId();
+public enum ResourceType {
+  BPMN_XML,
+
+  YAML_WORKFLOW
 }

--- a/exporter/src/main/java/io/zeebe/exporter/record/value/job/Headers.java
+++ b/exporter/src/main/java/io/zeebe/exporter/record/value/job/Headers.java
@@ -13,21 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.exporter.record.value.deployment;
+package io.zeebe.exporter.record.value.job;
 
-/** Lists the different types of deploy-able resources */
-public enum DeploymentResourceType {
-  /**
-   * Implies the resource blob is a BPMN XML document.
-   *
-   * @see <a href="https://docs.zeebe.io/bpmn-workflows/README.html">
-   *     https://docs.zeebe.io/bpmn-workflows/README.html</a>
-   */
-  BPMN_XML,
-  /**
-   * Implies the resource blob is a YAML document. See {@see
-   * @see <a href="https://docs.zeebe.io/yaml-workflows/README.html">
-   *   https://docs.zeebe.io/yaml-workflows/README.html</a>
-   */
-  YAML_WORKFLOW;
+/** represents broker-defined headers associated with this job */
+public interface Headers {
+  String getActivityId();
+
+  long getActivityInstanceKey();
+
+  String getBpmnProcessId();
+
+  int getWorkflowDefinitionVersion();
+
+  long getWorkflowInstanceKey();
+
+  long getWorkflowKey();
 }

--- a/gateway/src/main/java/io/zeebe/gateway/impl/data/MsgPackConverter.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/data/MsgPackConverter.java
@@ -56,7 +56,11 @@ public class MsgPackConverter {
   }
 
   public String convertToJson(byte[] msgPack) {
-    final byte[] jsonBytes = convertToJsonBytes(msgPack);
+    return convertToJson(new ByteArrayInputStream(msgPack));
+  }
+
+  public String convertToJson(InputStream msgPackInputStream) {
+    final byte[] jsonBytes = convertToJsonBytes(msgPackInputStream);
     return new String(jsonBytes, JSON_CHARSET);
   }
 
@@ -67,12 +71,14 @@ public class MsgPackConverter {
 
   protected byte[] convertToJsonBytes(byte[] msgPack) {
     final InputStream inputStream = new ByteArrayInputStream(msgPack);
+    return convertToJsonBytes(inputStream);
+  }
 
+  protected byte[] convertToJsonBytes(InputStream msgPackInputStream) {
     try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-      convert(inputStream, outputStream, msgPackFactory, jsonFactory);
+      convert(msgPackInputStream, outputStream, msgPackFactory, jsonFactory);
 
-      final byte[] jsonBytes = outputStream.toByteArray();
-      return jsonBytes;
+      return outputStream.toByteArray();
     } catch (Exception e) {
       throw new RuntimeException("Failed to convert MessagePack to JSON", e);
     }

--- a/gateway/src/main/java/io/zeebe/gateway/impl/data/ZeebeObjectMapperImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/data/ZeebeObjectMapperImpl.java
@@ -90,11 +90,14 @@ public class ZeebeObjectMapperImpl implements ZeebeObjectMapper {
 
   @Override
   public String toJson(Record record) {
+    return toJson((Object) record);
+  }
+
+  public String toJson(Object value) {
     try {
-      return jsonObjectMapper.writeValueAsString(record);
+      return jsonObjectMapper.writeValueAsString(value);
     } catch (JsonProcessingException e) {
-      throw new ClientException(
-          String.format("Failed to serialize object '%s' to JSON", record), e);
+      throw new ClientException(String.format("Failed to serialize object '%s' to JSON", value), e);
     }
   }
 
@@ -127,6 +130,14 @@ public class ZeebeObjectMapperImpl implements ZeebeObjectMapper {
           String.format(
               "Failed deserialize JSON '%s' to object of type '%s'", json, recordClass.getName()),
           e);
+    }
+  }
+
+  public Map<String, Object> fromJsonAsMap(String json) {
+    try {
+      return msgpackObjectMapper.readValue(json, MAP_TYPE_REFERENCE);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed deserialize JSON to map", e);
     }
   }
 
@@ -170,6 +181,14 @@ public class ZeebeObjectMapperImpl implements ZeebeObjectMapper {
   public Map<String, Object> fromMsgpackAsMap(byte[] msgpack) {
     try {
       return msgpackObjectMapper.readValue(msgpack, MAP_TYPE_REFERENCE);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed deserialize Msgpack JSON to map", e);
+    }
+  }
+
+  public Map<String, Object> fromMsgpackAsMap(InputStream inputStream) {
+    try {
+      return msgpackObjectMapper.readValue(inputStream, MAP_TYPE_REFERENCE);
     } catch (IOException e) {
       throw new RuntimeException("Failed deserialize Msgpack JSON to map", e);
     }

--- a/protocol/src/main/java/io/zeebe/protocol/intent/ExporterIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/ExporterIntent.java
@@ -13,10 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.exporter.record.value.raft;
+package io.zeebe.protocol.intent;
 
-/** Represents a single Raft member. */
-public interface RaftMember {
-  /** @return the node id of the member */
-  int getNodeId();
+public enum ExporterIntent implements Intent {
+  EXPORTED((short) 0);
+
+  private short value;
+
+  ExporterIntent(short value) {
+    this.value = value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(short value) {
+    switch (value) {
+      case 0:
+        return EXPORTED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
 }

--- a/protocol/src/main/java/io/zeebe/protocol/intent/Intent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/Intent.java
@@ -81,6 +81,8 @@ public interface Intent {
         return MessageSubscriptionIntent.from(intent);
       case WORKFLOW_INSTANCE_SUBSCRIPTION:
         return WorkflowInstanceSubscriptionIntent.from(intent);
+      case EXPORTER:
+        return ExporterIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -42,6 +42,7 @@
         <validValue name="MESSAGE">10</validValue>
         <validValue name="MESSAGE_SUBSCRIPTION">11</validValue>
         <validValue name="WORKFLOW_INSTANCE_SUBSCRIPTION">12</validValue>
+        <validValue name="EXPORTER">13</validValue>
     </enum>
 
     <enum name="ControlMessageType" encodingType="uint8" description="The type of the control message.">

--- a/util/src/main/java/io/zeebe/util/buffer/BufferUtil.java
+++ b/util/src/main/java/io/zeebe/util/buffer/BufferUtil.java
@@ -194,15 +194,16 @@ public final class BufferUtil {
     return builder.toString();
   }
 
-  public static byte[] bufferAsArray(DirectBuffer buffer) {
-    byte[] array = null;
+  public static byte[] bufferAsArray(final DirectBuffer buffer) {
+    final byte[] array;
 
-    if (buffer.byteArray() != null) {
+    if (buffer.byteArray() != null && buffer.wrapAdjustment() == 0) {
       array = buffer.byteArray();
     } else {
       array = new byte[buffer.capacity()];
       buffer.getBytes(0, array);
     }
+
     return array;
   }
 

--- a/util/src/test/java/io/zeebe/util/buffer/BufferUtilTest.java
+++ b/util/src/test/java/io/zeebe/util/buffer/BufferUtilTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
+import org.agrona.ExpandableDirectByteBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Test;
@@ -66,6 +67,52 @@ public class BufferUtilTest {
 
     // then
     assertThat(dst).isNotSameAs(src).isEqualTo(src).hasSameClassAs(src);
+  }
+
+  @Test
+  public void shouldReturnCopyOfByteArrayWhenWrappingPartialArray() {
+    // given
+    final byte[] expected = new byte[BYTES1.length - 1];
+    final DirectBuffer buffer = new UnsafeBuffer();
+    buffer.wrap(BYTES1, 1, BYTES1.length - 1);
+
+    // when
+    final byte[] bytes = BufferUtil.bufferAsArray(buffer);
+    System.arraycopy(BYTES1, 1, expected, 0, expected.length);
+
+    // then
+    assertThat(buffer.byteArray()).isEqualTo(BYTES1);
+    assertThat(bytes).isEqualTo(expected);
+    assertThat(bytes).isNotEqualTo(BYTES1);
+  }
+
+  @Test
+  public void shouldReturnNewByteArrayWhenNotWrappingByteArray() {
+    // given
+    final MutableDirectBuffer buffer = new ExpandableDirectByteBuffer();
+    buffer.putBytes(0, BYTES1);
+
+    // when
+    final byte[] bytes = BufferUtil.bufferAsArray(buffer);
+
+    // then
+    assertThat(buffer.byteArray()).isNull();
+    for (int i = 0; i < BYTES1.length; i++) {
+      assertThat(bytes[i]).isEqualTo(buffer.getByte(i));
+    }
+  }
+
+  @Test
+  public void shouldReturnWrappedArray() {
+    // given
+    final DirectBuffer buffer = new UnsafeBuffer(BYTES1);
+
+    // when
+    final byte[] bytes = BufferUtil.bufferAsArray(buffer);
+
+    // then
+    assertThat(buffer.byteArray()).isEqualTo(BYTES1);
+    assertThat(bytes).isSameAs(BYTES1);
   }
 
   public DirectBuffer asBuffer(byte[] bytes) {


### PR DESCRIPTION
- adds ExporterStreamProcessor which should be installed on a partition,
and maintains a list of exporters, their positions, and exports all
relevant events to them.
- adds implementations of all record/record values from zb-exporter
- minor fixups to the exporter API
- adds way to map LoggedEvent to zb-exporter Record

closes #1171