### PR TITLE
fix(broker): reliably activate jobs

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/job/JobSubscriptionManager.java
+++ b/broker-core/src/main/java/io/zeebe/broker/job/JobSubscriptionManager.java
@@ -17,13 +17,13 @@
  */
 package io.zeebe.broker.job;
 
-import static io.zeebe.broker.logstreams.processor.StreamProcessorIds.JOB_ACTIVATE_STREAM_PROCESSOR_ID;
 import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.zeebe.broker.Loggers;
 import io.zeebe.broker.clustering.base.partitions.Partition;
 import io.zeebe.broker.job.processor.ActivateJobStreamProcessor;
 import io.zeebe.broker.job.processor.JobSubscription;
+import io.zeebe.broker.logstreams.processor.StreamProcessorIds;
 import io.zeebe.broker.logstreams.processor.StreamProcessorServiceFactory;
 import io.zeebe.broker.logstreams.processor.TypedStreamEnvironment;
 import io.zeebe.logstreams.impl.service.LogStreamServiceNames;
@@ -401,11 +401,15 @@ public class JobSubscriptionManager extends Actor implements TransportListener {
     private ActorFuture<StreamProcessorService> createStreamProcessor(DirectBuffer type) {
       final ActivateJobStreamProcessor processor = new ActivateJobStreamProcessor(type);
 
+      // generating the id based on the type is a hack; motivation and proper solution are
+      // discussed in https://github.com/zeebe-io/zeebe/issues/927
+      final int streamProcessorId = StreamProcessorIds.generateJobActivationStreamProcessorId(type);
+
       final ActorFuture<StreamProcessorService> openFuture =
           factory
               .createService(partition, partitionServiceName)
               .processor(processor.createStreamProcessor(env))
-              .processorId(JOB_ACTIVATE_STREAM_PROCESSOR_ID)
+              .processorId(streamProcessorId)
               .processorName(streamProcessorName(type))
               .build();
 

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/StreamProcessorIds.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/StreamProcessorIds.java
@@ -17,12 +17,13 @@
  */
 package io.zeebe.broker.logstreams.processor;
 
+import io.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+
 public class StreamProcessorIds {
   // a stream processor partitionId should be unique to distinguish event producers
 
   public static final int JOB_QUEUE_STREAM_PROCESSOR_ID = 10;
-
-  public static final int JOB_ACTIVATE_STREAM_PROCESSOR_ID = 20;
 
   public static final int JOB_TIME_OUT_STREAM_PROCESSOR_ID = 30;
 
@@ -45,4 +46,15 @@ public class StreamProcessorIds {
   public static final int EXPORTER_PROCESSOR_ID = 1003;
 
   public static final int CLUSTER_TOPIC_STATE = 2000;
+
+  // BEWARE: everything above 3000 is reserved for job activation processors
+  // via https://github.com/zeebe-io/zeebe/issues/927
+  public static final int JOB_ACTIVATE_STREAM_PROCESSOR_BASE_ID = 3000;
+
+  public static int generateJobActivationStreamProcessorId(DirectBuffer type) {
+    final int typeHash = BufferUtil.bufferContentsHash(type);
+    final int idRange = Integer.MAX_VALUE - JOB_ACTIVATE_STREAM_PROCESSOR_BASE_ID;
+
+    return JOB_ACTIVATE_STREAM_PROCESSOR_BASE_ID + (Math.abs(typeHash) % idRange);
+  }
 }

--- a/broker-core/src/test/java/io/zeebe/broker/job/JobSubscriptionTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/job/JobSubscriptionTest.java
@@ -46,7 +46,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -741,7 +740,6 @@ public class JobSubscriptionTest {
   }
 
   @Test
-  @Ignore("https://github.com/zeebe-io/zeebe/issues/927")
   public void shouldActivateJobsOfDifferentTypeLocatedInFrontOfAlreadyActivatedJob() {
     // given
     final String jobType1 = "foo";
@@ -762,7 +760,7 @@ public class JobSubscriptionTest {
     final SubscribedRecord secondSubscribedJob =
         apiRule.subscribedEvents().skip(1).findFirst().get();
     final Object secondJobType = secondSubscribedJob.value().get("type");
-    assertThat(secondJobType).isEqualTo(jobType2);
+    assertThat(secondJobType).isEqualTo(jobType1);
   }
 
   @Test

--- a/util/src/main/java/io/zeebe/util/buffer/BufferUtil.java
+++ b/util/src/main/java/io/zeebe/util/buffer/BufferUtil.java
@@ -216,6 +216,16 @@ public final class BufferUtil {
     return new UnsafeBuffer(intArrayToByteArray(bytes));
   }
 
+  public static int bufferContentsHash(DirectBuffer buffer) {
+    int hashCode = 1;
+
+    for (int i = 0, length = buffer.capacity(); i < length; i++) {
+      hashCode = 31 * hashCode + buffer.getByte(i);
+    }
+
+    return hashCode;
+  }
+
   protected static byte[] intArrayToByteArray(int[] input) {
     final byte[] result = new byte[input.length];
     for (int i = 0; i < input.length; i++) {


### PR DESCRIPTION
- fixes an issue such that job activation would miss jobs if subscriptions
  were opened in a certain order
- fix is to make it very likely that different job activation processors
  receive different stream processor ids, so their produced records
  do not interfere during stream processing
- this is a hackfix because the ids are based on a hash function, which may
  have collisions; a proper solution is discussed in issue #927

closes #927
