### PR TITLE
1230 parallel split

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
@@ -19,6 +19,7 @@ import io.zeebe.model.bpmn.instance.EndEvent;
 import io.zeebe.model.bpmn.instance.ExclusiveGateway;
 import io.zeebe.model.bpmn.instance.FlowElement;
 import io.zeebe.model.bpmn.instance.IntermediateCatchEvent;
+import io.zeebe.model.bpmn.instance.ParallelGateway;
 import io.zeebe.model.bpmn.instance.ReceiveTask;
 import io.zeebe.model.bpmn.instance.SequenceFlow;
 import io.zeebe.model.bpmn.instance.ServiceTask;
@@ -37,6 +38,7 @@ public class FlowElementValidator implements ModelElementValidator<FlowElement> 
     SUPPORTED_ELEMENT_TYPES.add(EndEvent.class);
     SUPPORTED_ELEMENT_TYPES.add(ExclusiveGateway.class);
     SUPPORTED_ELEMENT_TYPES.add(IntermediateCatchEvent.class);
+    SUPPORTED_ELEMENT_TYPES.add(ParallelGateway.class);
     SUPPORTED_ELEMENT_TYPES.add(ReceiveTask.class);
     SUPPORTED_ELEMENT_TYPES.add(SequenceFlow.class);
     SUPPORTED_ELEMENT_TYPES.add(ServiceTask.class);

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ParallelGatewayValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ParallelGatewayValidator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.validation.zeebe;
+
+import io.zeebe.model.bpmn.instance.ParallelGateway;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ParallelGatewayValidator implements ModelElementValidator<ParallelGateway> {
+
+  @Override
+  public Class<ParallelGateway> getElementType() {
+    return ParallelGateway.class;
+  }
+
+  @Override
+  public void validate(
+      ParallelGateway element, ValidationResultCollector validationResultCollector) {
+    if (element.getIncoming().size() > 1) {
+      // parallel join not yet supported
+      validationResultCollector.addError(0, "Must not have more than one incoming sequence flow");
+    }
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -31,6 +31,7 @@ public class ZeebeDesignTimeValidators {
     VALIDATORS.add(new ExclusiveGatewayValidator());
     VALIDATORS.add(new FlowElementValidator());
     VALIDATORS.add(new MessageValidator());
+    VALIDATORS.add(new ParallelGatewayValidator());
     VALIDATORS.add(new ProcessValidator());
     VALIDATORS.add(new SequenceFlowValidator());
     VALIDATORS.add(new ServiceTaskValidator());

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
@@ -212,6 +212,17 @@ public class ZeebeValidationTest {
       {
         "no-start-event-sub-process.bpmn",
         Arrays.asList(expect("subProcess", "Must have exactly one start event"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .parallelGateway("fork")
+            .parallelGateway("join")
+            .moveToNode("fork")
+            .connectTo("join")
+            .endEvent()
+            .done(),
+        Arrays.asList(expect("join", "Must not have more than one incoming sequence flow"))
       }
     };
   }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/index/ElementInstance.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/index/ElementInstance.java
@@ -43,6 +43,8 @@ public class ElementInstance implements Serializable {
 
   private long jobKey;
 
+  private int activeTokens = 0;
+
   public ElementInstance(long key, ElementInstance parent) {
     this.key = key;
     this.parent = parent;
@@ -108,6 +110,18 @@ public class ElementInstance implements Serializable {
 
   public boolean canTerminate() {
     return WorkflowInstanceLifecycle.canTerminate(state);
+  }
+
+  public void spawnTokens(int number) {
+    this.activeTokens += number;
+  }
+
+  public void consumeTokens(int number) {
+    this.activeTokens -= number;
+  }
+
+  public int getActiveTokens() {
+    return activeTokens;
   }
 
   private void writeObject(java.io.ObjectOutputStream out) throws IOException {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/BpmnStep.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/BpmnStep.java
@@ -29,6 +29,9 @@ public enum BpmnStep {
   // xor-gateway
   EXCLUSIVE_SPLIT,
 
+  // parallel gateway
+  PARALLEL_SPLIT,
+
   CREATE_JOB,
 
   APPLY_INPUT_MAPPING,

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/BpmnTransformer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/BpmnTransformer.java
@@ -25,6 +25,7 @@ import io.zeebe.broker.workflow.model.transformation.handler.ExclusiveGatewayHan
 import io.zeebe.broker.workflow.model.transformation.handler.FlowElementHandler;
 import io.zeebe.broker.workflow.model.transformation.handler.FlowNodeHandler;
 import io.zeebe.broker.workflow.model.transformation.handler.IntermediateCatchEventHandler;
+import io.zeebe.broker.workflow.model.transformation.handler.ParallelGatewayHandler;
 import io.zeebe.broker.workflow.model.transformation.handler.ProcessHandler;
 import io.zeebe.broker.workflow.model.transformation.handler.ReceiveTaskHandler;
 import io.zeebe.broker.workflow.model.transformation.handler.SequenceFlowHandler;
@@ -62,6 +63,7 @@ public class BpmnTransformer {
     step2Visitor.registerHandler(new ExclusiveGatewayHandler());
     step2Visitor.registerHandler(new FlowNodeHandler());
     step2Visitor.registerHandler(new IntermediateCatchEventHandler());
+    step2Visitor.registerHandler(new ParallelGatewayHandler());
     step2Visitor.registerHandler(new ProcessHandler());
     step2Visitor.registerHandler(new SequenceFlowHandler());
     step2Visitor.registerHandler(new ServiceTaskHandler());

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/handler/FlowElementHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/handler/FlowElementHandler.java
@@ -31,6 +31,7 @@ import io.zeebe.model.bpmn.instance.EndEvent;
 import io.zeebe.model.bpmn.instance.ExclusiveGateway;
 import io.zeebe.model.bpmn.instance.FlowElement;
 import io.zeebe.model.bpmn.instance.IntermediateCatchEvent;
+import io.zeebe.model.bpmn.instance.ParallelGateway;
 import io.zeebe.model.bpmn.instance.ReceiveTask;
 import io.zeebe.model.bpmn.instance.SequenceFlow;
 import io.zeebe.model.bpmn.instance.ServiceTask;
@@ -50,6 +51,7 @@ public class FlowElementHandler implements ModelElementTransformer<FlowElement> 
     ELEMENT_FACTORIES.put(EndEvent.class, ExecutableFlowNode::new);
     ELEMENT_FACTORIES.put(ExclusiveGateway.class, ExecutableExclusiveGateway::new);
     ELEMENT_FACTORIES.put(IntermediateCatchEvent.class, ExecutableMessageCatchElement::new);
+    ELEMENT_FACTORIES.put(ParallelGateway.class, ExecutableFlowNode::new);
     ELEMENT_FACTORIES.put(SequenceFlow.class, ExecutableSequenceFlow::new);
     ELEMENT_FACTORIES.put(ServiceTask.class, ExecutableServiceTask::new);
     ELEMENT_FACTORIES.put(ReceiveTask.class, ExecutableMessageCatchElement::new);

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/handler/FlowNodeHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/handler/FlowNodeHandler.java
@@ -57,8 +57,10 @@ public class FlowNodeHandler implements ModelElementTransformer<FlowNode> {
 
     if (outgoingFlows == 0) {
       return BpmnStep.CONSUME_TOKEN;
-    } else {
+    } else if (outgoingFlows == 1) {
       return BpmnStep.TAKE_SEQUENCE_FLOW;
+    } else {
+      return BpmnStep.PARALLEL_SPLIT;
     }
   }
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/handler/ParallelGatewayHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/handler/ParallelGatewayHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow.model.transformation.handler;
+
+import io.zeebe.broker.workflow.model.ExecutableFlowNode;
+import io.zeebe.broker.workflow.model.ExecutableWorkflow;
+import io.zeebe.broker.workflow.model.transformation.ModelElementTransformer;
+import io.zeebe.broker.workflow.model.transformation.TransformContext;
+import io.zeebe.model.bpmn.instance.ParallelGateway;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+
+public class ParallelGatewayHandler implements ModelElementTransformer<ParallelGateway> {
+
+  @Override
+  public Class<ParallelGateway> getType() {
+    return ParallelGateway.class;
+  }
+
+  @Override
+  public void transform(ParallelGateway element, TransformContext context) {
+    final ExecutableWorkflow workflow = context.getCurrentWorkflow();
+    final ExecutableFlowNode gateway =
+        workflow.getElementById(element.getId(), ExecutableFlowNode.class);
+
+    gateway.bindLifecycleState(
+        WorkflowInstanceIntent.GATEWAY_ACTIVATED, context.getCurrentFlowNodeOutgoingStep());
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/handler/SequenceFlowHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/handler/SequenceFlowHandler.java
@@ -29,6 +29,7 @@ import io.zeebe.model.bpmn.instance.EndEvent;
 import io.zeebe.model.bpmn.instance.ExclusiveGateway;
 import io.zeebe.model.bpmn.instance.FlowNode;
 import io.zeebe.model.bpmn.instance.IntermediateCatchEvent;
+import io.zeebe.model.bpmn.instance.ParallelGateway;
 import io.zeebe.model.bpmn.instance.SequenceFlow;
 import io.zeebe.msgpack.el.CompiledJsonCondition;
 import io.zeebe.msgpack.el.JsonConditionFactory;
@@ -59,7 +60,7 @@ public class SequenceFlowHandler implements ModelElementTransformer<SequenceFlow
 
     if (target instanceof Activity || target instanceof IntermediateCatchEvent) {
       step = BpmnStep.START_STATEFUL_ELEMENT;
-    } else if (target instanceof ExclusiveGateway) {
+    } else if (target instanceof ExclusiveGateway || target instanceof ParallelGateway) {
       step = BpmnStep.ACTIVATE_GATEWAY;
     } else if (target instanceof EndEvent) {
       step = BpmnStep.TRIGGER_END_EVENT;

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepProcessor.java
@@ -37,10 +37,11 @@ import io.zeebe.broker.workflow.processor.activity.InputMappingHandler;
 import io.zeebe.broker.workflow.processor.activity.OutputMappingHandler;
 import io.zeebe.broker.workflow.processor.activity.PropagateTerminationHandler;
 import io.zeebe.broker.workflow.processor.catchevent.SubscribeMessageHandler;
-import io.zeebe.broker.workflow.processor.exclusivegw.ExclusiveSplitHandler;
 import io.zeebe.broker.workflow.processor.flownode.ConsumeTokenHandler;
 import io.zeebe.broker.workflow.processor.flownode.TakeSequenceFlowHandler;
 import io.zeebe.broker.workflow.processor.flownode.TerminateElementHandler;
+import io.zeebe.broker.workflow.processor.gateway.ExclusiveSplitHandler;
+import io.zeebe.broker.workflow.processor.gateway.ParallelSplitHandler;
 import io.zeebe.broker.workflow.processor.process.CompleteProcessHandler;
 import io.zeebe.broker.workflow.processor.sequenceflow.ActivateGatewayHandler;
 import io.zeebe.broker.workflow.processor.sequenceflow.StartStatefulElementHandler;
@@ -100,6 +101,9 @@ public class BpmnStepProcessor implements TypedRecordProcessor<WorkflowInstanceR
 
     // flow element container (process, sub process)
     stepHandlers.put(BpmnStep.TRIGGER_START_EVENT, new TriggerStartEventHandler());
+
+    // parallel gateway
+    stepHandlers.put(BpmnStep.PARALLEL_SPLIT, new ParallelSplitHandler());
 
     // termination
     stepHandlers.put(BpmnStep.TERMINATE_ELEMENT, new TerminateElementHandler());

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/activity/PropagateTerminationHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/activity/PropagateTerminationHandler.java
@@ -29,7 +29,9 @@ public class PropagateTerminationHandler implements BpmnStepHandler<ExecutableFl
   public void handle(BpmnStepContext<ExecutableFlowNode> context) {
     final ElementInstance flowScopeInstance = context.getFlowScopeInstance();
 
-    if (flowScopeInstance.getChildren().isEmpty()) {
+    flowScopeInstance.consumeTokens(1);
+
+    if (flowScopeInstance.getActiveTokens() == 0) {
       context
           .getStreamWriter()
           .writeFollowUpEvent(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/flownode/ConsumeTokenHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/flownode/ConsumeTokenHandler.java
@@ -34,11 +34,15 @@ public class ConsumeTokenHandler implements BpmnStepHandler<ExecutableFlowNode> 
     final ElementInstance scopeInstance = context.getFlowScopeInstance();
     final WorkflowInstanceRecord scopeInstanceValue = scopeInstance.getValue();
 
-    scopeInstanceValue.setPayload(value.getPayload());
+    scopeInstance.consumeTokens(1);
 
-    context
-        .getStreamWriter()
-        .writeFollowUpEvent(
-            scopeInstanceKey, WorkflowInstanceIntent.ELEMENT_COMPLETING, scopeInstanceValue);
+    if (scopeInstance.getActiveTokens() == 0) {
+      scopeInstanceValue.setPayload(value.getPayload());
+
+      context
+          .getStreamWriter()
+          .writeFollowUpEvent(
+              scopeInstanceKey, WorkflowInstanceIntent.ELEMENT_COMPLETING, scopeInstanceValue);
+    }
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/gateway/ExclusiveSplitHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/gateway/ExclusiveSplitHandler.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.zeebe.broker.workflow.processor.exclusivegw;
+package io.zeebe.broker.workflow.processor.gateway;
 
 import io.zeebe.broker.incident.data.ErrorType;
 import io.zeebe.broker.workflow.data.WorkflowInstanceRecord;

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceEventProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceEventProcessor.java
@@ -75,7 +75,7 @@ public final class CreateWorkflowInstanceEventProcessor
     final DirectBuffer bpmnProcessId = value.getBpmnProcessId();
     final int version = value.getVersion();
 
-    DeployedWorkflow workflowDefinition;
+    final DeployedWorkflow workflowDefinition;
     if (workflowKey <= 0) {
       if (version > 0) {
         workflowDefinition = workflowCache.getWorkflowByProcessIdAndVersion(bpmnProcessId, version);

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/gateway/ParallelGatewayTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/gateway/ParallelGatewayTest.java
@@ -1,0 +1,255 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.zeebe.model.bpmn.instance.ServiceTask;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
+import io.zeebe.test.broker.protocol.clientapi.SubscribedRecord;
+import io.zeebe.test.broker.protocol.clientapi.TestTopicClient;
+import io.zeebe.test.util.MsgPackUtil;
+import io.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class ParallelGatewayTest {
+
+  private static final String PROCESS_ID = "process";
+
+  private static final BpmnModelInstance FORK_PROCESS;
+
+  static {
+    final AbstractFlowNodeBuilder<?, ?> builder =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent("start")
+            .parallelGateway("fork")
+            .serviceTask("task1", b -> b.zeebeTaskType("type1"))
+            .endEvent("end1")
+            .moveToNode("fork");
+
+    FORK_PROCESS =
+        builder.serviceTask("task2", b -> b.zeebeTaskType("type2")).endEvent("end2").done();
+  }
+
+  public EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule();
+  public ClientApiRule apiRule = new ClientApiRule(brokerRule::getClientAddress);
+
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(apiRule);
+
+  private TestTopicClient testClient;
+
+  @Before
+  public void init() {
+    testClient = apiRule.topic();
+  }
+
+  @Test
+  public void shouldActivateTasksOnParallelBranches() {
+    // given
+    testClient.deploy(FORK_PROCESS);
+
+    // when
+    testClient.createWorkflowInstance(PROCESS_ID);
+
+    // then
+    final List<SubscribedRecord> taskEvents =
+        testClient
+            .receiveEvents()
+            .ofTypeWorkflowInstance()
+            .withIntent(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .filter(e -> isServiceTaskInProcess((String) e.value().get("activityId"), FORK_PROCESS))
+            .limit(2)
+            .collect(Collectors.toList());
+
+    assertThat(taskEvents).hasSize(2);
+    assertThat(taskEvents)
+        .extracting(e -> e.value().get("activityId"))
+        .containsExactlyInAnyOrder("task1", "task2");
+    assertThat(taskEvents.get(0).key()).isNotEqualTo(taskEvents.get(1).key());
+  }
+
+  @Test
+  public void shouldCompleteScopeWhenAllPathsCompleted() {
+    // given
+    testClient.deploy(FORK_PROCESS);
+    testClient.createWorkflowInstance(PROCESS_ID);
+    testClient.completeJobOfType("type1");
+
+    // when
+    testClient.completeJobOfType("type2");
+
+    // then
+    final List<SubscribedRecord> completedEvents =
+        testClient
+            .receiveEvents()
+            .ofTypeWorkflowInstance()
+            .withIntent(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+            .limit(3)
+            .collect(Collectors.toList());
+
+    assertThat(completedEvents)
+        .extracting(e -> e.value().get("activityId"))
+        .containsExactly("task1", "task2", PROCESS_ID);
+  }
+
+  @Test
+  public void shouldCompleteScopeWithMultipleTokensOnSamePath() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .exclusiveGateway("join")
+            .endEvent("end")
+            .moveToNode("fork")
+            .connectTo("join")
+            .done();
+
+    testClient.deploy(process);
+
+    // when
+    testClient.createWorkflowInstance(PROCESS_ID);
+
+    // then
+    final SubscribedRecord completedEvent =
+        testClient.receiveElementInState(PROCESS_ID, WorkflowInstanceIntent.ELEMENT_COMPLETED);
+    final List<SubscribedRecord> workflowInstanceEvents =
+        testClient
+            .receiveEvents()
+            .ofTypeWorkflowInstance()
+            .limit(r -> r.position() == completedEvent.position())
+            .collect(Collectors.toList());
+
+    assertThat(workflowInstanceEvents)
+        .extracting(e -> e.value().get("activityId"), e -> e.intent())
+        .containsSubsequence(
+            tuple("end", WorkflowInstanceIntent.END_EVENT_OCCURRED),
+            tuple("end", WorkflowInstanceIntent.END_EVENT_OCCURRED),
+            tuple(PROCESS_ID, WorkflowInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldPropagatePayloadOnSplit() {
+    // given
+    testClient.deploy(FORK_PROCESS);
+    final byte[] payload = BufferUtil.bufferAsArray(MsgPackUtil.asMsgPack("key", "val"));
+
+    // when
+    testClient.createWorkflowInstance(PROCESS_ID, payload);
+
+    // then
+    final List<SubscribedRecord> taskEvents =
+        testClient
+            .receiveEvents()
+            .ofTypeWorkflowInstance()
+            .withIntent(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .filter(e -> isServiceTaskInProcess((String) e.value().get("activityId"), FORK_PROCESS))
+            .limit(2)
+            .collect(Collectors.toList());
+
+    assertThat(taskEvents)
+        .extracting(e -> e.value().get("payload"))
+        .allSatisfy(p -> p.equals(payload));
+  }
+
+  @Test
+  public void shouldPassThroughParallelGateway() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent("start")
+            .sequenceFlowId("flow1")
+            .parallelGateway("fork")
+            .sequenceFlowId("flow2")
+            .endEvent("end")
+            .done();
+
+    testClient.deploy(process);
+
+    // when
+    testClient.createWorkflowInstance(PROCESS_ID);
+
+    // then
+    final SubscribedRecord completedEvent =
+        testClient.receiveElementInState(PROCESS_ID, WorkflowInstanceIntent.ELEMENT_COMPLETED);
+    final List<SubscribedRecord> workflowInstanceEvents =
+        testClient
+            .receiveEvents()
+            .ofTypeWorkflowInstance()
+            .limit(r -> r.position() == completedEvent.position())
+            .collect(Collectors.toList());
+
+    assertThat(workflowInstanceEvents)
+        .extracting(e -> e.value().get("activityId"), e -> e.intent())
+        .containsSequence(
+            tuple("fork", WorkflowInstanceIntent.GATEWAY_ACTIVATED),
+            tuple("flow2", WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN),
+            tuple("end", WorkflowInstanceIntent.END_EVENT_OCCURRED),
+            tuple(PROCESS_ID, WorkflowInstanceIntent.ELEMENT_COMPLETING));
+  }
+
+  @Test
+  public void shouldCompleteScopeOnParallelGateway() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent("start")
+            .sequenceFlowId("flow1")
+            .parallelGateway("fork")
+            .done();
+
+    testClient.deploy(process);
+
+    // when
+    testClient.createWorkflowInstance(PROCESS_ID);
+
+    // then
+    final SubscribedRecord completedEvent =
+        testClient.receiveElementInState(PROCESS_ID, WorkflowInstanceIntent.ELEMENT_COMPLETED);
+    final List<SubscribedRecord> workflowInstanceEvents =
+        testClient
+            .receiveEvents()
+            .ofTypeWorkflowInstance()
+            .limit(r -> r.position() == completedEvent.position())
+            .collect(Collectors.toList());
+
+    assertThat(workflowInstanceEvents)
+        .extracting(e -> e.value().get("activityId"), e -> e.intent())
+        .containsSequence(
+            tuple("fork", WorkflowInstanceIntent.GATEWAY_ACTIVATED),
+            tuple(PROCESS_ID, WorkflowInstanceIntent.ELEMENT_COMPLETING));
+  }
+
+  private static boolean isServiceTaskInProcess(String activityId, BpmnModelInstance process) {
+    return process
+        .getModelElementsByType(ServiceTask.class)
+        .stream()
+        .anyMatch(t -> t.getId().equals(activityId));
+  }
+}

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/SubscribedRecordStream.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/SubscribedRecordStream.java
@@ -43,8 +43,8 @@ public class SubscribedRecordStream extends StreamWrapper<SubscribedRecord> {
     return recordsOfType(RecordType.COMMAND);
   }
 
-  public SubscribedRecordStream ofTypeWorkflowInstance() {
-    return recordsOfValueType(ValueType.WORKFLOW_INSTANCE);
+  public WorkflowInstanceRecordStream ofTypeWorkflowInstance() {
+    return new WorkflowInstanceRecordStream(recordsOfValueType(ValueType.WORKFLOW_INSTANCE));
   }
 
   public SubscribedRecordStream ofTypeDeployment() {
@@ -65,6 +65,10 @@ public class SubscribedRecordStream extends StreamWrapper<SubscribedRecord> {
 
   public SubscribedRecordStream withIntent(Intent intent) {
     return new SubscribedRecordStream(filter(r -> r.intent() == intent));
+  }
+
+  public SubscribedRecordStream withKey(long key) {
+    return new SubscribedRecordStream(filter(r -> r.key() == key));
   }
 
   public SubscribedRecord getFirst() {

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/TestTopicClient.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/TestTopicClient.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
 public class TestTopicClient {
@@ -481,6 +482,24 @@ public class TestTopicClient {
         .withIntent(intent)
         .filter(r -> (Long) r.value().get("workflowInstanceKey") == wfInstanceKey)
         .filter(r -> activityId.equals(r.value().get("activityId")))
+        .findFirst()
+        .get();
+  }
+
+  public List<SubscribedRecord> receiveElementInstancesInState(Intent intent, int expectedNumber) {
+    return receiveEvents()
+        .ofTypeWorkflowInstance()
+        .withIntent(intent)
+        .limit(expectedNumber)
+        .collect(Collectors.toList());
+  }
+
+  public SubscribedRecord receiveElementInstanceInState(long key, Intent intent) {
+    return receiveEvents()
+        .ofTypeWorkflowInstance()
+        .withIntent(intent)
+        .filter(r -> r.key() == key)
+        .limit(1)
         .findFirst()
         .get();
   }

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/WorkflowInstanceRecordStream.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/WorkflowInstanceRecordStream.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.test.broker.protocol.clientapi;
+
+import java.util.stream.Stream;
+
+public class WorkflowInstanceRecordStream extends SubscribedRecordStream {
+
+  public WorkflowInstanceRecordStream(Stream<SubscribedRecord> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  public WorkflowInstanceRecordStream inElement(String elementId) {
+    return new WorkflowInstanceRecordStream(
+        filter(r -> elementId.equals(r.value().get("activityId"))));
+  }
+}


### PR DESCRIPTION
Scope as described in issue. 

I am not completely happy with the token counting idea in order to decide if a scope can complete or not. It may be error-prone, because it is not obvious when tokens are spawned and consumed. In the future there may be non-obvious issues with concurrent commands and event processing that could lead to inconsistent state. I decided to do it for the moment, because it is the most simple implementation.

closes #1230
