### PR TITLE
feat(broker): install partitions via cfg 

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/clustering/api/SnapshotReplicationRequestHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/api/SnapshotReplicationRequestHandler.java
@@ -52,7 +52,8 @@ public class SnapshotReplicationRequestHandler {
       new FetchSnapshotChunkResponse();
 
   private final ErrorResponse errorResponse = new ErrorResponse();
-  public static final String PARTITION_NOT_FOUND_MESSAGE = "not currently tracking given partition";
+  public static final String PARTITION_NOT_FOUND_MESSAGE =
+      "not currently tracking given partition %d";
   public static final String GET_SNAPSHOT_ERROR_MESSAGE = "could not open snapshot";
   public static final String INVALID_CHUNK_OFFSET_MESSAGE = "chunkOffset must be >= 0";
   public static final String INVALID_CHUNK_LENGTH_MESSAGE =
@@ -81,7 +82,10 @@ public class SnapshotReplicationRequestHandler {
     final Partition partition = trackedPartitions.get(partitionId);
 
     if (partition == null) {
-      return () -> prepareError(ErrorResponseCode.PARTITION_NOT_FOUND, PARTITION_NOT_FOUND_MESSAGE);
+      return () ->
+          prepareError(
+              ErrorResponseCode.PARTITION_NOT_FOUND,
+              String.format(PARTITION_NOT_FOUND_MESSAGE, partitionId));
     }
 
     final SnapshotStorage storage = partition.getSnapshotStorage();
@@ -158,7 +162,7 @@ public class SnapshotReplicationRequestHandler {
     }
 
     int bytesRead = 0;
-    try (InputStream snapshotData = snapshot.getData()) {
+    try (final InputStream snapshotData = snapshot.getData()) {
       final long bytesSkipped = snapshotData.skip(chunkOffset);
       if (bytesSkipped < chunkOffset) {
         return prepareError(ErrorResponseCode.READ_ERROR, SEEK_ERROR_MESSAGE);

--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/bootstrap/BootstrapLocalPartitions.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/bootstrap/BootstrapLocalPartitions.java
@@ -42,12 +42,12 @@ public class BootstrapLocalPartitions implements Service<Object> {
       new Injector<>();
   private final BrokerCfg brokerCfg;
 
-  public BootstrapLocalPartitions(BrokerCfg brokerCfg) {
+  public BootstrapLocalPartitions(final BrokerCfg brokerCfg) {
     this.brokerCfg = brokerCfg;
   }
 
   @Override
-  public void start(ServiceStartContext startContext) {
+  public void start(final ServiceStartContext startContext) {
     final RaftPersistentConfigurationManager configurationManager =
         configurationManagerInjector.getValue();
 
@@ -56,14 +56,14 @@ public class BootstrapLocalPartitions implements Service<Object> {
           final List<RaftPersistentConfiguration> configurations =
               configurationManager.getConfigurations().join();
 
-          for (RaftPersistentConfiguration configuration : configurations) {
+          for (final RaftPersistentConfiguration configuration : configurations) {
             installPartition(startContext, configuration);
           }
         });
   }
 
   private void installPartition(
-      ServiceStartContext startContext, RaftPersistentConfiguration configuration) {
+      final ServiceStartContext startContext, final RaftPersistentConfiguration configuration) {
     final String partitionName =
         String.format(
             "%s-%d",

--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/partitions/PartitionInstallService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/partitions/PartitionInstallService.java
@@ -19,7 +19,6 @@ package io.zeebe.broker.clustering.base.partitions;
 
 import static io.zeebe.broker.clustering.base.ClusterBaseLayerServiceNames.FOLLOWER_PARTITION_GROUP_NAME;
 import static io.zeebe.broker.clustering.base.ClusterBaseLayerServiceNames.LEADER_PARTITION_GROUP_NAME;
-import static io.zeebe.broker.clustering.base.ClusterBaseLayerServiceNames.LEADER_PARTITION_SYSTEM_GROUP_NAME;
 import static io.zeebe.broker.clustering.base.ClusterBaseLayerServiceNames.RAFT_SERVICE_GROUP;
 import static io.zeebe.broker.clustering.base.ClusterBaseLayerServiceNames.followerPartitionServiceName;
 import static io.zeebe.broker.clustering.base.ClusterBaseLayerServiceNames.leaderPartitionServiceName;
@@ -244,10 +243,7 @@ public class PartitionInstallService implements Service<Void>, RaftStateListener
             .dependency(logStreamServiceName, partition.getLogStreamInjector())
             .dependency(snapshotStorageServiceName, partition.getSnapshotStorageInjector())
             .dependency(stateStorageFactoryServiceName, partition.getStateStorageFactoryInjector())
-            .group(
-                isInternalSystemPartition
-                    ? LEADER_PARTITION_SYSTEM_GROUP_NAME
-                    : LEADER_PARTITION_GROUP_NAME)
+            .group(LEADER_PARTITION_GROUP_NAME)
             .install();
       } else {
         LOG.debug(

--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/TopologyPartitionListenerImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/TopologyPartitionListenerImpl.java
@@ -17,7 +17,6 @@
  */
 package io.zeebe.broker.clustering.base.topology;
 
-import io.zeebe.protocol.Protocol;
 import io.zeebe.util.sched.ActorCondition;
 import io.zeebe.util.sched.ActorControl;
 import io.zeebe.util.sched.channel.ActorConditions;
@@ -30,26 +29,22 @@ public class TopologyPartitionListenerImpl implements TopologyPartitionListener 
   private final ActorControl actor;
   private final ActorConditions conditions = new ActorConditions();
 
-  public TopologyPartitionListenerImpl(ActorControl actor) {
+  public TopologyPartitionListenerImpl(final ActorControl actor) {
     this.actor = actor;
   }
 
   @Override
-  public void onPartitionUpdated(PartitionInfo partitionInfo, NodeInfo member) {
+  public void onPartitionUpdated(final PartitionInfo partitionInfo, final NodeInfo member) {
     if (member.getLeaders().contains(partitionInfo)) {
       actor.submit(
           () -> {
-            if (partitionInfo.getPartitionId() == Protocol.SYSTEM_PARTITION) {
-              updateSystemPartitionLeader(member);
-            } else {
-              updatePartitionLeader(partitionInfo, member);
-            }
+            updatePartitionLeader(partitionInfo, member);
             conditions.signalConsumers();
           });
     }
   }
 
-  private void updateSystemPartitionLeader(NodeInfo member) {
+  private void updateSystemPartitionLeader(final NodeInfo member) {
     final Integer currentLeader = systemPartitionLeaderId;
 
     if (currentLeader == null || !currentLeader.equals(member.getNodeId())) {
@@ -57,7 +52,7 @@ public class TopologyPartitionListenerImpl implements TopologyPartitionListener 
     }
   }
 
-  private void updatePartitionLeader(PartitionInfo partitionInfo, NodeInfo member) {
+  private void updatePartitionLeader(final PartitionInfo partitionInfo, final NodeInfo member) {
     final NodeInfo currentLeader = partitionLeaders.get(partitionInfo.getPartitionId());
 
     if (currentLeader == null || !currentLeader.equals(member)) {
@@ -73,11 +68,11 @@ public class TopologyPartitionListenerImpl implements TopologyPartitionListener 
     return systemPartitionLeaderId;
   }
 
-  public void addCondition(ActorCondition condition) {
+  public void addCondition(final ActorCondition condition) {
     conditions.registerConsumer(condition);
   }
 
-  public void removeCondition(ActorCondition condition) {
+  public void removeCondition(final ActorCondition condition) {
     conditions.removeConsumer(condition);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/clustering/orchestration/PartitionsLeaderMatrix.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/orchestration/PartitionsLeaderMatrix.java
@@ -1,0 +1,147 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.clustering.orchestration;
+
+import io.zeebe.broker.Loggers;
+import org.agrona.collections.IntArrayList;
+import org.slf4j.Logger;
+
+public class PartitionsLeaderMatrix {
+
+  public static final int LEADER = 1;
+  public static final int FOLLOWER = 2;
+  public static final Logger LOG = Loggers.CLUSTERING_LOGGER;
+
+  final int[][] matrix;
+
+  private final int rowCount;
+  private final int columnCount;
+  private final int replicationFactor;
+
+  public PartitionsLeaderMatrix(
+      final int partitionsCount, final int clusterSize, final int replicationFactor) {
+    ensureValidValues(partitionsCount, clusterSize, replicationFactor);
+
+    this.rowCount = partitionsCount;
+    this.columnCount = clusterSize;
+
+    matrix = new int[rowCount][columnCount];
+
+    this.replicationFactor = replicationFactor;
+    init();
+
+    printMatrix();
+  }
+
+  private void printMatrix() {
+    if (LOG.isTraceEnabled()) {
+      final StringBuilder builder = new StringBuilder("\nPartitionsmatrix:\n");
+      builder.append("\t|");
+      for (int column = 0; column < columnCount; column++) {
+        builder.append("\t").append(column).append("|");
+      }
+      builder.append("\n");
+
+      for (int row = 0; row < rowCount; row++) {
+        builder.append(row).append("\t|");
+        for (int column = 0; column < columnCount; column++) {
+          final int value = this.matrix[row][column];
+
+          builder.append("\t");
+          if (value == LEADER) {
+            builder.append("L");
+          } else if (value == FOLLOWER) {
+            builder.append("F");
+          } else {
+            builder.append("-");
+          }
+          builder.append("|");
+        }
+        builder.append("\n");
+      }
+      LOG.trace(builder.toString());
+    }
+  }
+
+  private void ensureValidValues(
+      final int partitionsCount, final int clusterSize, final int replicationFactor) {
+    ensureLargerThen(partitionsCount, 1, "Partitions count must not be smaller then one.");
+    ensureLargerThen(clusterSize, 1, "Cluster size must not be smaller then one.");
+    ensureLargerThen(replicationFactor, 1, "Replication factor must not be smaller then one.");
+
+    ensureLargerThen(
+        clusterSize,
+        replicationFactor,
+        "Cluster size must not be smaller then replication factor.");
+  }
+
+  private void ensureLargerThen(final int partitionsCount, final int i, final String s) {
+    if (partitionsCount < i) {
+      throw new IllegalArgumentException(s);
+    }
+  }
+
+  private void init() {
+    for (int row = 0; row < rowCount; row++) {
+      final int leader = row % columnCount;
+      matrix[row][leader] = LEADER;
+
+      int column;
+      for (int i = 1; i < replicationFactor; i++) {
+        column = (leader + i) % columnCount;
+        matrix[row][column] = FOLLOWER;
+      }
+    }
+  }
+
+  public IntArrayList getLeadingPartitions(final int nodeId) {
+    final IntArrayList leadingPartitions = new IntArrayList();
+    for (int row = 0; row < rowCount; row++) {
+      final int state = this.matrix[row][nodeId];
+      if (LEADER == state) {
+        leadingPartitions.add(row);
+      }
+    }
+    return leadingPartitions;
+  }
+
+  public IntArrayList getFollowingPartitions(final int nodeId) {
+
+    final IntArrayList followingPartitions = new IntArrayList();
+    for (int row = 0; row < rowCount; row++) {
+      final int state = this.matrix[row][nodeId];
+      if (FOLLOWER == state) {
+        followingPartitions.add(row);
+      }
+    }
+    return followingPartitions;
+  }
+
+  public IntArrayList getMembersForPartition(final int nodeId, final int partitionId) {
+    final IntArrayList members = new IntArrayList();
+    for (int column = 0; column < columnCount; column++) {
+      if (column != nodeId) {
+        final int state = this.matrix[partitionId][column];
+        if (state > 0) {
+          members.add(column);
+        }
+      }
+    }
+    return members;
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/clustering/orchestration/state/KnownTopics.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/orchestration/state/KnownTopics.java
@@ -17,65 +17,43 @@
  */
 package io.zeebe.broker.clustering.orchestration.state;
 
-import static io.zeebe.logstreams.impl.service.LogStreamServiceNames.streamProcessorService;
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
 
-import io.zeebe.broker.Loggers;
-import io.zeebe.broker.clustering.base.partitions.Partition;
-import io.zeebe.broker.clustering.orchestration.topic.TopicRecord;
-import io.zeebe.broker.logstreams.processor.KeyGenerator;
-import io.zeebe.broker.logstreams.processor.StreamProcessorIds;
 import io.zeebe.broker.logstreams.processor.StreamProcessorLifecycleAware;
-import io.zeebe.broker.logstreams.processor.StreamProcessorServiceFactory;
-import io.zeebe.broker.logstreams.processor.TypedStreamEnvironment;
-import io.zeebe.broker.logstreams.processor.TypedStreamProcessor;
-import io.zeebe.logstreams.impl.service.StreamProcessorService;
+import io.zeebe.broker.system.configuration.ClusterCfg;
 import io.zeebe.msgpack.property.ArrayProperty;
 import io.zeebe.msgpack.value.ArrayValue;
 import io.zeebe.msgpack.value.IntegerValue;
-import io.zeebe.msgpack.value.ValueArray;
-import io.zeebe.protocol.clientapi.ValueType;
-import io.zeebe.protocol.intent.TopicIntent;
-import io.zeebe.servicecontainer.Injector;
+import io.zeebe.protocol.Protocol;
 import io.zeebe.servicecontainer.Service;
-import io.zeebe.servicecontainer.ServiceContainer;
-import io.zeebe.servicecontainer.ServiceName;
 import io.zeebe.servicecontainer.ServiceStartContext;
-import io.zeebe.servicecontainer.ServiceStopContext;
-import io.zeebe.transport.ServerTransport;
-import io.zeebe.util.buffer.BufferUtil;
-import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.future.ActorFuture;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-import org.agrona.DirectBuffer;
-import org.slf4j.Logger;
 
-public class KnownTopics implements Service<KnownTopics>, StreamProcessorLifecycleAware {
-  private static final Logger LOG = Loggers.CLUSTERING_LOGGER;
-
-  private final Injector<Partition> partitionInjector = new Injector<>();
-  private final Injector<ServerTransport> serverTransportInjector = new Injector<>();
-  private final Injector<StreamProcessorServiceFactory> streamProcessorServiceFactoryInjector =
-      new Injector<>();
-
-  private final TopicCreateProcessor topicCreateProcessor;
-  private final TopicCreatedProcessor topicCreatedProcessor;
-
+public class KnownTopics extends Actor
+    implements Service<KnownTopics>, StreamProcessorLifecycleAware {
   private final List<KnownTopicsListener> topicsListeners = new ArrayList<>();
 
   private final ArrayValue<TopicInfo> knownTopics = new ArrayValue<>(new TopicInfo());
-  private ActorControl actor;
-  private ServiceContainer serviceContainer;
-  private ServiceName<StreamProcessorService> streamProcessorServiceName;
 
-  public KnownTopics(final ServiceContainer serviceContainer) {
-    this.serviceContainer = serviceContainer;
-    topicCreateProcessor =
-        new TopicCreateProcessor(this::topicExists, this::notifyTopicAdded, this::addTopic);
-    topicCreatedProcessor =
-        new TopicCreatedProcessor(
-            this::topicCreated, this::notifyTopicCreated, this::completeTopicCreation);
+  public KnownTopics(final ClusterCfg clusterCfg) {
+    initKnownTopics(clusterCfg);
+  }
+
+  private void initKnownTopics(final ClusterCfg clusterCfg) {
+    final TopicInfo topicInfo = knownTopics.add();
+
+    topicInfo
+        .setTopicName(wrapString(Protocol.SYSTEM_TOPIC))
+        .setPartitionCount(clusterCfg.getPartitionsCount())
+        .setReplicationFactor(clusterCfg.getReplicationFactor())
+        .setKey(-1);
+    final ArrayProperty<IntegerValue> partitionIds = topicInfo.partitionIds;
+    partitionIds.reset();
+    clusterCfg.getPartitionIds().forEach(id -> partitionIds.add().setValue(id));
   }
 
   @Override
@@ -87,129 +65,9 @@ public class KnownTopics implements Service<KnownTopics>, StreamProcessorLifecyc
     actor.run(() -> topicsListeners.add(topicsListener));
   }
 
-  private boolean topicExists(final DirectBuffer topicName) {
-    return getTopic(topicName) != null;
-  }
-
-  private boolean topicCreated(final DirectBuffer topicName) {
-    final TopicInfo topicInfo = getTopic(topicName);
-    return topicInfo != null && topicInfo.getPartitionIds().iterator().hasNext();
-  }
-
-  private TopicInfo getTopic(final DirectBuffer topicName) {
-    for (final TopicInfo topicInfo : knownTopics) {
-      if (topicInfo.getTopicNameBuffer().equals(topicName)) {
-        return topicInfo;
-      }
-    }
-
-    return null;
-  }
-
-  private void addTopic(final long key, final TopicRecord topicEvent) {
-    final TopicInfo topicInfo = createTopicInfo(key, topicEvent);
-
-    final ValueArray<IntegerValue> partitionIds = topicInfo.getPartitionIds();
-    topicEvent.getPartitionIds().forEach(id -> partitionIds.add().setValue(id.getValue()));
-
-    LOG.info("Adding topic {}", topicInfo);
-  }
-
-  private void notifyTopicAdded(final DirectBuffer topicName) {
-    final String name = BufferUtil.bufferAsString(topicName);
-    topicsListeners.forEach(l -> l.topicAdded(name));
-  }
-
-  private void notifyTopicCreated(final DirectBuffer topicName) {
-    final String name = BufferUtil.bufferAsString(topicName);
-    topicsListeners.forEach(l -> l.topicCreated(name));
-  }
-
-  private TopicInfo createTopicInfo(final long key, final TopicRecord topicEvent) {
-    final TopicInfo topicInfo = knownTopics.add();
-    topicInfo
-        .setTopicName(topicEvent.getName())
-        .setPartitionCount(topicEvent.getPartitions())
-        .setReplicationFactor(topicEvent.getReplicationFactor())
-        .setKey(key);
-
-    return topicInfo;
-  }
-
-  private TopicInfo getOrCreateTopicInfo(final long key, final TopicRecord topicEvent) {
-    final TopicInfo topicInfo = getTopic(topicEvent.getName());
-
-    if (topicInfo != null) {
-      return topicInfo;
-    } else {
-      return createTopicInfo(key, topicEvent);
-    }
-  }
-
-  private void completeTopicCreation(final long key, final TopicRecord topicEvent) {
-    final TopicInfo topicInfo = getOrCreateTopicInfo(key, topicEvent);
-
-    final ArrayProperty<IntegerValue> partitionIds = topicInfo.partitionIds;
-    partitionIds.reset();
-    topicEvent.getPartitionIds().forEach(id -> partitionIds.add().setValue(id.getValue()));
-
-    LOG.info("Updating topic {}", topicInfo);
-  }
-
-  @Override
-  public void onOpen(final TypedStreamProcessor streamProcessor) {
-    actor = streamProcessor.getActor();
-  }
-
   @Override
   public void start(final ServiceStartContext startContext) {
-    final Partition partition = partitionInjector.getValue();
-    final ServerTransport serverTransport = serverTransportInjector.getValue();
-    final StreamProcessorServiceFactory streamProcessorServiceFactory =
-        streamProcessorServiceFactoryInjector.getValue();
-
-    final TypedStreamProcessor streamProcessor =
-        new TypedStreamEnvironment(partition.getLogStream(), serverTransport.getOutput())
-            .newStreamProcessor()
-            .keyGenerator(KeyGenerator.createTopicKeyGenerator())
-            .onCommand(ValueType.TOPIC, TopicIntent.CREATE, topicCreateProcessor)
-            .onCommand(ValueType.TOPIC, TopicIntent.CREATE_COMPLETE, topicCreatedProcessor)
-            .withListener(this)
-            .withStateResource(knownTopics)
-            .build();
-
-    final String streamProcessorName = "topics";
-    streamProcessorServiceName =
-        streamProcessorService(
-            partitionInjector.getValue().getLogStream().getLogName(), streamProcessorName);
-    final ActorFuture<StreamProcessorService> future =
-        streamProcessorServiceFactory
-            .createService(partition, partitionInjector.getInjectedServiceName())
-            .processor(streamProcessor)
-            .processorId(StreamProcessorIds.CLUSTER_TOPIC_STATE)
-            .processorName(streamProcessorName)
-            .build();
-
-    startContext.async(future);
-  }
-
-  @Override
-  public void stop(final ServiceStopContext stopContext) {
-    if (serviceContainer.hasService(streamProcessorServiceName)) {
-      stopContext.async(serviceContainer.removeService(streamProcessorServiceName));
-    }
-  }
-
-  public Injector<Partition> getPartitionInjector() {
-    return partitionInjector;
-  }
-
-  public Injector<ServerTransport> getServerTransportInjector() {
-    return serverTransportInjector;
-  }
-
-  public Injector<StreamProcessorServiceFactory> getStreamProcessorServiceFactoryInjector() {
-    return streamProcessorServiceFactoryInjector;
+    startContext.getScheduler().submitActor(this);
   }
 
   public <R> ActorFuture<R> queryTopics(final Function<Iterable<TopicInfo>, R> query) {

--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/ClusterCfg.java
@@ -47,8 +47,7 @@ public class ClusterCfg implements ConfigurationEntry {
   private void initPartitionIds() {
     final IntArrayList list = new IntArrayList();
     for (int i = 0; i < partitionsCount; i++) {
-      // +1 'cause of system partition
-      final int partitionId = i + 1;
+      final int partitionId = i;
       list.add(partitionId);
     }
 

--- a/broker-core/src/test/java/io/zeebe/broker/clustering/management/ManagementApiRequestHandlerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/clustering/management/ManagementApiRequestHandlerTest.java
@@ -72,13 +72,15 @@ import org.junit.rules.TemporaryFolder;
 
 public class ManagementApiRequestHandlerTest {
   private Map<Integer, Partition> trackedSnapshotPartitions;
-  private TestActor actor = new TestActor();
+  private final TestActor actor = new TestActor();
   private BufferingServerOutput output = new BufferingServerOutput();
   private ManagementApiRequestHandler handler = createHandler();
 
-  private TemporaryFolder tempFolder = new TemporaryFolder();
-  private ControlledActorSchedulerRule actorSchedulerRule = new ControlledActorSchedulerRule();
-  private ServiceContainerRule serviceContainerRule = new ServiceContainerRule(actorSchedulerRule);
+  private final TemporaryFolder tempFolder = new TemporaryFolder();
+  private final ControlledActorSchedulerRule actorSchedulerRule =
+      new ControlledActorSchedulerRule();
+  private final ServiceContainerRule serviceContainerRule =
+      new ServiceContainerRule(actorSchedulerRule);
 
   @Rule
   public RuleChain ruleChain =
@@ -154,7 +156,8 @@ public class ManagementApiRequestHandlerTest {
     assertError(
         output,
         ErrorResponseCode.PARTITION_NOT_FOUND,
-        SnapshotReplicationRequestHandler.PARTITION_NOT_FOUND_MESSAGE);
+        String.format(
+            SnapshotReplicationRequestHandler.PARTITION_NOT_FOUND_MESSAGE, partitionId + 1));
   }
 
   @Test
@@ -572,7 +575,7 @@ public class ManagementApiRequestHandlerTest {
       return mocked;
     }
 
-    void run(Runnable r) {
+    void run(final Runnable r) {
       mocked.run(r);
     }
   }

--- a/broker-core/src/test/java/io/zeebe/broker/clustering/orchestration/PartitionsLeaderMatrixTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/clustering/orchestration/PartitionsLeaderMatrixTest.java
@@ -1,0 +1,225 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.clustering.orchestration;
+
+import static io.zeebe.broker.clustering.orchestration.PartitionsLeaderMatrix.FOLLOWER;
+import static io.zeebe.broker.clustering.orchestration.PartitionsLeaderMatrix.LEADER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.agrona.collections.IntArrayList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PartitionsLeaderMatrixTest {
+
+  @Rule public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void shouldCreateDefaultPartitionsMatrix() {
+    // given
+    final PartitionsLeaderMatrix partitionsLeaderMatrix = new PartitionsLeaderMatrix(1, 1, 1);
+
+    // then
+    final int[][] matrix = partitionsLeaderMatrix.matrix;
+    assertThat(matrix).hasSize(1);
+    assertThat(matrix[0]).hasSize(1);
+    assertThat(matrix).containsExactly(new int[] {LEADER});
+  }
+
+  @Test
+  public void shouldCreatePartitionsMatrixWithMorePartitionsThenNodes() {
+    // given
+    final PartitionsLeaderMatrix partitionsLeaderMatrix = new PartitionsLeaderMatrix(2, 1, 1);
+
+    // then
+    final int[][] matrix = partitionsLeaderMatrix.matrix;
+
+    assertThat(matrix).hasSize(2);
+    assertThat(matrix[0]).hasSize(1);
+    assertThat(matrix[1]).hasSize(1);
+
+    assertThat(matrix[0]).containsExactly(LEADER);
+    assertThat(matrix[1]).containsExactly(LEADER);
+  }
+
+  @Test
+  public void shouldCreatePartitionsMatrixWithMoreNodesThenPartitions() {
+    // given
+    final PartitionsLeaderMatrix partitionsLeaderMatrix = new PartitionsLeaderMatrix(1, 2, 1);
+
+    // then
+    final int[][] matrix = partitionsLeaderMatrix.matrix;
+
+    assertThat(matrix).hasSize(1);
+    assertThat(matrix[0]).hasSize(2);
+
+    assertThat(matrix[0]).containsExactly(LEADER, 0);
+  }
+
+  @Test
+  public void shouldCreatePartitionsMatrixWithMoreNodesThenPartitionsAndReplicationFactor() {
+    // given
+    final PartitionsLeaderMatrix partitionsLeaderMatrix = new PartitionsLeaderMatrix(1, 2, 2);
+
+    // then
+    final int[][] matrix = partitionsLeaderMatrix.matrix;
+
+    assertThat(matrix).hasSize(1);
+    assertThat(matrix[0]).hasSize(2);
+
+    assertThat(matrix[0]).containsExactly(LEADER, FOLLOWER);
+  }
+
+  @Test
+  public void shouldCreatePartitionsWithMorePartitionsAndNodes() {
+    // given
+    final PartitionsLeaderMatrix partitionsLeaderMatrix = new PartitionsLeaderMatrix(6, 5, 3);
+
+    // then
+    final int[][] matrix = partitionsLeaderMatrix.matrix;
+
+    assertThat(matrix).hasSize(6);
+    assertThat(matrix).extracting(v -> v.length).containsOnly(5);
+
+    assertThat(matrix[0]).containsExactly(LEADER, FOLLOWER, FOLLOWER, 0, 0);
+    assertThat(matrix[1]).containsExactly(0, LEADER, FOLLOWER, FOLLOWER, 0);
+    assertThat(matrix[2]).containsExactly(0, 0, LEADER, FOLLOWER, FOLLOWER);
+    assertThat(matrix[3]).containsExactly(FOLLOWER, 0, 0, LEADER, FOLLOWER);
+    assertThat(matrix[4]).containsExactly(FOLLOWER, FOLLOWER, 0, 0, LEADER);
+    assertThat(matrix[5]).containsExactly(LEADER, FOLLOWER, FOLLOWER, 0, 0);
+  }
+
+  @Test
+  public void shouldReturnLeadingPartitionsForNodeId() {
+    // given
+    final PartitionsLeaderMatrix partitionsLeaderMatrix = new PartitionsLeaderMatrix(6, 5, 3);
+
+    // when
+    final IntArrayList leadingPartitions = partitionsLeaderMatrix.getLeadingPartitions(0);
+
+    // then
+    assertThat(leadingPartitions).containsExactly(0, 5);
+  }
+
+  @Test
+  public void shouldReturnFollowingPartitionsForNodeId() {
+    // given
+    final PartitionsLeaderMatrix partitionsLeaderMatrix = new PartitionsLeaderMatrix(6, 5, 3);
+
+    // when
+    final IntArrayList followingPartitions = partitionsLeaderMatrix.getFollowingPartitions(1);
+
+    // then
+    assertThat(followingPartitions).containsExactly(0, 4, 5);
+  }
+
+  @Test
+  public void shouldReturnMembersForPartition() {
+    // given
+    final PartitionsLeaderMatrix partitionsLeaderMatrix = new PartitionsLeaderMatrix(6, 5, 3);
+
+    // when
+    final IntArrayList membersForPartition = partitionsLeaderMatrix.getMembersForPartition(0, 1);
+
+    // then
+    assertThat(membersForPartition).containsExactly(1, 2, 3);
+  }
+
+  @Test
+  public void shouldReturnMembersForPartitionWithoutSelf() {
+    // given
+    final PartitionsLeaderMatrix partitionsLeaderMatrix = new PartitionsLeaderMatrix(6, 5, 3);
+
+    // when
+    final IntArrayList membersForPartition = partitionsLeaderMatrix.getMembersForPartition(0, 5);
+
+    // then
+    assertThat(membersForPartition).containsExactly(1, 2);
+  }
+
+  @Test
+  public void shouldThrowExceptionOnZeroPartitionsCount() {
+    // expect
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Partitions count must not be smaller then one.");
+
+    // when
+    new PartitionsLeaderMatrix(0, 1, 1);
+  }
+
+  @Test
+  public void shouldThrowExceptionOnNegativePartitionsCount() {
+    // expect
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Partitions count must not be smaller then one.");
+
+    // when
+    new PartitionsLeaderMatrix(-1, 1, 1);
+  }
+
+  @Test
+  public void shouldThrowExceptionOnZeroClusterSize() {
+    // expect
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Cluster size must not be smaller then one.");
+
+    // when
+    new PartitionsLeaderMatrix(1, 0, 1);
+  }
+
+  @Test
+  public void shouldThrowExceptionOnNegativeClusterSize() {
+    // expect
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Cluster size must not be smaller then one.");
+
+    // when
+    new PartitionsLeaderMatrix(1, -1, 1);
+  }
+
+  @Test
+  public void shouldThrowExceptionOnZeroReplicationFactor() {
+    // expect
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Replication factor must not be smaller then one.");
+
+    // when
+    new PartitionsLeaderMatrix(1, 1, -1);
+  }
+
+  @Test
+  public void shouldThrowExceptionOnNegativeReplicationFactor() {
+    // expect
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Replication factor must not be smaller then one.");
+
+    // when
+    new PartitionsLeaderMatrix(1, 1, -1);
+  }
+
+  @Test
+  public void shouldThrowExceptionOnSmallerClusterSizeThenReplicationFactor() {
+    // expect
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Cluster size must not be smaller then replication factor.");
+
+    // when
+    new PartitionsLeaderMatrix(1, 1, 2);
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/ExporterManagerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/ExporterManagerTest.java
@@ -43,6 +43,7 @@ public class ExporterManagerTest {
       new EmbeddedBrokerRule(
           brokerCfg -> {
             brokerCfg.getTopics().get(0).setPartitions(PARTITIONS);
+            brokerCfg.getCluster().setPartitionsCount(PARTITIONS);
 
             final ExporterCfg exporterCfg = new ExporterCfg();
             exporterCfg.setClassName(TestExporter.class.getName());
@@ -57,7 +58,7 @@ public class ExporterManagerTest {
   @Test
   public void shouldRunExporterForEveryPartition() throws InterruptedException {
     // given
-    IntStream.range(1, PARTITIONS + 1) // shift after internal system topic
+    IntStream.range(0, PARTITIONS) // shift after internal system topic
         .forEach(this::createJob);
 
     // then

--- a/broker-core/src/test/java/io/zeebe/broker/system/ConfigurationTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/system/ConfigurationTest.java
@@ -345,7 +345,7 @@ public class ConfigurationTest {
     // when - then
     assertThat(cfgCluster.getPartitionsCount()).isEqualTo(3);
     final List<Integer> partitionIds = cfgCluster.getPartitionIds();
-    assertThat(partitionIds).contains(1, 2, 3);
+    assertThat(partitionIds).contains(0, 1, 2);
   }
 
   @Test

--- a/broker-core/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker-core/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -73,15 +73,16 @@ public class EmbeddedBrokerRule extends ExternalResource {
     this(NOOP_CONFIGURATOR);
   }
 
-  public EmbeddedBrokerRule(String configFileClasspathLocation) {
+  public EmbeddedBrokerRule(final String configFileClasspathLocation) {
     this(configFileClasspathLocation, NOOP_CONFIGURATOR);
   }
 
-  public EmbeddedBrokerRule(Consumer<BrokerCfg> configurator) {
+  public EmbeddedBrokerRule(final Consumer<BrokerCfg> configurator) {
     this("zeebe.unit-test.cfg.toml", configurator);
   }
 
-  public EmbeddedBrokerRule(String configFileClasspathLocation, Consumer<BrokerCfg> configurator) {
+  public EmbeddedBrokerRule(
+      final String configFileClasspathLocation, final Consumer<BrokerCfg> configurator) {
     this(
         () ->
             EmbeddedBrokerRule.class
@@ -91,7 +92,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
   }
 
   public EmbeddedBrokerRule(
-      Supplier<InputStream> configSupplier, Consumer<BrokerCfg> configurator) {
+      final Supplier<InputStream> configSupplier, final Consumer<BrokerCfg> configurator) {
     this.configSupplier = configSupplier;
     this.configurator = configurator;
   }
@@ -127,7 +128,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
     } finally {
       try {
         FileUtil.deleteFolder(newTemporaryFolder.getAbsolutePath());
-      } catch (IOException e) {
+      } catch (final IOException e) {
         e.printStackTrace();
       }
     }
@@ -168,7 +169,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
 
   public void startBroker() {
     if (brokerCfg == null) {
-      try (InputStream configStream = configSupplier.get()) {
+      try (final InputStream configStream = configSupplier.get()) {
         brokerCfg = TomlConfigurationReader.read(configStream);
         if (ENABLE_DEBUG_EXPORTER) {
           brokerCfg.getExporters().add(DebugExporter.defaultConfig(false));
@@ -197,31 +198,31 @@ public class EmbeddedBrokerRule extends ExternalResource {
           .dependency(
               TransportServiceNames.serverTransport(TransportServiceNames.CLIENT_API_SERVER_NAME))
           .install()
-          .get(25, TimeUnit.SECONDS);
+          .get(5, TimeUnit.SECONDS);
 
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+    } catch (final InterruptedException | ExecutionException | TimeoutException e) {
       stopBroker();
       throw new RuntimeException(
-          "System patition not installed into the container withing 25 seconds.");
+          "System patition not installed into the container withing 25 seconds.", e);
     }
 
     dataDirectories = broker.getBrokerContext().getBrokerConfiguration().getData().getDirectories();
   }
 
   public void purgeSnapshots() {
-    for (String dataDirectoryName : dataDirectories) {
+    for (final String dataDirectoryName : dataDirectories) {
       final File dataDirectory = new File(dataDirectoryName);
 
       final File[] partitionDirectories =
           dataDirectory.listFiles((d, f) -> new File(d, f).isDirectory());
 
-      for (File partitionDirectory : partitionDirectories) {
+      for (final File partitionDirectory : partitionDirectories) {
         deleteSnapshots(partitionDirectory);
 
         final File stateDirectory = new File(partitionDirectory, STATE_DIRECTORY);
         if (stateDirectory.exists()) {
           final File[] stateDirs = stateDirectory.listFiles();
-          for (File processorStateDir : stateDirs) {
+          for (final File processorStateDir : stateDirs) {
             if (processorStateDir.exists()) {
               deleteSnapshots(processorStateDir);
             }
@@ -231,28 +232,28 @@ public class EmbeddedBrokerRule extends ExternalResource {
     }
   }
 
-  private void deleteSnapshots(File parentDir) {
+  private void deleteSnapshots(final File parentDir) {
     final File snapshotDirectory = new File(parentDir, SNAPSHOTS_DIRECTORY);
 
     if (snapshotDirectory.exists()) {
       try {
         FileUtil.deleteFolder(snapshotDirectory.getAbsolutePath());
-      } catch (IOException e) {
+      } catch (final IOException e) {
         throw new RuntimeException(
             "Could not delete snapshot directory " + snapshotDirectory.getAbsolutePath(), e);
       }
     }
   }
 
-  public <T> void removeService(ServiceName<T> name) {
+  public <T> void removeService(final ServiceName<T> name) {
     try {
       broker.getBrokerContext().getServiceContainer().removeService(name).get(10, TimeUnit.SECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+    } catch (final InterruptedException | ExecutionException | TimeoutException e) {
       throw new RuntimeException("Could not remove service " + name.getName() + " in 10 seconds.");
     }
   }
 
-  public void assignSocketAddresses(BrokerCfg brokerCfg) {
+  public void assignSocketAddresses(final BrokerCfg brokerCfg) {
     final NetworkCfg network = brokerCfg.getNetwork();
     final List<SocketBindingCfg> socketBindingCfgs =
         Arrays.asList(
@@ -267,7 +268,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
           "Please don't set the port offset in a test configuration");
     }
 
-    for (SocketBindingCfg socketBindingCfg : socketBindingCfgs) {
+    for (final SocketBindingCfg socketBindingCfg : socketBindingCfgs) {
       final SocketAddress address = SocketUtil.getNextAddress();
       socketBindingCfg.setPort(address.port());
     }
@@ -279,10 +280,10 @@ public class EmbeddedBrokerRule extends ExternalResource {
         ServiceName.newServiceName("testService", TestService.class);
 
     @Override
-    public void start(ServiceStartContext startContext) {}
+    public void start(final ServiceStartContext startContext) {}
 
     @Override
-    public void stop(ServiceStopContext stopContext) {}
+    public void stop(final ServiceStopContext stopContext) {}
 
     @Override
     public TestService get() {

--- a/broker-core/src/test/java/io/zeebe/broker/topic/RequestPartitionsTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/topic/RequestPartitionsTest.java
@@ -23,10 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.zeebe.broker.test.EmbeddedBrokerRule;
 import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.clientapi.ControlMessageType;
-import io.zeebe.protocol.clientapi.ErrorCode;
 import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
 import io.zeebe.test.broker.protocol.clientapi.ControlMessageResponse;
-import io.zeebe.test.broker.protocol.clientapi.ErrorResponse;
 import java.util.List;
 import java.util.Map;
 import org.junit.Rule;
@@ -73,28 +71,6 @@ public class RequestPartitionsTest {
 
     // then
     assertResponse(apiRule.requestPartitions(), EXPECTED_TOTAL_PARTITIONS, DEFAULT_TOPIC);
-  }
-
-  @Test
-  public void shouldRespondWithErrorWhenRequestAddressesNonSystemPartition() {
-    // given
-
-    // when
-    // have to do this multiple times as the stream processor for answering the request may not be
-    // available yet
-    final ErrorResponse errorResponse =
-        apiRule
-            .createControlMessageRequest()
-            .messageType(ControlMessageType.REQUEST_PARTITIONS)
-            .partitionId(Protocol.SYSTEM_PARTITION + 1)
-            .send()
-            .awaitError();
-
-    // then
-    assertThat(errorResponse.getErrorCode()).isEqualTo(ErrorCode.REQUEST_PROCESSING_FAILURE);
-    assertThat(errorResponse.getErrorData())
-        .isEqualTo(
-            "Partitions request must address the system partition " + Protocol.SYSTEM_PARTITION);
   }
 
   private void assertResponse(

--- a/broker-core/src/test/java/io/zeebe/broker/util/LogStreamPrinterTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/LogStreamPrinterTest.java
@@ -18,6 +18,7 @@
 package io.zeebe.broker.util;
 
 import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.protocol.Protocol;
 import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,6 +38,6 @@ public class LogStreamPrinterTest {
   @Test
   public void testExistanceOfClass() {
     LogStreamPrinter.printRecords(
-        brokerRule.getBroker(), "default-topic", apiRule.getDefaultPartitionId());
+        brokerRule.getBroker(), Protocol.DEFAULT_TOPIC, apiRule.getDefaultPartitionId());
   }
 }

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/CreateDeploymentTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/CreateDeploymentTest.java
@@ -28,6 +28,7 @@ import io.zeebe.broker.workflow.data.WorkflowInstanceRecord;
 import io.zeebe.broker.workflow.deployment.data.ResourceType;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.clientapi.ExecuteCommandResponseDecoder;
 import io.zeebe.protocol.clientapi.RecordType;
 import io.zeebe.protocol.clientapi.RejectionType;
@@ -165,7 +166,7 @@ public class CreateDeploymentTest {
     final ExecuteCommandResponse resp =
         apiRule
             .createCmdRequest()
-            .partitionId(1)
+            .partitionId(Protocol.DEPLOYMENT_PARTITION)
             .type(ValueType.DEPLOYMENT, DeploymentIntent.CREATE)
             .command()
             .put("topicName", DEFAULT_TOPIC)

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/MessageCorrelationTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/MessageCorrelationTest.java
@@ -106,8 +106,8 @@ public class MessageCorrelationTest {
     final long deploymentKey = testClient.deploy(workflow);
 
     testClient.receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentKey);
+    apiRule.topic(1).receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentKey);
     apiRule.topic(2).receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentKey);
-    apiRule.topic(3).receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentKey);
   }
 
   @Test

--- a/clients/go/tests/integration/healthCheck_test.go
+++ b/clients/go/tests/integration/healthCheck_test.go
@@ -40,15 +40,11 @@ var _ = Describe("should send HealthRequest to Gateway and receive HealthRespons
 				Expect(response.Brokers[0].Host).To(Equal("0.0.0.0"))
 				Expect(response.Brokers[0].Port).To(Equal(int32(26501)))
 
-				Expect(len(response.Brokers[0].Partitions)).To(Equal(2))
+				Expect(len(response.Brokers[0].Partitions)).To(Equal(1))
 
 				Expect(response.Brokers[0].Partitions[0].PartitionId).To(Equal(int32(0)))
 				Expect(response.Brokers[0].Partitions[0].Role).To(Equal(pb.Partition_LEADER))
 				Expect(response.Brokers[0].Partitions[0].TopicName).To(Equal("internal-system"))
-
-				Expect(response.Brokers[0].Partitions[1].PartitionId).To(Equal(int32(1)))
-				Expect(response.Brokers[0].Partitions[1].Role).To(Equal(pb.Partition_LEADER))
-				Expect(response.Brokers[0].Partitions[1].TopicName).To(Equal("default-topic"))
 
 				Expect(err).To(BeNil())
 				Expect(response).NotTo(BeNil())

--- a/gateway/src/test/java/io/zeebe/gateway/AsyncClusterRequestTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/AsyncClusterRequestTest.java
@@ -21,6 +21,7 @@ import io.zeebe.gateway.api.commands.FinalCommandStep;
 import io.zeebe.gateway.api.events.JobEvent;
 import io.zeebe.gateway.impl.ZeebeClientImpl;
 import io.zeebe.gateway.util.ClientRule;
+import io.zeebe.protocol.Protocol;
 import io.zeebe.test.broker.protocol.brokerapi.StubBrokerRule;
 import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.future.ActorFuture;
@@ -34,7 +35,7 @@ import org.junit.rules.RuleChain;
 
 public class AsyncClusterRequestTest {
 
-  private static final int PARTITION_ID = 123;
+  private static final int PARTITION_ID = Protocol.DEPLOYMENT_PARTITION;
 
   public StubBrokerRule brokerRule = new StubBrokerRule();
   public ClientRule clientRule = new ClientRule(brokerRule);
@@ -77,7 +78,7 @@ public class AsyncClusterRequestTest {
   static class TestRequestActor extends Actor {
 
     @SuppressWarnings("unchecked")
-    <R> void awaitResponse(FinalCommandStep<R> request, Consumer<R> responseConsumer) {
+    <R> void awaitResponse(final FinalCommandStep<R> request, final Consumer<R> responseConsumer) {
       actor.call(
           () ->
               actor.runOnCompletion(

--- a/gateway/src/test/java/io/zeebe/gateway/ZeebeClientTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/ZeebeClientTest.java
@@ -77,7 +77,7 @@ public class ZeebeClientTest {
   @Rule public RuleChain ruleChain = RuleChain.outerRule(broker).around(clientRule);
 
   private int clientMaxRequests;
-  private String topic = DEFAULT_TOPIC;
+  private final String topic = DEFAULT_TOPIC;
 
   @Before
   public void setUp() {
@@ -185,7 +185,7 @@ public class ZeebeClientTest {
     }
 
     // when
-    for (ZeebeFuture<JobEvent> future : futures) {
+    for (final ZeebeFuture<JobEvent> future : futures) {
       future.join();
     }
 
@@ -215,11 +215,11 @@ public class ZeebeClientTest {
     }
 
     // when
-    for (ZeebeFuture<JobEvent> future : futures) {
+    for (final ZeebeFuture<JobEvent> future : futures) {
       try {
         future.join();
         fail("exception expected");
-      } catch (Exception e) {
+      } catch (final Exception e) {
         // expected
       }
     }
@@ -270,7 +270,7 @@ public class ZeebeClientTest {
         "Request timed out (PT3S). "
             + "Request was: [ topic = "
             + DEFAULT_TOPIC
-            + ", partition = 1, value type = JOB, command = COMPLETE ]");
+            + ", partition = 0, value type = JOB, command = COMPLETE ]");
 
     // when
     client.topicClient().jobClient().newCompleteCommand(baseEvent).send().join();
@@ -288,7 +288,7 @@ public class ZeebeClientTest {
       client.topicClient().jobClient().newCompleteCommand(baseEvent).send().join();
 
       fail("should throw exception");
-    } catch (ClientCommandRejectedException e) {
+    } catch (final ClientCommandRejectedException e) {
       // then
       assertThat(e.getStackTrace())
           .anySatisfy(
@@ -311,7 +311,7 @@ public class ZeebeClientTest {
       client.topicClient().jobClient().newCompleteCommand(baseEvent).send().join();
 
       fail("should throw exception");
-    } catch (Exception e) {
+    } catch (final Exception e) {
       // then
       assertThat(e.getStackTrace())
           .anySatisfy(
@@ -506,12 +506,12 @@ public class ZeebeClientTest {
     protected List<ConnectionState> connectionState = new CopyOnWriteArrayList<>();
 
     @Override
-    public void onConnectionEstablished(RemoteAddress remoteAddress) {
+    public void onConnectionEstablished(final RemoteAddress remoteAddress) {
       connectionState.add(ConnectionState.CONNECTED);
     }
 
     @Override
-    public void onConnectionClosed(RemoteAddress remoteAddress) {
+    public void onConnectionClosed(final RemoteAddress remoteAddress) {
       connectionState.add(ConnectionState.CLOSED);
     }
   }

--- a/gateway/src/test/java/io/zeebe/gateway/ZeebeClientTopologyTimeoutTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/ZeebeClientTopologyTimeoutTest.java
@@ -60,7 +60,7 @@ public class ZeebeClientTopologyTimeoutTest {
         "Request timed out (PT1S). "
             + "Request was: [ topic = "
             + DEFAULT_TOPIC
-            + ", partition = 1, value type = JOB, command = COMPLETE ]");
+            + ", partition = 0, value type = JOB, command = COMPLETE ]");
 
     // when
     client.topicClient().jobClient().newCompleteCommand(baseEvent).send().join();

--- a/gateway/src/test/java/io/zeebe/gateway/event/PartitionedTopicSubscriptionTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/event/PartitionedTopicSubscriptionTest.java
@@ -51,8 +51,8 @@ import org.junit.rules.RuleChain;
 
 public class PartitionedTopicSubscriptionTest {
 
-  public static final int PARTITION_1 = 1;
-  public static final int PARTITION_2 = 2;
+  public static final int PARTITION_1 = 0;
+  public static final int PARTITION_2 = 1;
 
   public StubBrokerRule broker1 = new StubBrokerRule(0);
   public StubBrokerRule broker2 = new StubBrokerRule(1);
@@ -106,7 +106,7 @@ public class PartitionedTopicSubscriptionTest {
     assertThat(request2.partitionId()).isEqualTo(PARTITION_2);
   }
 
-  protected List<ExecuteCommandRequest> getSubscribeRequests(StubBrokerRule broker) {
+  protected List<ExecuteCommandRequest> getSubscribeRequests(final StubBrokerRule broker) {
     return broker
         .getReceivedCommandRequests()
         .stream()
@@ -426,7 +426,7 @@ public class PartitionedTopicSubscriptionTest {
     assertThat(broker2Request.getCommand()).containsEntry("startPosition", -1L);
   }
 
-  protected List<ExecuteCommandRequest> getOpenSubscriptionRequests(StubBrokerRule broker) {
+  protected List<ExecuteCommandRequest> getOpenSubscriptionRequests(final StubBrokerRule broker) {
     return broker
         .getReceivedCommandRequests()
         .stream()
@@ -435,7 +435,7 @@ public class PartitionedTopicSubscriptionTest {
         .collect(Collectors.toList());
   }
 
-  protected List<ControlMessageRequest> getCloseSubscriptionRequests(StubBrokerRule broker) {
+  protected List<ControlMessageRequest> getCloseSubscriptionRequests(final StubBrokerRule broker) {
     return broker
         .getReceivedControlMessageRequests()
         .stream()
@@ -443,7 +443,7 @@ public class PartitionedTopicSubscriptionTest {
         .collect(Collectors.toList());
   }
 
-  private void assertFailed(Future<?> future) {
+  private void assertFailed(final Future<?> future) {
     assertThatThrownBy(() -> future.get()).isInstanceOf(ExecutionException.class);
   }
 }

--- a/gateway/src/test/java/io/zeebe/gateway/job/subscription/PartitionedJobSubscriptionTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/job/subscription/PartitionedJobSubscriptionTest.java
@@ -43,8 +43,8 @@ import org.junit.rules.RuleChain;
 
 public class PartitionedJobSubscriptionTest {
 
-  public static final int PARTITION_1 = 1;
-  public static final int PARTITION_2 = 2;
+  public static final int PARTITION_1 = 0;
+  public static final int PARTITION_2 = 1;
 
   public static final String JOB_TYPE = "foo";
 
@@ -103,7 +103,7 @@ public class PartitionedJobSubscriptionTest {
     assertThat(request2.partitionId()).isEqualTo(PARTITION_2);
   }
 
-  protected List<ControlMessageRequest> getSubscribeRequests(StubBrokerRule broker) {
+  protected List<ControlMessageRequest> getSubscribeRequests(final StubBrokerRule broker) {
     return broker
         .getReceivedControlMessageRequests()
         .stream()

--- a/gateway/src/test/java/io/zeebe/gateway/util/ClientRule.java
+++ b/gateway/src/test/java/io/zeebe/gateway/util/ClientRule.java
@@ -22,6 +22,7 @@ import io.zeebe.gateway.api.clients.TopicClient;
 import io.zeebe.gateway.api.clients.WorkflowClient;
 import io.zeebe.gateway.impl.ZeebeClientBuilderImpl;
 import io.zeebe.gateway.impl.ZeebeClientImpl;
+import io.zeebe.protocol.Protocol;
 import io.zeebe.test.broker.protocol.brokerapi.StubBrokerRule;
 import io.zeebe.util.sched.clock.ControlledActorClock;
 import java.util.function.Consumer;
@@ -29,18 +30,19 @@ import org.junit.rules.ExternalResource;
 
 public class ClientRule extends ExternalResource {
 
-  public static final int DEFAULT_PARTITION = 1;
+  public static final int DEFAULT_PARTITION = Protocol.DEPLOYMENT_PARTITION;
 
   protected final Consumer<ZeebeClientBuilder> configurator;
 
   protected ZeebeClient client;
   protected ControlledActorClock clock;
 
-  public ClientRule(StubBrokerRule brokerRule) {
+  public ClientRule(final StubBrokerRule brokerRule) {
     this(brokerRule, c -> {});
   }
 
-  public ClientRule(StubBrokerRule brokerRule, Consumer<ZeebeClientBuilder> configurator) {
+  public ClientRule(
+      final StubBrokerRule brokerRule, final Consumer<ZeebeClientBuilder> configurator) {
     this.configurator =
         config -> {
           config.brokerContactPoint(brokerRule.getSocketAddress().toString());

--- a/gateway/src/test/java/io/zeebe/gateway/workflow/PublishMessageTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/workflow/PublishMessageTest.java
@@ -41,7 +41,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
 
 public class PublishMessageTest {
-  private static final int FIRST_PARTITION = 1;
+  private static final int FIRST_PARTITION = 0;
   private static final int PARTITION_COUNT = 10;
 
   public StubBrokerRule brokerRule = new StubBrokerRule(0, PARTITION_COUNT);

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/brokerapi/DeploymentStubs.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/brokerapi/DeploymentStubs.java
@@ -15,16 +15,17 @@
  */
 package io.zeebe.test.broker.protocol.brokerapi;
 
+import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.protocol.intent.DeploymentIntent;
 import java.util.function.Consumer;
 
 public class DeploymentStubs {
 
-  public static final int DEFAULT_PARTITION = 1;
-  private StubBrokerRule broker;
+  public static final int DEFAULT_PARTITION = Protocol.SYSTEM_PARTITION;
+  private final StubBrokerRule broker;
 
-  public DeploymentStubs(StubBrokerRule broker) {
+  public DeploymentStubs(final StubBrokerRule broker) {
     this.broker = broker;
   }
 
@@ -32,7 +33,7 @@ public class DeploymentStubs {
     registerCreateCommand(b -> b.sourceRecordPosition(1L));
   }
 
-  public void registerCreateCommand(Consumer<ExecuteCommandResponseBuilder> modifier) {
+  public void registerCreateCommand(final Consumer<ExecuteCommandResponseBuilder> modifier) {
     final ExecuteCommandResponseBuilder builder =
         broker
             .onExecuteCommandRequest(

--- a/protocol/src/main/java/io/zeebe/protocol/Protocol.java
+++ b/protocol/src/main/java/io/zeebe/protocol/Protocol.java
@@ -39,11 +39,11 @@ public class Protocol {
   public static final DirectBuffer SYSTEM_TOPIC_BUF = BufferUtil.wrapString(SYSTEM_TOPIC);
 
   /** By convention, the name of the topic that is the default */
-  public static final String DEFAULT_TOPIC = "default-topic";
+  public static final String DEFAULT_TOPIC = SYSTEM_TOPIC;
 
   /** By convention, the partition id that can be used for topic creation commands */
   public static final int SYSTEM_PARTITION = 0;
 
   /** By convention, the partition to deploy to */
-  public static final int DEPLOYMENT_PARTITION = 1;
+  public static final int DEPLOYMENT_PARTITION = SYSTEM_PARTITION;
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/ClientRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/ClientRule.java
@@ -32,6 +32,7 @@ import io.zeebe.gateway.api.commands.Topology;
 import io.zeebe.gateway.api.record.ValueType;
 import io.zeebe.gateway.impl.ZeebeClientBuilderImpl;
 import io.zeebe.gateway.impl.ZeebeClientImpl;
+import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.intent.DeploymentIntent;
 import io.zeebe.transport.ClientTransport;
 import io.zeebe.util.sched.clock.ControlledActorClock;
@@ -48,13 +49,14 @@ public class ClientRule extends ExternalResource {
   private final Consumer<ZeebeClientBuilder> configurator;
 
   protected ZeebeClient client;
-  private ControlledActorClock actorClock = new ControlledActorClock();
+  private final ControlledActorClock actorClock = new ControlledActorClock();
 
-  public ClientRule(EmbeddedBrokerRule brokerRule) {
+  public ClientRule(final EmbeddedBrokerRule brokerRule) {
     this(brokerRule, config -> {});
   }
 
-  public ClientRule(EmbeddedBrokerRule brokerRule, Consumer<ZeebeClientBuilder> configurator) {
+  public ClientRule(
+      final EmbeddedBrokerRule brokerRule, final Consumer<ZeebeClientBuilder> configurator) {
     this(
         config -> {
           config.brokerContactPoint(brokerRule.getClientAddress().toString());
@@ -62,7 +64,7 @@ public class ClientRule extends ExternalResource {
         });
   }
 
-  public ClientRule(ClusteringRule clusteringRule) {
+  public ClientRule(final ClusteringRule clusteringRule) {
     this(config -> config.brokerContactPoint(clusteringRule.getClientAddress().toString()));
   }
 
@@ -99,7 +101,7 @@ public class ClientRule extends ExternalResource {
         .until(t -> t != null && t.keySet().containsAll(expectedTopicNames));
   }
 
-  public void waitUntilDeploymentIsDone(long key) {
+  public void waitUntilDeploymentIsDone(final long key) {
     final AtomicBoolean deploymentFound = new AtomicBoolean(false);
 
     client
@@ -108,7 +110,7 @@ public class ClientRule extends ExternalResource {
         .name("deployment-await")
         .recordHandler(
             record -> {
-              if (record.getMetadata().getPartitionId() == 1
+              if (record.getMetadata().getPartitionId() == Protocol.DEPLOYMENT_PARTITION
                   && record.getMetadata().getValueType() == ValueType.DEPLOYMENT
                   && record.getMetadata().getIntent().equals(DeploymentIntent.CREATED.name())
                   && record.getKey() == key) {

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BootstrapDefaultTopicsTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BootstrapDefaultTopicsTest.java
@@ -31,13 +31,11 @@ import org.junit.rules.Timeout;
 public class BootstrapDefaultTopicsTest {
   private static final String BOOTSTRAPPED_BROKER_CONFIG = "zeebe.cluster.defaultTopics.1.cfg.toml";
   private static final String OTHER_BROKER_CONFIG = "zeebe.cluster.defaultTopics.2.cfg.toml";
-  private final String[] clusterConfigs = {
-    BOOTSTRAPPED_BROKER_CONFIG, OTHER_BROKER_CONFIG, ClusteringRule.BROKER_3_TOML
-  };
+  private final String[] clusterConfigs = {BOOTSTRAPPED_BROKER_CONFIG, OTHER_BROKER_CONFIG};
 
-  private Timeout testTimeout = Timeout.seconds(30);
-  private ClusteringRule clusteringRule = new ClusteringRule(clusterConfigs);
-  private ClientRule clientRule = new ClientRule(clusteringRule);
+  private final Timeout testTimeout = Timeout.seconds(30);
+  private final ClusteringRule clusteringRule = new ClusteringRule(clusterConfigs);
+  private final ClientRule clientRule = new ClientRule(clusteringRule);
 
   @Rule
   public RuleChain ruleChain =
@@ -54,7 +52,6 @@ public class BootstrapDefaultTopicsTest {
     // then
     assertThat(topics.containsKey(DEFAULT_TOPIC)).isTrue();
     assertThat(topics.get(DEFAULT_TOPIC).size()).isEqualTo(2);
-    assertThat(topics.containsKey("default-topic-2")).isFalse();
-    assertThat(topics.size()).isEqualTo(2); // default + internal
+    assertThat(topics.size()).isEqualTo(1); // only internal
   }
 }

--- a/qa/integration-tests/src/test/resources/zeebe.cluster.defaultTopics.1.cfg.toml
+++ b/qa/integration-tests/src/test/resources/zeebe.cluster.defaultTopics.1.cfg.toml
@@ -3,6 +3,12 @@
 
 bootstrap = 3
 
+[cluster]
+nodeId = 0
+clusterSize = 2
+partitionsCount = 2
+replicationFactor = 2
+
 [[topics]]
 name = "default-topic"
 partitions = 2


### PR DESCRIPTION
 * each broker creates from the config the partitions matrix
 * the matrix contains for each partition and node the corresponding
 leader and follower
 * the martrix can be used for bootstrapping the partitions
 * since the partition matrix is created on each broker they can
 determine, which partition they have to start and lead or follow
 * partitions request is now made static

This pull request only concentrates on bootstrapping the partition with the given information from the cluster cfg. The clean up and removing all topic related will be done in #1224 

closes #1223
