### PR TITLE
fix(bpmn-model): do not return raw type on connectTo

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractFlowNodeBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractFlowNodeBuilder.java
@@ -365,8 +365,7 @@ public abstract class AbstractFlowNodeBuilder<
     }
   }
 
-  @SuppressWarnings("rawtypes")
-  public AbstractFlowNodeBuilder connectTo(String identifier) {
+  public AbstractFlowNodeBuilder<?, ?> connectTo(String identifier) {
     final ModelElementInstance target = modelInstance.getModelElementById(identifier);
     if (target == null) {
       throw new BpmnModelException(

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/builder/ProcessBuilderTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/builder/ProcessBuilderTest.java
@@ -1919,6 +1919,17 @@ public class ProcessBuilderTest {
         .serviceTask("task", b -> b.name("name"));
   }
 
+  /** or else generic types in parameters are not available and things won't compile */
+  @Test
+  public void testConnectToDoesNotReturnRawBuilder() {
+    Bpmn.createProcess()
+        .startEvent()
+        .serviceTask("goto")
+        .connectTo("goto")
+        .serviceTask("task", b -> b.name("name"))
+        .done();
+  }
+
   protected Message assertMessageEventDefinition(String elementId, String messageName) {
     final MessageEventDefinition messageEventDefinition =
         assertAndGetSingleEventDefinition(elementId, MessageEventDefinition.class);


### PR DESCRIPTION
- there are some instances of rawtypes left when creating event definitions (i.e. on the `eventDefinitionDone` methods), but I guess we should rather replace them by methods with function parameters anyway, i.e. `.message(b -> b.name("foo")...)`.

closes #1297
