### PR TITLE
fix(broker): messages with same name and correlation key

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageTimeToLiveChecker.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageTimeToLiveChecker.java
@@ -23,7 +23,6 @@ import io.zeebe.broker.subscription.message.state.MessageStateController;
 import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.intent.MessageIntent;
 import io.zeebe.util.sched.clock.ActorClock;
-import java.util.List;
 
 public class MessageTimeToLiveChecker implements Runnable {
 
@@ -40,15 +39,8 @@ public class MessageTimeToLiveChecker implements Runnable {
 
   @Override
   public void run() {
-    final List<Message> messages =
-        messageStateController.findMessageBefore(ActorClock.currentTimeMillis());
-
-    for (Message message : messages) {
-      final boolean success = writeDeleteMessageCommand(message);
-      if (!success) {
-        return;
-      }
-    }
+    messageStateController.findMessagesWithDeadlineBefore(
+        ActorClock.currentTimeMillis(), this::writeDeleteMessageCommand);
   }
 
   private boolean writeDeleteMessageCommand(Message message) {

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/OpenMessageSubscriptionProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/OpenMessageSubscriptionProcessor.java
@@ -84,7 +84,7 @@ public class OpenMessageSubscriptionProcessor
       Consumer<SideEffectProducer> sideEffect,
       MessageSubscription subscription) {
     final Message message =
-        messageStateController.findMessage(
+        messageStateController.findFirstMessage(
             subscriptionRecord.getMessageName(), subscriptionRecord.getCorrelationKey());
 
     if (message != null) {


### PR DESCRIPTION
* store message by unique message key instead of the composite key
<name, correlation-key>
* use batches for write operations
* fix message deletion

closes #1405 
