### PR TITLE
1400 update payload

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/incident/processor/IncidentStreamProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/incident/processor/IncidentStreamProcessor.java
@@ -128,7 +128,8 @@ public class IncidentStreamProcessor {
   private final class CreateIncidentProcessor implements CommandProcessor<IncidentRecord> {
 
     @Override
-    public void onCommand(TypedRecord<IncidentRecord> command, CommandControl commandControl) {
+    public void onCommand(
+        TypedRecord<IncidentRecord> command, CommandControl<IncidentRecord> commandControl) {
       final IncidentRecord incidentEvent = command.getValue();
 
       final boolean isJobIncident = incidentEvent.getJobKey() > 0;
@@ -139,7 +140,7 @@ public class IncidentStreamProcessor {
         return;
       }
 
-      final long incidentKey = commandControl.accept(IncidentIntent.CREATED);
+      final long incidentKey = commandControl.accept(IncidentIntent.CREATED, incidentEvent);
 
       if (isJobIncident) {
         failedJobMap.put(incidentEvent.getJobKey(), incidentKey);

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/CommandProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/CommandProcessor.java
@@ -27,11 +27,11 @@ import io.zeebe.protocol.intent.Intent;
  */
 public interface CommandProcessor<T extends UnpackedObject> {
 
-  void onCommand(TypedRecord<T> command, CommandControl commandControl);
+  void onCommand(TypedRecord<T> command, CommandControl<T> commandControl);
 
-  interface CommandControl {
+  interface CommandControl<T> {
     /** @return the key of the entity */
-    long accept(Intent newState);
+    long accept(Intent newState, T updatedValue);
 
     void reject(RejectionType type, String reason);
   }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepContext.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepContext.java
@@ -141,6 +141,8 @@ public class BpmnStepContext<T extends ExecutableFlowElement> {
         .setErrorType(errorType)
         .setErrorMessage(errorMessage);
 
+    eventOutput.storeFailedToken(record);
+
     if (!record.getMetadata().hasIncidentKey()) {
       commandWriter.writeNewCommand(IncidentIntent.CREATE, incidentCommand);
     } else {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/EventOutput.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/EventOutput.java
@@ -84,7 +84,11 @@ public class EventOutput {
   }
 
   public void deferEvent(final TypedRecord<WorkflowInstanceRecord> event) {
-    materializedState.deferEvent(event);
+    materializedState.deferTokenEvent(event);
+  }
+
+  public void storeFailedToken(final TypedRecord<WorkflowInstanceRecord> event) {
+    materializedState.storeFailedToken(event);
   }
 
   public void storeFinishedToken(final TypedRecord<WorkflowInstanceRecord> event) {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/state/StoredRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/state/StoredRecord.java
@@ -75,6 +75,7 @@ public class StoredRecord implements BufferReader, BufferWriter {
   public enum Purpose {
     // Order is important, as we use the ordinal for persistence
     DEFERRED_TOKEN,
+    FAILED_TOKEN,
     FINISHED_TOKEN
   }
 }

--- a/broker-core/src/test/java/io/zeebe/broker/incident/IncidentTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/incident/IncidentTest.java
@@ -1226,7 +1226,6 @@ public class IncidentTest {
             .type(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.UPDATE_PAYLOAD)
             .key(activityInstanceKey)
             .command()
-            .put("workflowInstanceKey", workflowInstanceKey)
             .put("payload", payload)
             .done()
             .sendAndAwait();

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/state/ElementInstanceStateTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/state/ElementInstanceStateTest.java
@@ -385,7 +385,7 @@ public class ElementInstanceStateTest {
 
     // when
     final TypedRecord<WorkflowInstanceRecord> typedRecord = mockTypedRecord();
-    elementInstanceState.storeRecord(100, typedRecord, Purpose.DEFERRED_TOKEN);
+    elementInstanceState.storeTokenEvent(100, typedRecord, Purpose.DEFERRED_TOKEN);
 
     // then
     final List<IndexedRecord> storedRecords = elementInstanceState.getDeferredTokens(100);
@@ -406,9 +406,9 @@ public class ElementInstanceStateTest {
 
     // when
     final TypedRecord<WorkflowInstanceRecord> typedRecord = mockTypedRecord(123L);
-    elementInstanceState.storeRecord(100, typedRecord, Purpose.DEFERRED_TOKEN);
+    elementInstanceState.storeTokenEvent(100, typedRecord, Purpose.DEFERRED_TOKEN);
     final TypedRecord<WorkflowInstanceRecord> typedRecord2 = mockTypedRecord(124L);
-    elementInstanceState.storeRecord(100, typedRecord2, Purpose.FINISHED_TOKEN);
+    elementInstanceState.storeTokenEvent(100, typedRecord2, Purpose.FINISHED_TOKEN);
 
     // then
     final List<IndexedRecord> deferredTokens = elementInstanceState.getDeferredTokens(100);
@@ -432,9 +432,9 @@ public class ElementInstanceStateTest {
     elementInstanceState.newInstance(
         100, workflowInstanceRecord, WorkflowInstanceIntent.ELEMENT_ACTIVATED);
     final TypedRecord<WorkflowInstanceRecord> typedRecord = mockTypedRecord(123L);
-    elementInstanceState.storeRecord(100, typedRecord, Purpose.DEFERRED_TOKEN);
+    elementInstanceState.storeTokenEvent(100, typedRecord, Purpose.DEFERRED_TOKEN);
     final TypedRecord<WorkflowInstanceRecord> typedRecord2 = mockTypedRecord(124L);
-    elementInstanceState.storeRecord(100, typedRecord2, Purpose.DEFERRED_TOKEN);
+    elementInstanceState.storeTokenEvent(100, typedRecord2, Purpose.DEFERRED_TOKEN);
 
     // when
     elementInstanceState.removeStoredRecord(100, 123, Purpose.DEFERRED_TOKEN);
@@ -459,7 +459,7 @@ public class ElementInstanceStateTest {
         key, workflowInstanceRecord, WorkflowInstanceIntent.ELEMENT_ACTIVATED);
 
     final TypedRecord<WorkflowInstanceRecord> typedRecord = mockTypedRecord(123L);
-    elementInstanceState.storeRecord(key, typedRecord, Purpose.DEFERRED_TOKEN);
+    elementInstanceState.storeTokenEvent(key, typedRecord, Purpose.DEFERRED_TOKEN);
 
     // when
     elementInstanceState.removeInstance(key);

--- a/clients/java/src/main/java/io/zeebe/client/api/clients/WorkflowClient.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/clients/WorkflowClient.java
@@ -22,7 +22,6 @@ import io.zeebe.client.api.commands.PublishMessageCommandStep1;
 import io.zeebe.client.api.commands.UpdatePayloadWorkflowInstanceCommandStep1;
 import io.zeebe.client.api.commands.WorkflowRequestStep1;
 import io.zeebe.client.api.commands.WorkflowResourceRequestStep1;
-import io.zeebe.client.api.events.WorkflowInstanceEvent;
 
 /**
  * A client with access to all workflow-related operations:
@@ -104,7 +103,7 @@ public interface WorkflowClient {
    * @param event the latest workflow instance event
    * @return a builder for the command
    */
-  UpdatePayloadWorkflowInstanceCommandStep1 newUpdatePayloadCommand(WorkflowInstanceEvent event);
+  UpdatePayloadWorkflowInstanceCommandStep1 newUpdatePayloadCommand(long activityInstanceKey);
 
   /**
    * Command to publish a message which can be correlated to a workflow instance.

--- a/clients/java/src/main/java/io/zeebe/client/api/commands/UpdatePayloadWorkflowInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/commands/UpdatePayloadWorkflowInstanceCommandStep1.java
@@ -15,7 +15,6 @@
  */
 package io.zeebe.client.api.commands;
 
-import io.zeebe.client.api.events.WorkflowInstanceEvent;
 import java.io.InputStream;
 import java.util.Map;
 
@@ -56,8 +55,7 @@ public interface UpdatePayloadWorkflowInstanceCommandStep1 {
    */
   UpdatePayloadWorkflowInstanceCommandStep2 payload(Object payload);
 
-  interface UpdatePayloadWorkflowInstanceCommandStep2
-      extends FinalCommandStep<WorkflowInstanceEvent> {
+  interface UpdatePayloadWorkflowInstanceCommandStep2 extends FinalCommandStep<Void> {
     // the place for new optional parameters
   }
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/WorkflowsClientImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/WorkflowsClientImpl.java
@@ -24,11 +24,11 @@ import io.zeebe.client.api.commands.PublishMessageCommandStep1;
 import io.zeebe.client.api.commands.UpdatePayloadWorkflowInstanceCommandStep1;
 import io.zeebe.client.api.commands.WorkflowRequestStep1;
 import io.zeebe.client.api.commands.WorkflowResourceRequestStep1;
-import io.zeebe.client.api.events.WorkflowInstanceEvent;
 import io.zeebe.client.impl.workflow.CancelWorkflowInstanceCommandImpl;
 import io.zeebe.client.impl.workflow.CreateWorkflowInstanceCommandImpl;
 import io.zeebe.client.impl.workflow.DeployWorkflowCommandImpl;
 import io.zeebe.client.impl.workflow.PublishMessageCommandImpl;
+import io.zeebe.client.impl.workflow.UpdateWorkflowInstancePayloadCommandImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 
 public class WorkflowsClientImpl implements WorkflowClient {
@@ -59,8 +59,8 @@ public class WorkflowsClientImpl implements WorkflowClient {
 
   @Override
   public UpdatePayloadWorkflowInstanceCommandStep1 newUpdatePayloadCommand(
-      final WorkflowInstanceEvent event) {
-    return null;
+      final long activityInstanceKey) {
+    return new UpdateWorkflowInstancePayloadCommandImpl(asyncStub, activityInstanceKey);
   }
 
   @Override

--- a/clients/java/src/main/java/io/zeebe/client/impl/workflow/UpdateWorkflowInstancePayloadCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/workflow/UpdateWorkflowInstancePayloadCommandImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl.workflow;
+
+import io.zeebe.client.api.ZeebeFuture;
+import io.zeebe.client.api.commands.UpdatePayloadWorkflowInstanceCommandStep1;
+import io.zeebe.client.api.commands.UpdatePayloadWorkflowInstanceCommandStep1.UpdatePayloadWorkflowInstanceCommandStep2;
+import io.zeebe.client.impl.CommandWithPayload;
+import io.zeebe.client.impl.ZeebeClientFutureImpl;
+import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateWorkflowInstancePayloadRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateWorkflowInstancePayloadRequest.Builder;
+import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateWorkflowInstancePayloadResponse;
+
+public class UpdateWorkflowInstancePayloadCommandImpl
+    extends CommandWithPayload<UpdatePayloadWorkflowInstanceCommandStep2>
+    implements UpdatePayloadWorkflowInstanceCommandStep1,
+        UpdatePayloadWorkflowInstanceCommandStep2 {
+
+  private final GatewayStub asyncStub;
+  private final Builder builder;
+
+  public UpdateWorkflowInstancePayloadCommandImpl(GatewayStub asyncStub, long activityInstanceKey) {
+    this.asyncStub = asyncStub;
+    this.builder = UpdateWorkflowInstancePayloadRequest.newBuilder();
+    builder.setActivityInstanceKey(activityInstanceKey);
+  }
+
+  @Override
+  public ZeebeFuture<Void> send() {
+    final UpdateWorkflowInstancePayloadRequest request = builder.build();
+
+    final ZeebeClientFutureImpl<Void, UpdateWorkflowInstancePayloadResponse> future =
+        new ZeebeClientFutureImpl<>();
+
+    asyncStub.updateWorkflowInstancePayload(request, future);
+    return future;
+  }
+
+  @Override
+  protected UpdatePayloadWorkflowInstanceCommandStep2 setPayloadInternal(String payload) {
+    builder.setPayload(payload);
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/zeebe/client/workflow/UpdateWorkflowInstancePayloadTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/workflow/UpdateWorkflowInstancePayloadTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.workflow;
+
+import static io.zeebe.test.util.record.RecordingExporter.workflowInstanceRecords;
+
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.api.commands.Workflow;
+import io.zeebe.client.util.TestEnvironmentRule;
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.test.util.JsonUtil;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.util.StringUtil;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class UpdateWorkflowInstancePayloadTest {
+
+  public static final BpmnModelInstance TEST_WORKFLOW =
+      Bpmn.createExecutableProcess("testProcess")
+          .startEvent()
+          .serviceTask("task", b -> b.zeebeTaskType("taskType"))
+          .endEvent()
+          .done();
+
+  @Rule public TestEnvironmentRule rule = new TestEnvironmentRule();
+
+  private ZeebeClient client;
+
+  @Before
+  public void setUp() {
+    client = rule.getClient();
+  }
+
+  @Test
+  public void shouldCommandWithPayloadAsString() {
+    // given
+    final Workflow workflow = deployWorkflow();
+    client
+        .workflowClient()
+        .newCreateInstanceCommand()
+        .workflowKey(workflow.getWorkflowKey())
+        .send()
+        .join()
+        .getWorkflowInstanceKey();
+
+    final Record<WorkflowInstanceRecordValue> taskActivatedEvent =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .withActivityId("task")
+            .getFirst();
+
+    final String updatedPayload = "{\"key\": \"val\"}";
+
+    // when
+    client
+        .workflowClient()
+        .newUpdatePayloadCommand(taskActivatedEvent.getKey())
+        .payload(updatedPayload)
+        .send()
+        .join();
+
+    // then
+    final Record<WorkflowInstanceRecordValue> updatedEvent =
+        workflowInstanceRecords(WorkflowInstanceIntent.PAYLOAD_UPDATED).getFirst();
+    JsonUtil.assertEquality(updatedEvent.getValue().getPayload(), updatedPayload);
+  }
+
+  @Test
+  public void shouldCommandWithPayloadAsStream() {
+    // given
+    final Workflow workflow = deployWorkflow();
+    client
+        .workflowClient()
+        .newCreateInstanceCommand()
+        .workflowKey(workflow.getWorkflowKey())
+        .send()
+        .join()
+        .getWorkflowInstanceKey();
+
+    final Record<WorkflowInstanceRecordValue> taskActivatedEvent =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .withActivityId("task")
+            .getFirst();
+
+    final String updatedPayload = "{\"key\": \"val\"}";
+    final InputStream payloadStream = new ByteArrayInputStream(StringUtil.getBytes(updatedPayload));
+
+    // when
+    client
+        .workflowClient()
+        .newUpdatePayloadCommand(taskActivatedEvent.getKey())
+        .payload(payloadStream)
+        .send()
+        .join();
+
+    // then
+    final Record<WorkflowInstanceRecordValue> updatedEvent =
+        workflowInstanceRecords(WorkflowInstanceIntent.PAYLOAD_UPDATED).getFirst();
+    JsonUtil.assertEquality(updatedEvent.getValue().getPayload(), updatedPayload);
+  }
+
+  @Test
+  public void shouldCommandWithPayloadAsMap() {
+    // given
+    final Workflow workflow = deployWorkflow();
+    client
+        .workflowClient()
+        .newCreateInstanceCommand()
+        .workflowKey(workflow.getWorkflowKey())
+        .send()
+        .join()
+        .getWorkflowInstanceKey();
+
+    final Record<WorkflowInstanceRecordValue> taskActivatedEvent =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .withActivityId("task")
+            .getFirst();
+
+    final String updatedPayload = "{\"key\": \"val\"}";
+    final Map<String, Object> payloadMap = Collections.<String, Object>singletonMap("key", "val");
+
+    // when
+    client
+        .workflowClient()
+        .newUpdatePayloadCommand(taskActivatedEvent.getKey())
+        .payload(payloadMap)
+        .send()
+        .join();
+
+    // then
+    final Record<WorkflowInstanceRecordValue> updatedEvent =
+        workflowInstanceRecords(WorkflowInstanceIntent.PAYLOAD_UPDATED).getFirst();
+    JsonUtil.assertEquality(updatedEvent.getValue().getPayload(), updatedPayload);
+  }
+
+  @Test
+  public void shouldCommandWithPayloadAsObject() {
+    // given
+    final Workflow workflow = deployWorkflow();
+    client
+        .workflowClient()
+        .newCreateInstanceCommand()
+        .workflowKey(workflow.getWorkflowKey())
+        .send()
+        .join()
+        .getWorkflowInstanceKey();
+
+    final Record<WorkflowInstanceRecordValue> taskActivatedEvent =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .withActivityId("task")
+            .getFirst();
+
+    final String updatedPayload = "{\"key\": \"val\"}";
+    final Map<String, Object> payloadMap = Collections.<String, Object>singletonMap("key", "val");
+
+    // when
+    client
+        .workflowClient()
+        .newUpdatePayloadCommand(taskActivatedEvent.getKey())
+        .payload((Object) payloadMap)
+        .send()
+        .join();
+
+    // then
+    final Record<WorkflowInstanceRecordValue> updatedEvent =
+        workflowInstanceRecords(WorkflowInstanceIntent.PAYLOAD_UPDATED).getFirst();
+    JsonUtil.assertEquality(updatedEvent.getValue().getPayload(), updatedPayload);
+  }
+
+  private Workflow deployWorkflow() {
+    return client
+        .workflowClient()
+        .newDeployCommand()
+        .addWorkflowModel(TEST_WORKFLOW, "testProcess.bpmn")
+        .send()
+        .join()
+        .getDeployedWorkflows()
+        .get(0);
+  }
+}

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -100,6 +100,15 @@ message CancelWorkflowInstanceRequest {
 message CancelWorkflowInstanceResponse {
 }
 
+message UpdateWorkflowInstancePayloadRequest {
+  int64 activityInstanceKey = 1;
+  /* payload has to be a valid json object as string */
+  string payload = 2;
+}
+
+message UpdateWorkflowInstancePayloadResponse {
+}
+
 service Gateway {
   rpc Health (HealthRequest) returns (HealthResponse) {
   }
@@ -112,5 +121,7 @@ service Gateway {
   rpc CreateWorkflowInstance (CreateWorkflowInstanceRequest) returns (CreateWorkflowInstanceResponse) {
   }
   rpc CancelWorkflowInstance (CancelWorkflowInstanceRequest) returns (CancelWorkflowInstanceResponse) {
+  }
+  rpc UpdateWorkflowInstancePayload (UpdateWorkflowInstancePayloadRequest) returns (UpdateWorkflowInstancePayloadResponse) {
   }
 }

--- a/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
@@ -38,6 +38,8 @@ import io.zeebe.gateway.protocol.GatewayOuterClass.DeployWorkflowResponse;
 import io.zeebe.gateway.protocol.GatewayOuterClass.HealthRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.HealthResponse;
 import io.zeebe.gateway.protocol.GatewayOuterClass.PublishMessageRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateWorkflowInstancePayloadRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateWorkflowInstancePayloadResponse;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
@@ -111,6 +113,17 @@ public class EndpointManager extends GatewayGrpc.GatewayImplBase {
         request,
         RequestMapper::toCancelWorkflowInstanceRequest,
         ResponseMapper::toCancelWorkflowInstanceResponse,
+        responseObserver);
+  }
+
+  @Override
+  public void updateWorkflowInstancePayload(
+      UpdateWorkflowInstancePayloadRequest request,
+      StreamObserver<UpdateWorkflowInstancePayloadResponse> responseObserver) {
+    sendRequest(
+        request,
+        RequestMapper::toUpdateWorkflowInstancePayloadRequest,
+        ResponseMapper::toUpdateWorkflowInstancePayloadResponse,
         responseObserver);
   }
 

--- a/gateway/src/main/java/io/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/zeebe/gateway/RequestMapper.java
@@ -21,6 +21,7 @@ import io.zeebe.gateway.impl.broker.request.BrokerCreateWorkflowInstanceRequest;
 import io.zeebe.gateway.impl.broker.request.BrokerDeployWorkflowRequest;
 import io.zeebe.gateway.impl.broker.request.BrokerPublishMessageRequest;
 import io.zeebe.gateway.impl.broker.request.BrokerTopologyRequest;
+import io.zeebe.gateway.impl.broker.request.BrokerUpdateWorkflowInstancePayloadRequest;
 import io.zeebe.gateway.impl.data.MsgPackConverter;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CancelWorkflowInstanceRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CreateJobRequest;
@@ -28,6 +29,7 @@ import io.zeebe.gateway.protocol.GatewayOuterClass.CreateWorkflowInstanceRequest
 import io.zeebe.gateway.protocol.GatewayOuterClass.DeployWorkflowRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.HealthRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.PublishMessageRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateWorkflowInstancePayloadRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.WorkflowRequestObject;
 import io.zeebe.msgpack.value.DocumentValue;
 import org.agrona.DirectBuffer;
@@ -95,6 +97,17 @@ public class RequestMapper {
         new BrokerCancelWorkflowInstanceRequest();
 
     brokerRequest.setWorkflowInstanceKey(grpcRequest.getWorkflowInstanceKey());
+
+    return brokerRequest;
+  }
+
+  public static BrokerUpdateWorkflowInstancePayloadRequest toUpdateWorkflowInstancePayloadRequest(
+      UpdateWorkflowInstancePayloadRequest grpcRequest) {
+    final BrokerUpdateWorkflowInstancePayloadRequest brokerRequest =
+        new BrokerUpdateWorkflowInstancePayloadRequest();
+
+    brokerRequest.setActivityInstanceKey(grpcRequest.getActivityInstanceKey());
+    brokerRequest.setPayload(ensureJsonSet(grpcRequest.getPayload()));
 
     return brokerRequest;
   }

--- a/gateway/src/main/java/io/zeebe/gateway/ResponseMapper.java
+++ b/gateway/src/main/java/io/zeebe/gateway/ResponseMapper.java
@@ -28,6 +28,7 @@ import io.zeebe.gateway.protocol.GatewayOuterClass.DeployWorkflowResponse;
 import io.zeebe.gateway.protocol.GatewayOuterClass.HealthResponse;
 import io.zeebe.gateway.protocol.GatewayOuterClass.Partition;
 import io.zeebe.gateway.protocol.GatewayOuterClass.Partition.PartitionBrokerRole;
+import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateWorkflowInstancePayloadResponse;
 import io.zeebe.gateway.protocol.GatewayOuterClass.WorkflowResponseObject;
 import io.zeebe.protocol.impl.data.cluster.TopologyResponseDto;
 import io.zeebe.protocol.impl.data.cluster.TopologyResponseDto.BrokerDto;
@@ -125,6 +126,11 @@ public class ResponseMapper {
   public static CancelWorkflowInstanceResponse toCancelWorkflowInstanceResponse(
       int partitionId, long key, WorkflowInstanceRecord brokerResponse) {
     return CancelWorkflowInstanceResponse.newBuilder().build();
+  }
+
+  public static UpdateWorkflowInstancePayloadResponse toUpdateWorkflowInstancePayloadResponse(
+      int partitionId, long key, WorkflowInstanceRecord brokerResponse) {
+    return UpdateWorkflowInstancePayloadResponse.newBuilder().build();
   }
 
   @FunctionalInterface

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/request/BrokerUpdateWorkflowInstancePayloadRequest.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/request/BrokerUpdateWorkflowInstancePayloadRequest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.gateway.impl.broker.request;
+
+import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public class BrokerUpdateWorkflowInstancePayloadRequest
+    extends BrokerExecuteCommand<WorkflowInstanceRecord> {
+
+  private final WorkflowInstanceRecord requestDto = new WorkflowInstanceRecord();
+
+  public BrokerUpdateWorkflowInstancePayloadRequest() {
+    super(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.UPDATE_PAYLOAD);
+  }
+
+  public BrokerUpdateWorkflowInstancePayloadRequest setActivityInstanceKey(
+      long activityInstanceKey) {
+    request.setKey(activityInstanceKey);
+    return this;
+  }
+
+  public BrokerUpdateWorkflowInstancePayloadRequest setPayload(DirectBuffer payload) {
+    requestDto.setPayload(payload);
+    return this;
+  }
+
+  @Override
+  protected BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected WorkflowInstanceRecord toResponseDto(DirectBuffer buffer) {
+    final WorkflowInstanceRecord responseDto = new WorkflowInstanceRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/StateController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/StateController.java
@@ -569,12 +569,14 @@ public class StateController implements AutoCloseable {
     }
   }
 
-  public void removeEntriesWithPrefix(final ColumnFamilyHandle handle, byte[] prefix) {
+  public void removeEntriesWithPrefix(
+      final ColumnFamilyHandle handle, byte[] prefix, BiConsumer<byte[], byte[]> entryConsumer) {
     whileEqualPrefix(
         handle,
         prefix,
         (k, v) -> {
           remove(handle, k, 0, k.length);
+          entryConsumer.accept(k, v);
         });
   }
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/UpdatePayloadTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/UpdatePayloadTest.java
@@ -162,12 +162,12 @@ public class UpdatePayloadTest {
     // given
     waitUntil(
         () -> eventRecorder.hasElementInState("task-1", WorkflowInstanceState.ELEMENT_ACTIVATED));
-    final WorkflowInstanceEvent activtyInstance =
-        eventRecorder.getElementInState("task-1", WorkflowInstanceState.ELEMENT_ACTIVATED);
+    final WorkflowInstanceEvent workflowInstanceActivated =
+        eventRecorder.getElementInState("process", WorkflowInstanceState.ELEMENT_ACTIVATED);
 
     clientRule
         .getWorkflowClient()
-        .newUpdatePayloadCommand(activtyInstance)
+        .newUpdatePayloadCommand(workflowInstanceActivated)
         .payload(PAYLOAD)
         .send()
         .join();


### PR DESCRIPTION
Also fixes the update command to actually update the payload of the addressed activity instance. Before, we always updated the workflow instance's payload (see https://github.com/zeebe-io/zeebe/blob/3fff3c1/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/UpdatePayloadProcessor.java#L41-L46).

closes #1400
