### PR TITLE
RFC: RocksDB Iterator/Iterable/Spliterator/Stream and ZbRocksDb improvements

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/job/old/JobSubscriptionProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/job/old/JobSubscriptionProcessor.java
@@ -194,19 +194,15 @@ public class JobSubscriptionProcessor
     final JobSubscriptions subscriptions = typeSubscriptions.get(type);
 
     if (subscriptions != null) {
-      state.activatableJobs(
-          type,
-          (key, record, control) -> {
-            final JobSubscription subscription = getNextAvailableSubscription(subscriptions);
+      for (final JobStateController.Entry entry : state.activatableJobs(type)) {
+        final JobSubscription subscription = getNextAvailableSubscription(subscriptions);
+        if (subscription == null) {
+          break;
+        }
 
-            if (subscription == null) {
-              control.stop();
-              return;
-            }
-
-            activateJob(key, record, writer, subscriptions, subscription);
-            writer.flush();
-          });
+        activateJob(entry.getKey(), entry.getRecord(), writer, subscriptions, subscription);
+        writer.flush();
+      }
     }
   }
 

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageStateController.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageStateController.java
@@ -20,7 +20,9 @@ package io.zeebe.broker.subscription.message.state;
 import static io.zeebe.broker.workflow.state.PersistenceHelper.EXISTENCE;
 
 import io.zeebe.broker.util.KeyStateController;
+import io.zeebe.logstreams.rocksdb.ZbIterator;
 import io.zeebe.logstreams.rocksdb.ZbRocksDb;
+import io.zeebe.logstreams.rocksdb.ZbRocksEntry;
 import io.zeebe.logstreams.rocksdb.ZbWriteBatch;
 import java.io.File;
 import java.nio.ByteOrder;
@@ -196,17 +198,19 @@ public class MessageStateController extends KeyStateController {
 
     final AtomicBoolean found = new AtomicBoolean();
 
-    db.forEachPrefixed(
-        messageColumnFamily,
-        prefixBuffer,
-        (entry, control) -> {
-          iterateKeyBuffer.wrap(entry.getKey());
+    try (final ZbIterator iterator = db.prefixedIterator(messageColumnFamily, prefixBuffer)) {
+      // This could be replaced by:
+      // final ZbRocksEntry entry =
+      //    db.stream(messageColumnFamily).findFirst(e -> startsWith(e.getKey(), prefixBuffer));
+      for (final ZbRocksEntry entry : iterator) {
+        iterateKeyBuffer.wrap(entry.getKey());
 
-          final long messageKey = iterateKeyBuffer.getLong(prefixLength, ByteOrder.LITTLE_ENDIAN);
-          found.set(readMessage(messageKey, message));
+        final long messageKey = iterateKeyBuffer.getLong(prefixLength, ByteOrder.LITTLE_ENDIAN);
+        found.set(readMessage(messageKey, message));
 
-          control.stop();
-        });
+        break; // ???
+      }
+    }
 
     if (found.get()) {
       return message;
@@ -227,24 +231,24 @@ public class MessageStateController extends KeyStateController {
   }
 
   public void findMessagesWithDeadlineBefore(final long timestamp, IteratorConsumer consumer) {
+    try (final ZbIterator iterator = db.iterator(deadlineColumnFamily)) {
+      for (final ZbRocksEntry entry : iterator) {
+        iterateKeyBuffer.wrap(entry.getKey());
+        final long deadline = iterateKeyBuffer.getLong(0, ByteOrder.LITTLE_ENDIAN);
 
-    db.forEach(
-        deadlineColumnFamily,
-        (entry, control) -> {
-          iterateKeyBuffer.wrap(entry.getKey());
-          final long deadline = iterateKeyBuffer.getLong(0, ByteOrder.LITTLE_ENDIAN);
+        boolean consumed = false;
+        if (deadline <= timestamp) {
+          final long messageKey = iterateKeyBuffer.getLong(Long.BYTES, ByteOrder.LITTLE_ENDIAN);
 
-          boolean consumed = false;
-          if (deadline <= timestamp) {
-            final long messageKey = iterateKeyBuffer.getLong(Long.BYTES, ByteOrder.LITTLE_ENDIAN);
+          readMessage(messageKey, message);
+          consumed = consumer.accept(message);
+        }
 
-            readMessage(messageKey, message);
-            consumed = consumer.accept(message);
-          }
-          if (!consumed) {
-            control.stop();
-          }
-        });
+        if (!consumed) {
+          break;
+        }
+      }
+    }
   }
 
   public boolean exist(

--- a/logstreams/src/main/java/io/zeebe/logstreams/rocksdb/AutoCloseableManager.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/rocksdb/AutoCloseableManager.java
@@ -1,0 +1,27 @@
+package io.zeebe.logstreams.rocksdb;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.agrona.CloseHelper;
+
+public class AutoCloseableManager implements AutoCloseable {
+  protected final List<AutoCloseable> managedCloseables;
+
+  public AutoCloseableManager() {
+    managedCloseables = new ArrayList<>();
+  }
+
+  public AutoCloseableManager(List<AutoCloseable> closeables) {
+    this.managedCloseables = closeables;
+  }
+
+  public void addCloseable(AutoCloseable... closeables) {
+    this.managedCloseables.addAll(Arrays.asList(closeables));
+  }
+
+  @Override
+  public void close() {
+    managedCloseables.forEach(CloseHelper::quietClose);
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/rocksdb/ZbIterator.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/rocksdb/ZbIterator.java
@@ -1,0 +1,72 @@
+package io.zeebe.logstreams.rocksdb;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.function.Predicate;
+
+public class ZbIterator extends AutoCloseableManager
+    implements Iterator<ZbRocksEntry>, Iterable<ZbRocksEntry> {
+  protected final ZbRocksIterator rocksIterator;
+
+  protected Predicate<? super ZbRocksEntry> predicate;
+
+  public ZbIterator(ZbRocksIterator iterator) {
+    rocksIterator = iterator;
+  }
+
+  public ZbIterator(ZbRocksIterator rocksIterator, List<AutoCloseable> closeables) {
+    super(closeables);
+    this.rocksIterator = rocksIterator;
+  }
+
+  @Override
+  public Iterator<ZbRocksEntry> iterator() {
+    return this;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (predicate != null) {
+      findNextAcceptedEntry();
+    }
+
+    return rocksIterator.isValid();
+  }
+
+  @Override
+  public ZbRocksEntry next() {
+    if (!rocksIterator.isValid()) {
+      throw new NoSuchElementException();
+    }
+
+    final ZbRocksEntry entry =
+        new ZbRocksEntry(rocksIterator.keyBuffer(), rocksIterator.valueBuffer());
+    rocksIterator.next();
+
+    return entry;
+  }
+
+  @Override
+  public Spliterator<ZbRocksEntry> spliterator() {
+    return new ZbSpliterator(rocksIterator, 0, managedCloseables);
+  }
+
+  public void setPredicate(Predicate<? super ZbRocksEntry> predicate) {
+    this.predicate = predicate;
+  }
+
+  private void findNextAcceptedEntry() {
+    while (rocksIterator.isValid()) {
+      final ZbRocksEntry entry =
+          new ZbRocksEntry(rocksIterator.keyBuffer(), rocksIterator.valueBuffer());
+
+      if (predicate.test(entry)) {
+        break;
+      }
+
+      rocksIterator.next();
+    }
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/rocksdb/ZbRocksEntry.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/rocksdb/ZbRocksEntry.java
@@ -16,6 +16,7 @@
 package io.zeebe.logstreams.rocksdb;
 
 import java.util.Map.Entry;
+import java.util.Objects;
 import org.agrona.DirectBuffer;
 
 public class ZbRocksEntry implements Entry<DirectBuffer, DirectBuffer> {
@@ -24,13 +25,21 @@ public class ZbRocksEntry implements Entry<DirectBuffer, DirectBuffer> {
 
   public ZbRocksEntry() {}
 
+  public ZbRocksEntry(final ZbRocksEntry other) {
+    this(other.getKey(), other.getValue());
+  }
+
   public ZbRocksEntry(final DirectBuffer key, final DirectBuffer value) {
     wrap(key, value);
   }
 
+  public ZbRocksEntry wrap(final ZbRocksEntry entry) {
+    return wrap(entry.getKey(), entry.getValue());
+  }
+
   public ZbRocksEntry wrap(final DirectBuffer key, final DirectBuffer value) {
-    this.key = key;
-    this.value = value;
+    this.setKey(key);
+    this.setValue(value);
 
     return this;
   }
@@ -40,6 +49,12 @@ public class ZbRocksEntry implements Entry<DirectBuffer, DirectBuffer> {
     return key;
   }
 
+  public DirectBuffer setKey(DirectBuffer key) {
+    final DirectBuffer oldKey = this.key;
+    this.key = key;
+    return oldKey;
+  }
+
   @Override
   public DirectBuffer getValue() {
     return value;
@@ -47,7 +62,28 @@ public class ZbRocksEntry implements Entry<DirectBuffer, DirectBuffer> {
 
   @Override
   public DirectBuffer setValue(DirectBuffer value) {
+    final DirectBuffer oldValue = this.value;
     this.value = value;
-    return this.value;
+    return oldValue;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof ZbRocksEntry)) {
+      return false;
+    }
+
+    final ZbRocksEntry that = (ZbRocksEntry) o;
+
+    return Objects.equals(getKey(), that.getKey()) && Objects.equals(getValue(), that.getValue());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getKey(), getValue());
   }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/rocksdb/ZbSpliterator.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/rocksdb/ZbSpliterator.java
@@ -1,0 +1,66 @@
+package io.zeebe.logstreams.rocksdb;
+
+import java.util.List;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+/**
+ * Spliterator implementation that cannot actually be split (as there is no use at the moment for
+ * this).
+ *
+ * <p>Main reason to implement this is if you need for use with Stream API: >
+ * StreamSupport.stream(mySpliterator, false); // false ensures it is sequential
+ *
+ * <p>Until Java 9 migration, streams have no filtering short-circuiting functions (e.g. takeWhile),
+ * so it's recommended you use streams strictly if you're OK with iterating over the whole column
+ * family.
+ */
+public class ZbSpliterator extends AutoCloseableManager implements Spliterator<ZbRocksEntry> {
+  protected final ZbRocksIterator iterator;
+  protected final long estimateSize;
+
+  public ZbSpliterator(ZbRocksIterator iterator, long estimateSize) {
+    this.iterator = iterator;
+    this.estimateSize = estimateSize;
+  }
+
+  public ZbSpliterator(ZbRocksIterator iterator, long estimateSize, AutoCloseable... closeables) {
+    super(closeables);
+    this.iterator = iterator;
+    this.estimateSize = estimateSize;
+  }
+
+  public ZbSpliterator(
+      ZbRocksIterator iterator, long estimateSize, List<AutoCloseable> closeables) {
+    super(closeables);
+    this.iterator = iterator;
+    this.estimateSize = estimateSize;
+  }
+
+  @Override
+  public boolean tryAdvance(Consumer<? super ZbRocksEntry> action) {
+    if (!iterator.isValid()) {
+      return false;
+    }
+
+    action.accept(new ZbRocksEntry(iterator.keyBuffer(), iterator.valueBuffer()));
+    iterator.next();
+
+    return true;
+  }
+
+  @Override
+  public Spliterator<ZbRocksEntry> trySplit() {
+    return null;
+  }
+
+  @Override
+  public long estimateSize() {
+    return estimateSize;
+  }
+
+  @Override
+  public int characteristics() {
+    return Spliterator.ORDERED | Spliterator.IMMUTABLE | Spliterator.NONNULL;
+  }
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/rocksdb/ZbIteratorTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/rocksdb/ZbIteratorTest.java
@@ -1,0 +1,93 @@
+package io.zeebe.logstreams.rocksdb;
+
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.NoSuchElementException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.ColumnFamilyHandle;
+
+public class ZbIteratorTest {
+  private final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private final ZbRocksDbRule dbRule = new ZbRocksDbRule(temporaryFolder);
+
+  @Rule public final RuleChain ruleChain = RuleChain.outerRule(temporaryFolder).around(dbRule);
+
+  private ZbRocksDb db;
+  private ColumnFamilyHandle handle;
+
+  @Before
+  public void setup() {
+    db = dbRule.getDb();
+    handle = db.getDefaultColumnFamily();
+  }
+
+  @Test
+  public void shouldIterateOverAllEntries() {
+    // given
+    final ZbRocksEntry[] data =
+        new ZbRocksEntry[] {
+          new ZbRocksEntry(wrapString("1"), wrapString("1")),
+          new ZbRocksEntry(wrapString("2"), wrapString("2")),
+          new ZbRocksEntry(wrapString("3"), wrapString("3"))
+        };
+    final ZbRocksIterator wrappedIterator;
+    final ZbIterator iterator;
+
+    // when
+    dbRule.put(handle, data);
+    wrappedIterator = db.newIterator(handle);
+    iterator = new ZbIterator(wrappedIterator);
+    wrappedIterator.seekToFirst();
+
+    // then
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(data[0]);
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(data[1]);
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(data[2]);
+    assertThat(iterator.hasNext()).isFalse();
+    assertThatThrownBy(iterator::next).isInstanceOf(NoSuchElementException.class);
+  }
+
+  @Test
+  public void shouldBeControllableFromOutsideUsingWrappedIterator() {
+    // given
+    final ZbRocksEntry[] data =
+        new ZbRocksEntry[] {
+          new ZbRocksEntry(wrapString("1"), wrapString("1")),
+          new ZbRocksEntry(wrapString("2"), wrapString("2")),
+          new ZbRocksEntry(wrapString("3"), wrapString("3"))
+        };
+    final ZbRocksIterator wrappedIterator;
+    final ZbIterator iterator;
+
+    // when
+    dbRule.put(handle, data);
+    wrappedIterator = db.newIterator(handle);
+    iterator = new ZbIterator(wrappedIterator);
+
+    // then
+    assertThat(iterator.hasNext()).isFalse();
+
+    wrappedIterator.seek(data[1].getKey());
+    assertThat(iterator.next()).isEqualTo(data[1]);
+    assertThat(iterator.hasNext()).isTrue();
+
+    wrappedIterator.seekToFirst();
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(data[0]);
+    assertThat(iterator.hasNext()).isTrue();
+
+    wrappedIterator.seekToLast();
+    assertThat(iterator.hasNext()).isTrue();
+    assertThat(iterator.next()).isEqualTo(data[2]);
+    assertThat(iterator.hasNext()).isFalse();
+  }
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/rocksdb/ZbRocksDbRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/rocksdb/ZbRocksDbRule.java
@@ -1,0 +1,69 @@
+package io.zeebe.logstreams.rocksdb;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.WriteOptions;
+
+/**
+ * Sets up and tears down a ZbRocksDb instance for a test.
+ *
+ * <p>Suggested to add useful debugging/testing methods here.
+ */
+public class ZbRocksDbRule extends ExternalResource {
+  private final TemporaryFolder temporaryFolder;
+
+  private Options options;
+  private ZbRocksDb db;
+
+  public ZbRocksDbRule(final TemporaryFolder temporaryFolder) {
+    this.temporaryFolder = temporaryFolder;
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    super.before();
+    final String dbDirectory = temporaryFolder.newFolder().getAbsolutePath();
+    options = new Options().setCreateIfMissing(true);
+    db = ZbRocksDb.open(options, dbDirectory);
+  }
+
+  @Override
+  protected void after() {
+    super.after();
+    if (db != null) {
+      db.close();
+    }
+    if (options != null) {
+      options.close();
+    }
+  }
+
+  public ZbRocksDb getDb() {
+    return db;
+  }
+
+  public List<ZbRocksEntry> list(final ColumnFamilyHandle handle) {
+    final List<ZbRocksEntry> entries = new ArrayList<>();
+    db.forEach(handle, (e) -> entries.add(new ZbRocksEntry(e)));
+
+    return entries;
+  }
+
+  public void put(final ColumnFamilyHandle handle, ZbRocksEntry... entries) {
+    try (final WriteOptions options = new WriteOptions();
+        final ZbWriteBatch batch = new ZbWriteBatch()) {
+      for (ZbRocksEntry entry : entries) {
+        batch.put(handle, entry.getKey(), entry.getValue());
+      }
+
+      db.write(options, batch);
+    } catch (final RocksDBException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/rocksdb/ZbSpliteratorTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/rocksdb/ZbSpliteratorTest.java
@@ -1,0 +1,87 @@
+package io.zeebe.logstreams.rocksdb;
+
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.ColumnFamilyHandle;
+
+public class ZbSpliteratorTest {
+  private final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private final ZbRocksDbRule dbRule = new ZbRocksDbRule(temporaryFolder);
+
+  @Rule public final RuleChain ruleChain = RuleChain.outerRule(temporaryFolder).around(dbRule);
+
+  private ZbRocksDb db;
+  private ColumnFamilyHandle handle;
+
+  @Before
+  public void setup() {
+    db = dbRule.getDb();
+    handle = db.getDefaultColumnFamily();
+  }
+
+  @Test
+  public void shouldIterateOverAllEntries() {
+    // given
+    final ZbRocksEntry[] data =
+        new ZbRocksEntry[] {
+          new ZbRocksEntry(wrapString("1"), wrapString("1")),
+          new ZbRocksEntry(wrapString("2"), wrapString("2")),
+          new ZbRocksEntry(wrapString("3"), wrapString("3"))
+        };
+    final ZbRocksIterator wrappedIterator;
+    final ZbSpliterator spliterator;
+    final ZbRocksEntry entry = new ZbRocksEntry();
+
+    // when
+    dbRule.put(handle, data);
+    wrappedIterator = db.newIterator(handle);
+    spliterator = new ZbSpliterator(wrappedIterator, 3);
+    wrappedIterator.seekToFirst();
+
+    // then
+    assertThat(spliterator.tryAdvance(entry::wrap)).isTrue();
+    assertThat(entry).isEqualTo(data[0]);
+    assertThat(spliterator.tryAdvance(entry::wrap)).isTrue();
+    assertThat(entry).isEqualTo(data[1]);
+    assertThat(spliterator.tryAdvance(entry::wrap)).isTrue();
+    assertThat(entry).isEqualTo(data[2]);
+    assertThat(spliterator.tryAdvance(entry::wrap)).isFalse();
+    assertThat(entry).isEqualTo(data[2]);
+  }
+
+  @Test
+  public void shouldNeverSplit() {
+    // given
+    final ZbRocksEntry[] data =
+      new ZbRocksEntry[] {
+        new ZbRocksEntry(wrapString("1"), wrapString("1")),
+        new ZbRocksEntry(wrapString("2"), wrapString("2")),
+        new ZbRocksEntry(wrapString("3"), wrapString("3"))
+      };
+    final ZbRocksIterator wrappedIterator;
+    final ZbSpliterator spliterator;
+    final ZbRocksEntry entry = new ZbRocksEntry();
+
+    // when
+    dbRule.put(handle, data);
+    wrappedIterator = db.newIterator(handle);
+    spliterator = new ZbSpliterator(wrappedIterator, 3);
+    wrappedIterator.seekToFirst();
+
+    // then
+    assertThat(spliterator.tryAdvance(entry::wrap)).isTrue();
+    assertThat(spliterator.trySplit()).isNull();
+    assertThat(spliterator.tryAdvance(entry::wrap)).isTrue();
+    assertThat(spliterator.trySplit()).isNull();
+    assertThat(spliterator.tryAdvance(entry::wrap)).isTrue();
+    assertThat(spliterator.trySplit()).isNull();
+    assertThat(spliterator.tryAdvance(entry::wrap)).isFalse();
+    assertThat(spliterator.trySplit()).isNull();
+  }
+}


### PR DESCRIPTION
This is more of a RFC regarding some "improvements" to RocksDB, namely adding implementations for `Iterator`, `Iterable`, and some basic stream support (which isn't super useful until something like `takeWhile/dropWhile` is implemented). I personally preferred having the option to use `Iterable` to control loops over passing around a control object, or using something like `whileTrue`, but that's personal preference.

Nothing here is necessarily going to make it to production, it's more of me fiddling around with possibilities.

This isn't really meant to be merged, it's just the PR UI allows you to get a nice overview of changes, and I just wanted some comments on them. It'll be easier to check changes vs commits, since the commits, well, mean nothing...

Side note, it might make sense eventually to have a rocksdb module somewhere. It's kind of weird having all of this in logstreams.