### PR TITLE
fix(broker): move standalone broker into dist

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Distribution</name>
   <artifactId>zeebe-distribution</artifactId>
-  <packaging>pom</packaging>
+  <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>

--- a/dist/src/main/java/io/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/zeebe/broker/StandaloneBroker.java
@@ -1,19 +1,17 @@
 /*
- * Zeebe Broker Core
  * Copyright © 2017 camunda services GmbH (info@camunda.com)
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.zeebe.broker;
 
@@ -24,12 +22,14 @@ import io.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Scanner;
+import java.util.concurrent.CountDownLatch;
 
 public class StandaloneBroker {
   private static String tempFolder;
 
-  public static void main(final String[] args) {
+  private static final CountDownLatch WAITING_LATCH = new CountDownLatch(1);
+
+  public static void main(final String[] args) throws Exception {
     final Broker broker;
 
     if (args.length == 1) {
@@ -52,20 +52,7 @@ public class StandaloneBroker {
                 }
               }
             });
-
-    try (final Scanner scanner = new Scanner(System.in)) {
-      while (scanner.hasNextLine()) {
-        final String nextLine = scanner.nextLine();
-        if (nextLine.contains("exit")
-            || nextLine.contains("close")
-            || nextLine.contains("quit")
-            || nextLine.contains("halt")
-            || nextLine.contains("shutdown")
-            || nextLine.contains("stop")) {
-          System.exit(0);
-        }
-      }
-    }
+    WAITING_LATCH.await();
   }
 
   private static Broker startBrokerFromConfiguration(final String[] args) {


### PR DESCRIPTION
 * moved standalone broker to dist, since we need dependencies like log4j or msgpack to run it correctly
 * useful for testing and debugging
 * use an latch to park the main thread instead of running in a while loop

closes #1480 
