### PR TITLE
chore(broker): fix unstable test

### DIFF
--- a/broker-core/src/test/java/io/zeebe/broker/workflow/gateway/ParallelGatewayStreamProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/gateway/ParallelGatewayStreamProcessorTest.java
@@ -94,11 +94,10 @@ public class ParallelGatewayStreamProcessorTest {
         "flowToJoin", WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN);
 
     // when
-    streamProcessorRule.completeFirstJob();
-
     // waiting until the end event has been reached
     streamProcessor.blockAfterWorkflowInstanceRecord(
         r -> r.getMetadata().getIntent() == WorkflowInstanceIntent.END_EVENT_OCCURRED);
+    streamProcessorRule.completeFirstJob();
 
     waitUntil(() -> streamProcessor.isBlocked());
 


### PR DESCRIPTION
- avoids race condition between job completion and waiting for
  a record

closes #1340 
