### PR TITLE
fix(broker-core): fix persistence cache

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/workflow/state/PersistedInt.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/state/PersistedInt.java
@@ -1,0 +1,49 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow.state;
+
+import static io.zeebe.logstreams.rocksdb.ZeebeStateConstants.STATE_BYTE_ORDER;
+
+import io.zeebe.util.buffer.BufferReader;
+import io.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class PersistedInt implements BufferWriter, BufferReader {
+
+  private int value;
+
+  public int getValue() {
+    return value;
+  }
+
+  @Override
+  public void wrap(DirectBuffer buffer, int offset, int length) {
+    value = buffer.getInt(offset, STATE_BYTE_ORDER);
+  }
+
+  @Override
+  public int getLength() {
+    return Integer.BYTES;
+  }
+
+  @Override
+  public void write(MutableDirectBuffer buffer, int offset) {
+    buffer.putInt(offset, value, STATE_BYTE_ORDER);
+  }
+}


### PR DESCRIPTION
Fixes the persistence cache and stores in the latest column family only the version instead of the whole resource. 

This fixes allows to use the cache more properly for latest versions, instead of transforming the resource every time the latest version is requested. This means it will check if the version, which is stored in the DB, is already in the cache. If so it will be returned, otherwise the deployment is requested from rocksdb and transformed and put to the cache for later use.

Heap and cpu usage looks much better then before.

![fixed-cpu](https://user-images.githubusercontent.com/2758593/46932737-4ac2aa00-d051-11e8-86fe-fc0aaca30d03.png)
![fixed-heap](https://user-images.githubusercontent.com/2758593/46932738-4ac2aa00-d051-11e8-95a7-9e0cae23f43a.png)
[fixed.zip](https://github.com/zeebe-io/zeebe/files/2477561/fixed.zip)




closes #1505 
