### PR TITLE
chore(dist): skip zbctl build by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             steps {
                 withMaven(jdk: jdkVersion, maven: mavenVersion, mavenSettingsConfig: mavenSettingsConfig) {
                     sh setupGoPath()
-                    sh 'mvn -B -T 1C clean com.mycila:license-maven-plugin:check com.coveo:fmt-maven-plugin:check install -DskipTests'
+                    sh 'mvn -B -T 1C clean com.mycila:license-maven-plugin:check com.coveo:fmt-maven-plugin:check install -DskipTests -Dskip-zbctl=false'
                 }
 
                 stash name: "zeebe-dist", includes: "dist/target/zeebe-broker/**/*"

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Distribution</name>
@@ -11,6 +13,10 @@
     <version>0.13.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
+
+  <properties>
+    <skip-zbctl>true</skip-zbctl>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -86,12 +92,20 @@
             </goals>
             <configuration>
               <target>
-                <exec executable="${maven.multiModuleProjectDirectory}/clients/zbctl/build.sh" osfamily="unix" />
-                <copy file="${maven.multiModuleProjectDirectory}/clients/zbctl/dist/zbctl" tofile="${project.build.directory}/zeebe-broker/bin/zbctl" failonerror="false" />
-                <copy file="${maven.multiModuleProjectDirectory}/clients/zbctl/dist/zbctl.exe" tofile="${project.build.directory}/zeebe-broker/bin/zbctl.exe" failonerror="false" />
-                <copy file="${maven.multiModuleProjectDirectory}/clients/zbctl/dist/zbctl.darwin" tofile="${project.build.directory}/zeebe-broker/bin/zbctl.darwin" failonerror="false" />
-                <chmod dir="${project.build.directory}/zeebe-broker/bin" perm="ugo+rx" includes="zbctl*" />
+                <exec executable="${maven.multiModuleProjectDirectory}/clients/zbctl/build.sh"
+                  osfamily="unix"/>
+                <copy file="${maven.multiModuleProjectDirectory}/clients/zbctl/dist/zbctl"
+                  tofile="${project.build.directory}/zeebe-broker/bin/zbctl" failonerror="false"/>
+                <copy file="${maven.multiModuleProjectDirectory}/clients/zbctl/dist/zbctl.exe"
+                  tofile="${project.build.directory}/zeebe-broker/bin/zbctl.exe"
+                  failonerror="false"/>
+                <copy file="${maven.multiModuleProjectDirectory}/clients/zbctl/dist/zbctl.darwin"
+                  tofile="${project.build.directory}/zeebe-broker/bin/zbctl.darwin"
+                  failonerror="false"/>
+                <chmod dir="${project.build.directory}/zeebe-broker/bin" perm="ugo+rx"
+                  includes="zbctl*"/>
               </target>
+              <skip>${skip-zbctl}</skip>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
- add property skip-zbctl to control build of zbctl during distro packaging
- do not build zbctl locally
- build zbctl on Jenkins

