### PR TITLE
chore(broker-core): create incident if correlation-key extraction fails

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/incident/data/ErrorType.java
+++ b/broker-core/src/main/java/io/zeebe/broker/incident/data/ErrorType.java
@@ -25,4 +25,6 @@ public enum ErrorType {
   JOB_NO_RETRIES,
 
   CONDITION_ERROR,
+
+  EXTRACT_VALUE_ERROR
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepHandlers.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepHandlers.java
@@ -23,12 +23,12 @@ import io.zeebe.broker.workflow.model.element.ExecutableFlowElement;
 import io.zeebe.broker.workflow.processor.activity.InputMappingHandler;
 import io.zeebe.broker.workflow.processor.activity.OutputMappingHandler;
 import io.zeebe.broker.workflow.processor.activity.PropagateTerminationHandler;
-import io.zeebe.broker.workflow.processor.catchevent.SubscribeMessageHandler;
 import io.zeebe.broker.workflow.processor.flownode.ConsumeTokenHandler;
 import io.zeebe.broker.workflow.processor.flownode.TakeSequenceFlowHandler;
 import io.zeebe.broker.workflow.processor.flownode.TerminateElementHandler;
 import io.zeebe.broker.workflow.processor.gateway.ExclusiveSplitHandler;
 import io.zeebe.broker.workflow.processor.gateway.ParallelSplitHandler;
+import io.zeebe.broker.workflow.processor.message.MessageCatchElementHandler;
 import io.zeebe.broker.workflow.processor.process.CompleteProcessHandler;
 import io.zeebe.broker.workflow.processor.sequenceflow.ActivateGatewayHandler;
 import io.zeebe.broker.workflow.processor.sequenceflow.ParallelMergeHandler;
@@ -91,7 +91,7 @@ public class BpmnStepHandlers {
     // intermediate catch event
     stepHandlers.put(
         BpmnStep.SUBSCRIBE_TO_INTERMEDIATE_MESSAGE,
-        new SubscribeMessageHandler(subscriptionCommandSender, workflowState));
+        new MessageCatchElementHandler(subscriptionCommandSender, workflowState));
     stepHandlers.put(BpmnStep.CREATE_TIMER, new CreateTimerHandler());
 
     // process

--- a/broker-core/src/test/java/io/zeebe/broker/incident/MessageIncidentTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/incident/MessageIncidentTest.java
@@ -1,0 +1,138 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.incident.data.ErrorType;
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.exporter.record.Assertions;
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.record.value.IncidentRecordValue;
+import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.intent.IncidentIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceSubscriptionIntent;
+import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
+import io.zeebe.test.broker.protocol.clientapi.PartitionTestClient;
+import io.zeebe.test.util.MsgPackUtil;
+import io.zeebe.test.util.record.RecordingExporter;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class MessageIncidentTest {
+
+  private static final String PROCESS_ID = "process";
+
+  private static final BpmnModelInstance WORKFLOW =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .intermediateCatchEvent(
+              "catch", e -> e.message(m -> m.name("cancel").zeebeCorrelationKey("$.orderId")))
+          .done();
+
+  public EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule();
+  public ClientApiRule apiRule = new ClientApiRule(brokerRule::getClientAddress);
+
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(apiRule);
+
+  private PartitionTestClient testClient;
+
+  @Before
+  public void init() {
+    testClient = apiRule.partitionClient();
+    apiRule.waitForPartition(1);
+
+    // given
+    testClient.deploy(WORKFLOW);
+  }
+
+  @Test
+  public void shouldCreateIncidentIfCorrelationKeyNotFound() {
+    // when
+    final long workflowInstanceKey = testClient.createWorkflowInstance(PROCESS_ID);
+
+    final Record<WorkflowInstanceRecordValue> failureEvent =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .withActivityId("catch")
+            .getFirst();
+
+    // then
+    final Record<IncidentRecordValue> incidentRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED).getFirst();
+
+    Assertions.assertThat(incidentRecord.getValue())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR.name())
+        .hasErrorMessage("Failed to extract the correlation-key by '$.orderId': no value found")
+        .hasBpmnProcessId(PROCESS_ID)
+        .hasWorkflowInstanceKey(workflowInstanceKey)
+        .hasActivityId("catch")
+        .hasActivityInstanceKey(failureEvent.getKey())
+        .hasJobKey(-1L);
+  }
+
+  @Test
+  public void shouldCreateIncidentIfCorrelationKeyOfInvalidType() {
+    // when
+    final long workflowInstanceKey =
+        testClient.createWorkflowInstance(PROCESS_ID, MsgPackUtil.asMsgPack("orderId", true));
+
+    final Record<WorkflowInstanceRecordValue> failureEvent =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .withActivityId("catch")
+            .getFirst();
+
+    // then
+    final Record<IncidentRecordValue> incidentRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED).getFirst();
+
+    Assertions.assertThat(incidentRecord.getValue())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR.name())
+        .hasErrorMessage(
+            "Failed to extract the correlation-key by '$.orderId': the value must be either a string or a number")
+        .hasBpmnProcessId(PROCESS_ID)
+        .hasWorkflowInstanceKey(workflowInstanceKey)
+        .hasActivityId("catch")
+        .hasActivityInstanceKey(failureEvent.getKey())
+        .hasJobKey(-1L);
+  }
+
+  @Test
+  public void shouldResolveIncidentIfCorrelationKeyNotFound() {
+    // when
+    testClient.createWorkflowInstance(PROCESS_ID);
+
+    final Record<IncidentRecordValue> incidentCreatedRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED).getFirst();
+
+    testClient.updatePayload(
+        incidentCreatedRecord.getValue().getActivityInstanceKey(), "{\"orderId\":\"order123\"}");
+
+    // then
+    assertThat(
+        RecordingExporter.workflowInstanceSubscriptionRecords(
+                WorkflowInstanceSubscriptionIntent.OPENED)
+            .exists());
+
+    // note that the incident itself is not resolved
+  }
+}


### PR DESCRIPTION
* create an incident when a message catch event is entered and the
correlation-key can't be extracted because it doesn't exist or has an
invalid type
* resolve the incident by updating the payload

closes #1018 
