### PR TITLE
chore(exporters/elasticsearch): set number of shards and replicas in all templates

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -3,6 +3,10 @@
     "zeebe-record-deployment_*"
   ],
   "order": 20,
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
   "mappings": {
     "_doc": {
       "properties": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
@@ -3,6 +3,10 @@
     "zeebe-record-incident_*"
   ],
   "order": 20,
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
   "mappings": {
     "_doc": {
       "properties": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -3,6 +3,10 @@
     "zeebe-record-job-batch_*"
   ],
   "order": 20,
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
   "mappings": {
     "_doc": {
       "properties": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -3,6 +3,10 @@
     "zeebe-record-job_*"
   ],
   "order": 20,
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
   "mappings": {
     "_doc": {
       "properties": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -3,6 +3,10 @@
     "zeebe-record-message-subscription_*"
   ],
   "order": 30,
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
   "mappings": {
     "_doc": {
       "properties": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
@@ -3,6 +3,10 @@
     "zeebe-record-message_*"
   ],
   "order": 20,
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
   "mappings": {
     "_doc": {
       "properties": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-raft-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-raft-template.json
@@ -3,6 +3,10 @@
     "zeebe-record-raft_*"
   ],
   "order": 20,
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
   "mappings": {
     "_doc": {
       "properties": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -5,7 +5,7 @@
   "order": 10,
   "settings": {
     "number_of_shards": 1,
-    "number_of_replicas": 1
+    "number_of_replicas": 0
   },
   "mappings": {
     "_doc": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-subscription-template.json
@@ -3,6 +3,10 @@
     "zeebe-record-workflow-instance-subscription_*"
   ],
   "order": 30,
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
   "mappings": {
     "_doc": {
       "properties": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-template.json
@@ -3,6 +3,10 @@
     "zeebe-record-workflow-instance_*"
   ],
   "order": 20,
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
   "mappings": {
     "_doc": {
       "properties": {


### PR DESCRIPTION
- it seems that elasticsearch is not merging the settings number_of_shards and
number_of_replicas during index creation from multiple templates
- set number_of_shards and number_of_replicas in all index templates
- set number_of_shards to 1
- set number_of_replicas to 0 as this can be later changed
- add tests to verify index settings

