### PR TITLE
fix(exporters/elasticsearch): use correct index delimiter in root template

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
@@ -114,11 +114,12 @@ public class ElasticsearchClient {
   public boolean putIndexTemplate(final ValueType valueType) {
     final String templateName = indexPrefixForValueType(valueType);
     final String filename = indexTemplateForValueType(valueType);
-    return putIndexTemplate(templateName, filename);
+    return putIndexTemplate(templateName, filename, INDEX_DELIMITER);
   }
 
   /** @return true if request was acknowledged */
-  public boolean putIndexTemplate(final String templateName, final String filename) {
+  public boolean putIndexTemplate(
+      final String templateName, final String filename, final String indexDelimiter) {
     final Map<String, Object> template;
     try (InputStream inputStream = ElasticsearchExporter.class.getResourceAsStream(filename)) {
       if (inputStream != null) {
@@ -133,7 +134,7 @@ public class ElasticsearchClient {
     }
 
     // update prefix in template in case it was changed in configuration
-    template.put("index_patterns", Collections.singletonList(templateName + INDEX_DELIMITER + "*"));
+    template.put("index_patterns", Collections.singletonList(templateName + indexDelimiter + "*"));
 
     // update alias in template in case it was changed in configuration
     template.put("aliases", Collections.singletonMap(templateName, Collections.EMPTY_MAP));

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
@@ -139,7 +139,7 @@ public class ElasticsearchExporter implements Exporter {
   private void createRootIndexTemplate() {
     final String templateName = configuration.index.prefix;
     final String filename = ZEEBE_RECORD_TEMPLATE_JSON;
-    if (!client.putIndexTemplate(templateName, filename)) {
+    if (!client.putIndexTemplate(templateName, filename, "-")) {
       log.warn("Put index template {} from file {} was not acknowledged", templateName, filename);
     }
   }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -3,6 +3,9 @@
     "zeebe-record-deployment_*"
   ],
   "order": 20,
+  "aliases": {
+    "zeebe-record-deployment": {}
+  },
   "mappings": {
     "_doc": {
       "properties": {
@@ -42,8 +45,5 @@
         }
       }
     }
-  },
-  "aliases": {
-    "zeebe-record-deployment": {}
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
@@ -3,6 +3,9 @@
     "zeebe-record-incident_*"
   ],
   "order": 20,
+  "aliases": {
+    "zeebe-record-incident": {}
+  },
   "mappings": {
     "_doc": {
       "properties": {
@@ -37,8 +40,5 @@
         }
       }
     }
-  },
-  "aliases": {
-    "zeebe-record-incident": {}
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -3,6 +3,9 @@
     "zeebe-record-job-batch_*"
   ],
   "order": 20,
+  "aliases": {
+    "zeebe-record-job-batch": {}
+  },
   "mappings": {
     "_doc": {
       "properties": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -3,6 +3,9 @@
     "zeebe-record-job_*"
   ],
   "order": 20,
+  "aliases": {
+    "zeebe-record-job": {}
+  },
   "mappings": {
     "_doc": {
       "properties": {
@@ -54,8 +57,5 @@
         }
       }
     }
-  },
-  "aliases": {
-    "zeebe-record-job": {}
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -2,7 +2,10 @@
   "index_patterns": [
     "zeebe-record-message-subscription_*"
   ],
-  "order": 30,
+  "order": 20,
+  "aliases": {
+    "zeebe-record-message-subscription": {}
+  },
   "mappings": {
     "_doc": {
       "properties": {
@@ -28,8 +31,5 @@
         }
       }
     }
-  },
-  "aliases": {
-    "zeebe-record-message-subscription": {}
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
@@ -3,6 +3,9 @@
     "zeebe-record-message_*"
   ],
   "order": 20,
+  "aliases": {
+    "zeebe-record-message": {}
+  },
   "mappings": {
     "_doc": {
       "properties": {
@@ -28,8 +31,5 @@
         }
       }
     }
-  },
-  "aliases": {
-    "zeebe-record-message": {}
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-raft-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-raft-template.json
@@ -3,6 +3,9 @@
     "zeebe-record-raft_*"
   ],
   "order": 20,
+  "aliases": {
+    "zeebe-record-raft": {}
+  },
   "mappings": {
     "_doc": {
       "properties": {
@@ -20,8 +23,5 @@
         }
       }
     }
-  },
-  "aliases": {
-    "zeebe-record-raft": {}
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -5,7 +5,10 @@
   "order": 10,
   "settings": {
     "number_of_shards": 1,
-    "number_of_replicas": 1
+    "number_of_replicas": 0
+  },
+  "aliases": {
+    "zeebe-record": {}
   },
   "mappings": {
     "_doc": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-subscription-template.json
@@ -2,7 +2,10 @@
   "index_patterns": [
     "zeebe-record-workflow-instance-subscription_*"
   ],
-  "order": 30,
+  "order": 20,
+  "aliases": {
+    "zeebe-record-workflow-instance-subscription": {}
+  },
   "mappings": {
     "_doc": {
       "properties": {
@@ -25,8 +28,5 @@
         }
       }
     }
-  },
-  "aliases": {
-    "zeebe-record-workflow-instance-subscription": {}
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-template.json
@@ -3,6 +3,9 @@
     "zeebe-record-workflow-instance_*"
   ],
   "order": 20,
+  "aliases": {
+    "zeebe-record-workflow-instance": {}
+  },
   "mappings": {
     "_doc": {
       "properties": {
@@ -34,8 +37,5 @@
         }
       }
     }
-  },
-  "aliases": {
-    "zeebe-record-workflow-instance": {}
   }
 }

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
@@ -70,7 +70,7 @@ public class ElasticsearchExporterTest {
     createExporter(config);
 
     // then
-    verify(esClient).putIndexTemplate("foo-bar", ZEEBE_RECORD_TEMPLATE_JSON);
+    verify(esClient).putIndexTemplate("foo-bar", ZEEBE_RECORD_TEMPLATE_JSON, "-");
 
     verify(esClient).putIndexTemplate(ValueType.DEPLOYMENT);
     verify(esClient).putIndexTemplate(ValueType.INCIDENT);
@@ -318,7 +318,7 @@ public class ElasticsearchExporterTest {
     final ElasticsearchClient client = mock(ElasticsearchClient.class);
     when(client.flush()).thenReturn(true);
     when(client.putIndexTemplate(any(ValueType.class))).thenReturn(true);
-    when(client.putIndexTemplate(anyString(), anyString())).thenReturn(true);
+    when(client.putIndexTemplate(anyString(), anyString(), anyString())).thenReturn(true);
     return client;
   }
 


### PR DESCRIPTION
- the root template should use the index delimiter `-` to allow other templates to be merged
- index templates of higher order should use the `_` delimiter to prevent merging, i.e. message vs message-subscription


closes #1566
