### PR TITLE
fix(broker-core): correlate a message only once per wf instance

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageTimeToLiveChecker.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageTimeToLiveChecker.java
@@ -39,7 +39,7 @@ public class MessageTimeToLiveChecker implements Runnable {
 
   @Override
   public void run() {
-    messageStateController.findMessagesWithDeadlineBefore(
+    messageStateController.visitMessagesWithDeadlineBefore(
         ActorClock.currentTimeMillis(), this::writeDeleteMessageCommand);
   }
 

--- a/broker-core/src/test/java/io/zeebe/broker/subscription/message/state/MessageStateControllerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/subscription/message/state/MessageStateControllerTest.java
@@ -135,7 +135,24 @@ public class MessageStateControllerTest {
   }
 
   @Test
-  public void shouldFindFirstMessage() {
+  public void shouldVisitMessages() {
+    // given
+    final Message message = createMessage(1L, "name", "correlationKey");
+    stateController.put(message);
+
+    // when
+    final List<Message> messages = new ArrayList<Message>();
+    stateController.visitMessages(wrapString("name"), wrapString("correlationKey"), messages::add);
+
+    // then
+    assertThat(messages).hasSize(1);
+    assertThat(messages.get(0).getKey()).isEqualTo(message.getKey());
+    assertThat(messages.get(0).getName()).isEqualTo(message.getName());
+    assertThat(messages.get(0).getCorrelationKey()).isEqualTo(message.getCorrelationKey());
+  }
+
+  @Test
+  public void shouldVisitMessagesInOrder() {
     // given
     final Message message = createMessage(1L, "name", "correlationKey");
     stateController.put(message);
@@ -144,49 +161,72 @@ public class MessageStateControllerTest {
     stateController.put(message2);
 
     // when
-    final Message readMessage =
-        stateController.findFirstMessage(wrapString("name"), wrapString("correlationKey"));
+    final List<Long> keys = new ArrayList<>();
+    stateController.visitMessages(
+        wrapString("name"), wrapString("correlationKey"), m -> keys.add(m.getKey()));
 
     // then
-    assertThat(readMessage).isNotNull();
-    assertThat(readMessage.getKey()).isEqualTo(message.getKey());
-    assertThat(readMessage.getName()).isEqualTo(message.getName());
-    assertThat(readMessage.getCorrelationKey()).isEqualTo(message.getCorrelationKey());
+    assertThat(keys).hasSize(2).containsExactly(1L, 2L);
   }
 
   @Test
-  public void shouldNotFindMessageIfNameDoesntMatch() {
+  public void shouldVisitMessagesUntilStop() {
+    // given
+    final Message message = createMessage(1L, "name", "correlationKey");
+    stateController.put(message);
+
+    final Message message2 = createMessage(2L, "name", "correlationKey");
+    stateController.put(message2);
+
+    // when
+    final List<Long> keys = new ArrayList<>();
+    stateController.visitMessages(
+        wrapString("name"),
+        wrapString("correlationKey"),
+        m -> {
+          keys.add(m.getKey());
+          return false;
+        });
+
+    // then
+    assertThat(keys).hasSize(1).contains(1L);
+  }
+
+  @Test
+  public void shouldNotVisitMessagesIfNameDoesntMatch() {
     // given
     final Message message = createMessage(1L, "name", "correlationKey");
     stateController.put(message);
 
     // when
-    final Message readMessage =
-        stateController.findFirstMessage(wrapString("otherName"), wrapString("correlationKey"));
+    final List<Long> keys = new ArrayList<>();
+    stateController.visitMessages(
+        wrapString("otherName"), wrapString("correlationKey"), m -> keys.add(m.getKey()));
 
     // then
-    assertThat(readMessage).isNull();
+    assertThat(keys).isEmpty();
   }
 
   @Test
-  public void shouldNotFindMessageIfCorrelationKeyDoesntMatch() {
+  public void shouldNotVisitMessageIfCorrelationKeyDoesntMatch() {
     // given
     final Message message = createMessage(1L, "name", "correlationKey");
     stateController.put(message);
 
     // when
-    final Message readMessage =
-        stateController.findFirstMessage(wrapString("name"), wrapString("otherCorrelationKey"));
+    final List<Long> keys = new ArrayList<>();
+    stateController.visitMessages(
+        wrapString("name"), wrapString("otherCorrelationKey"), m -> keys.add(m.getKey()));
 
     // then
-    assertThat(readMessage).isNull();
+    assertThat(keys).isEmpty();
   }
 
   @Test
   public void shouldFindSubscription() {
     // given
     final MessageSubscription subscription =
-        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 1, 2, 1234);
+        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 1, 2, 0);
     stateController.put(subscription);
 
     // when
@@ -204,11 +244,11 @@ public class MessageStateControllerTest {
   public void shouldFindMoreSubscriptions() {
     // given
     final MessageSubscription subscription =
-        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 1, 2, 1234);
+        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 1, 2, 0);
     final MessageSubscription subscription2 =
-        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 2, 3, 1234);
+        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 2, 3, 0);
     final MessageSubscription subscription3 =
-        new MessageSubscription("otherName", "correlationKey", "{\"foo\":\"bar\"}", 3, 4, 1234);
+        new MessageSubscription("otherName", "correlationKey", "{\"foo\":\"bar\"}", 3, 4, 0);
     stateController.put(subscription);
     stateController.put(subscription2);
     stateController.put(subscription3);
@@ -221,23 +261,23 @@ public class MessageStateControllerTest {
     assertThat(readSubscriptions.size()).isEqualTo(2);
 
     MessageSubscription readSubscription = readSubscriptions.get(0);
-    assertSubscription(subscription, readSubscription, 1234, 1, 2);
+    assertSubscription(subscription, readSubscription, 0, 1, 2);
     readSubscription = readSubscriptions.get(1);
-    assertSubscription(subscription2, readSubscription, 1234, 2, 3);
+    assertSubscription(subscription2, readSubscription, 0, 2, 3);
 
     // and
     final List<MessageSubscription> otherSubscriptions =
         stateController.findSubscriptions(wrapString("otherName"), wrapString("correlationKey"));
 
     assertThat(otherSubscriptions.size()).isEqualTo(1);
-    assertSubscription(subscription3, otherSubscriptions.get(0), 1234, 3, 4);
+    assertSubscription(subscription3, otherSubscriptions.get(0), 0, 3, 4);
   }
 
   @Test
   public void shouldFindSubscriptionWithMessageStored() {
     // given
     final MessageSubscription subscription =
-        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 1, 2, 1234);
+        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 1, 2, 0);
     final Message message = createMessage(1L, "name", "correlationKey");
 
     stateController.put(message);
@@ -254,9 +294,28 @@ public class MessageStateControllerTest {
     assertSubscription(subscription, readSubscription);
   }
 
+  @Test
+  public void shouldFindOnlySubscriptionsWithoutSendTime() {
+    // given
+    final MessageSubscription subscription =
+        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 1, 2, 1234);
+    final MessageSubscription subscription2 =
+        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 3, 4, 0);
+    stateController.put(subscription);
+    stateController.put(subscription2);
+
+    // when
+    final List<MessageSubscription> readSubscriptions =
+        stateController.findSubscriptions(wrapString("messageName"), wrapString("correlationKey"));
+
+    // then
+    assertThat(readSubscriptions.size()).isEqualTo(1);
+    assertThat(readSubscriptions.get(0).getWorkflowInstanceKey()).isEqualTo(3);
+  }
+
   private void assertSubscription(
       MessageSubscription subscription, MessageSubscription readSubscription) {
-    assertSubscription(subscription, readSubscription, 1234, 1, 2);
+    assertSubscription(subscription, readSubscription, 0, 1, 2);
   }
 
   private void assertSubscription(
@@ -275,7 +334,7 @@ public class MessageStateControllerTest {
   }
 
   @Test
-  public void shouldNotFindMessageBeforeTime() {
+  public void shouldNotVisitMessagesBeforeTime() {
     // given
     final Message message = createMessage(1L, "name", "correlationKey", "{}", "nr1", 1234);
     final Message message2 = createMessage(2L, "name", "correlationKey", "{}", "nr2", 4567);
@@ -285,7 +344,7 @@ public class MessageStateControllerTest {
 
     // then
     final List<Message> readMessage = new ArrayList<>();
-    stateController.findMessagesWithDeadlineBefore(1_000, readMessage::add);
+    stateController.visitMessagesWithDeadlineBefore(1_000, readMessage::add);
 
     assertThat(readMessage).isEmpty();
   }
@@ -313,7 +372,7 @@ public class MessageStateControllerTest {
   }
 
   @Test
-  public void shouldFindMessageBeforeTime() {
+  public void shouldVisitMessagesBeforeTime() {
     // given
     final Message message = createMessage(1L, "name", "correlationKey", "{}", "nr1", 1234);
     final Message message2 = createMessage(2L, "otherName", "correlationKey", "{}", "nr2", 2000);
@@ -323,14 +382,14 @@ public class MessageStateControllerTest {
 
     // then
     final List<Message> readMessage = new ArrayList<>();
-    stateController.findMessagesWithDeadlineBefore(1_999, readMessage::add);
+    stateController.visitMessagesWithDeadlineBefore(1_999, readMessage::add);
 
     assertThat(readMessage.size()).isEqualTo(1);
     assertThat(readMessage.get(0).getKey()).isEqualTo(1L);
   }
 
   @Test
-  public void shouldFindMessageBeforeTimeInOrder() {
+  public void shouldVisitMessagesBeforeTimeInOrder() {
     // given
     final long now = ActorClock.currentTimeMillis();
 
@@ -345,7 +404,7 @@ public class MessageStateControllerTest {
 
     // then
     final List<Long> readMessage = new ArrayList<>();
-    stateController.findMessagesWithDeadlineBefore(deadline, m -> readMessage.add(m.getKey()));
+    stateController.visitMessagesWithDeadlineBefore(deadline, m -> readMessage.add(m.getKey()));
 
     assertThat(readMessage.size()).isEqualTo(2);
     assertThat(readMessage).containsExactly(1L, 2L);
@@ -409,25 +468,34 @@ public class MessageStateControllerTest {
     final Message message = createMessage(1L, "name", "correlationKey", "{}", "id", 1234);
     stateController.put(message);
 
+    stateController.putMessageCorrelation(1L, 2L);
+    stateController.putMessageCorrelation(1L, 3L);
+
     // when
     stateController.remove(message.getKey());
 
     // then
     final List<Message> readMessages = new ArrayList<>();
-    stateController.findMessagesWithDeadlineBefore(2000, readMessages::add);
+    stateController.visitMessagesWithDeadlineBefore(2000, readMessages::add);
 
     assertThat(readMessages.size()).isEqualTo(0);
 
     // and
-    final Message readMessage =
-        stateController.findFirstMessage(wrapString("messageName"), wrapString("correlationKey"));
-    assertThat(readMessage).isNull();
+    final List<Long> keys = new ArrayList<>();
+    stateController.visitMessages(
+        wrapString("name"), wrapString("correlationKey"), m -> keys.add(m.getKey()));
+
+    assertThat(keys).isEmpty();
 
     // and
     final boolean exist =
         stateController.exist(
             wrapString("messageName"), wrapString("correlationKey"), wrapString("id"));
     assertThat(exist).isFalse();
+
+    // and
+    assertThat(stateController.existMessageCorrelation(1L, 2L)).isFalse();
+    assertThat(stateController.existMessageCorrelation(1L, 3L)).isFalse();
   }
 
   @Test
@@ -442,14 +510,16 @@ public class MessageStateControllerTest {
 
     // then
     final List<Message> readMessages = new ArrayList<>();
-    stateController.findMessagesWithDeadlineBefore(2000, readMessages::add);
+    stateController.visitMessagesWithDeadlineBefore(2000, readMessages::add);
 
     assertThat(readMessages.size()).isEqualTo(0);
 
     // and
-    final Message readMessage =
-        stateController.findFirstMessage(wrapString("name"), wrapString("correlationKey"));
-    assertThat(readMessage).isNull();
+    final List<Long> keys = new ArrayList<>();
+    stateController.visitMessages(
+        wrapString("name"), wrapString("correlationKey"), m -> keys.add(m.getKey()));
+
+    assertThat(keys).isEmpty();
   }
 
   @Test
@@ -465,14 +535,16 @@ public class MessageStateControllerTest {
 
     // then
     final List<Message> readMessages = new ArrayList<>();
-    stateController.findMessagesWithDeadlineBefore(2000, readMessages::add);
+    stateController.visitMessagesWithDeadlineBefore(2000, readMessages::add);
 
     assertThat(readMessages.size()).isEqualTo(0);
 
     // and
-    final Message readMessage =
-        stateController.findFirstMessage(wrapString("messageName"), wrapString("correlationKey"));
-    assertThat(readMessage).isNull();
+    final List<Long> keys = new ArrayList<>();
+    stateController.visitMessages(
+        wrapString("name"), wrapString("correlationKey"), m -> keys.add(m.getKey()));
+
+    assertThat(keys).isEmpty();
 
     // and
     final boolean exist =
@@ -489,25 +561,45 @@ public class MessageStateControllerTest {
 
     stateController.put(message);
 
+    stateController.putMessageCorrelation(1L, 3L);
+    stateController.putMessageCorrelation(2L, 4L);
+
     // when
     stateController.remove(message2.getKey());
 
     // then
     final long deadline = ActorClock.currentTimeMillis() + 2_000L;
     final List<Message> readMessages = new ArrayList<>();
-    stateController.findMessagesWithDeadlineBefore(deadline, readMessages::add);
+    stateController.visitMessagesWithDeadlineBefore(deadline, readMessages::add);
 
     assertThat(readMessages.size()).isEqualTo(1);
 
     // and
-    final Message readMessage =
-        stateController.findFirstMessage(wrapString("name"), wrapString("correlationKey"));
-    assertThat(readMessage).isNotNull();
+    final List<Long> keys = new ArrayList<>();
+    stateController.visitMessages(
+        wrapString("name"), wrapString("correlationKey"), m -> keys.add(m.getKey()));
+
+    assertThat(keys).hasSize(1).contains(1L);
 
     // and
     final boolean exist =
         stateController.exist(wrapString("name"), wrapString("correlationKey"), wrapString("id1"));
     assertThat(exist).isTrue();
+
+    // and
+    assertThat(stateController.existMessageCorrelation(1L, 3L));
+  }
+
+  @Test
+  public void shouldExistCorrelatedMessage() {
+    // when
+    stateController.putMessageCorrelation(1L, 2L);
+
+    // then
+    assertThat(stateController.existMessageCorrelation(1L, 2L)).isTrue();
+
+    assertThat(stateController.existMessageCorrelation(3L, 2L)).isFalse();
+    assertThat(stateController.existMessageCorrelation(1L, 3L)).isFalse();
   }
 
   @Test
@@ -590,9 +682,9 @@ public class MessageStateControllerTest {
   public void shouldNotRemoveSubscriptionOnDifferentKey() {
     // given
     final MessageSubscription subscription =
-        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 1, 2, 1234);
+        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 1, 2, 0);
     final MessageSubscription subscription2 =
-        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 2, 3, 1234);
+        new MessageSubscription("messageName", "correlationKey", "{\"foo\":\"bar\"}", 2, 3, 0);
 
     stateController.put(subscription);
 
@@ -600,11 +692,7 @@ public class MessageStateControllerTest {
     stateController.remove(subscription2);
 
     // then
-    List<MessageSubscription> readSubscriptions = stateController.findSubscriptionBefore(2000);
-    assertThat(readSubscriptions.size()).isEqualTo(1);
-
-    // and
-    readSubscriptions =
+    final List<MessageSubscription> readSubscriptions =
         stateController.findSubscriptions(wrapString("messageName"), wrapString("correlationKey"));
     assertThat(readSubscriptions.size()).isEqualTo(1);
   }

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageCatchElementTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageCatchElementTest.java
@@ -1,0 +1,362 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow.message;
+
+import static io.zeebe.broker.test.EmbeddedBrokerConfigurator.setPartitionCount;
+import static io.zeebe.broker.workflow.WorkflowAssert.assertMessageSubscription;
+import static io.zeebe.broker.workflow.WorkflowAssert.assertWorkflowInstanceRecord;
+import static io.zeebe.broker.workflow.WorkflowAssert.assertWorkflowSubscription;
+import static io.zeebe.broker.workflow.gateway.ParallelGatewayStreamProcessorTest.PROCESS_ID;
+import static io.zeebe.test.util.MsgPackUtil.asMsgPack;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.exporter.record.Assertions;
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.record.RecordMetadata;
+import io.zeebe.exporter.record.value.MessageSubscriptionRecordValue;
+import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.exporter.record.value.WorkflowInstanceSubscriptionRecordValue;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.clientapi.RecordType;
+import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.impl.SubscriptionUtil;
+import io.zeebe.protocol.intent.DeploymentIntent;
+import io.zeebe.protocol.intent.MessageSubscriptionIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceSubscriptionIntent;
+import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
+import io.zeebe.test.broker.protocol.clientapi.PartitionTestClient;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.agrona.DirectBuffer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class MessageCatchElementTest {
+
+  public EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule(setPartitionCount(3));
+
+  public ClientApiRule apiRule = new ClientApiRule(brokerRule::getClientAddress);
+
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(apiRule);
+
+  private static final BpmnModelInstance CATCH_EVENT_WORKFLOW =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .intermediateCatchEvent("receive-message")
+          .message(m -> m.name("order canceled").zeebeCorrelationKey("$.orderId"))
+          .sequenceFlowId("to-end")
+          .endEvent()
+          .done();
+
+  private static final BpmnModelInstance RECEIVE_TASK_WORKFLOW =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .receiveTask("receive-message")
+          .message(m -> m.name("order canceled").zeebeCorrelationKey("$.orderId"))
+          .sequenceFlowId("to-end")
+          .endEvent()
+          .done();
+
+  @Parameter(0)
+  public String elementType;
+
+  @Parameter(1)
+  public BpmnModelInstance workflow;
+
+  @Parameters(name = "{0}")
+  public static final Object[][] parameters() {
+    return new Object[][] {
+      {"intermediate message catch event", CATCH_EVENT_WORKFLOW},
+      {"receive task", RECEIVE_TASK_WORKFLOW}
+    };
+  }
+
+  private PartitionTestClient testClient;
+
+  @Before
+  public void init() {
+    apiRule.waitForPartition(3);
+    testClient = apiRule.partitionClient();
+    final long deploymentKey = testClient.deploy(workflow);
+
+    testClient.receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentKey);
+    apiRule.partitionClient(1).receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentKey);
+    apiRule.partitionClient(2).receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentKey);
+  }
+
+  @Test
+  public void testWorkflowInstanceLifeCycle() {
+
+    testClient.publishMessage("order canceled", "order-123");
+
+    testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+
+    final List<Record<WorkflowInstanceRecordValue>> events =
+        testClient.receiveWorkflowInstances().limit(11).collect(Collectors.toList());
+
+    assertThat(events)
+        .extracting(Record::getMetadata)
+        .extracting(RecordMetadata::getIntent)
+        .containsExactly(
+            WorkflowInstanceIntent.CREATE,
+            WorkflowInstanceIntent.CREATED,
+            WorkflowInstanceIntent.ELEMENT_READY,
+            WorkflowInstanceIntent.ELEMENT_ACTIVATED,
+            WorkflowInstanceIntent.START_EVENT_OCCURRED,
+            WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN,
+            WorkflowInstanceIntent.ELEMENT_READY,
+            WorkflowInstanceIntent.ELEMENT_ACTIVATED,
+            WorkflowInstanceIntent.ELEMENT_COMPLETING,
+            WorkflowInstanceIntent.ELEMENT_COMPLETED,
+            WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN);
+  }
+
+  @Test
+  public void shouldActivateElement() {
+
+    final long workflowInstanceKey =
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+
+    final Record<WorkflowInstanceRecordValue> event =
+        testClient.receiveElementInState(
+            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+
+    assertWorkflowInstanceRecord(workflowInstanceKey, "receive-message", event);
+  }
+
+  @Test
+  public void shouldOpenMessageSubscription() {
+
+    final long workflowInstanceKey =
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+
+    final Record<WorkflowInstanceRecordValue> catchEventEntered =
+        testClient.receiveElementInState(
+            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+
+    final Record<MessageSubscriptionRecordValue> messageSubscription =
+        RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED).getFirst();
+    assertThat(messageSubscription.getMetadata().getValueType())
+        .isEqualTo(ValueType.MESSAGE_SUBSCRIPTION);
+    assertThat(messageSubscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
+
+    assertMessageSubscription(
+        workflowInstanceKey, "order-123", catchEventEntered, messageSubscription);
+  }
+
+  @Test
+  public void shouldOpenMessageSubscriptionsOnSamePartition() {
+    // given
+    final List<Integer> partitionIds = apiRule.getPartitionIds();
+
+    final String correlationKey = "order-123";
+
+    final PartitionTestClient workflowPartition = apiRule.partitionClient(partitionIds.get(0));
+    final PartitionTestClient subscriptionPartition =
+        apiRule.partitionClient(getPartitionId(correlationKey));
+
+    testClient.deploy(CATCH_EVENT_WORKFLOW);
+
+    // when
+    final long workflowInstanceKey1 =
+        workflowPartition.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", correlationKey));
+
+    final long workflowInstanceKey2 =
+        workflowPartition.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", correlationKey));
+
+    // then
+    final List<Record<MessageSubscriptionRecordValue>> subscriptions =
+        subscriptionPartition
+            .receiveMessageSubscriptions()
+            .withIntent(MessageSubscriptionIntent.OPENED)
+            .limit(2)
+            .collect(Collectors.toList());
+
+    assertThat(subscriptions)
+        .extracting(s -> s.getValue().getWorkflowInstanceKey())
+        .contains(workflowInstanceKey1, workflowInstanceKey2);
+  }
+
+  @Test
+  public void shouldOpenWorkflowInstanceSubscription() {
+    final long workflowInstanceKey =
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+
+    final Record<WorkflowInstanceRecordValue> catchEventEntered =
+        testClient.receiveElementInState(
+            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+
+    final Record<WorkflowInstanceSubscriptionRecordValue> workflowInstanceSubscription =
+        testClient
+            .receiveWorkflowInstanceSubscriptions()
+            .withIntent(WorkflowInstanceSubscriptionIntent.OPENED)
+            .getFirst();
+
+    assertThat(workflowInstanceSubscription.getMetadata().getValueType())
+        .isEqualTo(ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION);
+    assertThat(workflowInstanceSubscription.getMetadata().getRecordType())
+        .isEqualTo(RecordType.EVENT);
+
+    assertWorkflowSubscription(
+        workflowInstanceKey, catchEventEntered, workflowInstanceSubscription);
+  }
+
+  @Test
+  public void shouldCorrelateWorkflowInstanceSubscription() {
+    // given
+    final long workflowInstanceKey =
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+
+    final Record<WorkflowInstanceRecordValue> catchEventEntered =
+        testClient.receiveElementInState(
+            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+
+    // when
+    final DirectBuffer messagePayload = asMsgPack("foo", "bar");
+    testClient.publishMessage("order canceled", "order-123", messagePayload);
+
+    // then
+    final Record<WorkflowInstanceSubscriptionRecordValue> subscription =
+        testClient
+            .receiveWorkflowInstanceSubscriptions()
+            .withIntent(WorkflowInstanceSubscriptionIntent.CORRELATED)
+            .getFirst();
+
+    assertThat(subscription.getMetadata().getValueType())
+        .isEqualTo(ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION);
+    assertThat(subscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
+
+    assertWorkflowSubscription(
+        workflowInstanceKey, "{\"foo\":\"bar\"}", catchEventEntered, subscription);
+  }
+
+  @Test
+  public void shouldCorrelateMessageSubscription() {
+    // given
+    final long workflowInstanceKey =
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+
+    final Record<WorkflowInstanceRecordValue> catchEventEntered =
+        testClient.receiveElementInState(
+            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+
+    // when
+    testClient.publishMessage("order canceled", "order-123", asMsgPack("foo", "bar"));
+
+    // then
+    final Record<MessageSubscriptionRecordValue> subscription =
+        testClient
+            .receiveMessageSubscriptions()
+            .withIntent(MessageSubscriptionIntent.CORRELATED)
+            .getFirst();
+
+    assertThat(subscription.getMetadata().getValueType()).isEqualTo(ValueType.MESSAGE_SUBSCRIPTION);
+    assertThat(subscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
+
+    assertMessageSubscription(workflowInstanceKey, catchEventEntered, subscription);
+  }
+
+  @Test
+  public void shouldCloseMessageSubscription() {
+
+    final long workflowInstanceKey =
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+
+    final Record<WorkflowInstanceRecordValue> catchEventEntered =
+        testClient.receiveElementInState(
+            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+
+    testClient.cancelWorkflowInstance(workflowInstanceKey);
+
+    final Record<MessageSubscriptionRecordValue> messageSubscription =
+        RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CLOSED).getFirst();
+
+    assertThat(messageSubscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
+
+    Assertions.assertThat(messageSubscription.getValue())
+        .hasWorkflowInstanceKey(workflowInstanceKey)
+        .hasActivityInstanceKey(catchEventEntered.getKey())
+        .hasMessageName("")
+        .hasCorrelationKey("");
+  }
+
+  @Test
+  public void shouldCloseWorkflowInstanceSubscription() {
+
+    final long workflowInstanceKey =
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+
+    final Record<WorkflowInstanceRecordValue> catchEventEntered =
+        testClient.receiveElementInState(
+            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+
+    testClient.cancelWorkflowInstance(workflowInstanceKey);
+
+    final Record<WorkflowInstanceSubscriptionRecordValue> subscription =
+        RecordingExporter.workflowInstanceSubscriptionRecords(
+                WorkflowInstanceSubscriptionIntent.CLOSED)
+            .getFirst();
+
+    assertThat(subscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
+
+    Assertions.assertThat(subscription.getValue())
+        .hasWorkflowInstanceKey(workflowInstanceKey)
+        .hasActivityInstanceKey(catchEventEntered.getKey())
+        .hasMessageName("");
+  }
+
+  @Test
+  public void shouldCorrelateMessageAndContinue() {
+    // given
+    testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+
+    // when
+    testClient.publishMessage("order canceled", "order-123");
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+                .withActivityId("receive-message")
+                .exists())
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN)
+                .withActivityId("to-end")
+                .exists())
+        .isTrue();
+  }
+
+  private int getPartitionId(final String correlationKey) {
+    final List<Integer> partitionIds = apiRule.getPartitionIds();
+    return SubscriptionUtil.getSubscriptionPartitionId(
+        BufferUtil.wrapString(correlationKey), partitionIds.size());
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageCorrelationTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageCorrelationTest.java
@@ -17,301 +17,137 @@
  */
 package io.zeebe.broker.workflow.message;
 
-import static io.zeebe.broker.test.EmbeddedBrokerConfigurator.setPartitionCount;
-import static io.zeebe.broker.workflow.WorkflowAssert.assertMessageSubscription;
 import static io.zeebe.broker.workflow.WorkflowAssert.assertWorkflowInstancePayload;
 import static io.zeebe.broker.workflow.WorkflowAssert.assertWorkflowInstanceRecord;
-import static io.zeebe.broker.workflow.WorkflowAssert.assertWorkflowSubscription;
-import static io.zeebe.broker.workflow.gateway.ParallelGatewayStreamProcessorTest.PROCESS_ID;
 import static io.zeebe.test.util.MsgPackUtil.asMsgPack;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.zeebe.broker.test.EmbeddedBrokerRule;
-import io.zeebe.exporter.record.Assertions;
 import io.zeebe.exporter.record.Record;
-import io.zeebe.exporter.record.RecordMetadata;
-import io.zeebe.exporter.record.value.MessageSubscriptionRecordValue;
 import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
-import io.zeebe.exporter.record.value.WorkflowInstanceSubscriptionRecordValue;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
-import io.zeebe.protocol.clientapi.RecordType;
-import io.zeebe.protocol.clientapi.ValueType;
-import io.zeebe.protocol.impl.SubscriptionUtil;
-import io.zeebe.protocol.intent.DeploymentIntent;
 import io.zeebe.protocol.intent.MessageSubscriptionIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceSubscriptionIntent;
 import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
 import io.zeebe.test.broker.protocol.clientapi.PartitionTestClient;
 import io.zeebe.test.util.record.RecordingExporter;
-import io.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.agrona.DirectBuffer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 
-@RunWith(Parameterized.class)
 public class MessageCorrelationTest {
 
-  public EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule(setPartitionCount(3));
+  private static final String PROCESS_ID = "process";
+
+  private static final BpmnModelInstance SINGLE_MESSAGE_WORKFLOW =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .intermediateCatchEvent("receive-message")
+          .message(m -> m.name("message").zeebeCorrelationKey("$.key"))
+          .endEvent()
+          .done();
+
+  private static final BpmnModelInstance TWO_MESSAGES_WORKFLOW =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .intermediateCatchEvent("message1")
+          .message(m -> m.name("ping").zeebeCorrelationKey("$.key"))
+          .intermediateCatchEvent("message2")
+          .message(m -> m.name("ping").zeebeCorrelationKey("$.key"))
+          .done();
+
+  public EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule();
 
   public ClientApiRule apiRule = new ClientApiRule(brokerRule::getClientAddress);
 
   @Rule public RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(apiRule);
 
-  private static final BpmnModelInstance CATCH_EVENT_WORKFLOW =
-      Bpmn.createExecutableProcess(PROCESS_ID)
-          .startEvent()
-          .intermediateCatchEvent("receive-message")
-          .message(m -> m.name("order canceled").zeebeCorrelationKey("$.orderId"))
-          .sequenceFlowId("to-end")
-          .endEvent()
-          .done();
-
-  private static final BpmnModelInstance RECEIVE_TASK_WORKFLOW =
-      Bpmn.createExecutableProcess(PROCESS_ID)
-          .startEvent()
-          .receiveTask("receive-message")
-          .message(m -> m.name("order canceled").zeebeCorrelationKey("$.orderId"))
-          .sequenceFlowId("to-end")
-          .endEvent()
-          .done();
-
-  @Parameter(0)
-  public String elementType;
-
-  @Parameter(1)
-  public BpmnModelInstance workflow;
-
-  @Parameters(name = "{0}")
-  public static final Object[][] parameters() {
-    return new Object[][] {
-      {"intermediate message catch event", CATCH_EVENT_WORKFLOW},
-      {"receive task", RECEIVE_TASK_WORKFLOW}
-    };
-  }
-
   private PartitionTestClient testClient;
 
   @Before
   public void init() {
-    apiRule.waitForPartition(3);
     testClient = apiRule.partitionClient();
-    final long deploymentKey = testClient.deploy(workflow);
-
-    testClient.receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentKey);
-    apiRule.partitionClient(1).receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentKey);
-    apiRule.partitionClient(2).receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentKey);
-  }
-
-  @Test
-  public void testWorkflowInstanceLifeCycle() {
-
-    testClient.publishMessage("order canceled", "order-123");
-
-    testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
-
-    final List<Record<WorkflowInstanceRecordValue>> events =
-        testClient.receiveWorkflowInstances().limit(11).collect(Collectors.toList());
-
-    assertThat(events)
-        .extracting(Record::getMetadata)
-        .extracting(RecordMetadata::getIntent)
-        .containsExactly(
-            WorkflowInstanceIntent.CREATE,
-            WorkflowInstanceIntent.CREATED,
-            WorkflowInstanceIntent.ELEMENT_READY,
-            WorkflowInstanceIntent.ELEMENT_ACTIVATED,
-            WorkflowInstanceIntent.START_EVENT_OCCURRED,
-            WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN,
-            WorkflowInstanceIntent.ELEMENT_READY,
-            WorkflowInstanceIntent.ELEMENT_ACTIVATED,
-            WorkflowInstanceIntent.ELEMENT_COMPLETING,
-            WorkflowInstanceIntent.ELEMENT_COMPLETED,
-            WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN);
-  }
-
-  @Test
-  public void shouldActivateElement() {
-
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
-
-    final Record event =
-        testClient.receiveElementInState(
-            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
-
-    assertWorkflowInstanceRecord(workflowInstanceKey, "receive-message", event);
-  }
-
-  @Test
-  public void shouldOpenMessageSubscription() {
-
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
-
-    final Record catchEventEntered =
-        testClient.receiveElementInState(
-            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
-
-    final Record<MessageSubscriptionRecordValue> messageSubscription =
-        RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED).getFirst();
-    assertThat(messageSubscription.getMetadata().getValueType())
-        .isEqualTo(ValueType.MESSAGE_SUBSCRIPTION);
-    assertThat(messageSubscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
-
-    assertMessageSubscription(
-        workflowInstanceKey, "order-123", catchEventEntered, messageSubscription);
-  }
-
-  @Test
-  public void shouldOpenMessageSubscriptionsOnSamePartition() {
-    // given
-    final List<Integer> partitionIds = apiRule.getPartitionIds();
-
-    final String correlationKey = "order-123";
-
-    final PartitionTestClient workflowPartition = apiRule.partitionClient(partitionIds.get(0));
-    final PartitionTestClient subscriptionPartition =
-        apiRule.partitionClient(getPartitionId(correlationKey));
-
-    testClient.deploy(CATCH_EVENT_WORKFLOW);
-
-    // when
-    final long workflowInstanceKey1 =
-        workflowPartition.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", correlationKey));
-
-    final long workflowInstanceKey2 =
-        workflowPartition.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", correlationKey));
-
-    // then
-    final List<Record<MessageSubscriptionRecordValue>> subscriptions =
-        subscriptionPartition
-            .receiveMessageSubscriptions()
-            .withIntent(MessageSubscriptionIntent.OPENED)
-            .limit(2)
-            .collect(Collectors.toList());
-
-    assertThat(subscriptions)
-        .extracting(s -> s.getValue().getWorkflowInstanceKey())
-        .contains(workflowInstanceKey1, workflowInstanceKey2);
-  }
-
-  @Test
-  public void shouldOpenWorkflowInstanceSubscription() {
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
-
-    final Record catchEventEntered =
-        testClient.receiveElementInState(
-            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
-
-    final Record workflowInstanceSubscription =
-        testClient
-            .receiveWorkflowInstanceSubscriptions()
-            .withIntent(WorkflowInstanceSubscriptionIntent.OPENED)
-            .getFirst();
-
-    assertThat(workflowInstanceSubscription.getMetadata().getValueType())
-        .isEqualTo(ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION);
-    assertThat(workflowInstanceSubscription.getMetadata().getRecordType())
-        .isEqualTo(RecordType.EVENT);
-
-    assertWorkflowSubscription(
-        workflowInstanceKey, catchEventEntered, workflowInstanceSubscription);
   }
 
   @Test
   public void shouldCorrelateMessageIfEnteredBefore() {
     // given
+    testClient.deploy(SINGLE_MESSAGE_WORKFLOW);
+
     final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "order-123"));
 
     assertThat(
             RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED).exists())
         .isTrue();
 
     // when
-    testClient.publishMessage("order canceled", "order-123", asMsgPack("foo", "bar"));
-
-    // then
-    final Record event =
-        testClient.receiveFirstWorkflowInstanceEvent(WorkflowInstanceIntent.ELEMENT_COMPLETED);
-
-    assertWorkflowInstanceRecord(workflowInstanceKey, "receive-message", event);
-    assertWorkflowInstancePayload(event, "{'orderId':'order-123', 'foo':'bar'}");
-  }
-
-  @Test
-  public void shouldCorrelateMessageIfPublishedBefore() {
-    // given
-    testClient.publishMessage("order canceled", "order-123", asMsgPack("foo", "bar"));
-
-    // when
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
-
-    // then
-    final Record event =
-        testClient.receiveFirstWorkflowInstanceEvent(WorkflowInstanceIntent.ELEMENT_COMPLETED);
-    assertWorkflowInstanceRecord(workflowInstanceKey, "receive-message", event);
-    assertWorkflowInstancePayload(event, "{'orderId':'order-123', 'foo':'bar'}");
-  }
-
-  @Test
-  public void shouldCorrelateFirstPublishedMessage() {
-    // given
-    testClient.publishMessage("order canceled", "order-123", asMsgPack("nr", "first"));
-
-    testClient.publishMessage("order canceled", "order-123", asMsgPack("nr", "second"));
-
-    // when
-    testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+    testClient.publishMessage("message", "order-123", asMsgPack("foo", "bar"));
 
     // then
     final Record<WorkflowInstanceRecordValue> event =
         testClient.receiveFirstWorkflowInstanceEvent(WorkflowInstanceIntent.ELEMENT_COMPLETED);
 
-    assertWorkflowInstancePayload(event, "{'orderId':'order-123', 'nr':'first'}");
+    assertWorkflowInstanceRecord(workflowInstanceKey, "receive-message", event);
+    assertWorkflowInstancePayload(event, "{'key':'order-123', 'foo':'bar'}");
   }
 
   @Test
-  public void shouldContinueInstanceAfteMessageIsCorrelated() {
+  public void shouldCorrelateMessageIfPublishedBefore() {
     // given
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+    testClient.deploy(SINGLE_MESSAGE_WORKFLOW);
+
+    testClient.publishMessage("message", "order-123", asMsgPack("foo", "bar"));
 
     // when
-    testClient.publishMessage("order canceled", "order-123");
+    final long workflowInstanceKey =
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "order-123"));
 
     // then
-    final Record event =
-        testClient.receiveFirstWorkflowInstanceEvent(
-            workflowInstanceKey, "to-end", WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN);
+    final Record<WorkflowInstanceRecordValue> event =
+        testClient.receiveFirstWorkflowInstanceEvent(WorkflowInstanceIntent.ELEMENT_COMPLETED);
+    assertWorkflowInstanceRecord(workflowInstanceKey, "receive-message", event);
+    assertWorkflowInstancePayload(event, "{'key':'order-123', 'foo':'bar'}");
+  }
 
-    assertWorkflowInstanceRecord(workflowInstanceKey, "to-end", event);
+  @Test
+  public void shouldCorrelateFirstPublishedMessage() {
+    // given
+    testClient.deploy(SINGLE_MESSAGE_WORKFLOW);
+
+    testClient.publishMessage("message", "order-123", asMsgPack("nr", 1));
+    testClient.publishMessage("message", "order-123", asMsgPack("nr", 2));
+
+    // when
+    testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "order-123"));
+
+    // then
+    final Record<WorkflowInstanceRecordValue> event =
+        testClient.receiveFirstWorkflowInstanceEvent(WorkflowInstanceIntent.ELEMENT_COMPLETED);
+
+    assertWorkflowInstancePayload(event, "{'key':'order-123', 'nr':1}");
   }
 
   @Test
   public void shouldCorrelateMessageWithZeroTTL() {
     // given
+    testClient.deploy(SINGLE_MESSAGE_WORKFLOW);
+
     final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "order-123"));
 
     assertThat(
             RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED).exists())
         .isTrue();
 
     // when
-    testClient.publishMessage("order canceled", "order-123", asMsgPack("foo", "bar"), 0);
+    testClient.publishMessage("message", "order-123", asMsgPack("foo", "bar"), 0);
 
     // then
     final Record<WorkflowInstanceRecordValue> event =
@@ -324,54 +160,60 @@ public class MessageCorrelationTest {
   @Test
   public void shouldNotCorrelateMessageAfterTTL() {
     // given
-    testClient.publishMessage("order canceled", "order-123", asMsgPack("nr", "first"), 0);
-    testClient.publishMessage("order canceled", "order-123", asMsgPack("nr", "second"), 10_000);
+    testClient.deploy(SINGLE_MESSAGE_WORKFLOW);
+
+    testClient.publishMessage("message", "order-123", asMsgPack("nr", 1), 0);
+    testClient.publishMessage("message", "order-123", asMsgPack("nr", 2), 10_000);
 
     // when
-    testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+    testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "order-123"));
 
     // then
     final Record<WorkflowInstanceRecordValue> event =
         testClient.receiveElementInState(
             "receive-message", WorkflowInstanceIntent.ELEMENT_COMPLETED);
 
-    assertWorkflowInstancePayload(event, "{'orderId':'order-123', 'nr':'second'}");
+    assertWorkflowInstancePayload(event, "{'key':'order-123', 'nr':2}");
   }
 
   @Test
   public void shouldCorrelateMessageByCorrelationKey() {
     // given
+    testClient.deploy(SINGLE_MESSAGE_WORKFLOW);
+
     final long workflowInstanceKey1 =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "order-123"));
     final long workflowInstanceKey2 =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-456"));
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "order-456"));
 
     // when
-    testClient.publishMessage("order canceled", "order-123", asMsgPack("foo", "bar"));
-    testClient.publishMessage("order canceled", "order-456", asMsgPack("foo", "baz"));
+    testClient.publishMessage("message", "order-123", asMsgPack("nr", 1));
+    testClient.publishMessage("message", "order-456", asMsgPack("nr", 2));
 
     // then
     final Record<WorkflowInstanceRecordValue> catchEventOccurred1 =
         testClient.receiveFirstWorkflowInstanceEvent(
             workflowInstanceKey1, WorkflowInstanceIntent.ELEMENT_COMPLETED);
-    assertWorkflowInstancePayload(catchEventOccurred1, "{'orderId':'order-123', 'foo':'bar'}");
+    assertWorkflowInstancePayload(catchEventOccurred1, "{'key':'order-123', 'nr':1}");
 
     final Record<WorkflowInstanceRecordValue> catchEventOccurred2 =
         testClient.receiveFirstWorkflowInstanceEvent(
             workflowInstanceKey2, WorkflowInstanceIntent.ELEMENT_COMPLETED);
-    assertWorkflowInstancePayload(catchEventOccurred2, "{'orderId':'order-456', 'foo':'baz'}");
+    assertWorkflowInstancePayload(catchEventOccurred2, "{'key':'order-456', 'nr':2}");
   }
 
   @Test
   public void shouldCorrelateMessageToAllSubscriptions() {
     // given
+    testClient.deploy(SINGLE_MESSAGE_WORKFLOW);
+
     final long workflowInstanceKey1 =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "order-123"));
     final long workflowInstanceKey2 =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "order-123"));
 
     // when
-    testClient.publishMessage("order canceled", "order-123");
+    testClient.publishMessage("message", "order-123");
 
     // then
     final List<Record<WorkflowInstanceRecordValue>> events =
@@ -388,112 +230,121 @@ public class MessageCorrelationTest {
   }
 
   @Test
-  public void shouldCorrelateWorkflowInstanceSubscription() {
+  public void shouldCorrelateMessageOnlyOnceIfPublishedBefore() {
     // given
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+    testClient.deploy(TWO_MESSAGES_WORKFLOW);
 
-    final Record catchEventEntered =
-        testClient.receiveElementInState(
-            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+    testClient.publishMessage("ping", "123", asMsgPack("nr", 1));
+    testClient.publishMessage("ping", "123", asMsgPack("nr", 2));
 
     // when
-    final DirectBuffer messagePayload = asMsgPack("foo", "bar");
-    testClient.publishMessage("order canceled", "order-123", messagePayload);
+    testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "123"));
 
     // then
-    final Record<WorkflowInstanceSubscriptionRecordValue> subscription =
-        testClient
-            .receiveWorkflowInstanceSubscriptions()
-            .withIntent(WorkflowInstanceSubscriptionIntent.CORRELATED)
-            .getFirst();
-
-    assertThat(subscription.getMetadata().getValueType())
-        .isEqualTo(ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION);
-    assertThat(subscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
-
-    assertWorkflowSubscription(
-        workflowInstanceKey, "{\"foo\":\"bar\"}", catchEventEntered, subscription);
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+                .limit(2)
+                .asList())
+        .extracting(
+            r -> tuple(r.getValue().getActivityId(), r.getValue().getPayloadAsMap().get("nr")))
+        .contains(tuple("message1", 1), tuple("message2", 2));
   }
 
   @Test
-  public void shouldCorrelateMessageSubscription() {
+  public void shouldCorrelateMessageOnlyOnceIfEnteredBefore() {
     // given
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+    testClient.deploy(TWO_MESSAGES_WORKFLOW);
 
-    final Record catchEventEntered =
-        testClient.receiveElementInState(
-            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+    testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "123"));
 
     // when
-    testClient.publishMessage("order canceled", "order-123", asMsgPack("foo", "bar"));
+    assertThat(
+            RecordingExporter.workflowInstanceSubscriptionRecords(
+                    WorkflowInstanceSubscriptionIntent.OPENED)
+                .exists())
+        .isTrue();
+
+    testClient.publishMessage("ping", "123", asMsgPack("nr", 1));
+
+    assertThat(
+            RecordingExporter.workflowInstanceSubscriptionRecords(
+                    WorkflowInstanceSubscriptionIntent.OPENED)
+                .limit(2)
+                .count())
+        .isEqualTo(2);
+
+    testClient.publishMessage("ping", "123", asMsgPack("nr", 2));
 
     // then
-    final Record<MessageSubscriptionRecordValue> subscription =
-        testClient
-            .receiveMessageSubscriptions()
-            .withIntent(MessageSubscriptionIntent.CORRELATED)
-            .getFirst();
-
-    assertThat(subscription.getMetadata().getValueType()).isEqualTo(ValueType.MESSAGE_SUBSCRIPTION);
-    assertThat(subscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
-
-    assertMessageSubscription(workflowInstanceKey, catchEventEntered, subscription);
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+                .limit(2)
+                .asList())
+        .extracting(
+            r -> tuple(r.getValue().getActivityId(), r.getValue().getPayloadAsMap().get("nr")))
+        .contains(tuple("message1", 1), tuple("message2", 2));
   }
 
   @Test
-  public void shouldCloseMessageSubscription() {
+  public void shouldCorrelateMessageOnlyOnceToInstance() {
+    // given
+    testClient.deploy(
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway()
+            .intermediateCatchEvent("message1")
+            .message(m -> m.name("ping").zeebeCorrelationKey("$.key"))
+            .moveToLastGateway()
+            .intermediateCatchEvent("message2")
+            .message(m -> m.name("ping").zeebeCorrelationKey("$.key"))
+            .done());
 
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+    testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "123"));
 
-    final Record<WorkflowInstanceRecordValue> catchEventEntered =
-        testClient.receiveElementInState(
-            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+    // when
+    assertThat(
+            RecordingExporter.workflowInstanceSubscriptionRecords(
+                    WorkflowInstanceSubscriptionIntent.OPENED)
+                .limit(2)
+                .count())
+        .isEqualTo(2);
 
-    testClient.cancelWorkflowInstance(workflowInstanceKey);
+    testClient.publishMessage("ping", "123", asMsgPack("nr", 1));
+    testClient.publishMessage("ping", "123", asMsgPack("nr", 2));
 
-    final Record<MessageSubscriptionRecordValue> messageSubscription =
-        RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CLOSED).getFirst();
-
-    assertThat(messageSubscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
-
-    Assertions.assertThat(messageSubscription.getValue())
-        .hasWorkflowInstanceKey(workflowInstanceKey)
-        .hasActivityInstanceKey(catchEventEntered.getKey())
-        .hasMessageName("")
-        .hasCorrelationKey("");
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+                .limit(2)
+                .asList())
+        .extracting(r -> r.getValue().getPayloadAsMap().get("nr"))
+        .contains(1, 2);
   }
 
   @Test
-  public void shouldCloseWorkflowInstanceSubscription() {
+  public void shouldCorrelateOnlyOneMessagePerCatchElement() {
+    // given
+    testClient.deploy(TWO_MESSAGES_WORKFLOW);
 
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+    testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "123"));
 
-    final Record<WorkflowInstanceRecordValue> catchEventEntered =
-        testClient.receiveElementInState(
-            "receive-message", WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+    assertThat(
+            RecordingExporter.workflowInstanceSubscriptionRecords(
+                    WorkflowInstanceSubscriptionIntent.OPENED)
+                .exists())
+        .isTrue();
 
-    testClient.cancelWorkflowInstance(workflowInstanceKey);
+    // when
+    testClient.publishMessage("ping", "123", asMsgPack("nr", 1));
+    testClient.publishMessage("ping", "123", asMsgPack("nr", 2));
 
-    final Record<WorkflowInstanceSubscriptionRecordValue> subscription =
-        RecordingExporter.workflowInstanceSubscriptionRecords(
-                WorkflowInstanceSubscriptionIntent.CLOSED)
-            .getFirst();
-
-    assertThat(subscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
-
-    Assertions.assertThat(subscription.getValue())
-        .hasWorkflowInstanceKey(workflowInstanceKey)
-        .hasActivityInstanceKey(catchEventEntered.getKey())
-        .hasMessageName("");
-  }
-
-  private int getPartitionId(final String correlationKey) {
-    final List<Integer> partitionIds = apiRule.getPartitionIds();
-    return SubscriptionUtil.getSubscriptionPartitionId(
-        BufferUtil.wrapString(correlationKey), partitionIds.size());
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+                .limit(2)
+                .asList())
+        .extracting(
+            r -> tuple(r.getValue().getActivityId(), r.getValue().getPayloadAsMap().get("nr")))
+        .contains(tuple("message1", 1), tuple("message2", 2));
   }
 }

--- a/docs/src/reference/message-correlation.md
+++ b/docs/src/reference/message-correlation.md
@@ -14,7 +14,7 @@ An instance of the order workflow is created and wait at the message catch event
 
 A message is published by the payment service using one of the Zeebe clients. It has the name `Money collected` and the correlation key `order-123`. Since the correlation information matches, the message is correlated to the workflow instance. That means its payload is merged into the workflow instance payload and the message catch event is left.
 
-> Note that a message can be correlated to multiple workflow instances if they share the same correlation information.
+> Note that a message can be correlated to multiple workflow instances if they share the same correlation information. But it can be correlated only once per workflow instance.
 
 ## Message Buffering
 


### PR DESCRIPTION
* store the correlated messages in state
* check if a message is already correlated to a wf instance before
correlating
* check if a subscription is already correlated before correlating
* update message correlation docs

closes #1017 
