### PR TITLE
chore(broker): remove workflow instance CREATED/CANCELING intents

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CancelWorkflowInstanceHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CancelWorkflowInstanceHandler.java
@@ -40,14 +40,13 @@ public class CancelWorkflowInstanceHandler implements WorkflowInstanceCommandHan
       final EventOutput output = commandContext.getOutput();
       final WorkflowInstanceRecord value = workflowInstance.getValue();
 
-      output.newBatch();
-      output.writeFollowUpEvent(command.getKey(), WorkflowInstanceIntent.CANCELING, value);
       output.writeFollowUpEvent(
           command.getKey(), WorkflowInstanceIntent.ELEMENT_TERMINATING, value);
 
       commandContext
           .getResponseWriter()
-          .writeEventOnCommand(command.getKey(), WorkflowInstanceIntent.CANCELING, value, command);
+          .writeEventOnCommand(
+              command.getKey(), WorkflowInstanceIntent.ELEMENT_TERMINATING, value, command);
     } else {
       commandContext.reject(RejectionType.NOT_APPLICABLE, "Workflow instance is not running");
     }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceHandler.java
@@ -59,13 +59,11 @@ public class CreateWorkflowInstanceHandler implements WorkflowInstanceCommandHan
           .setElementId(bpmnId);
 
       final EventOutput eventOutput = commandContext.getOutput();
-      eventOutput.newBatch();
-      eventOutput.writeFollowUpEvent(workflowInstanceKey, WorkflowInstanceIntent.CREATED, command);
       eventOutput.writeFollowUpEvent(
           workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, command);
 
       responseWriter.writeEventOnCommand(
-          workflowInstanceKey, WorkflowInstanceIntent.CREATED, command, record);
+          workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, command, record);
     } else {
       commandContext.reject(RejectionType.BAD_VALUE, "Workflow is not deployed");
     }

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessorTest.java
@@ -581,7 +581,7 @@ public class ExporterStreamProcessorTest {
             scopeInstanceKey);
 
     // then
-    assertRecordExported(WorkflowInstanceIntent.CREATED, record, recordValue);
+    assertRecordExported(WorkflowInstanceIntent.ELEMENT_READY, record, recordValue);
   }
 
   @Test

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/CancelWorkflowInstanceTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/CancelWorkflowInstanceTest.java
@@ -113,7 +113,7 @@ public class CancelWorkflowInstanceTest {
         testClient.receiveFirstWorkflowInstanceCommand(WorkflowInstanceIntent.CANCEL);
 
     assertThat(response.getSourceRecordPosition()).isEqualTo(cancelWorkflow.getPosition());
-    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.CANCELING);
+    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.ELEMENT_TERMINATING);
 
     final Record<WorkflowInstanceRecordValue> workflowInstanceCanceledEvent =
         testClient.receiveElementInState(PROCESS_ID, WorkflowInstanceIntent.ELEMENT_TERMINATED);
@@ -132,7 +132,6 @@ public class CancelWorkflowInstanceTest {
         .extracting(e -> e.getValue().getElementId(), e -> e.getMetadata().getIntent())
         .containsSequence(
             tuple("", WorkflowInstanceIntent.CANCEL),
-            tuple(PROCESS_ID, WorkflowInstanceIntent.CANCELING),
             tuple(PROCESS_ID, WorkflowInstanceIntent.ELEMENT_TERMINATING),
             tuple("task", WorkflowInstanceIntent.ELEMENT_TERMINATING),
             tuple("task", WorkflowInstanceIntent.ELEMENT_TERMINATED),
@@ -161,7 +160,6 @@ public class CancelWorkflowInstanceTest {
         .extracting(e -> e.getValue().getElementId(), e -> e.getMetadata().getIntent())
         .containsSequence(
             tuple("", WorkflowInstanceIntent.CANCEL),
-            tuple(PROCESS_ID, WorkflowInstanceIntent.CANCELING),
             tuple(PROCESS_ID, WorkflowInstanceIntent.ELEMENT_TERMINATING),
             tuple("subProcess", WorkflowInstanceIntent.ELEMENT_TERMINATING),
             tuple("task", WorkflowInstanceIntent.ELEMENT_TERMINATING),
@@ -183,7 +181,7 @@ public class CancelWorkflowInstanceTest {
     final ExecuteCommandResponse response = cancelWorkflowInstance(workflowInstanceKey);
 
     // then
-    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.CANCELING);
+    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.ELEMENT_TERMINATING);
 
     final Record<WorkflowInstanceRecordValue> activityTerminatedEvent =
         testClient.receiveElementInState("task", WorkflowInstanceIntent.ELEMENT_TERMINATED);
@@ -248,7 +246,7 @@ public class CancelWorkflowInstanceTest {
     final ExecuteCommandResponse response = cancelWorkflowInstance(workflowInstanceKey);
 
     // then
-    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.CANCELING);
+    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.ELEMENT_TERMINATING);
 
     final Record<WorkflowInstanceRecordValue> activityTerminatingEvent =
         testClient.receiveElementInState("catch-event", WorkflowInstanceIntent.ELEMENT_TERMINATING);
@@ -274,7 +272,7 @@ public class CancelWorkflowInstanceTest {
     final ExecuteCommandResponse response = cancelWorkflowInstance(workflowInstanceKey);
 
     // then
-    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.CANCELING);
+    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.ELEMENT_TERMINATING);
 
     final Record<WorkflowInstanceRecordValue> terminateActivity =
         testClient.receiveElementInState("task", WorkflowInstanceIntent.ELEMENT_TERMINATING);
@@ -376,7 +374,7 @@ public class CancelWorkflowInstanceTest {
         response.getRawValue(), activatedEvent.getValue().toJson(), "payload");
 
     final io.zeebe.exporter.record.Record<WorkflowInstanceRecordValue> cancelingEvent =
-        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.CANCELING)
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_TERMINATING)
             .withElementId(PROCESS_ID)
             .getFirst();
 

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/WorkflowInstanceFunctionalTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/WorkflowInstanceFunctionalTest.java
@@ -322,14 +322,13 @@ public class WorkflowInstanceFunctionalTest {
 
     // then
     final List<Record> workflowEvents =
-        testClient.receiveWorkflowInstances().limit(14).collect(Collectors.toList());
+        testClient.receiveWorkflowInstances().limit(13).collect(Collectors.toList());
 
     assertThat(workflowEvents)
         .extracting(Record::getMetadata)
         .extracting(e -> e.getIntent())
         .containsExactly(
             WorkflowInstanceIntent.CREATE,
-            WorkflowInstanceIntent.CREATED,
             WorkflowInstanceIntent.ELEMENT_READY,
             WorkflowInstanceIntent.ELEMENT_ACTIVATED,
             WorkflowInstanceIntent.START_EVENT_OCCURRED,

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/gateway/ExclusiveGatewayTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/gateway/ExclusiveGatewayTest.java
@@ -245,14 +245,13 @@ public class ExclusiveGatewayTest {
 
     // then
     final List<Record> workflowEvents =
-        testClient.receiveWorkflowInstances().limit(11).collect(Collectors.toList());
+        testClient.receiveWorkflowInstances().limit(10).collect(Collectors.toList());
 
     assertThat(workflowEvents)
         .extracting(Record::getMetadata)
         .extracting(e -> e.getIntent())
         .containsExactly(
             WorkflowInstanceIntent.CREATE,
-            WorkflowInstanceIntent.CREATED,
             WorkflowInstanceIntent.ELEMENT_READY,
             WorkflowInstanceIntent.ELEMENT_ACTIVATED,
             WorkflowInstanceIntent.START_EVENT_OCCURRED,
@@ -313,7 +312,6 @@ public class ExclusiveGatewayTest {
     assertThat(completedEvents)
         .extracting(r -> r.getMetadata().getIntent())
         .containsExactly(
-            WorkflowInstanceIntent.CREATED,
             WorkflowInstanceIntent.ELEMENT_READY,
             WorkflowInstanceIntent.ELEMENT_ACTIVATED,
             WorkflowInstanceIntent.START_EVENT_OCCURRED,

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageCatchElementTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageCatchElementTest.java
@@ -119,14 +119,13 @@ public class MessageCatchElementTest {
     testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
 
     final List<Record<WorkflowInstanceRecordValue>> events =
-        testClient.receiveWorkflowInstances().limit(11).collect(Collectors.toList());
+        testClient.receiveWorkflowInstances().limit(10).collect(Collectors.toList());
 
     assertThat(events)
         .extracting(Record::getMetadata)
         .extracting(RecordMetadata::getIntent)
         .containsExactly(
             WorkflowInstanceIntent.CREATE,
-            WorkflowInstanceIntent.CREATED,
             WorkflowInstanceIntent.ELEMENT_READY,
             WorkflowInstanceIntent.ELEMENT_ACTIVATED,
             WorkflowInstanceIntent.START_EVENT_OCCURRED,

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/LifecycleAssert.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/LifecycleAssert.java
@@ -17,8 +17,6 @@
  */
 package io.zeebe.broker.workflow.processor;
 
-import static io.zeebe.protocol.intent.WorkflowInstanceIntent.CANCELING;
-import static io.zeebe.protocol.intent.WorkflowInstanceIntent.CREATED;
 import static io.zeebe.protocol.intent.WorkflowInstanceIntent.ELEMENT_ACTIVATED;
 import static io.zeebe.protocol.intent.WorkflowInstanceIntent.ELEMENT_COMPLETED;
 import static io.zeebe.protocol.intent.WorkflowInstanceIntent.ELEMENT_COMPLETING;
@@ -26,12 +24,10 @@ import static io.zeebe.protocol.intent.WorkflowInstanceIntent.ELEMENT_READY;
 import static io.zeebe.protocol.intent.WorkflowInstanceIntent.ELEMENT_TERMINATED;
 import static io.zeebe.protocol.intent.WorkflowInstanceIntent.ELEMENT_TERMINATING;
 
-import io.zeebe.protocol.intent.Intent;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.util.Lists;
@@ -61,9 +57,6 @@ public class LifecycleAssert
     ELEMENT_LIFECYCLE.put(ELEMENT_COMPLETED, EnumSet.noneOf(WorkflowInstanceIntent.class));
     ELEMENT_LIFECYCLE.put(ELEMENT_TERMINATING, EnumSet.of(ELEMENT_TERMINATED));
     ELEMENT_LIFECYCLE.put(ELEMENT_TERMINATED, EnumSet.noneOf(WorkflowInstanceIntent.class));
-
-    ELEMENT_LIFECYCLE.put(CREATED, EnumSet.of(ELEMENT_READY));
-    ELEMENT_LIFECYCLE.put(CANCELING, EnumSet.of(ELEMENT_TERMINATING));
   }
 
   public LifecycleAssert(List<WorkflowInstanceIntent> actual) {
@@ -123,18 +116,6 @@ public class LifecycleAssert
   }
 
   public static LifecycleAssert assertThat(List<WorkflowInstanceIntent> trajectory) {
-    return new LifecycleAssert(filterWorkflowInstanceEvents(trajectory));
-  }
-
-  private static List<WorkflowInstanceIntent> filterWorkflowInstanceEvents(
-      List<WorkflowInstanceIntent> trajectory) {
-    return trajectory
-        .stream()
-        .filter(s -> !isWorkflowInstanceState(s))
-        .collect(Collectors.toList());
-  }
-
-  private static boolean isWorkflowInstanceState(Intent state) {
-    return state == WorkflowInstanceIntent.CANCELING || state == WorkflowInstanceIntent.CREATED;
+    return new LifecycleAssert(trajectory);
   }
 }

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorRule.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorRule.java
@@ -145,7 +145,7 @@ public class WorkflowInstanceStreamProcessorRule extends ExternalResource {
         WorkflowInstanceIntent.CREATE,
         workflowInstanceRecord(BufferUtil.wrapString(processId), payload));
     final TypedRecord<WorkflowInstanceRecord> createdEvent =
-        awaitAndGetFirstRecordInState(WorkflowInstanceIntent.CREATED);
+        awaitAndGetFirstRecordInState(WorkflowInstanceIntent.ELEMENT_READY);
     return createdEvent;
   }
 

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/subprocess/EmbeddedSubProcessTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/subprocess/EmbeddedSubProcessTest.java
@@ -109,14 +109,16 @@ public class EmbeddedSubProcessTest {
     final List<Record<WorkflowInstanceRecordValue>> workflowInstanceEvents =
         testClient
             .receiveWorkflowInstances()
-            .skipUntil(e -> e.getMetadata().getIntent() == WorkflowInstanceIntent.CREATED)
-            .limit(11)
+            .limit(
+                r ->
+                    r.getMetadata().getIntent() == WorkflowInstanceIntent.ELEMENT_ACTIVATED
+                        && "subProcessTask".equals(r.getValue().getElementId()))
             .collect(Collectors.toList());
 
     assertThat(workflowInstanceEvents)
         .extracting(e -> e.getMetadata().getIntent(), e -> e.getValue().getElementId())
         .containsExactly(
-            tuple(WorkflowInstanceIntent.CREATED, PROCESS_ID),
+            tuple(WorkflowInstanceIntent.CREATE, ""),
             tuple(WorkflowInstanceIntent.ELEMENT_READY, PROCESS_ID),
             tuple(WorkflowInstanceIntent.ELEMENT_ACTIVATED, PROCESS_ID),
             tuple(WorkflowInstanceIntent.START_EVENT_OCCURRED, "start"),
@@ -149,14 +151,13 @@ public class EmbeddedSubProcessTest {
     final List<Record<WorkflowInstanceRecordValue>> workflowInstanceEvents =
         testClient
             .receiveWorkflowInstances()
-            .skipUntil(e -> e.getMetadata().getIntent() == WorkflowInstanceIntent.CREATED)
-            .limit(21)
+            .limitToWorkflowInstanceCompleted()
             .collect(Collectors.toList());
 
     assertThat(workflowInstanceEvents)
         .extracting(e -> e.getMetadata().getIntent(), e -> e.getValue().getElementId())
         .containsExactly(
-            tuple(WorkflowInstanceIntent.CREATED, PROCESS_ID),
+            tuple(WorkflowInstanceIntent.CREATE, ""),
             tuple(WorkflowInstanceIntent.ELEMENT_READY, PROCESS_ID),
             tuple(WorkflowInstanceIntent.ELEMENT_ACTIVATED, PROCESS_ID),
             tuple(WorkflowInstanceIntent.START_EVENT_OCCURRED, "start"),

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/brokerapi/WorkflowInstanceStubs.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/brokerapi/WorkflowInstanceStubs.java
@@ -38,7 +38,7 @@ public class WorkflowInstanceStubs {
             .onExecuteCommandRequest(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.CREATE)
             .respondWith()
             .event()
-            .intent(WorkflowInstanceIntent.CREATED)
+            .intent(WorkflowInstanceIntent.ELEMENT_READY)
             .value()
             .allOf(r -> r.getCommand())
             .done();
@@ -58,7 +58,7 @@ public class WorkflowInstanceStubs {
             .onExecuteCommandRequest(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.CANCEL)
             .respondWith()
             .event()
-            .intent(WorkflowInstanceIntent.CANCELING)
+            .intent(WorkflowInstanceIntent.ELEMENT_TERMINATING)
             .value()
             .allOf(r -> r.getCommand())
             .done();

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/PartitionTestClient.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/PartitionTestClient.java
@@ -138,7 +138,7 @@ public class PartitionTestClient {
     final ExecuteCommandResponse response = createWorkflowInstanceWithResponse(bpmnProcessId);
 
     assertThat(response.getRecordType()).isEqualTo(RecordType.EVENT);
-    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.CREATED);
+    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.ELEMENT_READY);
     assertThat(response.getPosition()).isGreaterThanOrEqualTo(0L);
 
     return response.getKey();
@@ -165,7 +165,7 @@ public class PartitionTestClient {
             .sendAndAwait();
 
     assertThat(response.getRecordType()).isEqualTo(RecordType.EVENT);
-    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.CREATED);
+    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.ELEMENT_READY);
 
     return response.getKey();
   }

--- a/protocol/src/main/java/io/zeebe/protocol/intent/WorkflowInstanceIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/WorkflowInstanceIntent.java
@@ -17,25 +17,22 @@ package io.zeebe.protocol.intent;
 
 public enum WorkflowInstanceIntent implements Intent {
   CREATE((short) 0),
-  CREATED((short) 1),
+  START_EVENT_OCCURRED((short) 1),
+  END_EVENT_OCCURRED((short) 2),
+  SEQUENCE_FLOW_TAKEN((short) 3),
+  GATEWAY_ACTIVATED((short) 4),
 
-  START_EVENT_OCCURRED((short) 2),
-  END_EVENT_OCCURRED((short) 3),
-  SEQUENCE_FLOW_TAKEN((short) 4),
-  GATEWAY_ACTIVATED((short) 5),
+  ELEMENT_READY((short) 5),
+  ELEMENT_ACTIVATED((short) 6),
+  ELEMENT_COMPLETING((short) 7),
+  ELEMENT_COMPLETED((short) 8),
+  ELEMENT_TERMINATING((short) 9),
+  ELEMENT_TERMINATED((short) 10),
 
-  ELEMENT_READY((short) 6),
-  ELEMENT_ACTIVATED((short) 7),
-  ELEMENT_COMPLETING((short) 8),
-  ELEMENT_COMPLETED((short) 9),
-  ELEMENT_TERMINATING((short) 10),
-  ELEMENT_TERMINATED((short) 11),
+  CANCEL((short) 11),
 
-  CANCEL((short) 12),
-  CANCELING((short) 13),
-
-  UPDATE_PAYLOAD((short) 14),
-  PAYLOAD_UPDATED((short) 15);
+  UPDATE_PAYLOAD((short) 12),
+  PAYLOAD_UPDATED((short) 13);
 
   private final short value;
 
@@ -52,34 +49,30 @@ public enum WorkflowInstanceIntent implements Intent {
       case 0:
         return CREATE;
       case 1:
-        return CREATED;
-      case 2:
         return START_EVENT_OCCURRED;
-      case 3:
+      case 2:
         return END_EVENT_OCCURRED;
-      case 4:
+      case 3:
         return SEQUENCE_FLOW_TAKEN;
-      case 5:
+      case 4:
         return GATEWAY_ACTIVATED;
-      case 6:
+      case 5:
         return ELEMENT_READY;
-      case 7:
+      case 6:
         return ELEMENT_ACTIVATED;
-      case 8:
+      case 7:
         return ELEMENT_COMPLETING;
-      case 9:
+      case 8:
         return ELEMENT_COMPLETED;
-      case 10:
+      case 9:
         return ELEMENT_TERMINATING;
-      case 11:
+      case 10:
         return ELEMENT_TERMINATED;
-      case 12:
+      case 11:
         return CANCEL;
-      case 13:
-        return CANCELING;
-      case 14:
+      case 12:
         return UPDATE_PAYLOAD;
-      case 15:
+      case 13:
         return PAYLOAD_UPDATED;
       default:
         return Intent.UNKNOWN;

--- a/test-util/src/main/java/io/zeebe/test/util/record/WorkflowInstanceRecordStream.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/WorkflowInstanceRecordStream.java
@@ -64,4 +64,11 @@ public class WorkflowInstanceRecordStream
             r.getMetadata().getIntent() == WorkflowInstanceIntent.ELEMENT_COMPLETED
                 && r.getKey() == r.getValue().getWorkflowInstanceKey());
   }
+
+  /**
+   * @return stream with only records for the workflow instance (i.e. root scope of the instance)
+   */
+  public WorkflowInstanceRecordStream filterRootScope() {
+    return filter(r -> r.getKey() == r.getValue().getWorkflowInstanceKey());
+  }
 }


### PR DESCRIPTION
- they are redundant with ELEMENT_READY and ELEMENT_TERMINATING

closes #1187
