### PR TITLE
feat(bpmn-model): allow timer boundary events

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
@@ -15,9 +15,8 @@
  */
 package io.zeebe.model.bpmn.validation.zeebe;
 
+import io.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.zeebe.model.bpmn.instance.EventDefinition;
-import io.zeebe.model.bpmn.instance.IntermediateCatchEvent;
-import io.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.zeebe.model.bpmn.instance.TimerEventDefinition;
 import java.util.Arrays;
 import java.util.Collection;
@@ -25,19 +24,38 @@ import java.util.List;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
-public class IntermediateCatchEventValidator
-    implements ModelElementValidator<IntermediateCatchEvent> {
+public class BoundaryEventValidator implements ModelElementValidator<BoundaryEvent> {
   private static final List<Class<? extends EventDefinition>> SUPPORTED_EVENTS =
-      Arrays.asList(MessageEventDefinition.class, TimerEventDefinition.class);
+      Arrays.asList(TimerEventDefinition.class);
 
   @Override
-  public Class<IntermediateCatchEvent> getElementType() {
-    return IntermediateCatchEvent.class;
+  public Class<BoundaryEvent> getElementType() {
+    return BoundaryEvent.class;
   }
 
   @Override
-  public void validate(
-      IntermediateCatchEvent element, ValidationResultCollector validationResultCollector) {
+  public void validate(BoundaryEvent element, ValidationResultCollector validationResultCollector) {
+    if (element.getAttachedTo() == null) {
+      validationResultCollector.addError(0, "Must be attached to an activity");
+    }
+
+    if (element.getIncoming().size() > 0) {
+      validationResultCollector.addError(0, "Cannot have incoming sequence flows");
+    }
+
+    if (element.getOutgoing().size() < 1) {
+      validationResultCollector.addError(0, "Must have at least one outgoing sequence flow");
+    }
+
+    if (!element.cancelActivity()) {
+      validationResultCollector.addError(0, "Non-interrupting boundary events are not supported");
+    }
+
+    validateEventDefinition(element, validationResultCollector);
+  }
+
+  private void validateEventDefinition(
+      BoundaryEvent element, ValidationResultCollector validationResultCollector) {
     final Collection<EventDefinition> eventDefinitions = element.getEventDefinitions();
 
     if (eventDefinitions.size() != 1) {
@@ -47,7 +65,7 @@ public class IntermediateCatchEventValidator
       final Class<? extends EventDefinition> type = eventDefinition.getClass();
 
       if (SUPPORTED_EVENTS.stream().noneMatch(c -> c.isAssignableFrom(type))) {
-        validationResultCollector.addError(0, "Event definition must be one of: message, timer");
+        validationResultCollector.addError(0, "Event definition must be one of: timer");
       }
     }
   }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/CatchEventValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/CatchEventValidator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.validation.zeebe;
+
+import io.zeebe.model.bpmn.instance.CatchEvent;
+import io.zeebe.model.bpmn.instance.EventDefinition;
+import io.zeebe.model.bpmn.instance.Message;
+import io.zeebe.model.bpmn.instance.MessageEventDefinition;
+import io.zeebe.model.bpmn.instance.TimeDuration;
+import io.zeebe.model.bpmn.instance.TimerEventDefinition;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.Collection;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class CatchEventValidator implements ModelElementValidator<CatchEvent> {
+  @Override
+  public Class<CatchEvent> getElementType() {
+    return CatchEvent.class;
+  }
+
+  @Override
+  public void validate(CatchEvent element, ValidationResultCollector validationResultCollector) {
+    final Collection<EventDefinition> eventDefinitions = element.getEventDefinitions();
+    for (final EventDefinition eventDefinition : eventDefinitions) {
+      if (eventDefinition instanceof MessageEventDefinition) {
+        validateMessageEventDefinition(
+            validationResultCollector, (MessageEventDefinition) eventDefinition);
+      } else if (eventDefinition instanceof TimerEventDefinition) {
+        validateTimerEventDefinition(
+            validationResultCollector, (TimerEventDefinition) eventDefinition);
+      }
+    }
+  }
+
+  private void validateMessageEventDefinition(
+      ValidationResultCollector validationResultCollector,
+      MessageEventDefinition messageEventDefinition) {
+    final Message message = messageEventDefinition.getMessage();
+
+    if (message == null) {
+      validationResultCollector.addError(0, "Must reference a message");
+    }
+  }
+
+  private void validateTimerEventDefinition(
+      ValidationResultCollector validationResultCollector,
+      TimerEventDefinition timerEventDefinition) {
+    final TimeDuration timeDuration = timerEventDefinition.getTimeDuration();
+
+    if (timeDuration == null) {
+      validationResultCollector.addError(0, "Must have a time duration");
+    } else {
+      try {
+        Duration.parse(timeDuration.getTextContent());
+      } catch (DateTimeParseException e) {
+        validationResultCollector.addError(0, "Time duration is invalid");
+      }
+    }
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
@@ -15,6 +15,7 @@
  */
 package io.zeebe.model.bpmn.validation.zeebe;
 
+import io.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.zeebe.model.bpmn.instance.EndEvent;
 import io.zeebe.model.bpmn.instance.ExclusiveGateway;
 import io.zeebe.model.bpmn.instance.FlowElement;
@@ -35,6 +36,7 @@ public class FlowElementValidator implements ModelElementValidator<FlowElement> 
   private static final Set<Class<?>> SUPPORTED_ELEMENT_TYPES = new HashSet<>();
 
   static {
+    SUPPORTED_ELEMENT_TYPES.add(BoundaryEvent.class);
     SUPPORTED_ELEMENT_TYPES.add(EndEvent.class);
     SUPPORTED_ELEMENT_TYPES.add(ExclusiveGateway.class);
     SUPPORTED_ELEMENT_TYPES.add(IntermediateCatchEvent.class);

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -25,6 +25,8 @@ public class ZeebeDesignTimeValidators {
 
   static {
     VALIDATORS = new ArrayList<>();
+    VALIDATORS.add(new BoundaryEventValidator());
+    VALIDATORS.add(new CatchEventValidator());
     VALIDATORS.add(new DefinitionsValidator());
     VALIDATORS.add(new EndEventValidator());
     VALIDATORS.add(new EventDefinitionValidator());

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.validation;
+
+import static io.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+import static java.util.Collections.singletonList;
+
+import io.zeebe.model.bpmn.Bpmn;
+import org.junit.runners.Parameterized.Parameters;
+
+public class ZeebeBoundaryEventValidationTest extends AbstractZeebeValidationTest {
+
+  @Parameters(name = "{index}: {1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask("task", b -> b.zeebeTaskType("type"))
+            .boundaryEvent("boundary")
+            .cancelActivity(true)
+            .message(b -> b.name("message").zeebeCorrelationKey("$.id"))
+            .endEvent("end")
+            .done(),
+        singletonList(expect("boundary", "Event definition must be one of: timer"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask("task", b -> b.zeebeTaskType("type"))
+            .boundaryEvent("boundary")
+            .cancelActivity(true)
+            .endEvent("end")
+            .done(),
+        singletonList(expect("boundary", "Must have exactly one event definition"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask("task", b -> b.zeebeTaskType("type"))
+            .boundaryEvent("boundary")
+            .cancelActivity(true)
+            .timerWithDuration("PT0.5S")
+            .timerWithDuration("PT0.5S")
+            .endEvent("end")
+            .done(),
+        singletonList(expect("boundary", "Must have exactly one event definition"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask("task", b -> b.zeebeTaskType("type"))
+            .boundaryEvent("boundary")
+            .cancelActivity(true)
+            .timerWithDuration("PT0.5S")
+            .moveToActivity("task")
+            .endEvent("end")
+            .done(),
+        singletonList(expect("boundary", "Must have at least one outgoing sequence flow"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask("task1", b -> b.zeebeTaskType("type"))
+            .boundaryEvent("boundary")
+            .cancelActivity(true)
+            .timerWithDuration("PT0.5S")
+            .moveToActivity("task1")
+            .serviceTask("task2", b -> b.zeebeTaskType("type"))
+            .sequenceFlowId("taskOut")
+            .connectTo("boundary")
+            .endEvent("end")
+            .done(),
+        singletonList(expect("boundary", "Cannot have incoming sequence flows"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", b -> b.zeebeTaskType("type"))
+            .boundaryEvent("boundary")
+            .cancelActivity(false)
+            .timerWithDuration("PT1S")
+            .endEvent()
+            .moveToActivity("task")
+            .endEvent()
+            .done(),
+        singletonList(expect("boundary", "Non-interrupting boundary events are not supported"))
+      }
+    };
+  }
+}

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
@@ -19,7 +19,6 @@ import static io.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
 import static java.util.Collections.singletonList;
 
 import io.zeebe.model.bpmn.Bpmn;
-import io.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.zeebe.model.bpmn.instance.EndEvent;
 import io.zeebe.model.bpmn.instance.IntermediateThrowEvent;
 import io.zeebe.model.bpmn.instance.Message;
@@ -99,15 +98,6 @@ public class ZeebeMessageValidationTest extends AbstractZeebeValidationTest {
             .message(b -> b.name("foo").zeebeCorrelationKey("correlationKey"))
             .done(),
         singletonList(expect(StartEvent.class, "Must be a none start event"))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .serviceTask("task", t -> t.zeebeTaskType("foo"))
-            .boundaryEvent()
-            .message(b -> b.name("foo").zeebeCorrelationKey("correlationKey"))
-            .done(),
-        singletonList(expect(BoundaryEvent.class, "Elements of this type are not supported"))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
@@ -69,7 +69,7 @@ public class ZeebeValidationTest extends AbstractZeebeValidationTest {
         Arrays.asList(
             expect(
                 CompensateEventDefinition.class, "Event definition of this type is not supported"),
-            expect(IntermediateCatchEvent.class, "Must have a message or timer event definition"))
+            expect(IntermediateCatchEvent.class, "Event definition must be one of: message, timer"))
       },
       {
         "no-start-event-sub-process.bpmn",


### PR DESCRIPTION
- refactor event definition validation in CatchEventValidator
- IntermediateCatchEventValidator only validates type of definition and
  number of definitions
- adds general boundary event validation


closes #1589 
