### PR TITLE
feat(bpmn-model): enable interrupting message boundary events

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ActivityValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ActivityValidator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.validation.zeebe;
+
+import io.zeebe.model.bpmn.instance.Activity;
+import io.zeebe.model.bpmn.instance.BoundaryEvent;
+import io.zeebe.model.bpmn.instance.EventDefinition;
+import io.zeebe.model.bpmn.instance.MessageEventDefinition;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ActivityValidator implements ModelElementValidator<Activity> {
+  @Override
+  public Class<Activity> getElementType() {
+    return Activity.class;
+  }
+
+  @Override
+  public void validate(Activity element, ValidationResultCollector validationResultCollector) {
+    final Collection<BoundaryEvent> boundaryEvents =
+        element.getParentElement().getChildElementsByType(BoundaryEvent.class);
+
+    if (!boundaryEvents.isEmpty()) {
+      final Set<String> boundaryEventMessageNames = new HashSet<>(boundaryEvents.size());
+
+      for (final BoundaryEvent event : boundaryEvents) {
+        if (event.getAttachedTo().equals(element) && !event.getEventDefinitions().isEmpty()) {
+          final EventDefinition trigger = event.getEventDefinitions().iterator().next();
+          if (trigger instanceof MessageEventDefinition) {
+            validateMessageTriggerUniqueness(
+                validationResultCollector,
+                boundaryEventMessageNames,
+                (MessageEventDefinition) trigger);
+          }
+        }
+      }
+    }
+  }
+
+  private void validateMessageTriggerUniqueness(
+      ValidationResultCollector validationResultCollector,
+      Set<String> boundaryEventMessageNames,
+      MessageEventDefinition messageDefinition) {
+    final String name = messageDefinition.getMessage().getName();
+    final boolean didNotContain = boundaryEventMessageNames.add(name);
+
+    if (!didNotContain) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "Cannot have two message catch boundary events with the same name: %s", name));
+    }
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
@@ -17,6 +17,7 @@ package io.zeebe.model.bpmn.validation.zeebe;
 
 import io.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.zeebe.model.bpmn.instance.EventDefinition;
+import io.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.zeebe.model.bpmn.instance.TimerEventDefinition;
 import java.util.Arrays;
 import java.util.Collection;
@@ -26,7 +27,7 @@ import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
 public class BoundaryEventValidator implements ModelElementValidator<BoundaryEvent> {
   private static final List<Class<? extends EventDefinition>> SUPPORTED_EVENTS =
-      Arrays.asList(TimerEventDefinition.class);
+      Arrays.asList(TimerEventDefinition.class, MessageEventDefinition.class);
 
   @Override
   public Class<BoundaryEvent> getElementType() {
@@ -65,7 +66,7 @@ public class BoundaryEventValidator implements ModelElementValidator<BoundaryEve
       final Class<? extends EventDefinition> type = eventDefinition.getClass();
 
       if (SUPPORTED_EVENTS.stream().noneMatch(c -> c.isAssignableFrom(type))) {
-        validationResultCollector.addError(0, "Event definition must be one of: timer");
+        validationResultCollector.addError(0, "Event definition must be one of: timer, message");
       }
     }
   }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -25,6 +25,7 @@ public class ZeebeDesignTimeValidators {
 
   static {
     VALIDATORS = new ArrayList<>();
+    VALIDATORS.add(new ActivityValidator());
     VALIDATORS.add(new BoundaryEventValidator());
     VALIDATORS.add(new CatchEventValidator());
     VALIDATORS.add(new DefinitionsValidator());

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
@@ -19,6 +19,8 @@ import static io.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
 import static java.util.Collections.singletonList;
 
 import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.instance.SignalEventDefinition;
+import java.util.Arrays;
 import org.junit.runners.Parameterized.Parameters;
 
 public class ZeebeBoundaryEventValidationTest extends AbstractZeebeValidationTest {
@@ -32,10 +34,12 @@ public class ZeebeBoundaryEventValidationTest extends AbstractZeebeValidationTes
             .serviceTask("task", b -> b.zeebeTaskType("type"))
             .boundaryEvent("boundary")
             .cancelActivity(true)
-            .message(b -> b.name("message").zeebeCorrelationKey("$.id"))
+            .signal("signal")
             .endEvent("end")
             .done(),
-        singletonList(expect("boundary", "Event definition must be one of: timer"))
+        Arrays.asList(
+            expect(SignalEventDefinition.class, "Event definition of this type is not supported"),
+            expect("boundary", "Event definition must be one of: timer, message"))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
@@ -89,6 +89,23 @@ public class ZeebeValidationTest extends AbstractZeebeValidationTest {
                 ZeebeIoMapping.class,
                 "Output behavior 'none' cannot be used in combination without zeebe:output elements"))
       },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", b -> b.zeebeTaskType("type"))
+            .boundaryEvent("msg1")
+            .message(m -> m.name("message").zeebeCorrelationKey("$.id"))
+            .endEvent()
+            .moveToActivity("task")
+            .boundaryEvent("msg2")
+            .message(m -> m.name("message").zeebeCorrelationKey("$.orderId"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                "task",
+                "Cannot have two message catch boundary events with the same name: message"))
+      },
     };
   }
 }


### PR DESCRIPTION
 feat(bpmn-model): enable interrupting message boundary events

- validates that an activity cannot have two boundary events waiting on
the exact same message

closes #1588 
