### PR TITLE
chore(broker-core): index subscriptions by element and name

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionApiCommandMessageHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionApiCommandMessageHandler.java
@@ -203,7 +203,8 @@ public class SubscriptionApiCommandMessageHandler implements ServerMessageHandle
     messageSubscriptionRecord.reset();
     messageSubscriptionRecord
         .setWorkflowInstanceKey(closeMessageSubscriptionCommand.getWorkflowInstanceKey())
-        .setElementInstanceKey(closeMessageSubscriptionCommand.getElementInstanceKey());
+        .setElementInstanceKey(closeMessageSubscriptionCommand.getElementInstanceKey())
+        .setMessageName(closeMessageSubscriptionCommand.getMessageName());
 
     return writeCommand(
         closeMessageSubscriptionCommand.getSubscriptionPartitionId(),
@@ -225,7 +226,7 @@ public class SubscriptionApiCommandMessageHandler implements ServerMessageHandle
             closeWorkflowInstanceSubscriptionCommand.getSubscriptionPartitionId())
         .setWorkflowInstanceKey(workflowInstanceKey)
         .setElementInstanceKey(closeWorkflowInstanceSubscriptionCommand.getElementInstanceKey())
-        .setMessageName(correlateWorkflowInstanceSubscriptionCommand.getMessageName());
+        .setMessageName(closeWorkflowInstanceSubscriptionCommand.getMessageName());
 
     return writeCommand(
         workflowInstancePartitionId,

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionCommandSender.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionCommandSender.java
@@ -162,23 +162,28 @@ public class SubscriptionCommandSender {
   public boolean closeMessageSubscription(
       final int subscriptionPartitionId,
       final long workflowInstanceKey,
-      final long elementInstanceKey) {
+      final long elementInstanceKey,
+      final DirectBuffer messageName) {
 
     closeMessageSubscriptionCommand.setSubscriptionPartitionId(subscriptionPartitionId);
     closeMessageSubscriptionCommand.setWorkflowInstanceKey(workflowInstanceKey);
     closeMessageSubscriptionCommand.setElementInstanceKey(elementInstanceKey);
+    closeMessageSubscriptionCommand.setMessageName(messageName);
 
     return sendSubscriptionCommand(subscriptionPartitionId, closeMessageSubscriptionCommand);
   }
 
   public boolean closeWorkflowInstanceSubscription(
-      final long workflowInstanceKey, final long elementInstanceKey) {
+      final long workflowInstanceKey,
+      final long elementInstanceKey,
+      final DirectBuffer messageName) {
 
     final int workflowInstancePartitionId = Protocol.decodePartitionId(workflowInstanceKey);
 
     closeWorkflowInstanceSubscriptionCommand.setSubscriptionPartitionId(partitionId);
     closeWorkflowInstanceSubscriptionCommand.setWorkflowInstanceKey(workflowInstanceKey);
     closeWorkflowInstanceSubscriptionCommand.setElementInstanceKey(elementInstanceKey);
+    closeWorkflowInstanceSubscriptionCommand.setMessageName(messageName);
 
     return sendSubscriptionCommand(
         workflowInstancePartitionId, closeWorkflowInstanceSubscriptionCommand);

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/CloseMessageSubscriptionProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/CloseMessageSubscriptionProcessor.java
@@ -52,7 +52,9 @@ public class CloseMessageSubscriptionProcessor
       final Consumer<SideEffectProducer> sideEffect) {
     subscriptionRecord = record.getValue();
 
-    final boolean removed = subscriptionState.remove(subscriptionRecord.getElementInstanceKey());
+    final boolean removed =
+        subscriptionState.remove(
+            subscriptionRecord.getElementInstanceKey(), subscriptionRecord.getMessageName());
     if (removed) {
       streamWriter.appendFollowUpEvent(
           record.getKey(), MessageSubscriptionIntent.CLOSED, subscriptionRecord);
@@ -67,6 +69,8 @@ public class CloseMessageSubscriptionProcessor
 
   private boolean sendAcknowledgeCommand() {
     return commandSender.closeWorkflowInstanceSubscription(
-        subscriptionRecord.getWorkflowInstanceKey(), subscriptionRecord.getElementInstanceKey());
+        subscriptionRecord.getWorkflowInstanceKey(),
+        subscriptionRecord.getElementInstanceKey(),
+        subscriptionRecord.getMessageName());
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/CorrelateMessageSubscriptionProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/CorrelateMessageSubscriptionProcessor.java
@@ -46,7 +46,9 @@ public class CorrelateMessageSubscriptionProcessor
 
     final MessageSubscriptionRecord subscriptionRecord = record.getValue();
 
-    final boolean removed = subscriptionState.remove(subscriptionRecord.getElementInstanceKey());
+    final boolean removed =
+        subscriptionState.remove(
+            subscriptionRecord.getElementInstanceKey(), subscriptionRecord.getMessageName());
 
     if (removed) {
       streamWriter.appendFollowUpEvent(

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/OpenMessageSubscriptionProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/OpenMessageSubscriptionProcessor.java
@@ -67,7 +67,7 @@ public class OpenMessageSubscriptionProcessor
     subscriptionRecord = record.getValue();
 
     if (subscriptionState.existSubscriptionForElementInstance(
-        subscriptionRecord.getElementInstanceKey())) {
+        subscriptionRecord.getElementInstanceKey(), subscriptionRecord.getMessageName())) {
       sideEffect.accept(this::sendAcknowledgeCommand);
 
       streamWriter.appendRejection(

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageSubscription.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageSubscription.java
@@ -51,6 +51,14 @@ public class MessageSubscription implements BufferReader, BufferWriter {
     this.correlationKey.wrap(correlationKey);
   }
 
+  public void setElementInstanceKey(long elementInstanceKey) {
+    this.elementInstanceKey = elementInstanceKey;
+  }
+
+  public void setMessageName(DirectBuffer messageName) {
+    this.messageName.wrap(messageName);
+  }
+
   public DirectBuffer getMessageName() {
     return messageName;
   }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageSubscriptionState.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageSubscriptionState.java
@@ -19,11 +19,14 @@ package io.zeebe.broker.subscription.message.state;
 
 import static io.zeebe.broker.workflow.state.PersistenceHelper.EXISTENCE;
 import static io.zeebe.logstreams.rocksdb.ZeebeStateConstants.STATE_BYTE_ORDER;
+import static io.zeebe.util.buffer.BufferUtil.readIntoBuffer;
+import static io.zeebe.util.buffer.BufferUtil.writeIntoBuffer;
 
 import io.zeebe.logstreams.rocksdb.ZbRocksDb;
 import io.zeebe.logstreams.rocksdb.ZbWriteBatch;
 import io.zeebe.logstreams.state.StateController;
 import io.zeebe.logstreams.state.StateLifecycleListener;
+import io.zeebe.util.buffer.BufferUtil;
 import java.util.Arrays;
 import java.util.List;
 import org.agrona.DirectBuffer;
@@ -31,6 +34,7 @@ import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteOptions;
 
@@ -52,13 +56,16 @@ public class MessageSubscriptionState implements StateLifecycleListener {
   };
 
   private ZbRocksDb db;
+  // (elementInstanceKey, messageName) => MessageSubscription
   private ColumnFamilyHandle subscriptionColumnFamily;
+  // (sentTime, elementInstanceKey, messageName) => \0
   private ColumnFamilyHandle sentTimeColumnFamily;
+  // (messageName, correlationKey, elementInstanceKey) => \0
   private ColumnFamilyHandle messageNameAndCorrelationKeyColumnFamily;
 
   private final ExpandableArrayBuffer keyBuffer = new ExpandableArrayBuffer();
   private final ExpandableArrayBuffer valueBuffer = new ExpandableArrayBuffer();
-  private final UnsafeBuffer iterateKeyBuffer = new UnsafeBuffer(0, 0);
+  private final UnsafeBuffer bufferView = new UnsafeBuffer(0, 0);
 
   private final MessageSubscription subscription = new MessageSubscription();
 
@@ -78,19 +85,19 @@ public class MessageSubscriptionState implements StateLifecycleListener {
   }
 
   public void put(final MessageSubscription subscription) {
-
     try (final WriteOptions options = new WriteOptions();
         final ZbWriteBatch batch = new ZbWriteBatch()) {
-
+      int keyLength = writeSubscriptionKey(keyBuffer, 0, subscription);
       subscription.write(valueBuffer, 0);
 
       batch.put(
           subscriptionColumnFamily,
-          subscription.getElementInstanceKey(),
+          keyBuffer.byteArray(),
+          keyLength,
           valueBuffer.byteArray(),
           subscription.getLength());
 
-      final int keyLength = writeMessageNameAndCorrelationKey(keyBuffer, subscription);
+      keyLength = writeMessageNameAndCorrelationKey(keyBuffer, subscription);
       batch.put(
           messageNameAndCorrelationKeyColumnFamily,
           keyBuffer.byteArray(),
@@ -125,34 +132,68 @@ public class MessageSubscriptionState implements StateLifecycleListener {
   }
 
   private int writeSentTimeKey(MutableDirectBuffer buffer, final MessageSubscription subscription) {
+    final int expectedLength = Long.BYTES + getSubscriptionKeyLength(subscription.getMessageName());
     int offset = 0;
 
     buffer.putLong(offset, subscription.getCommandSentTime(), STATE_BYTE_ORDER);
     offset += Long.BYTES;
 
-    buffer.putLong(offset, subscription.getElementInstanceKey(), STATE_BYTE_ORDER);
-    offset += Long.BYTES;
+    offset = writeSubscriptionKey(buffer, offset, subscription);
+    assert offset == expectedLength : "End offset differs from expected length";
 
-    assert (2 * Long.BYTES) == offset
-        : "Offset problem: offset is not equal to expected key length";
     return offset;
   }
 
-  private boolean readSubscription(long key, MessageSubscription subscription) {
-    final int readBytes = db.get(subscriptionColumnFamily, key, valueBuffer);
-    if (readBytes > 0) {
+  private int writeSubscriptionKey(
+      MutableDirectBuffer buffer, int offset, final MessageSubscription subscription) {
+    return writeSubscriptionKey(
+        buffer, offset, subscription.getElementInstanceKey(), subscription.getMessageName());
+  }
+
+  private int writeSubscriptionKey(
+      MutableDirectBuffer buffer, int offset, long elementInstanceKey, DirectBuffer messageName) {
+    final int startOffset = offset;
+    final int expectedLength = getSubscriptionKeyLength(messageName);
+
+    buffer.putLong(offset, elementInstanceKey, STATE_BYTE_ORDER);
+    offset += Long.BYTES;
+
+    offset = writeIntoBuffer(buffer, offset, messageName);
+    assert (offset - startOffset) == expectedLength : "End offset differs from expected length";
+
+    return offset;
+  }
+
+  private void wrapSubscriptionKey(
+      DirectBuffer source, int offset, final MessageSubscription subscription) {
+    subscription.setElementInstanceKey(source.getLong(offset, STATE_BYTE_ORDER));
+    offset += Long.BYTES;
+
+    readIntoBuffer(source, offset, subscription.getMessageName());
+  }
+
+  private int getSubscriptionKeyLength(DirectBuffer messageName) {
+    return Long.BYTES + Integer.BYTES + messageName.capacity();
+  }
+
+  private boolean readSubscription(
+      long elementInstanceKey, DirectBuffer messageName, MessageSubscription subscription) {
+    final int keyLength = writeSubscriptionKey(keyBuffer, 0, elementInstanceKey, messageName);
+    bufferView.wrap(keyBuffer, 0, keyLength);
+
+    final int readBytes = db.get(subscriptionColumnFamily, bufferView, valueBuffer);
+    if (readBytes != RocksDB.NOT_FOUND) {
       subscription.wrap(valueBuffer, 0, readBytes);
       return true;
-    } else {
-      return false;
     }
+
+    return false;
   }
 
   public void visitSubscriptions(
       final DirectBuffer messageName,
       final DirectBuffer correlationKey,
       MessageSubscriptionVisitor visitor) {
-
     int offset = 0;
     final int prefixLength = messageName.capacity() + correlationKey.capacity();
     final MutableDirectBuffer prefixBuffer = new UnsafeBuffer(new byte[prefixLength]);
@@ -166,16 +207,15 @@ public class MessageSubscriptionState implements StateLifecycleListener {
         messageNameAndCorrelationKeyColumnFamily,
         prefixBuffer,
         (entry, control) -> {
-          iterateKeyBuffer.wrap(entry.getKey());
+          final DirectBuffer keyBuffer = entry.getKey();
+          final long elementInstanceKey = keyBuffer.getLong(prefixLength, STATE_BYTE_ORDER);
 
-          final long subscriptionKey = iterateKeyBuffer.getLong(prefixLength, STATE_BYTE_ORDER);
-
-          final boolean found = readSubscription(subscriptionKey, subscription);
+          final boolean found = readSubscription(elementInstanceKey, messageName, subscription);
           if (!found) {
             throw new IllegalStateException(
                 String.format(
                     "Expected to find subscription with key %d, but no subscription found",
-                    subscriptionKey));
+                    elementInstanceKey));
           }
 
           final boolean visited = visitor.visit(subscription);
@@ -187,17 +227,13 @@ public class MessageSubscriptionState implements StateLifecycleListener {
 
   public void updateToCorrelatingState(
       final MessageSubscription subscription, DirectBuffer messagePayload, long sentTime) {
-
     subscription.setMessagePayload(messagePayload);
-
     updateSentTime(subscription, sentTime);
   }
 
   public void updateSentTime(final MessageSubscription subscription, long sentTime) {
-
     try (final WriteOptions options = new WriteOptions();
         final ZbWriteBatch batch = new ZbWriteBatch()) {
-
       int keyLength;
 
       if (subscription.getCommandSentTime() > 0) {
@@ -206,11 +242,12 @@ public class MessageSubscriptionState implements StateLifecycleListener {
       }
 
       subscription.setCommandSentTime(sentTime);
-
+      keyLength = writeSubscriptionKey(keyBuffer, 0, subscription);
       subscription.write(valueBuffer, 0);
       batch.put(
           subscriptionColumnFamily,
-          subscription.getElementInstanceKey(),
+          keyBuffer.byteArray(),
+          keyLength,
           valueBuffer.byteArray(),
           subscription.getLength());
 
@@ -225,24 +262,27 @@ public class MessageSubscriptionState implements StateLifecycleListener {
   }
 
   public void visitSubscriptionBefore(final long deadline, MessageSubscriptionVisitor visitor) {
-
     db.forEach(
         sentTimeColumnFamily,
         (entry, control) -> {
-          iterateKeyBuffer.wrap(entry.getKey());
-
-          final long sentTime = iterateKeyBuffer.getLong(0, STATE_BYTE_ORDER);
+          final DirectBuffer keyBuffer = entry.getKey();
+          final long sentTime = keyBuffer.getLong(0, STATE_BYTE_ORDER);
 
           boolean visited = false;
           if (sentTime < deadline) {
-            final long subscriptionKey = iterateKeyBuffer.getLong(Long.BYTES, STATE_BYTE_ORDER);
+            wrapSubscriptionKey(keyBuffer, Long.BYTES, subscription);
+            final boolean found =
+                readSubscription(
+                    subscription.getElementInstanceKey(),
+                    subscription.getMessageName(),
+                    subscription);
 
-            final boolean found = readSubscription(subscriptionKey, subscription);
             if (!found) {
               throw new IllegalStateException(
                   String.format(
-                      "Expected to find subscription with key %d, but no subscription found",
-                      subscriptionKey));
+                      "No subscription found matching %d - %s",
+                      subscription.getElementInstanceKey(),
+                      BufferUtil.bufferAsString(subscription.getMessageName())));
             }
 
             visited = visitor.visit(subscription);
@@ -254,12 +294,14 @@ public class MessageSubscriptionState implements StateLifecycleListener {
         });
   }
 
-  public boolean existSubscriptionForElementInstance(final long elementInstanceKey) {
-    return db.exists(subscriptionColumnFamily, elementInstanceKey);
+  public boolean existSubscriptionForElementInstance(
+      long elementInstanceKey, DirectBuffer messageName) {
+    final int keyLength = writeSubscriptionKey(keyBuffer, 0, elementInstanceKey, messageName);
+    return db.exists(subscriptionColumnFamily, keyBuffer.byteArray(), 0, keyLength);
   }
 
-  public boolean remove(final long elementInstanceKey) {
-    final boolean found = readSubscription(elementInstanceKey, subscription);
+  public boolean remove(long elementInstanceKey, DirectBuffer messageName) {
+    final boolean found = readSubscription(elementInstanceKey, messageName, subscription);
     if (found) {
       remove(subscription);
     }
@@ -269,10 +311,10 @@ public class MessageSubscriptionState implements StateLifecycleListener {
   private void remove(final MessageSubscription subscription) {
     try (final WriteOptions options = new WriteOptions();
         final ZbWriteBatch batch = new ZbWriteBatch()) {
+      int keyLength = writeSubscriptionKey(keyBuffer, 0, subscription);
+      batch.delete(subscriptionColumnFamily, keyBuffer.byteArray(), keyLength);
 
-      batch.delete(subscriptionColumnFamily, subscription.getElementInstanceKey());
-
-      int keyLength = writeMessageNameAndCorrelationKey(keyBuffer, subscription);
+      keyLength = writeMessageNameAndCorrelationKey(keyBuffer, subscription);
       batch.delete(messageNameAndCorrelationKeyColumnFamily, keyBuffer.byteArray(), keyLength);
 
       if (subscription.getCommandSentTime() > 0) {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepContext.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepContext.java
@@ -19,7 +19,6 @@ package io.zeebe.broker.workflow.processor;
 
 import io.zeebe.broker.incident.data.ErrorType;
 import io.zeebe.broker.incident.data.IncidentRecord;
-import io.zeebe.broker.logstreams.processor.SideEffectProducer;
 import io.zeebe.broker.logstreams.processor.TypedCommandWriter;
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
@@ -29,11 +28,11 @@ import io.zeebe.msgpack.mapping.MsgPackMergeTool;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.IncidentIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
-import java.util.function.Consumer;
 
 public class BpmnStepContext<T extends ExecutableFlowElement> {
 
   private final IncidentRecord incidentCommand = new IncidentRecord();
+  private final SideEffectQueue sideEffect = new SideEffectQueue();
   private final EventOutput eventOutput;
   private final MsgPackMergeTool mergeTool;
   private final CatchEventOutput catchEventOutput;
@@ -41,7 +40,6 @@ public class BpmnStepContext<T extends ExecutableFlowElement> {
   private TypedRecord<WorkflowInstanceRecord> record;
   private ExecutableFlowElement element;
   private TypedCommandWriter commandWriter;
-  private Consumer<SideEffectProducer> sideEffect;
 
   private ElementInstance flowScopeInstance;
   private ElementInstance elementInstance;
@@ -118,11 +116,7 @@ public class BpmnStepContext<T extends ExecutableFlowElement> {
     this.elementInstance = elementInstance;
   }
 
-  public void setSideEffect(final Consumer<SideEffectProducer> sideEffect) {
-    this.sideEffect = sideEffect;
-  }
-
-  public Consumer<SideEffectProducer> getSideEffect() {
+  public SideEffectQueue getSideEffect() {
     return sideEffect;
   }
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepProcessor.java
@@ -90,7 +90,9 @@ public class BpmnStepProcessor implements TypedRecordProcessor<WorkflowInstanceR
 
     context.setRecord(record);
     context.setStreamWriter(streamWriter);
-    context.setSideEffect(sideEffect);
+
+    context.getSideEffect().clear();
+    sideEffect.accept(context.getSideEffect());
 
     final long workflowKey = record.getValue().getWorkflowKey();
     final DeployedWorkflow deployedWorkflow = workflowState.getWorkflowByKey(workflowKey);

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/SideEffectQueue.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/SideEffectQueue.java
@@ -1,0 +1,65 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow.processor;
+
+import io.zeebe.broker.logstreams.processor.SideEffectProducer;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SideEffectQueue implements SideEffectProducer {
+  private final List<SideEffectProducer> sideEffects = new ArrayList<>();
+
+  public void clear() {
+    sideEffects.clear();
+  }
+
+  @Override
+  public boolean flush() {
+    if (sideEffects.isEmpty()) {
+      return true;
+    }
+
+    boolean flushed = true;
+
+    // iterates once over everything, setting the side effect to null to avoid reprocessing if we
+    // couldn't flush and this is retried. considered lesser evil than removing from the list and
+    // having to shuffle elements around in the list.
+    for (int i = 0; i < sideEffects.size(); i++) {
+      final SideEffectProducer sideEffect = sideEffects.get(i);
+
+      if (sideEffect != null) {
+        if (sideEffect.flush()) {
+          sideEffects.set(i, null);
+        } else {
+          flushed = false;
+        }
+      }
+    }
+
+    // reset list size to 0 if everything was flushed
+    if (flushed) {
+      sideEffects.clear();
+    }
+
+    return flushed;
+  }
+
+  public void add(SideEffectProducer sideEffectProducer) {
+    sideEffects.add(sideEffectProducer);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/CloseWorkflowInstanceSubscription.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/CloseWorkflowInstanceSubscription.java
@@ -44,7 +44,9 @@ public final class CloseWorkflowInstanceSubscription
 
     final WorkflowInstanceSubscriptionRecord subscription = record.getValue();
 
-    final boolean removed = subscriptionState.remove(subscription.getElementInstanceKey());
+    final boolean removed =
+        subscriptionState.remove(
+            subscription.getElementInstanceKey(), subscription.getMessageName());
     if (removed) {
       streamWriter.appendFollowUpEvent(
           record.getKey(), WorkflowInstanceSubscriptionIntent.CLOSED, subscription);

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/CorrelateWorkflowInstanceSubscription.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/CorrelateWorkflowInstanceSubscription.java
@@ -115,7 +115,9 @@ public final class CorrelateWorkflowInstanceSubscription
 
   private void onWorkflowAvailable() {
     // remove subscription if pending
-    final boolean removed = subscriptionState.remove(subscription.getElementInstanceKey());
+    final boolean removed =
+        subscriptionState.remove(
+            subscription.getElementInstanceKey(), subscription.getMessageName());
     if (!removed) {
       streamWriter.appendRejection(
           record, RejectionType.NOT_APPLICABLE, "subscription is already correlated");

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/OpenWorkflowInstanceSubscriptionProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/OpenWorkflowInstanceSubscriptionProcessor.java
@@ -46,7 +46,8 @@ public class OpenWorkflowInstanceSubscriptionProcessor
     final WorkflowInstanceSubscriptionRecord subscriptionRecord = record.getValue();
 
     final WorkflowInstanceSubscription subscription =
-        subscriptionState.getSubscription(subscriptionRecord.getElementInstanceKey());
+        subscriptionState.getSubscription(
+            subscriptionRecord.getElementInstanceKey(), subscriptionRecord.getMessageName());
     if (subscription != null && subscription.isOpening()) {
 
       subscriptionState.updateToOpenedState(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/PendingWorkflowInstanceSubscriptionChecker.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/PendingWorkflowInstanceSubscriptionChecker.java
@@ -73,6 +73,7 @@ public class PendingWorkflowInstanceSubscriptionChecker implements Runnable {
     return commandSender.closeMessageSubscription(
         subscription.getSubscriptionPartitionId(),
         subscription.getWorkflowInstanceKey(),
-        subscription.getElementInstanceKey());
+        subscription.getElementInstanceKey(),
+        subscription.getMessageName());
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/TerminateIntermediateMessageHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/TerminateIntermediateMessageHandler.java
@@ -31,6 +31,6 @@ public class TerminateIntermediateMessageHandler
 
   @Override
   protected void terminate(BpmnStepContext<ExecutableIntermediateCatchElement> context) {
-    context.getCatchEventOutput().unsubscribeFromMessageEvent(context);
+    context.getCatchEventOutput().unsubscribeFromMessageEvents(context);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/state/WorkflowInstanceSubscription.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/state/WorkflowInstanceSubscription.java
@@ -22,6 +22,7 @@ import static io.zeebe.util.buffer.BufferUtil.readIntoBuffer;
 import static io.zeebe.util.buffer.BufferUtil.writeIntoBuffer;
 
 import io.zeebe.util.buffer.BufferReader;
+import io.zeebe.util.buffer.BufferUtil;
 import io.zeebe.util.buffer.BufferWriter;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -68,12 +69,28 @@ public class WorkflowInstanceSubscription implements BufferReader, BufferWriter 
     return messageName;
   }
 
+  public void setMessageName(DirectBuffer messageName) {
+    this.messageName.wrap(messageName);
+  }
+
   public DirectBuffer getCorrelationKey() {
     return correlationKey;
   }
 
+  public void setCorrelationKey(DirectBuffer correlationKey) {
+    this.correlationKey.wrap(correlationKey);
+  }
+
   public long getWorkflowInstanceKey() {
     return workflowInstanceKey;
+  }
+
+  public void setWorkflowInstanceKey(long workflowInstanceKey) {
+    this.workflowInstanceKey = workflowInstanceKey;
+  }
+
+  public void setElementInstanceKey(long elementInstanceKey) {
+    this.elementInstanceKey = elementInstanceKey;
   }
 
   public long getElementInstanceKey() {
@@ -158,5 +175,25 @@ public class WorkflowInstanceSubscription implements BufferReader, BufferWriter 
     offset = writeIntoBuffer(buffer, offset, messageName);
     offset = writeIntoBuffer(buffer, offset, correlationKey);
     assert offset == getLength() : "End offset differs with getLength()";
+  }
+
+  @Override
+  public String toString() {
+    return "WorkflowInstanceSubscription{"
+        + "elementInstanceKey="
+        + elementInstanceKey
+        + ", messageName="
+        + BufferUtil.bufferAsString(messageName)
+        + ", correlationKey="
+        + BufferUtil.bufferAsString(correlationKey)
+        + ", workflowInstanceKey="
+        + workflowInstanceKey
+        + ", subscriptionPartitionId="
+        + subscriptionPartitionId
+        + ", commandSentTime="
+        + commandSentTime
+        + ", state="
+        + state
+        + '}';
   }
 }

--- a/broker-core/src/main/resources/subscription-schema.xml
+++ b/broker-core/src/main/resources/subscription-schema.xml
@@ -1,70 +1,74 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
-    package="io.zeebe.broker.subscription" id="6" version="1"
-    semanticVersion="${project.version}" description="Zeebe Subscription Protocol" byteOrder="littleEndian">
+  package="io.zeebe.broker.subscription" id="6" version="1"
+  semanticVersion="${project.version}" description="Zeebe Subscription Protocol"
+  byteOrder="littleEndian">
 
-    <types>
+  <types>
 
-        <composite name="messageHeader"
-            description="Message identifiers and length of message root">
-            <type name="blockLength" primitiveType="uint16" />
-            <type name="templateId" primitiveType="uint16" />
-            <type name="schemaId" primitiveType="uint16" />
-            <type name="version" primitiveType="uint16" />
-        </composite>
+    <composite name="messageHeader"
+      description="Message identifiers and length of message root">
+      <type name="blockLength" primitiveType="uint16"/>
+      <type name="templateId" primitiveType="uint16"/>
+      <type name="schemaId" primitiveType="uint16"/>
+      <type name="version" primitiveType="uint16"/>
+    </composite>
 
-        <composite name="varDataEncoding">
-            <type name="length" primitiveType="uint16" />
-            <type name="varData" primitiveType="uint8" length="0" characterEncoding="UTF-8" />
-        </composite>
+    <composite name="varDataEncoding">
+      <type name="length" primitiveType="uint16"/>
+      <type name="varData" primitiveType="uint8" length="0" characterEncoding="UTF-8"/>
+    </composite>
 
-        <composite name="groupSizeEncoding">
-            <type name="blockLength" primitiveType="uint16" />
-            <type name="numInGroup" primitiveType="uint8" semanticType="NumInGroup" />
-        </composite>
+    <composite name="groupSizeEncoding">
+      <type name="blockLength" primitiveType="uint16"/>
+      <type name="numInGroup" primitiveType="uint8" semanticType="NumInGroup"/>
+    </composite>
 
-    </types>
+  </types>
 
-    <sbe:message name="OpenMessageSubscription" id="0">
-    	<field name="subscriptionPartitionId" id="0" type="uint16"/>
-      <field name="workflowInstanceKey" id="1" type="uint64" />
-      <field name="elementInstanceKey" id="2" type="uint64" />  
-      <data name="messageName" id="3" type="varDataEncoding" />
-      <data name="correlationKey" id="4" type="varDataEncoding" />
-    </sbe:message>
-    
-    <sbe:message name="OpenWorkflowInstanceSubscription" id="1">
-    	<field name="subscriptionPartitionId" id="0" type="uint16"/>
-      <field name="workflowInstanceKey" id="1" type="uint64" />
-      <field name="elementInstanceKey" id="2" type="uint64" />  
-      <data name="messageName" id="3" type="varDataEncoding" />
-    </sbe:message>
-    
-    <sbe:message name="CorrelateWorkflowInstanceSubscription" id="2">
-      <field name="subscriptionPartitionId" id="0" type="uint16"/>
-      <field name="workflowInstanceKey" id="1" type="uint64" />
-      <field name="elementInstanceKey" id="2" type="uint64" />  
-      <data name="messageName" id="3" type="varDataEncoding" />
-      <data name="payload" id="4" type="varDataEncoding" />
-    </sbe:message>
-    
-    <sbe:message name="CorrelateMessageSubscription" id="3">
-      <field name="subscriptionPartitionId" id="0" type="uint16"/>
-      <field name="workflowInstanceKey" id="1" type="uint64" />
-      <field name="elementInstanceKey" id="2" type="uint64" />  
-      <data name="messageName" id="3" type="varDataEncoding" />
-    </sbe:message>
-    
-    <sbe:message name="CloseMessageSubscription" id="4">
-    	<field name="subscriptionPartitionId" id="0" type="uint16"/>
-      <field name="workflowInstanceKey" id="1" type="uint64" />
-      <field name="elementInstanceKey" id="2" type="uint64" />  
-    </sbe:message>s
-    
-    <sbe:message name="CloseWorkflowInstanceSubscription" id="5">
-    	<field name="subscriptionPartitionId" id="0" type="uint16"/>
-      <field name="workflowInstanceKey" id="1" type="uint64" />
-      <field name="elementInstanceKey" id="2" type="uint64" />  
-    </sbe:message>
+  <sbe:message name="OpenMessageSubscription" id="0">
+    <field name="subscriptionPartitionId" id="0" type="uint16"/>
+    <field name="workflowInstanceKey" id="1" type="uint64"/>
+    <field name="elementInstanceKey" id="2" type="uint64"/>
+    <data name="messageName" id="3" type="varDataEncoding"/>
+    <data name="correlationKey" id="4" type="varDataEncoding"/>
+  </sbe:message>
+
+  <sbe:message name="OpenWorkflowInstanceSubscription" id="1">
+    <field name="subscriptionPartitionId" id="0" type="uint16"/>
+    <field name="workflowInstanceKey" id="1" type="uint64"/>
+    <field name="elementInstanceKey" id="2" type="uint64"/>
+    <data name="messageName" id="3" type="varDataEncoding"/>
+  </sbe:message>
+
+  <sbe:message name="CorrelateWorkflowInstanceSubscription" id="2">
+    <field name="subscriptionPartitionId" id="0" type="uint16"/>
+    <field name="workflowInstanceKey" id="1" type="uint64"/>
+    <field name="elementInstanceKey" id="2" type="uint64"/>
+    <data name="messageName" id="3" type="varDataEncoding"/>
+    <data name="payload" id="4" type="varDataEncoding"/>
+  </sbe:message>
+
+  <sbe:message name="CorrelateMessageSubscription" id="3">
+    <field name="subscriptionPartitionId" id="0" type="uint16"/>
+    <field name="workflowInstanceKey" id="1" type="uint64"/>
+    <field name="elementInstanceKey" id="2" type="uint64"/>
+    <data name="messageName" id="3" type="varDataEncoding"/>
+  </sbe:message>
+
+  <sbe:message name="CloseMessageSubscription" id="4">
+    <field name="subscriptionPartitionId" id="0" type="uint16"/>
+    <field name="workflowInstanceKey" id="1" type="uint64"/>
+    <field name="elementInstanceKey" id="2" type="uint64"/>
+    <data name="messageName" id="3" type="varDataEncoding"/>
+  </sbe:message>
+  s
+
+  <sbe:message name="CloseWorkflowInstanceSubscription" id="5">
+    <field name="subscriptionPartitionId" id="0" type="uint16"/>
+    <field name="workflowInstanceKey" id="1" type="uint64"/>
+    <field name="elementInstanceKey" id="2" type="uint64"/>
+    <data name="messageName" id="3" type="varDataEncoding"/>
+  </sbe:message>
 
 </sbe:messageSchema>

--- a/broker-core/src/test/java/io/zeebe/broker/incident/IncidentStreamProcessorRule.java
+++ b/broker-core/src/test/java/io/zeebe/broker/incident/IncidentStreamProcessorRule.java
@@ -82,7 +82,8 @@ public class IncidentStreamProcessorRule extends ExternalResource {
     when(mockSubscriptionCommandSender.correlateMessageSubscription(
             anyInt(), anyLong(), anyLong(), any()))
         .thenReturn(true);
-    when(mockSubscriptionCommandSender.closeMessageSubscription(anyInt(), anyLong(), anyLong()))
+    when(mockSubscriptionCommandSender.closeMessageSubscription(
+            anyInt(), anyLong(), anyLong(), any(DirectBuffer.class)))
         .thenReturn(true);
 
     streamProcessor =

--- a/broker-core/src/test/java/io/zeebe/broker/subscription/message/state/MessageSubscriptionStateTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/subscription/message/state/MessageSubscriptionStateTest.java
@@ -48,12 +48,29 @@ public class MessageSubscriptionStateTest {
   }
 
   @Test
-  public void shouldNotExist() {
+  public void shouldNotExistWithDifferentElementKey() {
     // given
-    state.put(subscriptionWithElementInstanceKey(1));
+    final MessageSubscription subscription = subscriptionWithElementInstanceKey(1);
+    state.put(subscription);
 
     // when
-    final boolean exist = state.existSubscriptionForElementInstance(2);
+    final boolean exist =
+        state.existSubscriptionForElementInstance(2, subscription.getMessageName());
+
+    // then
+    assertThat(exist).isFalse();
+  }
+
+  @Test
+  public void shouldNotExistWithDifferentMessageName() {
+    // given
+    final MessageSubscription subscription = subscriptionWithElementInstanceKey(1);
+    state.put(subscription);
+
+    // when
+    final boolean exist =
+        state.existSubscriptionForElementInstance(
+            subscription.getElementInstanceKey(), wrapString("\0"));
 
     // then
     assertThat(exist).isFalse();
@@ -62,10 +79,13 @@ public class MessageSubscriptionStateTest {
   @Test
   public void shouldExistSubscription() {
     // given
-    state.put(subscriptionWithElementInstanceKey(1));
+    final MessageSubscription subscription = subscriptionWithElementInstanceKey(1);
+    state.put(subscription);
 
     // when
-    final boolean exist = state.existSubscriptionForElementInstance(1);
+    final boolean exist =
+        state.existSubscriptionForElementInstance(
+            subscription.getElementInstanceKey(), subscription.getMessageName());
 
     // then
     assertThat(exist).isTrue();
@@ -269,7 +289,7 @@ public class MessageSubscriptionStateTest {
     state.updateSentTime(subscription, 1_000);
 
     // when
-    state.remove(1L);
+    state.remove(1L, subscription.getMessageName());
 
     // then
     final List<Long> keys = new ArrayList<>();
@@ -286,20 +306,23 @@ public class MessageSubscriptionStateTest {
     assertThat(keys).isEmpty();
 
     // and
-    assertThat(state.existSubscriptionForElementInstance(1L)).isFalse();
+    assertThat(state.existSubscriptionForElementInstance(1L, subscription.getMessageName()))
+        .isFalse();
   }
 
   @Test
   public void shouldNotFailOnRemoveSubscriptionTwice() {
     // given
-    state.put(subscriptionWithElementInstanceKey(1L));
+    final MessageSubscription subscription = subscriptionWithElementInstanceKey(1L);
+    state.put(subscription);
 
     // when
-    state.remove(1L);
-    state.remove(1L);
+    state.remove(1L, subscription.getMessageName());
+    state.remove(1L, subscription.getMessageName());
 
     // then
-    assertThat(state.existSubscriptionForElementInstance(1L)).isFalse();
+    assertThat(state.existSubscriptionForElementInstance(1L, subscription.getMessageName()))
+        .isFalse();
   }
 
   @Test
@@ -309,7 +332,7 @@ public class MessageSubscriptionStateTest {
     state.put(subscription("messageName", "correlationKey", 2L));
 
     // when
-    state.remove(2L);
+    state.remove(2L, wrapString("messageName"));
 
     // then
     final List<Long> keys = new ArrayList<>();

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageCatchElementTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageCatchElementTest.java
@@ -267,7 +267,7 @@ public class MessageCatchElementTest {
     Assertions.assertThat(messageSubscription.getValue())
         .hasWorkflowInstanceKey(workflowInstanceKey)
         .hasElementInstanceKey(catchEventEntered.getKey())
-        .hasMessageName("")
+        .hasMessageName("order canceled")
         .hasCorrelationKey("");
   }
 
@@ -293,7 +293,7 @@ public class MessageCatchElementTest {
     Assertions.assertThat(subscription.getValue())
         .hasWorkflowInstanceKey(workflowInstanceKey)
         .hasElementInstanceKey(catchEventEntered.getKey())
-        .hasMessageName("");
+        .hasMessageName("order canceled");
   }
 
   @Test

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorRule.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorRule.java
@@ -94,7 +94,8 @@ public class WorkflowInstanceStreamProcessorRule extends ExternalResource {
     when(mockSubscriptionCommandSender.correlateMessageSubscription(
             anyInt(), anyLong(), anyLong(), any()))
         .thenReturn(true);
-    when(mockSubscriptionCommandSender.closeMessageSubscription(anyInt(), anyLong(), anyLong()))
+    when(mockSubscriptionCommandSender.closeMessageSubscription(
+            anyInt(), anyLong(), anyLong(), any(DirectBuffer.class)))
         .thenReturn(true);
 
     streamProcessor =

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorTest.java
@@ -510,7 +510,8 @@ public class WorkflowInstanceStreamProcessorTest {
         .closeMessageSubscription(
             subscription.getSubscriptionPartitionId(),
             subscription.getWorkflowInstanceKey(),
-            subscription.getElementInstanceKey());
+            subscription.getElementInstanceKey(),
+            subscription.getMessageName());
   }
 
   @Test


### PR DESCRIPTION
- adds messageName to close subscription commands
- indexes subscriptions in WorkflowInstanceSubscriptionState by
elementInstanceKey and messageName
- indexes subscriptions in MessageSubscriptionState by
elementInstanceKey and messageName
- allows CatchEventOutput to (un)subscribe to many messages
- introduces SideEffectQueue to BpmnStepContext to allow queueing many
side effect producers with correct retry strategy


closes #1587 
