### PR TITLE
Provided go client.AddResource([]byte, string, pb.WorkflowRequestObject_ResourceType) method

### DIFF
--- a/clients/go/commands/deploy_command.go
+++ b/clients/go/commands/deploy_command.go
@@ -19,8 +19,11 @@ func (cmd *DeployCommand) AddResourceFile(path string) *DeployCommand {
 	if err != nil {
 		log.Fatal(err)
 	}
+	return cmd.AddResource(b, path, pb.WorkflowRequestObject_FILE)
+}
 
-	cmd.request.Workflows = append(cmd.request.Workflows, &pb.WorkflowRequestObject{Definition: b, Name: path, Type: pb.WorkflowRequestObject_FILE})
+func (cmd *DeployCommand) AddResource(definition []byte, name string, resourceType pb.WorkflowRequestObject_ResourceType) *DeployCommand {
+	cmd.request.Workflows = append(cmd.request.Workflows, &pb.WorkflowRequestObject{Definition: definition, Name: name, Type: resourceType})
 	return cmd
 }
 


### PR DESCRIPTION
Provided a direct way to add a byte array with name and type to a command workflow,
besides client.AddResourceFile(string) limited to filesystem. This could be useful
for the case when *.bpmn descriptor is bundled within executable binary, with
popular go-bindata asset generator and possibly some others, including runtime
acquisition in read-only fs environment.