### PR TITLE
feat(broker-core): support interrupting message boundary events

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractActivityBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractActivityBuilder.java
@@ -29,6 +29,7 @@ import io.zeebe.model.bpmn.instance.zeebe.ZeebeOutputBehavior;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.function.Consumer;
 
 /** @author Sebastian Menski */
 public abstract class AbstractActivityBuilder<
@@ -51,6 +52,12 @@ public abstract class AbstractActivityBuilder<
     setBoundaryEventCoordinates(boundaryEventBpmnShape);
 
     return boundaryEvent.builder();
+  }
+
+  public BoundaryEventBuilder boundaryEvent(String id, Consumer<BoundaryEventBuilder> consumer) {
+    final BoundaryEventBuilder builder = boundaryEvent(id);
+    consumer.accept(builder);
+    return builder;
   }
 
   public MultiInstanceLoopCharacteristicsBuilder multiInstance() {

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/ModelUtil.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/ModelUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.util;
+
+import io.zeebe.model.bpmn.instance.Activity;
+import io.zeebe.model.bpmn.instance.BoundaryEvent;
+import io.zeebe.model.bpmn.instance.MessageEventDefinition;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ModelUtil {
+  public static List<BoundaryEvent> getActivityBoundaryEvent(Activity activity) {
+    final Collection<BoundaryEvent> boundaryEvents =
+        activity.getParentElement().getChildElementsByType(BoundaryEvent.class);
+
+    return boundaryEvents
+        .stream()
+        .filter(event -> event.getAttachedTo().equals(activity))
+        .collect(Collectors.toList());
+  }
+
+  public static List<MessageEventDefinition> getActivityMessageBoundaryEvents(Activity activity) {
+    return getActivityBoundaryEvent(activity)
+        .stream()
+        .flatMap(event -> event.getEventDefinitions().stream())
+        .filter(definition -> definition instanceof MessageEventDefinition)
+        .map(MessageEventDefinition.class::cast)
+        .collect(Collectors.toList());
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ReceiveTaskValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ReceiveTaskValidator.java
@@ -17,6 +17,7 @@ package io.zeebe.model.bpmn.validation.zeebe;
 
 import io.zeebe.model.bpmn.instance.Message;
 import io.zeebe.model.bpmn.instance.ReceiveTask;
+import io.zeebe.model.bpmn.util.ModelUtil;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
@@ -29,10 +30,19 @@ public class ReceiveTaskValidator implements ModelElementValidator<ReceiveTask> 
 
   @Override
   public void validate(ReceiveTask element, ValidationResultCollector validationResultCollector) {
-
     final Message message = element.getMessage();
     if (message == null) {
       validationResultCollector.addError(0, "Must reference a message");
+    }
+
+    final boolean hasDuplicateMessageListener =
+        ModelUtil.getActivityMessageBoundaryEvents(element)
+            .stream()
+            .anyMatch(event -> event.getMessage().getName().equals(message.getName()));
+
+    if (hasDuplicateMessageListener) {
+      validationResultCollector.addError(
+          0, "Cannot reference the same message name as a boundary event");
     }
   }
 }

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
@@ -125,6 +125,17 @@ public class ZeebeMessageValidationTest extends AbstractZeebeValidationTest {
             .done(),
         singletonList(expect("subProcessStart", "Must be a none start event"))
       },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .receiveTask("task")
+            .message(m -> m.name("message").zeebeCorrelationKey("correlationKey"))
+            .boundaryEvent("boundary")
+            .message(m -> m.name("message").zeebeCorrelationKey("correlationKey"))
+            .endEvent()
+            .done(),
+        singletonList(expect("task", "Cannot reference the same message name as a boundary event"))
+      },
     };
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageSubscription.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageSubscription.java
@@ -55,10 +55,6 @@ public class MessageSubscription implements BufferReader, BufferWriter {
     this.elementInstanceKey = elementInstanceKey;
   }
 
-  public void setMessageName(DirectBuffer messageName) {
-    this.messageName.wrap(messageName);
-  }
-
   public DirectBuffer getMessageName() {
     return messageName;
   }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/WorkflowInstanceSubscriptionState.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/WorkflowInstanceSubscriptionState.java
@@ -292,7 +292,7 @@ public class WorkflowInstanceSubscriptionState implements StateLifecycleListener
     return found;
   }
 
-  private void remove(final WorkflowInstanceSubscription subscription) {
+  public void remove(final WorkflowInstanceSubscription subscription) {
     try (final WriteOptions options = new WriteOptions();
         final ZbWriteBatch batch = new ZbWriteBatch()) {
       int keyLength = writeSubscriptionKey(keyBuffer, 0, subscription);

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/handler/BoundaryEventHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/handler/BoundaryEventHandler.java
@@ -20,12 +20,15 @@ package io.zeebe.broker.workflow.model.transformation.handler;
 import io.zeebe.broker.workflow.model.BpmnStep;
 import io.zeebe.broker.workflow.model.element.ExecutableActivity;
 import io.zeebe.broker.workflow.model.element.ExecutableBoundaryEvent;
+import io.zeebe.broker.workflow.model.element.ExecutableMessage;
 import io.zeebe.broker.workflow.model.element.ExecutableWorkflow;
 import io.zeebe.broker.workflow.model.transformation.ModelElementTransformer;
 import io.zeebe.broker.workflow.model.transformation.TransformContext;
 import io.zeebe.model.bpmn.instance.Activity;
 import io.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.zeebe.model.bpmn.instance.EventDefinition;
+import io.zeebe.model.bpmn.instance.Message;
+import io.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.zeebe.model.bpmn.instance.TimerEventDefinition;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import java.time.Duration;
@@ -43,7 +46,7 @@ public class BoundaryEventHandler implements ModelElementTransformer<BoundaryEve
         workflow.getElementById(event.getId(), ExecutableBoundaryEvent.class);
 
     element.setCancelActivity(event.cancelActivity());
-    transformEventDefinition(event, element);
+    transformEventDefinition(event, context, element);
     attachToActivity(event, workflow, element);
 
     element.bindLifecycleState(
@@ -52,10 +55,13 @@ public class BoundaryEventHandler implements ModelElementTransformer<BoundaryEve
         WorkflowInstanceIntent.CATCH_EVENT_TRIGGERED, context.getCurrentFlowNodeOutgoingStep());
   }
 
-  private void transformEventDefinition(BoundaryEvent event, ExecutableBoundaryEvent element) {
+  private void transformEventDefinition(
+      BoundaryEvent event, TransformContext context, ExecutableBoundaryEvent element) {
     final EventDefinition eventDefinition = event.getEventDefinitions().iterator().next();
     if (eventDefinition instanceof TimerEventDefinition) {
       transformTimerEventDefinition(element, (TimerEventDefinition) eventDefinition);
+    } else if (eventDefinition instanceof MessageEventDefinition) {
+      transformMessageEventDefinition(element, context, (MessageEventDefinition) eventDefinition);
     }
   }
 
@@ -64,6 +70,15 @@ public class BoundaryEventHandler implements ModelElementTransformer<BoundaryEve
     final String timeDuration = eventDefinition.getTimeDuration().getTextContent();
     final Duration duration = Duration.parse(timeDuration);
     element.setDuration(duration);
+  }
+
+  private void transformMessageEventDefinition(
+      ExecutableBoundaryEvent element,
+      TransformContext context,
+      MessageEventDefinition eventDefinition) {
+    final Message message = eventDefinition.getMessage();
+    final ExecutableMessage executableMessage = context.getMessage(message.getId());
+    element.setMessage(executableMessage);
   }
 
   private void attachToActivity(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/MessageCatchElementHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/MessageCatchElementHandler.java
@@ -24,8 +24,6 @@ import io.zeebe.broker.workflow.processor.BpmnStepHandler;
 public class MessageCatchElementHandler implements BpmnStepHandler<ExecutableMessageCatchElement> {
   @Override
   public void handle(final BpmnStepContext<ExecutableMessageCatchElement> context) {
-    context
-        .getCatchEventOutput()
-        .subscribeToMessageEvent(context, context.getElement().getMessage());
+    context.getCatchEventOutput().subscribeToMessageEvent(context, context.getElement());
   }
 }

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/state/WorkflowInstanceSubscriptionStateTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/state/WorkflowInstanceSubscriptionStateTest.java
@@ -291,12 +291,22 @@ public class WorkflowInstanceSubscriptionStateTest {
   }
 
   private WorkflowInstanceSubscription subscriptionWithElementInstanceKey(long elementInstanceKey) {
-    return subscription("messageName", "correlationKey", elementInstanceKey);
+    return subscription("handler", "messageName", "correlationKey", elementInstanceKey);
   }
 
   private WorkflowInstanceSubscription subscription(
       String name, String correlationKey, long elementInstanceKey) {
+    return subscription("handler", name, correlationKey, elementInstanceKey);
+  }
+
+  private WorkflowInstanceSubscription subscription(
+      String handlerId, String name, String correlationKey, long elementInstanceKey) {
     return new WorkflowInstanceSubscription(
-        1L, elementInstanceKey, wrapString(name), wrapString(correlationKey), 1_000);
+        1L,
+        elementInstanceKey,
+        wrapString(handlerId),
+        wrapString(name),
+        wrapString(correlationKey),
+        1_000);
   }
 }

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/subprocess/EmbeddedSubProcessTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/subprocess/EmbeddedSubProcessTest.java
@@ -17,6 +17,7 @@
  */
 package io.zeebe.broker.workflow.subprocess;
 
+import static io.zeebe.test.util.MsgPackUtil.asMsgPack;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -28,14 +29,17 @@ import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
 import io.zeebe.exporter.record.value.job.Headers;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.builder.SubProcessBuilder;
 import io.zeebe.protocol.intent.JobIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceSubscriptionIntent;
 import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
 import io.zeebe.test.broker.protocol.clientapi.PartitionTestClient;
 import io.zeebe.test.util.MsgPackUtil;
 import io.zeebe.util.buffer.BufferUtil;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Rule;
@@ -356,5 +360,78 @@ public class EmbeddedSubProcessTest {
             tuple(WorkflowInstanceIntent.ELEMENT_COMPLETED, "innerSubProcess"),
             tuple(WorkflowInstanceIntent.ELEMENT_COMPLETING, "outerSubProcess"),
             tuple(WorkflowInstanceIntent.ELEMENT_COMPLETED, "outerSubProcess"));
+  }
+
+  @Test
+  public void shouldTerminateBeforeTriggeringBoundaryEvent() {
+    // given
+    final Consumer<SubProcessBuilder> innerSubProcess =
+        inner ->
+            inner
+                .embeddedSubProcess()
+                .startEvent()
+                .serviceTask("task", b -> b.zeebeTaskType("type"))
+                .endEvent();
+    final Consumer<SubProcessBuilder> outSubProcess =
+        outer ->
+            outer
+                .embeddedSubProcess()
+                .startEvent()
+                .subProcess("innerSubProcess", innerSubProcess)
+                .endEvent();
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess("outerSubProcess", outSubProcess)
+            .boundaryEvent("event")
+            .message(m -> m.name("msg").zeebeCorrelationKey("$.key"))
+            .endEvent("msgEnd")
+            .moveToActivity("outerSubProcess")
+            .endEvent()
+            .done();
+    testClient.deploy(model);
+    testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("key", "123"));
+
+    // when
+    assertThat(
+            testClient
+                .receiveWorkflowInstanceSubscriptions()
+                .withIntent(WorkflowInstanceSubscriptionIntent.OPENED)
+                .limit(1)
+                .exists())
+        .isTrue(); // await first subscription opened
+    final Record<WorkflowInstanceRecordValue> activatedRecord =
+        testClient
+            .receiveWorkflowInstances()
+            .withIntent(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .withElementId("task")
+            .limit(1)
+            .getFirst();
+    testClient.publishMessage("msg", "123", asMsgPack("foo", 1));
+
+    // then
+    final List<String> elementFilter =
+        Arrays.asList("innerSubProcess", "outerSubProcess", "task", "event");
+    final List<Record<WorkflowInstanceRecordValue>> workflowInstanceEvents =
+        testClient
+            .receiveWorkflowInstances()
+            .limitToWorkflowInstanceCompleted()
+            .filter(
+                r ->
+                    r.getPosition() > activatedRecord.getPosition()
+                        && elementFilter.contains(r.getValue().getElementId()))
+            .collect(Collectors.toList());
+
+    assertThat(workflowInstanceEvents)
+        .extracting(e -> e.getMetadata().getIntent(), e -> e.getValue().getElementId())
+        .containsExactly(
+            tuple(WorkflowInstanceIntent.ELEMENT_TERMINATING, "outerSubProcess"),
+            tuple(WorkflowInstanceIntent.ELEMENT_TERMINATING, "innerSubProcess"),
+            tuple(WorkflowInstanceIntent.ELEMENT_TERMINATING, "task"),
+            tuple(WorkflowInstanceIntent.ELEMENT_TERMINATED, "task"),
+            tuple(WorkflowInstanceIntent.ELEMENT_TERMINATED, "innerSubProcess"),
+            tuple(WorkflowInstanceIntent.CATCH_EVENT_TRIGGERING, "event"),
+            tuple(WorkflowInstanceIntent.ELEMENT_TERMINATED, "outerSubProcess"),
+            tuple(WorkflowInstanceIntent.CATCH_EVENT_TRIGGERED, "event"));
   }
 }


### PR DESCRIPTION
- CorrelateWorkflowInstanceProcessor has similar triggering logic as
TriggerTimerProcessor
- ReceiveTask instances cannot wait for same message as one of their
boundary events
- add ModelUtil in bpmn-model to reuse listing an activity's boundary
events

closes #1591 
