### PR TITLE
Update job state on update retries

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/job/JobState.java
+++ b/broker-core/src/main/java/io/zeebe/broker/job/JobState.java
@@ -301,6 +301,18 @@ public class JobState implements StateLifecycleListener {
         });
   }
 
+  public JobRecord updateJobRetries(final long jobKey, final int retries) {
+    final JobRecord job = getJob(jobKey);
+    if (job != null) {
+      job.setRetries(retries);
+
+      final DirectBuffer keyBuffer = getDefaultKey(jobKey);
+      final DirectBuffer valueBuffer = writeValue(job);
+      db.put(jobsColumnFamily, keyBuffer, valueBuffer);
+    }
+    return job;
+  }
+
   public JobRecord getJob(final long key) {
     final DirectBuffer keyBuffer = getDefaultKey(key);
     return getJob(keyBuffer);

--- a/broker-core/src/test/java/io/zeebe/broker/incident/JobFailIncidentTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/incident/JobFailIncidentTest.java
@@ -18,6 +18,7 @@
 package io.zeebe.broker.incident;
 
 import static io.zeebe.broker.incident.IncidentAssert.assertIncidentRecordValue;
+import static io.zeebe.exporter.record.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -207,7 +208,7 @@ public class JobFailIncidentTest {
         incidentEvent);
 
     // and the job is published again
-    final Record republishedEvent =
+    final Record<JobRecordValue> republishedEvent =
         testClient
             .receiveJobs()
             .skipUntil(job -> job.getMetadata().getIntent() == JobIntent.RETRIES_UPDATED)
@@ -217,6 +218,7 @@ public class JobFailIncidentTest {
     assertThat(republishedEvent.getPosition()).isNotEqualTo(jobEvent.getPosition());
     assertThat(republishedEvent.getTimestamp().toEpochMilli())
         .isGreaterThanOrEqualTo(jobEvent.getTimestamp().toEpochMilli());
+    assertThat(republishedEvent.getValue()).hasRetries(1);
 
     // and the job lifecycle is correct
     final List<Record> jobEvents = testClient.receiveJobs().limit(8).collect(Collectors.toList());


### PR DESCRIPTION
You are correct the job was not updated correctly on the update retries processor.

@menski is there a good reason that I'm able to update the retries only if the job is in failed state?

closes #1693 
