### PR TITLE
feat(broker-core): support non-interrupting timer boundary events

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/time/RepeatingInterval.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/time/RepeatingInterval.java
@@ -79,31 +79,25 @@ public class RepeatingInterval {
    * @return a RepeatingInterval based on the given text
    */
   public static RepeatingInterval parse(String text, String intervalDesignator) {
-    final int intervalDesignatorOffset = text.indexOf(intervalDesignator);
-    int repetitions = INFINITE;
-    final Interval interval;
-
-    if (text.charAt(0) != 'R') {
+    if (!text.startsWith("R")) {
       throw new DateTimeParseException("Repetition spec must start with R", text, 0);
     }
 
-    if (intervalDesignatorOffset == -1 || intervalDesignatorOffset == text.length() - 1) {
+    final int intervalDesignatorOffset = text.indexOf(intervalDesignator);
+    if (intervalDesignatorOffset == -1) {
       throw new DateTimeParseException("No interval given", text, intervalDesignatorOffset);
     }
 
-    final String intervalText = text.substring(intervalDesignatorOffset + 1);
-    interval = Interval.parse(intervalText);
-
-    if (intervalDesignatorOffset > 1) {
-      final String repetitionsText = text.substring(1, intervalDesignatorOffset);
-
-      try {
-        repetitions = Integer.parseInt(repetitionsText);
-      } catch (NumberFormatException e) {
-        throw new DateTimeParseException("Cannot parse repetitions count", repetitionsText, 1, e);
-      }
+    if (intervalDesignatorOffset == 1) { // startsWith("R/")
+      return new RepeatingInterval(INFINITE, Interval.parse(text.substring(2)));
     }
 
-    return new RepeatingInterval(repetitions, interval);
+    try {
+      return new RepeatingInterval(
+          Integer.parseInt(text.substring(1, intervalDesignatorOffset)),
+          Interval.parse(text.substring(intervalDesignatorOffset + 1)));
+    } catch (NumberFormatException e) {
+      throw new DateTimeParseException("Cannot parse repetitions count", text, 1, e);
+    }
   }
 }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/TimerEventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/TimerEventDefinitionValidator.java
@@ -19,8 +19,8 @@ import io.zeebe.model.bpmn.instance.TimeCycle;
 import io.zeebe.model.bpmn.instance.TimeDate;
 import io.zeebe.model.bpmn.instance.TimeDuration;
 import io.zeebe.model.bpmn.instance.TimerEventDefinition;
+import io.zeebe.model.bpmn.util.time.Interval;
 import io.zeebe.model.bpmn.util.time.RepeatingInterval;
-import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
@@ -75,7 +75,7 @@ public class TimerEventDefinitionValidator implements ModelElementValidator<Time
   private void validateTimeDuration(
       ValidationResultCollector validationResultCollector, TimeDuration timeDuration) {
     try {
-      Duration.parse(timeDuration.getTextContent());
+      Interval.parse(timeDuration.getTextContent());
     } catch (DateTimeParseException e) {
       validationResultCollector.addError(0, "Time duration is invalid");
     }

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/util/time/IntervalTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/util/time/IntervalTest.java
@@ -19,8 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.time.Period;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.UnsupportedTemporalTypeException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.Test;
 
 public class IntervalTest {
@@ -67,6 +73,38 @@ public class IntervalTest {
   }
 
   @Test
+  public void shouldParseNegativeInterval() {
+    // given
+    final String text = "-P1Y2M4DT1H2M3S";
+    final Interval expected =
+        new Interval(
+            Period.of(-1, -2, -4),
+            Duration.ofHours(-1).plus(Duration.ofMinutes(-2)).plus(Duration.ofSeconds(-3)));
+
+    // when
+    final Interval interval = Interval.parse(text);
+
+    // then
+    assertThat(interval).isEqualTo(expected);
+  }
+
+  @Test
+  public void shouldParsePositiveInterval() {
+    // given
+    final String text = "+P1Y2M4DT1H2M3S";
+    final Interval expected =
+        new Interval(
+            Period.of(1, 2, 4),
+            Duration.ofHours(1).plus(Duration.ofMinutes(2)).plus(Duration.ofSeconds(3)));
+
+    // when
+    final Interval interval = Interval.parse(text);
+
+    // then
+    assertThat(interval).isEqualTo(expected);
+  }
+
+  @Test
   public void shouldFailToParseWrongPeriod() {
     // given
     final String text = "P,DT1H2M3S";
@@ -100,5 +138,86 @@ public class IntervalTest {
 
     // then
     assertThatThrownBy(() -> Interval.parse(text)).isInstanceOf(DateTimeParseException.class);
+  }
+
+  @Test
+  public void shouldGetDurationTemporalUnit() {
+    // given
+    final Interval interval = new Interval(Period.of(1, 2, 3), Duration.ofSeconds(5, 35));
+    final ChronoUnit[] durationUnits = new ChronoUnit[] {ChronoUnit.SECONDS, ChronoUnit.NANOS};
+
+    // then
+    for (final ChronoUnit unit : durationUnits) {
+      assertThat(interval.get(unit)).isEqualTo(interval.getDuration().get(unit));
+    }
+  }
+
+  @Test
+  public void shouldGetPeriodTemporalUnit() {
+    // given
+    final Interval interval = new Interval(Period.of(1, 2, 3), Duration.ofSeconds(5, 35));
+    final ChronoUnit[] periodUnits =
+        new ChronoUnit[] {ChronoUnit.DAYS, ChronoUnit.MONTHS, ChronoUnit.YEARS};
+
+    // then
+    for (final ChronoUnit unit : periodUnits) {
+      assertThat(interval.get(unit)).isEqualTo(interval.getPeriod().get(unit));
+    }
+  }
+
+  @Test
+  public void shouldThrowExceptionOnGetUnsupportedTemporalUnit() {
+    // given
+    final Interval interval = new Interval(Period.of(1, 2, 3), Duration.ofSeconds(5, 35));
+    final List<ChronoUnit> supportedUnits =
+        Arrays.asList(
+            ChronoUnit.SECONDS,
+            ChronoUnit.NANOS,
+            ChronoUnit.DAYS,
+            ChronoUnit.MONTHS,
+            ChronoUnit.YEARS);
+    final List<ChronoUnit> unsupportedUnits =
+        Arrays.stream(ChronoUnit.values())
+            .filter(unit -> !supportedUnits.contains(unit))
+            .collect(Collectors.toList());
+
+    // then
+    for (final ChronoUnit unit : unsupportedUnits) {
+      assertThatThrownBy(() -> interval.get(unit))
+          .isInstanceOf(UnsupportedTemporalTypeException.class);
+    }
+  }
+
+  @Test
+  public void shouldReturnAllPeriodAndDurationUnits() {
+    // given
+    final Interval interval = new Interval(Period.of(1, 2, 3), Duration.ofSeconds(5, 35));
+
+    // then
+    assertThat(interval.getUnits())
+        .containsExactlyInAnyOrder(
+            ChronoUnit.SECONDS,
+            ChronoUnit.NANOS,
+            ChronoUnit.MONTHS,
+            ChronoUnit.DAYS,
+            ChronoUnit.YEARS);
+  }
+
+  @Test
+  public void shouldAddToTemporalAmount() {
+    // given
+    final Period period = Period.of(1, 2, 3);
+    final Duration duration = Duration.ofSeconds(5, 35);
+    final Interval interval = new Interval(period, duration);
+    final LocalDateTime amount = LocalDateTime.parse("2007-12-03T10:15:30");
+    final LocalDateTime expected = amount.plus(period).plus(duration);
+
+    // then
+    assertThat(interval.addTo(amount)).isEqualTo(expected);
+  }
+
+  @Test
+  public void shouldFailToParseEmptyString() {
+    assertThatThrownBy(() -> Interval.parse("")).isInstanceOf(DateTimeParseException.class);
   }
 }

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/util/time/RepeatingIntervalTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/util/time/RepeatingIntervalTest.java
@@ -122,4 +122,9 @@ public class RepeatingIntervalTest {
     assertThatThrownBy(() -> RepeatingInterval.parse(text))
         .isInstanceOf(DateTimeParseException.class);
   }
+
+  @Test
+  public void shouldFailToParseEmptyString() {
+    assertThatThrownBy(() -> Interval.parse("")).isInstanceOf(DateTimeParseException.class);
+  }
 }

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeTimerValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeTimerValidationTest.java
@@ -41,6 +41,14 @@ public class ZeebeTimerValidationTest extends AbstractZeebeValidationTest {
       {
         Bpmn.createExecutableProcess("process")
             .startEvent()
+            .intermediateCatchEvent("catch", c -> c.timerWithDuration("R/PT01S"))
+            .endEvent()
+            .done(),
+        singletonList(expect(TimerEventDefinition.class, "Time duration is invalid"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
             .intermediateCatchEvent("catch", c -> c.timerWithCycle("R5/PT05S"))
             .endEvent()
             .done(),

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/data/TimerRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/data/TimerRecord.java
@@ -18,6 +18,7 @@
 package io.zeebe.broker.workflow.data;
 
 import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.msgpack.property.IntegerProperty;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
 import org.agrona.DirectBuffer;
@@ -27,11 +28,13 @@ public class TimerRecord extends UnpackedObject {
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey");
   private final LongProperty dueDateProp = new LongProperty("dueDate");
   private final StringProperty handlerNodeId = new StringProperty("handlerNodeId");
+  private final IntegerProperty repetitionsProp = new IntegerProperty("repetitions");
 
   public TimerRecord() {
     this.declareProperty(elementInstanceKeyProp)
         .declareProperty(dueDateProp)
-        .declareProperty(handlerNodeId);
+        .declareProperty(handlerNodeId)
+        .declareProperty(repetitionsProp);
   }
 
   public long getElementInstanceKey() {
@@ -58,6 +61,15 @@ public class TimerRecord extends UnpackedObject {
 
   public TimerRecord setHandlerNodeId(DirectBuffer handlerNodeId) {
     this.handlerNodeId.setValue(handlerNodeId);
+    return this;
+  }
+
+  public int getRepetitions() {
+    return repetitionsProp.getValue();
+  }
+
+  public TimerRecord setRepetitions(int repetitions) {
+    this.repetitionsProp.setValue(repetitions);
     return this;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableBoundaryEvent.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableBoundaryEvent.java
@@ -17,7 +17,7 @@
  */
 package io.zeebe.broker.workflow.model.element;
 
-public class ExecutableBoundaryEvent extends ExecutableIntermediateCatchElement {
+public class ExecutableBoundaryEvent extends ExecutableCatchEventElement {
   private boolean cancelActivity;
 
   public ExecutableBoundaryEvent(String id) {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableCatchEvent.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableCatchEvent.java
@@ -17,15 +17,14 @@
  */
 package io.zeebe.broker.workflow.model.element;
 
-import java.time.Duration;
+import io.zeebe.model.bpmn.util.time.RepeatingInterval;
 
 public interface ExecutableCatchEvent extends ExecutableFlowElement {
-
   boolean isTimer();
 
   boolean isMessage();
 
   ExecutableMessage getMessage();
 
-  Duration getDuration();
+  RepeatingInterval getTimer();
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableCatchEventElement.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableCatchEventElement.java
@@ -17,20 +17,24 @@
  */
 package io.zeebe.broker.workflow.model.element;
 
-import java.time.Duration;
+import io.zeebe.model.bpmn.util.time.RepeatingInterval;
 import java.util.Collections;
 import java.util.List;
 
-public class ExecutableIntermediateCatchElement extends ExecutableFlowNode
+public class ExecutableCatchEventElement extends ExecutableFlowNode
     implements ExecutableCatchEvent, ExecutableCatchEventSupplier {
-
   private final List<ExecutableCatchEvent> events = Collections.singletonList(this);
 
   private ExecutableMessage message;
-  private Duration duration;
+  private RepeatingInterval timer;
 
-  public ExecutableIntermediateCatchElement(String id) {
+  public ExecutableCatchEventElement(String id) {
     super(id);
+  }
+
+  @Override
+  public boolean isMessage() {
+    return message != null;
   }
 
   @Override
@@ -43,22 +47,17 @@ public class ExecutableIntermediateCatchElement extends ExecutableFlowNode
   }
 
   @Override
-  public Duration getDuration() {
-    return duration;
-  }
-
-  public void setDuration(Duration duration) {
-    this.duration = duration;
-  }
-
-  @Override
   public boolean isTimer() {
-    return duration != null;
+    return timer != null;
   }
 
   @Override
-  public boolean isMessage() {
-    return message != null;
+  public RepeatingInterval getTimer() {
+    return timer;
+  }
+
+  public void setTimer(RepeatingInterval timer) {
+    this.timer = timer;
   }
 
   @Override

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableEventBasedGateway.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableEventBasedGateway.java
@@ -22,18 +22,18 @@ import java.util.List;
 public class ExecutableEventBasedGateway extends ExecutableFlowNode
     implements ExecutableCatchEventSupplier {
 
-  private List<ExecutableIntermediateCatchElement> events;
+  private List<ExecutableCatchEventElement> events;
 
   public ExecutableEventBasedGateway(String id) {
     super(id);
   }
 
   @Override
-  public List<ExecutableIntermediateCatchElement> getEvents() {
+  public List<ExecutableCatchEventElement> getEvents() {
     return events;
   }
 
-  public void setEvents(List<ExecutableIntermediateCatchElement> events) {
+  public void setEvents(List<ExecutableCatchEventElement> events) {
     this.events = events;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableReceiveTask.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableReceiveTask.java
@@ -17,7 +17,7 @@
  */
 package io.zeebe.broker.workflow.model.element;
 
-import java.time.Duration;
+import io.zeebe.model.bpmn.util.time.RepeatingInterval;
 import java.util.Collections;
 import java.util.List;
 
@@ -52,7 +52,7 @@ public class ExecutableReceiveTask extends ExecutableActivity
   }
 
   @Override
-  public Duration getDuration() {
+  public RepeatingInterval getTimer() {
     return null;
   }
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/BpmnTransformer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/BpmnTransformer.java
@@ -20,6 +20,7 @@ package io.zeebe.broker.workflow.model.transformation;
 import io.zeebe.broker.workflow.model.element.ExecutableWorkflow;
 import io.zeebe.broker.workflow.model.transformation.transformer.ActivityTransformer;
 import io.zeebe.broker.workflow.model.transformation.transformer.BoundaryEventTransformer;
+import io.zeebe.broker.workflow.model.transformation.transformer.CatchEventTransformer;
 import io.zeebe.broker.workflow.model.transformation.transformer.ContextProcessTransformer;
 import io.zeebe.broker.workflow.model.transformation.transformer.EndEventTransformer;
 import io.zeebe.broker.workflow.model.transformation.transformer.EventBasedGatewayTransformer;
@@ -68,6 +69,7 @@ public class BpmnTransformer {
     this.step2Visitor = new TransformationVisitor();
     step2Visitor.registerHandler(new ActivityTransformer());
     step2Visitor.registerHandler(new BoundaryEventTransformer());
+    step2Visitor.registerHandler(new CatchEventTransformer());
     step2Visitor.registerHandler(new ContextProcessTransformer());
     step2Visitor.registerHandler(new EndEventTransformer());
     step2Visitor.registerHandler(new ExclusiveGatewayTransformer());

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/CatchEventTransformer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/CatchEventTransformer.java
@@ -1,0 +1,83 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow.model.transformation.transformer;
+
+import io.zeebe.broker.workflow.model.element.ExecutableCatchEventElement;
+import io.zeebe.broker.workflow.model.element.ExecutableMessage;
+import io.zeebe.broker.workflow.model.element.ExecutableWorkflow;
+import io.zeebe.broker.workflow.model.transformation.ModelElementTransformer;
+import io.zeebe.broker.workflow.model.transformation.TransformContext;
+import io.zeebe.model.bpmn.instance.CatchEvent;
+import io.zeebe.model.bpmn.instance.EventDefinition;
+import io.zeebe.model.bpmn.instance.Message;
+import io.zeebe.model.bpmn.instance.MessageEventDefinition;
+import io.zeebe.model.bpmn.instance.TimerEventDefinition;
+import io.zeebe.model.bpmn.util.time.Interval;
+import io.zeebe.model.bpmn.util.time.RepeatingInterval;
+
+public class CatchEventTransformer implements ModelElementTransformer<CatchEvent> {
+  @Override
+  public Class<CatchEvent> getType() {
+    return CatchEvent.class;
+  }
+
+  @Override
+  public void transform(CatchEvent element, TransformContext context) {
+    final ExecutableWorkflow workflow = context.getCurrentWorkflow();
+    final ExecutableCatchEventElement executableElement =
+        workflow.getElementById(element.getId(), ExecutableCatchEventElement.class);
+
+    if (element.getEventDefinitions().isEmpty()) { // NONE catch event
+      return;
+    }
+
+    final EventDefinition eventDefinition = element.getEventDefinitions().iterator().next();
+    if (eventDefinition instanceof MessageEventDefinition) {
+      transformMessageEventDefinition(
+          context, executableElement, (MessageEventDefinition) eventDefinition);
+    } else if (eventDefinition instanceof TimerEventDefinition) {
+      transformTimerEventDefinition(executableElement, (TimerEventDefinition) eventDefinition);
+    }
+  }
+
+  private void transformMessageEventDefinition(
+      TransformContext context,
+      final ExecutableCatchEventElement executableElement,
+      final MessageEventDefinition messageEventDefinition) {
+
+    final Message message = messageEventDefinition.getMessage();
+    final ExecutableMessage executableMessage = context.getMessage(message.getId());
+    executableElement.setMessage(executableMessage);
+  }
+
+  private void transformTimerEventDefinition(
+      final ExecutableCatchEventElement executableElement,
+      final TimerEventDefinition timerEventDefinition) {
+    final RepeatingInterval timer;
+
+    if (timerEventDefinition.getTimeDuration() != null) {
+      final String duration = timerEventDefinition.getTimeDuration().getTextContent();
+      timer = new RepeatingInterval(1, Interval.parse(duration));
+    } else {
+      final String cycle = timerEventDefinition.getTimeCycle().getTextContent();
+      timer = RepeatingInterval.parse(cycle);
+    }
+
+    executableElement.setTimer(timer);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/EventBasedGatewayTransformer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/EventBasedGatewayTransformer.java
@@ -18,8 +18,8 @@
 package io.zeebe.broker.workflow.model.transformation.transformer;
 
 import io.zeebe.broker.workflow.model.BpmnStep;
+import io.zeebe.broker.workflow.model.element.ExecutableCatchEventElement;
 import io.zeebe.broker.workflow.model.element.ExecutableEventBasedGateway;
-import io.zeebe.broker.workflow.model.element.ExecutableIntermediateCatchElement;
 import io.zeebe.broker.workflow.model.element.ExecutableWorkflow;
 import io.zeebe.broker.workflow.model.transformation.ModelElementTransformer;
 import io.zeebe.broker.workflow.model.transformation.TransformContext;
@@ -41,8 +41,7 @@ public class EventBasedGatewayTransformer implements ModelElementTransformer<Eve
     final ExecutableEventBasedGateway gateway =
         workflow.getElementById(element.getId(), ExecutableEventBasedGateway.class);
 
-    final List<ExecutableIntermediateCatchElement> connectedEvents =
-        getConnectedCatchEvents(gateway);
+    final List<ExecutableCatchEventElement> connectedEvents = getConnectedCatchEvents(gateway);
     gateway.setEvents(connectedEvents);
 
     bindLifecycle(element, gateway, context);
@@ -51,12 +50,12 @@ public class EventBasedGatewayTransformer implements ModelElementTransformer<Eve
     connectedEvents.forEach(event -> bindLifecycle(event, context));
   }
 
-  private List<ExecutableIntermediateCatchElement> getConnectedCatchEvents(
+  private List<ExecutableCatchEventElement> getConnectedCatchEvents(
       final ExecutableEventBasedGateway gateway) {
     return gateway
         .getOutgoing()
         .stream()
-        .map(e -> (ExecutableIntermediateCatchElement) e.getTarget())
+        .map(e -> (ExecutableCatchEventElement) e.getTarget())
         .collect(Collectors.toList());
   }
 
@@ -69,7 +68,7 @@ public class EventBasedGatewayTransformer implements ModelElementTransformer<Eve
         WorkflowInstanceIntent.GATEWAY_ACTIVATED, BpmnStep.SUBSCRIBE_TO_EVENTS);
   }
 
-  private void bindLifecycle(ExecutableIntermediateCatchElement event, TransformContext context) {
+  private void bindLifecycle(ExecutableCatchEventElement event, TransformContext context) {
     event.bindLifecycleState(
         WorkflowInstanceIntent.CATCH_EVENT_TRIGGERING, BpmnStep.TRIGGER_EVENT_BASED_GATEWAY);
     event.bindLifecycleState(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/FlowElementInstantiationTransformer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/FlowElementInstantiationTransformer.java
@@ -20,11 +20,11 @@ package io.zeebe.broker.workflow.model.transformation.transformer;
 import io.zeebe.broker.workflow.model.element.AbstractFlowElement;
 import io.zeebe.broker.workflow.model.element.ExecutableActivity;
 import io.zeebe.broker.workflow.model.element.ExecutableBoundaryEvent;
+import io.zeebe.broker.workflow.model.element.ExecutableCatchEventElement;
 import io.zeebe.broker.workflow.model.element.ExecutableEventBasedGateway;
 import io.zeebe.broker.workflow.model.element.ExecutableExclusiveGateway;
 import io.zeebe.broker.workflow.model.element.ExecutableFlowElementContainer;
 import io.zeebe.broker.workflow.model.element.ExecutableFlowNode;
-import io.zeebe.broker.workflow.model.element.ExecutableIntermediateCatchElement;
 import io.zeebe.broker.workflow.model.element.ExecutableReceiveTask;
 import io.zeebe.broker.workflow.model.element.ExecutableSequenceFlow;
 import io.zeebe.broker.workflow.model.element.ExecutableServiceTask;
@@ -60,12 +60,12 @@ public class FlowElementInstantiationTransformer implements ModelElementTransfor
     ELEMENT_FACTORIES.put(EndEvent.class, ExecutableFlowNode::new);
     ELEMENT_FACTORIES.put(EventBasedGateway.class, ExecutableEventBasedGateway::new);
     ELEMENT_FACTORIES.put(ExclusiveGateway.class, ExecutableExclusiveGateway::new);
-    ELEMENT_FACTORIES.put(IntermediateCatchEvent.class, ExecutableIntermediateCatchElement::new);
+    ELEMENT_FACTORIES.put(IntermediateCatchEvent.class, ExecutableCatchEventElement::new);
     ELEMENT_FACTORIES.put(ParallelGateway.class, ExecutableFlowNode::new);
     ELEMENT_FACTORIES.put(SequenceFlow.class, ExecutableSequenceFlow::new);
     ELEMENT_FACTORIES.put(ServiceTask.class, ExecutableServiceTask::new);
     ELEMENT_FACTORIES.put(ReceiveTask.class, ExecutableReceiveTask::new);
-    ELEMENT_FACTORIES.put(StartEvent.class, ExecutableFlowNode::new);
+    ELEMENT_FACTORIES.put(StartEvent.class, ExecutableCatchEventElement::new);
     ELEMENT_FACTORIES.put(SubProcess.class, ExecutableFlowElementContainer::new);
   }
 
@@ -77,11 +77,11 @@ public class FlowElementInstantiationTransformer implements ModelElementTransfor
   @Override
   public void transform(FlowElement element, TransformContext context) {
     final ExecutableWorkflow workflow = context.getCurrentWorkflow();
-    final Class<?> elemenType = element.getElementType().getInstanceType();
+    final Class<?> elementType = element.getElementType().getInstanceType();
 
-    final Function<String, AbstractFlowElement> elementFactory = ELEMENT_FACTORIES.get(elemenType);
+    final Function<String, AbstractFlowElement> elementFactory = ELEMENT_FACTORIES.get(elementType);
     if (elementFactory == null) {
-      throw new IllegalStateException("no transformer found for element type: " + elemenType);
+      throw new IllegalStateException("no transformer found for element type: " + elementType);
     }
 
     final AbstractFlowElement executableElement = elementFactory.apply(element.getId());

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/IntermediateCatchEventTransformer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/IntermediateCatchEventTransformer.java
@@ -18,18 +18,12 @@
 package io.zeebe.broker.workflow.model.transformation.transformer;
 
 import io.zeebe.broker.workflow.model.BpmnStep;
-import io.zeebe.broker.workflow.model.element.ExecutableIntermediateCatchElement;
-import io.zeebe.broker.workflow.model.element.ExecutableMessage;
+import io.zeebe.broker.workflow.model.element.ExecutableCatchEventElement;
 import io.zeebe.broker.workflow.model.element.ExecutableWorkflow;
 import io.zeebe.broker.workflow.model.transformation.ModelElementTransformer;
 import io.zeebe.broker.workflow.model.transformation.TransformContext;
-import io.zeebe.model.bpmn.instance.EventDefinition;
 import io.zeebe.model.bpmn.instance.IntermediateCatchEvent;
-import io.zeebe.model.bpmn.instance.Message;
-import io.zeebe.model.bpmn.instance.MessageEventDefinition;
-import io.zeebe.model.bpmn.instance.TimerEventDefinition;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
-import java.time.Duration;
 
 public class IntermediateCatchEventTransformer
     implements ModelElementTransformer<IntermediateCatchEvent> {
@@ -41,44 +35,15 @@ public class IntermediateCatchEventTransformer
 
   @Override
   public void transform(IntermediateCatchEvent element, TransformContext context) {
-
     final ExecutableWorkflow workflow = context.getCurrentWorkflow();
-    final ExecutableIntermediateCatchElement executableElement =
-        workflow.getElementById(element.getId(), ExecutableIntermediateCatchElement.class);
-
-    final EventDefinition eventDefinition = element.getEventDefinitions().iterator().next();
-    if (eventDefinition instanceof MessageEventDefinition) {
-      transformMessageEventDefinition(
-          context, executableElement, (MessageEventDefinition) eventDefinition);
-
-    } else if (eventDefinition instanceof TimerEventDefinition) {
-      transformTimerEventDefinition(executableElement, (TimerEventDefinition) eventDefinition);
-    }
+    final ExecutableCatchEventElement executableElement =
+        workflow.getElementById(element.getId(), ExecutableCatchEventElement.class);
 
     bindLifecycle(context, executableElement);
   }
 
-  private void transformMessageEventDefinition(
-      TransformContext context,
-      final ExecutableIntermediateCatchElement executableElement,
-      final MessageEventDefinition messageEventDefinition) {
-
-    final Message message = messageEventDefinition.getMessage();
-    final ExecutableMessage executableMessage = context.getMessage(message.getId());
-    executableElement.setMessage(executableMessage);
-  }
-
-  private void transformTimerEventDefinition(
-      final ExecutableIntermediateCatchElement executableElement,
-      final TimerEventDefinition timerEventDefinition) {
-
-    final String timeDuration = timerEventDefinition.getTimeDuration().getTextContent();
-    final Duration duration = Duration.parse(timeDuration);
-    executableElement.setDuration(duration);
-  }
-
   private void bindLifecycle(
-      TransformContext context, ExecutableIntermediateCatchElement executableElement) {
+      TransformContext context, ExecutableCatchEventElement executableElement) {
     executableElement.bindLifecycleState(
         WorkflowInstanceIntent.ELEMENT_READY, BpmnStep.ACTIVATE_FLOW_NODE);
     executableElement.bindLifecycleState(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/ReceiveTaskTransformer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/ReceiveTaskTransformer.java
@@ -36,9 +36,6 @@ public class ReceiveTaskTransformer implements ModelElementTransformer<ReceiveTa
 
   @Override
   public void transform(ReceiveTask element, TransformContext context) {
-
-    // only message supported at this point
-
     final ExecutableWorkflow workflow = context.getCurrentWorkflow();
     final ExecutableReceiveTask executableElement =
         workflow.getElementById(element.getId(), ExecutableReceiveTask.class);

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventOutput.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventOutput.java
@@ -26,24 +26,24 @@ import io.zeebe.broker.subscription.command.SubscriptionCommandSender;
 import io.zeebe.broker.workflow.data.TimerRecord;
 import io.zeebe.broker.workflow.model.element.ExecutableCatchEvent;
 import io.zeebe.broker.workflow.model.element.ExecutableMessage;
-import io.zeebe.broker.workflow.processor.boundary.BoundaryEventHelper;
 import io.zeebe.broker.workflow.state.ElementInstance;
 import io.zeebe.broker.workflow.state.EventTrigger;
 import io.zeebe.broker.workflow.state.TimerInstance;
 import io.zeebe.broker.workflow.state.WorkflowInstanceSubscription;
+import io.zeebe.model.bpmn.util.time.RepeatingInterval;
 import io.zeebe.msgpack.query.MsgPackQueryProcessor;
 import io.zeebe.msgpack.query.MsgPackQueryProcessor.QueryResult;
 import io.zeebe.msgpack.query.MsgPackQueryProcessor.QueryResults;
 import io.zeebe.protocol.impl.record.value.incident.ErrorType;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.TimerIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import io.zeebe.util.sched.clock.ActorClock;
-import java.time.Duration;
 import java.util.List;
 import org.agrona.DirectBuffer;
 
 /** Split into multiple files once we have a reasonable amount of event triggers. */
 public class CatchEventOutput {
-  private final BoundaryEventHelper boundaryEventHelper = new BoundaryEventHelper();
   private final ZeebeState state;
   private final SubscriptionCommandSender subscriptionCommandSender;
 
@@ -64,19 +64,35 @@ public class CatchEventOutput {
     for (final ExecutableCatchEvent event : events) {
       if (event.isTimer()) {
         subscribeToTimerEvent(
-            context.getRecord().getKey(), event, context.getOutput().getStreamWriter());
+            context.getRecord().getKey(),
+            event.getId(),
+            event.getTimer(),
+            context.getOutput().getStreamWriter());
       } else if (event.isMessage()) {
         subscribeToMessageEvent(context, event);
       }
     }
   }
 
-  public void triggerBoundaryEventFromInterruptedElement(
-      ElementInstance element, TypedStreamWriter writer) {
-    assert element.isInterrupted() : "element must have been interrupted";
+  // CATCH EVENTS
+  private final WorkflowInstanceRecord workflowInstanceRecord = new WorkflowInstanceRecord();
 
+  public void triggerCatchEvent(
+      WorkflowInstanceRecord source,
+      DirectBuffer elementId,
+      DirectBuffer payload,
+      TypedStreamWriter writer) {
+    workflowInstanceRecord.wrap(source);
+    workflowInstanceRecord.setPayload(payload);
+    workflowInstanceRecord.setElementId(elementId);
+
+    writer.appendNewEvent(WorkflowInstanceIntent.CATCH_EVENT_TRIGGERING, workflowInstanceRecord);
+  }
+
+  public void triggerInterruptedElement(ElementInstance element, TypedStreamWriter writer) {
     final EventTrigger interruptingEventTrigger = element.getInterruptingEventTrigger();
-    boundaryEventHelper.triggerCatchEvent(
+
+    triggerCatchEvent(
         element.getValue(),
         interruptingEventTrigger.getHandlerNodeId(),
         interruptingEventTrigger.getPayload(),
@@ -87,14 +103,18 @@ public class CatchEventOutput {
   private final TimerRecord timerRecord = new TimerRecord();
 
   public void subscribeToTimerEvent(
-      long elementInstanceKey, ExecutableCatchEvent event, TypedStreamWriter writer) {
-    final Duration duration = event.getDuration();
-    final long dueDate = ActorClock.currentTimeMillis() + duration.toMillis();
+      long elementInstanceKey,
+      DirectBuffer handlerNodeId,
+      RepeatingInterval timer,
+      TypedStreamWriter writer) {
+    final long nowMs = ActorClock.currentTimeMillis();
+    final long dueDate = timer.getInterval().toEpochMilli(nowMs);
 
     timerRecord
-        .setElementInstanceKey(elementInstanceKey)
+        .setRepetitions(timer.getRepetitions())
         .setDueDate(dueDate)
-        .setHandlerNodeId(event.getId());
+        .setElementInstanceKey(elementInstanceKey)
+        .setHandlerNodeId(handlerNodeId);
     writer.appendNewCommand(TimerIntent.CREATE, timerRecord);
   }
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/boundary/BoundaryEventActivator.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/boundary/BoundaryEventActivator.java
@@ -22,26 +22,18 @@ import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
 import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
 import io.zeebe.broker.workflow.model.element.AbstractFlowElement;
 import io.zeebe.broker.workflow.model.element.ExecutableBoundaryEvent;
+import io.zeebe.broker.workflow.processor.CatchEventOutput;
 import io.zeebe.broker.workflow.state.DeployedWorkflow;
 import io.zeebe.broker.workflow.state.ElementInstance;
 import io.zeebe.broker.workflow.state.WorkflowState;
-import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import org.agrona.DirectBuffer;
 
-public class BoundaryEventHelper {
-  private final WorkflowInstanceRecord newRecord = new WorkflowInstanceRecord();
+public class BoundaryEventActivator {
+  private final CatchEventOutput catchEventOutput;
 
-  public void triggerCatchEvent(
-      WorkflowInstanceRecord source,
-      DirectBuffer elementId,
-      DirectBuffer payload,
-      TypedStreamWriter writer) {
-    newRecord.wrap(source);
-    newRecord.setPayload(payload);
-    newRecord.setElementId(elementId);
-
-    writer.appendNewEvent(WorkflowInstanceIntent.CATCH_EVENT_TRIGGERING, newRecord);
+  public BoundaryEventActivator(CatchEventOutput catchEventOutput) {
+    this.catchEventOutput = catchEventOutput;
   }
 
   /**
@@ -52,16 +44,31 @@ public class BoundaryEventHelper {
    * should be cancelled, it will also publish an ELEMENT_TERMINATING event to the log stream,
    * update the associated element instance state.
    */
-  public void triggerBoundaryEvent(
+  public void activateBoundaryEvent(
       WorkflowState state,
       ElementInstance attachedTo,
       DirectBuffer handlerNodeId,
       DirectBuffer payload,
       TypedStreamWriter writer) {
-    if (shouldTerminateAttachedActivity(state, attachedTo, handlerNodeId)) {
+    final ExecutableBoundaryEvent event =
+        getBoundaryEventById(state, attachedTo.getValue().getWorkflowKey(), handlerNodeId);
+    activateBoundaryEvent(state, attachedTo, handlerNodeId, payload, writer, event);
+  }
+
+  public void activateBoundaryEvent(
+      WorkflowState state,
+      ElementInstance attachedTo,
+      DirectBuffer handlerNodeId,
+      DirectBuffer payload,
+      TypedStreamWriter writer,
+      ExecutableBoundaryEvent event) {
+    if (event.cancelActivity()) {
       terminateAttachedToActivity(attachedTo, handlerNodeId, payload, writer);
     } else {
-      triggerCatchEvent(attachedTo.getValue(), handlerNodeId, payload, writer);
+      catchEventOutput.triggerCatchEvent(attachedTo.getValue(), handlerNodeId, payload, writer);
+      // ELEMENT_TERMINATED will spawn a token, but in the case of non-interrupting, it needs to be
+      // done manually
+      state.getElementInstanceState().spawnToken(attachedTo.getParentKey());
     }
   }
 
@@ -69,30 +76,13 @@ public class BoundaryEventHelper {
    * Returns true if the activity the boundary event trigger is attached to is activated, and the
    * handler node ID is not the same as the attached activity's ID.
    */
-  public boolean shouldTriggerBoundaryEvent(
+  public boolean shouldActivateBoundaryEvent(
       ElementInstance attachedTo, DirectBuffer handlerNodeId) {
     return attachedTo.getState() == WorkflowInstanceIntent.ELEMENT_ACTIVATED
         && !attachedTo.getValue().getElementId().equals(handlerNodeId);
   }
 
-  private void terminateAttachedToActivity(
-      ElementInstance attachedTo,
-      DirectBuffer handlerNodeId,
-      DirectBuffer payload,
-      TypedStreamWriter writer) {
-    writer.appendFollowUpEvent(
-        attachedTo.getKey(), WorkflowInstanceIntent.ELEMENT_TERMINATING, attachedTo.getValue());
-    attachedTo.setState(WorkflowInstanceIntent.ELEMENT_TERMINATING);
-    attachedTo.getInterruptingEventTrigger().setPayload(payload).setHandlerNodeId(handlerNodeId);
-  }
-
-  private boolean shouldTerminateAttachedActivity(
-      WorkflowState state, ElementInstance attachedTo, DirectBuffer boundaryId) {
-    return getBoundaryEventById(state, attachedTo.getValue().getWorkflowKey(), boundaryId)
-        .cancelActivity();
-  }
-
-  private ExecutableBoundaryEvent getBoundaryEventById(
+  public ExecutableBoundaryEvent getBoundaryEventById(
       WorkflowState state, long workflowKey, DirectBuffer id) {
     final DeployedWorkflow workflow = state.getWorkflowByKey(workflowKey);
     if (workflow == null) {
@@ -109,5 +99,20 @@ public class BoundaryEventHelper {
     }
 
     return (ExecutableBoundaryEvent) element;
+  }
+
+  public CatchEventOutput getCatchEventOutput() {
+    return catchEventOutput;
+  }
+
+  private void terminateAttachedToActivity(
+      ElementInstance attachedTo,
+      DirectBuffer handlerNodeId,
+      DirectBuffer payload,
+      TypedStreamWriter writer) {
+    writer.appendFollowUpEvent(
+        attachedTo.getKey(), WorkflowInstanceIntent.ELEMENT_TERMINATING, attachedTo.getValue());
+    attachedTo.setState(WorkflowInstanceIntent.ELEMENT_TERMINATING);
+    attachedTo.getInterruptingEventTrigger().setPayload(payload).setHandlerNodeId(handlerNodeId);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/event/TriggerEventHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/event/TriggerEventHandler.java
@@ -17,7 +17,7 @@
  */
 package io.zeebe.broker.workflow.processor.event;
 
-import io.zeebe.broker.workflow.model.element.ExecutableIntermediateCatchElement;
+import io.zeebe.broker.workflow.model.element.ExecutableCatchEventElement;
 import io.zeebe.broker.workflow.processor.BpmnStepContext;
 import io.zeebe.broker.workflow.processor.BpmnStepHandler;
 import io.zeebe.broker.workflow.processor.flownode.IOMappingHelper;
@@ -25,11 +25,11 @@ import io.zeebe.msgpack.mapping.MappingException;
 import io.zeebe.protocol.impl.record.value.incident.ErrorType;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 
-public class TriggerEventHandler implements BpmnStepHandler<ExecutableIntermediateCatchElement> {
+public class TriggerEventHandler implements BpmnStepHandler<ExecutableCatchEventElement> {
   private final IOMappingHelper ioMappingHelper = new IOMappingHelper();
 
   @Override
-  public void handle(BpmnStepContext<ExecutableIntermediateCatchElement> context) {
+  public void handle(BpmnStepContext<ExecutableCatchEventElement> context) {
     try {
       ioMappingHelper.applyOutputMappings(context);
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/flownode/PropagateTerminationHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/flownode/PropagateTerminationHandler.java
@@ -34,8 +34,7 @@ public class PropagateTerminationHandler implements BpmnStepHandler<ExecutableFl
       if (flowScopeInstance.isInterrupted()) {
         context
             .getCatchEventOutput()
-            .triggerBoundaryEventFromInterruptedElement(
-                flowScopeInstance, output.getStreamWriter());
+            .triggerInterruptedElement(flowScopeInstance, context.getOutput().getStreamWriter());
       }
 
       output.appendFollowUpEvent(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/flownode/TerminateFlowNodeHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/flownode/TerminateFlowNodeHandler.java
@@ -48,7 +48,7 @@ public class TerminateFlowNodeHandler implements BpmnStepHandler<ExecutableFlowN
     if (elementInstance.isInterrupted()) {
       context
           .getCatchEventOutput()
-          .triggerBoundaryEventFromInterruptedElement(elementInstance, output.getStreamWriter());
+          .triggerInterruptedElement(elementInstance, context.getOutput().getStreamWriter());
     }
 
     output.appendFollowUpEvent(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/gateway/TriggerEventBasedGatewayHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/gateway/TriggerEventBasedGatewayHandler.java
@@ -17,7 +17,7 @@
  */
 package io.zeebe.broker.workflow.processor.gateway;
 
-import io.zeebe.broker.workflow.model.element.ExecutableIntermediateCatchElement;
+import io.zeebe.broker.workflow.model.element.ExecutableCatchEventElement;
 import io.zeebe.broker.workflow.processor.BpmnStepContext;
 import io.zeebe.broker.workflow.processor.BpmnStepHandler;
 import io.zeebe.broker.workflow.processor.flownode.IOMappingHelper;
@@ -26,11 +26,11 @@ import io.zeebe.protocol.impl.record.value.incident.ErrorType;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 
 public class TriggerEventBasedGatewayHandler
-    implements BpmnStepHandler<ExecutableIntermediateCatchElement> {
+    implements BpmnStepHandler<ExecutableCatchEventElement> {
   private final IOMappingHelper ioMappingHelper = new IOMappingHelper();
 
   @Override
-  public void handle(BpmnStepContext<ExecutableIntermediateCatchElement> context) {
+  public void handle(BpmnStepContext<ExecutableCatchEventElement> context) {
 
     context.getCatchEventOutput().unsubscribeFromCatchEvents(context.getRecord().getKey(), context);
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/CorrelateWorkflowInstanceSubscription.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/CorrelateWorkflowInstanceSubscription.java
@@ -27,7 +27,7 @@ import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
 import io.zeebe.broker.subscription.command.SubscriptionCommandSender;
 import io.zeebe.broker.subscription.message.data.WorkflowInstanceSubscriptionRecord;
 import io.zeebe.broker.subscription.message.state.WorkflowInstanceSubscriptionState;
-import io.zeebe.broker.workflow.processor.boundary.BoundaryEventHelper;
+import io.zeebe.broker.workflow.processor.boundary.BoundaryEventActivator;
 import io.zeebe.broker.workflow.state.ElementInstance;
 import io.zeebe.broker.workflow.state.StoredRecord;
 import io.zeebe.broker.workflow.state.StoredRecord.Purpose;
@@ -48,7 +48,7 @@ public final class CorrelateWorkflowInstanceSubscription
   public static final Duration SUBSCRIPTION_TIMEOUT = Duration.ofSeconds(10);
   public static final Duration SUBSCRIPTION_CHECK_INTERVAL = Duration.ofSeconds(30);
 
-  private final BoundaryEventHelper boundaryEventHelper = new BoundaryEventHelper();
+  private final BoundaryEventActivator boundaryEventActivator;
   private final TopologyManager topologyManager;
   private final WorkflowState workflowState;
   private final WorkflowInstanceSubscriptionState subscriptionState;
@@ -60,11 +60,13 @@ public final class CorrelateWorkflowInstanceSubscription
       final TopologyManager topologyManager,
       final WorkflowState workflowState,
       final WorkflowInstanceSubscriptionState subscriptionState,
-      final SubscriptionCommandSender subscriptionCommandSender) {
+      final SubscriptionCommandSender subscriptionCommandSender,
+      final BoundaryEventActivator boundaryEventActivator) {
     this.topologyManager = topologyManager;
     this.workflowState = workflowState;
     this.subscriptionState = subscriptionState;
     this.subscriptionCommandSender = subscriptionCommandSender;
+    this.boundaryEventActivator = boundaryEventActivator;
   }
 
   @Override
@@ -131,9 +133,9 @@ public final class CorrelateWorkflowInstanceSubscription
       streamWriter.appendFollowUpEvent(
           record.getKey(), WorkflowInstanceSubscriptionIntent.CORRELATED, subscriptionRecord);
 
-      if (boundaryEventHelper.shouldTriggerBoundaryEvent(
+      if (boundaryEventActivator.shouldActivateBoundaryEvent(
           elementInstance, subscription.getHandlerNodeId())) {
-        boundaryEventHelper.triggerBoundaryEvent(
+        boundaryEventActivator.activateBoundaryEvent(
             workflowState,
             elementInstance,
             subscription.getHandlerNodeId(),

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/subprocess/TerminateContainedElementsHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/subprocess/TerminateContainedElementsHandler.java
@@ -65,7 +65,7 @@ public class TerminateContainedElementsHandler
       if (elementInstance.isInterrupted()) {
         context
             .getCatchEventOutput()
-            .triggerBoundaryEventFromInterruptedElement(elementInstance, output.getStreamWriter());
+            .triggerInterruptedElement(elementInstance, output.getStreamWriter());
       }
 
       elementInstanceState.visitFailedTokens(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/CreateTimerProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/CreateTimerProcessor.java
@@ -56,6 +56,7 @@ public class CreateTimerProcessor implements TypedRecordProcessor<TimerRecord> {
     timerInstance.setDueDate(timer.getDueDate());
     timerInstance.setKey(timerKey);
     timerInstance.setHandlerNodeId(timer.getHandlerNodeId());
+    timerInstance.setRepetitions(timer.getRepetitions());
 
     sideEffect.accept(this::scheduleTimer);
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/DueDateTimerChecker.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/DueDateTimerChecker.java
@@ -93,7 +93,8 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
     timerRecord
         .setElementInstanceKey(timer.getElementInstanceKey())
         .setDueDate(timer.getDueDate())
-        .setHandlerNodeId(timer.getHandlerNodeId());
+        .setHandlerNodeId(timer.getHandlerNodeId())
+        .setRepetitions(timer.getRepetitions());
 
     streamWriter.appendFollowUpCommand(timer.getKey(), TimerIntent.TRIGGER, timerRecord);
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/state/TimerInstance.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/state/TimerInstance.java
@@ -32,6 +32,7 @@ public class TimerInstance implements Persistable {
   private long key;
   private long elementInstanceKey;
   private long dueDate;
+  private int repetitions;
 
   public long getElementInstanceKey() {
     return elementInstanceKey;
@@ -65,9 +66,17 @@ public class TimerInstance implements Persistable {
     this.handlerNodeId.wrap(handlerNodeId);
   }
 
+  public int getRepetitions() {
+    return repetitions;
+  }
+
+  public void setRepetitions(int repetitions) {
+    this.repetitions = repetitions;
+  }
+
   @Override
   public int getLength() {
-    return 3 * Long.BYTES + Integer.BYTES + handlerNodeId.capacity();
+    return 3 * Long.BYTES + 2 * Integer.BYTES + handlerNodeId.capacity();
   }
 
   @Override
@@ -80,6 +89,9 @@ public class TimerInstance implements Persistable {
 
     buffer.putLong(offset, key, STATE_BYTE_ORDER);
     offset += Long.BYTES;
+
+    buffer.putInt(offset, repetitions, STATE_BYTE_ORDER);
+    offset += Integer.BYTES;
 
     offset = writeIntoBuffer(buffer, offset, handlerNodeId);
     assert offset == getLength() : "End offset differs from getLength()";
@@ -95,6 +107,9 @@ public class TimerInstance implements Persistable {
 
     key = buffer.getLong(offset, STATE_BYTE_ORDER);
     offset += Long.BYTES;
+
+    repetitions = buffer.getInt(offset, STATE_BYTE_ORDER);
+    offset += Integer.BYTES;
 
     offset = readIntoBuffer(buffer, offset, handlerNodeId);
     assert offset == length : "End offset differs from length";


### PR DESCRIPTION
- timeDuration now also uses Interval (i.e. supports P1Y2DT3S)
- timers are recreated until they run out of repetitions or are canceled
- number of repetitions is encoded in TimerRecord/TimerInstance
- fixed token count with non-interrupting boundary events
- rename BoundaryEventHelper to BoundaryEventActivator
- introduce ExecutableCatchEventElement

closes #1703 
