### PR TITLE
feat(msgpack-json-el): allow non-strict condtions

### DIFF
--- a/docs/src/reference/json-conditions.md
+++ b/docs/src/reference/json-conditions.md
@@ -49,7 +49,33 @@ $.orderCount >= 5 && $.orderCount < 15
 </table>
 
 A Null-Value can be used to check if a property is set (e.g., `$.owner == null`).
-If the property doesn't exist, then the JSON Path evaluation fails.
+If the any property in specified JSON Path doesn't exist, then it would be resolved as `null` and could be compared as such.
+
+<table style="width:100%">
+  <tr>
+    <th>Payload</th>
+    <th>JSON Path</th>
+    <th>Value</th
+  </tr>
+
+  <tr>
+    <td>{"foo": 3}</td>
+    <td>$.foo</td>
+    <td>3</td>
+  </tr>
+
+  <tr>
+    <td>{"foo": 3}</td>
+    <td>$.bar</td>
+    <td>null</td>
+  </tr>
+
+  <tr>
+    <td>{"foo": 3}</td>
+    <td>$.bar.baz</td>
+    <td>null</td>
+  </tr>
+</table>
 
 ### Comparison Operators
 
@@ -100,6 +126,7 @@ If the property doesn't exist, then the JSON Path evaluation fails.
 The operators `<`, `<=`, `>` and `>=` can only be used for numbers.
 
 If the values of an operator have different types, then the evaluation fails.
+Comparing null or missing property with a number is considered as comparing different types.
 
 ### Logical Operators
 

--- a/json-el/src/test/java/io/zeebe/msgpack/el/JsonConditionTest.java
+++ b/json-el/src/test/java/io/zeebe/msgpack/el/JsonConditionTest.java
@@ -78,14 +78,35 @@ public class JsonConditionTest {
   }
 
   @Test
-  public void shouldFailIfJsonPathDoesntMatch() {
+  public void shouldFailIfMissingPropertyComparedRelatively() {
     final CompiledJsonCondition condition = JsonConditionFactory.createCondition("$.foo > 3");
     assertThat(condition.isValid()).isTrue();
 
     thrown.expect(JsonConditionException.class);
-    thrown.expectMessage("JSON path '$.foo' has no result");
+    thrown.expectMessage("Cannot compare values of different types: NIL and INTEGER");
 
     interpreter.eval(condition.getCondition(), asMsgPack("bar", 4));
+  }
+
+  @Test
+  public void shouldEqualToNullIfJsonPathDoesntMatch() {
+    final CompiledJsonCondition condition = JsonConditionFactory.createCondition("$.foo == null");
+    assertThat(condition.isValid()).isTrue();
+
+    final boolean result = interpreter.eval(condition.getCondition(), asMsgPack("bar", 4));
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void shouldEqualToNullIfAnySegmentInJsonPathDoesntMatch() {
+    final CompiledJsonCondition condition =
+        JsonConditionFactory.createCondition("$.foo.baz == null");
+    assertThat(condition.isValid()).isTrue();
+
+    final boolean result = interpreter.eval(condition.getCondition(), asMsgPack("bar", 4));
+
+    assertThat(result).isTrue();
   }
 
   @Test

--- a/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgPackToken.java
+++ b/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgPackToken.java
@@ -19,10 +19,11 @@ import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public class MsgPackToken {
+  public static final MsgPackToken NIL = new MsgPackToken();
 
   protected static final int MAX_MAP_ELEMENTS = 0x3fff_ffff;
 
-  protected MsgPackType type;
+  protected MsgPackType type = MsgPackType.NIL;
   protected int totalLength;
 
   // string


### PR DESCRIPTION
Allows JsonPath conditions to be non-strict, evaluating to null when no values were found

closes #1751 
