### PR TITLE
fix(broker-core): close gateway before service containers

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -62,6 +62,7 @@ public class SystemContext implements AutoCloseable {
 
   protected final List<ActorFuture<?>> requiredStartActions = new ArrayList<>();
   private final List<Closeable> closeablesToReleaseResources = new ArrayList<>();
+  private Closeable gatewayResourceReleasingDelegate = null;
 
   protected Map<String, String> diagnosticContext;
   protected ActorScheduler scheduler;
@@ -215,6 +216,14 @@ public class SystemContext implements AutoCloseable {
     LOG.info("Closing...");
 
     try {
+      if (gatewayResourceReleasingDelegate != null) {
+        gatewayResourceReleasingDelegate.close();
+      }
+    } catch (IOException e) {
+      LOG.error("Failed to close gateway:", e);
+    }
+
+    try {
       serviceContainer.close(getCloseTimeout().toMillis(), TimeUnit.MILLISECONDS);
     } catch (final TimeoutException e) {
       LOG.error("Failed to close broker within {} seconds.", CLOSE_TIMEOUT, e);
@@ -250,6 +259,10 @@ public class SystemContext implements AutoCloseable {
 
   public void addResourceReleasingDelegate(final Closeable delegate) {
     closeablesToReleaseResources.add(delegate);
+  }
+
+  public void setGatewayResourceReleasingDelegate(final Closeable delegate) {
+    gatewayResourceReleasingDelegate = delegate;
   }
 
   public Map<String, String> getDiagnosticContext() {

--- a/broker-core/src/main/java/io/zeebe/broker/transport/GatewayComponent.java
+++ b/broker-core/src/main/java/io/zeebe/broker/transport/GatewayComponent.java
@@ -32,7 +32,7 @@ public class GatewayComponent implements Component {
       try {
         final Gateway gateway = new Gateway(config);
         gateway.start();
-        context.addResourceReleasingDelegate(gateway::stop);
+        context.setGatewayResourceReleasingDelegate(gateway::stop);
       } catch (final IOException e) {
         throw new RuntimeException("Gateway was not able to start", e);
       }


### PR DESCRIPTION
The gateway was being closed after the service containers so it would hang since these would never terminate. I separated the gateway's resource releasing delegate from the others, so we could close it before the service containers.
closes #1518 
