### PR TITLE
feat(broker-core): allow multiple correlations on single message sub

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/subscription/command/OpenMessageSubscriptionCommand.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/command/OpenMessageSubscriptionCommand.java
@@ -23,6 +23,7 @@ import static io.zeebe.broker.subscription.OpenMessageSubscriptionDecoder.messag
 import static io.zeebe.broker.subscription.OpenMessageSubscriptionDecoder.subscriptionPartitionIdNullValue;
 import static io.zeebe.broker.subscription.OpenMessageSubscriptionDecoder.workflowInstanceKeyNullValue;
 
+import io.zeebe.broker.subscription.BooleanType;
 import io.zeebe.broker.subscription.OpenMessageSubscriptionDecoder;
 import io.zeebe.broker.subscription.OpenMessageSubscriptionEncoder;
 import io.zeebe.broker.util.SbeBufferWriterReader;
@@ -39,6 +40,7 @@ public class OpenMessageSubscriptionCommand
   private int subscriptionPartitionId;
   private long workflowInstanceKey;
   private long elementInstanceKey;
+  private boolean closeOnCorrelate;
 
   private final UnsafeBuffer messageName = new UnsafeBuffer(0, 0);
   private final UnsafeBuffer correlationKey = new UnsafeBuffer(0, 0);
@@ -70,6 +72,7 @@ public class OpenMessageSubscriptionCommand
         .subscriptionPartitionId(subscriptionPartitionId)
         .workflowInstanceKey(workflowInstanceKey)
         .elementInstanceKey(elementInstanceKey)
+        .closeOnCorrelate(closeOnCorrelate ? BooleanType.TRUE : BooleanType.FALSE)
         .putMessageName(messageName, 0, messageName.capacity())
         .putCorrelationKey(correlationKey, 0, correlationKey.capacity());
   }
@@ -81,6 +84,7 @@ public class OpenMessageSubscriptionCommand
     subscriptionPartitionId = decoder.subscriptionPartitionId();
     workflowInstanceKey = decoder.workflowInstanceKey();
     elementInstanceKey = decoder.elementInstanceKey();
+    closeOnCorrelate = decoder.closeOnCorrelate() == BooleanType.TRUE;
 
     offset = decoder.limit();
 
@@ -136,5 +140,13 @@ public class OpenMessageSubscriptionCommand
 
   public DirectBuffer getCorrelationKey() {
     return correlationKey;
+  }
+
+  public boolean shouldCloseOnCorrelate() {
+    return closeOnCorrelate;
+  }
+
+  public void setCloseOnCorrelate(boolean closeOnCorrelate) {
+    this.closeOnCorrelate = closeOnCorrelate;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/command/OpenWorkflowInstanceSubscriptionCommand.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/command/OpenWorkflowInstanceSubscriptionCommand.java
@@ -22,6 +22,7 @@ import static io.zeebe.broker.subscription.OpenWorkflowInstanceSubscriptionDecod
 import static io.zeebe.broker.subscription.OpenWorkflowInstanceSubscriptionDecoder.subscriptionPartitionIdNullValue;
 import static io.zeebe.broker.subscription.OpenWorkflowInstanceSubscriptionDecoder.workflowInstanceKeyNullValue;
 
+import io.zeebe.broker.subscription.BooleanType;
 import io.zeebe.broker.subscription.OpenWorkflowInstanceSubscriptionDecoder;
 import io.zeebe.broker.subscription.OpenWorkflowInstanceSubscriptionEncoder;
 import io.zeebe.broker.util.SbeBufferWriterReader;
@@ -41,6 +42,7 @@ public class OpenWorkflowInstanceSubscriptionCommand
   private int subscriptionPartitionId;
   private long workflowInstanceKey;
   private long elementInstanceKey;
+  private boolean closeOnCorrelate;
 
   private final UnsafeBuffer messageName = new UnsafeBuffer(0, 0);
 
@@ -67,6 +69,7 @@ public class OpenWorkflowInstanceSubscriptionCommand
         .subscriptionPartitionId(subscriptionPartitionId)
         .workflowInstanceKey(workflowInstanceKey)
         .elementInstanceKey(elementInstanceKey)
+        .closeOnCorrelate(closeOnCorrelate ? BooleanType.TRUE : BooleanType.FALSE)
         .putMessageName(messageName, 0, messageName.capacity());
   }
 
@@ -77,6 +80,7 @@ public class OpenWorkflowInstanceSubscriptionCommand
     subscriptionPartitionId = decoder.subscriptionPartitionId();
     workflowInstanceKey = decoder.workflowInstanceKey();
     elementInstanceKey = decoder.elementInstanceKey();
+    closeOnCorrelate = decoder.closeOnCorrelate() == BooleanType.TRUE;
 
     offset = decoder.limit();
 
@@ -119,5 +123,13 @@ public class OpenWorkflowInstanceSubscriptionCommand
 
   public DirectBuffer getMessageName() {
     return messageName;
+  }
+
+  public boolean shouldCloseOnCorrelate() {
+    return closeOnCorrelate;
+  }
+
+  public void setCloseOnCorrelate(boolean closeOnCorrelate) {
+    this.closeOnCorrelate = closeOnCorrelate;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionApiCommandMessageHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionApiCommandMessageHandler.java
@@ -127,7 +127,8 @@ public class SubscriptionApiCommandMessageHandler implements ServerMessageHandle
         .setWorkflowInstanceKey(openMessageSubscriptionCommand.getWorkflowInstanceKey())
         .setElementInstanceKey(openMessageSubscriptionCommand.getElementInstanceKey())
         .setMessageName(openMessageSubscriptionCommand.getMessageName())
-        .setCorrelationKey(openMessageSubscriptionCommand.getCorrelationKey());
+        .setCorrelationKey(openMessageSubscriptionCommand.getCorrelationKey())
+        .setCloseOnCorrelate(openMessageSubscriptionCommand.shouldCloseOnCorrelate());
 
     return writeCommand(
         openMessageSubscriptionCommand.getSubscriptionPartitionId(),
@@ -149,7 +150,8 @@ public class SubscriptionApiCommandMessageHandler implements ServerMessageHandle
             openWorkflowInstanceSubscriptionCommand.getSubscriptionPartitionId())
         .setWorkflowInstanceKey(workflowInstanceKey)
         .setElementInstanceKey(openWorkflowInstanceSubscriptionCommand.getElementInstanceKey())
-        .setMessageName(openWorkflowInstanceSubscriptionCommand.getMessageName());
+        .setMessageName(openWorkflowInstanceSubscriptionCommand.getMessageName())
+        .setCloseOnCorrelate(openWorkflowInstanceSubscriptionCommand.shouldCloseOnCorrelate());
 
     return writeCommand(
         workflowInstancePartitionId,

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionCommandSender.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionCommandSender.java
@@ -97,7 +97,8 @@ public class SubscriptionCommandSender {
       final long workflowInstanceKey,
       final long elementInstanceKey,
       final DirectBuffer messageName,
-      final DirectBuffer correlationKey) {
+      final DirectBuffer correlationKey,
+      final boolean closeOnCorrelate) {
 
     final int subscriptionPartitionId =
         SubscriptionUtil.getSubscriptionPartitionId(correlationKey, partitionIds.size());
@@ -107,6 +108,7 @@ public class SubscriptionCommandSender {
     openMessageSubscriptionCommand.setElementInstanceKey(elementInstanceKey);
     openMessageSubscriptionCommand.getMessageName().wrap(messageName);
     openMessageSubscriptionCommand.getCorrelationKey().wrap(correlationKey);
+    openMessageSubscriptionCommand.setCloseOnCorrelate(closeOnCorrelate);
 
     return sendSubscriptionCommand(subscriptionPartitionId, openMessageSubscriptionCommand);
   }
@@ -114,7 +116,8 @@ public class SubscriptionCommandSender {
   public boolean openWorkflowInstanceSubscription(
       final long workflowInstanceKey,
       final long elementInstanceKey,
-      final DirectBuffer messageName) {
+      final DirectBuffer messageName,
+      final boolean closeOnCorrelate) {
 
     final int workflowInstancePartitionId = Protocol.decodePartitionId(workflowInstanceKey);
 
@@ -122,6 +125,7 @@ public class SubscriptionCommandSender {
     openWorkflowInstanceSubscriptionCommand.setWorkflowInstanceKey(workflowInstanceKey);
     openWorkflowInstanceSubscriptionCommand.setElementInstanceKey(elementInstanceKey);
     openWorkflowInstanceSubscriptionCommand.getMessageName().wrap(messageName);
+    openWorkflowInstanceSubscriptionCommand.setCloseOnCorrelate(closeOnCorrelate);
 
     return sendSubscriptionCommand(
         workflowInstancePartitionId, openWorkflowInstanceSubscriptionCommand);

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/MessageSubscriptionRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/MessageSubscriptionRecord.java
@@ -18,6 +18,7 @@
 package io.zeebe.broker.subscription.message.data;
 
 import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.msgpack.property.BooleanProperty;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
 import org.agrona.DirectBuffer;
@@ -28,12 +29,15 @@ public class MessageSubscriptionRecord extends UnpackedObject {
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey");
   private final StringProperty messageNameProp = new StringProperty("messageName", "");
   private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
+  private final BooleanProperty closeOnCorrelateProp =
+      new BooleanProperty("closeOnCorrelate", true);
 
   public MessageSubscriptionRecord() {
     this.declareProperty(workflowInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(messageNameProp)
-        .declareProperty(correlationKeyProp);
+        .declareProperty(correlationKeyProp)
+        .declareProperty(closeOnCorrelateProp);
   }
 
   public long getWorkflowInstanceKey() {
@@ -69,6 +73,15 @@ public class MessageSubscriptionRecord extends UnpackedObject {
 
   public MessageSubscriptionRecord setCorrelationKey(DirectBuffer correlationKey) {
     correlationKeyProp.setValue(correlationKey);
+    return this;
+  }
+
+  public boolean shouldCloseOnCorrelate() {
+    return closeOnCorrelateProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setCloseOnCorrelate(boolean closeOnCorrelate) {
+    this.closeOnCorrelateProp.setValue(closeOnCorrelate);
     return this;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/WorkflowInstanceSubscriptionRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/WorkflowInstanceSubscriptionRecord.java
@@ -18,6 +18,7 @@
 package io.zeebe.broker.subscription.message.data;
 
 import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.msgpack.property.BooleanProperty;
 import io.zeebe.msgpack.property.DocumentProperty;
 import io.zeebe.msgpack.property.IntegerProperty;
 import io.zeebe.msgpack.property.LongProperty;
@@ -32,13 +33,16 @@ public class WorkflowInstanceSubscriptionRecord extends UnpackedObject {
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey");
   private final StringProperty messageNameProp = new StringProperty("messageName", "");
   private final DocumentProperty payloadProp = new DocumentProperty("payload");
+  private final BooleanProperty closeOnCorrelateProp =
+      new BooleanProperty("closeOnCorrelate", true);
 
   public WorkflowInstanceSubscriptionRecord() {
     this.declareProperty(subscriptionPartitionIdProp)
         .declareProperty(workflowInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(messageNameProp)
-        .declareProperty(payloadProp);
+        .declareProperty(payloadProp)
+        .declareProperty(closeOnCorrelateProp);
   }
 
   public int getSubscriptionPartitionId() {
@@ -83,6 +87,15 @@ public class WorkflowInstanceSubscriptionRecord extends UnpackedObject {
 
   public WorkflowInstanceSubscriptionRecord setPayload(DirectBuffer payload) {
     payloadProp.setValue(payload);
+    return this;
+  }
+
+  public boolean shouldCloseOnCorrelate() {
+    return closeOnCorrelateProp.getValue();
+  }
+
+  public WorkflowInstanceSubscriptionRecord setCloseOnCorrelate(boolean closeOnCorrelate) {
+    this.closeOnCorrelateProp.setValue(closeOnCorrelate);
     return this;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageCorrelator.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageCorrelator.java
@@ -1,0 +1,95 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.subscription.message.processor;
+
+import io.zeebe.broker.logstreams.processor.SideEffectProducer;
+import io.zeebe.broker.subscription.command.SubscriptionCommandSender;
+import io.zeebe.broker.subscription.message.data.MessageSubscriptionRecord;
+import io.zeebe.broker.subscription.message.state.Message;
+import io.zeebe.broker.subscription.message.state.MessageState;
+import io.zeebe.broker.subscription.message.state.MessageSubscription;
+import io.zeebe.broker.subscription.message.state.MessageSubscriptionState;
+import io.zeebe.util.sched.clock.ActorClock;
+import java.util.function.Consumer;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public class MessageCorrelator {
+
+  private final DirectBuffer messagePayload = new UnsafeBuffer();
+  private final MessageState messageState;
+  private final MessageSubscriptionState subscriptionState;
+  private final SubscriptionCommandSender commandSender;
+
+  public MessageCorrelator(
+      MessageState messageState,
+      MessageSubscriptionState subscriptionState,
+      SubscriptionCommandSender commandSender) {
+    this.messageState = messageState;
+    this.subscriptionState = subscriptionState;
+    this.commandSender = commandSender;
+  }
+
+  private Consumer<SideEffectProducer> sideEffect;
+  private MessageSubscriptionRecord subscriptionRecord;
+  private MessageSubscription subscription;
+
+  public void correlateNextMessage(
+      MessageSubscription subscription,
+      MessageSubscriptionRecord subscriptionRecord,
+      Consumer<SideEffectProducer> sideEffect) {
+    this.subscription = subscription;
+    this.subscriptionRecord = subscriptionRecord;
+    this.sideEffect = sideEffect;
+
+    messageState.visitMessages(
+        subscriptionRecord.getMessageName(),
+        subscriptionRecord.getCorrelationKey(),
+        this::correlateMessage);
+  }
+
+  private boolean correlateMessage(final Message message) {
+    // correlate the first message which is not correlated to the workflow instance yet
+
+    final boolean isCorrelatedBefore =
+        messageState.existMessageCorrelation(
+            message.getKey(), subscriptionRecord.getWorkflowInstanceKey());
+
+    if (!isCorrelatedBefore) {
+      subscriptionState.updateToCorrelatingState(
+          subscription, message.getPayload(), ActorClock.currentTimeMillis());
+
+      // send the correlate instead of acknowledge command
+      messagePayload.wrap(message.getPayload());
+      sideEffect.accept(this::sendCorrelateCommand);
+
+      messageState.putMessageCorrelation(
+          message.getKey(), subscriptionRecord.getWorkflowInstanceKey());
+    }
+
+    return isCorrelatedBefore;
+  }
+
+  private boolean sendCorrelateCommand() {
+    return commandSender.correlateWorkflowInstanceSubscription(
+        subscriptionRecord.getWorkflowInstanceKey(),
+        subscriptionRecord.getElementInstanceKey(),
+        subscriptionRecord.getMessageName(),
+        messagePayload);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageEventProcessors.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageEventProcessors.java
@@ -53,7 +53,8 @@ public class MessageEventProcessors {
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CORRELATE,
-            new CorrelateMessageSubscriptionProcessor(subscriptionState))
+            new CorrelateMessageSubscriptionProcessor(
+                messageState, subscriptionState, subscriptionCommandSender))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CLOSE,

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableCatchEventElement.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableCatchEventElement.java
@@ -26,6 +26,7 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
   private final List<ExecutableCatchEvent> events = Collections.singletonList(this);
 
   private ExecutableMessage message;
+
   private RepeatingInterval timer;
 
   public ExecutableCatchEventElement(String id) {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepHandlers.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepHandlers.java
@@ -21,7 +21,6 @@ import io.zeebe.broker.incident.processor.IncidentState;
 import io.zeebe.broker.logstreams.state.ZeebeState;
 import io.zeebe.broker.workflow.model.BpmnStep;
 import io.zeebe.broker.workflow.model.element.ExecutableFlowElement;
-import io.zeebe.broker.workflow.model.element.ExecutableFlowNode;
 import io.zeebe.broker.workflow.processor.activity.ActivateActivityHandler;
 import io.zeebe.broker.workflow.processor.activity.CompleteActivityHandler;
 import io.zeebe.broker.workflow.processor.activity.TerminateActivityHandler;
@@ -65,8 +64,7 @@ public class BpmnStepHandlers {
         BpmnStep.TERMINATE_CONTAINED_INSTANCES, new TerminateContainedElementsHandler(zeebeState));
 
     // flow nodes
-    stepHandlers.put(
-        BpmnStep.ACTIVATE_FLOW_NODE, new ActivateFlowNodeHandler<ExecutableFlowNode>());
+    stepHandlers.put(BpmnStep.ACTIVATE_FLOW_NODE, new ActivateFlowNodeHandler<>());
     stepHandlers.put(BpmnStep.COMPLETE_FLOW_NODE, new CompleteFlowNodeHandler());
     stepHandlers.put(BpmnStep.TAKE_SEQUENCE_FLOW, new TakeSequenceFlowHandler());
     stepHandlers.put(BpmnStep.CONSUME_TOKEN, new ConsumeTokenHandler());

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
@@ -209,6 +209,7 @@ public class CatchEventBehavior {
     final long elementInstanceKey = context.getRecord().getKey();
     final DirectBuffer messageName = cloneBuffer(message.getMessageName());
     final DirectBuffer correlationKey = cloneBuffer(extractedKey);
+    final boolean closeOnCorrelate = true; // todo (npepinpe): will updated in #1592
 
     subscription.setMessageName(messageName);
     subscription.setElementInstanceKey(elementInstanceKey);
@@ -216,6 +217,7 @@ public class CatchEventBehavior {
     subscription.setWorkflowInstanceKey(workflowInstanceKey);
     subscription.setCorrelationKey(correlationKey);
     subscription.setHandlerNodeId(handler.getId());
+    subscription.setCloseOnCorrelate(closeOnCorrelate);
     state.getWorkflowInstanceSubscriptionState().put(subscription);
 
     context
@@ -223,7 +225,11 @@ public class CatchEventBehavior {
         .add(
             () ->
                 sendOpenMessageSubscription(
-                    workflowInstanceKey, elementInstanceKey, messageName, correlationKey));
+                    workflowInstanceKey,
+                    elementInstanceKey,
+                    messageName,
+                    correlationKey,
+                    closeOnCorrelate));
   }
 
   private void unsubscribeFromMessageEvents(long elementInstanceKey, BpmnStepContext<?> context) {
@@ -300,8 +306,9 @@ public class CatchEventBehavior {
       long workflowInstanceKey,
       long elementInstanceKey,
       DirectBuffer messageName,
-      DirectBuffer correlationKey) {
+      DirectBuffer correlationKey,
+      boolean closeOnCorrelate) {
     return subscriptionCommandSender.openMessageSubscription(
-        workflowInstanceKey, elementInstanceKey, messageName, correlationKey);
+        workflowInstanceKey, elementInstanceKey, messageName, correlationKey, closeOnCorrelate);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/PendingWorkflowInstanceSubscriptionChecker.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/PendingWorkflowInstanceSubscriptionChecker.java
@@ -46,8 +46,9 @@ public class PendingWorkflowInstanceSubscriptionChecker implements Runnable {
   }
 
   private boolean sendCommand(WorkflowInstanceSubscription subscription) {
-    boolean success = false;
+    final boolean success;
 
+    // can only be opening/closing as an opened subscription is not indexed in the sent time column
     if (subscription.isOpening()) {
       success = sendOpenCommand(subscription);
     } else {
@@ -66,7 +67,8 @@ public class PendingWorkflowInstanceSubscriptionChecker implements Runnable {
         subscription.getWorkflowInstanceKey(),
         subscription.getElementInstanceKey(),
         subscription.getMessageName(),
-        subscription.getCorrelationKey());
+        subscription.getCorrelationKey(),
+        subscription.shouldCloseOnCorrelate());
   }
 
   private boolean sendCloseCommand(WorkflowInstanceSubscription subscription) {

--- a/broker-core/src/main/resources/subscription-schema.xml
+++ b/broker-core/src/main/resources/subscription-schema.xml
@@ -24,21 +24,28 @@
       <type name="numInGroup" primitiveType="uint8" semanticType="NumInGroup"/>
     </composite>
 
+    <enum name="BooleanType" encodingType="uint8" semanticType="Boolean">
+      <validValue name="FALSE">0</validValue>
+      <validValue name="TRUE">1</validValue>
+    </enum>
+
   </types>
 
   <sbe:message name="OpenMessageSubscription" id="0">
     <field name="subscriptionPartitionId" id="0" type="uint16"/>
     <field name="workflowInstanceKey" id="1" type="uint64"/>
     <field name="elementInstanceKey" id="2" type="uint64"/>
-    <data name="messageName" id="3" type="varDataEncoding"/>
-    <data name="correlationKey" id="4" type="varDataEncoding"/>
+    <field name="closeOnCorrelate" id="3" type="BooleanType"/>
+    <data name="messageName" id="4" type="varDataEncoding"/>
+    <data name="correlationKey" id="5" type="varDataEncoding"/>
   </sbe:message>
 
   <sbe:message name="OpenWorkflowInstanceSubscription" id="1">
     <field name="subscriptionPartitionId" id="0" type="uint16"/>
     <field name="workflowInstanceKey" id="1" type="uint64"/>
     <field name="elementInstanceKey" id="2" type="uint64"/>
-    <data name="messageName" id="3" type="varDataEncoding"/>
+    <field name="closeOnCorrelate" id="3" type="BooleanType"/>
+    <data name="messageName" id="4" type="varDataEncoding"/>
   </sbe:message>
 
   <sbe:message name="CorrelateWorkflowInstanceSubscription" id="2">

--- a/broker-core/src/test/java/io/zeebe/broker/incident/IncidentStreamProcessorRule.java
+++ b/broker-core/src/test/java/io/zeebe/broker/incident/IncidentStreamProcessorRule.java
@@ -20,6 +20,7 @@ package io.zeebe.broker.incident;
 import static io.zeebe.test.util.TestUtil.waitUntil;
 import static io.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -77,7 +78,8 @@ public class IncidentStreamProcessorRule extends ExternalResource {
     mockTimerEventScheduler = mock(DueDateTimerChecker.class);
 
     when(mockSubscriptionCommandSender.hasPartitionIds()).thenReturn(true);
-    when(mockSubscriptionCommandSender.openMessageSubscription(anyLong(), anyLong(), any(), any()))
+    when(mockSubscriptionCommandSender.openMessageSubscription(
+            anyLong(), anyLong(), any(), any(), anyBoolean()))
         .thenReturn(true);
     when(mockSubscriptionCommandSender.correlateMessageSubscription(
             anyInt(), anyLong(), anyLong(), any()))

--- a/broker-core/src/test/java/io/zeebe/broker/subscription/message/state/MessageSubscriptionStateTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/subscription/message/state/MessageSubscriptionStateTest.java
@@ -351,6 +351,6 @@ public class MessageSubscriptionStateTest {
   private MessageSubscription subscription(
       String name, String correlationKey, long elementInstanceKey) {
     return new MessageSubscription(
-        1L, elementInstanceKey, wrapString(name), wrapString(correlationKey));
+        1L, elementInstanceKey, wrapString(name), wrapString(correlationKey), true);
   }
 }

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageCatchElementTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageCatchElementTest.java
@@ -230,15 +230,17 @@ public class MessageCatchElementTest {
 
   @Test
   public void shouldCloseMessageSubscription() {
-
+    // given
     final long workflowInstanceKey =
         testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
 
     final Record<WorkflowInstanceRecordValue> catchEventEntered =
         testClient.receiveElementInState("receive-message", enteredState);
 
+    // when
     testClient.cancelWorkflowInstance(workflowInstanceKey);
 
+    // then
     final Record<MessageSubscriptionRecordValue> messageSubscription =
         RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CLOSED).getFirst();
 
@@ -281,6 +283,14 @@ public class MessageCatchElementTest {
     testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
 
     // when
+    assertThat(
+            testClient
+                .receiveWorkflowInstanceSubscriptions()
+                .withMessageName("order canceled")
+                .withIntent(WorkflowInstanceSubscriptionIntent.OPENED)
+                .limit(1)
+                .getFirst())
+        .isNotNull();
     testClient.publishMessage("order canceled", "order-123");
 
     // then

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorRule.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorRule.java
@@ -21,6 +21,7 @@ import static io.zeebe.test.util.TestUtil.doRepeatedly;
 import static io.zeebe.test.util.TestUtil.waitUntil;
 import static io.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -89,7 +90,8 @@ public class WorkflowInstanceStreamProcessorRule extends ExternalResource {
     mockTimerEventScheduler = mock(DueDateTimerChecker.class);
 
     when(mockSubscriptionCommandSender.hasPartitionIds()).thenReturn(true);
-    when(mockSubscriptionCommandSender.openMessageSubscription(anyLong(), anyLong(), any(), any()))
+    when(mockSubscriptionCommandSender.openMessageSubscription(
+            anyLong(), anyLong(), any(), any(), anyBoolean()))
         .thenReturn(true);
     when(mockSubscriptionCommandSender.correlateMessageSubscription(
             anyInt(), anyLong(), anyLong(), any()))

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorTest.java
@@ -364,7 +364,8 @@ public class WorkflowInstanceStreamProcessorTest {
             catchEvent.getValue().getWorkflowInstanceKey(),
             catchEvent.getKey(),
             wrapString("order canceled"),
-            wrapString("order-123"));
+            wrapString("order-123"),
+            true);
   }
 
   @Test
@@ -434,7 +435,7 @@ public class WorkflowInstanceStreamProcessorTest {
     assertThat(rejection.getMetadata().getIntent())
         .isEqualTo(WorkflowInstanceSubscriptionIntent.CORRELATE);
     assertThat(BufferUtil.bufferAsString(rejection.getMetadata().getRejectionReason()))
-        .isEqualTo("subscription is already correlated");
+        .isEqualTo("subscription was already correlated or is closing");
 
     verify(streamProcessorRule.getMockSubscriptionCommandSender(), timeout(5_000).times(2))
         .correlateMessageSubscription(
@@ -482,7 +483,7 @@ public class WorkflowInstanceStreamProcessorTest {
     assertThat(rejection.getMetadata().getIntent())
         .isEqualTo(WorkflowInstanceSubscriptionIntent.CORRELATE);
     assertThat(BufferUtil.bufferAsString(rejection.getMetadata().getRejectionReason()))
-        .isEqualTo("activity is not active anymore");
+        .isEqualTo("subscription was already correlated or is closing");
   }
 
   @Test

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/state/WorkflowInstanceSubscriptionStateTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/state/WorkflowInstanceSubscriptionStateTest.java
@@ -307,6 +307,7 @@ public class WorkflowInstanceSubscriptionStateTest {
         wrapString(handlerId),
         wrapString(name),
         wrapString(correlationKey),
-        1_000);
+        1_000,
+        true);
   }
 }


### PR DESCRIPTION
- adds closeOnCorrelate to records/commands to indicate a subscription should be implicitly closed on correlation; this is the default behaviour.
- publishing will correlate more than one message at a time to the same subscription if closeOnCorrelate is false.
- removes workflow instance sub from state on correlate if closeOnCorrelate

closes #1581 
