### PR TITLE
chore(bpmn-model): allow timer start events in model

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/StartEventValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/StartEventValidator.java
@@ -15,11 +15,16 @@
  */
 package io.zeebe.model.bpmn.validation.zeebe;
 
+import io.zeebe.model.bpmn.instance.EventDefinition;
 import io.zeebe.model.bpmn.instance.StartEvent;
+import io.zeebe.model.bpmn.instance.TimerEventDefinition;
+import java.util.Collection;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
 public class StartEventValidator implements ModelElementValidator<StartEvent> {
+  private static final Class SUPPORTED_EVENT_TYPE = TimerEventDefinition.class;
+
   @Override
   public Class<StartEvent> getElementType() {
     return StartEvent.class;
@@ -27,8 +32,16 @@ public class StartEventValidator implements ModelElementValidator<StartEvent> {
 
   @Override
   public void validate(StartEvent element, ValidationResultCollector validationResultCollector) {
-    if (!element.getEventDefinitions().isEmpty()) {
-      validationResultCollector.addError(0, "Must be a none start event");
+    final Collection<EventDefinition> eventDefinitions = element.getEventDefinitions();
+    if (eventDefinitions.size() > 1) {
+      validationResultCollector.addError(0, "Start event can't have more than one type");
+    } else {
+      for (EventDefinition eventDef : eventDefinitions) {
+        if (!SUPPORTED_EVENT_TYPE.isAssignableFrom(eventDef.getClass())) {
+          validationResultCollector.addError(
+              0, "Start event must be one of the following types: none, timer");
+        }
+      }
     }
   }
 }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
@@ -35,5 +35,13 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
     if (startEvents.size() != 1) {
       validationResultCollector.addError(0, "Must have exactly one start event");
     }
+
+    startEvents.forEach(
+        event -> {
+          if (!event.getEventDefinitions().isEmpty()) {
+            validationResultCollector.addError(
+                0, "Start events in subprocesses must be of type none");
+          }
+        });
   }
 }

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/AbstractZeebeValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/AbstractZeebeValidationTest.java
@@ -116,7 +116,7 @@ public abstract class AbstractZeebeValidationTest {
       final List<ExpectedValidationResult> unmatchedExpectations,
       final List<ValidationResult> unmatchedResults) {
     final StringBuilder sb = new StringBuilder();
-    sb.append("Not all expecations were matched by results (or vice versa)\n\n");
+    sb.append("Not all expectations were matched by results (or vice versa)\n\n");
     describeUnmatchedExpectations(sb, unmatchedExpectations);
     sb.append("\n");
     describeUnmatchedResults(sb, unmatchedResults);

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
@@ -106,7 +106,8 @@ public class ZeebeMessageValidationTest extends AbstractZeebeValidationTest {
             .startEvent()
             .message(b -> b.name("foo").zeebeCorrelationKey("correlationKey"))
             .done(),
-        singletonList(expect(StartEvent.class, "Must be a none start event"))
+        singletonList(
+            expect(StartEvent.class, "Start event must be one of the following types: none, timer"))
       },
       {
         Bpmn.createExecutableProcess("process")
@@ -132,7 +133,10 @@ public class ZeebeMessageValidationTest extends AbstractZeebeValidationTest {
             .subProcessDone()
             .endEvent()
             .done(),
-        singletonList(expect("subProcessStart", "Must be a none start event"))
+        Arrays.asList(
+            expect("subProcess", "Start events in subprocesses must be of type none"),
+            expect(
+                "subProcessStart", "Start event must be one of the following types: none, timer"))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
@@ -22,6 +22,9 @@ import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.builder.AbstractCatchEventBuilder;
 import io.zeebe.model.bpmn.instance.CompensateEventDefinition;
 import io.zeebe.model.bpmn.instance.IntermediateCatchEvent;
+import io.zeebe.model.bpmn.instance.SignalEventDefinition;
+import io.zeebe.model.bpmn.instance.StartEvent;
+import io.zeebe.model.bpmn.instance.SubProcess;
 import io.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
 import io.zeebe.model.bpmn.instance.zeebe.ZeebeOutputBehavior;
 import java.util.Arrays;
@@ -105,6 +108,30 @@ public class ZeebeValidationTest extends AbstractZeebeValidationTest {
             expect(
                 "task",
                 "Cannot have two message catch boundary events with the same name: message"))
+      },
+      {
+        Bpmn.createExecutableProcess().startEvent().signal("signal").endEvent().done(),
+        Arrays.asList(
+            expect(StartEvent.class, "Start event must be one of the following types: none, timer"),
+            expect(SignalEventDefinition.class, "Event definition of this type is not supported")),
+      },
+      {
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .timerWithCycle("R1/PT2H")
+            .signal("signal")
+            .endEvent()
+            .done(),
+        Arrays.asList(
+            expect(StartEvent.class, "Start event can't have more than one type"),
+            expect(SignalEventDefinition.class, "Event definition of this type is not supported")),
+      },
+      {
+        "multiple-timer-start-event-sub-process.bpmn",
+        Arrays.asList(
+            expect(SubProcess.class, "Start events in subprocesses must be of type none"),
+            expect(SubProcess.class, "Start events in subprocesses must be of type none"),
+            expect(SubProcess.class, "Must have exactly one start event"))
       },
     };
   }

--- a/bpmn-model/src/test/resources/io/zeebe/model/bpmn/validation/multiple-timer-start-event-sub-process.bpmn
+++ b/bpmn-model/src/test/resources/io/zeebe/model/bpmn/validation/multiple-timer-start-event-sub-process.bpmn
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_0hcvp1u" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.4.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1kcbt7b</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="SubProcess_1h0ttun">
+      <bpmn:incoming>SequenceFlow_1kcbt7b</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0g3j5sa</bpmn:outgoing>
+      <bpmn:endEvent id="EndEvent_0cmwel4">
+        <bpmn:incoming>SequenceFlow_1js9tr3</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="StartEvent_0kw42np">
+        <bpmn:outgoing>SequenceFlow_1js9tr3</bpmn:outgoing>
+          <bpmn:timerEventDefinition>
+            <bpmn:timeCycle>R3/PT10H</bpmn:timeCycle>
+          </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_1js9tr3" sourceRef="StartEvent_0kw42np" targetRef="EndEvent_0cmwel4" />
+      <bpmn:startEvent id="StartEvent_0df2zym">
+        <bpmn:outgoing>SequenceFlow_0oqyrpg</bpmn:outgoing>
+        <bpmn:timerEventDefinition>
+          <bpmn:timeCycle>R/PT1S</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:endEvent id="EndEvent_0fcu42k">
+        <bpmn:incoming>SequenceFlow_0oqyrpg</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_0oqyrpg" sourceRef="StartEvent_0df2zym" targetRef="EndEvent_0fcu42k" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="SequenceFlow_1kcbt7b" sourceRef="StartEvent_1" targetRef="SubProcess_1h0ttun" />
+    <bpmn:endEvent id="EndEvent_1mmd6op">
+      <bpmn:incoming>SequenceFlow_0g3j5sa</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0g3j5sa" sourceRef="SubProcess_1h0ttun" targetRef="EndEvent_1mmd6op" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="441" y="415" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_1h0ttun_di" bpmnElement="SubProcess_1h0ttun" isExpanded="true">
+        <dc:Bounds x="576" y="333" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1kcbt7b_di" bpmnElement="SequenceFlow_1kcbt7b">
+        <di:waypoint x="477" y="433" />
+        <di:waypoint x="576" y="433" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1mmd6op_di" bpmnElement="EndEvent_1mmd6op">
+        <dc:Bounds x="1029" y="415" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0g3j5sa_di" bpmnElement="SequenceFlow_0g3j5sa">
+        <di:waypoint x="926" y="433" />
+        <di:waypoint x="1029" y="433" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0cmwel4_di" bpmnElement="EndEvent_0cmwel4">
+        <dc:Bounds x="828" y="361" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0kw42np_di" bpmnElement="StartEvent_0kw42np">
+        <dc:Bounds x="630" y="361" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1js9tr3_di" bpmnElement="SequenceFlow_1js9tr3">
+        <di:waypoint x="666" y="379" />
+        <di:waypoint x="828" y="379" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_0df2zym_di" bpmnElement="StartEvent_0df2zym">
+        <dc:Bounds x="630" y="448" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0fcu42k_di" bpmnElement="EndEvent_0fcu42k">
+        <dc:Bounds x="828" y="448" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0oqyrpg_di" bpmnElement="SequenceFlow_0oqyrpg">
+        <di:waypoint x="666" y="466" />
+        <di:waypoint x="828" y="466" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Allows BPMN models to specify start events with timer definitions.

closes #1786 