### PR TITLE
chore(broker-core): catch events can create workflow instances

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/workflow/data/TimerRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/data/TimerRecord.java
@@ -29,12 +29,14 @@ public class TimerRecord extends UnpackedObject {
   private final LongProperty dueDateProp = new LongProperty("dueDate");
   private final StringProperty handlerNodeId = new StringProperty("handlerNodeId");
   private final IntegerProperty repetitionsProp = new IntegerProperty("repetitions");
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId");
 
   public TimerRecord() {
     this.declareProperty(elementInstanceKeyProp)
         .declareProperty(dueDateProp)
         .declareProperty(handlerNodeId)
-        .declareProperty(repetitionsProp);
+        .declareProperty(repetitionsProp)
+        .declareProperty(bpmnProcessIdProp);
   }
 
   public long getElementInstanceKey() {
@@ -70,6 +72,15 @@ public class TimerRecord extends UnpackedObject {
 
   public TimerRecord setRepetitions(int repetitions) {
     this.repetitionsProp.setValue(repetitions);
+    return this;
+  }
+
+  public DirectBuffer getBpmnId() {
+    return bpmnProcessIdProp.getValue();
+  }
+
+  public TimerRecord setBpmnId(DirectBuffer bpmnId) {
+    this.bpmnProcessIdProp.setValue(bpmnId);
     return this;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/CorrelateWorkflowInstanceSubscription.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/CorrelateWorkflowInstanceSubscription.java
@@ -105,6 +105,7 @@ public final class CorrelateWorkflowInstanceSubscription
     final boolean isOccurred =
         catchEventBehavior.occurEventForElement(
             elementInstanceKey,
+            null,
             subscription.getHandlerNodeId(),
             record.getValue().getPayload(),
             streamWriter);

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/CreateTimerProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/CreateTimerProcessor.java
@@ -57,6 +57,7 @@ public class CreateTimerProcessor implements TypedRecordProcessor<TimerRecord> {
     timerInstance.setKey(timerKey);
     timerInstance.setHandlerNodeId(timer.getHandlerNodeId());
     timerInstance.setRepetitions(timer.getRepetitions());
+    timerInstance.setBpmnId(timer.getBpmnId());
 
     sideEffect.accept(this::scheduleTimer);
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/DueDateTimerChecker.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/DueDateTimerChecker.java
@@ -94,7 +94,8 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
         .setElementInstanceKey(timer.getElementInstanceKey())
         .setDueDate(timer.getDueDate())
         .setHandlerNodeId(timer.getHandlerNodeId())
-        .setRepetitions(timer.getRepetitions());
+        .setRepetitions(timer.getRepetitions())
+        .setBpmnId(timer.getBpmnId());
 
     streamWriter.appendFollowUpCommand(timer.getKey(), TimerIntent.TRIGGER, timerRecord);
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/TriggerTimerProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/TriggerTimerProcessor.java
@@ -69,7 +69,11 @@ public class TriggerTimerProcessor implements TypedRecordProcessor<TimerRecord> 
 
     final boolean isOccurred =
         catchEventBehavior.occurEventForElement(
-            elementInstanceKey, timer.getHandlerNodeId(), EMPTY_DOCUMENT, streamWriter);
+            elementInstanceKey,
+            timer.getBpmnId(),
+            timer.getHandlerNodeId(),
+            EMPTY_DOCUMENT,
+            streamWriter);
     if (isOccurred) {
       streamWriter.appendFollowUpEvent(record.getKey(), TimerIntent.TRIGGERED, timer);
 
@@ -113,7 +117,7 @@ public class TriggerTimerProcessor implements TypedRecordProcessor<TimerRecord> 
     final RepeatingInterval timer =
         new RepeatingInterval(repetitions, event.getTimer().getInterval());
     catchEventBehavior.subscribeToTimerEvent(
-        record.getElementInstanceKey(), event.getId(), timer, writer);
+        record.getElementInstanceKey(), event.getId(), record.getBpmnId(), timer, writer);
   }
 
   private ExecutableCatchEventElement getCatchEventById(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/state/TimerInstance.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/state/TimerInstance.java
@@ -29,6 +29,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 public class TimerInstance implements DbValue {
 
   private final DirectBuffer handlerNodeId = new UnsafeBuffer(0, 0);
+  private final DirectBuffer bpmnId = new UnsafeBuffer(0, 0);
   private long key;
   private long elementInstanceKey;
   private long dueDate;
@@ -74,9 +75,17 @@ public class TimerInstance implements DbValue {
     this.repetitions = repetitions;
   }
 
+  public DirectBuffer getBpmnId() {
+    return this.bpmnId;
+  }
+
+  public void setBpmnId(DirectBuffer bpmnId) {
+    this.bpmnId.wrap(bpmnId);
+  }
+
   @Override
   public int getLength() {
-    return 3 * Long.BYTES + 2 * Integer.BYTES + handlerNodeId.capacity();
+    return 3 * Long.BYTES + 3 * Integer.BYTES + handlerNodeId.capacity() + bpmnId.capacity();
   }
 
   @Override
@@ -92,6 +101,8 @@ public class TimerInstance implements DbValue {
 
     buffer.putInt(offset, repetitions, ZB_DB_BYTE_ORDER);
     offset += Integer.BYTES;
+
+    offset = writeIntoBuffer(buffer, offset, bpmnId);
 
     offset = writeIntoBuffer(buffer, offset, handlerNodeId);
     assert offset == getLength() : "End offset differs from getLength()";
@@ -110,6 +121,8 @@ public class TimerInstance implements DbValue {
 
     repetitions = buffer.getInt(offset, ZB_DB_BYTE_ORDER);
     offset += Integer.BYTES;
+
+    offset = readIntoBuffer(buffer, offset, bpmnId);
 
     offset = readIntoBuffer(buffer, offset, handlerNodeId);
     assert offset == length : "End offset differs from length";


### PR DESCRIPTION
Changes the catch event behavior to allow a workflow instance to be created when an event is triggered

closes #1785 
