### PR TITLE
fix(broker-core): don't open subscription if incident is raised

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractFlowNodeBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractFlowNodeBuilder.java
@@ -258,6 +258,10 @@ public abstract class AbstractFlowNodeBuilder<
     return createTarget(EventBasedGateway.class).builder();
   }
 
+  public EventBasedGatewayBuilder eventBasedGateway(String id) {
+    return createTarget(EventBasedGateway.class, id).builder();
+  }
+
   public ExclusiveGatewayBuilder exclusiveGateway(String id) {
     return createTarget(ExclusiveGateway.class, id).builder();
   }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/BpmnStep.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/BpmnStep.java
@@ -42,7 +42,7 @@ public enum BpmnStep {
   // task
   CREATE_JOB,
   TERMINATE_JOB_TASK,
-  SUBSCRIBE_RECEIVE_TASK,
+  ACTIVATE_RECEIVE_TASK,
 
   // exclusive gateway
   ACTIVATE_GATEWAY,

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableActivity.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableActivity.java
@@ -20,18 +20,19 @@ package io.zeebe.broker.workflow.model.element;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ExecutableActivity extends ExecutableFlowNode {
-  private List<ExecutableBoundaryEvent> boundaryEvents = new ArrayList<>();
+public class ExecutableActivity extends ExecutableFlowNode implements ExecutableCatchEventSupplier {
+  private List<ExecutableCatchEvent> boundaryEvents = new ArrayList<>();
 
   public ExecutableActivity(String id) {
     super(id);
   }
 
-  public List<ExecutableBoundaryEvent> getBoundaryEvents() {
-    return boundaryEvents;
-  }
-
   public void attach(ExecutableBoundaryEvent boundaryEvent) {
     boundaryEvents.add(boundaryEvent);
+  }
+
+  @Override
+  public List<ExecutableCatchEvent> getEvents() {
+    return boundaryEvents;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableReceiveTask.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableReceiveTask.java
@@ -18,16 +18,13 @@
 package io.zeebe.broker.workflow.model.element;
 
 import io.zeebe.model.bpmn.util.time.RepeatingInterval;
-import java.util.Collections;
-import java.util.List;
 
-public class ExecutableReceiveTask extends ExecutableActivity
-    implements ExecutableCatchEvent, ExecutableCatchEventSupplier {
-
-  private final List<ExecutableCatchEvent> events = Collections.singletonList(this);
+public class ExecutableReceiveTask extends ExecutableActivity implements ExecutableCatchEvent {
 
   public ExecutableReceiveTask(String id) {
     super(id);
+
+    getEvents().add(this);
   }
 
   private ExecutableMessage message;
@@ -54,10 +51,5 @@ public class ExecutableReceiveTask extends ExecutableActivity
   @Override
   public RepeatingInterval getTimer() {
     return null;
-  }
-
-  @Override
-  public List<ExecutableCatchEvent> getEvents() {
-    return events;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/ReceiveTaskTransformer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/ReceiveTaskTransformer.java
@@ -51,7 +51,7 @@ public class ReceiveTaskTransformer implements ModelElementTransformer<ReceiveTa
   private void bindLifecycle(
       TransformContext context, final ExecutableReceiveTask executableElement) {
     executableElement.bindLifecycleState(
-        WorkflowInstanceIntent.ELEMENT_ACTIVATED, BpmnStep.SUBSCRIBE_RECEIVE_TASK);
+        WorkflowInstanceIntent.ELEMENT_READY, BpmnStep.ACTIVATE_RECEIVE_TASK);
     executableElement.bindLifecycleState(
         WorkflowInstanceIntent.EVENT_OCCURRED, BpmnStep.TRIGGER_RECEIVE_TASK);
   }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepHandlers.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepHandlers.java
@@ -42,8 +42,8 @@ import io.zeebe.broker.workflow.processor.process.CompleteProcessHandler;
 import io.zeebe.broker.workflow.processor.sequenceflow.ParallelMergeHandler;
 import io.zeebe.broker.workflow.processor.sequenceflow.StartFlowNodeHandler;
 import io.zeebe.broker.workflow.processor.sequenceflow.TakeSequenceFlowHandler;
+import io.zeebe.broker.workflow.processor.servicetask.ActivateReceiveTaskHandler;
 import io.zeebe.broker.workflow.processor.servicetask.CreateJobHandler;
-import io.zeebe.broker.workflow.processor.servicetask.SubscribeReceiveTaskHandler;
 import io.zeebe.broker.workflow.processor.servicetask.TerminateServiceTaskHandler;
 import io.zeebe.broker.workflow.processor.subprocess.TerminateContainedElementsHandler;
 import io.zeebe.broker.workflow.processor.subprocess.TriggerStartEventHandler;
@@ -80,7 +80,7 @@ public class BpmnStepHandlers {
     // task
     stepHandlers.put(BpmnStep.CREATE_JOB, new CreateJobHandler());
     stepHandlers.put(BpmnStep.TERMINATE_JOB_TASK, new TerminateServiceTaskHandler(zeebeState));
-    stepHandlers.put(BpmnStep.SUBSCRIBE_RECEIVE_TASK, new SubscribeReceiveTaskHandler());
+    stepHandlers.put(BpmnStep.ACTIVATE_RECEIVE_TASK, new ActivateReceiveTaskHandler());
 
     // exclusive gateway
     stepHandlers.put(BpmnStep.EXCLUSIVE_SPLIT, new ExclusiveSplitHandler());

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
@@ -26,6 +26,7 @@ import io.zeebe.broker.logstreams.state.ZeebeState;
 import io.zeebe.broker.subscription.command.SubscriptionCommandSender;
 import io.zeebe.broker.workflow.data.TimerRecord;
 import io.zeebe.broker.workflow.model.element.ExecutableCatchEvent;
+import io.zeebe.broker.workflow.model.element.ExecutableCatchEventSupplier;
 import io.zeebe.broker.workflow.model.element.ExecutableMessage;
 import io.zeebe.broker.workflow.state.ElementInstance;
 import io.zeebe.broker.workflow.state.ElementInstanceState;
@@ -38,7 +39,6 @@ import io.zeebe.model.bpmn.util.time.RepeatingInterval;
 import io.zeebe.msgpack.query.MsgPackQueryProcessor;
 import io.zeebe.msgpack.query.MsgPackQueryProcessor.QueryResult;
 import io.zeebe.msgpack.query.MsgPackQueryProcessor.QueryResults;
-import io.zeebe.protocol.impl.record.value.incident.ErrorType;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.TimerIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
@@ -72,8 +72,16 @@ public class CatchEventBehavior {
   }
 
   public void subscribeToEvents(
-      BpmnStepContext<?> context, final List<? extends ExecutableCatchEvent> events) {
-    for (final ExecutableCatchEvent event : events) {
+      BpmnStepContext<?> context, final ExecutableCatchEventSupplier supplier)
+      throws MessageCorrelationKeyException {
+
+    // validate all subscriptions first, in case an incident is raised
+    for (ExecutableCatchEvent event : supplier.getEvents()) {
+      validateEventSubscription(context, event);
+    }
+
+    // if all subscriptions are valid then open the subscriptions
+    for (final ExecutableCatchEvent event : supplier.getEvents()) {
       if (event.isTimer()) {
         subscribeToTimerEvent(
             context.getRecord().getKey(),
@@ -83,6 +91,12 @@ public class CatchEventBehavior {
       } else if (event.isMessage()) {
         subscribeToMessageEvent(context, event);
       }
+    }
+  }
+
+  private void validateEventSubscription(BpmnStepContext<?> context, ExecutableCatchEvent event) {
+    if (event.isMessage()) {
+      extractCorrelationKey(context, event.getMessage());
     }
   }
 
@@ -121,7 +135,7 @@ public class CatchEventBehavior {
       streamWriter.appendFollowUpEvent(
           elementInstanceKey, WorkflowInstanceIntent.EVENT_OCCURRED, workflowInstanceRecord);
 
-      // TODO (phil): while processing the event a token is consumed, so I need to spawn a new one
+      // TODO (saig0): While processing the event a token is consumed. We need to spawn a new one
       // here explicitly - see #1767
       elementInstanceState.getInstance(elementInstance.getParentKey()).spawnToken();
       elementInstanceState.flushDirtyState();
@@ -200,11 +214,6 @@ public class CatchEventBehavior {
     final ExecutableMessage message = handler.getMessage();
     final DirectBuffer extractedKey = extractCorrelationKey(context, message);
 
-    if (extractedKey == null) {
-      // TODO (Phil): improve incident handling #1736
-      throw new RuntimeException("Failed to extract the message correlation key");
-    }
-
     final long workflowInstanceKey = context.getValue().getWorkflowInstanceKey();
     final long elementInstanceKey = context.getRecord().getKey();
     final DirectBuffer messageName = cloneBuffer(message.getMessageName());
@@ -282,9 +291,7 @@ public class CatchEventBehavior {
     final String failureMessage =
         String.format(
             "Failed to extract the correlation-key by '%s': %s", expression, errorMessage);
-
-    context.raiseIncident(ErrorType.EXTRACT_VALUE_ERROR, failureMessage);
-    return null;
+    throw new MessageCorrelationKeyException(failureMessage);
   }
 
   private boolean sendCloseMessageSubscriptionCommand(
@@ -303,5 +310,12 @@ public class CatchEventBehavior {
       DirectBuffer correlationKey) {
     return subscriptionCommandSender.openMessageSubscription(
         workflowInstanceKey, elementInstanceKey, messageName, correlationKey);
+  }
+
+  public class MessageCorrelationKeyException extends RuntimeException {
+
+    public MessageCorrelationKeyException(String message) {
+      super(message);
+    }
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/activity/ActivateActivityHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/activity/ActivateActivityHandler.java
@@ -24,9 +24,6 @@ import io.zeebe.broker.workflow.processor.flownode.ActivateFlowNodeHandler;
 public class ActivateActivityHandler extends ActivateFlowNodeHandler<ExecutableActivity> {
   @Override
   protected void activate(BpmnStepContext<ExecutableActivity> context) {
-    super.activate(context);
-    context
-        .getCatchEventBehavior()
-        .subscribeToEvents(context, context.getElement().getBoundaryEvents());
+    context.getCatchEventBehavior().subscribeToEvents(context, context.getElement());
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/flownode/ActivateFlowNodeHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/flownode/ActivateFlowNodeHandler.java
@@ -20,6 +20,7 @@ package io.zeebe.broker.workflow.processor.flownode;
 import io.zeebe.broker.workflow.model.element.ExecutableFlowNode;
 import io.zeebe.broker.workflow.processor.BpmnStepContext;
 import io.zeebe.broker.workflow.processor.BpmnStepHandler;
+import io.zeebe.broker.workflow.processor.CatchEventBehavior.MessageCorrelationKeyException;
 import io.zeebe.msgpack.mapping.MappingException;
 import io.zeebe.protocol.impl.record.value.incident.ErrorType;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
@@ -39,8 +40,11 @@ public class ActivateFlowNodeHandler<T extends ExecutableFlowNode> implements Bp
               context.getRecord().getKey(),
               WorkflowInstanceIntent.ELEMENT_ACTIVATED,
               context.getValue());
+
     } catch (MappingException e) {
       context.raiseIncident(ErrorType.IO_MAPPING_ERROR, e.getMessage());
+    } catch (MessageCorrelationKeyException e) {
+      context.raiseIncident(ErrorType.EXTRACT_VALUE_ERROR, e.getMessage());
     }
   }
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/servicetask/ActivateReceiveTaskHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/servicetask/ActivateReceiveTaskHandler.java
@@ -19,14 +19,14 @@ package io.zeebe.broker.workflow.processor.servicetask;
 
 import io.zeebe.broker.workflow.model.element.ExecutableReceiveTask;
 import io.zeebe.broker.workflow.processor.BpmnStepContext;
-import io.zeebe.broker.workflow.processor.BpmnStepHandler;
+import io.zeebe.broker.workflow.processor.flownode.ActivateFlowNodeHandler;
 
-public class SubscribeReceiveTaskHandler implements BpmnStepHandler<ExecutableReceiveTask> {
+public class ActivateReceiveTaskHandler extends ActivateFlowNodeHandler<ExecutableReceiveTask> {
 
   @Override
-  public void handle(final BpmnStepContext<ExecutableReceiveTask> context) {
+  protected void activate(BpmnStepContext<ExecutableReceiveTask> context) {
     final ExecutableReceiveTask receiveTask = context.getElement();
 
-    context.getCatchEventBehavior().subscribeToEvents(context, receiveTask.getEvents());
+    context.getCatchEventBehavior().subscribeToEvents(context, receiveTask);
   }
 }

--- a/broker-core/src/test/java/io/zeebe/broker/incident/EventSubscriptionIncidentTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/incident/EventSubscriptionIncidentTest.java
@@ -1,0 +1,319 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.exporter.record.Assertions;
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.record.value.IncidentRecordValue;
+import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.exporter.record.value.WorkflowInstanceSubscriptionRecordValue;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.impl.record.value.incident.ErrorType;
+import io.zeebe.protocol.intent.IncidentIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceSubscriptionIntent;
+import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
+import io.zeebe.test.broker.protocol.clientapi.PartitionTestClient;
+import io.zeebe.test.util.MsgPackUtil;
+import io.zeebe.test.util.record.RecordingExporter;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class EventSubscriptionIncidentTest {
+
+  private static final String PROCESS_ID = "process";
+
+  private static final BpmnModelInstance WF_RECEIVE_TASK =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .receiveTask("task")
+          .message(m -> m.name("msg-1").zeebeCorrelationKey("$.key-1"))
+          .boundaryEvent(
+              "msg-2", c -> c.message(m -> m.name("msg-2").zeebeCorrelationKey("$.key-2")))
+          .endEvent()
+          .done();
+
+  private static final BpmnModelInstance WF_RECEIVE_TASK_2 =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .receiveTask("task")
+          .message(m -> m.name("msg-2").zeebeCorrelationKey("$.key-2"))
+          .boundaryEvent(
+              "msg-1", c -> c.message(m -> m.name("msg-1").zeebeCorrelationKey("$.key-1")))
+          .endEvent()
+          .done();
+
+  private static final BpmnModelInstance WF_EVENT_BASED_GATEWAY =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .eventBasedGateway("gateway")
+          .intermediateCatchEvent(
+              "msg-1", i -> i.message(m -> m.name("msg-1").zeebeCorrelationKey("$.key-1")))
+          .endEvent()
+          .moveToLastGateway()
+          .intermediateCatchEvent(
+              "msg-2", i -> i.message(m -> m.name("msg-2").zeebeCorrelationKey("$.key-2")))
+          .endEvent()
+          .done();
+
+  private static final BpmnModelInstance WF_EVENT_BASED_GATEWAY_2 =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .eventBasedGateway("gateway")
+          .intermediateCatchEvent(
+              "msg-2", i -> i.message(m -> m.name("msg-2").zeebeCorrelationKey("$.key-2")))
+          .endEvent()
+          .moveToLastGateway()
+          .intermediateCatchEvent(
+              "msg-1", i -> i.message(m -> m.name("msg-1").zeebeCorrelationKey("$.key-1")))
+          .endEvent()
+          .done();
+
+  private static final BpmnModelInstance WF_BOUNDARY_EVENT =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .serviceTask("task", t -> t.zeebeTaskType("test"))
+          .boundaryEvent(
+              "msg-1", c -> c.message(m -> m.name("msg-1").zeebeCorrelationKey("$.key-1")))
+          .endEvent()
+          .moveToActivity("task")
+          .boundaryEvent(
+              "msg-2", c -> c.message(m -> m.name("msg-2").zeebeCorrelationKey("$.key-2")))
+          .endEvent()
+          .done();
+
+  private static final BpmnModelInstance WF_BOUNDARY_EVENT_2 =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .serviceTask("task", t -> t.zeebeTaskType("test"))
+          .boundaryEvent(
+              "msg-2", c -> c.message(m -> m.name("msg-2").zeebeCorrelationKey("$.key-2")))
+          .endEvent()
+          .moveToActivity("task")
+          .boundaryEvent(
+              "msg-1", c -> c.message(m -> m.name("msg-1").zeebeCorrelationKey("$.key-1")))
+          .endEvent()
+          .done();
+
+  public EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule();
+  public ClientApiRule apiRule = new ClientApiRule(brokerRule::getClientAddress);
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(apiRule);
+
+  private PartitionTestClient testClient;
+
+  @Parameters(name = "{0}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        "boundary catch event (first event)",
+        WF_BOUNDARY_EVENT,
+        "task",
+        WorkflowInstanceIntent.ELEMENT_READY,
+        WorkflowInstanceIntent.ELEMENT_ACTIVATED
+      },
+      {
+        "boundary catch event (second event)",
+        WF_BOUNDARY_EVENT_2,
+        "task",
+        WorkflowInstanceIntent.ELEMENT_READY,
+        WorkflowInstanceIntent.ELEMENT_ACTIVATED
+      },
+      {
+        "receive task (boundary event)",
+        WF_RECEIVE_TASK,
+        "task",
+        WorkflowInstanceIntent.ELEMENT_READY,
+        WorkflowInstanceIntent.ELEMENT_ACTIVATED
+      },
+      {
+        "receive task (task)",
+        WF_RECEIVE_TASK_2,
+        "task",
+        WorkflowInstanceIntent.ELEMENT_READY,
+        WorkflowInstanceIntent.ELEMENT_ACTIVATED
+      },
+      {
+        "event-based gateway (first event)",
+        WF_EVENT_BASED_GATEWAY,
+        "gateway",
+        WorkflowInstanceIntent.GATEWAY_ACTIVATED,
+        null
+      },
+      {
+        "event-based gateway (second event)",
+        WF_EVENT_BASED_GATEWAY_2,
+        "gateway",
+        WorkflowInstanceIntent.GATEWAY_ACTIVATED,
+        null
+      }
+    };
+  }
+
+  @Parameter(0)
+  public String elementType;
+
+  @Parameter(1)
+  public BpmnModelInstance workflow;
+
+  @Parameter(2)
+  public String elementId;
+
+  @Parameter(3)
+  public WorkflowInstanceIntent failureEventIntent;
+
+  @Parameter(4)
+  public WorkflowInstanceIntent resolvedEventIntent;
+
+  @Before
+  public void init() {
+    testClient = apiRule.partitionClient();
+
+    testClient.deploy(workflow);
+  }
+
+  @Test
+  public void shouldCreateIncidentIfMessageCorrelationKeyNotFound() {
+    // when
+    final long workflowInstanceKey =
+        testClient.createWorkflowInstance(PROCESS_ID, MsgPackUtil.asMsgPack("key-1", "k1"));
+
+    final Record<WorkflowInstanceRecordValue> failureEvent =
+        RecordingExporter.workflowInstanceRecords(failureEventIntent)
+            .withElementId(elementId)
+            .getFirst();
+
+    // then
+    final Record<IncidentRecordValue> incidentRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED).getFirst();
+
+    Assertions.assertThat(incidentRecord.getValue())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR.name())
+        .hasErrorMessage("Failed to extract the correlation-key by '$.key-2': no value found")
+        .hasBpmnProcessId(PROCESS_ID)
+        .hasWorkflowInstanceKey(workflowInstanceKey)
+        .hasElementId(failureEvent.getValue().getElementId())
+        .hasElementInstanceKey(failureEvent.getKey())
+        .hasJobKey(-1L);
+  }
+
+  @Test
+  public void shouldCreateIncidentIfMessageCorrelationKeyHasInvalidType() {
+    // when
+    final long workflowInstanceKey =
+        testClient.createWorkflowInstance(
+            PROCESS_ID, MsgPackUtil.asMsgPack("{'key-1':'k1', 'key-2':[1,2,3]}"));
+
+    final Record<WorkflowInstanceRecordValue> failureEvent =
+        RecordingExporter.workflowInstanceRecords(failureEventIntent)
+            .withElementId(elementId)
+            .getFirst();
+
+    // then
+    final Record<IncidentRecordValue> incidentRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED).getFirst();
+
+    Assertions.assertThat(incidentRecord.getValue())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR.name())
+        .hasErrorMessage(
+            "Failed to extract the correlation-key by '$.key-2': the value must be either a string or a number")
+        .hasBpmnProcessId(PROCESS_ID)
+        .hasWorkflowInstanceKey(workflowInstanceKey)
+        .hasElementId(failureEvent.getValue().getElementId())
+        .hasElementInstanceKey(failureEvent.getKey())
+        .hasJobKey(-1L);
+  }
+
+  @Test
+  public void shouldOpenSubscriptionsWhenIncidentIsResolved() {
+    // given
+    testClient.createWorkflowInstance(PROCESS_ID, MsgPackUtil.asMsgPack("key-1", "k1"));
+
+    final Record<IncidentRecordValue> incidentCreatedRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED).getFirst();
+
+    // when
+    testClient.updatePayload(
+        incidentCreatedRecord.getValue().getElementInstanceKey(), "{'key-1':'k1', 'key-2':'k2'}");
+
+    testClient.resolveIncident(incidentCreatedRecord.getKey());
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceSubscriptionRecords(
+                    WorkflowInstanceSubscriptionIntent.OPENED)
+                .limit(2))
+        .extracting(Record::getValue)
+        .extracting(WorkflowInstanceSubscriptionRecordValue::getMessageName)
+        .containsExactlyInAnyOrder("msg-1", "msg-2");
+
+    // and
+    testClient.publishMessage("msg-2", "k2");
+
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+                .withElementId(PROCESS_ID)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldNotOpenSubscriptionsWhenIncidentIsCreated() {
+    // given
+    testClient.createWorkflowInstance(PROCESS_ID, MsgPackUtil.asMsgPack("key-1", "k1"));
+
+    final Record<IncidentRecordValue> incidentCreatedRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED).getFirst();
+
+    // when
+    testClient.updatePayload(
+        incidentCreatedRecord.getValue().getElementInstanceKey(), "{'key-1':'k1', 'key-2':'k2'}");
+
+    testClient.resolveIncident(incidentCreatedRecord.getKey());
+
+    // then
+    final Record<IncidentRecordValue> incidentResolvedRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.RESOLVED).getFirst();
+
+    assertThat(
+            RecordingExporter.workflowInstanceSubscriptionRecords(
+                    WorkflowInstanceSubscriptionIntent.OPENED)
+                .limit(2))
+        .allMatch(r -> r.getPosition() > incidentResolvedRecord.getPosition());
+
+    // and
+    if (resolvedEventIntent != null) {
+      assertThat(
+              RecordingExporter.workflowInstanceRecords(resolvedEventIntent)
+                  .withElementId(elementId)
+                  .getFirst()
+                  .getPosition())
+          .isGreaterThan(incidentResolvedRecord.getPosition());
+    }
+  }
+}


### PR DESCRIPTION
* validate message subscriptions before opening them
* receive task: open subscriptions on ELEMENT_READY together with
boundary events
* spawn a token if an incident is raised on subscribing to events

closes #1736 
