### PR TITLE
 feat(broker): support non-interrupting message boundary events

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
@@ -63,7 +63,7 @@ public class BoundaryEventValidator implements ModelElementValidator<BoundaryEve
 
   private SupportLevel getSupportLevel(EventDefinition eventDefinition) {
     if (eventDefinition instanceof MessageEventDefinition) {
-      return SupportLevel.Interrupting;
+      return SupportLevel.All;
     } else if (eventDefinition instanceof TimerEventDefinition) {
       final TimerEventDefinition timerEventDefinition = (TimerEventDefinition) eventDefinition;
       if (timerEventDefinition.getTimeCycle() != null) {

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
@@ -89,32 +89,6 @@ public class ZeebeBoundaryEventValidationTest extends AbstractZeebeValidationTes
             .endEvent("end")
             .done(),
         singletonList(expect("boundary", "Cannot have incoming sequence flows"))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .serviceTask("task", b -> b.zeebeTaskType("type"))
-            .boundaryEvent("boundary")
-            .cancelActivity(false)
-            .message(m -> m.name("message").zeebeCorrelationKey("$.key"))
-            .endEvent()
-            .moveToActivity("task")
-            .endEvent()
-            .done(),
-        singletonList(expect("boundary", "Non-interrupting events of this type are not supported"))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .serviceTask("task", b -> b.zeebeTaskType("type"))
-            .boundaryEvent("boundary")
-            .cancelActivity(false)
-            .message(m -> m.name("message").zeebeCorrelationKey("$.key"))
-            .endEvent()
-            .moveToActivity("task")
-            .endEvent()
-            .done(),
-        singletonList(expect("boundary", "Non-interrupting events of this type are not supported"))
       }
     };
   }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageCorrelator.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageCorrelator.java
@@ -58,9 +58,7 @@ public class MessageCorrelator {
     this.sideEffect = sideEffect;
 
     messageState.visitMessages(
-        subscriptionRecord.getMessageName(),
-        subscriptionRecord.getCorrelationKey(),
-        this::correlateMessage);
+        subscription.getMessageName(), subscription.getCorrelationKey(), this::correlateMessage);
   }
 
   private boolean correlateMessage(final Message message) {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableBoundaryEvent.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableBoundaryEvent.java
@@ -28,6 +28,11 @@ public class ExecutableBoundaryEvent extends ExecutableCatchEventElement {
     return cancelActivity;
   }
 
+  @Override
+  public boolean shouldCloseMessageSubscriptionOnCorrelate() {
+    return cancelActivity;
+  }
+
   public void setCancelActivity(boolean cancelActivity) {
     this.cancelActivity = cancelActivity;
   }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableCatchEvent.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableCatchEvent.java
@@ -26,5 +26,9 @@ public interface ExecutableCatchEvent extends ExecutableFlowElement {
 
   ExecutableMessage getMessage();
 
+  default boolean shouldCloseMessageSubscriptionOnCorrelate() {
+    return true;
+  }
+
   RepeatingInterval getTimer();
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
@@ -241,7 +241,7 @@ public class CatchEventBehavior {
     final long elementInstanceKey = context.getRecord().getKey();
     final DirectBuffer messageName = cloneBuffer(message.getMessageName());
     final DirectBuffer correlationKey = cloneBuffer(extractedKey);
-    final boolean closeOnCorrelate = true; // todo (npepinpe): will updated in #1592
+    final boolean closeOnCorrelate = handler.shouldCloseMessageSubscriptionOnCorrelate();
 
     subscription.setMessageName(messageName);
     subscription.setElementInstanceKey(elementInstanceKey);

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageMappingTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageMappingTest.java
@@ -99,8 +99,8 @@ public class MessageMappingTest {
     return new Object[][] {
       {"intermediate message catch event", CATCH_EVENT_WORKFLOW},
       {"receive task", RECEIVE_TASK_WORKFLOW},
-      {"boundary event", BOUNDARY_EVENT_WORKFLOW},
       {"event-based gateway", EVENT_BASED_GATEWAY_WORKFLOW},
+      {"boundary event", BOUNDARY_EVENT_WORKFLOW},
     };
   }
 
@@ -200,11 +200,11 @@ public class MessageMappingTest {
   }
 
   private void assertCompletedPayload(String payload) {
-    final Record<WorkflowInstanceRecordValue> competedEvent =
+    final Record<WorkflowInstanceRecordValue> completedEvent =
         RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
             .withElementId(PROCESS_ID)
             .getFirst();
 
-    assertWorkflowInstancePayload(competedEvent, payload);
+    assertWorkflowInstancePayload(completedEvent, payload);
   }
 }


### PR DESCRIPTION
- enable non-interrupting message boundary events in BPMN model validation
- message subscriptions implicitly close for interrupting boundary events during correlation, but not for non-interrupting ones.

closes #1769 
