### PR TITLE
feat(broker): support timer start event

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/ZbStreamProcessorService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/ZbStreamProcessorService.java
@@ -35,6 +35,7 @@ import io.zeebe.broker.transport.controlmessage.ControlMessageHandlerManager;
 import io.zeebe.broker.workflow.deployment.distribute.processor.DeploymentCreatedProcessor;
 import io.zeebe.broker.workflow.deployment.distribute.processor.DeploymentDistributeProcessor;
 import io.zeebe.broker.workflow.processor.BpmnStepProcessor;
+import io.zeebe.broker.workflow.processor.CatchEventBehavior;
 import io.zeebe.broker.workflow.processor.WorkflowEventProcessors;
 import io.zeebe.broker.workflow.processor.deployment.DeploymentEventProcessors;
 import io.zeebe.broker.workflow.processor.timer.DueDateTimerChecker;
@@ -195,7 +196,10 @@ public class ZbStreamProcessorService implements Service<ZbStreamProcessorServic
               workflowState,
               partitionServiceName));
       DeploymentEventProcessors.addTransformingDeploymentProcessor(
-          typedProcessorBuilder, zeebeState);
+          typedProcessorBuilder,
+          zeebeState,
+          new CatchEventBehavior(
+              zeebeState, new SubscriptionCommandSender(clusterCfg, managementApi)));
     } else {
       DeploymentEventProcessors.addDeploymentCreateProcessor(typedProcessorBuilder, workflowState);
     }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/data/TimerRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/data/TimerRecord.java
@@ -29,14 +29,14 @@ public class TimerRecord extends UnpackedObject {
   private final LongProperty dueDateProp = new LongProperty("dueDate");
   private final StringProperty handlerNodeId = new StringProperty("handlerNodeId");
   private final IntegerProperty repetitionsProp = new IntegerProperty("repetitions");
-  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId");
+  private final LongProperty workflowKeyProp = new LongProperty("workflowKey");
 
   public TimerRecord() {
     this.declareProperty(elementInstanceKeyProp)
         .declareProperty(dueDateProp)
         .declareProperty(handlerNodeId)
         .declareProperty(repetitionsProp)
-        .declareProperty(bpmnProcessIdProp);
+        .declareProperty(workflowKeyProp);
   }
 
   public long getElementInstanceKey() {
@@ -75,12 +75,12 @@ public class TimerRecord extends UnpackedObject {
     return this;
   }
 
-  public DirectBuffer getBpmnId() {
-    return bpmnProcessIdProp.getValue();
+  public long getWorkflowKey() {
+    return workflowKeyProp.getValue();
   }
 
-  public TimerRecord setBpmnId(DirectBuffer bpmnId) {
-    this.bpmnProcessIdProp.setValue(bpmnId);
+  public TimerRecord setWorkflowKey(long workflowKey) {
+    this.workflowKeyProp.setValue(workflowKey);
     return this;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/deployment/distribute/processor/DeploymentCreatedProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/deployment/distribute/processor/DeploymentCreatedProcessor.java
@@ -32,6 +32,7 @@ public class DeploymentCreatedProcessor implements TypedRecordProcessor<Deployme
       final TypedResponseWriter responseWriter,
       final TypedStreamWriter streamWriter) {
     final DeploymentRecord deploymentEvent = event.getValue();
+
     streamWriter.appendFollowUpCommand(
         event.getKey(), DeploymentIntent.DISTRIBUTE, deploymentEvent);
   }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableFlowElementContainer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableFlowElementContainer.java
@@ -26,17 +26,17 @@ package io.zeebe.broker.workflow.model.element;
  */
 public class ExecutableFlowElementContainer extends ExecutableActivity {
 
-  private ExecutableFlowNode startEvent;
+  private ExecutableCatchEventElement startEvent;
 
   public ExecutableFlowElementContainer(String id) {
     super(id);
   }
 
-  public ExecutableFlowNode getStartEvent() {
+  public ExecutableCatchEventElement getStartEvent() {
     return startEvent;
   }
 
-  public void setStartEvent(ExecutableFlowNode startEvent) {
+  public void setStartEvent(ExecutableCatchEventElement startEvent) {
     this.startEvent = startEvent;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/StartEventTransformer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/StartEventTransformer.java
@@ -18,8 +18,8 @@
 package io.zeebe.broker.workflow.model.transformation.transformer;
 
 import io.zeebe.broker.workflow.model.BpmnStep;
+import io.zeebe.broker.workflow.model.element.ExecutableCatchEventElement;
 import io.zeebe.broker.workflow.model.element.ExecutableFlowElementContainer;
-import io.zeebe.broker.workflow.model.element.ExecutableFlowNode;
 import io.zeebe.broker.workflow.model.element.ExecutableWorkflow;
 import io.zeebe.broker.workflow.model.transformation.ModelElementTransformer;
 import io.zeebe.broker.workflow.model.transformation.TransformContext;
@@ -37,8 +37,8 @@ public class StartEventTransformer implements ModelElementTransformer<StartEvent
   @Override
   public void transform(StartEvent element, TransformContext context) {
     final ExecutableWorkflow workflow = context.getCurrentWorkflow();
-    final ExecutableFlowNode startEvent =
-        workflow.getElementById(element.getId(), ExecutableFlowNode.class);
+    final ExecutableCatchEventElement startEvent =
+        workflow.getElementById(element.getId(), ExecutableCatchEventElement.class);
 
     if (element.getScope() instanceof FlowNode) {
       final FlowNode scope = (FlowNode) element.getScope();
@@ -54,7 +54,8 @@ public class StartEventTransformer implements ModelElementTransformer<StartEvent
     bindLifecycle(context, startEvent);
   }
 
-  private void bindLifecycle(TransformContext context, final ExecutableFlowNode startEvent) {
+  private void bindLifecycle(
+      TransformContext context, final ExecutableCatchEventElement startEvent) {
     startEvent.bindLifecycleState(WorkflowInstanceIntent.EVENT_TRIGGERING, BpmnStep.APPLY_EVENT);
     startEvent.bindLifecycleState(
         WorkflowInstanceIntent.EVENT_TRIGGERED, context.getCurrentFlowNodeOutgoingStep());

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/deployment/DeploymentEventProcessors.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/deployment/DeploymentEventProcessors.java
@@ -21,6 +21,7 @@ import static io.zeebe.protocol.intent.DeploymentIntent.CREATE;
 
 import io.zeebe.broker.logstreams.processor.TypedEventStreamProcessorBuilder;
 import io.zeebe.broker.logstreams.state.ZeebeState;
+import io.zeebe.broker.workflow.processor.CatchEventBehavior;
 import io.zeebe.broker.workflow.state.WorkflowState;
 import io.zeebe.protocol.clientapi.ValueType;
 
@@ -33,8 +34,13 @@ public class DeploymentEventProcessors {
   }
 
   public static void addTransformingDeploymentProcessor(
-      TypedEventStreamProcessorBuilder processorBuilder, ZeebeState zeebeState) {
+      TypedEventStreamProcessorBuilder processorBuilder,
+      ZeebeState zeebeState,
+      CatchEventBehavior catchEventBehavior) {
+
     processorBuilder.onCommand(
-        ValueType.DEPLOYMENT, CREATE, new TransformingDeploymentCreateProcessor(zeebeState));
+        ValueType.DEPLOYMENT,
+        CREATE,
+        new TransformingDeploymentCreateProcessor(zeebeState, catchEventBehavior));
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/deployment/TransformingDeploymentCreateProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/deployment/TransformingDeploymentCreateProcessor.java
@@ -17,24 +17,37 @@
  */
 package io.zeebe.broker.workflow.processor.deployment;
 
-import io.zeebe.broker.logstreams.processor.*;
+import static io.zeebe.broker.workflow.state.TimerInstance.NO_ELEMENT_INSTANCE;
+
+import io.zeebe.broker.logstreams.processor.SideEffectProducer;
+import io.zeebe.broker.logstreams.processor.TypedRecord;
+import io.zeebe.broker.logstreams.processor.TypedRecordProcessor;
+import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
+import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
 import io.zeebe.broker.logstreams.state.ZeebeState;
 import io.zeebe.broker.workflow.deployment.transform.DeploymentTransformer;
+import io.zeebe.broker.workflow.model.element.ExecutableCatchEventElement;
+import io.zeebe.broker.workflow.processor.CatchEventBehavior;
 import io.zeebe.broker.workflow.state.WorkflowState;
 import io.zeebe.protocol.clientapi.RejectionType;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.zeebe.protocol.impl.record.value.deployment.Workflow;
 import io.zeebe.protocol.intent.DeploymentIntent;
 import java.util.function.Consumer;
+import org.agrona.DirectBuffer;
 
 public class TransformingDeploymentCreateProcessor
     implements TypedRecordProcessor<DeploymentRecord> {
 
   private final DeploymentTransformer deploymentTransformer;
   private final WorkflowState workflowState;
+  private final CatchEventBehavior catchEventBehavior;
 
-  public TransformingDeploymentCreateProcessor(final ZeebeState zeebeState) {
+  public TransformingDeploymentCreateProcessor(
+      final ZeebeState zeebeState, CatchEventBehavior catchEventBehavior) {
     this.workflowState = zeebeState.getWorkflowState();
     this.deploymentTransformer = new DeploymentTransformer(zeebeState);
+    this.catchEventBehavior = catchEventBehavior;
   }
 
   @Override
@@ -51,6 +64,8 @@ public class TransformingDeploymentCreateProcessor
       if (workflowState.putDeployment(key, deploymentEvent)) {
         responseWriter.writeEventOnCommand(key, DeploymentIntent.CREATED, deploymentEvent, command);
         streamWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
+
+        createTimerIfTimerStartEvent(command, streamWriter);
       } else {
         // should not be possible
         responseWriter.writeRejectionOnCommand(
@@ -67,6 +82,36 @@ public class TransformingDeploymentCreateProcessor
           command,
           deploymentTransformer.getRejectionType(),
           deploymentTransformer.getRejectionReason());
+    }
+  }
+
+  private void createTimerIfTimerStartEvent(
+      TypedRecord<DeploymentRecord> record, TypedStreamWriter streamWriter) {
+    for (Workflow workflow : record.getValue().workflows()) {
+      final ExecutableCatchEventElement startEvent =
+          workflowState.getWorkflowByKey(workflow.getKey()).getWorkflow().getStartEvent();
+
+      workflowState
+          .getTimerState()
+          .forEachTimerForElementInstance(
+              NO_ELEMENT_INSTANCE,
+              timer -> {
+                final DirectBuffer timerBpmnId =
+                    workflowState.getWorkflowByKey(timer.getWorkflowKey()).getBpmnProcessId();
+
+                if (timerBpmnId.equals(workflow.getBpmnProcessId())) {
+                  catchEventBehavior.unsubscribeFromTimerEvent(timer, streamWriter);
+                }
+              });
+
+      if (startEvent.isTimer()) {
+        catchEventBehavior.subscribeToTimerEvent(
+            NO_ELEMENT_INSTANCE,
+            workflow.getKey(),
+            startEvent.getId(),
+            startEvent.getTimer(),
+            streamWriter);
+      }
     }
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/CorrelateWorkflowInstanceSubscription.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/CorrelateWorkflowInstanceSubscription.java
@@ -105,7 +105,6 @@ public final class CorrelateWorkflowInstanceSubscription
     final boolean isOccurred =
         catchEventBehavior.occurEventForElement(
             elementInstanceKey,
-            null,
             subscription.getHandlerNodeId(),
             record.getValue().getPayload(),
             streamWriter);

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/CreateTimerProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/CreateTimerProcessor.java
@@ -57,7 +57,7 @@ public class CreateTimerProcessor implements TypedRecordProcessor<TimerRecord> {
     timerInstance.setKey(timerKey);
     timerInstance.setHandlerNodeId(timer.getHandlerNodeId());
     timerInstance.setRepetitions(timer.getRepetitions());
-    timerInstance.setBpmnId(timer.getBpmnId());
+    timerInstance.setWorkflowKey(timer.getWorkflowKey());
 
     sideEffect.accept(this::scheduleTimer);
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/DueDateTimerChecker.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/DueDateTimerChecker.java
@@ -95,7 +95,7 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
         .setDueDate(timer.getDueDate())
         .setHandlerNodeId(timer.getHandlerNodeId())
         .setRepetitions(timer.getRepetitions())
-        .setBpmnId(timer.getBpmnId());
+        .setWorkflowKey(timer.getWorkflowKey());
 
     streamWriter.appendFollowUpCommand(timer.getKey(), TimerIntent.TRIGGER, timerRecord);
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/state/TimerInstance.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/state/TimerInstance.java
@@ -28,8 +28,10 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public class TimerInstance implements DbValue {
 
+  public static final int NO_ELEMENT_INSTANCE = -1;
+
   private final DirectBuffer handlerNodeId = new UnsafeBuffer(0, 0);
-  private final DirectBuffer bpmnId = new UnsafeBuffer(0, 0);
+  private long workflowKey;
   private long key;
   private long elementInstanceKey;
   private long dueDate;
@@ -75,17 +77,17 @@ public class TimerInstance implements DbValue {
     this.repetitions = repetitions;
   }
 
-  public DirectBuffer getBpmnId() {
-    return this.bpmnId;
+  public long getWorkflowKey() {
+    return this.workflowKey;
   }
 
-  public void setBpmnId(DirectBuffer bpmnId) {
-    this.bpmnId.wrap(bpmnId);
+  public void setWorkflowKey(long workflowKey) {
+    this.workflowKey = workflowKey;
   }
 
   @Override
   public int getLength() {
-    return 3 * Long.BYTES + 3 * Integer.BYTES + handlerNodeId.capacity() + bpmnId.capacity();
+    return 4 * Long.BYTES + 2 * Integer.BYTES + handlerNodeId.capacity();
   }
 
   @Override
@@ -99,10 +101,11 @@ public class TimerInstance implements DbValue {
     buffer.putLong(offset, key, ZB_DB_BYTE_ORDER);
     offset += Long.BYTES;
 
+    buffer.putLong(offset, workflowKey, ZB_DB_BYTE_ORDER);
+    offset += Long.BYTES;
+
     buffer.putInt(offset, repetitions, ZB_DB_BYTE_ORDER);
     offset += Integer.BYTES;
-
-    offset = writeIntoBuffer(buffer, offset, bpmnId);
 
     offset = writeIntoBuffer(buffer, offset, handlerNodeId);
     assert offset == getLength() : "End offset differs from getLength()";
@@ -119,10 +122,11 @@ public class TimerInstance implements DbValue {
     key = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
     offset += Long.BYTES;
 
+    workflowKey = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
+    offset += Long.BYTES;
+
     repetitions = buffer.getInt(offset, ZB_DB_BYTE_ORDER);
     offset += Integer.BYTES;
-
-    offset = readIntoBuffer(buffer, offset, bpmnId);
 
     offset = readIntoBuffer(buffer, offset, handlerNodeId);
     assert offset == length : "End offset differs from length";

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/TimerStartEventTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/TimerStartEventTest.java
@@ -1,0 +1,323 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow;
+
+import static io.zeebe.broker.workflow.state.TimerInstance.NO_ELEMENT_INSTANCE;
+import static io.zeebe.protocol.intent.WorkflowInstanceIntent.EVENT_ACTIVATED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.exporter.record.Assertions;
+import io.zeebe.exporter.record.value.DeploymentRecordValue;
+import io.zeebe.exporter.record.value.TimerRecordValue;
+import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.intent.DeploymentIntent;
+import io.zeebe.protocol.intent.TimerIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
+import io.zeebe.test.broker.protocol.clientapi.ExecuteCommandResponse;
+import io.zeebe.test.broker.protocol.clientapi.PartitionTestClient;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class TimerStartEventTest {
+
+  public static final BpmnModelInstance SIMPLE_MODEL =
+      Bpmn.createExecutableProcess("process")
+          .startEvent("start_1")
+          .timerWithCycle("R1/PT1S")
+          .endEvent("end_1")
+          .done();
+
+  public static final BpmnModelInstance REPEATING_MODEL =
+      Bpmn.createExecutableProcess("process")
+          .startEvent("start_2")
+          .timerWithCycle("R/PT1S")
+          .endEvent("end_2")
+          .done();
+
+  public static final BpmnModelInstance THREE_SEC_MODEL =
+      Bpmn.createExecutableProcess("process_3")
+          .startEvent("start_3")
+          .timerWithCycle("R2/PT3S")
+          .endEvent("end_3")
+          .done();
+
+  public EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule();
+
+  public ClientApiRule apiRule = new ClientApiRule(brokerRule::getClientAddress);
+
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(apiRule);
+
+  private PartitionTestClient testClient;
+
+  @Before
+  public void setUp() {
+    brokerRule.getClock().pinCurrentTime();
+    testClient = apiRule.partitionClient();
+  }
+
+  @Test
+  public void shouldCreateTimer() {
+    // when
+    testClient.deploy(SIMPLE_MODEL);
+
+    // then
+    assertThat(RecordingExporter.deploymentRecords(DeploymentIntent.CREATED).exists()).isTrue();
+    final TimerRecordValue timerRecord =
+        RecordingExporter.timerRecords(TimerIntent.CREATED).getFirst().getValue();
+
+    Assertions.assertThat(timerRecord)
+        .hasDueDate(brokerRule.getClock().getCurrentTimeInMillis() + 1000)
+        .hasHandlerFlowNodeId("start_1")
+        .hasElementInstanceKey(NO_ELEMENT_INSTANCE);
+  }
+
+  @Test
+  public void shouldTriggerAndCreateWorkflowInstance() {
+    // when
+    final ExecuteCommandResponse response = testClient.deployWithResponse(SIMPLE_MODEL);
+    final DeploymentRecordValue deploymentRecord =
+        testClient
+            .receiveFirstDeploymentEvent(DeploymentIntent.CREATED, response.getKey())
+            .getValue();
+
+    // then
+    assertThat(RecordingExporter.timerRecords(TimerIntent.CREATED).exists()).isTrue();
+    brokerRule.getClock().addTime(Duration.ofSeconds(2));
+
+    assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).exists()).isTrue();
+    assertThat(RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.CREATE).exists())
+        .isTrue();
+
+    final WorkflowInstanceRecordValue wfInstanceRecord =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_READY)
+            .getFirst()
+            .getValue();
+
+    Assertions.assertThat(wfInstanceRecord)
+        .hasVersion(1)
+        .hasBpmnProcessId("process")
+        .hasWorkflowKey(deploymentRecord.getDeployedWorkflows().get(0).getWorkflowKey());
+  }
+
+  @Test
+  public void shouldCreateMultipleWorkflowInstancesWithRepeatingTimer() {
+    // when
+    testClient.deployWithResponse(THREE_SEC_MODEL);
+
+    // then
+    assertThat(RecordingExporter.timerRecords(TimerIntent.CREATED).exists()).isTrue();
+    brokerRule.getClock().addTime(Duration.ofSeconds(3));
+
+    assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).exists()).isTrue();
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_READY)
+                .withElementId("process_3")
+                .exists())
+        .isTrue();
+    assertThat(RecordingExporter.timerRecords(TimerIntent.CREATED).limit(2).count()).isEqualTo(2);
+
+    brokerRule.getClock().addTime(Duration.ofSeconds(3));
+    assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).limit(2).count()).isEqualTo(2);
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_READY)
+                .withElementId("process_3")
+                .limit(2)
+                .count())
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void shouldCompleteWorkflow() {
+    // when
+    final ExecuteCommandResponse response = testClient.deployWithResponse(SIMPLE_MODEL);
+    final DeploymentRecordValue deploymentRecord =
+        testClient
+            .receiveFirstDeploymentEvent(DeploymentIntent.CREATED, response.getKey())
+            .getValue();
+
+    // then
+    assertThat(RecordingExporter.timerRecords(TimerIntent.CREATED).exists()).isTrue();
+    brokerRule.getClock().addTime(Duration.ofSeconds(1));
+    final WorkflowInstanceRecordValue instanceCompleted =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+            .getFirst()
+            .getValue();
+
+    Assertions.assertThat(instanceCompleted)
+        .hasBpmnProcessId("process")
+        .hasVersion(1)
+        .hasWorkflowKey(deploymentRecord.getDeployedWorkflows().get(0).getWorkflowKey());
+  }
+
+  @Test
+  public void shouldUpdateWorkflow() {
+    // when
+    testClient.deploy(SIMPLE_MODEL);
+    assertThat(RecordingExporter.timerRecords(TimerIntent.CREATED).exists()).isTrue();
+    brokerRule.getClock().addTime(Duration.ofSeconds(1));
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(EVENT_ACTIVATED)
+                .withElementId("end_1")
+                .withBpmnProcessId("process")
+                .withVersion(1)
+                .exists())
+        .isTrue();
+
+    // when
+    testClient.deploy(REPEATING_MODEL);
+    assertThat(RecordingExporter.timerRecords(TimerIntent.CREATED).limit(2).count()).isEqualTo(2);
+    brokerRule.getClock().addTime(Duration.ofSeconds(2));
+
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(EVENT_ACTIVATED)
+                .withElementId("end_2")
+                .withBpmnProcessId("process")
+                .withVersion(2)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldReplaceTimerStartWithNoneStart() {
+    // when
+    testClient.deploy(REPEATING_MODEL);
+
+    assertThat(RecordingExporter.timerRecords(TimerIntent.CREATED).exists()).isTrue();
+    brokerRule.getClock().addTime(Duration.ofSeconds(1));
+
+    // then
+    assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).exists()).isTrue();
+
+    // when
+    final BpmnModelInstance nonTimerModel =
+        Bpmn.createExecutableProcess("process").startEvent("start_4").endEvent("end_4").done();
+    testClient.deploy(nonTimerModel);
+
+    assertThat(RecordingExporter.deploymentRecords(DeploymentIntent.CREATED).limit(2).count())
+        .isEqualTo(2);
+    brokerRule.getClock().addTime(Duration.ofSeconds(2));
+
+    // then
+    assertThat(RecordingExporter.timerRecords(TimerIntent.CANCELED).exists()).isTrue();
+    assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).exists()).isTrue();
+
+    final long workflowInstanceKey = testClient.createWorkflowInstance("process");
+
+    final WorkflowInstanceRecordValue lastRecord =
+        RecordingExporter.workflowInstanceRecords(EVENT_ACTIVATED)
+            .withElementId("end_4")
+            .getFirst()
+            .getValue();
+
+    Assertions.assertThat(lastRecord)
+        .hasVersion(2)
+        .hasBpmnProcessId("process")
+        .hasWorkflowInstanceKey(workflowInstanceKey);
+  }
+
+  @Test
+  public void shouldUpdateTimerPeriod() {
+    // when
+    long beginTime = brokerRule.getClock().getCurrentTimeInMillis();
+    testClient.deploy(THREE_SEC_MODEL);
+    assertThat(RecordingExporter.timerRecords(TimerIntent.CREATED).exists()).isTrue();
+    brokerRule.getClock().addTime(Duration.ofSeconds(3));
+
+    // then
+    TimerRecordValue timerRecord =
+        RecordingExporter.timerRecords(TimerIntent.TRIGGERED).getFirst().getValue();
+
+    Assertions.assertThat(timerRecord).hasDueDate(beginTime + 3000);
+
+    // when
+    beginTime = brokerRule.getClock().getCurrentTimeInMillis();
+    final BpmnModelInstance slowerModel =
+        Bpmn.createExecutableProcess("process_3")
+            .startEvent("start_4")
+            .timerWithCycle("R2/PT4S")
+            .endEvent("end_4")
+            .done();
+    testClient.deploy(slowerModel);
+
+    // then
+    assertThat(RecordingExporter.timerRecords(TimerIntent.CANCELED).getFirst()).isNotNull();
+
+    timerRecord = RecordingExporter.timerRecords(TimerIntent.CREATED).skip(2).getFirst().getValue();
+    Assertions.assertThat(timerRecord).hasDueDate(beginTime + 4000);
+    brokerRule.getClock().addTime(Duration.ofSeconds(3));
+    assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).limit(1).count()).isEqualTo(1);
+
+    brokerRule.getClock().addTime(Duration.ofSeconds(1));
+    assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).limit(2).count()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldTriggerDifferentWorkflowsSeparately() {
+    // when
+    brokerRule.getClock().pinCurrentTime();
+    testClient.deploy(THREE_SEC_MODEL);
+    testClient.deploy(REPEATING_MODEL);
+
+    // then
+    assertThat(RecordingExporter.timerRecords(TimerIntent.CREATED).limit(2).count()).isEqualTo(2);
+    brokerRule.getClock().addTime(Duration.ofSeconds(1));
+
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_READY)
+                .withElementId("process")
+                .exists())
+        .isTrue();
+    final Instant firstModelTimestamp =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_READY)
+            .withElementId("process")
+            .getFirst()
+            .getTimestamp();
+
+    brokerRule.getClock().addTime(Duration.ofSeconds(2));
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_READY)
+                .withElementId("process")
+                .limit(2)
+                .count())
+        .isEqualTo(2);
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_READY)
+                .withElementId("process_3")
+                .exists())
+        .isTrue();
+
+    final Instant secondModelTimestamp =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_READY)
+            .withElementId("process_3")
+            .getFirst()
+            .getTimestamp();
+
+    assertThat(secondModelTimestamp.isAfter(firstModelTimestamp)).isTrue();
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/TransformingDeploymentCreateProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/TransformingDeploymentCreateProcessorTest.java
@@ -20,6 +20,7 @@ package io.zeebe.broker.workflow.processor;
 import static io.zeebe.test.util.TestUtil.waitUntil;
 import static io.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.state.ZeebeState;
@@ -56,8 +57,10 @@ public class TransformingDeploymentCreateProcessorTest {
             (typedEventStreamProcessorBuilder, zeebeDb) -> {
               final ZeebeState zeebeState = new ZeebeState(zeebeDb);
               workflowState = zeebeState.getWorkflowState();
+
+              final CatchEventBehavior catchEventBehavior = mock(CatchEventBehavior.class);
               DeploymentEventProcessors.addTransformingDeploymentProcessor(
-                  typedEventStreamProcessorBuilder, zeebeState);
+                  typedEventStreamProcessorBuilder, zeebeState, catchEventBehavior);
 
               return typedEventStreamProcessorBuilder.build();
             });

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorTest.java
@@ -36,7 +36,6 @@ import io.zeebe.broker.util.StreamProcessorRule;
 import io.zeebe.broker.workflow.data.TimerRecord;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
-import io.zeebe.model.bpmn.util.time.RepeatingInterval;
 import io.zeebe.protocol.clientapi.RecordType;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
@@ -46,12 +45,10 @@ import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceSubscriptionIntent;
 import io.zeebe.test.util.MsgPackUtil;
 import io.zeebe.util.buffer.BufferUtil;
-import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -105,13 +102,6 @@ public class WorkflowInstanceStreamProcessorTest {
           .endEvent("end")
           .done();
 
-  private static final BpmnModelInstance TIMER_START_EVENT_WORKFLOW =
-      Bpmn.createExecutableProcess(PROCESS_ID)
-          .startEvent("start")
-          .timerWithCycle("R/PT1S")
-          .endEvent("end")
-          .done();
-
   public StreamProcessorRule envRule = new StreamProcessorRule();
   public WorkflowInstanceStreamProcessorRule streamProcessorRule =
       new WorkflowInstanceStreamProcessorRule(envRule);
@@ -123,42 +113,6 @@ public class WorkflowInstanceStreamProcessorTest {
   @Before
   public void setUp() {
     streamProcessor = streamProcessorRule.getStreamProcessor();
-  }
-
-  @Test
-  public void shouldCreateWorkflowInstanceWithTimerTrigger() {
-    // given
-    streamProcessorRule.deploy(TIMER_START_EVENT_WORKFLOW);
-    envRule.getClock().pinCurrentTime();
-    streamProcessor.blockAfterTimerEvent(e -> e.getMetadata().getIntent() == TimerIntent.CREATED);
-
-    final TimerRecord record = new TimerRecord();
-    record.setHandlerNodeId(wrapString("start"));
-    record.setDueDate(envRule.getClock().getTimeMillis() + 1000);
-    record.setRepetitions(RepeatingInterval.INFINITE);
-    record.setBpmnId(wrapString(PROCESS_ID));
-    record.setElementInstanceKey(-1);
-
-    // when
-    envRule.writeCommand(TimerIntent.CREATE, record);
-    waitUntil(() -> streamProcessor.isBlocked());
-    envRule.getClock().addTime(Duration.ofSeconds(1));
-    streamProcessor.unblock();
-
-    // then
-    assertThat(streamProcessorRule.awaitTimerInState("start", TimerIntent.TRIGGERED)).isNotNull();
-    Assertions.assertThat(
-            streamProcessorRule.awaitElementInState(
-                PROCESS_ID, WorkflowInstanceIntent.ELEMENT_READY))
-        .isNotNull();
-    final TypedRecord<WorkflowInstanceRecord> instanceCreatedRecord =
-        envRule.events().onlyWorkflowInstanceRecords().limit(1).getLast();
-    assertThat(instanceCreatedRecord.getValue().getBpmnProcessId())
-        .isEqualTo(wrapString(PROCESS_ID));
-    assertThat(instanceCreatedRecord.getValue().getVersion())
-        .isEqualTo(WorkflowInstanceStreamProcessorRule.VERSION);
-    assertThat(instanceCreatedRecord.getValue().getWorkflowKey())
-        .isEqualTo(WorkflowInstanceStreamProcessorRule.WORKFLOW_KEY);
   }
 
   @Test

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe QA Integration Tests</name>
@@ -70,7 +72,6 @@
       <artifactId>zb-exporter-asserts</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
 


### PR DESCRIPTION
Implements timer start events with the restriction that there can be only one per workflow.

closes #1787 