### PR TITLE
feat(broker): support multiple timer start events

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ProcessValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ProcessValidator.java
@@ -15,8 +15,6 @@
  */
 package io.zeebe.model.bpmn.validation.zeebe;
 
-import io.zeebe.model.bpmn.instance.EventDefinition;
-import io.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.zeebe.model.bpmn.instance.Process;
 import io.zeebe.model.bpmn.instance.StartEvent;
 import java.util.Collection;
@@ -32,21 +30,18 @@ public class ProcessValidator implements ModelElementValidator<Process> {
 
   @Override
   public void validate(Process element, ValidationResultCollector validationResultCollector) {
-
     final Collection<StartEvent> topLevelStartEvents =
         element.getChildElementsByType(StartEvent.class);
     if (topLevelStartEvents.size() == 0) {
       validationResultCollector.addError(0, "Must have at least one start event");
     } else if (topLevelStartEvents.size() > 1
-        && !topLevelStartEvents.stream().allMatch(this::isMessageEvent)) {
+        && topLevelStartEvents.stream().anyMatch(this::isNoneEvent)) {
       validationResultCollector.addError(
-          0, "Must be either one none/timer start event or multiple message start events");
+          0, "Must be either one none start event or multiple message/timer start events");
     }
   }
 
-  private boolean isMessageEvent(StartEvent startEvent) {
-    final Collection<EventDefinition> eventDefinitions = startEvent.getEventDefinitions();
-    return (eventDefinitions.size() != 0
-        && eventDefinitions.iterator().next() instanceof MessageEventDefinition);
+  private boolean isNoneEvent(StartEvent startEvent) {
+    return startEvent.getEventDefinitions().isEmpty();
   }
 }

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeStartEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeStartEventValidationTest.java
@@ -68,15 +68,7 @@ public class ZeebeStartEventValidationTest extends AbstractZeebeValidationTest {
         singletonList(
             expect(
                 Process.class,
-                "Must be either one none/timer start event or multiple message start events"))
-      },
-      {
-        // multiple start event types not supported yet
-        getProcessWithMultipleStartEventTypes(),
-        singletonList(
-            expect(
-                Process.class,
-                "Must be either one none/timer start event or multiple message start events"))
+                "Must be either one none start event or multiple message/timer start events"))
       },
     };
   }
@@ -85,13 +77,6 @@ public class ZeebeStartEventValidationTest extends AbstractZeebeValidationTest {
     final ProcessBuilder process = Bpmn.createExecutableProcess();
     process.startEvent().endEvent();
     process.startEvent().endEvent();
-    return process.done();
-  }
-
-  private static BpmnModelInstance getProcessWithMultipleStartEventTypes() {
-    final ProcessBuilder process = Bpmn.createExecutableProcess();
-    process.startEvent().message(m -> m.name("msgStart")).endEvent();
-    process.startEvent().timerWithCycle("R1/PT2H").endEvent();
     return process.done();
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableCatchEvent.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableCatchEvent.java
@@ -24,6 +24,10 @@ public interface ExecutableCatchEvent extends ExecutableFlowElement {
 
   boolean isMessage();
 
+  default boolean isNone() {
+    return !isTimer() && !isMessage();
+  }
+
   ExecutableMessage getMessage();
 
   default boolean shouldCloseMessageSubscriptionOnCorrelate() {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableFlowElementContainer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableFlowElementContainer.java
@@ -17,6 +17,9 @@
  */
 package io.zeebe.broker.workflow.model.element;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * ExecutableFlowElementContainer is currently used to represent processes as well ({@link
  * io.zeebe.model.bpmn.instance.Process}), which may seem counter intuitive; at the moment, the
@@ -26,17 +29,17 @@ package io.zeebe.broker.workflow.model.element;
  */
 public class ExecutableFlowElementContainer extends ExecutableActivity {
 
-  private ExecutableCatchEventElement startEvent;
+  private List<ExecutableCatchEventElement> startEvents = new ArrayList<>();
 
   public ExecutableFlowElementContainer(String id) {
     super(id);
   }
 
-  public ExecutableCatchEventElement getStartEvent() {
-    return startEvent;
+  public List<ExecutableCatchEventElement> getStartEvents() {
+    return startEvents;
   }
 
-  public void setStartEvent(ExecutableCatchEventElement startEvent) {
-    this.startEvent = startEvent;
+  public void addStartEvent(ExecutableCatchEventElement startEvent) {
+    startEvents.add(startEvent);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/StartEventTransformer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/StartEventTransformer.java
@@ -45,10 +45,10 @@ public class StartEventTransformer implements ModelElementTransformer<StartEvent
 
       final ExecutableFlowElementContainer subprocess =
           workflow.getElementById(scope.getId(), ExecutableFlowElementContainer.class);
-      subprocess.setStartEvent(startEvent);
+      subprocess.addStartEvent(startEvent);
     } else {
       // top-level start event
-      workflow.setStartEvent(startEvent);
+      workflow.addStartEvent(startEvent);
     }
 
     bindLifecycle(context, startEvent);

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepHandlers.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepHandlers.java
@@ -58,7 +58,7 @@ public class BpmnStepHandlers {
     final IncidentState incidentState = zeebeState.getIncidentState();
 
     // flow element container (process, sub process)
-    stepHandlers.put(BpmnStep.TRIGGER_START_EVENT, new TriggerStartEventHandler());
+    stepHandlers.put(BpmnStep.TRIGGER_START_EVENT, new TriggerStartEventHandler(workflowState));
     stepHandlers.put(BpmnStep.COMPLETE_PROCESS, new CompleteProcessHandler());
     stepHandlers.put(
         BpmnStep.TERMINATE_CONTAINED_INSTANCES, new TerminateContainedElementsHandler(zeebeState));

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
@@ -151,7 +151,10 @@ public class CatchEventBehavior {
   }
 
   public void occurStartEvent(
-      long workflowKey, DirectBuffer eventPayload, TypedStreamWriter streamWriter) {
+      long workflowKey,
+      DirectBuffer handlerId,
+      DirectBuffer eventPayload,
+      TypedStreamWriter streamWriter) {
     final DeployedWorkflow workflow = state.getWorkflowState().getWorkflowByKey(workflowKey);
 
     workflowInstanceRecord.reset();
@@ -159,6 +162,7 @@ public class CatchEventBehavior {
     workflowInstanceRecord.setWorkflowKey(workflow.getKey());
     workflowInstanceRecord.setBpmnProcessId(workflow.getBpmnProcessId());
     workflowInstanceRecord.setPayload(eventPayload);
+    workflowInstanceRecord.setElementId(handlerId);
     streamWriter.appendNewCommand(WorkflowInstanceIntent.CREATE, workflowInstanceRecord);
   }
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceCommandHandlers.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceCommandHandlers.java
@@ -20,7 +20,7 @@ package io.zeebe.broker.workflow.processor;
 import io.zeebe.broker.workflow.processor.instance.CancelWorkflowInstanceHandler;
 import io.zeebe.broker.workflow.processor.instance.CreateWorkflowInstanceHandler;
 import io.zeebe.broker.workflow.processor.instance.UpdatePayloadHandler;
-import io.zeebe.broker.workflow.state.WorkflowState;
+import io.zeebe.broker.workflow.state.WorkflowEngineState;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,10 +30,11 @@ public class WorkflowInstanceCommandHandlers {
   private final Map<WorkflowInstanceIntent, WorkflowInstanceCommandHandler> handlers =
       new HashMap<>();
 
-  public WorkflowInstanceCommandHandlers(WorkflowState workflowState) {
+  public WorkflowInstanceCommandHandlers(WorkflowEngineState state) {
     handlers.put(WorkflowInstanceIntent.CANCEL, new CancelWorkflowInstanceHandler());
-    handlers.put(WorkflowInstanceIntent.UPDATE_PAYLOAD, new UpdatePayloadHandler(workflowState));
-    handlers.put(WorkflowInstanceIntent.CREATE, new CreateWorkflowInstanceHandler(workflowState));
+    handlers.put(
+        WorkflowInstanceIntent.UPDATE_PAYLOAD, new UpdatePayloadHandler(state.getWorkflowState()));
+    handlers.put(WorkflowInstanceIntent.CREATE, new CreateWorkflowInstanceHandler(state));
   }
 
   public void handle(WorkflowInstanceCommandContext context) {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceCommandProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceCommandProcessor.java
@@ -34,7 +34,7 @@ public class WorkflowInstanceCommandProcessor
 
   public WorkflowInstanceCommandProcessor(WorkflowEngineState state) {
     this.state = state;
-    this.commandHandlers = new WorkflowInstanceCommandHandlers(state.getWorkflowState());
+    this.commandHandlers = new WorkflowInstanceCommandHandlers(state);
     final EventOutput output = new EventOutput(state);
     this.context = new WorkflowInstanceCommandContext(output);
   }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceHandler.java
@@ -17,24 +17,32 @@
  */
 package io.zeebe.broker.workflow.processor.instance;
 
+import io.zeebe.broker.incident.processor.TypedWorkflowInstanceRecord;
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
+import io.zeebe.broker.workflow.model.element.ExecutableCatchEventElement;
 import io.zeebe.broker.workflow.processor.EventOutput;
 import io.zeebe.broker.workflow.processor.WorkflowInstanceCommandContext;
 import io.zeebe.broker.workflow.processor.WorkflowInstanceCommandHandler;
 import io.zeebe.broker.workflow.state.DeployedWorkflow;
+import io.zeebe.broker.workflow.state.IndexedRecord;
+import io.zeebe.broker.workflow.state.WorkflowEngineState;
 import io.zeebe.broker.workflow.state.WorkflowState;
 import io.zeebe.protocol.clientapi.RejectionType;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import java.util.List;
 import org.agrona.DirectBuffer;
 
 public class CreateWorkflowInstanceHandler implements WorkflowInstanceCommandHandler {
 
-  private final WorkflowState workflowState;
+  private final WorkflowEngineState state;
 
-  public CreateWorkflowInstanceHandler(WorkflowState workflowState) {
-    this.workflowState = workflowState;
+  private final WorkflowInstanceRecord createWorkflowCommand = new WorkflowInstanceRecord();
+  private final WorkflowInstanceRecord deferredStartEvent = new WorkflowInstanceRecord();
+
+  public CreateWorkflowInstanceHandler(WorkflowEngineState state) {
+    this.state = state;
   }
 
   @Override
@@ -47,9 +55,11 @@ public class CreateWorkflowInstanceHandler implements WorkflowInstanceCommandHan
 
     if (workflowDefinition != null) {
       final long workflowInstanceKey = commandContext.getKeyGenerator().nextKey();
-      command.setWorkflowInstanceKey(workflowInstanceKey);
       final DirectBuffer bpmnId = workflowDefinition.getWorkflow().getId();
-      command
+
+      createWorkflowCommand.wrap(command);
+      createWorkflowCommand
+          .setWorkflowInstanceKey(workflowInstanceKey)
           .setBpmnProcessId(bpmnId)
           .setWorkflowKey(workflowDefinition.getKey())
           .setVersion(workflowDefinition.getVersion())
@@ -57,19 +67,53 @@ public class CreateWorkflowInstanceHandler implements WorkflowInstanceCommandHan
 
       final EventOutput eventOutput = commandContext.getOutput();
       eventOutput.appendFollowUpEvent(
-          workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, command);
+          workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, createWorkflowCommand);
+
+      final DirectBuffer handlerId = command.getElementId();
+
+      final List<ExecutableCatchEventElement> startEvents =
+          workflowDefinition.getWorkflow().getStartEvents();
+
+      if (handlerId != null && handlerId.capacity() != 0) {
+        createDeferredStartEvent(
+            handlerId, createWorkflowCommand, workflowInstanceKey, eventOutput);
+      } else if (startEvents.size() > 1
+          || (startEvents.size() == 1 && !startEvents.get(0).isNone())) {
+        commandContext.reject(
+            RejectionType.NOT_APPLICABLE,
+            "Can't manually instantiate workflow with start events of types other than none");
+      }
 
       responseWriter.writeEventOnCommand(
-          workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, command, record);
+          workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, createWorkflowCommand, record);
     } else {
       commandContext.reject(RejectionType.BAD_VALUE, "Workflow is not deployed");
     }
+  }
+
+  private void createDeferredStartEvent(
+      DirectBuffer startId,
+      WorkflowInstanceRecord createInstanceCommand,
+      long workflowInstanceKey,
+      EventOutput eventOutput) {
+    deferredStartEvent.wrap(createInstanceCommand);
+    deferredStartEvent.setElementId(startId);
+    deferredStartEvent.setScopeInstanceKey(workflowInstanceKey);
+
+    final IndexedRecord indexedRecord =
+        new IndexedRecord(
+            workflowInstanceKey, WorkflowInstanceIntent.EVENT_TRIGGERING, deferredStartEvent);
+    final TypedWorkflowInstanceRecord typedWfRecord = new TypedWorkflowInstanceRecord();
+    typedWfRecord.wrap(indexedRecord);
+
+    eventOutput.deferEvent(typedWfRecord);
   }
 
   private DeployedWorkflow getWorkflowDefinition(WorkflowInstanceRecord value) {
     final long workflowKey = value.getWorkflowKey();
     final DirectBuffer bpmnProcessId = value.getBpmnProcessId();
     final int version = value.getVersion();
+    final WorkflowState workflowState = state.getWorkflowState();
 
     final DeployedWorkflow workflowDefinition;
     if (workflowKey <= 0) {

--- a/zb-db/pom.xml
+++ b/zb-db/pom.xml
@@ -19,12 +19,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zb-util</artifactId>
     </dependency>


### PR DESCRIPTION
This feature adds support for workflows with multiple timer start events. It uses a deferred token to store information regarding what timer start event has been triggered.

closes #1816 