### PR TITLE
chore(broker-core): timer start is consistent with message start

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/StartEventValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/StartEventValidator.java
@@ -36,8 +36,8 @@ public class StartEventValidator implements ModelElementValidator<StartEvent> {
       validationResultCollector.addError(0, "Start event can't have more than one type");
     } else {
       for (EventDefinition eventDef : eventDefinitions) {
-        if (!(eventDef instanceof TimerEventDefinition)
-            && !(eventDef instanceof MessageEventDefinition)) {
+        if (!(eventDef instanceof TimerEventDefinition
+            || eventDef instanceof MessageEventDefinition)) {
           validationResultCollector.addError(
               0, "Start event must be one of the following types: none, timer, message");
         }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
@@ -28,7 +28,6 @@ import io.zeebe.broker.workflow.data.TimerRecord;
 import io.zeebe.broker.workflow.model.element.ExecutableCatchEvent;
 import io.zeebe.broker.workflow.model.element.ExecutableCatchEventSupplier;
 import io.zeebe.broker.workflow.model.element.ExecutableMessage;
-import io.zeebe.broker.workflow.state.DeployedWorkflow;
 import io.zeebe.broker.workflow.state.ElementInstance;
 import io.zeebe.broker.workflow.state.ElementInstanceState;
 import io.zeebe.broker.workflow.state.StoredRecord;
@@ -141,22 +140,6 @@ public class CatchEventBehavior {
       // ignore the event if the element is left
       return false;
     }
-  }
-
-  public void occurStartEvent(
-      long workflowKey,
-      DirectBuffer handlerId,
-      DirectBuffer eventPayload,
-      TypedStreamWriter streamWriter) {
-    final DeployedWorkflow workflow = state.getWorkflowState().getWorkflowByKey(workflowKey);
-
-    workflowInstanceRecord.reset();
-    workflowInstanceRecord.setVersion(workflow.getVersion());
-    workflowInstanceRecord.setWorkflowKey(workflow.getKey());
-    workflowInstanceRecord.setBpmnProcessId(workflow.getBpmnProcessId());
-    workflowInstanceRecord.setPayload(eventPayload);
-    workflowInstanceRecord.setElementId(handlerId);
-    streamWriter.appendNewCommand(WorkflowInstanceIntent.CREATE, workflowInstanceRecord);
   }
 
   public void deferEvent(BpmnStepContext<?> context) {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceCommandHandlers.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceCommandHandlers.java
@@ -34,7 +34,8 @@ public class WorkflowInstanceCommandHandlers {
     handlers.put(WorkflowInstanceIntent.CANCEL, new CancelWorkflowInstanceHandler());
     handlers.put(
         WorkflowInstanceIntent.UPDATE_PAYLOAD, new UpdatePayloadHandler(state.getWorkflowState()));
-    handlers.put(WorkflowInstanceIntent.CREATE, new CreateWorkflowInstanceHandler(state));
+    handlers.put(
+        WorkflowInstanceIntent.CREATE, new CreateWorkflowInstanceHandler(state.getWorkflowState()));
   }
 
   public void handle(WorkflowInstanceCommandContext context) {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceHandler.java
@@ -17,32 +17,24 @@
  */
 package io.zeebe.broker.workflow.processor.instance;
 
-import io.zeebe.broker.incident.processor.TypedWorkflowInstanceRecord;
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
-import io.zeebe.broker.workflow.model.element.ExecutableCatchEventElement;
 import io.zeebe.broker.workflow.processor.EventOutput;
 import io.zeebe.broker.workflow.processor.WorkflowInstanceCommandContext;
 import io.zeebe.broker.workflow.processor.WorkflowInstanceCommandHandler;
 import io.zeebe.broker.workflow.state.DeployedWorkflow;
-import io.zeebe.broker.workflow.state.IndexedRecord;
-import io.zeebe.broker.workflow.state.WorkflowEngineState;
 import io.zeebe.broker.workflow.state.WorkflowState;
 import io.zeebe.protocol.clientapi.RejectionType;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
-import java.util.List;
 import org.agrona.DirectBuffer;
 
 public class CreateWorkflowInstanceHandler implements WorkflowInstanceCommandHandler {
 
-  private final WorkflowEngineState state;
+  private final WorkflowState workflowState;
 
-  private final WorkflowInstanceRecord createWorkflowCommand = new WorkflowInstanceRecord();
-  private final WorkflowInstanceRecord deferredStartEvent = new WorkflowInstanceRecord();
-
-  public CreateWorkflowInstanceHandler(WorkflowEngineState state) {
-    this.state = state;
+  public CreateWorkflowInstanceHandler(WorkflowState workflowState) {
+    this.workflowState = workflowState;
   }
 
   @Override
@@ -55,11 +47,9 @@ public class CreateWorkflowInstanceHandler implements WorkflowInstanceCommandHan
 
     if (workflowDefinition != null) {
       final long workflowInstanceKey = commandContext.getKeyGenerator().nextKey();
+      command.setWorkflowInstanceKey(workflowInstanceKey);
       final DirectBuffer bpmnId = workflowDefinition.getWorkflow().getId();
-
-      createWorkflowCommand.wrap(command);
-      createWorkflowCommand
-          .setWorkflowInstanceKey(workflowInstanceKey)
+      command
           .setBpmnProcessId(bpmnId)
           .setWorkflowKey(workflowDefinition.getKey())
           .setVersion(workflowDefinition.getVersion())
@@ -67,58 +57,24 @@ public class CreateWorkflowInstanceHandler implements WorkflowInstanceCommandHan
 
       final EventOutput eventOutput = commandContext.getOutput();
       eventOutput.appendFollowUpEvent(
-          workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, createWorkflowCommand);
+          workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, command);
 
-      final DirectBuffer handlerId = command.getElementId();
-
-      final List<ExecutableCatchEventElement> startEvents =
-          workflowDefinition.getWorkflow().getStartEvents();
-
-      if (handlerId != null && handlerId.capacity() != 0) {
-        createDeferredStartEvent(
-            handlerId, createWorkflowCommand, workflowInstanceKey, eventOutput);
-      } else if (startEvents.size() > 1
-          || (startEvents.size() == 1 && !startEvents.get(0).isNone())) {
-        commandContext.reject(
-            RejectionType.NOT_APPLICABLE,
-            "Can't manually instantiate workflow with start events of types other than none");
-      }
-
-      state
+      workflowState
           .getElementInstanceState()
           .getVariablesState()
           .setVariablesLocalFromDocument(workflowInstanceKey, command.getPayload());
 
       responseWriter.writeEventOnCommand(
-          workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, createWorkflowCommand, record);
+          workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, command, record);
     } else {
       commandContext.reject(RejectionType.BAD_VALUE, "Workflow is not deployed");
     }
-  }
-
-  private void createDeferredStartEvent(
-      DirectBuffer startId,
-      WorkflowInstanceRecord createInstanceCommand,
-      long workflowInstanceKey,
-      EventOutput eventOutput) {
-    deferredStartEvent.wrap(createInstanceCommand);
-    deferredStartEvent.setElementId(startId);
-    deferredStartEvent.setScopeInstanceKey(workflowInstanceKey);
-
-    final IndexedRecord indexedRecord =
-        new IndexedRecord(
-            workflowInstanceKey, WorkflowInstanceIntent.EVENT_TRIGGERING, deferredStartEvent);
-    final TypedWorkflowInstanceRecord typedWfRecord = new TypedWorkflowInstanceRecord();
-    typedWfRecord.wrap(indexedRecord);
-
-    eventOutput.deferEvent(typedWfRecord);
   }
 
   private DeployedWorkflow getWorkflowDefinition(WorkflowInstanceRecord value) {
     final long workflowKey = value.getWorkflowKey();
     final DirectBuffer bpmnProcessId = value.getBpmnProcessId();
     final int version = value.getVersion();
-    final WorkflowState workflowState = state.getWorkflowState();
 
     final DeployedWorkflow workflowDefinition;
     if (workflowKey <= 0) {

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/TimerStartEventTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/TimerStartEventTest.java
@@ -26,10 +26,12 @@ import io.zeebe.exporter.record.Assertions;
 import io.zeebe.exporter.record.value.DeploymentRecordValue;
 import io.zeebe.exporter.record.value.TimerRecordValue;
 import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.exporter.record.value.deployment.DeployedWorkflow;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.model.bpmn.builder.ProcessBuilder;
 import io.zeebe.protocol.intent.DeploymentIntent;
+import io.zeebe.protocol.intent.MessageStartEventSubscriptionIntent;
 import io.zeebe.protocol.intent.TimerIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
@@ -66,9 +68,10 @@ public class TimerStartEventTest {
           .endEvent("end_3")
           .done();
 
-  public static BpmnModelInstance multiStartModel;
+  public static final BpmnModelInstance TIMER_AND_MESSAGE_MODEL =
+      createTimerAndMessageStartEventsModel();
 
-  public static BpmnModelInstance multiStartSameEndModel;
+  public static final BpmnModelInstance MULTI_TIMER_START_MODEL = createMultipleTimerStartModel();
 
   public EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule();
 
@@ -78,17 +81,16 @@ public class TimerStartEventTest {
 
   private PartitionTestClient testClient;
 
-  static {
-    ProcessBuilder builder = Bpmn.createExecutableProcess("process_4");
-    builder.startEvent("start_4").timerWithCycle("R/PT2S").endEvent("end_4");
-    multiStartModel =
-        builder.startEvent("start_5").timerWithCycle("R/PT3S").endEvent("end_5").done();
+  private static BpmnModelInstance createTimerAndMessageStartEventsModel() {
+    final ProcessBuilder builder = Bpmn.createExecutableProcess("process");
+    builder.startEvent("timer_start").timerWithCycle("R/PT1S").endEvent("timer_end");
+    return builder.startEvent("msg_start").message("msg1").endEvent("msg_end").done();
+  }
 
-    builder = Bpmn.createExecutableProcess("process_5");
-
+  private static BpmnModelInstance createMultipleTimerStartModel() {
+    final ProcessBuilder builder = Bpmn.createExecutableProcess("process_4");
     builder.startEvent("start_4").timerWithCycle("R/PT2S").endEvent("end_4");
-    multiStartSameEndModel =
-        builder.startEvent("start_5").timerWithCycle("R/PT2S").connectTo("end_4").done();
+    return builder.startEvent("start_5").timerWithCycle("R/PT3S").endEvent("end_5").done();
   }
 
   @Before
@@ -117,28 +119,42 @@ public class TimerStartEventTest {
   public void shouldTriggerAndCreateWorkflowInstance() {
     // when
     final ExecuteCommandResponse response = testClient.deployWithResponse(SIMPLE_MODEL);
-    final DeploymentRecordValue deploymentRecord =
+    final DeployedWorkflow workflow =
         testClient
             .receiveFirstDeploymentEvent(DeploymentIntent.CREATED, response.getKey())
-            .getValue();
+            .getValue()
+            .getDeployedWorkflows()
+            .get(0);
 
     // then
     assertThat(RecordingExporter.timerRecords(TimerIntent.CREATED).exists()).isTrue();
     brokerRule.getClock().addTime(Duration.ofSeconds(2));
 
-    assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).exists()).isTrue();
-    assertThat(RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.CREATE).exists())
-        .isTrue();
-
-    final WorkflowInstanceRecordValue wfInstanceRecord =
-        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_READY)
-            .getFirst()
-            .getValue();
-
-    Assertions.assertThat(wfInstanceRecord)
-        .hasVersion(1)
+    Assertions.assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.EVENT_TRIGGERING)
+                .getFirst()
+                .getValue())
+        .hasElementId("start_1")
         .hasBpmnProcessId("process")
-        .hasWorkflowKey(deploymentRecord.getDeployedWorkflows().get(0).getWorkflowKey());
+        .hasVersion(workflow.getVersion())
+        .hasWorkflowKey(workflow.getWorkflowKey());
+
+    final long triggerRecordPosition =
+        RecordingExporter.timerRecords(TimerIntent.TRIGGER).getFirst().getPosition();
+
+    assertThat(
+            RecordingExporter.getRecords()
+                .stream()
+                .filter(r -> r.getPosition() >= triggerRecordPosition)
+                .limit(6)
+                .map(r -> r.getMetadata().getIntent()))
+        .containsExactly(
+            TimerIntent.TRIGGER,
+            WorkflowInstanceIntent.EVENT_OCCURRED, // causes the instance creation
+            TimerIntent.TRIGGERED,
+            WorkflowInstanceIntent.ELEMENT_READY, // causes the flow node activation
+            WorkflowInstanceIntent.ELEMENT_ACTIVATED, // input mappings applied
+            WorkflowInstanceIntent.EVENT_TRIGGERING); // triggers the start event
   }
 
   @Test
@@ -341,7 +357,7 @@ public class TimerStartEventTest {
   @Test
   public void shouldCreateMultipleInstanceAtTheCorrectTimes() {
     // when
-    testClient.deploy(multiStartModel);
+    testClient.deploy(MULTI_TIMER_START_MODEL);
     assertThat(RecordingExporter.timerRecords(TimerIntent.CREATED).limit(2).count()).isEqualTo(2);
     brokerRule.getClock().addTime(Duration.ofSeconds(2));
 
@@ -370,6 +386,7 @@ public class TimerStartEventTest {
         .isTrue();
   }
 
+  @Test
   public void shouldTriggerAtSpecifiedTimeDate() {
     // given
     final Instant triggerTime = brokerRule.getClock().getCurrentTime().plusMillis(2000);
@@ -422,5 +439,49 @@ public class TimerStartEventTest {
         .hasDueDate(triggerTime.toEpochMilli())
         .hasHandlerFlowNodeId("start_2")
         .hasElementInstanceKey(NO_ELEMENT_INSTANCE);
+  }
+
+  @Test
+  public void shouldTriggerTimerAndMessageStartEvent() {
+    // given
+    testClient.deploy(TIMER_AND_MESSAGE_MODEL);
+
+    // when
+    assertThat(RecordingExporter.timerRecords(TimerIntent.CREATED).exists()).isTrue();
+    assertThat(
+            RecordingExporter.messageStartEventSubscriptionRecords(
+                    MessageStartEventSubscriptionIntent.OPENED)
+                .exists())
+        .isTrue();
+    brokerRule.getClock().addTime(Duration.ofSeconds(1));
+    testClient.publishMessage("msg1", "123");
+
+    // then
+    final long timerInstanceKey =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.EVENT_TRIGGERING)
+            .withElementId("timer_start")
+            .getFirst()
+            .getValue()
+            .getWorkflowInstanceKey();
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(EVENT_ACTIVATED)
+                .withElementId("timer_end")
+                .withWorkflowInstanceKey(timerInstanceKey)
+                .exists())
+        .isTrue();
+
+    final long messageInstanceKey =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.EVENT_TRIGGERING)
+            .withElementId("msg_start")
+            .getFirst()
+            .getValue()
+            .getWorkflowInstanceKey();
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(EVENT_ACTIVATED)
+                .withElementId("msg_end")
+                .withWorkflowInstanceKey(messageInstanceKey)
+                .exists())
+        .isTrue();
+    assertThat(messageInstanceKey).isNotEqualTo(timerInstanceKey);
   }
 }


### PR DESCRIPTION
Now instead of triggering the creation of a workflow instance directly, the timer start event writes a record with the EVENT_OCCURRED intent which triggers the same lifecycle used in the message start event.

closes #1835 
