### PR TITLE
feat(broker): added bpmn element type to WorkflowInstanceRecord

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/WorkflowInstanceRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/WorkflowInstanceRecordValueImpl.java
@@ -20,6 +20,7 @@ package io.zeebe.broker.exporter.record.value;
 import io.zeebe.broker.exporter.ExporterObjectMapper;
 import io.zeebe.broker.exporter.record.RecordValueWithPayloadImpl;
 import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.protocol.BpmnElementType;
 import java.util.Objects;
 
 public class WorkflowInstanceRecordValueImpl extends RecordValueWithPayloadImpl
@@ -30,6 +31,7 @@ public class WorkflowInstanceRecordValueImpl extends RecordValueWithPayloadImpl
   private final long workflowKey;
   private final long workflowInstanceKey;
   private final long scopeInstanceKey;
+  private final BpmnElementType bpmnElementType;
 
   public WorkflowInstanceRecordValueImpl(
       final ExporterObjectMapper objectMapper,
@@ -39,7 +41,8 @@ public class WorkflowInstanceRecordValueImpl extends RecordValueWithPayloadImpl
       final int version,
       final long workflowKey,
       final long workflowInstanceKey,
-      final long scopeInstanceKey) {
+      final long scopeInstanceKey,
+      final BpmnElementType bpmnElementType) {
     super(objectMapper, payload);
     this.bpmnProcessId = bpmnProcessId;
     this.elementId = elementId;
@@ -47,6 +50,7 @@ public class WorkflowInstanceRecordValueImpl extends RecordValueWithPayloadImpl
     this.workflowKey = workflowKey;
     this.workflowInstanceKey = workflowInstanceKey;
     this.scopeInstanceKey = scopeInstanceKey;
+    this.bpmnElementType = bpmnElementType;
   }
 
   @Override
@@ -80,6 +84,11 @@ public class WorkflowInstanceRecordValueImpl extends RecordValueWithPayloadImpl
   }
 
   @Override
+  public BpmnElementType getBpmnElementType() {
+    return bpmnElementType;
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (this == o) {
       return true;
@@ -96,7 +105,8 @@ public class WorkflowInstanceRecordValueImpl extends RecordValueWithPayloadImpl
         && workflowInstanceKey == that.workflowInstanceKey
         && scopeInstanceKey == that.scopeInstanceKey
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
-        && Objects.equals(elementId, that.elementId);
+        && Objects.equals(elementId, that.elementId)
+        && bpmnElementType == that.bpmnElementType;
   }
 
   @Override
@@ -108,7 +118,8 @@ public class WorkflowInstanceRecordValueImpl extends RecordValueWithPayloadImpl
         version,
         workflowKey,
         workflowInstanceKey,
-        scopeInstanceKey);
+        scopeInstanceKey,
+        bpmnElementType);
   }
 
   @Override
@@ -128,6 +139,8 @@ public class WorkflowInstanceRecordValueImpl extends RecordValueWithPayloadImpl
         + workflowInstanceKey
         + ", scopeInstanceKey="
         + scopeInstanceKey
+        + ", bpmnElementType="
+        + bpmnElementType
         + ", payload='"
         + payload
         + '\''

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
@@ -293,7 +293,8 @@ public class ExporterRecordMapper {
         record.getVersion(),
         record.getWorkflowKey(),
         record.getWorkflowInstanceKey(),
-        record.getScopeInstanceKey());
+        record.getScopeInstanceKey(),
+        record.getBpmnElementType());
   }
 
   private WorkflowInstanceSubscriptionRecordValue ofWorkflowInstanceSubscriptionRecord(

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/PublishMessageProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/PublishMessageProcessor.java
@@ -29,6 +29,7 @@ import io.zeebe.broker.subscription.message.state.Message;
 import io.zeebe.broker.subscription.message.state.MessageStartEventSubscriptionState;
 import io.zeebe.broker.subscription.message.state.MessageState;
 import io.zeebe.broker.subscription.message.state.MessageSubscriptionState;
+import io.zeebe.protocol.BpmnElementType;
 import io.zeebe.protocol.clientapi.RejectionType;
 import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
@@ -183,6 +184,7 @@ public class PublishMessageProcessor implements TypedRecordProcessor<MessageReco
           record
               .setWorkflowKey(workflowKey)
               .setElementId(startEventId)
+              .setBpmnElementType(BpmnElementType.START_EVENT)
               .setPayload(command.getValue().getPayload());
 
           streamWriter.appendNewEvent(WorkflowInstanceIntent.EVENT_OCCURRED, record);

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/AbstractFlowElement.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/AbstractFlowElement.java
@@ -18,6 +18,7 @@
 package io.zeebe.broker.workflow.model.element;
 
 import io.zeebe.broker.workflow.model.BpmnStep;
+import io.zeebe.protocol.BpmnElementType;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import io.zeebe.util.buffer.BufferUtil;
 import java.util.EnumMap;
@@ -29,9 +30,11 @@ public abstract class AbstractFlowElement implements ExecutableFlowElement {
   private final DirectBuffer id;
   private Map<WorkflowInstanceIntent, BpmnStep> bpmnSteps =
       new EnumMap<>(WorkflowInstanceIntent.class);
+  private BpmnElementType elementType;
 
   public AbstractFlowElement(String id) {
     this.id = BufferUtil.wrapString(id);
+    this.elementType = BpmnElementType.UNSPECIFIED;
   }
 
   @Override
@@ -46,5 +49,14 @@ public abstract class AbstractFlowElement implements ExecutableFlowElement {
   @Override
   public BpmnStep getStep(WorkflowInstanceIntent state) {
     return bpmnSteps.get(state);
+  }
+
+  public void setElementType(BpmnElementType elementType) {
+    this.elementType = elementType;
+  }
+
+  @Override
+  public BpmnElementType getElementType() {
+    return elementType;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableFlowElement.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/element/ExecutableFlowElement.java
@@ -18,6 +18,7 @@
 package io.zeebe.broker.workflow.model.element;
 
 import io.zeebe.broker.workflow.model.BpmnStep;
+import io.zeebe.protocol.BpmnElementType;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import org.agrona.DirectBuffer;
 
@@ -26,4 +27,6 @@ public interface ExecutableFlowElement {
   DirectBuffer getId();
 
   BpmnStep getStep(WorkflowInstanceIntent state);
+
+  BpmnElementType getElementType();
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/FlowElementInstantiationTransformer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/FlowElementInstantiationTransformer.java
@@ -44,6 +44,7 @@ import io.zeebe.model.bpmn.instance.SequenceFlow;
 import io.zeebe.model.bpmn.instance.ServiceTask;
 import io.zeebe.model.bpmn.instance.StartEvent;
 import io.zeebe.model.bpmn.instance.SubProcess;
+import io.zeebe.protocol.BpmnElementType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -85,6 +86,9 @@ public class FlowElementInstantiationTransformer implements ModelElementTransfor
     }
 
     final AbstractFlowElement executableElement = elementFactory.apply(element.getId());
+
+    executableElement.setElementType(
+        BpmnElementType.bpmnElementTypeFor(element.getElementType().getTypeName()));
 
     workflow.addFlowElement(executableElement);
   }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/ProcessTransformer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/transformation/transformer/ProcessTransformer.java
@@ -22,6 +22,7 @@ import io.zeebe.broker.workflow.model.element.ExecutableWorkflow;
 import io.zeebe.broker.workflow.model.transformation.ModelElementTransformer;
 import io.zeebe.broker.workflow.model.transformation.TransformContext;
 import io.zeebe.model.bpmn.instance.Process;
+import io.zeebe.protocol.BpmnElementType;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 
 public class ProcessTransformer implements ModelElementTransformer<Process> {
@@ -36,6 +37,8 @@ public class ProcessTransformer implements ModelElementTransformer<Process> {
 
     final String id = element.getId();
     final ExecutableWorkflow workflow = new ExecutableWorkflow(id);
+    workflow.setElementType(
+        BpmnElementType.bpmnElementTypeFor(element.getElementType().getTypeName()));
     context.addWorkflow(workflow);
     context.setCurrentWorkflow(workflow);
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
@@ -38,6 +38,7 @@ import io.zeebe.model.bpmn.util.time.Timer;
 import io.zeebe.msgpack.query.MsgPackQueryProcessor;
 import io.zeebe.msgpack.query.MsgPackQueryProcessor.QueryResult;
 import io.zeebe.msgpack.query.MsgPackQueryProcessor.QueryResults;
+import io.zeebe.protocol.BpmnElementType;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.TimerIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
@@ -133,6 +134,11 @@ public class CatchEventBehavior {
       workflowInstanceRecord.wrap(source);
       workflowInstanceRecord.setPayload(eventPayload);
       workflowInstanceRecord.setElementId(eventHandlerId);
+      // check if source element is the element handling the event (i.e. receive task), otherwise
+      // triggered element is a boundary event
+      if (!source.getElementId().equals(eventHandlerId)) {
+        workflowInstanceRecord.setBpmnElementType(BpmnElementType.BOUNDARY_EVENT);
+      }
 
       streamWriter.appendFollowUpEvent(
           elementInstanceKey, WorkflowInstanceIntent.EVENT_OCCURRED, workflowInstanceRecord);

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/EventOutput.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/EventOutput.java
@@ -19,6 +19,7 @@ package io.zeebe.broker.workflow.processor;
 
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
+import io.zeebe.broker.workflow.model.element.ExecutableFlowElement;
 import io.zeebe.broker.workflow.state.StoredRecord.Purpose;
 import io.zeebe.broker.workflow.state.WorkflowEngineState;
 import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
@@ -41,8 +42,20 @@ public class EventOutput {
 
   public long appendNewEvent(
       final WorkflowInstanceIntent state, final WorkflowInstanceRecord value) {
-    final long key;
-    key = streamWriter.appendNewEvent(state, value);
+    return appendNewEvent(state, value, null);
+  }
+
+  public long appendNewEvent(
+      final WorkflowInstanceIntent state,
+      final WorkflowInstanceRecord value,
+      final ExecutableFlowElement element) {
+
+    if (element != null) {
+      value.setElementId(element.getId());
+      value.setBpmnElementType(element.getElementType());
+    }
+
+    final long key = streamWriter.appendNewEvent(state, value);
 
     materializedState.onEventProduced(key, state, value);
 
@@ -51,6 +64,18 @@ public class EventOutput {
 
   public void appendFollowUpEvent(
       final long key, final WorkflowInstanceIntent state, final WorkflowInstanceRecord value) {
+    appendFollowUpEvent(key, state, value, null);
+  }
+
+  public void appendFollowUpEvent(
+      final long key,
+      final WorkflowInstanceIntent state,
+      final WorkflowInstanceRecord value,
+      final ExecutableFlowElement element) {
+    if (element != null) {
+      value.setElementId(element.getId());
+      value.setBpmnElementType(element.getElementType());
+    }
 
     streamWriter.appendFollowUpEvent(key, state, value);
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/gateway/ExclusiveSplitHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/gateway/ExclusiveSplitHandler.java
@@ -42,8 +42,9 @@ public class ExclusiveSplitHandler implements BpmnStepHandler<ExecutableExclusiv
           getSequenceFlowWithFulfilledCondition(context.getElement(), value.getPayload());
 
       if (sequenceFlow != null) {
-        value.setElementId(sequenceFlow.getId());
-        context.getOutput().appendNewEvent(WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN, value);
+        context
+            .getOutput()
+            .appendNewEvent(WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN, value, sequenceFlow);
       } else {
         final String errorMessage = "All conditions evaluated to false and no default flow is set.";
         context.raiseIncident(ErrorType.CONDITION_ERROR, errorMessage);

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/gateway/ParallelSplitHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/gateway/ParallelSplitHandler.java
@@ -37,8 +37,7 @@ public class ParallelSplitHandler implements BpmnStepHandler<ExecutableFlowNode>
     context.getFlowScopeInstance().consumeToken();
 
     for (final ExecutableSequenceFlow flow : element.getOutgoing()) {
-      value.setElementId(flow.getId());
-      eventOutput.appendNewEvent(WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN, value);
+      eventOutput.appendNewEvent(WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN, value, flow);
 
       context.getFlowScopeInstance().spawnToken();
     }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceHandler.java
@@ -19,6 +19,7 @@ package io.zeebe.broker.workflow.processor.instance;
 
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
+import io.zeebe.broker.workflow.model.element.ExecutableWorkflow;
 import io.zeebe.broker.workflow.processor.EventOutput;
 import io.zeebe.broker.workflow.processor.WorkflowInstanceCommandContext;
 import io.zeebe.broker.workflow.processor.WorkflowInstanceCommandHandler;
@@ -48,16 +49,16 @@ public class CreateWorkflowInstanceHandler implements WorkflowInstanceCommandHan
     if (workflowDefinition != null) {
       final long workflowInstanceKey = commandContext.getKeyGenerator().nextKey();
       command.setWorkflowInstanceKey(workflowInstanceKey);
-      final DirectBuffer bpmnId = workflowDefinition.getWorkflow().getId();
+      final ExecutableWorkflow workflow = workflowDefinition.getWorkflow();
+      final DirectBuffer bpmnId = workflow.getId();
       command
           .setBpmnProcessId(bpmnId)
           .setWorkflowKey(workflowDefinition.getKey())
-          .setVersion(workflowDefinition.getVersion())
-          .setElementId(bpmnId);
+          .setVersion(workflowDefinition.getVersion());
 
       final EventOutput eventOutput = commandContext.getOutput();
       eventOutput.appendFollowUpEvent(
-          workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, command);
+          workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, command, workflow);
 
       workflowState
           .getElementInstanceState()

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceOnStartEventHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceOnStartEventHandler.java
@@ -20,6 +20,7 @@ package io.zeebe.broker.workflow.processor.instance;
 import io.zeebe.broker.incident.processor.TypedWorkflowInstanceRecord;
 import io.zeebe.broker.logstreams.state.ZeebeState;
 import io.zeebe.broker.workflow.model.element.ExecutableFlowElementContainer;
+import io.zeebe.broker.workflow.model.element.ExecutableWorkflow;
 import io.zeebe.broker.workflow.processor.BpmnStepContext;
 import io.zeebe.broker.workflow.processor.BpmnStepHandler;
 import io.zeebe.broker.workflow.processor.EventOutput;
@@ -51,18 +52,18 @@ public class CreateWorkflowInstanceOnStartEventHandler
 
     if (workflowDefinition != null) {
       final long workflowInstanceKey = state.getKeyGenerator().nextKey();
-      final DirectBuffer bpmnId = workflowDefinition.getWorkflow().getId();
+      final ExecutableWorkflow workflow = workflowDefinition.getWorkflow();
+      final DirectBuffer bpmnId = workflow.getId();
       final WorkflowInstanceRecord record = new WorkflowInstanceRecord();
       record
           .setBpmnProcessId(bpmnId)
           .setWorkflowKey(workflowDefinition.getKey())
           .setVersion(workflowDefinition.getVersion())
-          .setElementId(bpmnId)
           .setWorkflowInstanceKey(workflowInstanceKey);
 
       final EventOutput eventOutput = context.getOutput();
       eventOutput.appendFollowUpEvent(
-          workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, record);
+          workflowInstanceKey, WorkflowInstanceIntent.ELEMENT_READY, record, workflow);
 
       // Defer token which will be used by the start event
       eventRecord.setWorkflowInstanceKey(workflowInstanceKey);

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/sequenceflow/ParallelMergeHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/sequenceflow/ParallelMergeHandler.java
@@ -25,7 +25,6 @@ import io.zeebe.broker.workflow.processor.EventOutput;
 import io.zeebe.broker.workflow.state.ElementInstance;
 import io.zeebe.broker.workflow.state.IndexedRecord;
 import io.zeebe.broker.workflow.state.WorkflowState;
-import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import java.util.ArrayList;
 import java.util.List;
@@ -57,9 +56,9 @@ public class ParallelMergeHandler implements BpmnStepHandler<ExecutableSequenceF
             context.getFlowScopeInstance().consumeToken();
           });
 
-      final WorkflowInstanceRecord value = context.getValue();
-      value.setElementId(gateway.getId());
-      context.getOutput().appendNewEvent(WorkflowInstanceIntent.GATEWAY_ACTIVATED, value);
+      context
+          .getOutput()
+          .appendNewEvent(WorkflowInstanceIntent.GATEWAY_ACTIVATED, context.getValue(), gateway);
 
       context.getFlowScopeInstance().spawnToken();
     }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/sequenceflow/StartFlowNodeHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/sequenceflow/StartFlowNodeHandler.java
@@ -38,8 +38,6 @@ public class StartFlowNodeHandler implements BpmnStepHandler<ExecutableSequenceF
     final ExecutableFlowNode targetNode = sequenceFlow.getTarget();
 
     final WorkflowInstanceRecord value = context.getValue();
-    value.setElementId(targetNode.getId());
-
-    context.getOutput().appendNewEvent(nodeIntent, value);
+    context.getOutput().appendNewEvent(nodeIntent, value, targetNode);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/sequenceflow/TakeSequenceFlowHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/sequenceflow/TakeSequenceFlowHandler.java
@@ -32,8 +32,9 @@ public class TakeSequenceFlowHandler implements BpmnStepHandler<ExecutableFlowNo
     final ExecutableSequenceFlow sequenceFlow = context.getElement().getOutgoing().get(0);
 
     final WorkflowInstanceRecord value = context.getValue();
-    value.setElementId(sequenceFlow.getId());
 
-    context.getOutput().appendNewEvent(WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN, value);
+    context
+        .getOutput()
+        .appendNewEvent(WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN, value, sequenceFlow);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/subprocess/TriggerStartEventHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/subprocess/TriggerStartEventHandler.java
@@ -17,6 +17,7 @@
  */
 package io.zeebe.broker.workflow.processor.subprocess;
 
+import io.zeebe.broker.workflow.model.element.ExecutableCatchEventElement;
 import io.zeebe.broker.workflow.model.element.ExecutableFlowElementContainer;
 import io.zeebe.broker.workflow.processor.BpmnStepContext;
 import io.zeebe.broker.workflow.processor.BpmnStepHandler;
@@ -42,9 +43,11 @@ public class TriggerStartEventHandler implements BpmnStepHandler<ExecutableFlowE
 
     final WorkflowInstanceRecord value = context.getValue();
 
-    if (element.getStartEvents().get(0).isNone()) {
+    final ExecutableCatchEventElement firstStartEvent = element.getStartEvents().get(0);
+    if (firstStartEvent.isNone()) {
       // if none start event
-      value.setElementId(element.getStartEvents().get(0).getId());
+      value.setElementId(firstStartEvent.getId());
+      value.setBpmnElementType(firstStartEvent.getElementType());
     } else {
       // if timer/message start event
 
@@ -56,6 +59,7 @@ public class TriggerStartEventHandler implements BpmnStepHandler<ExecutableFlowE
         final IndexedRecord deferredRecord = deferredRecords.get(0);
         final WorkflowInstanceRecord workflowInstanceRecord = deferredRecord.getValue();
         value.setElementId(workflowInstanceRecord.getElementId());
+        value.setBpmnElementType(workflowInstanceRecord.getBpmnElementType());
         value.setPayload(workflowInstanceRecord.getPayload());
         workflowState
             .getElementInstanceState()

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/TriggerTimerProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/TriggerTimerProcessor.java
@@ -34,6 +34,7 @@ import io.zeebe.broker.workflow.state.ElementInstance;
 import io.zeebe.broker.workflow.state.TimerInstance;
 import io.zeebe.broker.workflow.state.WorkflowState;
 import io.zeebe.model.bpmn.util.time.RepeatingInterval;
+import io.zeebe.protocol.BpmnElementType;
 import io.zeebe.protocol.clientapi.RejectionType;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.TimerIntent;
@@ -46,7 +47,8 @@ public class TriggerTimerProcessor implements TypedRecordProcessor<TimerRecord> 
 
   private final CatchEventBehavior catchEventBehavior;
   private final WorkflowState workflowState;
-  private final WorkflowInstanceRecord startEventRecord = new WorkflowInstanceRecord();
+  private final WorkflowInstanceRecord startEventRecord =
+      new WorkflowInstanceRecord().setBpmnElementType(BpmnElementType.START_EVENT);
 
   public TriggerTimerProcessor(
       final WorkflowState workflowState, CatchEventBehavior catchEventBehavior) {

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessorTest.java
@@ -61,6 +61,7 @@ import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
 import io.zeebe.exporter.record.value.WorkflowInstanceSubscriptionRecordValue;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.protocol.BpmnElementType;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.impl.record.value.deployment.ResourceType;
@@ -556,10 +557,12 @@ public class ExporterStreamProcessorTest {
     final int workflowInstanceKey = 1234;
     final String elementId = "activity";
     final int scopeInstanceKey = 123;
+    final BpmnElementType bpmnElementType = BpmnElementType.SERVICE_TASK;
 
     final WorkflowInstanceRecord record =
         new WorkflowInstanceRecord()
             .setElementId(elementId)
+            .setBpmnElementType(bpmnElementType)
             .setPayload(PAYLOAD_MSGPACK)
             .setBpmnProcessId(wrapString(bpmnProcessId))
             .setVersion(version)
@@ -576,7 +579,8 @@ public class ExporterStreamProcessorTest {
             version,
             workflowKey,
             workflowInstanceKey,
-            scopeInstanceKey);
+            scopeInstanceKey,
+            bpmnElementType);
 
     // then
     assertRecordExported(WorkflowInstanceIntent.ELEMENT_READY, record, recordValue);

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/BpmnElementTypeTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/BpmnElementTypeTest.java
@@ -1,0 +1,376 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.BpmnElementType;
+import io.zeebe.protocol.intent.MessageStartEventSubscriptionIntent;
+import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
+import io.zeebe.test.broker.protocol.clientapi.PartitionTestClient;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class BpmnElementTypeTest {
+
+  public static EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule();
+  public static ClientApiRule apiRule = new ClientApiRule(brokerRule::getClientAddress);
+
+  @ClassRule public static RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(apiRule);
+
+  private static PartitionTestClient testClient;
+
+  @BeforeClass
+  public static void init() {
+    testClient = apiRule.partitionClient();
+  }
+
+  private static List<BpmnElementTypeScenario> scenarios =
+      Arrays.asList(
+          new BpmnElementTypeScenario("Process", BpmnElementType.PROCESS) {
+            @Override
+            String elementId() {
+              return processId();
+            }
+
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId()).startEvent().done();
+            }
+          },
+          new BpmnElementTypeScenario("Sub Process", BpmnElementType.SUB_PROCESS) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .subProcess(elementId())
+                  .embeddedSubProcess()
+                  .startEvent()
+                  .subProcessDone()
+                  .done();
+            }
+          },
+          new BpmnElementTypeScenario("None Start Event", BpmnElementType.START_EVENT) {
+            @Override
+            public BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId()).startEvent(elementId()).done();
+            }
+          },
+          new BpmnElementTypeScenario("Message Start Event", BpmnElementType.START_EVENT) {
+            @Override
+            public BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent(elementId())
+                  .message(messageName())
+                  .done();
+            }
+
+            @Override
+            public void executeInstance() {
+              // wait for message subscription for the start event to be opened
+              RecordingExporter.messageStartEventSubscriptionRecords(
+                      MessageStartEventSubscriptionIntent.OPENED)
+                  .exists();
+
+              testClient.publishMessage(messageName(), "");
+            }
+          },
+          new BpmnElementTypeScenario("Timer Start Event", BpmnElementType.START_EVENT) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent(elementId())
+                  .timerWithCycle("R1/PT0.01S")
+                  .done();
+            }
+
+            @Override
+            void executeInstance() {
+              brokerRule.getClock().addTime(Duration.ofMinutes(1));
+            }
+          },
+          new BpmnElementTypeScenario(
+              "Intermediate Message Catch Event", BpmnElementType.INTERMEDIATE_CATCH_EVENT) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .intermediateCatchEvent(elementId())
+                  .message(b -> b.name(messageName()).zeebeCorrelationKey("$.id"))
+                  .done();
+            }
+
+            @Override
+            void executeInstance() {
+              super.executeInstance(Collections.singletonMap("id", "test"));
+              testClient.publishMessage(messageName(), "test");
+            }
+          },
+          new BpmnElementTypeScenario(
+              "Intermediate Timer Catch Event", BpmnElementType.INTERMEDIATE_CATCH_EVENT) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .intermediateCatchEvent(elementId())
+                  .timerWithDuration("PT0.01S")
+                  .done();
+            }
+          },
+          new BpmnElementTypeScenario("Message Boundary Event", BpmnElementType.BOUNDARY_EVENT) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .serviceTask("task", b -> b.zeebeTaskType(taskType()))
+                  .boundaryEvent(elementId())
+                  .message(b -> b.name(messageName()).zeebeCorrelationKey("$.id"))
+                  .endEvent()
+                  .done();
+            }
+
+            @Override
+            void executeInstance() {
+              super.executeInstance(Collections.singletonMap("id", "test"));
+              testClient.publishMessage(messageName(), "test");
+            }
+          },
+          new BpmnElementTypeScenario("Timer Boundary Event", BpmnElementType.BOUNDARY_EVENT) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .serviceTask("task", b -> b.zeebeTaskType(taskType()))
+                  .boundaryEvent(elementId())
+                  .timerWithDuration("PT0.01S")
+                  .endEvent()
+                  .done();
+            }
+          },
+          new BpmnElementTypeScenario("End Event", BpmnElementType.END_EVENT) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .endEvent(elementId())
+                  .done();
+            }
+          },
+          new BpmnElementTypeScenario("Service Task", BpmnElementType.SERVICE_TASK) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .serviceTask(elementId(), b -> b.zeebeTaskType(taskType()))
+                  .done();
+            }
+
+            @Override
+            void executeInstance() {
+              super.executeInstance();
+              testClient.completeJobOfType(taskType());
+            }
+          },
+          new BpmnElementTypeScenario("Receive Task", BpmnElementType.RECEIVE_TASK) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .receiveTask(elementId())
+                  .message(b -> b.name(messageName()).zeebeCorrelationKey("$.id"))
+                  .done();
+            }
+
+            @Override
+            void executeInstance() {
+              executeInstance(Collections.singletonMap("id", "test"));
+              testClient.publishMessage(messageName(), "test");
+            }
+          },
+          new BpmnElementTypeScenario("Exclusive Gateway", BpmnElementType.EXCLUSIVE_GATEWAY) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .exclusiveGateway(elementId())
+                  .defaultFlow()
+                  .endEvent()
+                  .done();
+            }
+          },
+          new BpmnElementTypeScenario("Event Based Gateway", BpmnElementType.EVENT_BASED_GATEWAY) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .eventBasedGateway(elementId())
+                  .intermediateCatchEvent()
+                  .message(b -> b.name(messageName()).zeebeCorrelationKey("$.id"))
+                  .moveToLastGateway()
+                  .intermediateCatchEvent()
+                  .timerWithDuration("PT0.01S")
+                  .done();
+            }
+
+            @Override
+            void executeInstance() {
+              executeInstance(Collections.singletonMap("id", "test"));
+              testClient.publishMessage(messageName(), "test");
+            }
+          },
+          new BpmnElementTypeScenario("Parallel Gateway", BpmnElementType.PARALLEL_GATEWAY) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .parallelGateway(elementId())
+                  .endEvent()
+                  .done();
+            }
+          },
+          new BpmnElementTypeScenario("Sequence Flow", BpmnElementType.SEQUENCE_FLOW) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .sequenceFlowId(elementId())
+                  .endEvent()
+                  .done();
+            }
+          });
+
+  @Parameters(name = "{0}")
+  public static Collection<Object[]> scenarios() {
+    return scenarios.stream().map(s -> new Object[] {s}).collect(Collectors.toList());
+  }
+
+  private final BpmnElementTypeScenario scenario;
+
+  public BpmnElementTypeTest(BpmnElementTypeScenario scenario) {
+    this.scenario = scenario;
+  }
+
+  @Test
+  public void test() {
+    // given
+    testClient.deploy(scenario.modelInstance());
+
+    // when
+    scenario.executeInstance();
+
+    // then
+    final List<Record<WorkflowInstanceRecordValue>> records =
+        RecordingExporter.workflowInstanceRecords()
+            .withBpmnProcessId(scenario.processId())
+            .limitToWorkflowInstanceCompleted()
+            .withElementId(scenario.elementId())
+            .asList();
+
+    assertThat(records)
+        .extracting(r -> r.getValue().getBpmnElementType())
+        .isNotEmpty()
+        .containsOnly(scenario.elementType());
+  }
+
+  abstract static class BpmnElementTypeScenario {
+    private final String name;
+    private final BpmnElementType elementType;
+
+    private final String processId = randomId();
+    private final String elementId = randomId();
+    private final String taskType = randomId();
+    private final String messageName = randomId();
+
+    BpmnElementTypeScenario(String name, BpmnElementType elementType) {
+      this.name = name;
+      this.elementType = elementType;
+    }
+
+    String name() {
+      return name;
+    }
+
+    abstract BpmnModelInstance modelInstance();
+
+    String processId() {
+      return processId;
+    }
+
+    String elementId() {
+      return elementId;
+    }
+
+    String taskType() {
+      return taskType;
+    }
+
+    String messageName() {
+      return messageName;
+    }
+
+    BpmnElementType elementType() {
+      return elementType;
+    }
+
+    void executeInstance() {
+      testClient.createWorkflowInstance(processId());
+    }
+
+    void executeInstance(Map<String, String> payload) {
+      final String json =
+          "{ "
+              + payload
+                  .entrySet()
+                  .stream()
+                  .map(e -> String.format("\"%s\":\"%s\"", e.getKey(), e.getValue()))
+                  .collect(Collectors.joining(","))
+              + " }";
+      testClient.createWorkflowInstance(processId(), json);
+    }
+
+    @Override
+    public String toString() {
+      return name();
+    }
+
+    static String randomId() {
+      // NCName xml values cannot start with a digit
+      return "id-" + UUID.randomUUID().toString();
+    }
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/WorkflowInstanceFunctionalTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/WorkflowInstanceFunctionalTest.java
@@ -110,7 +110,7 @@ public class WorkflowInstanceFunctionalTest {
   }
 
   @Test
-  public void shouldOccureEndEvent() {
+  public void shouldOccurEndEvent() {
     // given
     testClient.deploy(Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent("foo").done());
 

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/state/ElementInstanceStateTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/state/ElementInstanceStateTest.java
@@ -27,6 +27,7 @@ import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.state.ZeebeState;
 import io.zeebe.broker.util.ZeebeStateRule;
 import io.zeebe.broker.workflow.state.StoredRecord.Purpose;
+import io.zeebe.protocol.BpmnElementType;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
@@ -550,6 +551,7 @@ public class ElementInstanceStateTest {
     workflowInstanceRecord.setScopeInstanceKey(1001L);
     workflowInstanceRecord.setVersion(1);
     workflowInstanceRecord.setWorkflowKey(2);
+    workflowInstanceRecord.setBpmnElementType(BpmnElementType.START_EVENT);
 
     return workflowInstanceRecord;
   }
@@ -565,5 +567,6 @@ public class ElementInstanceStateTest {
     assertThat(record.getScopeInstanceKey()).isEqualTo(1001L);
     assertThat(record.getVersion()).isEqualTo(1);
     assertThat(record.getWorkflowKey()).isEqualTo(2);
+    assertThat(record.getBpmnElementType()).isEqualTo(BpmnElementType.START_EVENT);
   }
 }

--- a/exporter-api/src/main/java/io/zeebe/exporter/record/value/WorkflowInstanceRecordValue.java
+++ b/exporter-api/src/main/java/io/zeebe/exporter/record/value/WorkflowInstanceRecordValue.java
@@ -16,6 +16,7 @@
 package io.zeebe.exporter.record.value;
 
 import io.zeebe.exporter.record.RecordValueWithPayload;
+import io.zeebe.protocol.BpmnElementType;
 
 /**
  * Represents a workflow instance related command or event.
@@ -43,4 +44,7 @@ public interface WorkflowInstanceRecordValue extends RecordValueWithPayload {
    *     -1 for records of the workflow instance itself.
    */
   long getScopeInstanceKey();
+
+  /** @return the BPMN type of the current workflow element. */
+  BpmnElementType getBpmnElementType();
 }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-template.json
@@ -32,6 +32,9 @@
             },
             "payload": {
               "type": "text"
+            },
+            "bpmnElementType": {
+              "type": "keyword"
             }
           }
         }

--- a/protocol-impl/pom.xml
+++ b/protocol-impl/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Protocol Implementation</name>

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/workflowinstance/WorkflowInstanceRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/workflowinstance/WorkflowInstanceRecord.java
@@ -17,10 +17,12 @@ package io.zeebe.protocol.impl.record.value.workflowinstance;
 
 import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.msgpack.property.DocumentProperty;
+import io.zeebe.msgpack.property.EnumProperty;
 import io.zeebe.msgpack.property.IntegerProperty;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
 import io.zeebe.msgpack.spec.MsgPackHelper;
+import io.zeebe.protocol.BpmnElementType;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -33,6 +35,8 @@ public class WorkflowInstanceRecord extends UnpackedObject {
   public static final String PROP_WORKFLOW_VERSION = "version";
   public static final String PROP_WORKFLOW_KEY = "workflowKey";
   public static final String PROP_WORKFLOW_PAYLOAD = "payload";
+  public static final String PROP_WORKFLOW_BPMN_TYPE = "bpmnElementType";
+  public static final String PROP_WORKFLOW_SCOPE_KEY = "scopeInstanceKey";
 
   private final StringProperty bpmnProcessIdProp =
       new StringProperty(PROP_WORKFLOW_BPMN_PROCESS_ID, "");
@@ -45,7 +49,10 @@ public class WorkflowInstanceRecord extends UnpackedObject {
 
   private final DocumentProperty payloadProp = new DocumentProperty(PROP_WORKFLOW_PAYLOAD);
 
-  private final LongProperty scopeInstanceKey = new LongProperty("scopeInstanceKey", -1L);
+  private final LongProperty scopeInstanceKeyProp = new LongProperty(PROP_WORKFLOW_SCOPE_KEY, -1L);
+
+  private final EnumProperty<BpmnElementType> bpmnElementTypeProp =
+      new EnumProperty(PROP_WORKFLOW_BPMN_TYPE, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public WorkflowInstanceRecord() {
     this.declareProperty(bpmnProcessIdProp)
@@ -54,7 +61,8 @@ public class WorkflowInstanceRecord extends UnpackedObject {
         .declareProperty(workflowInstanceKeyProp)
         .declareProperty(elementIdProp)
         .declareProperty(payloadProp)
-        .declareProperty(scopeInstanceKey);
+        .declareProperty(scopeInstanceKeyProp)
+        .declareProperty(bpmnElementTypeProp);
   }
 
   public DirectBuffer getBpmnProcessId() {
@@ -105,11 +113,11 @@ public class WorkflowInstanceRecord extends UnpackedObject {
   }
 
   public long getScopeInstanceKey() {
-    return scopeInstanceKey.getValue();
+    return scopeInstanceKeyProp.getValue();
   }
 
   public WorkflowInstanceRecord setScopeInstanceKey(long scopeInstanceKey) {
-    this.scopeInstanceKey.setValue(scopeInstanceKey);
+    this.scopeInstanceKeyProp.setValue(scopeInstanceKey);
     return this;
   }
 
@@ -145,13 +153,23 @@ public class WorkflowInstanceRecord extends UnpackedObject {
     return this;
   }
 
+  public BpmnElementType getBpmnElementType() {
+    return bpmnElementTypeProp.getValue();
+  }
+
+  public WorkflowInstanceRecord setBpmnElementType(BpmnElementType bpmnType) {
+    bpmnElementTypeProp.setValue(bpmnType);
+    return this;
+  }
+
   public void wrap(WorkflowInstanceRecord record) {
     elementIdProp.setValue(record.getElementId());
     bpmnProcessIdProp.setValue(record.getBpmnProcessId());
     payloadProp.setValue(record.getPayload());
-    scopeInstanceKey.setValue(record.getScopeInstanceKey());
+    scopeInstanceKeyProp.setValue(record.getScopeInstanceKey());
     versionProp.setValue(record.getVersion());
     workflowKeyProp.setValue(record.getWorkflowKey());
     workflowInstanceKeyProp.setValue(record.getWorkflowInstanceKey());
+    bpmnElementTypeProp.setValue(record.getBpmnElementType());
   }
 }

--- a/protocol/src/main/java/io/zeebe/protocol/BpmnElementType.java
+++ b/protocol/src/main/java/io/zeebe/protocol/BpmnElementType.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.protocol;
+
+public enum BpmnElementType {
+
+  // Default
+  UNSPECIFIED,
+
+  // Containers
+  PROCESS,
+  SUB_PROCESS,
+
+  // Events
+  START_EVENT,
+  INTERMEDIATE_CATCH_EVENT,
+  BOUNDARY_EVENT,
+  END_EVENT,
+
+  // Tasks
+  SERVICE_TASK,
+  RECEIVE_TASK,
+
+  // Gateways
+  EXCLUSIVE_GATEWAY,
+  PARALLEL_GATEWAY,
+  EVENT_BASED_GATEWAY,
+
+  // Other
+  SEQUENCE_FLOW;
+
+  public static BpmnElementType bpmnElementTypeFor(String elementTypeName) {
+    switch (elementTypeName) {
+      case "process":
+        return BpmnElementType.PROCESS;
+      case "subProcess":
+        return BpmnElementType.SUB_PROCESS;
+      case "startEvent":
+        return BpmnElementType.START_EVENT;
+      case "intermediateCatchEvent":
+        return BpmnElementType.INTERMEDIATE_CATCH_EVENT;
+      case "boundaryEvent":
+        return BpmnElementType.BOUNDARY_EVENT;
+      case "endEvent":
+        return BpmnElementType.END_EVENT;
+      case "serviceTask":
+        return BpmnElementType.SERVICE_TASK;
+      case "receiveTask":
+        return BpmnElementType.RECEIVE_TASK;
+      case "exclusiveGateway":
+        return BpmnElementType.EXCLUSIVE_GATEWAY;
+      case "eventBasedGateway":
+        return BpmnElementType.EVENT_BASED_GATEWAY;
+      case "parallelGateway":
+        return BpmnElementType.PARALLEL_GATEWAY;
+      case "sequenceFlow":
+        return BpmnElementType.SEQUENCE_FLOW;
+      default:
+        throw new RuntimeException("Unsupported BPMN element of type " + elementTypeName);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a BpmnElementType to the WorkflowInstanceRecord. Couple of implementation choices that might be relevant:
* Most records should have one of the five specified bpmn element types since they will relate to a bpmn element. However, some records aren't in the scope of an element (e.g., create and cancel commands), which is why I added an UNSPECIFIED value. 
* Although not having a default element type would be good to prevent omiting future bugs, I made UNSPECIFIED the default because otherwise I'd have to add it to many classes (e.g., test rules, assert classes, broker response classes, etc) where the bpmnElementType isn't relevant. I thought the added complexity and code outweighted the advantage of not having a default.

closes #1839 
