### PR TITLE
chore(broker-core): the input mapping uses the scope variables

### DIFF
--- a/broker-core/src/test/java/io/zeebe/broker/incident/MappingIncidentTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/incident/MappingIncidentTest.java
@@ -215,7 +215,7 @@ public class MappingIncidentTest {
         testClient.receiveFirstIncidentEvent(IncidentIntent.CREATED);
 
     // when
-    testClient.updatePayload(failureEvent.getKey(), PAYLOAD);
+    testClient.updatePayload(failureEvent.getValue().getScopeInstanceKey(), PAYLOAD);
     testClient.resolveIncident(incidentEvent.getKey());
 
     // then
@@ -301,12 +301,14 @@ public class MappingIncidentTest {
     final long workflowInstanceKey = testClient.createWorkflowInstance("process", MSGPACK_PAYLOAD);
 
     // then incident is created
-    final Record failureEvent =
+    final Record<WorkflowInstanceRecordValue> failureEvent =
         testClient.receiveElementInState("service", WorkflowInstanceIntent.ELEMENT_READY);
-    final Record incidentEvent = testClient.receiveFirstIncidentEvent(IncidentIntent.CREATED);
+    final Record<IncidentRecordValue> incidentEvent =
+        testClient.receiveFirstIncidentEvent(IncidentIntent.CREATED);
 
     // when
-    testClient.updatePayload(failureEvent.getKey(), "{'string':{'obj':'test'}}");
+    testClient.updatePayload(
+        failureEvent.getValue().getScopeInstanceKey(), "{'string':{'obj':'test'}}");
     testClient.resolveIncident(incidentEvent.getKey());
 
     // then

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/incident/IncidentTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/incident/IncidentTest.java
@@ -79,13 +79,14 @@ public class IncidentTest {
     // given
     deploy();
 
-    clientRule
-        .getClient()
-        .newCreateInstanceCommand()
-        .bpmnProcessId("process")
-        .latestVersion()
-        .send()
-        .join();
+    final WorkflowInstanceEvent workflowInstanceEvent =
+        clientRule
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId("process")
+            .latestVersion()
+            .send()
+            .join();
 
     final Record<IncidentRecordValue> incident =
         RecordingExporter.incidentRecords(CREATED).getFirst();
@@ -93,7 +94,7 @@ public class IncidentTest {
     // when
     clientRule
         .getClient()
-        .newUpdatePayloadCommand(incident.getValue().getElementInstanceKey())
+        .newUpdatePayloadCommand(workflowInstanceEvent.getWorkflowInstanceKey())
         .payload(PAYLOAD)
         .send()
         .join();
@@ -109,13 +110,14 @@ public class IncidentTest {
     // given
     deploy();
 
-    clientRule
-        .getClient()
-        .newCreateInstanceCommand()
-        .bpmnProcessId("process")
-        .latestVersion()
-        .send()
-        .join();
+    final WorkflowInstanceEvent workflowInstanceEvent =
+        clientRule
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId("process")
+            .latestVersion()
+            .send()
+            .join();
 
     final Record<IncidentRecordValue> incident =
         RecordingExporter.incidentRecords(CREATED).getFirst();
@@ -123,7 +125,7 @@ public class IncidentTest {
     // when
     clientRule
         .getClient()
-        .newUpdatePayloadCommand(incident.getValue().getElementInstanceKey())
+        .newUpdatePayloadCommand(workflowInstanceEvent.getWorkflowInstanceKey())
         .payload(PAYLOAD)
         .send()
         .join();

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerReprocessingTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerReprocessingTest.java
@@ -397,13 +397,14 @@ public class BrokerReprocessingTest {
     // given
     deploy(WORKFLOW_INCIDENT, "incident.bpmn");
 
-    clientRule
-        .getClient()
-        .newCreateInstanceCommand()
-        .bpmnProcessId(PROCESS_ID)
-        .latestVersion()
-        .send()
-        .join();
+    final WorkflowInstanceEvent instanceEvent =
+        clientRule
+            .getClient()
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .send()
+            .join();
 
     assertIncidentCreated();
     assertElementReady("task");
@@ -416,7 +417,7 @@ public class BrokerReprocessingTest {
 
     clientRule
         .getClient()
-        .newUpdatePayloadCommand(incident.getValue().getElementInstanceKey())
+        .newUpdatePayloadCommand(instanceEvent.getWorkflowInstanceKey())
         .payload("{\"foo\":\"bar\"}")
         .send()
         .join();
@@ -450,7 +451,7 @@ public class BrokerReprocessingTest {
 
     clientRule
         .getClient()
-        .newUpdatePayloadCommand(incident.getValue().getElementInstanceKey())
+        .newUpdatePayloadCommand(instanceEvent.getWorkflowInstanceKey())
         .payload("{\"x\":\"y\"}")
         .send()
         .join();
@@ -466,7 +467,7 @@ public class BrokerReprocessingTest {
 
     clientRule
         .getClient()
-        .newUpdatePayloadCommand(incident.getValue().getElementInstanceKey())
+        .newUpdatePayloadCommand(instanceEvent.getWorkflowInstanceKey())
         .payload("{\"foo\":\"bar\"}")
         .send()
         .join();

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/message/MessageCorrelationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/workflow/message/MessageCorrelationTest.java
@@ -30,6 +30,7 @@ import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceSubscriptionIntent;
 import io.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import java.util.Collections;
@@ -115,8 +116,9 @@ public class MessageCorrelationTest {
         .join();
 
     assertThat(
-            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.EVENT_ACTIVATED)
-                .withElementId("catch-event")
+            RecordingExporter.workflowInstanceSubscriptionRecords(
+                    WorkflowInstanceSubscriptionIntent.OPENED)
+                .withMessageName("order canceled")
                 .exists())
         .isTrue();
 


### PR DESCRIPTION
* the input mapping uses the variables of the scope instead of the
record payload
* adjust incident tests since update payload doesn't propagate the
payload yet

closes #1612 
