### PR TITLE
fix(broker): limit JobBatchRecord to 65Kb

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedEventImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedEventImpl.java
@@ -33,6 +33,10 @@ public class TypedEventImpl implements TypedRecord {
     this.value = value;
   }
 
+  public int getMaxValueLength() {
+    return this.rawEvent.getMaxValueLength();
+  }
+
   public long getPosition() {
     return rawEvent.getPosition();
   }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedRecord.java
@@ -19,6 +19,7 @@ package io.zeebe.broker.logstreams.processor;
 
 import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.impl.record.RecordMetadata;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public interface TypedRecord<T extends UnpackedObject> {
 
@@ -27,4 +28,8 @@ public interface TypedRecord<T extends UnpackedObject> {
   RecordMetadata getMetadata();
 
   T getValue();
+
+  default int getMaxValueLength() {
+    throw new NotImplementedException();
+  }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/LoggedEventImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/LoggedEventImpl.java
@@ -30,6 +30,8 @@ import org.agrona.DirectBuffer;
 
 /** Represents the implementation of the logged event. */
 public class LoggedEventImpl implements ReadableFragment, LoggedEvent {
+
+  public static final int MAX_RECORD_SIZE = 0xFFFF;
   protected int fragmentOffset = -1;
   protected int messageOffset = -1;
   protected DirectBuffer buffer;
@@ -106,6 +108,11 @@ public class LoggedEventImpl implements ReadableFragment, LoggedEvent {
   @Override
   public short getMetadataLength() {
     return LogEntryDescriptor.getMetadataLength(buffer, messageOffset);
+  }
+
+  @Override
+  public int getMaxValueLength() {
+    return MAX_RECORD_SIZE - LogEntryDescriptor.headerLength(getMetadataLength());
   }
 
   @Override

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LoggedEvent.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LoggedEvent.java
@@ -53,6 +53,9 @@ public interface LoggedEvent {
   /** @return the length of the event's metadata */
   short getMetadataLength();
 
+  /** @return the maximum possible length of the event's value */
+  int getMaxValueLength();
+
   /**
    * Wraps the given buffer to read the event's metadata
    *


### PR DESCRIPTION
This is a hotfix for the problem of the broker crashing when the job records returned in the JobBatchRecord exceed a limit imposed by the SBE protocol definition. This fix simply limits the jobs returned in a JobBatchRecord such that its size doesn't exceed 65Kb and ignoring the remaining jobs. Issue #1896 improves on this by proposing a way for the gateway to request the remaining jobs that couldn't be included in the broker's response and also an increase of the maximum permitted size in the record payload.

closes #1578 
