### PR TITLE
fix(broker-core): reject empty correlation key

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/workflow/model/validation/ZeebeExpressionValidator.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/model/validation/ZeebeExpressionValidator.java
@@ -39,6 +39,11 @@ public class ZeebeExpressionValidator {
   }
 
   public void validateJsonPath(String jsonPath, ValidationResultCollector resultCollector) {
+    if (jsonPath == null) {
+      resultCollector.addError(0, String.format("JSON path query is empty"));
+      return;
+    }
+
     final JsonPathQueryCompiler queryCompiler = new JsonPathQueryCompiler();
     final JsonPathQuery compiledQuery = queryCompiler.compile(jsonPath);
 

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/model/validation/ZeebeRuntimeValidationTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/model/validation/ZeebeRuntimeValidationTest.java
@@ -163,6 +163,15 @@ public class ZeebeRuntimeValidationTest {
                 ZeebeSubscription.class,
                 "JSON path query is invalid: Unexpected json-path token LITERAL"))
       },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .receiveTask("catch")
+            .message(b -> b.name("message").zeebeCorrelationKey(null))
+            .endEvent()
+            .done(),
+        Arrays.asList(expect(ZeebeSubscription.class, "JSON path query is empty"))
+      },
     };
   }
 


### PR DESCRIPTION
closes #1900 
