### PR TITLE
fix(broker): ensure YAML transformation does not break the msgpack serialization

### DIFF
--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/deployment/DeploymentResource.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/deployment/DeploymentResource.java
@@ -30,9 +30,14 @@ public class DeploymentResource extends UnpackedObject {
   private final StringProperty resourceNameProp = new StringProperty("resourceName", "resource");
 
   public DeploymentResource() {
-    this.declareProperty(resourceProp)
-        .declareProperty(resourceTypeProp)
-        .declareProperty(resourceNameProp);
+    this.declareProperty(resourceTypeProp)
+        .declareProperty(resourceNameProp)
+        // the resource property is updated while iterating over the deployment record
+        // when a YAML workflow is transformed into its XML representation
+        // therefore the resource properties has to be the last one written to the buffer
+        // as otherwise it will potentially override other information
+        // https://github.com/zeebe-io/zeebe/issues/1931
+        .declareProperty(resourceProp);
   }
 
   public DirectBuffer getResource() {


### PR DESCRIPTION
This does not fix the underlying problem of the msgpack implementation but is a quickfix as the YAML transformation seems to be the only place where we change the content of memory view into a msgpack buffer while iterating over it.

To solve the underlying problem we would have to create a memory copy of the modified record before updating the iterator buffer. This would add some overhead which is at the moment not required.


closes #1931 
