### PR TITLE
chore(clients/java): make grpc-netty is a compile dependency

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -60,6 +60,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
@@ -90,12 +95,6 @@
     <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zb-test-util</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-netty</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
closes #1998 
