### PR TITLE
Migrate message catch element test to use class rule

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
             steps {
                 withMaven(jdk: jdkVersion, maven: mavenVersion, mavenSettingsConfig: mavenSettingsConfig) {
                     sh setupGoPath()
-                    sh 'mvn -B -T 1C clean com.mycila:license-maven-plugin:check com.coveo:fmt-maven-plugin:check install -DskipTests -Dskip-zbctl=false'
+                    sh 'mvn -B clean com.mycila:license-maven-plugin:check com.coveo:fmt-maven-plugin:check install -DskipTests -Dskip-zbctl=false'
                 }
 
                 stash name: "zeebe-dist", includes: "dist/target/zeebe-broker/**/*"

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/ZbStreamProcessorService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/ZbStreamProcessorService.java
@@ -169,14 +169,15 @@ public class ZbStreamProcessorService implements Service<ZbStreamProcessorServic
   private BpmnStepProcessor addWorkflowProcessors(
       ZeebeState zeebeState, TypedEventStreamProcessorBuilder typedProcessorBuilder) {
     final SubscriptionCommandSender subscriptionCommandSender =
-        new SubscriptionCommandSender(clusterCfg, subscriptionApiClientInjector.getValue());
+        new SubscriptionCommandSender(subscriptionApiClientInjector.getValue());
     final DueDateTimerChecker timerChecker = new DueDateTimerChecker(zeebeState.getWorkflowState());
     return WorkflowEventProcessors.addWorkflowProcessors(
         typedProcessorBuilder,
         zeebeState,
         subscriptionCommandSender,
         topologyManager,
-        timerChecker);
+        timerChecker,
+        clusterCfg.getPartitionsCount());
   }
 
   public void addDeploymentRelatedProcessorAndServices(
@@ -197,7 +198,9 @@ public class ZbStreamProcessorService implements Service<ZbStreamProcessorServic
           typedProcessorBuilder,
           zeebeState,
           new CatchEventBehavior(
-              zeebeState, new SubscriptionCommandSender(clusterCfg, managementApi)));
+              zeebeState,
+              new SubscriptionCommandSender(managementApi),
+              clusterCfg.getPartitionsCount()));
     } else {
       DeploymentEventProcessors.addDeploymentCreateProcessor(typedProcessorBuilder, workflowState);
     }
@@ -223,7 +226,7 @@ public class ZbStreamProcessorService implements Service<ZbStreamProcessorServic
   private void addMessageProcessors(
       ZeebeState zeebeState, TypedEventStreamProcessorBuilder typedProcessorBuilder) {
     final SubscriptionCommandSender subscriptionCommandSender =
-        new SubscriptionCommandSender(clusterCfg, getSubscriptionApiClientInjector().getValue());
+        new SubscriptionCommandSender(getSubscriptionApiClientInjector().getValue());
     MessageEventProcessors.addMessageProcessors(
         typedProcessorBuilder, zeebeState, subscriptionCommandSender, topologyManager);
   }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
@@ -36,6 +36,7 @@ import io.zeebe.msgpack.query.MsgPackQueryProcessor;
 import io.zeebe.msgpack.query.MsgPackQueryProcessor.QueryResult;
 import io.zeebe.msgpack.query.MsgPackQueryProcessor.QueryResults;
 import io.zeebe.protocol.BpmnElementType;
+import io.zeebe.protocol.impl.SubscriptionUtil;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.zeebe.protocol.intent.TimerIntent;
 import io.zeebe.util.sched.clock.ActorClock;
@@ -48,15 +49,18 @@ public class CatchEventBehavior {
 
   private final ZeebeState state;
   private final SubscriptionCommandSender subscriptionCommandSender;
+  private final int partitionsCount;
 
   private final MsgPackQueryProcessor queryProcessor = new MsgPackQueryProcessor();
   private final WorkflowInstanceSubscription subscription = new WorkflowInstanceSubscription();
   private final TimerRecord timerRecord = new TimerRecord();
   private final Map<DirectBuffer, DirectBuffer> extractedCorrelationKeys = new HashMap<>();
 
-  public CatchEventBehavior(ZeebeState state, SubscriptionCommandSender subscriptionCommandSender) {
+  public CatchEventBehavior(
+      ZeebeState state, SubscriptionCommandSender subscriptionCommandSender, int partitionsCount) {
     this.state = state;
     this.subscriptionCommandSender = subscriptionCommandSender;
+    this.partitionsCount = partitionsCount;
   }
 
   public void unsubscribeFromEvents(long elementInstanceKey, BpmnStepContext<?> context) {
@@ -145,7 +149,10 @@ public class CatchEventBehavior {
     final DirectBuffer messageName = cloneBuffer(message.getMessageName());
     final DirectBuffer correlationKey = extractedKey;
     final boolean closeOnCorrelate = handler.shouldCloseMessageSubscriptionOnCorrelate();
+    final int subscriptionPartitionId =
+        SubscriptionUtil.getSubscriptionPartitionId(correlationKey, partitionsCount);
 
+    subscription.setSubscriptionPartitionId(subscriptionPartitionId);
     subscription.setMessageName(messageName);
     subscription.setElementInstanceKey(elementInstanceKey);
     subscription.setCommandSentTime(ActorClock.currentTimeMillis());
@@ -160,6 +167,7 @@ public class CatchEventBehavior {
         .add(
             () ->
                 sendOpenMessageSubscription(
+                    subscriptionPartitionId,
                     workflowInstanceKey,
                     elementInstanceKey,
                     messageName,
@@ -236,13 +244,19 @@ public class CatchEventBehavior {
   }
 
   private boolean sendOpenMessageSubscription(
+      int subscriptionPartitionId,
       long workflowInstanceKey,
       long elementInstanceKey,
       DirectBuffer messageName,
       DirectBuffer correlationKey,
       boolean closeOnCorrelate) {
     return subscriptionCommandSender.openMessageSubscription(
-        workflowInstanceKey, elementInstanceKey, messageName, correlationKey, closeOnCorrelate);
+        subscriptionPartitionId,
+        workflowInstanceKey,
+        elementInstanceKey,
+        messageName,
+        correlationKey,
+        closeOnCorrelate);
   }
 
   private Map<DirectBuffer, DirectBuffer> extractMessageCorrelationKeys(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowEventProcessors.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowEventProcessors.java
@@ -56,7 +56,8 @@ public class WorkflowEventProcessors {
       ZeebeState zeebeState,
       SubscriptionCommandSender subscriptionCommandSender,
       TopologyManager topologyManager,
-      DueDateTimerChecker timerChecker) {
+      DueDateTimerChecker timerChecker,
+      int partitionsCount) {
     final WorkflowState workflowState = zeebeState.getWorkflowState();
     final WorkflowInstanceSubscriptionState subscriptionState =
         zeebeState.getWorkflowInstanceSubscriptionState();
@@ -67,7 +68,7 @@ public class WorkflowEventProcessors {
     addWorkflowInstanceCommandProcessor(typedProcessorBuilder, workflowEngineState);
 
     final CatchEventBehavior catchEventOutput =
-        new CatchEventBehavior(zeebeState, subscriptionCommandSender);
+        new CatchEventBehavior(zeebeState, subscriptionCommandSender, partitionsCount);
     final BpmnStepProcessor bpmnStepProcessor =
         new BpmnStepProcessor(workflowEngineState, zeebeState, catchEventOutput);
     addBpmnStepProcessor(typedProcessorBuilder, bpmnStepProcessor);

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/PendingWorkflowInstanceSubscriptionChecker.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/PendingWorkflowInstanceSubscriptionChecker.java
@@ -64,6 +64,7 @@ public class PendingWorkflowInstanceSubscriptionChecker implements Runnable {
 
   private boolean sendOpenCommand(WorkflowInstanceSubscription subscription) {
     return commandSender.openMessageSubscription(
+        subscription.getSubscriptionPartitionId(),
         subscription.getWorkflowInstanceKey(),
         subscription.getElementInstanceKey(),
         subscription.getMessageName(),

--- a/broker-core/src/test/java/io/zeebe/broker/incident/IncidentStreamProcessorRule.java
+++ b/broker-core/src/test/java/io/zeebe/broker/incident/IncidentStreamProcessorRule.java
@@ -75,9 +75,8 @@ public class IncidentStreamProcessorRule extends ExternalResource {
     mockTopologyManager = mock(TopologyManager.class);
     mockTimerEventScheduler = mock(DueDateTimerChecker.class);
 
-    when(mockSubscriptionCommandSender.hasPartitionIds()).thenReturn(true);
     when(mockSubscriptionCommandSender.openMessageSubscription(
-            anyLong(), anyLong(), any(), any(), anyBoolean()))
+            anyInt(), anyLong(), anyLong(), any(), any(), anyBoolean()))
         .thenReturn(true);
     when(mockSubscriptionCommandSender.correlateMessageSubscription(
             anyInt(), anyLong(), anyLong(), any()))
@@ -96,7 +95,8 @@ public class IncidentStreamProcessorRule extends ExternalResource {
                   zeebeState,
                   mockSubscriptionCommandSender,
                   mockTopologyManager,
-                  mockTimerEventScheduler);
+                  mockTimerEventScheduler,
+                  1);
 
           IncidentEventProcessors.addProcessors(
               typedEventStreamProcessorBuilder, zeebeState, stepProcessor);

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageCatchElementTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/message/MessageCatchElementTest.java
@@ -20,7 +20,6 @@ package io.zeebe.broker.workflow.message;
 import static io.zeebe.broker.test.EmbeddedBrokerConfigurator.setPartitionCount;
 import static io.zeebe.broker.workflow.WorkflowAssert.assertMessageSubscription;
 import static io.zeebe.broker.workflow.WorkflowAssert.assertWorkflowSubscription;
-import static io.zeebe.broker.workflow.gateway.ParallelGatewayStreamProcessorTest.PROCESS_ID;
 import static io.zeebe.test.util.MsgPackUtil.asMsgPack;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,10 +38,12 @@ import io.zeebe.protocol.intent.MessageSubscriptionIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceSubscriptionIntent;
 import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
-import io.zeebe.test.broker.protocol.clientapi.PartitionTestClient;
 import io.zeebe.test.util.record.RecordingExporter;
-import org.agrona.DirectBuffer;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.UUID;
 import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -53,54 +54,74 @@ import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
 public class MessageCatchElementTest {
-  public EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule(setPartitionCount(3));
-  public ClientApiRule apiRule = new ClientApiRule(brokerRule::getClientAddress);
-  @Rule public RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(apiRule);
 
+  private static final int PARTITION_COUNT = 3;
+
+  private static final String ELEMENT_ID = "receive-message";
+  private static final String CORRELATION_VARIABLE = "orderId";
+  private static final String MESSAGE_NAME = "order canceled";
+  private static final String SEQUENCE_FLOW_ID = "to-end";
+
+  private static final String CATCH_EVENT_WORKFLOW_PROCESS_ID = "catchEventWorkflow";
   private static final BpmnModelInstance CATCH_EVENT_WORKFLOW =
-      Bpmn.createExecutableProcess(PROCESS_ID)
+      Bpmn.createExecutableProcess(CATCH_EVENT_WORKFLOW_PROCESS_ID)
           .startEvent()
-          .intermediateCatchEvent("receive-message")
-          .message(m -> m.name("order canceled").zeebeCorrelationKey("$.orderId"))
-          .sequenceFlowId("to-end")
+          .intermediateCatchEvent(ELEMENT_ID)
+          .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKey("$." + CORRELATION_VARIABLE))
+          .sequenceFlowId(SEQUENCE_FLOW_ID)
           .endEvent()
           .done();
 
+  private static final String RECEIVE_TASK_WORKFLOW_PROCESS_ID = "receiveTaskWorkflow";
   private static final BpmnModelInstance RECEIVE_TASK_WORKFLOW =
-      Bpmn.createExecutableProcess(PROCESS_ID)
+      Bpmn.createExecutableProcess(RECEIVE_TASK_WORKFLOW_PROCESS_ID)
           .startEvent()
-          .receiveTask("receive-message")
-          .message(m -> m.name("order canceled").zeebeCorrelationKey("$.orderId"))
-          .sequenceFlowId("to-end")
+          .receiveTask(ELEMENT_ID)
+          .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKey("$." + CORRELATION_VARIABLE))
+          .sequenceFlowId(SEQUENCE_FLOW_ID)
           .endEvent()
           .done();
 
+  private static final String BOUNDARY_EVENT_WORKFLOW_PROCESS_ID = "boundaryEventWorkflow";
   private static final BpmnModelInstance BOUNDARY_EVENT_WORKFLOW =
-      Bpmn.createExecutableProcess(PROCESS_ID)
+      Bpmn.createExecutableProcess(BOUNDARY_EVENT_WORKFLOW_PROCESS_ID)
           .startEvent()
-          .serviceTask("receive-message", b -> b.zeebeTaskType("type"))
+          .serviceTask(ELEMENT_ID, b -> b.zeebeTaskType("type"))
           .boundaryEvent()
-          .message(m -> m.name("order canceled").zeebeCorrelationKey("$.orderId"))
-          .sequenceFlowId("to-end")
+          .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKey("$." + CORRELATION_VARIABLE))
+          .sequenceFlowId(SEQUENCE_FLOW_ID)
           .endEvent()
           .done();
 
+  private static final String NON_INT_BOUNDARY_EVENT_WORKFLOW_PROCESS_ID =
+      "nonIntBoundaryEventWorkflow";
   private static final BpmnModelInstance NON_INT_BOUNDARY_EVENT_WORKFLOW =
-      Bpmn.createExecutableProcess(PROCESS_ID)
+      Bpmn.createExecutableProcess(NON_INT_BOUNDARY_EVENT_WORKFLOW_PROCESS_ID)
           .startEvent()
-          .serviceTask("receive-message", b -> b.zeebeTaskType("type"))
+          .serviceTask(ELEMENT_ID, b -> b.zeebeTaskType("type"))
           .boundaryEvent("event")
           .cancelActivity(false)
-          .message(m -> m.name("order canceled").zeebeCorrelationKey("$.orderId"))
-          .sequenceFlowId("to-end")
+          .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKey("$." + CORRELATION_VARIABLE))
+          .sequenceFlowId(SEQUENCE_FLOW_ID)
           .endEvent()
           .done();
+
+  public static EmbeddedBrokerRule brokerRule =
+      new EmbeddedBrokerRule(setPartitionCount(PARTITION_COUNT));
+  public static ClientApiRule apiRule =
+      new ClientApiRule(0, PARTITION_COUNT, brokerRule::getClientAddress);
+
+  @ClassRule public static RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(apiRule);
+
+  @Rule
+  public RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
 
   @Parameter(0)
   public String elementType;
 
   @Parameter(1)
-  public BpmnModelInstance workflow;
+  public String bpmnProcessId;
 
   @Parameter(2)
   public WorkflowInstanceIntent enteredState;
@@ -116,28 +137,28 @@ public class MessageCatchElementTest {
     return new Object[][] {
       {
         "intermediate message catch event",
-        CATCH_EVENT_WORKFLOW,
+        CATCH_EVENT_WORKFLOW_PROCESS_ID,
         WorkflowInstanceIntent.ELEMENT_ACTIVATED,
         WorkflowInstanceIntent.ELEMENT_COMPLETED,
-        "receive-message"
+        ELEMENT_ID
       },
       {
         "receive task",
-        RECEIVE_TASK_WORKFLOW,
+        RECEIVE_TASK_WORKFLOW_PROCESS_ID,
         WorkflowInstanceIntent.ELEMENT_ACTIVATED,
         WorkflowInstanceIntent.ELEMENT_COMPLETED,
-        "receive-message"
+        ELEMENT_ID
       },
       {
         "int boundary event",
-        BOUNDARY_EVENT_WORKFLOW,
+        BOUNDARY_EVENT_WORKFLOW_PROCESS_ID,
         WorkflowInstanceIntent.ELEMENT_ACTIVATED,
         WorkflowInstanceIntent.ELEMENT_TERMINATED,
-        "receive-message"
+        ELEMENT_ID
       },
       {
         "non int boundary event",
-        NON_INT_BOUNDARY_EVENT_WORKFLOW,
+        NON_INT_BOUNDARY_EVENT_WORKFLOW_PROCESS_ID,
         WorkflowInstanceIntent.ELEMENT_ACTIVATED,
         WorkflowInstanceIntent.ELEMENT_COMPLETED,
         "event"
@@ -145,50 +166,56 @@ public class MessageCatchElementTest {
     };
   }
 
-  protected PartitionTestClient testClient;
+  private String correlationKey;
+  private long workflowInstanceKey;
+
+  @BeforeClass
+  public static void awaitCluster() {
+    apiRule.waitForPartition(PARTITION_COUNT);
+
+    deploy(CATCH_EVENT_WORKFLOW);
+    deploy(RECEIVE_TASK_WORKFLOW);
+    deploy(BOUNDARY_EVENT_WORKFLOW);
+    deploy(NON_INT_BOUNDARY_EVENT_WORKFLOW);
+  }
+
+  private static void deploy(BpmnModelInstance modelInstance) {
+    final long deploymentKey = apiRule.deployWorkflow(modelInstance);
+    RecordingExporter.deploymentRecords(DeploymentIntent.DISTRIBUTED)
+        .withKey(deploymentKey)
+        .await();
+  }
 
   @Before
   public void init() {
-    apiRule.waitForPartition(3);
-    testClient = apiRule.partitionClient();
-    final long deploymentKey = testClient.deploy(workflow);
-
-    testClient.receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentKey);
-    apiRule.partitionClient(1).receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentKey);
-    apiRule.partitionClient(2).receiveFirstDeploymentEvent(DeploymentIntent.CREATED, deploymentKey);
+    correlationKey = UUID.randomUUID().toString();
+    workflowInstanceKey =
+        apiRule.createWorkflowInstance(bpmnProcessId, asMsgPack("orderId", correlationKey));
   }
 
   @Test
   public void shouldOpenMessageSubscription() {
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
-
     final Record<WorkflowInstanceRecordValue> catchEventEntered =
-        testClient.receiveElementInState("receive-message", enteredState);
+        getFirstElementRecord(enteredState);
 
     final Record<MessageSubscriptionRecordValue> messageSubscription =
-        RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED).getFirst();
+        getFirstMessageSubscriptionRecord(MessageSubscriptionIntent.OPENED);
+
     assertThat(messageSubscription.getMetadata().getValueType())
         .isEqualTo(ValueType.MESSAGE_SUBSCRIPTION);
     assertThat(messageSubscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
 
     assertMessageSubscription(
-        workflowInstanceKey, "order-123", catchEventEntered, messageSubscription);
+        workflowInstanceKey, correlationKey, catchEventEntered, messageSubscription);
   }
 
   @Test
   public void shouldOpenWorkflowInstanceSubscription() {
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
-
     final Record<WorkflowInstanceRecordValue> catchEventEntered =
-        testClient.receiveElementInState("receive-message", enteredState);
+        getFirstElementRecord(enteredState);
 
     final Record<WorkflowInstanceSubscriptionRecordValue> workflowInstanceSubscription =
-        testClient
-            .receiveWorkflowInstanceSubscriptions()
-            .withIntent(WorkflowInstanceSubscriptionIntent.OPENED)
-            .getFirst();
+        getFirstWorkflowInstanceSubscriptionRecord(WorkflowInstanceSubscriptionIntent.OPENED);
 
     assertThat(workflowInstanceSubscription.getMetadata().getValueType())
         .isEqualTo(ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION);
@@ -202,22 +229,15 @@ public class MessageCatchElementTest {
   @Test
   public void shouldCorrelateWorkflowInstanceSubscription() {
     // given
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
-
     final Record<WorkflowInstanceRecordValue> catchEventEntered =
-        testClient.receiveElementInState("receive-message", enteredState);
+        getFirstElementRecord(enteredState);
 
     // when
-    final DirectBuffer messagePayload = asMsgPack("foo", "bar");
-    testClient.publishMessage("order canceled", "order-123", messagePayload);
+    apiRule.publishMessage(MESSAGE_NAME, correlationKey, asMsgPack("foo", "bar"));
 
     // then
     final Record<WorkflowInstanceSubscriptionRecordValue> subscription =
-        testClient
-            .receiveWorkflowInstanceSubscriptions()
-            .withIntent(WorkflowInstanceSubscriptionIntent.CORRELATED)
-            .getFirst();
+        getFirstWorkflowInstanceSubscriptionRecord(WorkflowInstanceSubscriptionIntent.CORRELATED);
 
     assertThat(subscription.getMetadata().getValueType())
         .isEqualTo(ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION);
@@ -230,21 +250,15 @@ public class MessageCatchElementTest {
   @Test
   public void shouldCorrelateMessageSubscription() {
     // given
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
-
     final Record<WorkflowInstanceRecordValue> catchEventEntered =
-        testClient.receiveElementInState("receive-message", enteredState);
+        getFirstElementRecord(enteredState);
 
     // when
-    testClient.publishMessage("order canceled", "order-123", asMsgPack("foo", "bar"));
+    apiRule.publishMessage(MESSAGE_NAME, correlationKey, asMsgPack("foo", "bar"));
 
     // then
     final Record<MessageSubscriptionRecordValue> subscription =
-        testClient
-            .receiveMessageSubscriptions()
-            .withIntent(MessageSubscriptionIntent.CORRELATED)
-            .getFirst();
+        getFirstMessageSubscriptionRecord(MessageSubscriptionIntent.CORRELATED);
 
     assertThat(subscription.getMetadata().getValueType()).isEqualTo(ValueType.MESSAGE_SUBSCRIPTION);
     assertThat(subscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
@@ -255,79 +269,97 @@ public class MessageCatchElementTest {
   @Test
   public void shouldCloseMessageSubscription() {
     // given
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
-
     final Record<WorkflowInstanceRecordValue> catchEventEntered =
-        testClient.receiveElementInState("receive-message", enteredState);
+        getFirstElementRecord(enteredState);
+
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .await();
 
     // when
-    testClient.cancelWorkflowInstance(workflowInstanceKey);
+    apiRule.cancelWorkflowInstance(workflowInstanceKey);
 
     // then
     final Record<MessageSubscriptionRecordValue> messageSubscription =
-        RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CLOSED).getFirst();
+        getFirstMessageSubscriptionRecord(MessageSubscriptionIntent.CLOSED);
 
     assertThat(messageSubscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
 
     Assertions.assertThat(messageSubscription.getValue())
         .hasWorkflowInstanceKey(workflowInstanceKey)
         .hasElementInstanceKey(catchEventEntered.getKey())
-        .hasMessageName("order canceled")
+        .hasMessageName(MESSAGE_NAME)
         .hasCorrelationKey("");
   }
 
   @Test
   public void shouldCloseWorkflowInstanceSubscription() {
-
-    final long workflowInstanceKey =
-        testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
-
+    // given
     final Record<WorkflowInstanceRecordValue> catchEventEntered =
-        testClient.receiveElementInState("receive-message", enteredState);
+        getFirstElementRecord(enteredState);
 
-    testClient.cancelWorkflowInstance(workflowInstanceKey);
+    // when
+    apiRule.cancelWorkflowInstance(workflowInstanceKey);
 
+    // then
     final Record<WorkflowInstanceSubscriptionRecordValue> subscription =
-        RecordingExporter.workflowInstanceSubscriptionRecords(
-                WorkflowInstanceSubscriptionIntent.CLOSED)
-            .getFirst();
+        getFirstWorkflowInstanceSubscriptionRecord(WorkflowInstanceSubscriptionIntent.CLOSED);
 
     assertThat(subscription.getMetadata().getRecordType()).isEqualTo(RecordType.EVENT);
 
     Assertions.assertThat(subscription.getValue())
         .hasWorkflowInstanceKey(workflowInstanceKey)
         .hasElementInstanceKey(catchEventEntered.getKey())
-        .hasMessageName("order canceled");
+        .hasMessageName(MESSAGE_NAME);
   }
 
   @Test
   public void shouldCorrelateMessageAndContinue() {
     // given
-    testClient.createWorkflowInstance(PROCESS_ID, asMsgPack("orderId", "order-123"));
+    RecordingExporter.workflowInstanceSubscriptionRecords(WorkflowInstanceSubscriptionIntent.OPENED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withMessageName(MESSAGE_NAME)
+        .await();
 
     // when
-    assertThat(
-            testClient
-                .receiveWorkflowInstanceSubscriptions()
-                .withMessageName("order canceled")
-                .withIntent(WorkflowInstanceSubscriptionIntent.OPENED)
-                .limit(1)
-                .getFirst())
-        .isNotNull();
-    testClient.publishMessage("order canceled", "order-123");
+    apiRule.publishMessage(MESSAGE_NAME, correlationKey);
 
     // then
     assertThat(
             RecordingExporter.workflowInstanceRecords(continueState)
+                .withWorkflowInstanceKey(workflowInstanceKey)
                 .withElementId(continuedElementId)
                 .exists())
         .isTrue();
 
     assertThat(
             RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN)
-                .withElementId("to-end")
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .withElementId(SEQUENCE_FLOW_ID)
                 .exists())
         .isTrue();
+  }
+
+  private Record<WorkflowInstanceRecordValue> getFirstElementRecord(WorkflowInstanceIntent intent) {
+    return RecordingExporter.workflowInstanceRecords(intent)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementId(ELEMENT_ID)
+        .getFirst();
+  }
+
+  private Record<MessageSubscriptionRecordValue> getFirstMessageSubscriptionRecord(
+      MessageSubscriptionIntent intent) {
+    return RecordingExporter.messageSubscriptionRecords(intent)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withMessageName(MESSAGE_NAME)
+        .getFirst();
+  }
+
+  private Record<WorkflowInstanceSubscriptionRecordValue>
+      getFirstWorkflowInstanceSubscriptionRecord(WorkflowInstanceSubscriptionIntent intent) {
+    return RecordingExporter.workflowInstanceSubscriptionRecords(intent)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withMessageName(MESSAGE_NAME)
+        .getFirst();
   }
 }

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorRule.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorRule.java
@@ -88,9 +88,8 @@ public class WorkflowInstanceStreamProcessorRule extends ExternalResource {
     mockSubscriptionCommandSender = mock(SubscriptionCommandSender.class);
     mockTopologyManager = mock(TopologyManager.class);
 
-    when(mockSubscriptionCommandSender.hasPartitionIds()).thenReturn(true);
     when(mockSubscriptionCommandSender.openMessageSubscription(
-            anyLong(), anyLong(), any(), any(), anyBoolean()))
+            anyInt(), anyLong(), anyLong(), any(), any(), anyBoolean()))
         .thenReturn(true);
     when(mockSubscriptionCommandSender.correlateMessageSubscription(
             anyInt(), anyLong(), anyLong(), any()))
@@ -109,7 +108,8 @@ public class WorkflowInstanceStreamProcessorRule extends ExternalResource {
                   zeebeState,
                   mockSubscriptionCommandSender,
                   mockTopologyManager,
-                  new DueDateTimerChecker(workflowState));
+                  new DueDateTimerChecker(workflowState),
+                  1);
 
               JobEventProcessors.addJobProcessors(typedEventStreamProcessorBuilder, zeebeState);
 

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorTest.java
@@ -373,6 +373,7 @@ public class WorkflowInstanceStreamProcessorTest {
     // then
     verify(streamProcessorRule.getMockSubscriptionCommandSender(), timeout(5_000).times(2))
         .openMessageSubscription(
+            0,
             catchEvent.getValue().getWorkflowInstanceKey(),
             catchEvent.getKey(),
             wrapString("order canceled"),

--- a/protocol-test-util/pom.xml
+++ b/protocol-test-util/pom.xml
@@ -20,6 +20,11 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
+      <artifactId>zb-protocol-impl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
       <artifactId>zb-transport</artifactId>
     </dependency>
 

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/ClientApiRule.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/ClientApiRule.java
@@ -17,24 +17,41 @@ package io.zeebe.test.broker.protocol.clientapi;
 
 import static io.zeebe.test.util.TestUtil.doRepeatedly;
 import static io.zeebe.test.util.TestUtil.waitUntil;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.clientapi.ControlMessageType;
+import io.zeebe.protocol.clientapi.RecordType;
 import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.impl.SubscriptionUtil;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.zeebe.protocol.impl.record.value.deployment.ResourceType;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.intent.DeploymentIntent;
 import io.zeebe.protocol.intent.JobBatchIntent;
 import io.zeebe.protocol.intent.JobIntent;
+import io.zeebe.protocol.intent.MessageIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import io.zeebe.test.broker.protocol.MsgPackHelper;
+import io.zeebe.test.util.MsgPackUtil;
 import io.zeebe.transport.ClientTransport;
 import io.zeebe.transport.SocketAddress;
 import io.zeebe.transport.Transports;
+import io.zeebe.util.buffer.BufferUtil;
 import io.zeebe.util.sched.ActorScheduler;
 import io.zeebe.util.sched.clock.ControlledActorClock;
+import java.io.ByteArrayOutputStream;
+import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.agrona.DirectBuffer;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.junit.rules.ExternalResource;
 
@@ -47,6 +64,8 @@ public class ClientApiRule extends ExternalResource {
 
   protected final int nodeId;
   protected final Supplier<SocketAddress> brokerAddressSupplier;
+  protected final int partitionCount;
+  protected int nextPartitionId = 0;
 
   protected MsgPackHelper msgPackHelper;
 
@@ -58,12 +77,17 @@ public class ClientApiRule extends ExternalResource {
   protected int defaultPartitionId = -1;
 
   public ClientApiRule(final Supplier<SocketAddress> brokerAddressSupplier) {
-    this.nodeId = 0;
-    this.brokerAddressSupplier = brokerAddressSupplier;
+    this(0, brokerAddressSupplier);
   }
 
   public ClientApiRule(final int nodeId, final Supplier<SocketAddress> brokerAddressSupplier) {
+    this(nodeId, 1, brokerAddressSupplier);
+  }
+
+  public ClientApiRule(
+      int nodeId, int partitionCount, Supplier<SocketAddress> brokerAddressSupplier) {
     this.nodeId = nodeId;
+    this.partitionCount = partitionCount;
     this.brokerAddressSupplier = brokerAddressSupplier;
   }
 
@@ -102,7 +126,6 @@ public class ClientApiRule extends ExternalResource {
         .partitionId(defaultPartitionId);
   }
 
-  /** targets the default partition by default */
   public ExecuteCommandRequestBuilder createCmdRequest(int partition) {
     return new ExecuteCommandRequestBuilder(transport.getOutput(), nodeId, msgPackHelper)
         .partitionId(partition);
@@ -190,5 +213,95 @@ public class ClientApiRule extends ExternalResource {
 
   public ControlledActorClock getClock() {
     return controlledActorClock;
+  }
+
+  /** @return the workflow key */
+  public long deployWorkflow(BpmnModelInstance modelInstance) {
+    final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+    Bpmn.writeModelToStream(outStream, modelInstance);
+    final byte[] resource = outStream.toByteArray();
+
+    final Map<String, Object> deploymentResource = new HashMap<>();
+    deploymentResource.put("resource", resource);
+    deploymentResource.put("resourceType", ResourceType.BPMN_XML.name());
+    deploymentResource.put("resourceName", "testProcess.bpmn");
+
+    final ExecuteCommandResponse commandResponse =
+        createCmdRequest()
+            .partitionId(Protocol.DEPLOYMENT_PARTITION)
+            .type(ValueType.DEPLOYMENT, DeploymentIntent.CREATE)
+            .command()
+            .put(DeploymentRecord.RESOURCES, Collections.singletonList(deploymentResource))
+            .done()
+            .sendAndAwait();
+
+    return commandResponse.getKey();
+  }
+
+  public long createWorkflowInstance(String bpmnProcessId, DirectBuffer payload) {
+    final ExecuteCommandResponse response =
+        createCmdRequest()
+            .partitionId(nextPartitionId())
+            .type(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.CREATE)
+            .command()
+            .put(WorkflowInstanceRecord.PROP_WORKFLOW_BPMN_PROCESS_ID, bpmnProcessId)
+            .put(WorkflowInstanceRecord.PROP_WORKFLOW_VERSION, -1)
+            .put(WorkflowInstanceRecord.PROP_WORKFLOW_PAYLOAD, BufferUtil.bufferAsArray(payload))
+            .done()
+            .sendAndAwait();
+
+    assertThat(response.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.ELEMENT_ACTIVATING);
+
+    return response.getKey();
+  }
+
+  public void publishMessage(String messageName, String correlationKey) {
+    publishMessage(messageName, correlationKey, MsgPackUtil.asMsgPack("{}"));
+  }
+
+  public void publishMessage(String messageName, String correlationKey, DirectBuffer payload) {
+    publishMessage(messageName, correlationKey, payload, Duration.ofHours(1).toMillis());
+  }
+
+  public void publishMessage(
+      String messageName, String correlationKey, DirectBuffer payload, long ttl) {
+    final ExecuteCommandResponse response =
+        createCmdRequest()
+            .partitionId(partitionForCorrelationKey(correlationKey))
+            .type(ValueType.MESSAGE, MessageIntent.PUBLISH)
+            .command()
+            .put("name", messageName)
+            .put("correlationKey", correlationKey)
+            .put("timeToLive", ttl)
+            .put("payload", BufferUtil.bufferAsArray(payload))
+            .done()
+            .sendAndAwait();
+
+    assertThat(response.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(response.getIntent()).isEqualTo(MessageIntent.PUBLISHED);
+  }
+
+  public void cancelWorkflowInstance(long workflowInstanceKey) {
+    final ExecuteCommandResponse response =
+        createCmdRequest()
+            .partitionId(Protocol.decodePartitionId(workflowInstanceKey))
+            .type(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.CANCEL)
+            .key(workflowInstanceKey)
+            .command()
+            .done()
+            .sendAndAwait();
+
+    assertThat(response.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(response.getIntent()).isEqualTo(WorkflowInstanceIntent.ELEMENT_TERMINATING);
+  }
+
+  protected int nextPartitionId() {
+    return nextPartitionId++ % partitionCount;
+  }
+
+  protected int partitionForCorrelationKey(String correlationKey) {
+    return SubscriptionUtil.getSubscriptionPartitionId(
+        BufferUtil.wrapString(correlationKey), partitionCount);
   }
 }

--- a/test-util/src/main/java/io/zeebe/test/util/stream/StreamWrapper.java
+++ b/test-util/src/main/java/io/zeebe/test/util/stream/StreamWrapper.java
@@ -70,6 +70,12 @@ public abstract class StreamWrapper<T, S extends StreamWrapper<T, S>> implements
     return wrappedStream.findFirst().isPresent();
   }
 
+  public void await() {
+    if (!exists()) {
+      throw new StreamWrapperException();
+    }
+  }
+
   public T getFirst() {
     return wrappedStream.findFirst().orElseThrow(StreamWrapperException::new);
   }


### PR DESCRIPTION
- add await helper method to wait for records in exporter stream
- use EmbeddedBrokerRule as ClassRule in MessageCatchElementTest, reduces the runtime on my local machine from 22 seconds to 2 seconds
- replaces partition test client usage with ClientApiRule usage, as events have to be send to correct partitions, these tests only worked before as the static correlation key `order-123` hashed to partition id 0
- send close message subscription command to correct partition

related to #2014
closes #2024
