### PR TITLE
Broker skips record on processing exception

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessor.java
@@ -182,7 +182,7 @@ public class ExporterStreamProcessor implements StreamProcessor {
     }
 
     @Override
-    public void updateState() {
+    public void processEvent() {
       for (final ExporterPosition position : record.getPositions()) {
         state.setPositionIfGreater(position.getId(), position.getPosition());
       }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/NoopEventProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/NoopEventProcessor.java
@@ -34,7 +34,4 @@ public class NoopEventProcessor implements EventProcessor {
   public long writeEvent(LogStreamRecordWriter writer) {
     return 0;
   }
-
-  @Override
-  public void updateState() {}
 }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedEventImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedEventImpl.java
@@ -59,4 +59,9 @@ public class TypedEventImpl implements TypedRecord {
   public UnpackedObject getValue() {
     return value;
   }
+
+  @Override
+  public String toString() {
+    return "TypedEventImpl{" + "metadata=" + metadata + ", value=" + value + '}';
+  }
 }

--- a/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
@@ -482,6 +482,16 @@ public class TestStreams {
       return this;
     }
 
+    public FluentLogWriter requestId(final long requestId) {
+      this.metadata.requestId(requestId);
+      return this;
+    }
+
+    public FluentLogWriter requestStreamId(final int requestStreamId) {
+      this.metadata.requestStreamId(requestStreamId);
+      return this;
+    }
+
     public FluentLogWriter recordType(final RecordType recordType) {
       this.metadata.recordType(recordType);
       return this;

--- a/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
@@ -436,19 +436,13 @@ public class TestStreams {
 
         @Override
         public long writeEvent(final LogStreamRecordWriter writer) {
-          return actualProcessor != null ? actualProcessor.writeEvent(writer) : 0;
-        }
-
-        @Override
-        public void updateState() {
-          if (actualProcessor != null) {
-            actualProcessor.updateState();
-          }
+          final long result = actualProcessor != null ? actualProcessor.writeEvent(writer) : 0;
 
           if (blockAfterCurrentEvent) {
             blockAfterCurrentEvent = false;
             context.suspendController();
           }
+          return result;
         }
       };
     }

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/EventProcessor.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/EventProcessor.java
@@ -50,9 +50,4 @@ public interface EventProcessor {
   default long writeEvent(LogStreamRecordWriter writer) {
     return 0;
   }
-
-  /** (Optional) Update the internal state of the processor based on the processed event. */
-  default void updateState() {
-    // do nothing
-  }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
@@ -366,8 +366,6 @@ public class StreamProcessorController extends Actor {
 
   private void updateState() {
     try {
-      eventProcessor.updateState();
-
       lastSuccessfulProcessedEventPosition = currentEvent.getPosition();
 
       final boolean hasWrittenEvent = eventPosition > 0;

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
@@ -32,8 +32,7 @@ public class RecordingStreamProcessor implements StreamProcessor {
   private final EventProcessor eventProcessor =
       spy(
           new EventProcessor() {
-            @Override
-            public void updateState() {
+            public void processEvent() {
               processedEvents.incrementAndGet();
             };
           });

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
@@ -122,7 +122,6 @@ public class StreamProcessorControllerTest {
     inOrder.verify(eventProcessor, times(1)).processEvent();
     inOrder.verify(eventProcessor, times(1)).executeSideEffects();
     inOrder.verify(eventProcessor, times(1)).writeEvent(any());
-    inOrder.verify(eventProcessor, times(1)).updateState();
 
     inOrder.verify(streamProcessor, times(1)).onClose();
     inOrder.verify(snapshotController, times(1)).takeSnapshot(any());
@@ -156,7 +155,6 @@ public class StreamProcessorControllerTest {
     inOrder.verify(eventProcessor, times(1)).processEvent();
     inOrder.verify(eventProcessor, times(3)).executeSideEffects();
     inOrder.verify(eventProcessor, times(1)).writeEvent(any());
-    inOrder.verify(eventProcessor, times(1)).updateState();
     inOrder.verifyNoMoreInteractions();
   }
 
@@ -171,7 +169,6 @@ public class StreamProcessorControllerTest {
     inOrder.verify(eventProcessor, times(1)).processEvent();
     inOrder.verify(eventProcessor, times(1)).executeSideEffects();
     inOrder.verify(eventProcessor, times(3)).writeEvent(any());
-    inOrder.verify(eventProcessor, times(1)).updateState();
     inOrder.verifyNoMoreInteractions();
   }
 
@@ -522,7 +519,6 @@ public class StreamProcessorControllerTest {
     inOrder.verify(eventProcessor, times(1)).processEvent();
     inOrder.verify(eventProcessor, times(1)).executeSideEffects();
     inOrder.verify(eventProcessor, times(1)).writeEvent(any());
-    inOrder.verify(eventProcessor, times(1)).updateState();
     inOrder.verifyNoMoreInteractions();
   }
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorReprocessingTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorReprocessingTest.java
@@ -156,7 +156,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(2)).processEvent();
     verify(eventProcessor, times(1)).executeSideEffects();
     verify(eventProcessor, times(1)).writeEvent(any());
-    verify(eventProcessor, times(2)).updateState();
   }
 
   @Test
@@ -179,7 +178,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(2)).processEvent();
     verify(eventProcessor, times(2)).executeSideEffects();
     verify(eventProcessor, times(2)).writeEvent(any());
-    verify(eventProcessor, times(2)).updateState();
   }
 
   @Test
@@ -204,7 +202,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(3)).processEvent();
     verify(eventProcessor, times(1)).executeSideEffects();
     verify(eventProcessor, times(1)).writeEvent(any());
-    verify(eventProcessor, times(3)).updateState();
   }
 
   @Test
@@ -228,7 +225,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(3)).processEvent();
     verify(eventProcessor, times(1)).executeSideEffects();
     verify(eventProcessor, times(1)).writeEvent(any());
-    verify(eventProcessor, times(3)).updateState();
   }
 
   @Test
@@ -253,7 +249,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(2)).processEvent();
     verify(eventProcessor, times(1)).executeSideEffects();
     verify(eventProcessor, times(1)).writeEvent(any());
-    verify(eventProcessor, times(2)).updateState();
   }
 
   @Test
@@ -279,7 +274,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(2)).processEvent();
     verify(eventProcessor, times(1)).executeSideEffects();
     verify(eventProcessor, times(1)).writeEvent(any());
-    verify(eventProcessor, times(2)).updateState();
   }
 
   @Test
@@ -332,7 +326,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(2)).processEvent();
     verify(eventProcessor, times(2)).executeSideEffects();
     verify(eventProcessor, times(2)).writeEvent(any());
-    verify(eventProcessor, times(2)).updateState();
   }
 
   @Test

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -66,6 +66,7 @@
       <validValue name="NOT_FOUND">1</validValue>
       <validValue name="ALREADY_EXISTS">2</validValue>
       <validValue name="INVALID_STATE">3</validValue>
+      <validValue name="PROCESSING_ERROR">4</validValue>
     </enum>
   </types>
 


### PR DESCRIPTION
StreamProcessorController skips the corresponding record when an exception was thrown in`#onEvent` or `#processEvent`. The `#updateState` method was removed, since it is not used.

When an exception/error appears on the command processing in the `TypedStreamProcessor` 
a corresponding command rejection is send and the exception is rethrown such that the `StreamProcessorController` can skip this record. 

An follow up issue #2028 was created to clean up the state, when an exception appears on processing an event. Since we hope/expect that not so many exceptions/errors appear this issue has no high priority, but should be done somehow in the near future.

I was not sure whether we should also write an command rejection on the log or not, currently I think it makes no real difference (?).

related to #1988
