### PR TITLE
chore(logstreams): remove update state method

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterStreamProcessor.java
@@ -182,7 +182,7 @@ public class ExporterStreamProcessor implements StreamProcessor {
     }
 
     @Override
-    public void updateState() {
+    public void processEvent() {
       for (final ExporterPosition position : record.getPositions()) {
         state.setPositionIfGreater(position.getId(), position.getPosition());
       }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/NoopEventProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/NoopEventProcessor.java
@@ -34,7 +34,4 @@ public class NoopEventProcessor implements EventProcessor {
   public long writeEvent(LogStreamRecordWriter writer) {
     return 0;
   }
-
-  @Override
-  public void updateState() {}
 }

--- a/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
@@ -436,19 +436,13 @@ public class TestStreams {
 
         @Override
         public long writeEvent(final LogStreamRecordWriter writer) {
-          return actualProcessor != null ? actualProcessor.writeEvent(writer) : 0;
-        }
-
-        @Override
-        public void updateState() {
-          if (actualProcessor != null) {
-            actualProcessor.updateState();
-          }
+          final long result = actualProcessor != null ? actualProcessor.writeEvent(writer) : 0;
 
           if (blockAfterCurrentEvent) {
             blockAfterCurrentEvent = false;
             context.suspendController();
           }
+          return result;
         }
       };
     }

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/EventProcessor.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/EventProcessor.java
@@ -50,9 +50,4 @@ public interface EventProcessor {
   default long writeEvent(LogStreamRecordWriter writer) {
     return 0;
   }
-
-  /** (Optional) Update the internal state of the processor based on the processed event. */
-  default void updateState() {
-    // do nothing
-  }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
@@ -242,7 +242,6 @@ public class StreamProcessorController extends Actor {
         if (eventProcessor != null) {
           // don't execute side effects or write events
           eventProcessor.processEvent();
-          eventProcessor.updateState();
           onRecordReprocessed(currentEvent);
         } else {
           onRecordReprocessed(currentEvent);
@@ -366,8 +365,6 @@ public class StreamProcessorController extends Actor {
 
   private void updateState() {
     try {
-      eventProcessor.updateState();
-
       lastSuccessfulProcessedEventPosition = currentEvent.getPosition();
 
       final boolean hasWrittenEvent = eventPosition > 0;

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
@@ -32,8 +32,7 @@ public class RecordingStreamProcessor implements StreamProcessor {
   private final EventProcessor eventProcessor =
       spy(
           new EventProcessor() {
-            @Override
-            public void updateState() {
+            public void processEvent() {
               processedEvents.incrementAndGet();
             };
           });

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
@@ -122,7 +122,6 @@ public class StreamProcessorControllerTest {
     inOrder.verify(eventProcessor, times(1)).processEvent();
     inOrder.verify(eventProcessor, times(1)).executeSideEffects();
     inOrder.verify(eventProcessor, times(1)).writeEvent(any());
-    inOrder.verify(eventProcessor, times(1)).updateState();
 
     inOrder.verify(streamProcessor, times(1)).onClose();
     inOrder.verify(snapshotController, times(1)).takeSnapshot(any());
@@ -156,7 +155,6 @@ public class StreamProcessorControllerTest {
     inOrder.verify(eventProcessor, times(1)).processEvent();
     inOrder.verify(eventProcessor, times(3)).executeSideEffects();
     inOrder.verify(eventProcessor, times(1)).writeEvent(any());
-    inOrder.verify(eventProcessor, times(1)).updateState();
     inOrder.verifyNoMoreInteractions();
   }
 
@@ -171,7 +169,6 @@ public class StreamProcessorControllerTest {
     inOrder.verify(eventProcessor, times(1)).processEvent();
     inOrder.verify(eventProcessor, times(1)).executeSideEffects();
     inOrder.verify(eventProcessor, times(3)).writeEvent(any());
-    inOrder.verify(eventProcessor, times(1)).updateState();
     inOrder.verifyNoMoreInteractions();
   }
 
@@ -505,24 +502,6 @@ public class StreamProcessorControllerTest {
     inOrder.verify(eventProcessor, times(1)).processEvent();
     inOrder.verify(eventProcessor, times(1)).executeSideEffects();
     inOrder.verify(eventProcessor, times(1)).writeEvent(any());
-    inOrder.verifyNoMoreInteractions();
-  }
-
-  @Test
-  public void shouldFailOnUpdateState() {
-    // when
-    changeMockInActorContext(
-        () -> doThrow(new RuntimeException("expected")).when(eventProcessor).updateState());
-    writer.writeEvents(2, EVENT_1, true);
-
-    // then
-    waitUntil(() -> streamProcessorController.isFailed());
-
-    final InOrder inOrder = inOrder(eventProcessor);
-    inOrder.verify(eventProcessor, times(1)).processEvent();
-    inOrder.verify(eventProcessor, times(1)).executeSideEffects();
-    inOrder.verify(eventProcessor, times(1)).writeEvent(any());
-    inOrder.verify(eventProcessor, times(1)).updateState();
     inOrder.verifyNoMoreInteractions();
   }
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorReprocessingTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorReprocessingTest.java
@@ -156,7 +156,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(2)).processEvent();
     verify(eventProcessor, times(1)).executeSideEffects();
     verify(eventProcessor, times(1)).writeEvent(any());
-    verify(eventProcessor, times(2)).updateState();
   }
 
   @Test
@@ -179,7 +178,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(2)).processEvent();
     verify(eventProcessor, times(2)).executeSideEffects();
     verify(eventProcessor, times(2)).writeEvent(any());
-    verify(eventProcessor, times(2)).updateState();
   }
 
   @Test
@@ -204,7 +202,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(3)).processEvent();
     verify(eventProcessor, times(1)).executeSideEffects();
     verify(eventProcessor, times(1)).writeEvent(any());
-    verify(eventProcessor, times(3)).updateState();
   }
 
   @Test
@@ -228,7 +225,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(3)).processEvent();
     verify(eventProcessor, times(1)).executeSideEffects();
     verify(eventProcessor, times(1)).writeEvent(any());
-    verify(eventProcessor, times(3)).updateState();
   }
 
   @Test
@@ -253,7 +249,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(2)).processEvent();
     verify(eventProcessor, times(1)).executeSideEffects();
     verify(eventProcessor, times(1)).writeEvent(any());
-    verify(eventProcessor, times(2)).updateState();
   }
 
   @Test
@@ -279,7 +274,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(2)).processEvent();
     verify(eventProcessor, times(1)).executeSideEffects();
     verify(eventProcessor, times(1)).writeEvent(any());
-    verify(eventProcessor, times(2)).updateState();
   }
 
   @Test
@@ -332,7 +326,6 @@ public class StreamProcessorReprocessingTest {
     verify(eventProcessor, times(2)).processEvent();
     verify(eventProcessor, times(2)).executeSideEffects();
     verify(eventProcessor, times(2)).writeEvent(any());
-    verify(eventProcessor, times(2)).updateState();
   }
 
   @Test


### PR DESCRIPTION
Removes the `EventProcessor#updatestate` method as it is not used. 
Is a preparation for the coming PR's. See related issue for explanations #1988 