### PR TITLE
chore(broker): add new VariableDocumentRecord

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/VariableDocumentRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/VariableDocumentRecordValueImpl.java
@@ -1,0 +1,93 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value;
+
+import io.zeebe.broker.exporter.ExporterObjectMapper;
+import io.zeebe.broker.exporter.record.RecordValueImpl;
+import io.zeebe.exporter.record.value.VariableDocumentRecordValue;
+import io.zeebe.protocol.VariableDocumentUpdateSemantic;
+import java.util.Map;
+import java.util.Objects;
+
+public class VariableDocumentRecordValueImpl extends RecordValueImpl
+    implements VariableDocumentRecordValue {
+
+  private final long scopeKey;
+  private final VariableDocumentUpdateSemantic updateSemantics;
+  private final Map<String, Object> document;
+
+  public VariableDocumentRecordValueImpl(
+      ExporterObjectMapper objectMapper,
+      long scopeKey,
+      VariableDocumentUpdateSemantic updateSemantics,
+      Map<String, Object> document) {
+    super(objectMapper);
+    this.scopeKey = scopeKey;
+    this.updateSemantics = updateSemantics;
+    this.document = document;
+  }
+
+  @Override
+  public long getScopeKey() {
+    return scopeKey;
+  }
+
+  @Override
+  public VariableDocumentUpdateSemantic getUpdateSemantics() {
+    return updateSemantics;
+  }
+
+  @Override
+  public Map<String, Object> getDocument() {
+    return document;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof VariableDocumentRecordValueImpl)) {
+      return false;
+    }
+
+    final VariableDocumentRecordValueImpl that = (VariableDocumentRecordValueImpl) o;
+    return getScopeKey() == that.getScopeKey()
+        && getUpdateSemantics() == that.getUpdateSemantics()
+        && Objects.equals(getDocument(), that.getDocument());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getScopeKey(), getUpdateSemantics(), getDocument());
+  }
+
+  @Override
+  public String toString() {
+    return "VariableDocumentRecordValueImpl{"
+        + "scopeKey="
+        + scopeKey
+        + ", updateSemantics="
+        + updateSemantics
+        + ", document="
+        + document
+        + "} "
+        + super.toString();
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
@@ -26,6 +26,7 @@ import io.zeebe.broker.exporter.record.value.MessageStartEventSubscriptionRecord
 import io.zeebe.broker.exporter.record.value.MessageSubscriptionRecordValueImpl;
 import io.zeebe.broker.exporter.record.value.RaftRecordValueImpl;
 import io.zeebe.broker.exporter.record.value.TimerRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.VariableDocumentRecordValueImpl;
 import io.zeebe.broker.exporter.record.value.VariableRecordValueImpl;
 import io.zeebe.broker.exporter.record.value.WorkflowInstanceRecordValueImpl;
 import io.zeebe.broker.exporter.record.value.WorkflowInstanceSubscriptionRecordValueImpl;
@@ -45,6 +46,7 @@ import io.zeebe.exporter.record.value.JobRecordValue;
 import io.zeebe.exporter.record.value.MessageRecordValue;
 import io.zeebe.exporter.record.value.MessageSubscriptionRecordValue;
 import io.zeebe.exporter.record.value.RaftRecordValue;
+import io.zeebe.exporter.record.value.VariableDocumentRecordValue;
 import io.zeebe.exporter.record.value.VariableRecordValue;
 import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
 import io.zeebe.exporter.record.value.WorkflowInstanceSubscriptionRecordValue;
@@ -63,6 +65,7 @@ import io.zeebe.protocol.impl.record.value.job.JobHeaders;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.zeebe.protocol.impl.record.value.variable.VariableRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.raft.event.RaftConfigurationEvent;
@@ -126,6 +129,9 @@ public class ExporterRecordMapper {
         break;
       case VARIABLE:
         valueSupplier = this::ofVariableRecord;
+        break;
+      case VARIABLE_DOCUMENT:
+        valueSupplier = this::ofVariableDocumentRecord;
         break;
       default:
         return null;
@@ -359,7 +365,16 @@ public class ExporterRecordMapper {
         record.getWorkflowInstanceKey());
   }
 
-  // UTILS
+  private VariableDocumentRecordValue ofVariableDocumentRecord(LoggedEvent event) {
+    final VariableDocumentRecord record = new VariableDocumentRecord();
+    event.readValue(record);
+
+    return new VariableDocumentRecordValueImpl(
+        objectMapper,
+        record.getScopeKey(),
+        record.getUpdateSemantics(),
+        asMsgPackMap(record.getDocument()));
+  }
 
   private byte[] asByteArray(final DirectBuffer buffer) {
     return BufferUtil.bufferAsArray(buffer);

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamEnvironment.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamEnvironment.java
@@ -30,6 +30,7 @@ import io.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.zeebe.protocol.impl.record.value.variable.VariableRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.transport.ServerOutput;
@@ -56,6 +57,7 @@ public class TypedStreamEnvironment {
     EVENT_REGISTRY.put(ValueType.JOB_BATCH, JobBatchRecord.class);
     EVENT_REGISTRY.put(ValueType.TIMER, TimerRecord.class);
     EVENT_REGISTRY.put(ValueType.VARIABLE, VariableRecord.class);
+    EVENT_REGISTRY.put(ValueType.VARIABLE_DOCUMENT, VariableDocumentRecord.class);
   }
 
   private TypedStreamReader reader;

--- a/broker-core/src/main/java/io/zeebe/broker/transport/clientapi/ClientApiMessageHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/transport/clientapi/ClientApiMessageHandler.java
@@ -37,6 +37,7 @@ import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.Intent;
 import io.zeebe.transport.RemoteAddress;
@@ -87,6 +88,7 @@ public class ClientApiMessageHandler implements ServerMessageHandler, ServerRequ
     recordsByType.put(ValueType.MESSAGE, new MessageRecord());
     recordsByType.put(ValueType.JOB_BATCH, new JobBatchRecord());
     recordsByType.put(ValueType.INCIDENT, new IncidentRecord());
+    recordsByType.put(ValueType.VARIABLE_DOCUMENT, new VariableDocumentRecord());
   }
 
   private boolean handleExecuteCommandRequest(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/variable/UpdateVariableDocumentProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/variable/UpdateVariableDocumentProcessor.java
@@ -1,0 +1,100 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow.processor.variable;
+
+import io.zeebe.broker.Loggers;
+import io.zeebe.broker.logstreams.processor.CommandProcessor;
+import io.zeebe.broker.logstreams.processor.TypedRecord;
+import io.zeebe.broker.workflow.state.ElementInstance;
+import io.zeebe.broker.workflow.state.ElementInstanceState;
+import io.zeebe.broker.workflow.state.VariablesState;
+import io.zeebe.msgpack.spec.MsgpackReaderException;
+import io.zeebe.protocol.VariableDocumentUpdateSemantic;
+import io.zeebe.protocol.clientapi.RejectionType;
+import io.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
+import io.zeebe.protocol.intent.VariableDocumentIntent;
+import org.agrona.DirectBuffer;
+
+public class UpdateVariableDocumentProcessor implements CommandProcessor<VariableDocumentRecord> {
+  private final ElementInstanceState elementInstanceState;
+  private final VariablesState variablesState;
+
+  public UpdateVariableDocumentProcessor(
+      ElementInstanceState elementInstanceState, VariablesState variablesState) {
+    this.elementInstanceState = elementInstanceState;
+    this.variablesState = variablesState;
+  }
+
+  @Override
+  public void onCommand(
+      TypedRecord<VariableDocumentRecord> command,
+      CommandControl<VariableDocumentRecord> controller) {
+    final VariableDocumentRecord record = command.getValue();
+
+    final ElementInstance scope = elementInstanceState.getInstance(record.getScopeKey());
+    if (scope == null) {
+      controller.reject(
+          RejectionType.NOT_FOUND,
+          String.format(
+              "Expected to update variables for element with key '%d', but no such element was found",
+              record.getScopeKey()));
+
+      return;
+    }
+
+    if (mergeDocument(record, controller)) {
+      controller.accept(VariableDocumentIntent.UPDATED, record);
+    }
+  }
+
+  private boolean mergeDocument(
+      VariableDocumentRecord record, CommandControl<VariableDocumentRecord> controller) {
+    try {
+      getUpdateOperation(record.getUpdateSemantics())
+          .apply(record.getScopeKey(), record.getDocument());
+      return true;
+    } catch (MsgpackReaderException e) {
+      Loggers.WORKFLOW_PROCESSOR_LOGGER.error(
+          "Expected to merge variable document for scope '{}', but its document could not be read",
+          record.getScopeKey(),
+          e);
+
+      controller.reject(
+          RejectionType.INVALID_ARGUMENT,
+          String.format(
+              "Expected document to be valid msgpack, but it could not be read: '%s'",
+              e.getMessage()));
+      return false;
+    }
+  }
+
+  private UpdateOperation getUpdateOperation(VariableDocumentUpdateSemantic updateSemantics) {
+    switch (updateSemantics) {
+      case LOCAL:
+        return variablesState::setVariablesLocalFromDocument;
+      case PROPAGATE:
+      default:
+        return variablesState::setVariablesFromDocument;
+    }
+  }
+
+  @FunctionalInterface
+  private interface UpdateOperation {
+    void apply(long scopeKey, DirectBuffer document);
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/util/MockTypedRecord.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/MockTypedRecord.java
@@ -1,0 +1,64 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.util;
+
+import io.zeebe.broker.logstreams.processor.TypedRecord;
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+
+public class MockTypedRecord<T extends UnpackedObject> implements TypedRecord<T> {
+
+  private long key;
+  private RecordMetadata metadata;
+  private T value;
+
+  public MockTypedRecord() {}
+
+  public MockTypedRecord(long key, RecordMetadata metadata, T value) {
+    this.key = key;
+    this.metadata = metadata;
+    this.value = value;
+  }
+
+  @Override
+  public long getKey() {
+    return key;
+  }
+
+  public void setKey(long key) {
+    this.key = key;
+  }
+
+  @Override
+  public RecordMetadata getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(RecordMetadata metadata) {
+    this.metadata = metadata;
+  }
+
+  @Override
+  public T getValue() {
+    return value;
+  }
+
+  public void setValue(T value) {
+    this.value = value;
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
@@ -53,6 +53,7 @@ import io.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.zeebe.protocol.impl.record.value.variable.VariableRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.Intent;
@@ -90,6 +91,7 @@ public class TestStreams {
     VALUE_TYPES.put(JobBatchRecord.class, ValueType.JOB_BATCH);
     VALUE_TYPES.put(TimerRecord.class, ValueType.TIMER);
     VALUE_TYPES.put(VariableRecord.class, ValueType.VARIABLE);
+    VALUE_TYPES.put(VariableDocumentRecord.class, ValueType.VARIABLE_DOCUMENT);
 
     VALUE_TYPES.put(UnpackedObject.class, ValueType.NOOP);
   }

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/variable/UpdateVariableDocumentProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/variable/UpdateVariableDocumentProcessorTest.java
@@ -1,0 +1,202 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow.processor.variable;
+
+import static io.zeebe.msgpack.value.DocumentValue.EMPTY_DOCUMENT;
+import static io.zeebe.test.util.MsgPackUtil.asMsgPack;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.zeebe.broker.logstreams.processor.CommandProcessor.CommandControl;
+import io.zeebe.broker.logstreams.processor.TypedRecord;
+import io.zeebe.broker.util.MockTypedRecord;
+import io.zeebe.broker.util.ZeebeStateRule;
+import io.zeebe.broker.workflow.state.ElementInstance;
+import io.zeebe.broker.workflow.state.ElementInstanceState;
+import io.zeebe.broker.workflow.state.VariablesState;
+import io.zeebe.msgpack.spec.MsgpackReaderException;
+import io.zeebe.protocol.VariableDocumentUpdateSemantic;
+import io.zeebe.protocol.clientapi.RecordType;
+import io.zeebe.protocol.clientapi.RejectionType;
+import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.intent.VariableDocumentIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+@SuppressWarnings("unchecked")
+public class UpdateVariableDocumentProcessorTest {
+  @Rule public ZeebeStateRule zeebeStateRule = new ZeebeStateRule();
+
+  private final CommandControl<VariableDocumentRecord> controller = mock(CommandControl.class);
+  private ElementInstanceState elementInstanceState;
+  private VariablesState variablesState;
+  private UpdateVariableDocumentProcessor processor;
+
+  @Before
+  public void setUp() {
+    elementInstanceState =
+        zeebeStateRule.getZeebeState().getWorkflowState().getElementInstanceState();
+    variablesState =
+        spy(
+            zeebeStateRule
+                .getZeebeState()
+                .getWorkflowState()
+                .getElementInstanceState()
+                .getVariablesState());
+    processor = new UpdateVariableDocumentProcessor(elementInstanceState, variablesState);
+  }
+
+  @After
+  public void tearDown() {
+    reset(variablesState, controller);
+  }
+
+  @Test
+  public void shouldRejectIfNoScopeFound() {
+    // given
+    final TypedRecord<VariableDocumentRecord> command = newCommand();
+
+    // when
+    processor.onCommand(command, controller);
+
+    // then
+    assertRejection(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldRejectOnMsgpackReadError() {
+    // given
+    final ElementInstance instance = newElementInstance();
+    final TypedRecord<VariableDocumentRecord> command = newCommand();
+    command
+        .getValue()
+        .setScopeKey(instance.getKey())
+        .setUpdateSemantics(VariableDocumentUpdateSemantic.PROPAGATE)
+        .setDocument(new UnsafeBuffer());
+
+    // when
+    doThrow(MsgpackReaderException.class)
+        .when(variablesState)
+        .setVariablesFromDocument(anyLong(), any());
+    processor.onCommand(command, controller);
+
+    // then
+    assertRejection(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldApplyPropagateUpdateOperation() {
+    // given
+    final DirectBuffer document = asMsgPack("a", 1);
+    final ElementInstance instance = newElementInstance();
+    final TypedRecord<VariableDocumentRecord> command = newCommand();
+    command
+        .getValue()
+        .setScopeKey(instance.getKey())
+        .setUpdateSemantics(VariableDocumentUpdateSemantic.PROPAGATE)
+        .setDocument(document);
+
+    // when
+    processor.onCommand(command, controller);
+
+    // then
+    verify(variablesState, times(1)).setVariablesFromDocument(instance.getKey(), document);
+  }
+
+  @Test
+  public void shouldApplyLocalUpdateOperation() {
+    // given
+    final DirectBuffer document = asMsgPack("a", 1);
+    final ElementInstance instance = newElementInstance();
+    final TypedRecord<VariableDocumentRecord> command = newCommand();
+    command
+        .getValue()
+        .setScopeKey(instance.getKey())
+        .setUpdateSemantics(VariableDocumentUpdateSemantic.LOCAL)
+        .setDocument(document);
+
+    // when
+    processor.onCommand(command, controller);
+
+    // then
+    verify(variablesState, times(1)).setVariablesLocalFromDocument(instance.getKey(), document);
+  }
+
+  @Test
+  public void shouldPublishUpdatedRecord() {
+    // given
+    final DirectBuffer document = asMsgPack("a", 1);
+    final ElementInstance instance = newElementInstance();
+    final TypedRecord<VariableDocumentRecord> command = newCommand();
+    command
+        .getValue()
+        .setScopeKey(instance.getKey())
+        .setUpdateSemantics(VariableDocumentUpdateSemantic.PROPAGATE)
+        .setDocument(document);
+
+    // when
+    processor.onCommand(command, controller);
+
+    // then
+    assertAccepted(command);
+  }
+
+  private ElementInstance newElementInstance() {
+    return elementInstanceState.newInstance(
+        1, new WorkflowInstanceRecord(), WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+  }
+
+  private void assertAccepted(TypedRecord<VariableDocumentRecord> command) {
+    verify(controller, times(1)).accept(VariableDocumentIntent.UPDATED, command.getValue());
+    verify(controller, never()).reject(any(), anyString());
+  }
+
+  private void assertRejection(RejectionType type) {
+    verify(controller, never()).accept(any(), any());
+    verify(controller, times(1)).reject(eq(type), anyString());
+  }
+
+  private TypedRecord<VariableDocumentRecord> newCommand() {
+    final RecordMetadata metadata =
+        new RecordMetadata()
+            .intent(VariableDocumentIntent.UPDATE)
+            .valueType(ValueType.VARIABLE_DOCUMENT)
+            .recordType(RecordType.COMMAND);
+    final VariableDocumentRecord value =
+        new VariableDocumentRecord().setScopeKey(-1).setDocument(EMPTY_DOCUMENT);
+
+    return new MockTypedRecord<>(-1, metadata, value);
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/variables/UpdateVariableDocumentTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/variables/UpdateVariableDocumentTest.java
@@ -1,0 +1,144 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow.variables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.BpmnElementType;
+import io.zeebe.protocol.VariableDocumentUpdateSemantic;
+import io.zeebe.protocol.intent.VariableDocumentIntent;
+import io.zeebe.protocol.intent.VariableIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
+import io.zeebe.test.broker.protocol.clientapi.PartitionTestClient;
+import io.zeebe.test.util.collection.Maps;
+import io.zeebe.test.util.record.RecordStream;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class UpdateVariableDocumentTest {
+
+  public static EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule();
+  public static ClientApiRule apiRule = new ClientApiRule(brokerRule::getClientAddress);
+  @ClassRule public static RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(apiRule);
+
+  @Rule
+  public RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private PartitionTestClient testClient;
+
+  @Before
+  public void init() {
+    testClient = apiRule.partitionClient();
+  }
+
+  @Test
+  public void shouldProduceCorrectSequenceOfEvents() {
+    // given
+    final String processId = "process";
+    final String taskId = "task";
+    final String type = UUID.randomUUID().toString();
+    final BpmnModelInstance process = newWorkflow(processId, taskId, type);
+    final Map<String, Object> document = Maps.of(entry("x", 2), entry("foo", "bar"));
+
+    // when
+    testClient.deploy(process);
+    final long workflowInstanceKey = testClient.createWorkflowInstance(processId, "{'x': 1}");
+    final Record<WorkflowInstanceRecordValue> activatedEvent = waitForActivityActivatedEvent();
+    testClient.updateVariables(
+        activatedEvent.getKey(), VariableDocumentUpdateSemantic.PROPAGATE, document);
+    testClient.completeJobOfType(type);
+
+    // then
+    final long completedPosition =
+        getWorkflowInstanceCompletedPosition(processId, workflowInstanceKey);
+    final Supplier<RecordStream> recordsSupplier =
+        () -> RecordingExporter.records().between(activatedEvent.getPosition(), completedPosition);
+
+    assertVariableRecordsProduced(workflowInstanceKey, recordsSupplier);
+    assertVariableDocumentEventProduced(document, activatedEvent, recordsSupplier);
+  }
+
+  private void assertVariableDocumentEventProduced(
+      Map<String, Object> document,
+      Record<WorkflowInstanceRecordValue> activatedEvent,
+      Supplier<RecordStream> records) {
+    assertThat(
+            records
+                .get()
+                .variableDocumentRecords()
+                .withIntent(VariableDocumentIntent.UPDATED)
+                .withScopeKey(activatedEvent.getKey())
+                .withUpdateSemantics(VariableDocumentUpdateSemantic.PROPAGATE)
+                .withDocument(document)
+                .getFirst())
+        .isNotNull();
+  }
+
+  private void assertVariableRecordsProduced(
+      long workflowInstanceKey, Supplier<RecordStream> records) {
+    assertThat(records.get().variableRecords().withWorkflowInstanceKey(workflowInstanceKey))
+        .hasSize(2)
+        .extracting(
+            r ->
+                tuple(
+                    r.getMetadata().getIntent(),
+                    r.getValue().getScopeKey(),
+                    r.getValue().getName(),
+                    r.getValue().getValue()))
+        .contains(
+            tuple(VariableIntent.CREATED, workflowInstanceKey, "foo", "\"bar\""),
+            tuple(VariableIntent.UPDATED, workflowInstanceKey, "x", "2"));
+  }
+
+  private BpmnModelInstance newWorkflow(String processId, String taskId, String type) {
+    return Bpmn.createExecutableProcess(processId)
+        .startEvent()
+        .serviceTask(taskId, b -> b.zeebeTaskType(type))
+        .endEvent()
+        .done();
+  }
+
+  private long getWorkflowInstanceCompletedPosition(String processId, long workflowInstanceKey) {
+    return testClient
+        .receiveElementInState(
+            workflowInstanceKey, processId, WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .getPosition();
+  }
+
+  private Record<WorkflowInstanceRecordValue> waitForActivityActivatedEvent() {
+    return testClient.receiveFirstWorkflowInstanceEvent(
+        WorkflowInstanceIntent.ELEMENT_ACTIVATED, BpmnElementType.SERVICE_TASK);
+  }
+}

--- a/exporter-api/src/main/java/io/zeebe/exporter/record/value/VariableDocumentRecordValue.java
+++ b/exporter-api/src/main/java/io/zeebe/exporter/record/value/VariableDocumentRecordValue.java
@@ -13,19 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.msgpack.spec;
+package io.zeebe.exporter.record.value;
 
-public class MsgPackHelper {
-  public static final byte[] EMTPY_OBJECT = new byte[] {MsgPackCodes.FIXMAP_PREFIX};
-  public static final byte[] EMPTY_ARRAY = new byte[] {MsgPackCodes.FIXARRAY_PREFIX};
-  public static final byte[] NIL = new byte[] {MsgPackCodes.NIL};
+import io.zeebe.exporter.record.RecordValue;
+import io.zeebe.protocol.VariableDocumentUpdateSemantic;
+import java.util.Map;
 
-  static long ensurePositive(long size) {
-    if (size < 0) {
-      throw new MsgpackException(
-          "Negative value should not be accepted by size value and unsigned 64bit integer");
-    } else {
-      return size;
-    }
-  }
+public interface VariableDocumentRecordValue extends RecordValue {
+  long getScopeKey();
+
+  VariableDocumentUpdateSemantic getUpdateSemantics();
+
+  Map<String, Object> getDocument();
 }

--- a/json-path/src/test/java/io/zeebe/msgpack/query/MsgPackTraverserTest.java
+++ b/json-path/src/test/java/io/zeebe/msgpack/query/MsgPackTraverserTest.java
@@ -252,7 +252,7 @@ public class MsgPackTraverserTest {
     // then
     assertThat(success).isFalse();
     assertThat(traverser.getInvalidPosition()).isEqualTo(encodedValidMessage.capacity());
-    assertThat(traverser.getErrorMessage()).isEqualTo("Unsupported token format");
+    assertThat(traverser.getErrorMessage()).isEqualTo("Unknown token format 'EXTENSION'");
   }
 
   protected static class MapKeyFilter implements MsgPackFilter {

--- a/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgPackWriter.java
+++ b/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgPackWriter.java
@@ -42,7 +42,6 @@ import static io.zeebe.msgpack.spec.MsgPackCodes.UINT16;
 import static io.zeebe.msgpack.spec.MsgPackCodes.UINT32;
 import static io.zeebe.msgpack.spec.MsgPackCodes.UINT64;
 import static io.zeebe.msgpack.spec.MsgPackCodes.UINT8;
-import static io.zeebe.msgpack.spec.MsgPackHelper.ensurePositive;
 import static org.agrona.BitUtil.SIZE_OF_BYTE;
 import static org.agrona.BitUtil.SIZE_OF_DOUBLE;
 import static org.agrona.BitUtil.SIZE_OF_FLOAT;
@@ -93,6 +92,7 @@ public class MsgPackWriter {
 
   public MsgPackWriter writeMapHeader(int size) {
     ensurePositive(size);
+
     if (size < (1 << 4)) {
       buffer.putByte(offset, (byte) (FIXMAP_PREFIX | size));
       ++offset;
@@ -427,5 +427,13 @@ public class MsgPackWriter {
     }
 
     return headerLength + len;
+  }
+
+  private void ensurePositive(long size) {
+    try {
+      MsgPackHelper.ensurePositive(size);
+    } catch (MsgpackException e) {
+      throw new MsgpackWriterException(e);
+    }
   }
 }

--- a/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgpackException.java
+++ b/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgpackException.java
@@ -15,17 +15,23 @@
  */
 package io.zeebe.msgpack.spec;
 
-public class MsgPackHelper {
-  public static final byte[] EMTPY_OBJECT = new byte[] {MsgPackCodes.FIXMAP_PREFIX};
-  public static final byte[] EMPTY_ARRAY = new byte[] {MsgPackCodes.FIXARRAY_PREFIX};
-  public static final byte[] NIL = new byte[] {MsgPackCodes.NIL};
+public class MsgpackException extends RuntimeException {
+  private static final long serialVersionUID = -514144849724509376L;
 
-  static long ensurePositive(long size) {
-    if (size < 0) {
-      throw new MsgpackException(
-          "Negative value should not be accepted by size value and unsigned 64bit integer");
-    } else {
-      return size;
-    }
+  public MsgpackException(String message) {
+    super(message);
+  }
+
+  public MsgpackException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public MsgpackException(Throwable cause) {
+    super(cause);
+  }
+
+  public MsgpackException(
+      String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
   }
 }

--- a/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgpackReaderException.java
+++ b/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgpackReaderException.java
@@ -15,17 +15,23 @@
  */
 package io.zeebe.msgpack.spec;
 
-public class MsgPackHelper {
-  public static final byte[] EMTPY_OBJECT = new byte[] {MsgPackCodes.FIXMAP_PREFIX};
-  public static final byte[] EMPTY_ARRAY = new byte[] {MsgPackCodes.FIXARRAY_PREFIX};
-  public static final byte[] NIL = new byte[] {MsgPackCodes.NIL};
+public class MsgpackReaderException extends MsgpackException {
+  private static final long serialVersionUID = 4909839783275678015L;
 
-  static long ensurePositive(long size) {
-    if (size < 0) {
-      throw new MsgpackException(
-          "Negative value should not be accepted by size value and unsigned 64bit integer");
-    } else {
-      return size;
-    }
+  public MsgpackReaderException(String message) {
+    super(message);
+  }
+
+  public MsgpackReaderException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public MsgpackReaderException(Throwable cause) {
+    super(cause);
+  }
+
+  public MsgpackReaderException(
+      String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
   }
 }

--- a/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgpackWriterException.java
+++ b/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgpackWriterException.java
@@ -15,17 +15,23 @@
  */
 package io.zeebe.msgpack.spec;
 
-public class MsgPackHelper {
-  public static final byte[] EMTPY_OBJECT = new byte[] {MsgPackCodes.FIXMAP_PREFIX};
-  public static final byte[] EMPTY_ARRAY = new byte[] {MsgPackCodes.FIXARRAY_PREFIX};
-  public static final byte[] NIL = new byte[] {MsgPackCodes.NIL};
+public class MsgpackWriterException extends MsgpackException {
+  private static final long serialVersionUID = 6432471139267928246L;
 
-  static long ensurePositive(long size) {
-    if (size < 0) {
-      throw new MsgpackException(
-          "Negative value should not be accepted by size value and unsigned 64bit integer");
-    } else {
-      return size;
-    }
+  public MsgpackWriterException(String message) {
+    super(message);
+  }
+
+  public MsgpackWriterException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public MsgpackWriterException(Throwable cause) {
+    super(cause);
+  }
+
+  public MsgpackWriterException(
+      String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
   }
 }

--- a/msgpack-core/src/test/java/io/zeebe/msgpack/spec/MsgPackReadingBoundaryCheckingExceptionTest.java
+++ b/msgpack-core/src/test/java/io/zeebe/msgpack/spec/MsgPackReadingBoundaryCheckingExceptionTest.java
@@ -38,7 +38,7 @@ import org.junit.runners.Parameterized.Parameters;
 public class MsgPackReadingBoundaryCheckingExceptionTest {
 
   protected static final String NEGATIVE_BUF_SIZE_EXCEPTION_MSG =
-      "Negative value should not be accepted by size value and unsiged 64bit integer";
+      "Negative value should not be accepted by size value and unsigned 64bit integer";
 
   @Rule public ExpectedException exception = ExpectedException.none();
 
@@ -99,7 +99,7 @@ public class MsgPackReadingBoundaryCheckingExceptionTest {
     reader.wrap(negativeTestingBuf, 0, negativeTestingBuf.capacity());
 
     // then
-    exception.expect(RuntimeException.class);
+    exception.expect(MsgpackReaderException.class);
     exception.expectMessage(NEGATIVE_BUF_SIZE_EXCEPTION_MSG);
 
     // when

--- a/msgpack-core/src/test/java/io/zeebe/msgpack/spec/MsgPackReadingExceptionTest.java
+++ b/msgpack-core/src/test/java/io/zeebe/msgpack/spec/MsgPackReadingExceptionTest.java
@@ -48,7 +48,7 @@ public class MsgPackReadingExceptionTest {
           {String.format(template, "float"), codeUnderTest(MsgPackReader::readFloat)},
           {String.format(template, "map"), codeUnderTest(MsgPackReader::readMapHeader)},
           {String.format(template, "string"), codeUnderTest(MsgPackReader::readStringLength)},
-          {"Unsupported token format", codeUnderTest(MsgPackReader::readToken)}
+          {"Unknown token format 'NEVER_USED'", codeUnderTest(MsgPackReader::readToken)}
         });
   }
 
@@ -71,7 +71,7 @@ public class MsgPackReadingExceptionTest {
     reader.wrap(NEVER_USED_BUF, 0, NEVER_USED_BUF.capacity());
 
     // then
-    exception.expect(RuntimeException.class);
+    exception.expect(MsgpackReaderException.class);
     exception.expectMessage(expectedExceptionMessage);
 
     // when

--- a/msgpack-core/src/test/java/io/zeebe/msgpack/spec/MsgPackWritingExceptionTest.java
+++ b/msgpack-core/src/test/java/io/zeebe/msgpack/spec/MsgPackWritingExceptionTest.java
@@ -35,11 +35,11 @@ public class MsgPackWritingExceptionTest {
   protected static final int WRITE_OFFSET = 123;
   protected MutableDirectBuffer actualValueBuffer = new UnsafeBuffer(new byte[BUFFER_CAPACITY]);
   protected static final String NEGATIVE_BUF_SIZE_EXCEPTION_MSG =
-      "Negative value should not be accepted by size value and unsiged 64bit integer";
+      "Negative value should not be accepted by size value and unsigned 64bit integer";
 
   @Rule public ExpectedException exception = ExpectedException.none();
 
-  @Parameters(name = "{0}")
+  @Parameters
   public static Iterable<Object[]> data() {
     return Arrays.asList(
         new Object[][] {
@@ -68,7 +68,7 @@ public class MsgPackWritingExceptionTest {
     writer.wrap(actualValueBuffer, WRITE_OFFSET);
 
     // then
-    exception.expect(RuntimeException.class);
+    exception.expect(MsgpackWriterException.class);
     exception.expectMessage(expectedExceptionMessage);
 
     // when

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/variable/VariableDocumentRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/variable/VariableDocumentRecord.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.protocol.impl.record.value.variable;
+
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.msgpack.property.DocumentProperty;
+import io.zeebe.msgpack.property.EnumProperty;
+import io.zeebe.msgpack.property.LongProperty;
+import io.zeebe.protocol.VariableDocumentUpdateSemantic;
+import java.util.Objects;
+import org.agrona.DirectBuffer;
+
+public class VariableDocumentRecord extends UnpackedObject {
+  private final LongProperty scopeKeyProperty = new LongProperty("scopeKey");
+  private final EnumProperty<VariableDocumentUpdateSemantic> updateSemanticsProperty =
+      new EnumProperty<>(
+          "updateSemantics",
+          VariableDocumentUpdateSemantic.class,
+          VariableDocumentUpdateSemantic.PROPAGATE);
+  private final DocumentProperty documentProperty = new DocumentProperty("document");
+
+  public VariableDocumentRecord() {
+    this.declareProperty(scopeKeyProperty)
+        .declareProperty(updateSemanticsProperty)
+        .declareProperty(documentProperty);
+  }
+
+  public long getScopeKey() {
+    return scopeKeyProperty.getValue();
+  }
+
+  public VariableDocumentRecord setScopeKey(long scopeKey) {
+    scopeKeyProperty.setValue(scopeKey);
+    return this;
+  }
+
+  public VariableDocumentUpdateSemantic getUpdateSemantics() {
+    return updateSemanticsProperty.getValue();
+  }
+
+  public VariableDocumentRecord setUpdateSemantics(VariableDocumentUpdateSemantic updateSemantics) {
+    updateSemanticsProperty.setValue(updateSemantics);
+    return this;
+  }
+
+  public DirectBuffer getDocument() {
+    return documentProperty.getValue();
+  }
+
+  public VariableDocumentRecord setDocument(DirectBuffer document) {
+    documentProperty.setValue(document);
+    return this;
+  }
+
+  public VariableDocumentRecord wrap(VariableDocumentRecord other) {
+    this.setScopeKey(other.getScopeKey())
+        .setDocument(other.getDocument())
+        .setUpdateSemantics(other.getUpdateSemantics());
+
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof VariableDocumentRecord)) {
+      return false;
+    }
+
+    final VariableDocumentRecord that = (VariableDocumentRecord) o;
+    return Objects.equals(scopeKeyProperty, that.scopeKeyProperty)
+        && Objects.equals(updateSemanticsProperty, that.updateSemanticsProperty)
+        && Objects.equals(documentProperty, that.documentProperty);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(scopeKeyProperty, updateSemanticsProperty, documentProperty);
+  }
+
+  @Override
+  public String toString() {
+    return "VariableDocumentRecord{"
+        + "scopeKey="
+        + getScopeKey()
+        + ", mergeSemantics="
+        + getUpdateSemantics()
+        + ", document="
+        + getDocument()
+        + "} "
+        + super.toString();
+  }
+}

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/PartitionTestClient.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/PartitionTestClient.java
@@ -32,6 +32,7 @@ import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.model.bpmn.builder.ServiceTaskBuilder;
 import io.zeebe.protocol.BpmnElementType;
 import io.zeebe.protocol.Protocol;
+import io.zeebe.protocol.VariableDocumentUpdateSemantic;
 import io.zeebe.protocol.clientapi.RecordType;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.protocol.intent.DeploymentIntent;
@@ -40,6 +41,7 @@ import io.zeebe.protocol.intent.Intent;
 import io.zeebe.protocol.intent.JobIntent;
 import io.zeebe.protocol.intent.MessageIntent;
 import io.zeebe.protocol.intent.TimerIntent;
+import io.zeebe.protocol.intent.VariableDocumentIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import io.zeebe.test.util.MsgPackUtil;
 import io.zeebe.test.util.record.DeploymentRecordStream;
@@ -185,6 +187,23 @@ public class PartitionTestClient {
         .command()
         .done()
         .sendAndAwait();
+  }
+
+  public void updateVariables(
+      long scopeKey, VariableDocumentUpdateSemantic updateSemantics, Map<String, Object> document) {
+    final ExecuteCommandResponse response =
+        apiRule
+            .createCmdRequest()
+            .type(ValueType.VARIABLE_DOCUMENT, VariableDocumentIntent.UPDATE)
+            .command()
+            .put("scopeKey", scopeKey)
+            .put("updateSemantics", updateSemantics)
+            .put("document", MsgPackUtil.asMsgPack(document).byteArray())
+            .done()
+            .sendAndAwait();
+
+    assertThat(response.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(response.getIntent()).isEqualTo(VariableDocumentIntent.UPDATED);
   }
 
   public void updatePayload(final long elementInstanceKey, final String jsonPayload) {

--- a/protocol/src/main/java/io/zeebe/protocol/VariableDocumentUpdateSemantic.java
+++ b/protocol/src/main/java/io/zeebe/protocol/VariableDocumentUpdateSemantic.java
@@ -13,19 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.msgpack.spec;
+package io.zeebe.protocol;
 
-public class MsgPackHelper {
-  public static final byte[] EMTPY_OBJECT = new byte[] {MsgPackCodes.FIXMAP_PREFIX};
-  public static final byte[] EMPTY_ARRAY = new byte[] {MsgPackCodes.FIXARRAY_PREFIX};
-  public static final byte[] NIL = new byte[] {MsgPackCodes.NIL};
-
-  static long ensurePositive(long size) {
-    if (size < 0) {
-      throw new MsgpackException(
-          "Negative value should not be accepted by size value and unsigned 64bit integer");
-    } else {
-      return size;
-    }
-  }
+public enum VariableDocumentUpdateSemantic {
+  LOCAL,
+  PROPAGATE,
 }

--- a/protocol/src/main/java/io/zeebe/protocol/intent/Intent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/Intent.java
@@ -83,6 +83,8 @@ public interface Intent {
         return TimerIntent.from(intent);
       case VARIABLE:
         return VariableIntent.from(intent);
+      case VARIABLE_DOCUMENT:
+        return VariableDocumentIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -124,6 +126,8 @@ public interface Intent {
         return TimerIntent.valueOf(intent);
       case VARIABLE:
         return VariableIntent.valueOf(intent);
+      case VARIABLE_DOCUMENT:
+        return VariableDocumentIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/zeebe/protocol/intent/VariableDocumentIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/VariableDocumentIntent.java
@@ -13,19 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.msgpack.spec;
+package io.zeebe.protocol.intent;
 
-public class MsgPackHelper {
-  public static final byte[] EMTPY_OBJECT = new byte[] {MsgPackCodes.FIXMAP_PREFIX};
-  public static final byte[] EMPTY_ARRAY = new byte[] {MsgPackCodes.FIXARRAY_PREFIX};
-  public static final byte[] NIL = new byte[] {MsgPackCodes.NIL};
+public enum VariableDocumentIntent implements Intent {
+  UPDATE(0),
+  UPDATED(1);
 
-  static long ensurePositive(long size) {
-    if (size < 0) {
-      throw new MsgpackException(
-          "Negative value should not be accepted by size value and unsigned 64bit integer");
-    } else {
-      return size;
+  private short value;
+
+  VariableDocumentIntent(int value) {
+    this((short) value);
+  }
+
+  VariableDocumentIntent(short value) {
+    this.value = value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  public static Intent from(short value) {
+    switch (value) {
+      case 0:
+        return UPDATE;
+      case 1:
+        return UPDATED;
+      default:
+        return Intent.UNKNOWN;
     }
   }
 }

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -46,6 +46,7 @@
       <validValue name="TIMER">15</validValue>
       <validValue name="MESSAGE_START_EVENT_SUBSCRIPTION">16</validValue>
       <validValue name="VARIABLE">17</validValue>
+      <validValue name="VARIABLE_DOCUMENT">18</validValue>
     </enum>
 
     <enum name="ControlMessageType" encodingType="uint8"

--- a/test-util/src/main/java/io/zeebe/test/util/collection/Maps.java
+++ b/test-util/src/main/java/io/zeebe/test/util/collection/Maps.java
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.msgpack.spec;
+package io.zeebe.test.util.collection;
 
-public class MsgPackHelper {
-  public static final byte[] EMTPY_OBJECT = new byte[] {MsgPackCodes.FIXMAP_PREFIX};
-  public static final byte[] EMPTY_ARRAY = new byte[] {MsgPackCodes.FIXARRAY_PREFIX};
-  public static final byte[] NIL = new byte[] {MsgPackCodes.NIL};
+import java.util.HashMap;
+import java.util.Map;
 
-  static long ensurePositive(long size) {
-    if (size < 0) {
-      throw new MsgpackException(
-          "Negative value should not be accepted by size value and unsigned 64bit integer");
-    } else {
-      return size;
+public class Maps {
+  public static <K, V> Map<K, V> of(Map.Entry<K, V>... entries) {
+    final Map<K, V> map = new HashMap<>();
+
+    for (final Map.Entry<K, V> entry : entries) {
+      map.put(entry.getKey(), entry.getValue());
     }
+
+    return map;
   }
 }

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordStream.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordStream.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.test.util.record;
+
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.record.RecordValue;
+import io.zeebe.protocol.clientapi.ValueType;
+import java.util.stream.Stream;
+
+@SuppressWarnings("unchecked")
+public class RecordStream extends ExporterRecordStream<RecordValue, RecordStream> {
+  public RecordStream(Stream<Record<RecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected RecordStream supply(Stream<Record<RecordValue>> wrappedStream) {
+    return new RecordStream(wrappedStream);
+  }
+
+  public RecordStream between(long lowerBoundPosition, long upperBoundPosition) {
+    return limit(r -> r.getPosition() >= upperBoundPosition)
+        .filter(r -> r.getPosition() > lowerBoundPosition);
+  }
+
+  public VariableDocumentRecordStream variableDocumentRecords() {
+    return new VariableDocumentRecordStream(
+        filter(r -> r.getMetadata().getValueType() == ValueType.VARIABLE_DOCUMENT)
+            .map(r -> (Record) r));
+  }
+
+  public VariableRecordStream variableRecords() {
+    return new VariableRecordStream(
+        filter(r -> r.getMetadata().getValueType() == ValueType.VARIABLE).map(r -> (Record) r));
+  }
+}

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
@@ -26,6 +26,7 @@ import io.zeebe.exporter.record.value.MessageStartEventSubscriptionRecordValue;
 import io.zeebe.exporter.record.value.MessageSubscriptionRecordValue;
 import io.zeebe.exporter.record.value.RaftRecordValue;
 import io.zeebe.exporter.record.value.TimerRecordValue;
+import io.zeebe.exporter.record.value.VariableDocumentRecordValue;
 import io.zeebe.exporter.record.value.VariableRecordValue;
 import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
 import io.zeebe.exporter.record.value.WorkflowInstanceSubscriptionRecordValue;
@@ -40,6 +41,7 @@ import io.zeebe.protocol.intent.MessageStartEventSubscriptionIntent;
 import io.zeebe.protocol.intent.MessageSubscriptionIntent;
 import io.zeebe.protocol.intent.RaftIntent;
 import io.zeebe.protocol.intent.TimerIntent;
+import io.zeebe.protocol.intent.VariableDocumentIntent;
 import io.zeebe.protocol.intent.VariableIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceSubscriptionIntent;
@@ -83,6 +85,13 @@ public class RecordingExporter implements Exporter {
     return StreamSupport.stream(spliterator, false)
         .filter(r -> r.getMetadata().getValueType() == valueType)
         .map(r -> (Record<T>) r);
+  }
+
+  public static RecordStream records() {
+    final Spliterator<Record<? extends RecordValue>> spliterator =
+        Spliterators.spliteratorUnknownSize(new RecordIterator(), Spliterator.ORDERED);
+    return new RecordStream(
+        StreamSupport.stream(spliterator, false).map(r -> (Record<RecordValue>) r));
   }
 
   public static RaftRecordStream raftRecords() {
@@ -191,6 +200,16 @@ public class RecordingExporter implements Exporter {
 
   public static VariableRecordStream variableRecords(final VariableIntent intent) {
     return variableRecords().withIntent(intent);
+  }
+
+  public static VariableDocumentRecordStream variableDocumentRecords() {
+    return new VariableDocumentRecordStream(
+        records(ValueType.VARIABLE_DOCUMENT, VariableDocumentRecordValue.class));
+  }
+
+  public static VariableDocumentRecordStream variableDocumentRecords(
+      final VariableDocumentIntent intent) {
+    return variableDocumentRecords().withIntent(intent);
   }
 
   public static class RecordIterator implements Iterator<Record<?>> {

--- a/test-util/src/main/java/io/zeebe/test/util/record/VariableDocumentRecordStream.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/VariableDocumentRecordStream.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.test.util.record;
+
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.record.value.VariableDocumentRecordValue;
+import io.zeebe.protocol.VariableDocumentUpdateSemantic;
+import io.zeebe.test.util.collection.Maps;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public class VariableDocumentRecordStream
+    extends ExporterRecordStream<VariableDocumentRecordValue, VariableDocumentRecordStream> {
+
+  public VariableDocumentRecordStream(
+      final Stream<Record<VariableDocumentRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected VariableDocumentRecordStream supply(
+      final Stream<Record<VariableDocumentRecordValue>> wrappedStream) {
+    return new VariableDocumentRecordStream(wrappedStream);
+  }
+
+  public VariableDocumentRecordStream withScopeKey(long scopeKey) {
+    return valueFilter(v -> v.getScopeKey() == scopeKey);
+  }
+
+  public VariableDocumentRecordStream withUpdateSemantics(
+      VariableDocumentUpdateSemantic updateSemantics) {
+    return valueFilter(v -> v.getUpdateSemantics() == updateSemantics);
+  }
+
+  public VariableDocumentRecordStream withDocument(Map<String, Object> document) {
+    return valueFilter(v -> v.getDocument().equals(document));
+  }
+
+  public VariableDocumentRecordStream withDocument(Map.Entry<String, Object>... entries) {
+    return withDocument(Maps.of(entries));
+  }
+
+  public VariableDocumentRecordStream withDocument(Predicate<Map<String, Object>> documentMatcher) {
+    return valueFilter(v -> documentMatcher.test(v.getDocument()));
+  }
+}


### PR DESCRIPTION
- adds new VariableDocumentRecord representing a JSON document of key/value pairs
- adds processor for single UPDATE command with support for different update semantics (local/propagate)
