### PR TITLE
Broker skips record on processing exception

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/TimerRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/TimerRecordValueImpl.java
@@ -25,18 +25,21 @@ import java.util.Objects;
 public class TimerRecordValueImpl extends RecordValueImpl implements TimerRecordValue {
 
   private final long elementInstanceKey;
+  private final long workflowInstanceKey;
   private final long dueDate;
   private final String handlerFlowNodeId;
 
   public TimerRecordValueImpl(
       ExporterObjectMapper objectMapper,
       long elementInstanceKey,
+      long workflowInstanceKey,
       long dueDate,
       String handlerFlowNodeId) {
     super(objectMapper);
     this.elementInstanceKey = elementInstanceKey;
     this.dueDate = dueDate;
     this.handlerFlowNodeId = handlerFlowNodeId;
+    this.workflowInstanceKey = workflowInstanceKey;
   }
 
   @Override
@@ -55,41 +58,42 @@ public class TimerRecordValueImpl extends RecordValueImpl implements TimerRecord
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hash(dueDate, elementInstanceKey, handlerFlowNodeId);
+  public long getWorkflowInstanceKey() {
+    return workflowInstanceKey;
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
+  public int hashCode() {
+    return Objects.hash(elementInstanceKey, workflowInstanceKey, dueDate, handlerFlowNodeId);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
     }
-    if (obj == null) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    final TimerRecordValueImpl other = (TimerRecordValueImpl) obj;
-    if (elementInstanceKey != other.elementInstanceKey) {
-      return false;
-    }
-
-    if (dueDate != other.dueDate) {
-      return false;
-    }
-
-    return handlerFlowNodeId.equals(other.handlerFlowNodeId);
+    final TimerRecordValueImpl that = (TimerRecordValueImpl) o;
+    return elementInstanceKey == that.elementInstanceKey
+        && workflowInstanceKey == that.workflowInstanceKey
+        && dueDate == that.dueDate
+        && Objects.equals(handlerFlowNodeId, that.handlerFlowNodeId);
   }
 
   @Override
   public String toString() {
-    return "TimerRecordValueImpl [elementInstanceKey="
+    return "TimerRecordValueImpl{"
+        + "elementInstanceKey="
         + elementInstanceKey
+        + ", workflowInstanceKey="
+        + workflowInstanceKey
         + ", dueDate="
         + dueDate
-        + ", handlerFlowNodeId"
+        + ", handlerFlowNodeId='"
         + handlerFlowNodeId
-        + "]";
+        + '\''
+        + '}';
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
@@ -349,6 +349,7 @@ public class ExporterRecordMapper {
     return new TimerRecordValueImpl(
         objectMapper,
         record.getElementInstanceKey(),
+        record.getWorkflowInstanceKey(),
         record.getDueDate(),
         asString(record.getHandlerNodeId()));
   }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/ZbStreamProcessorService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/ZbStreamProcessorService.java
@@ -133,7 +133,7 @@ public class ZbStreamProcessorService implements Service<ZbStreamProcessorServic
       TypedStreamEnvironment streamEnvironment,
       ZeebeState zeebeState) {
     final TypedEventStreamProcessorBuilder typedProcessorBuilder =
-        streamEnvironment.newStreamProcessor().keyGenerator(zeebeState.getKeyGenerator());
+        streamEnvironment.newStreamProcessor().zeebeState(zeebeState);
 
     addDistributeDeploymentProcessors(zeebeState, streamEnvironment, typedProcessorBuilder);
     final BpmnStepProcessor stepProcessor =

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedEventImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedEventImpl.java
@@ -59,4 +59,9 @@ public class TypedEventImpl implements TypedRecord {
   public UnpackedObject getValue() {
     return value;
   }
+
+  @Override
+  public String toString() {
+    return "TypedEventImpl{" + "metadata=" + metadata + ", value=" + value + '}';
+  }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedEventStreamProcessorBuilder.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedEventStreamProcessorBuilder.java
@@ -17,6 +17,7 @@
  */
 package io.zeebe.broker.logstreams.processor;
 
+import io.zeebe.broker.logstreams.state.ZeebeState;
 import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.clientapi.RecordType;
 import io.zeebe.protocol.clientapi.ValueType;
@@ -30,7 +31,7 @@ public class TypedEventStreamProcessorBuilder {
   protected RecordProcessorMap eventProcessors = new RecordProcessorMap();
   protected List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
 
-  private KeyGenerator keyGenerator;
+  private ZeebeState zeebeState;
 
   public TypedEventStreamProcessorBuilder(TypedStreamEnvironment environment) {
     this.environment = environment;
@@ -68,8 +69,8 @@ public class TypedEventStreamProcessorBuilder {
   }
 
   /** Only required if a stream processor writes events to its own stream. */
-  public TypedEventStreamProcessorBuilder keyGenerator(KeyGenerator keyGenerator) {
-    this.keyGenerator = keyGenerator;
+  public TypedEventStreamProcessorBuilder zeebeState(ZeebeState zeebeState) {
+    this.zeebeState = zeebeState;
     return this;
   }
 
@@ -80,7 +81,7 @@ public class TypedEventStreamProcessorBuilder {
         eventProcessors,
         lifecycleListeners,
         environment.getEventRegistry(),
-        keyGenerator,
+        zeebeState,
         environment);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessor.java
@@ -17,6 +17,8 @@
  */
 package io.zeebe.broker.logstreams.processor;
 
+import io.zeebe.broker.Loggers;
+import io.zeebe.broker.logstreams.state.ZeebeState;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.logstreams.log.LoggedEvent;
@@ -24,22 +26,29 @@ import io.zeebe.logstreams.processor.EventProcessor;
 import io.zeebe.logstreams.processor.StreamProcessor;
 import io.zeebe.logstreams.processor.StreamProcessorContext;
 import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.protocol.clientapi.RecordType;
+import io.zeebe.protocol.clientapi.RejectionType;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.intent.Intent;
+import io.zeebe.protocol.intent.WorkflowInstanceRelatedIntent;
 import io.zeebe.transport.ServerOutput;
 import io.zeebe.util.ReflectUtil;
 import io.zeebe.util.sched.ActorControl;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
+import org.slf4j.Logger;
 
 @SuppressWarnings({"unchecked"})
 public class TypedStreamProcessor implements StreamProcessor {
 
+  private static final Logger LOG = Loggers.WORKFLOW_PROCESSOR_LOGGER;
+
   protected final ServerOutput output;
   protected final RecordProcessorMap recordProcessors;
   protected final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
-  private final KeyGenerator keyGenerator;
+  protected final ZeebeState zeebeState;
 
   protected final RecordMetadata metadata = new RecordMetadata();
   protected final EnumMap<ValueType, Class<? extends UnpackedObject>> eventRegistry;
@@ -58,11 +67,11 @@ public class TypedStreamProcessor implements StreamProcessor {
       final RecordProcessorMap recordProcessors,
       final List<StreamProcessorLifecycleAware> lifecycleListeners,
       final EnumMap<ValueType, Class<? extends UnpackedObject>> eventRegistry,
-      final KeyGenerator keyGenerator,
+      final ZeebeState zeebeState,
       final TypedStreamEnvironment environment) {
     this.output = output;
     this.recordProcessors = recordProcessors;
-    this.keyGenerator = keyGenerator;
+    this.zeebeState = zeebeState;
     recordProcessors.values().forEachRemaining(p -> this.lifecycleListeners.add(p));
 
     this.lifecycleListeners.addAll(lifecycleListeners);
@@ -77,10 +86,10 @@ public class TypedStreamProcessor implements StreamProcessor {
   @Override
   public void onOpen(final StreamProcessorContext context) {
     final LogStream logStream = context.getLogStream();
-    this.streamWriter = new TypedStreamWriterImpl(logStream, eventRegistry, keyGenerator);
+    this.streamWriter = new TypedStreamWriterImpl(logStream, eventRegistry, getKeyGenerator());
 
     this.eventProcessorWrapper =
-        new DelegatingEventProcessor(context.getId(), output, logStream, streamWriter);
+        new DelegatingEventProcessor(context.getId(), output, logStream, streamWriter, zeebeState);
 
     this.actor = context.getActorControl();
     this.streamProcessorContext = context;
@@ -120,17 +129,16 @@ public class TypedStreamProcessor implements StreamProcessor {
     }
   }
 
-  public MetadataFilter buildTypeFilter() {
-    return m ->
-        recordProcessors.containsKey(m.getRecordType(), m.getValueType(), m.getIntent().value());
-  }
-
   protected static class DelegatingEventProcessor implements EventProcessor {
+
+    public static final String PROCESSING_ERROR_MESSAGE =
+        "Expected to process event %s without errors, but exception occurred with message %s .";
 
     protected final int streamProcessorId;
     protected final LogStream logStream;
     protected final TypedStreamWriterImpl writer;
     protected final TypedResponseWriterImpl responseWriter;
+    private final ZeebeState zeebeState;
 
     protected TypedRecordProcessor<?> eventProcessor;
     protected TypedEventImpl event;
@@ -141,11 +149,13 @@ public class TypedStreamProcessor implements StreamProcessor {
         final int streamProcessorId,
         final ServerOutput output,
         final LogStream logStream,
-        final TypedStreamWriterImpl writer) {
+        final TypedStreamWriterImpl writer,
+        final ZeebeState zeebeState) {
       this.streamProcessorId = streamProcessorId;
       this.logStream = logStream;
       this.writer = writer;
       this.responseWriter = new TypedResponseWriterImpl(output, logStream.getPartitionId());
+      this.zeebeState = zeebeState;
     }
 
     public void wrap(
@@ -159,16 +169,65 @@ public class TypedStreamProcessor implements StreamProcessor {
 
     @Override
     public void processEvent() {
-      writer.reset();
-      responseWriter.reset();
-
-      this.writer.configureSourceContext(streamProcessorId, position);
+      resetOutput();
 
       // default side effect is responses; can be changed by processor
       sideEffectProducer = responseWriter;
 
-      eventProcessor.processRecord(
-          position, event, responseWriter, writer, this::setSideEffectProducer);
+      final boolean isNotOnBlacklist = !zeebeState.isOnBlacklist(event);
+      if (isNotOnBlacklist) {
+        eventProcessor.processRecord(
+            position, event, responseWriter, writer, this::setSideEffectProducer);
+      }
+    }
+
+    @Override
+    public void processingFailed(Exception exception) {
+      resetOutput();
+
+      final String errorMessage =
+          String.format(PROCESSING_ERROR_MESSAGE, event, exception.getMessage());
+      LOG.error(errorMessage, exception);
+
+      if (event.metadata.getRecordType() == RecordType.COMMAND) {
+        sendCommandRejectionOnException(errorMessage);
+        writeCommandRejectionOnException(errorMessage);
+      }
+
+      final Intent intent = event.getMetadata().getIntent();
+      if (shouldBeBlacklisted(intent)) {
+        zeebeState.blacklist(event);
+      }
+    }
+
+    private boolean shouldBeBlacklisted(Intent intent) {
+
+      if (isWorkflowInstanceRelated(intent)) {
+        final WorkflowInstanceRelatedIntent workflowInstanceRelatedIntent =
+            (WorkflowInstanceRelatedIntent) intent;
+
+        return workflowInstanceRelatedIntent.shouldBlacklistInstanceOnError();
+      }
+
+      return false;
+    }
+
+    private boolean isWorkflowInstanceRelated(Intent intent) {
+      return intent instanceof WorkflowInstanceRelatedIntent;
+    }
+
+    private void resetOutput() {
+      responseWriter.reset();
+      writer.reset();
+      this.writer.configureSourceContext(streamProcessorId, position);
+    }
+
+    private void writeCommandRejectionOnException(String errorMessage) {
+      writer.appendRejection(event, RejectionType.PROCESSING_ERROR, errorMessage);
+    }
+
+    private void sendCommandRejectionOnException(String errorMessage) {
+      responseWriter.writeRejectionOnCommand(event, RejectionType.PROCESSING_ERROR, errorMessage);
     }
 
     public void setSideEffectProducer(final SideEffectProducer sideEffectProducer) {
@@ -199,7 +258,7 @@ public class TypedStreamProcessor implements StreamProcessor {
   }
 
   public KeyGenerator getKeyGenerator() {
-    return keyGenerator;
+    return zeebeState.getKeyGenerator();
   }
 
   public TypedStreamWriterImpl getStreamWriter() {

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/state/BlackList.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/state/BlackList.java
@@ -1,0 +1,45 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.logstreams.state;
+
+import io.zeebe.db.ColumnFamily;
+import io.zeebe.db.ZeebeDb;
+import io.zeebe.db.impl.DbLong;
+import io.zeebe.db.impl.DbNil;
+
+public class BlackList {
+
+  private final ColumnFamily<DbLong, DbNil> blackListColumnFamily;
+  private final DbLong workflowInstanceKey;
+
+  public BlackList(ZeebeDb<ZbColumnFamilies> zeebeDb) {
+    workflowInstanceKey = new DbLong();
+    blackListColumnFamily =
+        zeebeDb.createColumnFamily(ZbColumnFamilies.BLACKLIST, workflowInstanceKey, DbNil.INSTANCE);
+  }
+
+  public void blacklist(long key) {
+    workflowInstanceKey.wrapLong(key);
+    blackListColumnFamily.put(workflowInstanceKey, DbNil.INSTANCE);
+  }
+
+  public boolean isOnBlacklist(long key) {
+    workflowInstanceKey.wrapLong(key);
+    return blackListColumnFamily.exists(workflowInstanceKey);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/state/ZbColumnFamilies.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/state/ZbColumnFamilies.java
@@ -83,4 +83,6 @@ public enum ZbColumnFamilies {
   // event
   EVENT_SCOPE,
   EVENT_TRIGGER,
+
+  BLACKLIST
 }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/state/ZeebeState.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/state/ZeebeState.java
@@ -20,6 +20,7 @@ package io.zeebe.broker.logstreams.state;
 import io.zeebe.broker.incident.processor.IncidentState;
 import io.zeebe.broker.job.JobState;
 import io.zeebe.broker.logstreams.processor.KeyGenerator;
+import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.subscription.message.state.MessageStartEventSubscriptionState;
 import io.zeebe.broker.subscription.message.state.MessageState;
 import io.zeebe.broker.subscription.message.state.MessageSubscriptionState;
@@ -27,7 +28,9 @@ import io.zeebe.broker.subscription.message.state.WorkflowInstanceSubscriptionSt
 import io.zeebe.broker.workflow.deployment.distribute.processor.state.DeploymentsState;
 import io.zeebe.broker.workflow.state.WorkflowState;
 import io.zeebe.db.ZeebeDb;
+import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.Protocol;
+import io.zeebe.protocol.WorkflowInstanceRelated;
 
 public class ZeebeState {
 
@@ -40,6 +43,7 @@ public class ZeebeState {
   private final MessageStartEventSubscriptionState messageStartEventSubscriptionState;
   private final WorkflowInstanceSubscriptionState workflowInstanceSubscriptionState;
   private final IncidentState incidentState;
+  private final BlackList blackList;
 
   public ZeebeState(ZeebeDb<ZbColumnFamilies> zeebeDb) {
     this(Protocol.DEPLOYMENT_PARTITION, zeebeDb);
@@ -55,6 +59,7 @@ public class ZeebeState {
     messageStartEventSubscriptionState = new MessageStartEventSubscriptionState(zeebeDb);
     workflowInstanceSubscriptionState = new WorkflowInstanceSubscriptionState(zeebeDb);
     incidentState = new IncidentState(zeebeDb);
+    blackList = new BlackList(zeebeDb);
   }
 
   public DeploymentsState getDeploymentState() {
@@ -91,5 +96,26 @@ public class ZeebeState {
 
   public KeyGenerator getKeyGenerator() {
     return keyState;
+  }
+
+  public void blacklist(TypedRecord record) {
+    final UnpackedObject value = record.getValue();
+    if (value instanceof WorkflowInstanceRelated) {
+      final long workflowInstanceKey = ((WorkflowInstanceRelated) value).getWorkflowInstanceKey();
+      if (workflowInstanceKey >= 0) {
+        blackList.blacklist(workflowInstanceKey);
+      }
+    }
+  }
+
+  public boolean isOnBlacklist(TypedRecord record) {
+    final UnpackedObject value = record.getValue();
+    if (value instanceof WorkflowInstanceRelated) {
+      final long workflowInstanceKey = ((WorkflowInstanceRelated) value).getWorkflowInstanceKey();
+      if (workflowInstanceKey >= 0) {
+        return blackList.isOnBlacklist(workflowInstanceKey);
+      }
+    }
+    return false;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/MessageSubscriptionRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/MessageSubscriptionRecord.java
@@ -21,9 +21,10 @@ import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.msgpack.property.BooleanProperty;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
+import io.zeebe.protocol.WorkflowInstanceRelated;
 import org.agrona.DirectBuffer;
 
-public class MessageSubscriptionRecord extends UnpackedObject {
+public class MessageSubscriptionRecord extends UnpackedObject implements WorkflowInstanceRelated {
 
   private final LongProperty workflowInstanceKeyProp = new LongProperty("workflowInstanceKey");
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey");

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/WorkflowInstanceSubscriptionRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/WorkflowInstanceSubscriptionRecord.java
@@ -23,9 +23,11 @@ import io.zeebe.msgpack.property.DocumentProperty;
 import io.zeebe.msgpack.property.IntegerProperty;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
+import io.zeebe.protocol.WorkflowInstanceRelated;
 import org.agrona.DirectBuffer;
 
-public class WorkflowInstanceSubscriptionRecord extends UnpackedObject {
+public class WorkflowInstanceSubscriptionRecord extends UnpackedObject
+    implements WorkflowInstanceRelated {
 
   private final IntegerProperty subscriptionPartitionIdProp =
       new IntegerProperty("subscriptionPartitionId");

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
@@ -91,6 +91,7 @@ public class CatchEventBehavior {
       if (event.isTimer()) {
         subscribeToTimerEvent(
             context.getRecord().getKey(),
+            context.getRecord().getValue().getWorkflowInstanceKey(),
             context.getRecord().getValue().getWorkflowKey(),
             event.getId(),
             event.getTimer(),
@@ -108,6 +109,7 @@ public class CatchEventBehavior {
 
   public void subscribeToTimerEvent(
       long elementInstanceKey,
+      long workflowInstanceKey,
       long workflowKey,
       DirectBuffer handlerNodeId,
       Timer timer,
@@ -117,6 +119,7 @@ public class CatchEventBehavior {
         .setRepetitions(timer.getRepetitions())
         .setDueDate(timer.getDueDate(ActorClock.currentTimeMillis()))
         .setElementInstanceKey(elementInstanceKey)
+        .setWorkflowInstanceKey(workflowInstanceKey)
         .setHandlerNodeId(handlerNodeId)
         .setWorkflowKey(workflowKey);
     writer.appendNewCommand(TimerIntent.CREATE, timerRecord);
@@ -133,6 +136,7 @@ public class CatchEventBehavior {
   public void unsubscribeFromTimerEvent(TimerInstance timer, TypedStreamWriter writer) {
     timerRecord
         .setElementInstanceKey(timer.getElementInstanceKey())
+        .setWorkflowInstanceKey(timer.getWorkflowInstanceKey())
         .setDueDate(timer.getDueDate())
         .setHandlerNodeId(timer.getHandlerNodeId())
         .setWorkflowKey(timer.getWorkflowKey());

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/deployment/TransformingDeploymentCreateProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/deployment/TransformingDeploymentCreateProcessor.java
@@ -110,6 +110,7 @@ public class TransformingDeploymentCreateProcessor
         if (startEvent.isTimer()) {
           catchEventBehavior.subscribeToTimerEvent(
               NO_ELEMENT_INSTANCE,
+              NO_ELEMENT_INSTANCE,
               workflow.getKey(),
               startEvent.getId(),
               startEvent.getTimer(),

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/CreateTimerProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/CreateTimerProcessor.java
@@ -58,6 +58,7 @@ public class CreateTimerProcessor implements TypedRecordProcessor<TimerRecord> {
     timerInstance.setHandlerNodeId(timer.getHandlerNodeId());
     timerInstance.setRepetitions(timer.getRepetitions());
     timerInstance.setWorkflowKey(timer.getWorkflowKey());
+    timerInstance.setWorkflowInstanceKey(timer.getWorkflowInstanceKey());
 
     sideEffect.accept(this::scheduleTimer);
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/DueDateTimerChecker.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/DueDateTimerChecker.java
@@ -92,6 +92,7 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
   private boolean triggerTimer(TimerInstance timer) {
     timerRecord
         .setElementInstanceKey(timer.getElementInstanceKey())
+        .setWorkflowInstanceKey(timer.getWorkflowInstanceKey())
         .setDueDate(timer.getDueDate())
         .setHandlerNodeId(timer.getHandlerNodeId())
         .setRepetitions(timer.getRepetitions())

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/TriggerTimerProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/TriggerTimerProcessor.java
@@ -197,7 +197,12 @@ public class TriggerTimerProcessor implements TypedRecordProcessor<TimerRecord> 
     final RepeatingInterval timer =
         new RepeatingInterval(repetitions, event.getTimer().getInterval());
     catchEventBehavior.subscribeToTimerEvent(
-        record.getElementInstanceKey(), record.getWorkflowKey(), event.getId(), timer, writer);
+        record.getElementInstanceKey(),
+        record.getWorkflowInstanceKey(),
+        record.getWorkflowKey(),
+        event.getId(),
+        timer,
+        writer);
   }
 
   private ExecutableCatchEventElement getCatchEventById(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/state/TimerInstance.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/state/TimerInstance.java
@@ -34,6 +34,7 @@ public class TimerInstance implements DbValue {
   private long workflowKey;
   private long key;
   private long elementInstanceKey;
+  private long workflowInstanceKey;
   private long dueDate;
   private int repetitions;
 
@@ -85,14 +86,25 @@ public class TimerInstance implements DbValue {
     this.workflowKey = workflowKey;
   }
 
+  public long getWorkflowInstanceKey() {
+    return workflowInstanceKey;
+  }
+
+  public void setWorkflowInstanceKey(long workflowInstanceKey) {
+    this.workflowInstanceKey = workflowInstanceKey;
+  }
+
   @Override
   public int getLength() {
-    return 4 * Long.BYTES + 2 * Integer.BYTES + handlerNodeId.capacity();
+    return 5 * Long.BYTES + 2 * Integer.BYTES + handlerNodeId.capacity();
   }
 
   @Override
   public void write(MutableDirectBuffer buffer, int offset) {
     buffer.putLong(offset, elementInstanceKey, ZB_DB_BYTE_ORDER);
+    offset += Long.BYTES;
+
+    buffer.putLong(offset, workflowInstanceKey, ZB_DB_BYTE_ORDER);
     offset += Long.BYTES;
 
     buffer.putLong(offset, dueDate, ZB_DB_BYTE_ORDER);
@@ -114,6 +126,9 @@ public class TimerInstance implements DbValue {
   @Override
   public void wrap(DirectBuffer buffer, int offset, int length) {
     elementInstanceKey = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
+    offset += Long.BYTES;
+
+    workflowInstanceKey = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
     offset += Long.BYTES;
 
     dueDate = buffer.getLong(offset, ZB_DB_BYTE_ORDER);

--- a/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/BlacklistInstanceTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/BlacklistInstanceTest.java
@@ -1,0 +1,288 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.logstreams.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import io.zeebe.broker.logstreams.processor.TypedStreamProcessor.DelegatingEventProcessor;
+import io.zeebe.broker.util.ZeebeStateRule;
+import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.protocol.WorkflowInstanceRelated;
+import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.intent.DeploymentIntent;
+import io.zeebe.protocol.intent.ExporterIntent;
+import io.zeebe.protocol.intent.IncidentIntent;
+import io.zeebe.protocol.intent.Intent;
+import io.zeebe.protocol.intent.JobBatchIntent;
+import io.zeebe.protocol.intent.JobIntent;
+import io.zeebe.protocol.intent.MessageIntent;
+import io.zeebe.protocol.intent.MessageStartEventSubscriptionIntent;
+import io.zeebe.protocol.intent.MessageSubscriptionIntent;
+import io.zeebe.protocol.intent.RaftIntent;
+import io.zeebe.protocol.intent.TimerIntent;
+import io.zeebe.protocol.intent.VariableDocumentIntent;
+import io.zeebe.protocol.intent.VariableIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceSubscriptionIntent;
+import io.zeebe.transport.ServerOutput;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.Mock;
+
+@RunWith(Parameterized.class)
+public class BlacklistInstanceTest {
+
+  @ClassRule public static ZeebeStateRule zeebeStateRule = new ZeebeStateRule();
+  private static final AtomicLong KEY_GENERATOR = new AtomicLong(0);
+
+  @Parameter(0)
+  public ValueType recordValueType;
+
+  @Parameter(1)
+  public Intent recordIntent;
+
+  @Parameter(2)
+  public boolean expectedToBlacklist;
+
+  private DelegatingEventProcessor delegatingEventProcessor;
+
+  @Parameters(name = "{0} {1} should blacklist instance {2}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      ////////////////////////////////////////
+      ////////////// DEPLOYMENTS /////////////
+      ////////////////////////////////////////
+      {ValueType.DEPLOYMENT, DeploymentIntent.CREATE, false},
+      {ValueType.DEPLOYMENT, DeploymentIntent.CREATED, false},
+      {ValueType.DEPLOYMENT, DeploymentIntent.DISTRIBUTE, false},
+      {ValueType.DEPLOYMENT, DeploymentIntent.DISTRIBUTED, false},
+
+      ////////////////////////////////////////
+      /////////////// EXPORTER ///////////////
+      ////////////////////////////////////////
+      {ValueType.EXPORTER, ExporterIntent.EXPORTED, false},
+
+      ////////////////////////////////////////
+      ////////////// INCIDENTS ///////////////
+      ////////////////////////////////////////
+      {ValueType.INCIDENT, IncidentIntent.CREATE, true},
+      {ValueType.INCIDENT, IncidentIntent.CREATED, true},
+      {ValueType.INCIDENT, IncidentIntent.RESOLVED, true},
+
+      // USER COMMAND
+      {ValueType.INCIDENT, IncidentIntent.RESOLVE, false},
+
+      ////////////////////////////////////////
+      ////////////// JOB BATCH ///////////////
+      ////////////////////////////////////////
+      {ValueType.JOB_BATCH, JobBatchIntent.ACTIVATE, false},
+      {ValueType.JOB_BATCH, JobBatchIntent.ACTIVATED, false},
+
+      ////////////////////////////////////////
+      //////////////// JOBS //////////////////
+      ////////////////////////////////////////
+      {ValueType.JOB, JobIntent.CREATE, true},
+      {ValueType.JOB, JobIntent.CREATED, true},
+      {ValueType.JOB, JobIntent.ACTIVATED, true},
+      {ValueType.JOB, JobIntent.COMPLETED, true},
+      {ValueType.JOB, JobIntent.TIME_OUT, true},
+      {ValueType.JOB, JobIntent.TIMED_OUT, true},
+      {ValueType.JOB, JobIntent.FAILED, true},
+      {ValueType.JOB, JobIntent.RETRIES_UPDATED, true},
+      {ValueType.JOB, JobIntent.CANCEL, true},
+      {ValueType.JOB, JobIntent.CANCELED, true},
+
+      // USER COMMAND
+      {ValueType.JOB, JobIntent.COMPLETE, false},
+      {ValueType.JOB, JobIntent.FAIL, false},
+      {ValueType.JOB, JobIntent.UPDATE_RETRIES, false},
+
+      ////////////////////////////////////////
+      ////////////// MESSAGES ////////////////
+      ////////////////////////////////////////
+      {ValueType.MESSAGE, MessageIntent.PUBLISH, false},
+      {ValueType.MESSAGE, MessageIntent.PUBLISHED, false},
+      {ValueType.MESSAGE, MessageIntent.DELETE, false},
+      {ValueType.MESSAGE, MessageIntent.DELETED, false},
+
+      ////////////////////////////////////////
+      ////////// MSG START EVENT SUB /////////
+      ////////////////////////////////////////
+      {ValueType.MESSAGE_START_EVENT_SUBSCRIPTION, MessageStartEventSubscriptionIntent.OPEN, false},
+      {
+        ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
+        MessageStartEventSubscriptionIntent.OPENED,
+        false
+      },
+      {
+        ValueType.MESSAGE_START_EVENT_SUBSCRIPTION, MessageStartEventSubscriptionIntent.CLOSE, false
+      },
+      {
+        ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
+        MessageStartEventSubscriptionIntent.CLOSED,
+        false
+      },
+
+      ////////////////////////////////////////
+      /////////////// MSG SUB ////////////////
+      ////////////////////////////////////////
+      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.OPEN, true},
+      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.OPENED, true},
+      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CORRELATE, true},
+      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CORRELATE, true},
+      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CLOSE, true},
+      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CLOSED, true},
+
+      ////////////////////////////////////////
+      ////////////////// RAFT ////////////////
+      ////////////////////////////////////////
+      {ValueType.RAFT, RaftIntent.MEMBER_ADDED, false},
+      {ValueType.RAFT, RaftIntent.MEMBER_REMOVED, false},
+
+      ////////////////////////////////////////
+      //////////////// TIMERS ////////////////
+      ////////////////////////////////////////
+      {ValueType.TIMER, TimerIntent.CREATE, true},
+      {ValueType.TIMER, TimerIntent.CREATED, true},
+      {ValueType.TIMER, TimerIntent.TRIGGER, true},
+      {ValueType.TIMER, TimerIntent.TRIGGERED, true},
+      {ValueType.TIMER, TimerIntent.CANCEL, true},
+      {ValueType.TIMER, TimerIntent.CANCELED, true},
+
+      ////////////////////////////////////////
+      /////////////// VAR DOC ////////////////
+      ////////////////////////////////////////
+      {ValueType.VARIABLE_DOCUMENT, VariableDocumentIntent.UPDATE, false},
+      {ValueType.VARIABLE_DOCUMENT, VariableDocumentIntent.UPDATED, false},
+
+      ////////////////////////////////////////
+      /////////////// VARIABLE ///////////////
+      ////////////////////////////////////////
+      {ValueType.VARIABLE, VariableIntent.CREATED, false},
+      {ValueType.VARIABLE, VariableIntent.UPDATED, false},
+
+      ////////////////////////////////////////
+      ////////// WORKFLOW INSTANCE ///////////
+      ////////////////////////////////////////
+      {ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN, true},
+      {ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_ACTIVATING, true},
+      {ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_ACTIVATED, true},
+      {ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_COMPLETING, true},
+      {ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_COMPLETED, true},
+      {ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_TERMINATING, true},
+      {ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_TERMINATED, true},
+      {ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.EVENT_OCCURRED, true},
+
+      // USER COMMAND
+      {ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.CREATE, false},
+      {ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.CANCEL, false},
+
+      ////////////////////////////////////////
+      //////// WORKFLOW INSTANCE SUB /////////
+      ////////////////////////////////////////
+      {ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION, WorkflowInstanceSubscriptionIntent.OPEN, true},
+      {ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION, WorkflowInstanceSubscriptionIntent.OPENED, true},
+      {
+        ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION, WorkflowInstanceSubscriptionIntent.CORRELATE, true
+      },
+      {
+        ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION,
+        WorkflowInstanceSubscriptionIntent.CORRELATED,
+        true
+      },
+      {ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION, WorkflowInstanceSubscriptionIntent.CLOSE, true},
+      {ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION, WorkflowInstanceSubscriptionIntent.CLOSED, true}
+    };
+  }
+
+  @Mock ServerOutput output;
+
+  @Mock LogStream logStream;
+
+  @Mock TypedStreamWriterImpl typedStreamWriter;
+
+  private long workflowInstanceKey;
+
+  @Before
+  public void setup() {
+    initMocks(this);
+    delegatingEventProcessor =
+        new DelegatingEventProcessor(
+            0, output, logStream, typedStreamWriter, zeebeStateRule.getZeebeState());
+    workflowInstanceKey = KEY_GENERATOR.getAndIncrement();
+  }
+
+  @Test
+  public void shouldBlacklist() {
+    // given
+    final AtomicBoolean processed = new AtomicBoolean(false);
+    final TypedRecordProcessor processor =
+        new TypedRecordProcessor() {
+          @Override
+          public void processRecord(
+              long position,
+              TypedRecord record,
+              TypedResponseWriter responseWriter,
+              TypedStreamWriter streamWriter,
+              Consumer sideEffect) {
+            processed.set(true);
+          }
+        };
+
+    final RecordMetadata metadata = new RecordMetadata();
+    metadata.intent(recordIntent);
+    metadata.valueType(recordValueType);
+    final TypedEventImpl typedEvent = new TypedEventImpl();
+
+    typedEvent.wrap(null, metadata, new Value());
+    delegatingEventProcessor.wrap(processor, typedEvent, 1024);
+
+    // when
+    delegatingEventProcessor.processingFailed(new Exception("expected"));
+
+    // then
+    metadata.intent(WorkflowInstanceIntent.ELEMENT_ACTIVATING);
+    metadata.valueType(ValueType.WORKFLOW_INSTANCE);
+    typedEvent.wrap(null, metadata, new Value());
+    assertThat(zeebeStateRule.getZeebeState().isOnBlacklist(typedEvent))
+        .isEqualTo(expectedToBlacklist);
+
+    delegatingEventProcessor.wrap(processor, typedEvent, 1025);
+    delegatingEventProcessor.processEvent();
+    assertThat(processed.get()).isEqualTo(!expectedToBlacklist);
+  }
+
+  private final class Value extends UnpackedObject implements WorkflowInstanceRelated {
+
+    @Override
+    public long getWorkflowInstanceKey() {
+      return workflowInstanceKey;
+    }
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/SkipFailingEventsTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/SkipFailingEventsTest.java
@@ -1,0 +1,403 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.logstreams.processor;
+
+import static io.zeebe.broker.workflow.state.TimerInstance.NO_ELEMENT_INSTANCE;
+import static io.zeebe.test.util.TestUtil.doRepeatedly;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.zeebe.broker.logstreams.state.DefaultZeebeDbFactory;
+import io.zeebe.broker.logstreams.state.ZeebeState;
+import io.zeebe.broker.util.MockTypedRecord;
+import io.zeebe.broker.util.Records;
+import io.zeebe.broker.util.StreamProcessorControl;
+import io.zeebe.broker.util.TestStreams;
+import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.protocol.clientapi.RecordType;
+import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.intent.JobIntent;
+import io.zeebe.protocol.intent.TimerIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.servicecontainer.testing.ServiceContainerRule;
+import io.zeebe.test.util.AutoCloseableRule;
+import io.zeebe.transport.ServerOutput;
+import io.zeebe.util.buffer.BufferUtil;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class SkipFailingEventsTest {
+  public static final String STREAM_NAME = "foo";
+  public static final int STREAM_PROCESSOR_ID = 144144;
+
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+  public AutoCloseableRule closeables = new AutoCloseableRule();
+
+  public ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
+  public ServiceContainerRule serviceContainerRule = new ServiceContainerRule(actorSchedulerRule);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(tempFolder)
+          .around(actorSchedulerRule)
+          .around(serviceContainerRule)
+          .around(closeables);
+
+  protected TestStreams streams;
+  protected LogStream stream;
+
+  @Mock protected ServerOutput output;
+  private StreamProcessorControl streamProcessorControl;
+  private KeyGenerator keyGenerator;
+  private TypedStreamEnvironment env;
+  private ZeebeState zeebeState;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    streams =
+        new TestStreams(
+            tempFolder.getRoot(), closeables, serviceContainerRule.get(), actorSchedulerRule.get());
+
+    stream = streams.createLogStream(STREAM_NAME);
+    env = new TypedStreamEnvironment(streams.getLogStream(STREAM_NAME), output);
+
+    final AtomicLong key = new AtomicLong();
+    keyGenerator = () -> key.getAndIncrement();
+  }
+
+  @Test
+  public void shouldBlacklistInstance() {
+    // given
+    final DumpProcessor dumpProcessor = spy(new DumpProcessor());
+    final ErrorProneProcessor processor = new ErrorProneProcessor();
+
+    streamProcessorControl =
+        streams.initStreamProcessor(
+            STREAM_NAME,
+            STREAM_PROCESSOR_ID,
+            DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+            (db) -> {
+              zeebeState = new ZeebeState(db);
+              return env.newStreamProcessor()
+                  .zeebeState(zeebeState)
+                  .onEvent(
+                      ValueType.WORKFLOW_INSTANCE,
+                      WorkflowInstanceIntent.ELEMENT_ACTIVATING,
+                      processor)
+                  .onEvent(
+                      ValueType.WORKFLOW_INSTANCE,
+                      WorkflowInstanceIntent.ELEMENT_ACTIVATED,
+                      dumpProcessor)
+                  .build();
+            });
+    streamProcessorControl.start();
+
+    streams
+        .newRecord(STREAM_NAME)
+        .event(workflowInstance(1))
+        .recordType(RecordType.EVENT)
+        .intent(WorkflowInstanceIntent.ELEMENT_ACTIVATING)
+        .key(keyGenerator.nextKey())
+        .write();
+    streams
+        .newRecord(STREAM_NAME)
+        .event(workflowInstance(1))
+        .recordType(RecordType.EVENT)
+        .intent(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+        .key(keyGenerator.nextKey())
+        .write();
+
+    // other instance
+    streams
+        .newRecord(STREAM_NAME)
+        .event(workflowInstance(2))
+        .recordType(RecordType.EVENT)
+        .intent(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+        .key(keyGenerator.nextKey())
+        .write();
+    // when
+    streamProcessorControl.unblock();
+
+    doRepeatedly(
+            () ->
+                streams
+                    .events(STREAM_NAME)
+                    .filter(
+                        e ->
+                            Records.isEvent(
+                                e,
+                                ValueType.WORKFLOW_INSTANCE,
+                                WorkflowInstanceIntent.ELEMENT_COMPLETED))
+                    .findFirst())
+        .until(o -> o.isPresent())
+        .get();
+
+    // then
+    assertThat(processor.getProcessCount()).isEqualTo(1);
+
+    final RecordMetadata metadata = new RecordMetadata();
+    metadata.valueType(ValueType.WORKFLOW_INSTANCE);
+    final MockTypedRecord<WorkflowInstanceRecord> mockTypedRecord =
+        new MockTypedRecord<>(0, metadata, workflowInstance(1));
+    assertThat(zeebeState.isOnBlacklist(mockTypedRecord)).isTrue();
+
+    verify(dumpProcessor, times(1)).processRecord(any(), any(), any(), any());
+    assertThat(dumpProcessor.processedInstances).containsExactly(2L);
+  }
+
+  @Test
+  public void shouldNotBlacklistInstance() {
+    // given
+    when(output.sendResponse(any())).thenReturn(true);
+    final List<Long> processedInstances = new ArrayList<>();
+    final TypedRecordProcessor<JobRecord> dumpProcessor =
+        spy(
+            new TypedRecordProcessor<JobRecord>() {
+              @Override
+              public void processRecord(
+                  TypedRecord<JobRecord> record,
+                  TypedResponseWriter responseWriter,
+                  TypedStreamWriter streamWriter) {
+                processedInstances.add(record.getValue().getWorkflowInstanceKey());
+                streamWriter.appendFollowUpEvent(
+                    record.getKey(), WorkflowInstanceIntent.ELEMENT_COMPLETED, workflowInstance(2));
+              }
+            });
+    final TypedRecordProcessor<JobRecord> errorProneProcessor =
+        new TypedRecordProcessor<JobRecord>() {
+          @Override
+          public void processRecord(
+              TypedRecord<JobRecord> record,
+              TypedResponseWriter responseWriter,
+              TypedStreamWriter streamWriter) {
+            throw new RuntimeException("expected");
+          }
+        };
+
+    streamProcessorControl =
+        streams.initStreamProcessor(
+            STREAM_NAME,
+            STREAM_PROCESSOR_ID,
+            DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+            (db) -> {
+              zeebeState = new ZeebeState(db);
+              return env.newStreamProcessor()
+                  .zeebeState(zeebeState)
+                  .onCommand(ValueType.JOB, JobIntent.CREATE, errorProneProcessor)
+                  .onEvent(ValueType.JOB, JobIntent.ACTIVATED, dumpProcessor)
+                  .build();
+            });
+    streamProcessorControl.start();
+
+    streams
+        .newRecord(STREAM_NAME)
+        .event(job(1))
+        .recordType(RecordType.COMMAND)
+        .intent(JobIntent.COMPLETE)
+        .key(keyGenerator.nextKey())
+        .write();
+    streams
+        .newRecord(STREAM_NAME)
+        .event(job(1))
+        .recordType(RecordType.EVENT)
+        .intent(JobIntent.ACTIVATED)
+        .key(keyGenerator.nextKey())
+        .write();
+
+    // other instance
+    streams
+        .newRecord(STREAM_NAME)
+        .event(job(2))
+        .recordType(RecordType.EVENT)
+        .intent(JobIntent.ACTIVATED)
+        .key(keyGenerator.nextKey())
+        .write();
+    // when
+    streamProcessorControl.unblock();
+
+    doRepeatedly(
+            () ->
+                streams
+                    .events(STREAM_NAME)
+                    .filter(
+                        e ->
+                            Records.isEvent(
+                                e,
+                                ValueType.WORKFLOW_INSTANCE,
+                                WorkflowInstanceIntent.ELEMENT_COMPLETED))
+                    .findFirst())
+        .until(o -> o.isPresent())
+        .get();
+
+    // then
+    final RecordMetadata metadata = new RecordMetadata();
+    metadata.valueType(ValueType.WORKFLOW_INSTANCE);
+    final MockTypedRecord<WorkflowInstanceRecord> mockTypedRecord =
+        new MockTypedRecord<>(0, metadata, workflowInstance(1));
+    assertThat(zeebeState.isOnBlacklist(mockTypedRecord)).isFalse();
+
+    verify(dumpProcessor, times(2)).processRecord(any(), any(), any(), any());
+    assertThat(processedInstances).containsExactly(1L, 2L);
+  }
+
+  @Test
+  public void shouldNotBlacklistInstanceAndIgnoreTimerStartEvents() {
+    // given
+    when(output.sendResponse(any())).thenReturn(true);
+    final List<Long> processedInstances = new ArrayList<>();
+    final TypedRecordProcessor<TimerRecord> errorProneProcessor =
+        new TypedRecordProcessor<TimerRecord>() {
+          @Override
+          public void processRecord(
+              TypedRecord<TimerRecord> record,
+              TypedResponseWriter responseWriter,
+              TypedStreamWriter streamWriter) {
+            if (record.getKey() == 0) {
+              throw new RuntimeException("expected");
+            }
+            processedInstances.add(record.getValue().getWorkflowInstanceKey());
+            streamWriter.appendFollowUpEvent(
+                record.getKey(), TimerIntent.CREATED, timer(NO_ELEMENT_INSTANCE));
+          }
+        };
+
+    streamProcessorControl =
+        streams.initStreamProcessor(
+            STREAM_NAME,
+            STREAM_PROCESSOR_ID,
+            DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+            (db) -> {
+              zeebeState = new ZeebeState(db);
+              return env.newStreamProcessor()
+                  .zeebeState(zeebeState)
+                  .onCommand(ValueType.TIMER, TimerIntent.CREATE, errorProneProcessor)
+                  .build();
+            });
+    streamProcessorControl.start();
+
+    streams
+        .newRecord(STREAM_NAME)
+        .event(timer(NO_ELEMENT_INSTANCE))
+        .recordType(RecordType.COMMAND)
+        .intent(TimerIntent.CREATE)
+        .key(keyGenerator.nextKey())
+        .write();
+    streams
+        .newRecord(STREAM_NAME)
+        .event(timer(NO_ELEMENT_INSTANCE))
+        .recordType(RecordType.COMMAND)
+        .intent(TimerIntent.CREATE)
+        .key(keyGenerator.nextKey())
+        .write();
+
+    // when
+    streamProcessorControl.unblock();
+    doRepeatedly(
+            () ->
+                streams
+                    .events(STREAM_NAME)
+                    .filter(e -> Records.isEvent(e, ValueType.TIMER, TimerIntent.CREATED))
+                    .findFirst())
+        .until(o -> o.isPresent())
+        .get();
+
+    // then
+    final RecordMetadata metadata = new RecordMetadata();
+    metadata.valueType(ValueType.TIMER);
+    final MockTypedRecord<TimerRecord> mockTypedRecord =
+        new MockTypedRecord<>(0, metadata, timer(NO_ELEMENT_INSTANCE));
+    assertThat(zeebeState.isOnBlacklist(mockTypedRecord)).isFalse();
+    assertThat(processedInstances).containsExactly((long) NO_ELEMENT_INSTANCE);
+  }
+
+  protected WorkflowInstanceRecord workflowInstance(final int instanceKey) {
+    final WorkflowInstanceRecord event = new WorkflowInstanceRecord();
+    event.setWorkflowInstanceKey(instanceKey);
+    return event;
+  }
+
+  protected JobRecord job(final int instanceKey) {
+    final JobRecord event = new JobRecord();
+    event.getHeaders().setWorkflowInstanceKey(instanceKey);
+    return event;
+  }
+
+  protected TimerRecord timer(final int instanceKey) {
+    final TimerRecord event = new TimerRecord();
+    event
+        .setWorkflowInstanceKey(instanceKey)
+        .setElementInstanceKey(instanceKey)
+        .setDueDate(1245)
+        .setHandlerNodeId(BufferUtil.wrapString("foo"))
+        .setRepetitions(0)
+        .setWorkflowKey(1);
+    return event;
+  }
+
+  protected static class ErrorProneProcessor
+      implements TypedRecordProcessor<WorkflowInstanceRecord> {
+
+    public final AtomicLong processCount = new AtomicLong(0);
+
+    @Override
+    public void processRecord(
+        final TypedRecord<WorkflowInstanceRecord> record,
+        final TypedResponseWriter responseWriter,
+        final TypedStreamWriter streamWriter) {
+      processCount.incrementAndGet();
+      throw new RuntimeException("expected");
+    }
+
+    public long getProcessCount() {
+      return processCount.get();
+    }
+  }
+
+  protected static class DumpProcessor implements TypedRecordProcessor<WorkflowInstanceRecord> {
+    final List<Long> processedInstances = new ArrayList<>();
+
+    @Override
+    public void processRecord(
+        TypedRecord<WorkflowInstanceRecord> record,
+        TypedResponseWriter responseWriter,
+        TypedStreamWriter streamWriter) {
+      processedInstances.add(record.getValue().getWorkflowInstanceKey());
+      streamWriter.appendFollowUpEvent(
+          record.getKey(), WorkflowInstanceIntent.ELEMENT_COMPLETED, record.getValue());
+    }
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessorTest.java
@@ -20,14 +20,20 @@ package io.zeebe.broker.logstreams.processor;
 import static io.zeebe.test.util.TestUtil.doRepeatedly;
 import static io.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.zeebe.broker.logstreams.state.DefaultZeebeDbFactory;
+import io.zeebe.broker.logstreams.state.ZeebeState;
+import io.zeebe.broker.util.RecordStream;
 import io.zeebe.broker.util.Records;
 import io.zeebe.broker.util.StreamProcessorControl;
 import io.zeebe.broker.util.TestStreams;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.protocol.clientapi.RecordType;
+import io.zeebe.protocol.clientapi.RejectionType;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.impl.record.value.deployment.ResourceType;
@@ -35,7 +41,9 @@ import io.zeebe.protocol.intent.DeploymentIntent;
 import io.zeebe.servicecontainer.testing.ServiceContainerRule;
 import io.zeebe.test.util.AutoCloseableRule;
 import io.zeebe.transport.ServerOutput;
+import io.zeebe.transport.ServerResponse;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,6 +74,9 @@ public class TypedStreamProcessorTest {
   protected LogStream stream;
 
   @Mock protected ServerOutput output;
+  private StreamProcessorControl streamProcessorControl;
+  private KeyGenerator keyGenerator;
+  private TypedStreamEnvironment env;
 
   @Before
   public void setUp() {
@@ -76,27 +87,25 @@ public class TypedStreamProcessorTest {
             tempFolder.getRoot(), closeables, serviceContainerRule.get(), actorSchedulerRule.get());
 
     stream = streams.createLogStream(STREAM_NAME);
+    env = new TypedStreamEnvironment(streams.getLogStream(STREAM_NAME), output);
+
+    final AtomicLong key = new AtomicLong();
+    keyGenerator = () -> key.getAndIncrement();
   }
 
   @Test
   public void shouldWriteSourceEventAndProducerOnBatch() {
     // given
-    final TypedStreamEnvironment env =
-        new TypedStreamEnvironment(streams.getLogStream(STREAM_NAME), output);
-
-    final AtomicLong key = new AtomicLong();
-    final TypedStreamProcessor streamProcessor =
-        env.newStreamProcessor()
-            .keyGenerator(() -> key.getAndIncrement())
-            .onCommand(ValueType.DEPLOYMENT, DeploymentIntent.CREATE, new BatchProcessor())
-            .build();
-
-    final StreamProcessorControl streamProcessorControl =
+    streamProcessorControl =
         streams.initStreamProcessor(
             STREAM_NAME,
             STREAM_PROCESSOR_ID,
             DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
-            (db) -> streamProcessor);
+            (db) ->
+                env.newStreamProcessor()
+                    .zeebeState(new ZeebeState(db))
+                    .onCommand(ValueType.DEPLOYMENT, DeploymentIntent.CREATE, new BatchProcessor())
+                    .build());
     streamProcessorControl.start();
     final long firstEventPosition =
         streams
@@ -126,6 +135,91 @@ public class TypedStreamProcessorTest {
     assertThat(writtenEvent.getSourceEventPosition()).isEqualTo(firstEventPosition);
   }
 
+  @Test
+  public void shouldSkipFailingEvent() {
+    // given
+    streamProcessorControl =
+        streams.initStreamProcessor(
+            STREAM_NAME,
+            STREAM_PROCESSOR_ID,
+            DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+            (db) ->
+                env.newStreamProcessor()
+                    .zeebeState(new ZeebeState(db))
+                    .onCommand(
+                        ValueType.DEPLOYMENT, DeploymentIntent.CREATE, new ErrorProneProcessor())
+                    .build());
+    streamProcessorControl.start();
+    final AtomicLong requestId = new AtomicLong(0);
+    final AtomicInteger requestStreamId = new AtomicInteger(0);
+
+    when(output.sendResponse(any()))
+        .then(
+            (invocationOnMock -> {
+              final ServerResponse serverResponse = invocationOnMock.getArgument(0);
+
+              requestId.set(serverResponse.getRequestId());
+              requestStreamId.set(serverResponse.getRemoteStreamId());
+
+              return true;
+            }));
+
+    final long failingKey = keyGenerator.nextKey();
+    streams
+        .newRecord(STREAM_NAME)
+        .event(deployment("foo", ResourceType.BPMN_XML))
+        .recordType(RecordType.COMMAND)
+        .intent(DeploymentIntent.CREATE)
+        .requestId(255L)
+        .requestStreamId(99)
+        .key(failingKey)
+        .write();
+    final long secondEventPosition =
+        streams
+            .newRecord(STREAM_NAME)
+            .event(deployment("foo2", ResourceType.BPMN_XML))
+            .recordType(RecordType.COMMAND)
+            .intent(DeploymentIntent.CREATE)
+            .key(keyGenerator.nextKey())
+            .write();
+
+    // when
+    streamProcessorControl.unblock();
+
+    final LoggedEvent writtenEvent =
+        doRepeatedly(
+                () ->
+                    streams
+                        .events(STREAM_NAME)
+                        .filter(
+                            e -> Records.isEvent(e, ValueType.DEPLOYMENT, DeploymentIntent.CREATED))
+                        .findFirst())
+            .until(o -> o.isPresent())
+            .get();
+
+    // then
+    assertThat(writtenEvent.getKey()).isEqualTo(1);
+    assertThat(writtenEvent.getProducerId()).isEqualTo(STREAM_PROCESSOR_ID);
+    assertThat(writtenEvent.getSourceEventPosition()).isEqualTo(secondEventPosition);
+
+    // error response
+    verify(output).sendResponse(any());
+
+    assertThat(requestId.get()).isEqualTo(255L);
+    assertThat(requestStreamId.get()).isEqualTo(99);
+
+    final TypedRecord<DeploymentRecord> deploymentRejection =
+        new RecordStream(streams.events(STREAM_NAME))
+            .onlyDeploymentRecords()
+            .onlyRejections()
+            .withIntent(DeploymentIntent.CREATE)
+            .getFirst();
+
+    assertThat(deploymentRejection.getKey()).isEqualTo(failingKey);
+    assertThat(deploymentRejection.getMetadata().getRejectionType())
+        .isEqualTo(RejectionType.PROCESSING_ERROR);
+  }
+
   protected DeploymentRecord deployment(final String name, final ResourceType resourceType) {
     final DeploymentRecord event = new DeploymentRecord();
     event
@@ -135,6 +229,22 @@ public class TypedStreamProcessorTest {
         .setResource(wrapString("foo"))
         .setResourceName(wrapString(name));
     return event;
+  }
+
+  protected static class ErrorProneProcessor implements TypedRecordProcessor<DeploymentRecord> {
+
+    @Override
+    public void processRecord(
+        final TypedRecord<DeploymentRecord> record,
+        final TypedResponseWriter responseWriter,
+        final TypedStreamWriter streamWriter) {
+      if (record.getKey() == 0) {
+        throw new RuntimeException("expected");
+      }
+      streamWriter.appendFollowUpEvent(
+          record.getKey(), DeploymentIntent.CREATED, record.getValue());
+      streamWriter.flush();
+    }
   }
 
   protected static class BatchProcessor implements TypedRecordProcessor<DeploymentRecord> {

--- a/broker-core/src/test/java/io/zeebe/broker/util/StreamProcessorRule.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/StreamProcessorRule.java
@@ -125,7 +125,7 @@ public class StreamProcessorRule implements TestRule {
         (db) -> {
           zeebeState = new ZeebeState(db);
           final TypedEventStreamProcessorBuilder processorBuilder =
-              streamEnvironment.newStreamProcessor().keyGenerator(zeebeState.getKeyGenerator());
+              streamEnvironment.newStreamProcessor().zeebeState(zeebeState);
 
           return factory.apply(processorBuilder, db);
         });

--- a/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
@@ -432,6 +432,13 @@ public class TestStreams {
         }
 
         @Override
+        public void processingFailed(Exception exception) {
+          if (actualProcessor != null) {
+            actualProcessor.processingFailed(exception);
+          }
+        }
+
+        @Override
         public boolean executeSideEffects() {
           return actualProcessor == null || actualProcessor.executeSideEffects();
         }
@@ -481,6 +488,16 @@ public class TestStreams {
 
     public FluentLogWriter intent(final Intent intent) {
       this.metadata.intent(intent);
+      return this;
+    }
+
+    public FluentLogWriter requestId(final long requestId) {
+      this.metadata.requestId(requestId);
+      return this;
+    }
+
+    public FluentLogWriter requestStreamId(final int requestStreamId) {
+      this.metadata.requestStreamId(requestStreamId);
       return this;
     }
 

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/TimerStartEventTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/TimerStartEventTest.java
@@ -112,6 +112,7 @@ public class TimerStartEventTest {
 
     Assertions.assertThat(timerRecord)
         .hasDueDate(brokerRule.getClock().getCurrentTimeInMillis() + 1000)
+        .hasWorkflowInstanceKey(NO_ELEMENT_INSTANCE)
         .hasHandlerFlowNodeId("start_1")
         .hasElementInstanceKey(NO_ELEMENT_INSTANCE);
   }

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/state/TimerInstanceStateTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/state/TimerInstanceStateTest.java
@@ -93,6 +93,7 @@ public class TimerInstanceStateTest {
     // given
     final TimerInstance timer = new TimerInstance();
     timer.setElementInstanceKey(1L);
+    timer.setWorkflowInstanceKey(1L);
     timer.setKey(2L);
     timer.setDueDate(1000L);
     state.put(timer);
@@ -104,6 +105,7 @@ public class TimerInstanceStateTest {
     assertThat(readTimer).isNotNull();
     assertThat(readTimer.getElementInstanceKey()).isEqualTo(1L);
     assertThat(readTimer.getKey()).isEqualTo(2L);
+    assertThat(readTimer.getWorkflowInstanceKey()).isEqualTo(1L);
     assertThat(readTimer.getDueDate()).isEqualTo(1000L);
 
     // and

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/timer/TimerCatchEventTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/timer/TimerCatchEventTest.java
@@ -142,7 +142,7 @@ public class TimerCatchEventTest {
             .done();
 
     testClient.deploy(workflow);
-    testClient.createWorkflowInstance(PROCESS_ID);
+    final long workflowInstanceKey = testClient.createWorkflowInstance(PROCESS_ID);
 
     // when
     final Record<WorkflowInstanceRecordValue> activatedEvent =
@@ -154,7 +154,9 @@ public class TimerCatchEventTest {
     final Record<TimerRecordValue> createdEvent =
         RecordingExporter.timerRecords(TimerIntent.CREATED).getFirst();
 
-    Assertions.assertThat(createdEvent.getValue()).hasElementInstanceKey(activatedEvent.getKey());
+    Assertions.assertThat(createdEvent.getValue())
+        .hasElementInstanceKey(activatedEvent.getKey())
+        .hasWorkflowInstanceKey(workflowInstanceKey);
     assertThat(createdEvent.getValue().getDueDate())
         .isGreaterThan(brokerRule.getClock().getCurrentTimeInMillis());
   }

--- a/exporter-api/src/main/java/io/zeebe/exporter/record/value/TimerRecordValue.java
+++ b/exporter-api/src/main/java/io/zeebe/exporter/record/value/TimerRecordValue.java
@@ -28,6 +28,9 @@ public interface TimerRecordValue extends RecordValue {
   /** @return the key of the related element instance. */
   long getElementInstanceKey();
 
+  /** @return the key of the related workflow instance */
+  long getWorkflowInstanceKey();
+
   /** @return the due date of the timer as Unix timestamp in millis. */
   long getDueDate();
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/EventProcessor.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/EventProcessor.java
@@ -24,6 +24,12 @@ public interface EventProcessor {
    * state.
    */
   default void processEvent() {}
+  /**
+   * Is called when processing failed due to an unexpected exception. Do clean up work.
+   *
+   * @param exception the exception which was catched during processing
+   */
+  default void processingFailed(Exception exception) {}
 
   /**
    * (Optional) Execute the side effects which are caused by the processed event. A side effect can

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
@@ -44,10 +44,13 @@ public class StreamProcessorController extends Actor {
       "Stream processor '%s' failed to recover. Cannot find event with the snapshot position in target log stream.";
   private static final String ERROR_MESSAGE_REPROCESSING_NO_SOURCE_EVENT =
       "Stream processor '%s' failed to reprocess. Cannot find source event position: %d";
-  private static final String ERROR_MESSAGE_REPROCESSING_FAILED =
-      "Stream processor '%s' failed to reprocess event: %s";
+
   private static final String ERROR_MESSAGE_PROCESSING_FAILED =
       "Stream processor '{}' failed to process event. It stop processing further events.";
+  private static final String ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT =
+      "Stream processor '{}' failed to process event. Skip this event {}.";
+  private static final String ERROR_MESSAGE_REPROCESSING_FAILED_SKIP_EVENT =
+      "Stream processor '{}' failed to reprocess event. Skip this event {}.";
 
   private final StreamProcessorFactory streamProcessorFactory;
   private StreamProcessor streamProcessor;
@@ -239,21 +242,21 @@ public class StreamProcessorController extends Actor {
     if (eventFilter == null || eventFilter.applies(currentEvent)) {
       try {
         final EventProcessor eventProcessor = streamProcessor.onEvent(currentEvent);
-
         if (eventProcessor != null) {
-          // don't execute side effects or write events
-          zeebeDb.transaction(eventProcessor::processEvent);
-          onRecordReprocessed(currentEvent);
-        } else {
-          onRecordReprocessed(currentEvent);
+          try {
+            // don't execute side effects or write events
+            zeebeDb.transaction(eventProcessor::processEvent);
+          } catch (final Exception e) {
+            LOG.error(ERROR_MESSAGE_REPROCESSING_FAILED_SKIP_EVENT, getName(), currentEvent, e);
+            zeebeDb.transaction(() -> eventProcessor.processingFailed(e));
+          }
         }
       } catch (final Exception e) {
-        throw new RuntimeException(
-            String.format(ERROR_MESSAGE_REPROCESSING_FAILED, getName(), currentEvent), e);
+        LOG.error(ERROR_MESSAGE_REPROCESSING_FAILED_SKIP_EVENT, getName(), currentEvent, e);
       }
-    } else {
-      onRecordReprocessed(currentEvent);
     }
+
+    onRecordReprocessed(currentEvent);
   }
 
   private void onRecordReprocessed(final LoggedEvent currentEvent) {
@@ -286,33 +289,39 @@ public class StreamProcessorController extends Actor {
       if (eventFilter == null || eventFilter.applies(currentEvent)) {
         processEvent(currentEvent);
       } else {
-        // continue with the next event
-        actor.submit(readNextEvent);
-
-        metrics.incrementEventsSkippedCount();
+        skipRecord();
       }
     }
   }
 
   private void processEvent(final LoggedEvent event) {
-    eventProcessor = streamProcessor.onEvent(event);
+    try {
+      eventProcessor = streamProcessor.onEvent(event);
 
-    if (eventProcessor != null) {
-      try {
-        metrics.incrementEventsProcessedCount();
-
-        zeebeDb.transaction(eventProcessor::processEvent);
-        actor.runUntilDone(this::executeSideEffects);
-      } catch (final Exception e) {
-        LOG.error(ERROR_MESSAGE_PROCESSING_FAILED, getName(), e);
-        onFailure();
+      if (eventProcessor != null) {
+        try {
+          zeebeDb.transaction(eventProcessor::processEvent);
+          metrics.incrementEventsProcessedCount();
+          actor.runUntilDone(this::executeSideEffects);
+        } catch (final Exception e) {
+          LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT, getName(), event, e);
+          zeebeDb.transaction(() -> eventProcessor.processingFailed(e));
+          // send rejection etc
+          actor.runUntilDone(this::executeSideEffects);
+        }
+      } else {
+        skipRecord();
       }
-    } else {
-      // continue with the next event
-      actor.submit(readNextEvent);
-
-      metrics.incrementEventsSkippedCount();
+    } catch (final Exception e) {
+      LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT, getName(), event, e);
+      eventProcessor = null;
+      skipRecord();
     }
+  }
+
+  private void skipRecord() {
+    actor.submit(readNextEvent);
+    metrics.incrementEventsSkippedCount();
   }
 
   private void executeSideEffects() {

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
@@ -28,13 +28,19 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class RecordingStreamProcessor implements StreamProcessor {
   private final List<LoggedEvent> events = new ArrayList<>();
   private final AtomicInteger processedEvents = new AtomicInteger(0);
+  private final AtomicInteger failedEvents = new AtomicInteger(0);
   private final ZeebeDb zeebeDb;
   private final EventProcessor eventProcessor =
       spy(
           new EventProcessor() {
             public void processEvent() {
               processedEvents.incrementAndGet();
-            };
+            }
+
+            @Override
+            public void processingFailed(Exception exception) {
+              failedEvents.incrementAndGet();
+            }
           });
 
   private StreamProcessorContext context = null;
@@ -90,5 +96,9 @@ public class RecordingStreamProcessor implements StreamProcessor {
 
   public StreamProcessorContext getContext() {
     return context;
+  }
+
+  public int getProcessingFailedCount() {
+    return failedEvents.get();
   }
 }

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorReprocessingTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorReprocessingTest.java
@@ -19,6 +19,7 @@ import static io.zeebe.test.util.TestUtil.waitUntil;
 import static io.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -43,6 +44,7 @@ import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 import org.junit.Before;
@@ -181,6 +183,43 @@ public class StreamProcessorReprocessingTest {
   }
 
   @Test
+  public void shouldCallProcessingFailedOnReprocessingError() {
+    // given
+    final long eventPosition1 = writeEvent();
+    final long eventPosition2 = writeEvent();
+    final long eventPosition3 =
+        writeEventWith(w -> w.producerId(PROCESSOR_ID).sourceRecordPosition(eventPosition2));
+
+    // when
+    openStreamProcessorController(
+        () -> {
+          final EventProcessor eventProcessorSpy = streamProcessor.getEventProcessorSpy();
+          final AtomicLong count = new AtomicLong(0);
+          doAnswer(
+                  (invocationOnMock) -> {
+                    if (count.getAndIncrement() == 0) {
+                      throw new RuntimeException("expected");
+                    } else {
+                      return invocationOnMock.callRealMethod();
+                    }
+                  })
+              .when(eventProcessorSpy)
+              .processEvent();
+        });
+    waitUntilProcessedAndFailedCountReached(2, 1);
+
+    // then
+    assertThat(streamProcessor.getEvents())
+        .extracting(LoggedEvent::getPosition)
+        .containsExactly(eventPosition1, eventPosition2, eventPosition3);
+
+    verify(eventProcessor, times(3)).processEvent();
+    verify(eventProcessor, times(1)).processingFailed(any());
+    verify(eventProcessor, times(1)).executeSideEffects();
+    verify(eventProcessor, times(1)).writeEvent(any());
+  }
+
+  @Test
   public void shouldReprocessUntilLastSourceEvent() {
     // given [1|S:-] --> [2|S:1] --> [3|S:2]
     final long eventPosition1 = writeEvent();
@@ -277,24 +316,48 @@ public class StreamProcessorReprocessingTest {
   }
 
   @Test
-  public void shouldFailOnReprocessing() {
+  public void shouldSkipEventOnEventError() {
     // given [1|S:-] --> [2|S:1]
     final long eventPosition1 = writeEvent();
     writeEventWith(w -> w.producerId(PROCESSOR_ID).sourceRecordPosition(eventPosition1));
+
     final ActorFuture<StreamProcessorService> future =
         openStreamProcessorControllerAsync(
             () -> {
-              doThrow(new RuntimeException("expected")).when(eventProcessor).processEvent();
+              doThrow(new RuntimeException("expected")).when(streamProcessor).onEvent(any());
             });
 
     // when
     waitUntil(() -> future.isDone());
 
     // then
-    verify(streamProcessor, times(0)).onRecovered();
+    verify(streamProcessor, times(1)).onRecovered();
+  }
+
+  @Test
+  public void shouldSkipEventOnReprocessingError() {
+    // given [1|S:-] --> [2|S:1]
+    final long eventPosition1 = writeEvent();
+    final long eventPosition2 = writeEvent();
+    final long eventPosition3 =
+        writeEventWith(w -> w.producerId(PROCESSOR_ID).sourceRecordPosition(eventPosition2));
+
+    openStreamProcessorController(
+        () -> {
+          doThrow(new RuntimeException("expected")).when(eventProcessor).processEvent();
+        });
+
+    // when
+    waitUntilProcessedAndFailedCountReached(0, 3);
+
+    // then
     assertThat(streamProcessor.getEvents())
         .extracting(LoggedEvent::getPosition)
-        .containsExactly(eventPosition1);
+        .containsExactly(eventPosition1, eventPosition2, eventPosition3);
+
+    verify(streamProcessor, times(1)).onRecovered();
+    verify(eventProcessor, times(3)).processEvent();
+    verify(eventProcessor, times(3)).processingFailed(any());
   }
 
   @Test
@@ -449,5 +512,12 @@ public class StreamProcessorReprocessingTest {
           wr.accept(w);
         },
         true);
+  }
+
+  private void waitUntilProcessedAndFailedCountReached(int processCount, int failedCount) {
+    waitUntil(
+        () ->
+            streamProcessor.getProcessedEventCount() == processCount
+                && streamProcessor.getProcessingFailedCount() == failedCount);
   }
 }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -20,10 +20,11 @@ import io.zeebe.msgpack.property.EnumProperty;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
 import io.zeebe.protocol.ErrorType;
+import io.zeebe.protocol.WorkflowInstanceRelated;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import org.agrona.DirectBuffer;
 
-public class IncidentRecord extends UnpackedObject {
+public class IncidentRecord extends UnpackedObject implements WorkflowInstanceRelated {
   private final EnumProperty<ErrorType> errorTypeProp =
       new EnumProperty<>("errorType", ErrorType.class, ErrorType.UNKNOWN);
   private final StringProperty errorMessageProp = new StringProperty("errorMessage", "");

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -24,10 +24,11 @@ import io.zeebe.msgpack.property.PackedProperty;
 import io.zeebe.msgpack.property.StringProperty;
 import io.zeebe.msgpack.spec.MsgPackHelper;
 import io.zeebe.protocol.Protocol;
+import io.zeebe.protocol.WorkflowInstanceRelated;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
-public class JobRecord extends UnpackedObject {
+public class JobRecord extends UnpackedObject implements WorkflowInstanceRelated {
   public static final DirectBuffer NO_HEADERS = new UnsafeBuffer(MsgPackHelper.EMTPY_OBJECT);
 
   public static final String RETRIES = "retries";
@@ -155,5 +156,10 @@ public class JobRecord extends UnpackedObject {
   public JobRecord setErrorMessage(DirectBuffer buf, int offset, int length) {
     errorMessageProp.setValue(buf, offset, length);
     return this;
+  }
+
+  @Override
+  public long getWorkflowInstanceKey() {
+    return headersProp.getValue().getWorkflowInstanceKey();
   }
 }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/timer/TimerRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/timer/TimerRecord.java
@@ -19,11 +19,13 @@ import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.msgpack.property.IntegerProperty;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
+import io.zeebe.protocol.WorkflowInstanceRelated;
 import org.agrona.DirectBuffer;
 
-public class TimerRecord extends UnpackedObject {
+public class TimerRecord extends UnpackedObject implements WorkflowInstanceRelated {
 
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey");
+  private final LongProperty workflowInstanceKeyProp = new LongProperty("workflowInstanceKey");
   private final LongProperty dueDateProp = new LongProperty("dueDate");
   private final StringProperty handlerNodeId = new StringProperty("handlerNodeId");
   private final IntegerProperty repetitionsProp = new IntegerProperty("repetitions");
@@ -31,6 +33,7 @@ public class TimerRecord extends UnpackedObject {
 
   public TimerRecord() {
     this.declareProperty(elementInstanceKeyProp)
+        .declareProperty(workflowInstanceKeyProp)
         .declareProperty(dueDateProp)
         .declareProperty(handlerNodeId)
         .declareProperty(repetitionsProp)
@@ -80,5 +83,14 @@ public class TimerRecord extends UnpackedObject {
   public TimerRecord setWorkflowKey(long workflowKey) {
     this.workflowKeyProp.setValue(workflowKey);
     return this;
+  }
+
+  public TimerRecord setWorkflowInstanceKey(long workflowInstanceKey) {
+    this.workflowInstanceKeyProp.setValue(workflowInstanceKey);
+    return this;
+  }
+
+  public long getWorkflowInstanceKey() {
+    return workflowInstanceKeyProp.getValue();
   }
 }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -19,9 +19,10 @@ import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.msgpack.property.BinaryProperty;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
+import io.zeebe.protocol.WorkflowInstanceRelated;
 import org.agrona.DirectBuffer;
 
-public class VariableRecord extends UnpackedObject {
+public class VariableRecord extends UnpackedObject implements WorkflowInstanceRelated {
 
   private final StringProperty nameProp = new StringProperty("name");
   private final BinaryProperty valueProp = new BinaryProperty("value");

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/workflowinstance/WorkflowInstanceRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/workflowinstance/WorkflowInstanceRecord.java
@@ -23,10 +23,11 @@ import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
 import io.zeebe.msgpack.spec.MsgPackHelper;
 import io.zeebe.protocol.BpmnElementType;
+import io.zeebe.protocol.WorkflowInstanceRelated;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
-public class WorkflowInstanceRecord extends UnpackedObject {
+public class WorkflowInstanceRecord extends UnpackedObject implements WorkflowInstanceRelated {
   public static final DirectBuffer EMPTY_PAYLOAD = new UnsafeBuffer(MsgPackHelper.EMTPY_OBJECT);
 
   public static final String PROP_WORKFLOW_BPMN_PROCESS_ID = "bpmnProcessId";

--- a/protocol/src/main/java/io/zeebe/protocol/WorkflowInstanceRelated.java
+++ b/protocol/src/main/java/io/zeebe/protocol/WorkflowInstanceRelated.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.protocol;
+
+public interface WorkflowInstanceRelated {
+
+  long getWorkflowInstanceKey();
+}

--- a/protocol/src/main/java/io/zeebe/protocol/intent/IncidentIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/IncidentIntent.java
@@ -15,17 +15,23 @@
  */
 package io.zeebe.protocol.intent;
 
-public enum IncidentIntent implements Intent {
+public enum IncidentIntent implements WorkflowInstanceRelatedIntent {
   CREATE((short) 0),
   CREATED((short) 1),
 
-  RESOLVE((short) 2),
+  RESOLVE((short) 2, false),
   RESOLVED((short) 3);
 
   private final short value;
+  private final boolean shouldBlacklist;
 
   IncidentIntent(short value) {
+    this(value, true);
+  }
+
+  IncidentIntent(short value, boolean shouldBlacklist) {
     this.value = value;
+    this.shouldBlacklist = shouldBlacklist;
   }
 
   public short getIntent() {
@@ -50,5 +56,10 @@ public enum IncidentIntent implements Intent {
   @Override
   public short value() {
     return value;
+  }
+
+  @Override
+  public boolean shouldBlacklistInstanceOnError() {
+    return shouldBlacklist;
   }
 }

--- a/protocol/src/main/java/io/zeebe/protocol/intent/JobIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/JobIntent.java
@@ -15,31 +15,37 @@
  */
 package io.zeebe.protocol.intent;
 
-public enum JobIntent implements Intent {
+public enum JobIntent implements WorkflowInstanceRelatedIntent {
   CREATE((short) 0),
   CREATED((short) 1),
 
   ACTIVATED((short) 2),
 
-  COMPLETE((short) 3),
+  COMPLETE((short) 3, false),
   COMPLETED((short) 4),
 
   TIME_OUT((short) 5),
   TIMED_OUT((short) 6),
 
-  FAIL((short) 7),
+  FAIL((short) 7, false),
   FAILED((short) 8),
 
-  UPDATE_RETRIES((short) 9),
+  UPDATE_RETRIES((short) 9, false),
   RETRIES_UPDATED((short) 10),
 
   CANCEL((short) 11),
   CANCELED((short) 12);
 
   private final short value;
+  private final boolean shouldBlacklist;
 
   JobIntent(short value) {
+    this(value, true);
+  }
+
+  JobIntent(short value, boolean shouldBlacklist) {
     this.value = value;
+    this.shouldBlacklist = shouldBlacklist;
   }
 
   public short getIntent() {
@@ -82,5 +88,10 @@ public enum JobIntent implements Intent {
   @Override
   public short value() {
     return value;
+  }
+
+  @Override
+  public boolean shouldBlacklistInstanceOnError() {
+    return shouldBlacklist;
   }
 }

--- a/protocol/src/main/java/io/zeebe/protocol/intent/MessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/MessageSubscriptionIntent.java
@@ -15,7 +15,7 @@
  */
 package io.zeebe.protocol.intent;
 
-public enum MessageSubscriptionIntent implements Intent {
+public enum MessageSubscriptionIntent implements WorkflowInstanceRelatedIntent {
   OPEN((short) 0),
   OPENED((short) 1),
 
@@ -25,10 +25,16 @@ public enum MessageSubscriptionIntent implements Intent {
   CLOSE((short) 4),
   CLOSED((short) 5);
 
-  private short value;
+  private final short value;
+  private final boolean shouldBlacklist;
 
   MessageSubscriptionIntent(short value) {
+    this(value, true);
+  }
+
+  MessageSubscriptionIntent(short value, boolean shouldBlacklist) {
     this.value = value;
+    this.shouldBlacklist = shouldBlacklist;
   }
 
   @Override
@@ -53,5 +59,10 @@ public enum MessageSubscriptionIntent implements Intent {
       default:
         return Intent.UNKNOWN;
     }
+  }
+
+  @Override
+  public boolean shouldBlacklistInstanceOnError() {
+    return shouldBlacklist;
   }
 }

--- a/protocol/src/main/java/io/zeebe/protocol/intent/TimerIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/TimerIntent.java
@@ -15,7 +15,7 @@
  */
 package io.zeebe.protocol.intent;
 
-public enum TimerIntent implements Intent {
+public enum TimerIntent implements WorkflowInstanceRelatedIntent {
   CREATE((short) 0),
   CREATED((short) 1),
 
@@ -25,10 +25,16 @@ public enum TimerIntent implements Intent {
   CANCEL((short) 4),
   CANCELED((short) 5);
 
-  private short value;
+  private final short value;
+  private final boolean shouldBlacklist;
 
   TimerIntent(short value) {
+    this(value, true);
+  }
+
+  TimerIntent(short value, boolean shouldBlacklist) {
     this.value = value;
+    this.shouldBlacklist = shouldBlacklist;
   }
 
   @Override
@@ -53,5 +59,10 @@ public enum TimerIntent implements Intent {
       default:
         return Intent.UNKNOWN;
     }
+  }
+
+  @Override
+  public boolean shouldBlacklistInstanceOnError() {
+    return shouldBlacklist;
   }
 }

--- a/protocol/src/main/java/io/zeebe/protocol/intent/WorkflowInstanceIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/WorkflowInstanceIntent.java
@@ -15,9 +15,9 @@
  */
 package io.zeebe.protocol.intent;
 
-public enum WorkflowInstanceIntent implements Intent {
-  CREATE((short) 0),
-  CANCEL((short) 1),
+public enum WorkflowInstanceIntent implements WorkflowInstanceRelatedIntent {
+  CREATE((short) 0, false),
+  CANCEL((short) 1, false),
 
   SEQUENCE_FLOW_TAKEN((short) 2),
 
@@ -31,9 +31,15 @@ public enum WorkflowInstanceIntent implements Intent {
   EVENT_OCCURRED((short) 9);
 
   private final short value;
+  private final boolean shouldBlacklist;
 
   WorkflowInstanceIntent(short value) {
+    this(value, true);
+  }
+
+  WorkflowInstanceIntent(short value, boolean shouldBlacklist) {
     this.value = value;
+    this.shouldBlacklist = shouldBlacklist;
   }
 
   public short getIntent() {
@@ -70,5 +76,10 @@ public enum WorkflowInstanceIntent implements Intent {
   @Override
   public short value() {
     return value;
+  }
+
+  @Override
+  public boolean shouldBlacklistInstanceOnError() {
+    return shouldBlacklist;
   }
 }

--- a/protocol/src/main/java/io/zeebe/protocol/intent/WorkflowInstanceRelatedIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/WorkflowInstanceRelatedIntent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.protocol.intent;
+
+public interface WorkflowInstanceRelatedIntent extends Intent {
+
+  boolean shouldBlacklistInstanceOnError();
+}

--- a/protocol/src/main/java/io/zeebe/protocol/intent/WorkflowInstanceSubscriptionIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/WorkflowInstanceSubscriptionIntent.java
@@ -15,7 +15,7 @@
  */
 package io.zeebe.protocol.intent;
 
-public enum WorkflowInstanceSubscriptionIntent implements Intent {
+public enum WorkflowInstanceSubscriptionIntent implements WorkflowInstanceRelatedIntent {
   OPEN((short) 0),
   OPENED((short) 1),
 
@@ -25,10 +25,16 @@ public enum WorkflowInstanceSubscriptionIntent implements Intent {
   CLOSE((short) 4),
   CLOSED((short) 5);
 
-  private short value;
+  private final short value;
+  private final boolean shouldBlacklist;
 
   WorkflowInstanceSubscriptionIntent(short value) {
+    this(value, true);
+  }
+
+  WorkflowInstanceSubscriptionIntent(short value, boolean shouldBlacklist) {
     this.value = value;
+    this.shouldBlacklist = shouldBlacklist;
   }
 
   @Override
@@ -53,5 +59,10 @@ public enum WorkflowInstanceSubscriptionIntent implements Intent {
       default:
         return Intent.UNKNOWN;
     }
+  }
+
+  @Override
+  public boolean shouldBlacklistInstanceOnError() {
+    return shouldBlacklist;
   }
 }

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -67,6 +67,7 @@
       <validValue name="NOT_FOUND">1</validValue>
       <validValue name="ALREADY_EXISTS">2</validValue>
       <validValue name="INVALID_STATE">3</validValue>
+      <validValue name="PROCESSING_ERROR">4</validValue>
     </enum>
   </types>
 


### PR DESCRIPTION
Updated to the latest changes -> Reopen #2030

> StreamProcessorController skips the corresponding record when an exception was thrown in`#onEvent` or `#processEvent`. The `#updateState` method was removed, since it is not used.
> 
> When an exception/error appears on the command processing in the `TypedStreamProcessor`
> a corresponding command rejection is send and the exception is rethrown such that the `StreamProcessorController` can skip this record.
> 
> An follow up issue #2028 was created to clean up the state, when an exception appears on processing an event. Since we hope/expect that not so many exceptions/errors appear this issue has no high priority, but should be done somehow in the near future.
> 
> I was not sure whether we should also write an command rejection on the log or not, currently I think it makes no real difference (?).
> 
> related to #1988 

closes #2054