### PR TITLE
XOR-Gateway uses only needed variables

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/gateway/ExclusiveGatewayElementActivatingHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/gateway/ExclusiveGatewayElementActivatingHandler.java
@@ -20,7 +20,6 @@ package io.zeebe.broker.workflow.processor.handlers.gateway;
 import io.zeebe.broker.workflow.model.element.ExecutableExclusiveGateway;
 import io.zeebe.broker.workflow.model.element.ExecutableSequenceFlow;
 import io.zeebe.broker.workflow.processor.BpmnStepContext;
-import io.zeebe.broker.workflow.processor.handlers.IOMappingHelper;
 import io.zeebe.broker.workflow.processor.handlers.element.ElementActivatingHandler;
 import io.zeebe.msgpack.el.CompiledJsonCondition;
 import io.zeebe.msgpack.el.JsonConditionException;
@@ -29,7 +28,9 @@ import io.zeebe.protocol.BpmnElementType;
 import io.zeebe.protocol.impl.record.value.incident.ErrorType;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 
 public class ExclusiveGatewayElementActivatingHandler<T extends ExecutableExclusiveGateway>
@@ -48,20 +49,6 @@ public class ExclusiveGatewayElementActivatingHandler<T extends ExecutableExclus
     this.interpreter = interpreter;
   }
 
-  public ExclusiveGatewayElementActivatingHandler(
-      WorkflowInstanceIntent nextState, JsonConditionInterpreter interpreter) {
-    super(nextState);
-    this.interpreter = interpreter;
-  }
-
-  public ExclusiveGatewayElementActivatingHandler(
-      WorkflowInstanceIntent nextState,
-      IOMappingHelper ioMappingHelper,
-      JsonConditionInterpreter interpreter) {
-    super(nextState, ioMappingHelper);
-    this.interpreter = interpreter;
-  }
-
   @Override
   protected boolean handleState(BpmnStepContext<T> context) {
     if (!super.handleState(context)) {
@@ -69,15 +56,13 @@ public class ExclusiveGatewayElementActivatingHandler<T extends ExecutableExclus
     }
 
     final WorkflowInstanceRecord value = context.getValue();
-    final DirectBuffer payload =
-        context
-            .getElementInstanceState()
-            .getVariablesState()
-            .getVariablesAsDocument(context.getRecord().getKey());
-    final ExecutableSequenceFlow sequenceFlow;
 
+    final ExecutableSequenceFlow sequenceFlow;
     try {
-      sequenceFlow = getSequenceFlowWithFulfilledCondition(context.getElement(), payload);
+      final ExecutableExclusiveGateway exclusiveGateway = context.getElement();
+      final DirectBuffer payload = determinePayload(context, exclusiveGateway);
+
+      sequenceFlow = getSequenceFlowWithFulfilledCondition(exclusiveGateway, payload);
     } catch (JsonConditionException e) {
       context.raiseIncident(ErrorType.CONDITION_ERROR, e.getMessage());
       return false;
@@ -90,6 +75,23 @@ public class ExclusiveGatewayElementActivatingHandler<T extends ExecutableExclus
 
     deferSequenceFlowTaken(context, value, sequenceFlow);
     return true;
+  }
+
+  private DirectBuffer determinePayload(
+      BpmnStepContext<T> context, ExecutableExclusiveGateway exclusiveGateway) {
+    final List<ExecutableSequenceFlow> sequenceFlows = exclusiveGateway.getOutgoingWithCondition();
+
+    final Set<DirectBuffer> actualNeededVariables = new HashSet<>();
+    for (final ExecutableSequenceFlow seqFlow : sequenceFlows) {
+      final CompiledJsonCondition compiledCondition = seqFlow.getCondition();
+      final Set<DirectBuffer> variableNames = compiledCondition.getVariableNames();
+      actualNeededVariables.addAll(variableNames);
+    }
+
+    return context
+        .getElementInstanceState()
+        .getVariablesState()
+        .getVariablesAsDocument(context.getRecord().getKey(), actualNeededVariables);
   }
 
   private void deferSequenceFlowTaken(

--- a/json-el/src/main/java/io/zeebe/msgpack/el/CompiledJsonCondition.java
+++ b/json-el/src/main/java/io/zeebe/msgpack/el/CompiledJsonCondition.java
@@ -15,6 +15,10 @@
  */
 package io.zeebe.msgpack.el;
 
+import java.util.Set;
+import org.agrona.DirectBuffer;
+import scala.collection.JavaConverters;
+
 public final class CompiledJsonCondition {
   private final String expression;
   private final JsonCondition condition;
@@ -51,6 +55,10 @@ public final class CompiledJsonCondition {
 
   public String getErrorMessage() {
     return errorMessage;
+  }
+
+  public Set<DirectBuffer> getVariableNames() {
+    return JavaConverters.setAsJavaSet(condition.variableNames());
   }
 
   @Override

--- a/json-el/src/main/scala/io/zeebe/msgpack/el/JsonObject.scala
+++ b/json-el/src/main/scala/io/zeebe/msgpack/el/JsonObject.scala
@@ -67,6 +67,7 @@ case class JsonString(value: DirectBuffer) extends JsonObject with JsonConstant 
 
 case class JsonPath(value: String) extends JsonObject {
   val query: JsonPathQuery = new JsonPathQueryCompiler().compile(value)
+  val variableName = query.getTopLevelVariable
 
   var id_ = -1
 

--- a/json-el/src/test/java/io/zeebe/msgpack/el/JsonConditionVariableNamesTest.java
+++ b/json-el/src/test/java/io/zeebe/msgpack/el/JsonConditionVariableNamesTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.msgpack.el;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.util.buffer.BufferUtil;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.agrona.DirectBuffer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class JsonConditionVariableNamesTest {
+
+  private static DirectBuffer[] fromStrings(String... args) {
+    return Arrays.stream(args)
+        .map(str -> BufferUtil.wrapString(str))
+        .collect(Collectors.toList())
+        .toArray(new DirectBuffer[args.length]);
+  }
+
+  @Parameters(name = "{index}: expression = {0}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(
+        new Object[][] {
+          {"$.foo == $.bar || $.foo > 2 || $.bar <= 2", fromStrings("foo", "bar")},
+          {"$.foo == true", fromStrings("foo")},
+          {"$.foo == 21", fromStrings("foo")},
+          {"$.foo == 2.5", fromStrings("foo")},
+          {"$.foo == $.bar", fromStrings("foo", "bar")},
+          {"$.foo.bar == true", fromStrings("foo")},
+          {"$.foo[1] == true", fromStrings("foo")},
+          {"$.foo != 'bar'", fromStrings("foo")},
+          {"2 < 4", fromStrings()},
+          {"$.foo.bar > 2 || $.bar.foo < 4 || $.foobar == 21", fromStrings("foo", "bar", "foobar")},
+          {"$.foo > 2 && ($.foo < 4 || $.bar == 6)", fromStrings("foo", "bar")}
+        });
+  }
+
+  @Parameter public String expression;
+
+  @Parameter(1)
+  public DirectBuffer[] expectedVariableNames;
+
+  @Test
+  public void shouldReturnOnlyUniqueVariableNames() {
+    final CompiledJsonCondition condition = JsonConditionFactory.createCondition(expression);
+    assertThat(condition.isValid()).isTrue();
+
+    final Set<DirectBuffer> actualVariables = condition.getVariableNames();
+    assertThat(actualVariables).containsExactlyInAnyOrder(expectedVariableNames);
+  }
+}

--- a/json-path/src/main/java/io/zeebe/msgpack/jsonpath/JsonPathQuery.java
+++ b/json-path/src/main/java/io/zeebe/msgpack/jsonpath/JsonPathQuery.java
@@ -30,6 +30,7 @@ public class JsonPathQuery {
       new MsgPackFilterContext(MAX_DEPTH, MAX_FILTER_CONTEXT_LENGTH);
 
   protected UnsafeBuffer expressionBuffer = new UnsafeBuffer(0, 0);
+  protected DirectBuffer topLevelVariable = new UnsafeBuffer(0, 0);
 
   protected int invalidPosition;
   protected String errorMessage;
@@ -72,5 +73,17 @@ public class JsonPathQuery {
 
   public DirectBuffer getExpression() {
     return expressionBuffer;
+  }
+
+  public boolean hasTopLevelVariable() {
+    return topLevelVariable.capacity() > 0;
+  }
+
+  public DirectBuffer getTopLevelVariable() {
+    return topLevelVariable;
+  }
+
+  public void setTopLevelVariable(byte[] topLevelVariable) {
+    this.topLevelVariable.wrap(topLevelVariable);
   }
 }

--- a/json-path/src/main/java/io/zeebe/msgpack/jsonpath/JsonPathQueryCompiler.java
+++ b/json-path/src/main/java/io/zeebe/msgpack/jsonpath/JsonPathQueryCompiler.java
@@ -104,6 +104,12 @@ public class JsonPathQueryCompiler implements JsonPathTokenVisitor {
             filterInstances.filterId(ARRAY_INDEX_FILTER_ID);
             ArrayIndexFilter.encodeDynamicContext(filterInstances.dynamicContext(), arrayIndex);
           } else {
+            if (!currentQuery.hasTopLevelVariable()) {
+              final byte[] variable = new byte[valueLength];
+              valueBuffer.getBytes(valueOffset, variable);
+              currentQuery.setTopLevelVariable(variable);
+            }
+
             filterInstances.appendElement();
             filterInstances.filterId(MAP_VALUE_FILTER_ID);
             MapValueWithKeyFilter.encodeDynamicContext(

--- a/json-path/src/test/java/io/zeebe/msgpack/jsonpath/JsonPathQueryCompilerTest.java
+++ b/json-path/src/test/java/io/zeebe/msgpack/jsonpath/JsonPathQueryCompilerTest.java
@@ -23,6 +23,7 @@ import io.zeebe.msgpack.filter.MsgPackFilter;
 import io.zeebe.msgpack.filter.RootCollectionFilter;
 import io.zeebe.msgpack.filter.WildcardFilter;
 import io.zeebe.msgpack.query.MsgPackFilterContext;
+import io.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 import org.junit.Test;
 
@@ -38,6 +39,7 @@ public class JsonPathQueryCompilerTest {
 
     // then
     assertThat(jsonPathQuery.isValid()).isTrue();
+    assertThat(jsonPathQuery.getTopLevelVariable()).isEqualTo(BufferUtil.wrapString("key1"));
 
     final MsgPackFilter[] filters = jsonPathQuery.getFilters();
     assertThat(filters).hasSize(4);

--- a/json-path/src/test/java/io/zeebe/msgpack/jsonpath/JsonPathQueryValidationTest.java
+++ b/json-path/src/test/java/io/zeebe/msgpack/jsonpath/JsonPathQueryValidationTest.java
@@ -30,10 +30,12 @@ public class JsonPathQueryValidationTest {
   public static Iterable<Object[]> data() {
     return Arrays.asList(
         new Object[][] {
-          {"$..", 1, "Unexpected json-path token RECURSION_OPERATOR"}, // currently not supported
-          {"foo", 0, "Unexpected json-path token LITERAL"},
-          {"$.foo.$", 6, "Unexpected json-path token ROOT_OBJECT"},
-          {"$.[foo", 2, "Unexpected json-path token SUBSCRIPT_OPERATOR_BEGIN"}
+          {
+            "$..", 1, "Unexpected json-path token RECURSION_OPERATOR", false
+          }, // currently not supported
+          {"foo", 0, "Unexpected json-path token LITERAL", false},
+          {"$.foo.$", 6, "Unexpected json-path token ROOT_OBJECT", true},
+          {"$.[foo", 2, "Unexpected json-path token SUBSCRIPT_OPERATOR_BEGIN", false}
         });
   }
 
@@ -45,6 +47,9 @@ public class JsonPathQueryValidationTest {
 
   @Parameter(2)
   public String expectedErrorMessage;
+
+  @Parameter(3)
+  public boolean expectedHasVariable;
 
   @Test
   public void testCompileInvalidQuery() {
@@ -58,5 +63,6 @@ public class JsonPathQueryValidationTest {
     assertThat(jsonPathQuery.isValid()).isFalse(); // as recursion is not yet supported
     assertThat(jsonPathQuery.getInvalidPosition()).isEqualTo(expectedInvalidPosition);
     assertThat(jsonPathQuery.getErrorReason()).isEqualTo(expectedErrorMessage);
+    assertThat(jsonPathQuery.hasTopLevelVariable()).isEqualTo(expectedHasVariable);
   }
 }


### PR DESCRIPTION
 * the JsonPathQuery contains the top level variable name
 * the CompiledJsonCondition provide a set of variable names, which are
 used in the condition
 * the handler for the XOR-Gateway uses the new functionallity
 to only request the needed variables
 * the top level variable name in the JsonPathQuery can also be used
 later for input and output mappings


closes #2097 
