### PR TITLE
chore(broker): adds WorkflowInstanceCreationRecord

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/WorkflowInstanceCreationRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/WorkflowInstanceCreationRecordValueImpl.java
@@ -1,0 +1,115 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value;
+
+import io.zeebe.broker.exporter.ExporterObjectMapper;
+import io.zeebe.broker.exporter.record.RecordValueImpl;
+import io.zeebe.exporter.record.value.WorkflowInstanceCreationRecordValue;
+import java.util.Map;
+import java.util.Objects;
+
+public class WorkflowInstanceCreationRecordValueImpl extends RecordValueImpl
+    implements WorkflowInstanceCreationRecordValue {
+  private final String bpmnProcessId;
+  private final int version;
+  private final long key;
+  private final long instanceKey;
+  private final Map<String, Object> variables;
+
+  public WorkflowInstanceCreationRecordValueImpl(
+      ExporterObjectMapper objectMapper,
+      String bpmnProcessId,
+      int version,
+      long key,
+      long instanceKey,
+      Map<String, Object> variables) {
+    super(objectMapper);
+    this.bpmnProcessId = bpmnProcessId;
+    this.version = version;
+    this.key = key;
+    this.instanceKey = instanceKey;
+    this.variables = variables;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  @Override
+  public int getVersion() {
+    return version;
+  }
+
+  @Override
+  public long getKey() {
+    return key;
+  }
+
+  @Override
+  public long getInstanceKey() {
+    return instanceKey;
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return variables;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof WorkflowInstanceCreationRecordValueImpl)) {
+      return false;
+    }
+
+    final WorkflowInstanceCreationRecordValueImpl that =
+        (WorkflowInstanceCreationRecordValueImpl) o;
+    return getVersion() == that.getVersion()
+        && getKey() == that.getKey()
+        && getInstanceKey() == that.getInstanceKey()
+        && Objects.equals(getBpmnProcessId(), that.getBpmnProcessId())
+        && Objects.equals(getVariables(), that.getVariables());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        getBpmnProcessId(), getVersion(), getKey(), getInstanceKey(), getVariables());
+  }
+
+  @Override
+  public String toString() {
+    return "WorkflowInstanceCreationRecordValueImpl{"
+        + "bpmnProcessId='"
+        + bpmnProcessId
+        + '\''
+        + ", version="
+        + version
+        + ", key="
+        + key
+        + ", workflowInstanceKey="
+        + instanceKey
+        + ", variables="
+        + variables
+        + "}";
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
@@ -28,6 +28,7 @@ import io.zeebe.broker.exporter.record.value.RaftRecordValueImpl;
 import io.zeebe.broker.exporter.record.value.TimerRecordValueImpl;
 import io.zeebe.broker.exporter.record.value.VariableDocumentRecordValueImpl;
 import io.zeebe.broker.exporter.record.value.VariableRecordValueImpl;
+import io.zeebe.broker.exporter.record.value.WorkflowInstanceCreationRecordValueImpl;
 import io.zeebe.broker.exporter.record.value.WorkflowInstanceRecordValueImpl;
 import io.zeebe.broker.exporter.record.value.WorkflowInstanceSubscriptionRecordValueImpl;
 import io.zeebe.broker.exporter.record.value.deployment.DeployedWorkflowImpl;
@@ -48,6 +49,7 @@ import io.zeebe.exporter.record.value.MessageSubscriptionRecordValue;
 import io.zeebe.exporter.record.value.RaftRecordValue;
 import io.zeebe.exporter.record.value.VariableDocumentRecordValue;
 import io.zeebe.exporter.record.value.VariableRecordValue;
+import io.zeebe.exporter.record.value.WorkflowInstanceCreationRecordValue;
 import io.zeebe.exporter.record.value.WorkflowInstanceRecordValue;
 import io.zeebe.exporter.record.value.WorkflowInstanceSubscriptionRecordValue;
 import io.zeebe.exporter.record.value.deployment.DeployedWorkflow;
@@ -67,6 +69,7 @@ import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.zeebe.protocol.impl.record.value.variable.VariableRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.raft.event.RaftConfigurationEvent;
 import io.zeebe.raft.event.RaftConfigurationEventMember;
@@ -132,6 +135,9 @@ public class ExporterRecordMapper {
         break;
       case VARIABLE_DOCUMENT:
         valueSupplier = this::ofVariableDocumentRecord;
+        break;
+      case WORKFLOW_INSTANCE_CREATION:
+        valueSupplier = this::ofWorkflowInstanceCreationRecord;
         break;
       default:
         return null;
@@ -374,6 +380,19 @@ public class ExporterRecordMapper {
         record.getScopeKey(),
         record.getUpdateSemantics(),
         asMsgPackMap(record.getDocument()));
+  }
+
+  private WorkflowInstanceCreationRecordValue ofWorkflowInstanceCreationRecord(LoggedEvent event) {
+    final WorkflowInstanceCreationRecord record = new WorkflowInstanceCreationRecord();
+    event.readValue(record);
+
+    return new WorkflowInstanceCreationRecordValueImpl(
+        objectMapper,
+        asString(record.getBpmnProcessId()),
+        record.getVersion(),
+        record.getKey(),
+        record.getInstanceKey(),
+        asMsgPackMap(record.getVariables()));
   }
 
   private byte[] asByteArray(final DirectBuffer buffer) {

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/CommandProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/CommandProcessor.java
@@ -27,7 +27,12 @@ import io.zeebe.protocol.intent.Intent;
  */
 public interface CommandProcessor<T extends UnpackedObject> {
 
-  void onCommand(TypedRecord<T> command, CommandControl<T> commandControl);
+  default void onCommand(TypedRecord<T> command, CommandControl<T> commandControl) {}
+
+  default void onCommand(
+      TypedRecord<T> command, CommandControl<T> commandControl, TypedStreamWriter streamWriter) {
+    onCommand(command, commandControl);
+  }
 
   interface CommandControl<T> {
     /** @return the key of the entity */

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/CommandProcessorImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/CommandProcessorImpl.java
@@ -54,8 +54,7 @@ public class CommandProcessorImpl<T extends UnpackedObject>
       final TypedStreamWriter streamWriter) {
 
     entityKey = command.getKey();
-
-    wrappedProcessor.onCommand(command, this);
+    wrappedProcessor.onCommand(command, this, streamWriter);
 
     final boolean respond = command.getMetadata().hasRequestMetadata();
 

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamEnvironment.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamEnvironment.java
@@ -32,6 +32,7 @@ import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.zeebe.protocol.impl.record.value.variable.VariableRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.transport.ServerOutput;
 import java.util.EnumMap;
@@ -58,6 +59,7 @@ public class TypedStreamEnvironment {
     EVENT_REGISTRY.put(ValueType.TIMER, TimerRecord.class);
     EVENT_REGISTRY.put(ValueType.VARIABLE, VariableRecord.class);
     EVENT_REGISTRY.put(ValueType.VARIABLE_DOCUMENT, VariableDocumentRecord.class);
+    EVENT_REGISTRY.put(ValueType.WORKFLOW_INSTANCE_CREATION, WorkflowInstanceCreationRecord.class);
   }
 
   private TypedStreamReader reader;

--- a/broker-core/src/main/java/io/zeebe/broker/transport/clientapi/ClientApiMessageHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/transport/clientapi/ClientApiMessageHandler.java
@@ -38,6 +38,7 @@ import io.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.Intent;
 import io.zeebe.transport.RemoteAddress;
@@ -89,6 +90,7 @@ public class ClientApiMessageHandler implements ServerMessageHandler, ServerRequ
     recordsByType.put(ValueType.JOB_BATCH, new JobBatchRecord());
     recordsByType.put(ValueType.INCIDENT, new IncidentRecord());
     recordsByType.put(ValueType.VARIABLE_DOCUMENT, new VariableDocumentRecord());
+    recordsByType.put(ValueType.WORKFLOW_INSTANCE_CREATION, new WorkflowInstanceCreationRecord());
   }
 
   private boolean handleExecuteCommandRequest(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceProcessor.java
@@ -1,0 +1,210 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow.processor.instance;
+
+import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.zeebe.broker.Loggers;
+import io.zeebe.broker.logstreams.processor.CommandProcessor;
+import io.zeebe.broker.logstreams.processor.KeyGenerator;
+import io.zeebe.broker.logstreams.processor.TypedRecord;
+import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
+import io.zeebe.broker.workflow.state.DeployedWorkflow;
+import io.zeebe.broker.workflow.state.ElementInstance;
+import io.zeebe.broker.workflow.state.ElementInstanceState;
+import io.zeebe.broker.workflow.state.VariablesState;
+import io.zeebe.broker.workflow.state.WorkflowState;
+import io.zeebe.msgpack.spec.MsgpackReaderException;
+import io.zeebe.protocol.BpmnElementType;
+import io.zeebe.protocol.clientapi.RejectionType;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.intent.WorkflowInstanceCreationIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import org.agrona.DirectBuffer;
+
+public class CreateWorkflowInstanceProcessor
+    implements CommandProcessor<WorkflowInstanceCreationRecord> {
+
+  private static final String ERROR_MESSAGE_NO_IDENTIFIER_SPECIFIED =
+      "Expected at least a bpmnProcessId or a key greater than -1, but none given";
+  private static final String ERROR_MESSAGE_NOT_FOUND_BY_PROCESS =
+      "Expected to find workflow definition with process ID '%s', but none found";
+  private static final String ERROR_MESSAGE_NOT_FOUND_BY_PROCESS_AND_VERSION =
+      "Expected to find workflow definition with process ID '%s' and version '%d', but none found";
+  private static final String ERROR_MESSAGE_NOT_FOUND_BY_KEY =
+      "Expected to find workflow definition with key '%d', but none found";
+  private static final String ERROR_MESSAGE_NO_NONE_START_EVENT =
+      "Expected to create instance of workflow with none start event, but there is no such event";
+  private static final String ERROR_INVALID_VARIABLES_REJECTION_MESSAGE =
+      "Expected to set variables from document, but the document is invalid: '%s'";
+  private static final String ERROR_INVALID_VARIABLES_LOGGED_MESSAGE =
+      "Expected to set variables from document, but the document is invalid";
+
+  private final WorkflowState workflowState;
+  private final ElementInstanceState elementInstanceState;
+  private final VariablesState variablesState;
+  private final KeyGenerator keyGenerator;
+
+  private final WorkflowInstanceRecord newWorkflowInstance = new WorkflowInstanceRecord();
+
+  public CreateWorkflowInstanceProcessor(
+      WorkflowState workflowState,
+      ElementInstanceState elementInstanceState,
+      VariablesState variablesState,
+      KeyGenerator keyGenerator) {
+    this.workflowState = workflowState;
+    this.elementInstanceState = elementInstanceState;
+    this.variablesState = variablesState;
+    this.keyGenerator = keyGenerator;
+  }
+
+  @Override
+  public void onCommand(
+      TypedRecord<WorkflowInstanceCreationRecord> command,
+      CommandControl<WorkflowInstanceCreationRecord> controller,
+      TypedStreamWriter streamWriter) {
+    final WorkflowInstanceCreationRecord record = command.getValue();
+    final DeployedWorkflow workflow = getWorkflow(record, controller);
+    if (workflow == null || !isValidWorkflow(controller, workflow)) {
+      return;
+    }
+
+    final long workflowInstanceKey = keyGenerator.nextKey();
+    if (!setVariablesFromDocument(controller, record, workflowInstanceKey)) {
+      return;
+    }
+
+    final ElementInstance workflowInstance =
+        createElementInstance(workflow, workflowInstanceKey, record.getVariables());
+    streamWriter.appendFollowUpEvent(
+        workflowInstanceKey,
+        WorkflowInstanceIntent.ELEMENT_ACTIVATING,
+        workflowInstance.getValue());
+    controller.accept(
+        WorkflowInstanceCreationIntent.CREATED, record.setInstanceKey(workflowInstanceKey));
+  }
+
+  private boolean isValidWorkflow(
+      CommandControl<WorkflowInstanceCreationRecord> controller, DeployedWorkflow workflow) {
+    if (workflow.getWorkflow().getNoneStartEvent() == null) {
+      controller.reject(RejectionType.INVALID_STATE, ERROR_MESSAGE_NO_NONE_START_EVENT);
+      return false;
+    }
+
+    return true;
+  }
+
+  private boolean setVariablesFromDocument(
+      CommandControl<WorkflowInstanceCreationRecord> controller,
+      WorkflowInstanceCreationRecord record,
+      long workflowInstanceKey) {
+    try {
+      variablesState.setVariablesLocalFromDocument(workflowInstanceKey, record.getVariables());
+    } catch (MsgpackReaderException e) {
+      Loggers.WORKFLOW_PROCESSOR_LOGGER.error(ERROR_INVALID_VARIABLES_LOGGED_MESSAGE, e);
+      controller.reject(
+          RejectionType.INVALID_ARGUMENT,
+          String.format(ERROR_INVALID_VARIABLES_REJECTION_MESSAGE, e.getMessage()));
+
+      return false;
+    }
+
+    return true;
+  }
+
+  private ElementInstance createElementInstance(
+      DeployedWorkflow workflow, long workflowInstanceKey, DirectBuffer variables) {
+    newWorkflowInstance.reset();
+    newWorkflowInstance.setBpmnProcessId(workflow.getBpmnProcessId());
+    newWorkflowInstance.setVersion(workflow.getVersion());
+    newWorkflowInstance.setWorkflowKey(workflow.getKey());
+    newWorkflowInstance.setWorkflowInstanceKey(workflowInstanceKey);
+    newWorkflowInstance.setBpmnElementType(BpmnElementType.PROCESS);
+    newWorkflowInstance.setElementId(workflow.getWorkflow().getId());
+    newWorkflowInstance.setFlowScopeKey(-1);
+    newWorkflowInstance.setPayload(variables); // todo: to be removed in follow up issues (#1858)
+
+    final ElementInstance instance =
+        elementInstanceState.newInstance(
+            workflowInstanceKey, newWorkflowInstance, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
+    elementInstanceState.flushDirtyState();
+
+    return instance;
+  }
+
+  private DeployedWorkflow getWorkflow(
+      WorkflowInstanceCreationRecord record, CommandControl controller) {
+    final DeployedWorkflow workflow;
+
+    if (record.getKey() >= 0) {
+      workflow = getWorkflow(record.getKey(), controller);
+    } else {
+      final DirectBuffer bpmnProcessId = record.getBpmnProcessId();
+
+      if (bpmnProcessId.capacity() == 0) {
+        controller.reject(RejectionType.INVALID_ARGUMENT, ERROR_MESSAGE_NO_IDENTIFIER_SPECIFIED);
+        workflow = null;
+      } else if (record.getVersion() >= 0) {
+        workflow = getWorkflow(bpmnProcessId, record.getVersion(), controller);
+      } else {
+        workflow = getWorkflow(bpmnProcessId, controller);
+      }
+    }
+
+    return workflow;
+  }
+
+  private DeployedWorkflow getWorkflow(DirectBuffer bpmnProcessId, CommandControl controller) {
+    final DeployedWorkflow workflow =
+        workflowState.getLatestWorkflowVersionByProcessId(bpmnProcessId);
+    if (workflow == null) {
+      controller.reject(
+          RejectionType.NOT_FOUND,
+          String.format(ERROR_MESSAGE_NOT_FOUND_BY_PROCESS, bufferAsString(bpmnProcessId)));
+    }
+
+    return workflow;
+  }
+
+  private DeployedWorkflow getWorkflow(
+      DirectBuffer bpmnProcessId, int version, CommandControl controller) {
+    final DeployedWorkflow workflow =
+        workflowState.getWorkflowByProcessIdAndVersion(bpmnProcessId, version);
+    if (workflow == null) {
+      controller.reject(
+          RejectionType.NOT_FOUND,
+          String.format(
+              ERROR_MESSAGE_NOT_FOUND_BY_PROCESS_AND_VERSION,
+              bufferAsString(bpmnProcessId),
+              version));
+    }
+
+    return workflow;
+  }
+
+  private DeployedWorkflow getWorkflow(long key, CommandControl controller) {
+    final DeployedWorkflow workflow = workflowState.getWorkflowByKey(key);
+    if (workflow == null) {
+      controller.reject(
+          RejectionType.NOT_FOUND, String.format(ERROR_MESSAGE_NOT_FOUND_BY_KEY, key));
+    }
+
+    return workflow;
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/CommandProcessorTestCase.java
+++ b/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/CommandProcessorTestCase.java
@@ -1,0 +1,101 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.logstreams.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.zeebe.broker.logstreams.processor.CommandProcessor.CommandControl;
+import io.zeebe.broker.util.MockTypedRecord;
+import io.zeebe.broker.util.ZeebeStateRule;
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.protocol.clientapi.RecordType;
+import io.zeebe.protocol.clientapi.RejectionType;
+import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.intent.Intent;
+import io.zeebe.protocol.intent.WorkflowInstanceCreationIntent;
+import org.junit.ClassRule;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+/**
+ * Abstract test class that command processor implementation can use for their unit tests.
+ *
+ * <p>Implementations should use {@link org.mockito.junit.MockitoJUnitRunner.StrictStubs} as a
+ * runner, or instantiate the mocks themselves.
+ */
+public abstract class CommandProcessorTestCase<T extends UnpackedObject> {
+  @ClassRule public static ZeebeStateRule zeebeStateRule = new ZeebeStateRule();
+
+  @Mock(name = "CommandControl")
+  protected CommandControl<T> controller;
+
+  @Mock(name = "TypedStreamWriter")
+  protected TypedStreamWriter streamWriter;
+
+  @Captor protected ArgumentCaptor<T> acceptedRecordCaptor;
+
+  protected T getAcceptedRecord(Intent intent) {
+    assertAccepted(intent);
+    return acceptedRecordCaptor.getValue();
+  }
+
+  protected void assertAccepted(Intent intent, T record) {
+    assertThat(getAcceptedRecord(intent)).isEqualTo(record);
+  }
+
+  protected void assertAccepted(Intent intent) {
+    verify(controller, times(1)).accept(eq(intent), acceptedRecordCaptor.capture());
+  }
+
+  protected void refuteAccepted() {
+    verify(controller, never()).accept(any(), any());
+  }
+
+  protected void assertRejected(RejectionType type) {
+    verify(controller, times(1)).reject(eq(type), anyString());
+  }
+
+  protected void refuteRejected() {
+    verify(controller, never()).reject(any(), anyString());
+  }
+
+  protected TypedRecord<T> newCommand(Class<T> clazz) {
+    final RecordMetadata metadata =
+        new RecordMetadata()
+            .intent(WorkflowInstanceCreationIntent.CREATE)
+            .valueType(ValueType.WORKFLOW_INSTANCE_CREATION)
+            .recordType(RecordType.COMMAND);
+    final T value;
+
+    try {
+      value = clazz.newInstance();
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new AssertionError("Failed to create new record", e);
+    }
+
+    return new MockTypedRecord<>(-1, metadata, value);
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/util/RecordStream.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/RecordStream.java
@@ -25,6 +25,7 @@ import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.Intent;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
@@ -101,6 +102,12 @@ public class RecordStream extends StreamWrapper<LoggedEvent, RecordStream> {
     return new TypedRecordStream<>(
         filter(Records::isTimerRecord)
             .map(e -> CopiedTypedEvent.toTypedEvent(e, TimerRecord.class)));
+  }
+
+  public TypedRecordStream<WorkflowInstanceCreationRecord> onlyWorkflowInstanceCreationRecords() {
+    return new TypedRecordStream<>(
+        filter(Records::isWorkflowInstanceCreationRecord)
+            .map(e -> CopiedTypedEvent.toTypedEvent(e, WorkflowInstanceCreationRecord.class)));
   }
 
   /**

--- a/broker-core/src/test/java/io/zeebe/broker/util/Records.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/Records.java
@@ -85,6 +85,10 @@ public class Records {
     return isRecordOfType(event, ValueType.TIMER);
   }
 
+  public static boolean isWorkflowInstanceCreationRecord(final LoggedEvent event) {
+    return isRecordOfType(event, ValueType.WORKFLOW_INSTANCE_CREATION);
+  }
+
   public static boolean hasIntent(final LoggedEvent event, final Intent intent) {
     if (event == null) {
       return false;

--- a/broker-core/src/test/java/io/zeebe/broker/util/StreamProcessorControl.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/StreamProcessorControl.java
@@ -26,6 +26,7 @@ import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import java.util.function.Predicate;
 
@@ -40,6 +41,9 @@ public interface StreamProcessorControl {
   void blockAfterDeploymentEvent(Predicate<TypedRecord<DeploymentRecord>> test);
 
   void blockAfterWorkflowInstanceRecord(Predicate<TypedRecord<WorkflowInstanceRecord>> test);
+
+  void blockAfterWorkflowInstanceCreationRecord(
+      final Predicate<TypedRecord<WorkflowInstanceCreationRecord>> test);
 
   void blockAfterIncidentEvent(Predicate<TypedRecord<IncidentRecord>> test);
 

--- a/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
@@ -55,6 +55,7 @@ import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.zeebe.protocol.impl.record.value.variable.VariableRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.intent.Intent;
 import io.zeebe.raft.event.RaftConfigurationEvent;
@@ -92,6 +93,7 @@ public class TestStreams {
     VALUE_TYPES.put(TimerRecord.class, ValueType.TIMER);
     VALUE_TYPES.put(VariableRecord.class, ValueType.VARIABLE);
     VALUE_TYPES.put(VariableDocumentRecord.class, ValueType.VARIABLE_DOCUMENT);
+    VALUE_TYPES.put(WorkflowInstanceCreationRecord.class, ValueType.WORKFLOW_INSTANCE_CREATION);
 
     VALUE_TYPES.put(UnpackedObject.class, ValueType.NOOP);
   }
@@ -300,6 +302,16 @@ public class TestStreams {
           e ->
               Records.isWorkflowInstanceRecord(e)
                   && test.test(CopiedTypedEvent.toTypedEvent(e, WorkflowInstanceRecord.class)));
+    }
+
+    @Override
+    public void blockAfterWorkflowInstanceCreationRecord(
+        final Predicate<TypedRecord<WorkflowInstanceCreationRecord>> test) {
+      blockAfterEvent(
+          e ->
+              Records.isWorkflowInstanceCreationRecord(e)
+                  && test.test(
+                      CopiedTypedEvent.toTypedEvent(e, WorkflowInstanceCreationRecord.class)));
     }
 
     @Override

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/CreateDeploymentMultiplePartitionsTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/CreateDeploymentMultiplePartitionsTest.java
@@ -112,7 +112,7 @@ public class CreateDeploymentMultiplePartitionsTest {
                   .withPartitionId(partitionId)
                   .limit(r -> r.getKey() == deploymentKey2)
                   .withIntent(DeploymentIntent.DISTRIBUTE)
-                  .withKey(deploymentKey1)
+                  .withRecordKey(deploymentKey1)
                   .exists())
           .isEqualTo(partitionId == DEPLOYMENT_PARTITION);
     }
@@ -344,7 +344,7 @@ public class CreateDeploymentMultiplePartitionsTest {
             .partitionClient(expectedPartition)
             .receiveDeployments()
             .withIntent(DeploymentIntent.CREATED)
-            .withKey(expectedKey)
+            .withRecordKey(expectedKey)
             .getFirst();
 
     assertThat(deploymentCreatedEvent.getKey()).isEqualTo(expectedKey);

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceProcessorTest.java
@@ -1,0 +1,294 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow.processor.instance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.zeebe.broker.logstreams.processor.CommandProcessorTestCase;
+import io.zeebe.broker.logstreams.processor.KeyGenerator;
+import io.zeebe.broker.logstreams.processor.TypedRecord;
+import io.zeebe.broker.logstreams.state.ZeebeState;
+import io.zeebe.broker.workflow.deployment.transform.DeploymentTransformer;
+import io.zeebe.broker.workflow.state.DeployedWorkflow;
+import io.zeebe.broker.workflow.state.ElementInstance;
+import io.zeebe.broker.workflow.state.ElementInstanceState;
+import io.zeebe.broker.workflow.state.VariablesState;
+import io.zeebe.broker.workflow.state.WorkflowState;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.BpmnElementType;
+import io.zeebe.protocol.clientapi.RejectionType;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.zeebe.protocol.impl.record.value.deployment.Workflow;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.intent.WorkflowInstanceCreationIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.test.util.MsgPackUtil;
+import io.zeebe.test.util.collection.Maps;
+import io.zeebe.util.buffer.BufferUtil;
+import java.io.ByteArrayOutputStream;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@SuppressWarnings("unchecked")
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class CreateWorkflowInstanceProcessorTest
+    extends CommandProcessorTestCase<WorkflowInstanceCreationRecord> {
+
+  public static final BpmnModelInstance VALID_WORKFLOW =
+      Bpmn.createExecutableProcess().startEvent().endEvent().done();
+  private static DeploymentTransformer transformer;
+
+  @Captor private ArgumentCaptor<WorkflowInstanceRecord> newWorkflowInstanceCaptor;
+
+  private ZeebeState state;
+  private KeyGenerator keyGenerator;
+  private WorkflowState workflowState;
+  private ElementInstanceState elementInstanceState;
+  private VariablesState variablesState;
+  private CreateWorkflowInstanceProcessor processor;
+
+  @BeforeClass
+  public static void init() {
+    transformer = new DeploymentTransformer(zeebeStateRule.getZeebeState());
+  }
+
+  @Before
+  public void setUp() {
+    state = zeebeStateRule.getZeebeState();
+    keyGenerator = state.getKeyGenerator();
+    workflowState = state.getWorkflowState();
+    elementInstanceState = workflowState.getElementInstanceState();
+    variablesState = elementInstanceState.getVariablesState();
+
+    processor =
+        new CreateWorkflowInstanceProcessor(
+            workflowState, elementInstanceState, variablesState, keyGenerator);
+  }
+
+  @Test
+  public void shouldRejectIfNoBpmnProcessIdOrKeyGiven() {
+    // given
+    final TypedRecord<WorkflowInstanceCreationRecord> command =
+        newCommand(WorkflowInstanceCreationRecord.class);
+
+    // when
+    processor.onCommand(command, controller, streamWriter);
+
+    // then
+    refuteAccepted();
+    assertRejected(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldRejectIfNoWorkflowFoundByKey() {
+    // given
+    final TypedRecord<WorkflowInstanceCreationRecord> command =
+        newCommand(WorkflowInstanceCreationRecord.class);
+    command.getValue().setKey(keyGenerator.nextKey());
+
+    // when
+    processor.onCommand(command, controller, streamWriter);
+
+    // then
+    refuteAccepted();
+    assertRejected(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldRejectIfNoWorkflowFoundByProcessId() {
+    // given
+    final TypedRecord<WorkflowInstanceCreationRecord> command =
+        newCommand(WorkflowInstanceCreationRecord.class);
+    command.getValue().setBpmnProcessId("workflow");
+
+    // when
+    processor.onCommand(command, controller, streamWriter);
+
+    // then
+    refuteAccepted();
+    assertRejected(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldRejectIfNoWorkflowFoundByProcessIdAndVersion() {
+    // given
+    final TypedRecord<WorkflowInstanceCreationRecord> command =
+        newCommand(WorkflowInstanceCreationRecord.class);
+    command.getValue().setBpmnProcessId("workflow").setVersion(1);
+
+    // when
+    processor.onCommand(command, controller, streamWriter);
+
+    // then
+    refuteAccepted();
+    assertRejected(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldRejectIfWorkflowHasNoNoneStartEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .message(m -> m.name("message").zeebeCorrelationKey("$.key"))
+            .endEvent()
+            .done();
+    final DeployedWorkflow workflow = newWorkflow(process);
+    final TypedRecord<WorkflowInstanceCreationRecord> command =
+        newCommand(WorkflowInstanceCreationRecord.class);
+    command.getValue().setBpmnProcessId(workflow.getBpmnProcessId());
+
+    // when
+    processor.onCommand(command, controller, streamWriter);
+
+    // then
+    refuteAccepted();
+    assertRejected(RejectionType.INVALID_STATE);
+  }
+
+  @Test
+  public void shouldRejectIfVariablesIsAnInvalidDocument() {
+    // given
+    final DeployedWorkflow workflow = newWorkflow();
+    final TypedRecord<WorkflowInstanceCreationRecord> command =
+        newCommand(WorkflowInstanceCreationRecord.class);
+    final MutableDirectBuffer badDocument = new UnsafeBuffer(MsgPackUtil.asMsgPack("{ 'foo': 1 }"));
+    command.getValue().setBpmnProcessId(workflow.getBpmnProcessId()).setVariables(badDocument);
+    badDocument.putByte(0, (byte) 0); // overwrites map header
+
+    // when
+    processor.onCommand(command, controller, streamWriter);
+
+    // then
+    refuteAccepted();
+    assertRejected(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldActivateElementInstance() {
+    // given
+    final DirectBuffer payload =
+        MsgPackUtil.asMsgPack(Maps.of(entry("foo", "bar"), entry("baz", "boz")));
+    final DeployedWorkflow workflow = newWorkflow();
+    final TypedRecord<WorkflowInstanceCreationRecord> command =
+        newCommand(WorkflowInstanceCreationRecord.class);
+    command.getValue().setBpmnProcessId(workflow.getBpmnProcessId()).setVariables(payload);
+
+    // when
+    processor.onCommand(command, controller, streamWriter);
+
+    // then
+    final WorkflowInstanceCreationRecord acceptedRecord =
+        getAcceptedRecord(WorkflowInstanceCreationIntent.CREATED);
+    final long instanceKey = acceptedRecord.getInstanceKey();
+    final ElementInstance instance = elementInstanceState.getInstance(instanceKey);
+    final WorkflowInstanceRecord expectedElementActivatingRecord =
+        newExpectedElementActivatingRecord(workflow, instanceKey, payload);
+    assertThat(instance.getState()).isEqualTo(WorkflowInstanceIntent.ELEMENT_ACTIVATING);
+    assertThat(instance.getValue()).isEqualTo(expectedElementActivatingRecord);
+    verifyElementActivatingPublished(instanceKey, instance);
+  }
+
+  @Test
+  public void shouldSetVariablesFromDocument() {
+    // given
+    final Map<String, Object> document = Maps.of(entry("foo", "bar"), entry("baz", "boz"));
+    final DeployedWorkflow workflow = newWorkflow();
+    final TypedRecord<WorkflowInstanceCreationRecord> command =
+        newCommand(WorkflowInstanceCreationRecord.class);
+    command
+        .getValue()
+        .setBpmnProcessId(workflow.getBpmnProcessId())
+        .setVariables(MsgPackUtil.asMsgPack(document));
+
+    // when
+    processor.onCommand(command, controller, streamWriter);
+
+    // then
+    final WorkflowInstanceCreationRecord acceptedRecord =
+        getAcceptedRecord(WorkflowInstanceCreationIntent.CREATED);
+    final long scopeKey = acceptedRecord.getInstanceKey();
+    MsgPackUtil.assertEquality(
+        variablesState.getVariableLocal(scopeKey, BufferUtil.wrapString("foo")), "\"bar\"");
+    MsgPackUtil.assertEquality(
+        variablesState.getVariableLocal(scopeKey, BufferUtil.wrapString("baz")), "\"boz\"");
+  }
+
+  private WorkflowInstanceRecord newExpectedElementActivatingRecord(
+      DeployedWorkflow workflow, long instanceKey, DirectBuffer payload) {
+    return new WorkflowInstanceRecord()
+        .setElementId(workflow.getBpmnProcessId())
+        .setPayload(payload)
+        .setBpmnElementType(BpmnElementType.PROCESS)
+        .setWorkflowKey(workflow.getKey())
+        .setFlowScopeKey(-1L)
+        .setVersion(workflow.getVersion())
+        .setWorkflowInstanceKey(instanceKey)
+        .setBpmnProcessId(workflow.getBpmnProcessId());
+  }
+
+  private void verifyElementActivatingPublished(long instanceKey, ElementInstance instance) {
+    verify(streamWriter, times(1))
+        .appendFollowUpEvent(
+            eq(instanceKey),
+            eq(WorkflowInstanceIntent.ELEMENT_ACTIVATING),
+            eq(instance.getValue()));
+  }
+
+  private DeployedWorkflow newWorkflow() {
+    return newWorkflow(VALID_WORKFLOW);
+  }
+
+  private DeployedWorkflow newWorkflow(BpmnModelInstance model) {
+    final long key = keyGenerator.nextKey();
+    final DeploymentRecord deployment = newDeployment(model);
+    final Workflow workflow = deployment.workflows().iterator().next();
+    workflowState.putDeployment(key, deployment);
+
+    return workflowState.getLatestWorkflowVersionByProcessId(workflow.getBpmnProcessId());
+  }
+
+  private DeploymentRecord newDeployment(BpmnModelInstance model) {
+    final ByteArrayOutputStream output = new ByteArrayOutputStream();
+    final DeploymentRecord record = new DeploymentRecord();
+    Bpmn.writeModelToStream(output, model);
+    record.resources().add().setResource(output.toByteArray());
+
+    final boolean transformed = transformer.transform(record);
+    assertThat(transformed)
+        .as("Failed to transform deployment: %s", transformer.getRejectionReason())
+        .isTrue();
+
+    return record;
+  }
+}

--- a/exporter-api/src/main/java/io/zeebe/exporter/record/value/WorkflowInstanceCreationRecordValue.java
+++ b/exporter-api/src/main/java/io/zeebe/exporter/record/value/WorkflowInstanceCreationRecordValue.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.record.value;
+
+import io.zeebe.exporter.record.RecordValue;
+import java.util.Map;
+
+public interface WorkflowInstanceCreationRecordValue extends RecordValue {
+  /** @return the BPMN process id to create a workflow from */
+  String getBpmnProcessId();
+
+  /** @return the version of the BPMN process to create a workflow from */
+  int getVersion();
+
+  /** @return the unique key of the BPMN process definition to create a workflow from */
+  long getKey();
+
+  /** @return the created workflow instance key */
+  long getInstanceKey();
+
+  /** @return the initial variables to use when starting the workflow instance */
+  Map<String, Object> getVariables();
+}

--- a/msgpack-value/src/main/java/io/zeebe/msgpack/property/BaseProperty.java
+++ b/msgpack-value/src/main/java/io/zeebe/msgpack/property/BaseProperty.java
@@ -117,4 +117,26 @@ public abstract class BaseProperty<T extends BaseValue> implements Recyclable {
     builder.append(value.toString());
     return builder.toString();
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof BaseProperty)) {
+      return false;
+    }
+
+    final BaseProperty<?> that = (BaseProperty<?>) o;
+    return isSet == that.isSet
+        && Objects.equals(getKey(), that.getKey())
+        && Objects.equals(value, that.value)
+        && Objects.equals(defaultValue, that.defaultValue);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getKey(), value, defaultValue, isSet);
+  }
 }

--- a/msgpack-value/src/main/java/io/zeebe/msgpack/value/ArrayValue.java
+++ b/msgpack-value/src/main/java/io/zeebe/msgpack/value/ArrayValue.java
@@ -19,6 +19,7 @@ import io.zeebe.msgpack.spec.MsgPackReader;
 import io.zeebe.msgpack.spec.MsgPackWriter;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import org.agrona.ExpandableArrayBuffer;
 
 public class ArrayValue<T extends BaseValue> extends BaseValue implements Iterator<T>, Iterable<T> {
@@ -182,6 +183,27 @@ public class ArrayValue<T extends BaseValue> extends BaseValue implements Iterat
     moveValuesLeft(cursorOffset + oldInnerValueLength, oldInnerValueLength);
 
     innerValueState = InnerValueState.Uninitialized;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof ArrayValue)) {
+      return false;
+    }
+
+    final ArrayValue<?> that = (ArrayValue<?>) o;
+    return elementCount == that.elementCount
+        && bufferLength == that.bufferLength
+        && Objects.equals(buffer, that.buffer);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(buffer, elementCount, bufferLength);
   }
 
   private int getInnerValueLength() {

--- a/msgpack-value/src/main/java/io/zeebe/msgpack/value/BinaryValue.java
+++ b/msgpack-value/src/main/java/io/zeebe/msgpack/value/BinaryValue.java
@@ -19,6 +19,7 @@ import io.zeebe.msgpack.spec.MsgPackReader;
 import io.zeebe.msgpack.spec.MsgPackWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Objects;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -89,5 +90,24 @@ public class BinaryValue extends BaseValue {
   @Override
   public int getEncodedLength() {
     return MsgPackWriter.getEncodedBinaryValueLength(length);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof BinaryValue)) {
+      return false;
+    }
+
+    final BinaryValue that = (BinaryValue) o;
+    return length == that.length && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data, length);
   }
 }

--- a/msgpack-value/src/main/java/io/zeebe/msgpack/value/BooleanValue.java
+++ b/msgpack-value/src/main/java/io/zeebe/msgpack/value/BooleanValue.java
@@ -17,6 +17,7 @@ package io.zeebe.msgpack.value;
 
 import io.zeebe.msgpack.spec.MsgPackReader;
 import io.zeebe.msgpack.spec.MsgPackWriter;
+import java.util.Objects;
 
 public class BooleanValue extends BaseValue {
   protected boolean val = false;
@@ -60,5 +61,24 @@ public class BooleanValue extends BaseValue {
   @Override
   public int getEncodedLength() {
     return MsgPackWriter.getEncodedBooleanValueLength();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof BooleanValue)) {
+      return false;
+    }
+
+    final BooleanValue that = (BooleanValue) o;
+    return val == that.val;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(val);
   }
 }

--- a/msgpack-value/src/main/java/io/zeebe/msgpack/value/EnumValue.java
+++ b/msgpack-value/src/main/java/io/zeebe/msgpack/value/EnumValue.java
@@ -17,6 +17,7 @@ package io.zeebe.msgpack.value;
 
 import io.zeebe.msgpack.spec.MsgPackReader;
 import io.zeebe.msgpack.spec.MsgPackWriter;
+import java.util.Objects;
 
 public class EnumValue<E extends Enum<E>> extends BaseValue {
   private final StringValue decodedValue = new StringValue();
@@ -84,5 +85,24 @@ public class EnumValue<E extends Enum<E>> extends BaseValue {
   @Override
   public int getEncodedLength() {
     return binaryEnumValues[value.ordinal()].getEncodedLength();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof EnumValue)) {
+      return false;
+    }
+
+    final EnumValue<?> enumValue = (EnumValue<?>) o;
+    return Objects.equals(getValue(), enumValue.getValue());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getValue());
   }
 }

--- a/msgpack-value/src/main/java/io/zeebe/msgpack/value/IntegerValue.java
+++ b/msgpack-value/src/main/java/io/zeebe/msgpack/value/IntegerValue.java
@@ -17,6 +17,7 @@ package io.zeebe.msgpack.value;
 
 import io.zeebe.msgpack.spec.MsgPackReader;
 import io.zeebe.msgpack.spec.MsgPackWriter;
+import java.util.Objects;
 
 public class IntegerValue extends BaseValue {
   protected int value;
@@ -67,5 +68,24 @@ public class IntegerValue extends BaseValue {
   @Override
   public int getEncodedLength() {
     return MsgPackWriter.getEncodedLongValueLength(value);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof IntegerValue)) {
+      return false;
+    }
+
+    final IntegerValue that = (IntegerValue) o;
+    return getValue() == that.getValue();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getValue());
   }
 }

--- a/msgpack-value/src/main/java/io/zeebe/msgpack/value/LongValue.java
+++ b/msgpack-value/src/main/java/io/zeebe/msgpack/value/LongValue.java
@@ -17,6 +17,7 @@ package io.zeebe.msgpack.value;
 
 import io.zeebe.msgpack.spec.MsgPackReader;
 import io.zeebe.msgpack.spec.MsgPackWriter;
+import java.util.Objects;
 
 public class LongValue extends BaseValue {
   protected long value;
@@ -60,5 +61,24 @@ public class LongValue extends BaseValue {
   @Override
   public int getEncodedLength() {
     return MsgPackWriter.getEncodedLongValueLength(value);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof LongValue)) {
+      return false;
+    }
+
+    final LongValue longValue = (LongValue) o;
+    return getValue() == longValue.getValue();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getValue());
   }
 }

--- a/msgpack-value/src/main/java/io/zeebe/msgpack/value/ObjectValue.java
+++ b/msgpack-value/src/main/java/io/zeebe/msgpack/value/ObjectValue.java
@@ -21,6 +21,7 @@ import io.zeebe.msgpack.spec.MsgPackReader;
 import io.zeebe.msgpack.spec.MsgPackWriter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class ObjectValue extends BaseValue {
   private final List<BaseProperty<? extends BaseValue>> declaredProperties = new ArrayList<>();
@@ -160,6 +161,27 @@ public class ObjectValue extends BaseValue {
     length += getEncodedLength(undeclaredProperties);
 
     return length;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof ObjectValue)) {
+      return false;
+    }
+
+    final ObjectValue that = (ObjectValue) o;
+    return Objects.equals(declaredProperties, that.declaredProperties)
+        && Objects.equals(undeclaredProperties, that.undeclaredProperties)
+        && Objects.equals(recycledProperties, that.recycledProperties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(declaredProperties, undeclaredProperties, recycledProperties);
   }
 
   protected <T extends BaseProperty<?>> int getEncodedLength(List<T> properties) {

--- a/msgpack-value/src/main/java/io/zeebe/msgpack/value/PackedValue.java
+++ b/msgpack-value/src/main/java/io/zeebe/msgpack/value/PackedValue.java
@@ -17,6 +17,7 @@ package io.zeebe.msgpack.value;
 
 import io.zeebe.msgpack.spec.MsgPackReader;
 import io.zeebe.msgpack.spec.MsgPackWriter;
+import java.util.Objects;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -70,5 +71,23 @@ public class PackedValue extends BaseValue {
     builder.append("[packed value (length=");
     builder.append(length);
     builder.append(")]");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PackedValue)) {
+      return false;
+    }
+
+    final PackedValue that = (PackedValue) o;
+    return length == that.length && Objects.equals(buffer, that.buffer);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(buffer, length);
   }
 }

--- a/msgpack-value/src/main/java/io/zeebe/msgpack/value/StringValue.java
+++ b/msgpack-value/src/main/java/io/zeebe/msgpack/value/StringValue.java
@@ -19,6 +19,7 @@ import static io.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.zeebe.msgpack.spec.MsgPackReader;
 import io.zeebe.msgpack.spec.MsgPackWriter;
+import java.util.Objects;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -98,27 +99,6 @@ public class StringValue extends BaseValue {
   }
 
   @Override
-  public boolean equals(Object s) {
-    if (s == null) {
-      return false;
-    } else if (s instanceof StringValue) {
-      final StringValue otherString = (StringValue) s;
-      final MutableDirectBuffer otherBytes = otherString.bytes;
-      return bytes.equals(otherBytes);
-    }
-    return false;
-  }
-
-  @Override
-  public int hashCode() {
-    if (hashCode == 0 && length > 0) {
-      hashCode = bytes.hashCode();
-    }
-
-    return hashCode;
-  }
-
-  @Override
   public void read(MsgPackReader reader) {
     final DirectBuffer buffer = reader.getBuffer();
     final int stringLength = reader.readStringLength();
@@ -137,5 +117,24 @@ public class StringValue extends BaseValue {
   @Override
   public int getEncodedLength() {
     return MsgPackWriter.getEncodedStringLength(length);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof StringValue)) {
+      return false;
+    }
+
+    final StringValue that = (StringValue) o;
+    return getLength() == that.getLength() && Objects.equals(bytes, that.bytes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(bytes, getLength());
   }
 }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/workflowinstance/WorkflowInstanceCreationRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/workflowinstance/WorkflowInstanceCreationRecord.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.protocol.impl.record.value.workflowinstance;
+
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.msgpack.property.DocumentProperty;
+import io.zeebe.msgpack.property.IntegerProperty;
+import io.zeebe.msgpack.property.LongProperty;
+import io.zeebe.msgpack.property.StringProperty;
+import org.agrona.DirectBuffer;
+
+public class WorkflowInstanceCreationRecord extends UnpackedObject {
+  private static final String PROP_BPMN_PROCESS_ID = "bpmnProcessId";
+  private static final String PROP_KEY = "key";
+  private static final String PROP_INSTANCE_KEY = "instanceKey";
+  private static final String PROP_VARIABLES = "variables";
+  private static final String PROP_VERSION = "version";
+
+  private final StringProperty bpmnProcessIdProperty = new StringProperty(PROP_BPMN_PROCESS_ID, "");
+  private final LongProperty keyProperty = new LongProperty(PROP_KEY, -1);
+  private final IntegerProperty versionProperty = new IntegerProperty(PROP_VERSION, -1);
+  private final DocumentProperty variablesProperty = new DocumentProperty(PROP_VARIABLES);
+  private final LongProperty instanceKeyProperty = new LongProperty(PROP_INSTANCE_KEY, -1);
+
+  public WorkflowInstanceCreationRecord() {
+    this.declareProperty(bpmnProcessIdProperty)
+        .declareProperty(keyProperty)
+        .declareProperty(instanceKeyProperty)
+        .declareProperty(versionProperty)
+        .declareProperty(variablesProperty);
+  }
+
+  public WorkflowInstanceCreationRecord setBpmnProcessId(String bpmnProcessId) {
+    this.bpmnProcessIdProperty.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public WorkflowInstanceCreationRecord setBpmnProcessId(DirectBuffer bpmnProcessId) {
+    this.bpmnProcessIdProperty.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public DirectBuffer getBpmnProcessId() {
+    return bpmnProcessIdProperty.getValue();
+  }
+
+  public WorkflowInstanceCreationRecord setKey(long key) {
+    this.keyProperty.setValue(key);
+    return this;
+  }
+
+  public long getKey() {
+    return keyProperty.getValue();
+  }
+
+  public WorkflowInstanceCreationRecord setVersion(int version) {
+    this.versionProperty.setValue(version);
+    return this;
+  }
+
+  public WorkflowInstanceCreationRecord setInstanceKey(long instanceKey) {
+    this.instanceKeyProperty.setValue(instanceKey);
+    return this;
+  }
+
+  public long getInstanceKey() {
+    return instanceKeyProperty.getValue();
+  }
+
+  public int getVersion() {
+    return versionProperty.getValue();
+  }
+
+  public DirectBuffer getVariables() {
+    return variablesProperty.getValue();
+  }
+
+  public WorkflowInstanceCreationRecord setVariables(DirectBuffer variables) {
+    variablesProperty.setValue(variables);
+    return this;
+  }
+}

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/ClientApiRule.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/ClientApiRule.java
@@ -243,7 +243,7 @@ public class ClientApiRule extends ExternalResource {
     assertThat(commandResponse.getIntent()).isEqualTo(DeploymentIntent.CREATED);
 
     return RecordingExporter.deploymentRecords(DeploymentIntent.DISTRIBUTED)
-        .withKey(commandResponse.getKey())
+        .withRecordKey(commandResponse.getKey())
         .getFirst();
   }
 

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/PartitionTestClient.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/PartitionTestClient.java
@@ -422,7 +422,7 @@ public class PartitionTestClient {
 
   public Record<DeploymentRecordValue> receiveFirstDeploymentEvent(
       final DeploymentIntent intent, final long deploymentKey) {
-    return receiveDeployments().withIntent(intent).withKey(deploymentKey).getFirst();
+    return receiveDeployments().withIntent(intent).withRecordKey(deploymentKey).getFirst();
   }
 
   /////////////////////////////////////////////

--- a/protocol/src/main/java/io/zeebe/protocol/intent/Intent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/Intent.java
@@ -32,7 +32,9 @@ public interface Intent {
           ExporterIntent.class,
           JobBatchIntent.class,
           TimerIntent.class,
-          VariableIntent.class);
+          VariableIntent.class,
+          VariableDocumentIntent.class,
+          WorkflowInstanceCreationIntent.class);
 
   Intent UNKNOWN =
       new Intent() {
@@ -85,6 +87,8 @@ public interface Intent {
         return VariableIntent.from(intent);
       case VARIABLE_DOCUMENT:
         return VariableDocumentIntent.from(intent);
+      case WORKFLOW_INSTANCE_CREATION:
+        return WorkflowInstanceCreationIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -128,6 +132,8 @@ public interface Intent {
         return VariableIntent.valueOf(intent);
       case VARIABLE_DOCUMENT:
         return VariableDocumentIntent.valueOf(intent);
+      case WORKFLOW_INSTANCE_CREATION:
+        return WorkflowInstanceCreationIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/zeebe/protocol/intent/WorkflowInstanceCreationIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/WorkflowInstanceCreationIntent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.protocol.intent;
+
+public enum WorkflowInstanceCreationIntent implements Intent {
+  CREATE(0),
+  CREATED(1);
+
+  private short value;
+
+  WorkflowInstanceCreationIntent(int value) {
+    this((short) value);
+  }
+
+  WorkflowInstanceCreationIntent(short value) {
+    this.value = value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  public static Intent from(short value) {
+    switch (value) {
+      case 0:
+        return CREATE;
+      case 1:
+        return CREATED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -47,6 +47,7 @@
       <validValue name="MESSAGE_START_EVENT_SUBSCRIPTION">16</validValue>
       <validValue name="VARIABLE">17</validValue>
       <validValue name="VARIABLE_DOCUMENT">18</validValue>
+      <validValue name="WORKFLOW_INSTANCE_CREATION">19</validValue>
     </enum>
 
     <enum name="ControlMessageType" encodingType="uint8"

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
@@ -83,7 +83,7 @@ public class GrpcClientRule extends ExternalResource {
     waitUntil(
         () ->
             RecordingExporter.deploymentRecords(DeploymentIntent.DISTRIBUTED)
-                .withKey(key)
+                .withRecordKey(key)
                 .exists());
   }
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/util/ZeebeAssertHelper.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/util/ZeebeAssertHelper.java
@@ -43,7 +43,7 @@ public class ZeebeAssertHelper {
   public static void assertWorkflowInstanceCreated(long workflowInstanceKey) {
     assertThat(
             RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATING)
-                .withKey(workflowInstanceKey)
+                .withRecordKey(workflowInstanceKey)
                 .withWorkflowInstanceKey(workflowInstanceKey)
                 .exists())
         .isTrue();
@@ -74,7 +74,7 @@ public class ZeebeAssertHelper {
       long workflowInstanceKey, Consumer<WorkflowInstanceRecordValue> consumer) {
     final Record<WorkflowInstanceRecordValue> record =
         RecordingExporter.workflowInstanceRecords(ELEMENT_COMPLETED)
-            .withKey(workflowInstanceKey)
+            .withRecordKey(workflowInstanceKey)
             .getFirst();
 
     assertThat(record).isNotNull();

--- a/test-util/src/main/java/io/zeebe/test/util/record/ExporterRecordStream.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/ExporterRecordStream.java
@@ -71,7 +71,7 @@ public abstract class ExporterRecordStream<
     return filter(r -> r.getProducerId() == producerId);
   }
 
-  public S withKey(final long key) {
+  public S withRecordKey(final long key) {
     return filter(r -> r.getKey() == key);
   }
 

--- a/test-util/src/main/java/io/zeebe/test/util/record/WorkflowInstanceCreationRecordStream.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/WorkflowInstanceCreationRecordStream.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.test.util.record;
+
+import io.zeebe.exporter.record.Record;
+import io.zeebe.exporter.record.value.WorkflowInstanceCreationRecordValue;
+import io.zeebe.test.util.collection.Maps;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public class WorkflowInstanceCreationRecordStream
+    extends ExporterRecordStream<
+        WorkflowInstanceCreationRecordValue, WorkflowInstanceCreationRecordStream> {
+
+  public WorkflowInstanceCreationRecordStream(
+      final Stream<Record<WorkflowInstanceCreationRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected WorkflowInstanceCreationRecordStream supply(
+      final Stream<Record<WorkflowInstanceCreationRecordValue>> wrappedStream) {
+    return new WorkflowInstanceCreationRecordStream(wrappedStream);
+  }
+
+  public WorkflowInstanceCreationRecordStream withBpmnProcessId(String bpmnProcessId) {
+    return valueFilter(v -> v.getBpmnProcessId().equals(bpmnProcessId));
+  }
+
+  public WorkflowInstanceCreationRecordStream withVersion(int version) {
+    return valueFilter(v -> v.getVersion() == version);
+  }
+
+  public WorkflowInstanceCreationRecordStream withKey(long key) {
+    return valueFilter(v -> v.getKey() == key);
+  }
+
+  public WorkflowInstanceCreationRecordStream withInstanceKey(long instanceKey) {
+    return valueFilter(v -> v.getInstanceKey() == instanceKey);
+  }
+
+  public WorkflowInstanceCreationRecordStream withVariables(Map<String, Object> variables) {
+    return valueFilter(v -> v.getVariables().equals(variables));
+  }
+
+  public WorkflowInstanceCreationRecordStream withVariables(Map.Entry<String, Object>... entries) {
+    return withVariables(Maps.of(entries));
+  }
+
+  public WorkflowInstanceCreationRecordStream withVariables(
+      Predicate<Map<String, Object>> matcher) {
+    return valueFilter(v -> matcher.test(v.getVariables()));
+  }
+}

--- a/test/src/main/java/io/zeebe/test/WorkflowInstanceAssert.java
+++ b/test/src/main/java/io/zeebe/test/WorkflowInstanceAssert.java
@@ -61,7 +61,7 @@ public class WorkflowInstanceAssert
         exists(
             RecordingExporter.workflowInstanceRecords()
                 .withWorkflowInstanceKey(workflowInstanceKey)
-                .withKey(workflowInstanceKey)
+                .withRecordKey(workflowInstanceKey)
                 .filter(intent(INSTANCE_ENDED_INTENTS)));
 
     if (!isEnded) {
@@ -163,7 +163,7 @@ public class WorkflowInstanceAssert
     final Optional<Record<WorkflowInstanceRecordValue>> record =
         RecordingExporter.workflowInstanceRecords()
             .withWorkflowInstanceKey(workflowInstanceKey)
-            .withKey(workflowInstanceKey)
+            .withRecordKey(workflowInstanceKey)
             .filter(intent(INSTANCE_ENDED_INTENTS))
             .findFirst();
 


### PR DESCRIPTION
- adds new WorkflowInstanceCreationRecord with two intents, CREATE and CREATED
- adds processor for CREATE intent
- implements equals/hashCode for msgpack values to ease comparing `UnpackedObject`

Closes #2087
Closes #2092 
