### PR TITLE
fix(broker-core): set repetitions on cancel timer

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/TimerRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/TimerRecordValueImpl.java
@@ -28,18 +28,30 @@ public class TimerRecordValueImpl extends RecordValueImpl implements TimerRecord
   private final long workflowInstanceKey;
   private final long dueDate;
   private final String handlerFlowNodeId;
+  private final int repetitions;
+  private final long workflowKey;
 
   public TimerRecordValueImpl(
       ExporterObjectMapper objectMapper,
       long elementInstanceKey,
       long workflowInstanceKey,
       long dueDate,
-      String handlerFlowNodeId) {
+      String handlerFlowNodeId,
+      int repetitions,
+      long workflowKey) {
     super(objectMapper);
     this.elementInstanceKey = elementInstanceKey;
     this.dueDate = dueDate;
     this.handlerFlowNodeId = handlerFlowNodeId;
     this.workflowInstanceKey = workflowInstanceKey;
+
+    this.repetitions = repetitions;
+    this.workflowKey = workflowKey;
+  }
+
+  @Override
+  public long getWorkflowKey() {
+    return workflowKey;
   }
 
   @Override
@@ -63,8 +75,20 @@ public class TimerRecordValueImpl extends RecordValueImpl implements TimerRecord
   }
 
   @Override
+  public int getRepetitions() {
+    return repetitions;
+  }
+
+  @Override
   public int hashCode() {
-    return Objects.hash(elementInstanceKey, workflowInstanceKey, dueDate, handlerFlowNodeId);
+
+    return Objects.hash(
+        elementInstanceKey,
+        workflowInstanceKey,
+        dueDate,
+        handlerFlowNodeId,
+        workflowKey,
+        repetitions);
   }
 
   @Override
@@ -75,11 +99,15 @@ public class TimerRecordValueImpl extends RecordValueImpl implements TimerRecord
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final TimerRecordValueImpl that = (TimerRecordValueImpl) o;
-    return elementInstanceKey == that.elementInstanceKey
-        && workflowInstanceKey == that.workflowInstanceKey
-        && dueDate == that.dueDate
-        && Objects.equals(handlerFlowNodeId, that.handlerFlowNodeId);
+
+    final TimerRecordValueImpl other = (TimerRecordValueImpl) o;
+
+    return elementInstanceKey == other.elementInstanceKey
+        && workflowInstanceKey == other.workflowInstanceKey
+        && dueDate == other.dueDate
+        && repetitions == other.repetitions
+        && workflowKey == other.workflowKey
+        && Objects.equals(handlerFlowNodeId, other.handlerFlowNodeId);
   }
 
   @Override
@@ -89,8 +117,12 @@ public class TimerRecordValueImpl extends RecordValueImpl implements TimerRecord
         + elementInstanceKey
         + ", workflowInstanceKey="
         + workflowInstanceKey
+        + ", workflowKey="
+        + workflowKey
         + ", dueDate="
         + dueDate
+        + ", repetitions="
+        + repetitions
         + ", handlerFlowNodeId='"
         + handlerFlowNodeId
         + '\''

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
@@ -357,7 +357,9 @@ public class ExporterRecordMapper {
         record.getElementInstanceKey(),
         record.getWorkflowInstanceKey(),
         record.getDueDate(),
-        asString(record.getHandlerNodeId()));
+        asString(record.getHandlerNodeId()),
+        record.getRepetitions(),
+        record.getWorkflowKey());
   }
 
   private VariableRecordValue ofVariableRecord(LoggedEvent event) {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/CatchEventBehavior.java
@@ -114,7 +114,7 @@ public class CatchEventBehavior {
       DirectBuffer handlerNodeId,
       Timer timer,
       TypedStreamWriter writer) {
-
+    timerRecord.reset();
     timerRecord
         .setRepetitions(timer.getRepetitions())
         .setDueDate(timer.getDueDate(ActorClock.currentTimeMillis()))
@@ -134,10 +134,12 @@ public class CatchEventBehavior {
   }
 
   public void unsubscribeFromTimerEvent(TimerInstance timer, TypedStreamWriter writer) {
+    timerRecord.reset();
     timerRecord
         .setElementInstanceKey(timer.getElementInstanceKey())
         .setWorkflowInstanceKey(timer.getWorkflowInstanceKey())
         .setDueDate(timer.getDueDate())
+        .setRepetitions(timer.getRepetitions())
         .setHandlerNodeId(timer.getHandlerNodeId())
         .setWorkflowKey(timer.getWorkflowKey());
 

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/CatchEventBehaviorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/CatchEventBehaviorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.workflow.processor;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+
+import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
+import io.zeebe.broker.logstreams.state.ZeebeState;
+import io.zeebe.broker.subscription.command.SubscriptionCommandSender;
+import io.zeebe.broker.workflow.state.TimerInstance;
+import io.zeebe.model.bpmn.util.time.TimeDateTimer;
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.zeebe.protocol.intent.TimerIntent;
+import java.util.Random;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public class CatchEventBehaviorTest {
+  private static final String TIME_DATE = "1990-01-01T00:00:00Z";
+
+  @Mock private ZeebeState zeebeState;
+  @Mock private SubscriptionCommandSender commandSender;
+  @Mock private TypedStreamWriter streamWriter;
+  @Captor private ArgumentCaptor<UnpackedObject> captor;
+
+  private CatchEventBehavior catchEventBehavior;
+  private Random random = new Random();
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    catchEventBehavior = new CatchEventBehavior(zeebeState, commandSender, 1);
+  }
+
+  @Test
+  public void shouldWriteCorrectTimerRecord() {
+    // given
+    final TimeDateTimer timer = TimeDateTimer.parse(TIME_DATE);
+    final long dueDate = timer.getDueDate(0);
+    final long repetitions = timer.getRepetitions();
+    final long elementInstanceKey = random.nextLong();
+    final long workflowKey = random.nextLong();
+    final long workflowInstanceKey = random.nextLong();
+
+    final byte[] buffer = new byte[5];
+    random.nextBytes(buffer);
+    final UnsafeBuffer handlerNodeId = new UnsafeBuffer(buffer);
+
+    // when
+    catchEventBehavior.subscribeToTimerEvent(
+        elementInstanceKey,
+        workflowInstanceKey,
+        workflowKey,
+        new UnsafeBuffer(handlerNodeId),
+        timer,
+        streamWriter);
+
+    // then
+    Mockito.verify(streamWriter).appendNewCommand(eq(TimerIntent.CREATE), captor.capture());
+    final TimerRecord record = (TimerRecord) captor.getValue();
+
+    assertThat(record.getHandlerNodeId()).isEqualTo(handlerNodeId);
+    assertThat(record.getElementInstanceKey()).isEqualTo(elementInstanceKey);
+    assertThat(record.getWorkflowKey()).isEqualTo(workflowKey);
+    assertThat(record.getRepetitions()).isEqualTo(repetitions);
+    assertThat(record.getDueDate()).isEqualTo(dueDate);
+  }
+
+  @Test
+  public void shouldWriteCorrectCancelTimerRecord() {
+    // given
+    final TimerInstance timer = new TimerInstance();
+    timer.setKey(random.nextLong());
+    timer.setDueDate(random.nextLong());
+    timer.setRepetitions(random.nextInt());
+    timer.setWorkflowKey(random.nextLong());
+    timer.setElementInstanceKey(random.nextLong());
+    timer.setWorkflowInstanceKey(random.nextLong());
+
+    final byte[] buffer = new byte[5];
+    random.nextBytes(buffer);
+    timer.setHandlerNodeId(new UnsafeBuffer(buffer));
+
+    // when
+    catchEventBehavior.unsubscribeFromTimerEvent(timer, streamWriter);
+
+    // then
+    Mockito.verify(streamWriter)
+        .appendFollowUpCommand(eq(timer.getKey()), eq(TimerIntent.CANCEL), captor.capture());
+    final TimerRecord record = (TimerRecord) captor.getValue();
+
+    assertThat(record.getHandlerNodeId()).isEqualTo(timer.getHandlerNodeId());
+    assertThat(record.getElementInstanceKey()).isEqualTo(timer.getElementInstanceKey());
+    assertThat(record.getWorkflowKey()).isEqualTo(timer.getWorkflowKey());
+    assertThat(record.getWorkflowInstanceKey()).isEqualTo(timer.getWorkflowInstanceKey());
+    assertThat(record.getRepetitions()).isEqualTo(timer.getRepetitions());
+    assertThat(record.getDueDate()).isEqualTo(timer.getDueDate());
+  }
+}

--- a/exporter-api/src/main/java/io/zeebe/exporter/record/value/TimerRecordValue.java
+++ b/exporter-api/src/main/java/io/zeebe/exporter/record/value/TimerRecordValue.java
@@ -25,6 +25,9 @@ import io.zeebe.protocol.intent.TimerIntent;
  */
 public interface TimerRecordValue extends RecordValue {
 
+  /** @return the key of the workflow in which this timer was created */
+  long getWorkflowKey();
+
   /** @return the key of the related element instance. */
   long getElementInstanceKey();
 
@@ -43,4 +46,7 @@ public interface TimerRecordValue extends RecordValue {
    * @return the ID of the flow node which will handle the trigger element
    */
   String getHandlerFlowNodeId();
+
+  /** @return the number of times this timer should trigger */
+  int getRepetitions();
 }

--- a/test-util/src/main/java/io/zeebe/test/util/record/TimerRecordStream.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/TimerRecordStream.java
@@ -48,4 +48,12 @@ public class TimerRecordStream extends ExporterRecordStream<TimerRecordValue, Ti
   public TimerRecordStream withHandlerNodeId(final DirectBuffer handlerNodeId) {
     return withHandlerNodeId(bufferAsString(handlerNodeId));
   }
+
+  public TimerRecordStream withRepetitions(final int repetitions) {
+    return valueFilter(v -> v.getRepetitions() == repetitions);
+  }
+
+  public TimerRecordStream withWorkflowKey(final long workflowKey) {
+    return valueFilter(v -> v.getWorkflowKey() == workflowKey);
+  }
 }


### PR DESCRIPTION
Besides the bug fix and test, this PR also adds some data that was missing from the timer's exported record.

closes #2114 
