### PR TITLE
fix(bpmn-model): limit timeDates to 100 years into the future

### DIFF
--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeTimerValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeTimerValidationTest.java
@@ -101,7 +101,45 @@ public class ZeebeTimerValidationTest extends AbstractZeebeValidationTest {
             .endEvent()
             .done(),
         singletonList(expect(TimerEventDefinition.class, "Time cycle is invalid"))
-      }
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .timerWithDate("2218-03-01T13:00:00Z")
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                TimerEventDefinition.class,
+                "Time date can't be more than 100 years into the future"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .timerWithDate("9999-03-01T13:00:00Z")
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                TimerEventDefinition.class,
+                "Time date can't be more than 100 years into the future"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .timerWithDate("2018-03-01T13:00:00Z")
+            .endEvent()
+            .done(),
+        singletonList(expect(TimerEventDefinition.class, "Time date can't have passed already"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .timerWithDate("0000-03-01T13:00:00Z")
+            .endEvent()
+            .done(),
+        singletonList(expect(TimerEventDefinition.class, "Time date can't have passed already"))
+      },
     };
   }
 }

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeTimerValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeTimerValidationTest.java
@@ -16,6 +16,7 @@
 package io.zeebe.model.bpmn.validation;
 
 import static io.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+import static io.zeebe.model.bpmn.validation.zeebe.TimerEventDefinitionValidator.MAXIMUM_TIME_IN_YEARS;
 import static java.util.Collections.singletonList;
 
 import io.zeebe.model.bpmn.Bpmn;
@@ -111,7 +112,9 @@ public class ZeebeTimerValidationTest extends AbstractZeebeValidationTest {
         singletonList(
             expect(
                 TimerEventDefinition.class,
-                "Time date can't be more than 100 years into the future"))
+                String.format(
+                    "Specified time can't be more than %d years into the future",
+                    MAXIMUM_TIME_IN_YEARS)))
       },
       {
         Bpmn.createExecutableProcess("process")
@@ -122,7 +125,9 @@ public class ZeebeTimerValidationTest extends AbstractZeebeValidationTest {
         singletonList(
             expect(
                 TimerEventDefinition.class,
-                "Time date can't be more than 100 years into the future"))
+                String.format(
+                    "Specified time can't be more than %d years into the future",
+                    MAXIMUM_TIME_IN_YEARS)))
       },
       {
         Bpmn.createExecutableProcess("process")
@@ -130,7 +135,8 @@ public class ZeebeTimerValidationTest extends AbstractZeebeValidationTest {
             .timerWithDate("2018-03-01T13:00:00Z")
             .endEvent()
             .done(),
-        singletonList(expect(TimerEventDefinition.class, "Time date can't have passed already"))
+        singletonList(
+            expect(TimerEventDefinition.class, "Specified time can't have passed already"))
       },
       {
         Bpmn.createExecutableProcess("process")
@@ -138,7 +144,43 @@ public class ZeebeTimerValidationTest extends AbstractZeebeValidationTest {
             .timerWithDate("0000-03-01T13:00:00Z")
             .endEvent()
             .done(),
-        singletonList(expect(TimerEventDefinition.class, "Time date can't have passed already"))
+        singletonList(
+            expect(TimerEventDefinition.class, "Specified time can't have passed already"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .timerWithCycle("R5/P101Y")
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                TimerEventDefinition.class,
+                String.format(
+                    "Specified time can't be more than %d years into the future",
+                    MAXIMUM_TIME_IN_YEARS)))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateCatchEvent("catch", c -> c.timerWithDuration("P356000D"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                TimerEventDefinition.class,
+                String.format(
+                    "Specified time can't be more than %d years into the future",
+                    MAXIMUM_TIME_IN_YEARS)))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateCatchEvent("catch", c -> c.timerWithDuration("PT-1S"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(TimerEventDefinition.class, "Specified time can't have passed already"))
       },
     };
   }

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/TimerStartEventTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/TimerStartEventTest.java
@@ -431,29 +431,6 @@ public class TimerStartEventTest {
   }
 
   @Test
-  public void shouldTriggerIfTimeDatePassedOnDeployment() {
-    // given
-    final Instant triggerTime = brokerRule.getClock().getCurrentTime().minusMillis(2000);
-    final BpmnModelInstance model =
-        Bpmn.createExecutableProcess("process")
-            .startEvent("start_2")
-            .timerWithDate(triggerTime.toString())
-            .endEvent("end_2")
-            .done();
-
-    testClient.deploy(model);
-
-    // then
-    final TimerRecordValue timerRecord =
-        RecordingExporter.timerRecords(TimerIntent.TRIGGERED).getFirst().getValue();
-
-    Assertions.assertThat(timerRecord)
-        .hasDueDate(triggerTime.toEpochMilli())
-        .hasHandlerFlowNodeId("start_2")
-        .hasElementInstanceKey(NO_ELEMENT_INSTANCE);
-  }
-
-  @Test
   public void shouldTriggerTimerAndMessageStartEvent() {
     // given
     testClient.deploy(TIMER_AND_MESSAGE_MODEL);

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/timer/TimerCatchEventTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/timer/TimerCatchEventTest.java
@@ -223,23 +223,6 @@ public class TimerCatchEventTest {
   }
 
   @Test
-  public void shouldTriggerTimerWithNegativeDuration() {
-    // given
-    final BpmnModelInstance workflow =
-        Bpmn.createExecutableProcess(PROCESS_ID)
-            .startEvent()
-            .intermediateCatchEvent("timer", c -> c.timerWithDuration("-PT1H"))
-            .endEvent()
-            .done();
-
-    testClient.deploy(workflow);
-    testClient.createWorkflowInstance(PROCESS_ID);
-
-    // then
-    assertThat(RecordingExporter.timerRecords(TimerIntent.TRIGGERED).exists()).isTrue();
-  }
-
-  @Test
   public void shouldTriggerMultipleTimers() {
     // given
     final BpmnModelInstance workflow =


### PR DESCRIPTION
Since the actor uses nanoseconds when scheduling a timer, having long timeDates causes a long overflow and a bound needs to be imposed. I rejected past timeDates because it didn't seem to make sense to only allow them to be 100 years into the past (if we always execute them immediately, why restrict them to 100 years).

closes #2108 