### PR TITLE
feat(clients/go): replace update payload with set variables

### DIFF
--- a/clients/zbctl/cmd/root.go
+++ b/clients/zbctl/cmd/root.go
@@ -42,7 +42,7 @@ It is designed for regular maintenance jobs such as:
 	* deploying workflows,
 	* creating jobs and workflow instances
 	* activating, completing or failing jobs
-	* update payload and retries
+	* update variables and retries
 	* view cluster status`,
 }
 

--- a/clients/zbctl/cmd/set.go
+++ b/clients/zbctl/cmd/set.go
@@ -1,0 +1,28 @@
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var setCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set a resource",
+}
+
+func init() {
+	rootCmd.AddCommand(setCmd)
+}

--- a/clients/zbctl/cmd/setVariables.go
+++ b/clients/zbctl/cmd/setVariables.go
@@ -26,7 +26,7 @@ var (
 )
 
 var setVariablesCmd = &cobra.Command{
-	Use:     "payload <key>",
+	Use:     "variables <key>",
 	Short:   "Sets the variables of a given flow element",
 	Args:    keyArg(&setVariablesKey),
 	PreRunE: initClient,
@@ -39,7 +39,7 @@ var setVariablesCmd = &cobra.Command{
 		request.Local(setVariablesLocalFlag)
 		_, err = request.Send()
 		if err == nil {
-			log.Println("Updated the variables of element instance with key", setVariablesKey, "to", setVariablesVariablesFlag)
+			log.Println("Set the variables of element instance with key", setVariablesKey, "to", setVariablesVariablesFlag)
 		}
 
 		return err
@@ -47,10 +47,10 @@ var setVariablesCmd = &cobra.Command{
 }
 
 func init() {
-	updateCmd.AddCommand(setVariablesCmd)
+	setCmd.AddCommand(setVariablesCmd)
 
 	setVariablesCmd.Flags().StringVar(&setVariablesVariablesFlag, "variables", "{}", "Specify the variables as JSON object string")
-	_ = setVariablesCmd.MarkFlagRequired("variables")
+	setVariablesCmd.MarkFlagRequired("variables")
 
 	setVariablesCmd.Flags().BoolVar(&setVariablesLocalFlag, "local", false, "Specify local or propagating update semantics")
 }


### PR DESCRIPTION
- instead of `zbctl update payload <key> --payload '{"foo": "bar"}'` the
command is now `zbctl set variables <key> --variables '{"foo": "bar"}'`

closes #2136 
