### PR TITLE
feat(broker): add HTTP metrics endpoint

### DIFF
--- a/broker-core/pom.xml
+++ b/broker-core/pom.xml
@@ -244,6 +244,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
       <scope>test</scope>

--- a/broker-core/pom.xml
+++ b/broker-core/pom.xml
@@ -212,6 +212,26 @@
     </dependency>
 
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <scope>test</scope>

--- a/broker-core/src/main/java/io/zeebe/broker/system/SystemServiceNames.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/SystemServiceNames.java
@@ -19,11 +19,15 @@ package io.zeebe.broker.system;
 
 import io.zeebe.broker.system.management.LeaderManagementRequestHandler;
 import io.zeebe.broker.system.metrics.MetricsFileWriter;
+import io.zeebe.broker.system.metrics.MetricsHttpServer;
 import io.zeebe.servicecontainer.ServiceName;
 
 public class SystemServiceNames {
   public static final ServiceName<MetricsFileWriter> METRICS_FILE_WRITER =
       ServiceName.newServiceName("broker.metricsFileWriter", MetricsFileWriter.class);
+
+  public static final ServiceName<MetricsHttpServer> METRICS_HTTP_SERVER =
+      ServiceName.newServiceName("broker.metricsHttpServer", MetricsHttpServer.class);
 
   public static final ServiceName<LeaderManagementRequestHandler>
       LEADER_MANAGEMENT_REQUEST_HANDLER =

--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
@@ -28,4 +28,5 @@ public class EnvironmentConstants {
   public static final String ENV_REPLICATION_FACTOR = "ZEEBE_REPLICATION_FACTOR";
   public static final String ENV_CLUSTER_SIZE = "ZEEBE_CLUSTER_SIZE";
   public static final String ENV_EMBED_GATEWAY = "ZEEBE_EMBED_GATEWAY";
+  public static final String ENV_METRICS_HTTP_SERVER = "ZEEBE_METRICS_HTTP_SERVER";
 }

--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/MetricsCfg.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/MetricsCfg.java
@@ -17,17 +17,33 @@
  */
 package io.zeebe.broker.system.configuration;
 
+import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_METRICS_HTTP_SERVER;
+
 import io.zeebe.util.DurationUtil;
 import io.zeebe.util.Environment;
 import java.time.Duration;
 
 public class MetricsCfg implements ConfigurationEntry {
+
+  public static final int DEFAULT_PORT = 9600;
+
   private String reportingInterval = "5s";
   private String file = "metrics/zeebe.prom";
+  private boolean enableHttpServer = false;
+  private String host;
+  private int port = DEFAULT_PORT;
 
   @Override
   public void init(BrokerCfg brokerCfg, String brokerBase, Environment environment) {
     file = ConfigurationUtil.toAbsolutePath(file, brokerBase);
+
+    environment.getBool(ENV_METRICS_HTTP_SERVER).ifPresent(this::setEnableHttpServer);
+
+    final NetworkCfg networkCfg = brokerCfg.getNetwork();
+    if (host == null) {
+      host = networkCfg.getHost();
+    }
+    port += networkCfg.getPortOffset() * 10;
   }
 
   public Duration getReportingIntervalDuration() {
@@ -50,6 +66,33 @@ public class MetricsCfg implements ConfigurationEntry {
     this.file = metricsFile;
   }
 
+  public boolean isEnableHttpServer() {
+    return enableHttpServer;
+  }
+
+  public MetricsCfg setEnableHttpServer(boolean enableHttpServer) {
+    this.enableHttpServer = enableHttpServer;
+    return this;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public MetricsCfg setHost(String host) {
+    this.host = host;
+    return this;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public MetricsCfg setPort(int port) {
+    this.port = port;
+    return this;
+  }
+
   @Override
   public String toString() {
     return "MetricsCfg{"
@@ -59,6 +102,13 @@ public class MetricsCfg implements ConfigurationEntry {
         + ", file='"
         + file
         + '\''
+        + ", enableHttpServer="
+        + enableHttpServer
+        + ", host='"
+        + host
+        + '\''
+        + ", port="
+        + port
         + '}';
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/system/metrics/MetricsHttpServer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/metrics/MetricsHttpServer.java
@@ -1,0 +1,52 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.system.metrics;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.zeebe.util.metrics.MetricsManager;
+
+public class MetricsHttpServer implements AutoCloseable {
+
+  private final NioEventLoopGroup bossGroup;
+  private final NioEventLoopGroup workerGroup;
+  private final Channel channel;
+
+  public MetricsHttpServer(MetricsManager metricsManager, String host, int port) {
+    bossGroup = new NioEventLoopGroup(1);
+    workerGroup = new NioEventLoopGroup();
+
+    channel =
+        new ServerBootstrap()
+            .group(bossGroup, workerGroup)
+            .channel(NioServerSocketChannel.class)
+            .childHandler(new MetricsHttpServerInitializer(metricsManager))
+            .bind(host, port)
+            .syncUninterruptibly()
+            .channel();
+  }
+
+  @Override
+  public void close() {
+    workerGroup.shutdownGracefully();
+    bossGroup.shutdownGracefully();
+    channel.close().syncUninterruptibly();
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/system/metrics/MetricsHttpServerHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/metrics/MetricsHttpServerHandler.java
@@ -1,0 +1,80 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.system.metrics;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.zeebe.util.metrics.MetricsManager;
+import java.time.Instant;
+import org.agrona.ExpandableDirectByteBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class MetricsHttpServerHandler extends ChannelInboundHandlerAdapter {
+
+  private final MutableDirectBuffer metricsBuffer = new ExpandableDirectByteBuffer();
+  private final MetricsManager metricsManager;
+
+  public MetricsHttpServerHandler(MetricsManager metricsManager) {
+    this.metricsManager = metricsManager;
+  }
+
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+    if (!(msg instanceof HttpRequest)) {
+      super.channelRead(ctx, msg);
+      return;
+    }
+
+    final HttpRequest request = (HttpRequest) msg;
+
+    if (!request.decoderResult().isSuccess()) {
+      ctx.writeAndFlush(
+          new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST));
+      return;
+    }
+
+    if (request.method() != HttpMethod.GET) {
+      ctx.writeAndFlush(
+          new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.METHOD_NOT_ALLOWED));
+      return;
+    }
+
+    final int length = metricsManager.dump(metricsBuffer, 0, Instant.now().toEpochMilli());
+
+    final DefaultFullHttpResponse response =
+        new DefaultFullHttpResponse(
+            HttpVersion.HTTP_1_1,
+            HttpResponseStatus.OK,
+            Unpooled.copiedBuffer(metricsBuffer.byteBuffer()).slice(0, length));
+
+    response.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN);
+    response.headers().set(HttpHeaderNames.CONTENT_LENGTH, length);
+    HttpUtil.setKeepAlive(response, HttpUtil.isKeepAlive(request));
+
+    ctx.writeAndFlush(response);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/system/metrics/MetricsHttpServerInitializer.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/metrics/MetricsHttpServerInitializer.java
@@ -1,0 +1,39 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.system.metrics;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.zeebe.util.metrics.MetricsManager;
+
+public class MetricsHttpServerInitializer extends ChannelInitializer<SocketChannel> {
+
+  private final MetricsManager metricsManager;
+
+  public MetricsHttpServerInitializer(MetricsManager metricsManager) {
+    this.metricsManager = metricsManager;
+  }
+
+  @Override
+  protected void initChannel(SocketChannel ch) throws Exception {
+    ch.pipeline()
+        .addLast("codec", new HttpServerCodec())
+        .addLast("request", new MetricsHttpServerHandler(metricsManager));
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/system/metrics/MetricsHttpServerService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/metrics/MetricsHttpServerService.java
@@ -1,0 +1,56 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.system.metrics;
+
+import io.zeebe.broker.system.configuration.MetricsCfg;
+import io.zeebe.servicecontainer.Service;
+import io.zeebe.servicecontainer.ServiceStartContext;
+import io.zeebe.servicecontainer.ServiceStopContext;
+import io.zeebe.util.metrics.MetricsManager;
+
+public class MetricsHttpServerService implements Service<MetricsHttpServer> {
+
+  private MetricsHttpServer metricsHttpServer;
+  private MetricsCfg configuration;
+
+  public MetricsHttpServerService(MetricsCfg cfg) {
+    this.configuration = cfg;
+  }
+
+  @Override
+  public void start(ServiceStartContext startContext) {
+    final MetricsManager metricsManager = startContext.getScheduler().getMetricsManager();
+
+    startContext.run(
+        () -> {
+          metricsHttpServer =
+              new MetricsHttpServer(
+                  metricsManager, configuration.getHost(), configuration.getPort());
+        });
+  }
+
+  @Override
+  public void stop(ServiceStopContext stopContext) {
+    stopContext.run(metricsHttpServer::close);
+  }
+
+  @Override
+  public MetricsHttpServer get() {
+    return metricsHttpServer;
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/system/MetricsHttpServerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/system/MetricsHttpServerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.system;
+
+import static org.assertj.core.api.AssertionsForClassTypes.fail;
+
+import io.zeebe.broker.system.configuration.MetricsCfg;
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import java.net.Socket;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MetricsHttpServerTest {
+
+  @Rule
+  public final EmbeddedBrokerRule brokerWithEnabledMetricsHttpServer =
+      new EmbeddedBrokerRule(cfg -> cfg.getMetrics().setEnableHttpServer(true));
+
+  @Rule
+  public final EmbeddedBrokerRule brokerWithDisabledMetricsHttpServer =
+      new EmbeddedBrokerRule(cfg -> cfg.getMetrics().setEnableHttpServer(false));
+
+  @Test
+  public void shouldConfigureGateway() {
+    MetricsCfg metricsCfg = brokerWithEnabledMetricsHttpServer.getBrokerCfg().getMetrics();
+    try (Socket socket = new Socket(metricsCfg.getHost(), metricsCfg.getPort())) {
+      // expect no error
+    } catch (Exception e) {
+      fail("Failed to connect to metrics http server with config: " + metricsCfg, e);
+    }
+
+    metricsCfg = brokerWithDisabledMetricsHttpServer.getBrokerCfg().getMetrics();
+    try (Socket socket = new Socket(metricsCfg.getHost(), metricsCfg.getPort())) {
+      fail("Unexpected to be able to connect to metrics http server with config: " + metricsCfg);
+    } catch (Exception e) {
+      // expect error
+    }
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/test/EmbeddedBrokerConfigurator.java
+++ b/broker-core/src/test/java/io/zeebe/broker/test/EmbeddedBrokerConfigurator.java
@@ -88,4 +88,8 @@ public class EmbeddedBrokerConfigurator {
   public static Consumer<BrokerCfg> setSubscriptionApiPort(final int port) {
     return cfg -> cfg.getNetwork().getSubscription().setPort(port);
   }
+
+  public static Consumer<BrokerCfg> setMetricsPort(final int port) {
+    return cfg -> cfg.getMetrics().setPort(port);
+  }
 }

--- a/broker-core/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker-core/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -23,6 +23,7 @@ import static io.zeebe.broker.test.EmbeddedBrokerConfigurator.TEST_RECORDER;
 import static io.zeebe.broker.test.EmbeddedBrokerConfigurator.setClientApiPort;
 import static io.zeebe.broker.test.EmbeddedBrokerConfigurator.setGatewayApiPort;
 import static io.zeebe.broker.test.EmbeddedBrokerConfigurator.setManagementApiPort;
+import static io.zeebe.broker.test.EmbeddedBrokerConfigurator.setMetricsPort;
 import static io.zeebe.broker.test.EmbeddedBrokerConfigurator.setReplicationApiPort;
 import static io.zeebe.broker.test.EmbeddedBrokerConfigurator.setSubscriptionApiPort;
 import static io.zeebe.broker.workflow.WorkflowServiceNames.WORKFLOW_REPOSITORY_SERVICE;
@@ -343,6 +344,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
     setManagementApiPort(SocketUtil.getNextAddress().port()).accept(brokerCfg);
     setReplicationApiPort(SocketUtil.getNextAddress().port()).accept(brokerCfg);
     setSubscriptionApiPort(SocketUtil.getNextAddress().port()).accept(brokerCfg);
+    setMetricsPort(SocketUtil.getNextAddress().port()).accept(brokerCfg);
   }
 
   public void interruptClientConnections() {

--- a/broker-core/src/test/resources/system/enabled-metrics-http-server.toml
+++ b/broker-core/src/test/resources/system/enabled-metrics-http-server.toml
@@ -1,0 +1,2 @@
+[metrics]
+enableHttpServer = true

--- a/broker-core/src/test/resources/system/specific-hosts.toml
+++ b/broker-core/src/test/resources/system/specific-hosts.toml
@@ -12,3 +12,6 @@ host = "replicationHost"
 
 [network.subscription]
 host = "subscriptionHost"
+
+[metrics]
+host = "metricsHost"

--- a/broker-core/src/test/resources/system/specific-ports-offset.toml
+++ b/broker-core/src/test/resources/system/specific-ports-offset.toml
@@ -12,3 +12,6 @@ port = 3
 
 [network.subscription]
 port = 4
+
+[metrics]
+port = 5

--- a/broker-core/src/test/resources/system/specific-ports.toml
+++ b/broker-core/src/test/resources/system/specific-ports.toml
@@ -9,3 +9,6 @@ port = 3
 
 [network.subscription]
 port = 4
+
+[metrics]
+port = 5

--- a/test/src/main/java/io/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/zeebe/test/EmbeddedBrokerRule.java
@@ -313,6 +313,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
     network.getManagement().setPort(SocketUtil.getNextAddress().port());
     network.getReplication().setPort(SocketUtil.getNextAddress().port());
     network.getSubscription().setPort(SocketUtil.getNextAddress().port());
+    brokerCfg.getMetrics().setPort(SocketUtil.getNextAddress().port());
   }
 
   static class TestService implements Service<TestService> {


### PR DESCRIPTION
- by default disabled
- can be enabled by setting metrics.enableHttpServer = true

closes #2144 
