### PR TITLE
docs(CONTRIBUTING, transport, README): Slack url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,7 +197,7 @@ code-of-conduct@zeebe.io.
 
 [issues]: https://github.com/zeebe-io/zeebe/issues
 [forum]: https://forum.zeebe.io/
-[slack]: https://zeebe-slackin.herokuapp.com/
+[slack]: https://zeebe-slack-invite.herokuapp.com/
 [sample]: https://github.com/zeebe-io/zeebe-test-template-java
 
 [status]: https://github.com/zeebe-io/zeebe/labels?q=Type

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Zeebe is currently a tech preview and not meant for production use - See [Roadma
 * [Web Site](https://zeebe.io)
 * [Documentation](https://docs.zeebe.io)
 * [Issue Tracker](https://github.com/zeebe-io/zeebe/issues)
-* [Slack Channel](https://zeebe-slackin.herokuapp.com/)
+* [Slack Channel](https://zeebe-slack-invite.herokuapp.com/)
 * [User Forum](https://forum.zeebe.io)
 * [Contribution Guidelines](/CONTRIBUTING.md)
 

--- a/transport/README.md
+++ b/transport/README.md
@@ -13,7 +13,7 @@ Simple asynchronous Message Transport over TCP/IP.
 * [Web Site](https://zeebe.io)
 * [Documentation](https://docs.zeebe.io)
 * [Issue Tracker](https://github.com/zeebe-io/zeebe/issues)
-* [Slack Channel](https://zeebe-slackin.herokuapp.com/)
+* [Slack Channel](https://zeebe-slack-invite.herokuapp.com/)
 * [User Forum](https://forum.zeebe.io)
 * [Contribution Guidelines](/CONTRIBUTING.md)
 * Connection Management (reconnect, keep-alive)


### PR DESCRIPTION
This url https://zeebe-slackin.herokuapp.com/ seems outdated.
I change for https://zeebe-slack-invite.herokuapp.com/


closes #2180
