### PR TITLE
Open rocksDB idempotent

### DIFF
--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -26,7 +26,6 @@ import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDB;
-import org.rocksdb.RocksDBException;
 
 public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamilyType>>
     implements ZeebeDbFactory<ColumnFamilyType> {
@@ -59,31 +58,27 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
       final File dbDirectory, List<byte[]> columnFamilyNames) {
 
     final ZeebeTransactionDb<ColumnFamilyType> db;
-    try {
-      final List<AutoCloseable> closeables = new ArrayList<>();
-      final ColumnFamilyOptions columnFamilyOptions = createColumnFamilyOptions();
-      closeables.add(columnFamilyOptions);
+    final List<AutoCloseable> closeables = new ArrayList<>();
+    final ColumnFamilyOptions columnFamilyOptions = createColumnFamilyOptions();
+    closeables.add(columnFamilyOptions);
 
-      final List<ColumnFamilyDescriptor> columnFamilyDescriptors =
-          createFamilyDescriptors(columnFamilyNames, columnFamilyOptions);
+    final List<ColumnFamilyDescriptor> columnFamilyDescriptors =
+        createFamilyDescriptors(columnFamilyNames, columnFamilyOptions);
 
-      final DBOptions dbOptions =
-          new DBOptions()
-              .setCreateMissingColumnFamilies(true)
-              .setErrorIfExists(false)
-              .setCreateIfMissing(true);
-      closeables.add(dbOptions);
+    final DBOptions dbOptions =
+        new DBOptions()
+            .setCreateMissingColumnFamilies(true)
+            .setErrorIfExists(false)
+            .setCreateIfMissing(true);
+    closeables.add(dbOptions);
 
-      db =
-          ZeebeTransactionDb.openTransactionalDb(
-              dbOptions,
-              dbDirectory.getAbsolutePath(),
-              columnFamilyDescriptors,
-              closeables,
-              columnFamilyTypeClass);
-    } catch (final RocksDBException e) {
-      throw new RuntimeException("Unexpected error occurred trying to open the database", e);
-    }
+    db =
+        ZeebeTransactionDb.openTransactionalDb(
+            dbOptions,
+            dbDirectory.getAbsolutePath(),
+            columnFamilyDescriptors,
+            closeables,
+            columnFamilyTypeClass);
     return db;
   }
 

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/DbReference.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/DbReference.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.db.impl.rocksdb.transaction;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.OptimisticTransactionDB;
+import org.rocksdb.Transaction;
+import org.rocksdb.WriteOptions;
+
+class DbReference implements AutoCloseable {
+
+  private final OptimisticTransactionDB transactionDB;
+  private final AtomicLong referenceCount;
+  private final Consumer<String> onCloseCallback;
+  private final String databasePath;
+  private final List<ColumnFamilyHandle> familyHandles;
+
+  DbReference(
+      String databasePath,
+      OptimisticTransactionDB transactionDB,
+      List<ColumnFamilyHandle> familyHandles,
+      Consumer<String> onCloseCallback) {
+    this.databasePath = databasePath;
+    this.transactionDB = transactionDB;
+    this.referenceCount = new AtomicLong(0);
+    this.onCloseCallback = onCloseCallback;
+    this.familyHandles = Collections.unmodifiableList(familyHandles);
+  }
+
+  OptimisticTransactionDB getTransactionDB() {
+    return transactionDB;
+  }
+
+  DbReference newReference() {
+    referenceCount.incrementAndGet();
+    return this;
+  }
+
+  @Override
+  public void close() {
+    if (referenceCount.decrementAndGet() == 0) {
+      onCloseCallback.accept(databasePath);
+      transactionDB.close();
+    }
+  }
+
+  Transaction beginTransaction(WriteOptions options) {
+    return transactionDB.beginTransaction(options);
+  }
+
+  List<ColumnFamilyHandle> getFamilyHandles() {
+    return familyHandles;
+  }
+}

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/RocksDbInternal.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/RocksDbInternal.java
@@ -23,7 +23,7 @@ import org.rocksdb.RocksIterator;
 import org.rocksdb.RocksObject;
 import org.rocksdb.Transaction;
 
-public class RocksDbInternal {
+class RocksDbInternal {
 
   static Field nativeHandle;
 

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/RocksDbRegistry.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/RocksDbRegistry.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.db.impl.rocksdb.transaction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.DBOptions;
+import org.rocksdb.OptimisticTransactionDB;
+import org.rocksdb.RocksDBException;
+
+class RocksDbRegistry {
+
+  private static final ConcurrentHashMap<String, DbReference> DB_REGISTRY =
+      new ConcurrentHashMap<>();
+
+  static DbReference open(
+      final DBOptions dbOptions,
+      final String path,
+      final List<ColumnFamilyDescriptor> columnFamilyDescriptors,
+      final List<ColumnFamilyHandle> columnFamilyHandles) {
+    final DbReference dbReference =
+        DB_REGISTRY
+            .computeIfAbsent(
+                path,
+                (missingPath) ->
+                    createNewDbReference(dbOptions, missingPath, columnFamilyDescriptors))
+            .newReference();
+
+    columnFamilyHandles.addAll(dbReference.getFamilyHandles());
+    return dbReference;
+  }
+
+  private static DbReference createNewDbReference(
+      final DBOptions dbOptions,
+      final String missingPath,
+      final List<ColumnFamilyDescriptor> columnFamilyDescriptors) {
+    try {
+      final List<ColumnFamilyHandle> familyHandles = new ArrayList<>();
+
+      final OptimisticTransactionDB transactionDB =
+          OptimisticTransactionDB.open(
+              dbOptions, missingPath, columnFamilyDescriptors, familyHandles);
+      return new DbReference(missingPath, transactionDB, familyHandles, DB_REGISTRY::remove);
+    } catch (final RocksDBException e) {
+      throw new RuntimeException("Unexpected error occurred trying to open the database", e);
+    }
+  }
+}

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
@@ -21,12 +21,12 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.Transaction;
 
-public class ZeebeTransaction {
+class ZeebeTransaction {
 
   private final Transaction transaction;
   private final long nativeHandle;
 
-  public ZeebeTransaction(Transaction transaction) {
+  ZeebeTransaction(Transaction transaction) {
     this.transaction = transaction;
     try {
       nativeHandle = RocksDbInternal.nativeHandle.getLong(transaction);


### PR DESCRIPTION
Opens the RocksDB idempotent, means that it only opens the DB once and stores the object reference in a registry. If a consumer or other thread tries to open the DB again the already open instance is reused. 
Only the wrapping ZeebeDB instance is newly created, since the ZeebeDB classes are not thread safe.
The references are counted and on close the last one will close the corresponding RocksDB object and remove it from the registry.

This can be seen as a preparation for https://github.com/zeebe-io/zeebe/issues/2094