### PR TITLE
chore(gateway): increase topology timeout to 5 seconds

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
@@ -43,6 +43,8 @@ public class BrokerTopologyManagerImpl extends Actor implements BrokerTopologyMa
    */
   public static final Duration MIN_REFRESH_INTERVAL_MILLIS = Duration.ofMillis(300);
 
+  public static final Duration TOPOLOGY_TIMEOUT = Duration.ofSeconds(5);
+
   protected final ClientOutput output;
   protected final BiConsumer<Integer, SocketAddress> registerEndpoint;
 
@@ -148,7 +150,7 @@ public class BrokerTopologyManagerImpl extends Actor implements BrokerTopologyMa
       endpoint = ClientTransport.UNKNOWN_NODE_ID;
     }
     final ActorFuture<ClientResponse> responseFuture =
-        output.sendRequest(endpoint, topologyRequest, Duration.ofSeconds(1));
+        output.sendRequest(endpoint, topologyRequest, TOPOLOGY_TIMEOUT);
 
     refreshAttempt++;
     lastRefreshTime = ActorClock.currentTimeMillis();

--- a/gateway/src/test/java/io/zeebe/gateway/broker/BrokerClientTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/broker/BrokerClientTest.java
@@ -428,7 +428,7 @@ public class BrokerClientTest {
 
     // then
     exception.expect(ExecutionException.class);
-    exception.expectMessage("Request timed out after PT1S");
+    exception.expectMessage("Request timed out after PT5S");
 
     // when
     client.sendRequest(new BrokerCompleteJobRequest(0, DocumentValue.EMPTY_DOCUMENT)).join();


### PR DESCRIPTION
- in higher load scenarios the broker might not respond to a topology request in one second
