### PR TITLE
Add retry strategy for write event and execute side effects

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessor.java
@@ -132,7 +132,7 @@ public class TypedStreamProcessor implements StreamProcessor {
   protected static class DelegatingEventProcessor implements EventProcessor {
 
     public static final String PROCESSING_ERROR_MESSAGE =
-        "Expected to process event %s without errors, but exception occurred with message %s .";
+        "Expected to process event '%s' without errors, but exception occurred with message '%s' .";
 
     protected final int streamProcessorId;
     protected final LogStream logStream;
@@ -182,7 +182,7 @@ public class TypedStreamProcessor implements StreamProcessor {
     }
 
     @Override
-    public void processingFailed(Exception exception) {
+    public void onError(Throwable exception) {
       resetOutput();
 
       final String errorMessage =
@@ -194,6 +194,10 @@ public class TypedStreamProcessor implements StreamProcessor {
         writeCommandRejectionOnException(errorMessage);
       }
 
+      blacklist();
+    }
+
+    private void blacklist() {
       final Intent intent = event.getMetadata().getIntent();
       if (shouldBeBlacklisted(intent)) {
         zeebeState.blacklist(event);

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/state/ZeebeState.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/state/ZeebeState.java
@@ -17,6 +17,7 @@
  */
 package io.zeebe.broker.logstreams.state;
 
+import io.zeebe.broker.Loggers;
 import io.zeebe.broker.incident.processor.IncidentState;
 import io.zeebe.broker.job.JobState;
 import io.zeebe.broker.logstreams.processor.KeyGenerator;
@@ -31,8 +32,14 @@ import io.zeebe.db.ZeebeDb;
 import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.WorkflowInstanceRelated;
+import org.slf4j.Logger;
 
 public class ZeebeState {
+
+  public static final String BLACKLIST_INSTANCE_MESSAGE =
+      "Blacklist workflow instance {}, due to previous errors.";
+
+  private static final Logger LOG = Loggers.STREAM_PROCESSING;
 
   private final KeyState keyState;
   private final WorkflowState workflowState;
@@ -103,6 +110,7 @@ public class ZeebeState {
     if (value instanceof WorkflowInstanceRelated) {
       final long workflowInstanceKey = ((WorkflowInstanceRelated) value).getWorkflowInstanceKey();
       if (workflowInstanceKey >= 0) {
+        LOG.warn(BLACKLIST_INSTANCE_MESSAGE, workflowInstanceKey);
         blackList.blacklist(workflowInstanceKey);
       }
     }

--- a/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/BlacklistInstanceTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/BlacklistInstanceTest.java
@@ -270,7 +270,7 @@ public class BlacklistInstanceTest {
     delegatingEventProcessor.wrap(processor, typedEvent, 1024);
 
     // when
-    delegatingEventProcessor.processingFailed(new Exception("expected"));
+    delegatingEventProcessor.onError(new Exception("expected"));
 
     // then
     metadata.intent(WorkflowInstanceIntent.ELEMENT_ACTIVATING);

--- a/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
@@ -458,9 +458,9 @@ public class TestStreams {
         }
 
         @Override
-        public void processingFailed(Exception exception) {
+        public void onError(Throwable throwable) {
           if (actualProcessor != null) {
-            actualProcessor.processingFailed(exception);
+            actualProcessor.onError(throwable);
           }
         }
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/Loggers.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/Loggers.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 
 public class Loggers {
   public static final Logger LOGSTREAMS_LOGGER = new ZbLogger("io.zeebe.logstreams");
+  public static final Logger PROCESSOR_LOGGER = new ZbLogger("io.zeebe.processor");
   public static final Logger ROCKSDB_LOGGER = new ZbLogger("io.zeebe.logstreams.rocksdb");
   public static final Logger FS_SNAPSHOT_LOGGER = new ZbLogger("io.zeebe.logstreams.snapshot.fs");
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/EventProcessor.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/EventProcessor.java
@@ -25,11 +25,14 @@ public interface EventProcessor {
    */
   default void processEvent() {}
   /**
-   * Is called when processing failed due to an unexpected exception. Do clean up work.
+   * Is called when during the execution of {@link #processEvent()} or {@link
+   * #writeEvent(LogStreamRecordWriter)} an unexpected exception was thrown.
    *
-   * @param exception the exception which was catched during processing
+   * <p>The implementation should do clean up work.
+   *
+   * @param throwable the throwable which was catched during execution
    */
-  default void processingFailed(Exception exception) {}
+  default void onError(Throwable throwable) {}
 
   /**
    * (Optional) Execute the side effects which are caused by the processed event. A side effect can

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/ProcessingStateMachine.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/ProcessingStateMachine.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.processor;
+
+import io.zeebe.db.ZeebeDb;
+import io.zeebe.db.ZeebeDbTransaction;
+import io.zeebe.logstreams.impl.Loggers;
+import io.zeebe.logstreams.log.LogStreamReader;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.util.exception.RecoverableException;
+import io.zeebe.util.retry.AbortableRetryStrategy;
+import io.zeebe.util.retry.RecoverableRetryStrategy;
+import io.zeebe.util.retry.RetryStrategy;
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.future.ActorFuture;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+import org.slf4j.Logger;
+
+/**
+ * Represents the processing state machine, which is executed on normal processing.
+ *
+ * <pre>
+ *
+ * +-----------------+             +--------------------+
+ * |                 |             |                    |      exception
+ * | readNextEvent() |------------>|   processEvent()   |------------------+
+ * |                 |             |                    |                  v
+ * +-----------------+             +--------------------+            +---------------+
+ *           ^                             |                         |               |------+
+ *           |                             |         +-------------->|   onError()   |      | exception
+ *           |                             |         |  exception    |               |<-----+
+ *           |                     +-------v-------------+           +---------------+
+ *           |                     |                     |                 |
+ *           |                     |    writeEvent()     |                 |
+ *           |                     |                     |<----------------+
+ * +----------------------+        +---------------------+
+ * |                      |                 |
+ * | executeSideEffects() |                 v
+ * |                      |       +----------------------+
+ * +----------------------+       |                      |
+ *           ^                    |     updateState()    |
+ *           +--------------------|                      |
+ *                                +----------------------+
+ *                                       ^      |
+ *                                       |      | exception
+ *                                       |      |
+ *                                    +---------v----+
+ *                                    |              |
+ *                                    |   onError()  |
+ *                                    |              |
+ *                                    +--------------+
+ *                                       ^     |
+ *                                       |     |  exception
+ *                                       +-----+
+ *
+ * </pre>
+ */
+public final class ProcessingStateMachine {
+
+  private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
+
+  public static final String ERROR_MESSAGE_WRITE_EVENT_ABORTED =
+      "Expected to write one or more follow up events for event '{}' without errors, but exception was thrown.";
+  private static final String ERROR_MESSAGE_ROLLBACK_ABORTED =
+      "Expected to roll back the current transaction for event '{}' successfully, but exception was thrown.";
+  private static final String ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED =
+      "Expected to execute side effects for event '{}' successfully, but exception was thrown.";
+  private static final String ERROR_MESSAGE_UPDATE_STATE_FAILED =
+      "Expected to successfully update state for event '{}' with processor '{}', but caught an exception. Retry.";
+  private static final String ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT =
+      "Expected to find event processor for event '{}' with processor '{}', but caught an exception. Skip this event.";
+  private static final String ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT =
+      "Expected to successfully process event '{}' with processor '{}', but caught an exception. Skip this event.";
+  private static final String ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING =
+      "Expected to process event '{}' successfully on stream processor '{}', but caught recoverable exception. Retry processing.";
+
+  private static final Duration PROCESSING_RETRY_DELAY = Duration.ofMillis(250);
+
+  public static ProcessingStateMachineBuilder builder() {
+    return new ProcessingStateMachineBuilder();
+  }
+
+  private final ActorControl actor;
+  private final int producerId;
+  private final String streamProcessorName;
+  private final StreamProcessorMetrics metrics;
+  private final StreamProcessor streamProcessor;
+  private final EventFilter eventFilter;
+  private final LogStreamReader logStreamReader;
+  private final LogStreamRecordWriter logStreamWriter;
+
+  private final ZeebeDb zeebeDb;
+  private final RetryStrategy writeRetryStrategy;
+  private final RetryStrategy sideEffectsRetryStrategy;
+  private final RetryStrategy updateStateRetryStrategy;
+
+  private final BooleanSupplier shouldProcessNext;
+  private final BooleanSupplier abortCondition;
+
+  private ProcessingStateMachine(
+      StreamProcessorContext context,
+      StreamProcessorMetrics metrics,
+      StreamProcessor streamProcessor,
+      ZeebeDb zeebeDb,
+      BooleanSupplier shouldProcessNext,
+      BooleanSupplier abortCondition) {
+    this.actor = context.getActorControl();
+    this.producerId = context.getId();
+    this.streamProcessorName = context.getName();
+    this.eventFilter = context.getEventFilter();
+    this.logStreamReader = context.getLogStreamReader();
+    this.logStreamWriter = context.logStreamWriter;
+
+    this.metrics = metrics;
+    this.streamProcessor = streamProcessor;
+    this.zeebeDb = zeebeDb;
+    this.writeRetryStrategy = new AbortableRetryStrategy(actor);
+    this.sideEffectsRetryStrategy = new AbortableRetryStrategy(actor);
+    this.updateStateRetryStrategy = new RecoverableRetryStrategy(actor);
+    this.shouldProcessNext = shouldProcessNext;
+    this.abortCondition = abortCondition;
+  }
+
+  // current iteration
+  private LoggedEvent currentEvent;
+  private EventProcessor eventProcessor;
+  private ZeebeDbTransaction zeebeDbTransaction;
+
+  private long eventPosition = -1L;
+  private long lastSuccessfulProcessedEventPosition = -1L;
+  private long lastWrittenEventPosition = -1L;
+
+  private void skipRecord() {
+    actor.submit(this::readNextEvent);
+    metrics.incrementEventsSkippedCount();
+  }
+
+  void readNextEvent() {
+    if (shouldProcessNext.getAsBoolean() && logStreamReader.hasNext() && eventProcessor == null) {
+      currentEvent = logStreamReader.next();
+
+      if (eventFilter == null || eventFilter.applies(currentEvent)) {
+        processEvent(currentEvent);
+      } else {
+        skipRecord();
+      }
+    }
+  }
+
+  private void processEvent(final LoggedEvent event) {
+    try {
+      eventProcessor = streamProcessor.onEvent(event);
+    } catch (final Exception e) {
+      LOG.error(ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT, event, streamProcessorName, e);
+      skipRecord();
+      return;
+    }
+
+    if (eventProcessor == null) {
+      skipRecord();
+      return;
+    }
+
+    try {
+      zeebeDbTransaction = zeebeDb.transaction();
+      zeebeDbTransaction.run(eventProcessor::processEvent);
+      metrics.incrementEventsProcessedCount();
+      writeEvent();
+    } catch (final RecoverableException recoverableException) {
+      // recoverable
+      LOG.error(
+          ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING,
+          event,
+          streamProcessorName,
+          recoverableException);
+      actor.runDelayed(PROCESSING_RETRY_DELAY, () -> processEvent(currentEvent));
+    } catch (final Exception e) {
+      LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT, event, streamProcessorName, e);
+      onProcessingError(e, this::writeEvent);
+    }
+  }
+
+  private void onProcessingError(Throwable t, Runnable nextStep) {
+    final ActorFuture<Boolean> retryFuture =
+        updateStateRetryStrategy.runWithRetry(
+            () -> {
+              zeebeDbTransaction.rollback();
+              return true;
+            },
+            abortCondition);
+
+    actor.runOnCompletion(
+        retryFuture,
+        (bool, throwable) -> {
+          if (throwable != null) {
+            LOG.error(ERROR_MESSAGE_ROLLBACK_ABORTED, currentEvent, throwable);
+          }
+          try {
+            zeebeDbTransaction = zeebeDb.transaction();
+            zeebeDbTransaction.run(() -> eventProcessor.onError(t));
+            nextStep.run();
+          } catch (Exception ex) {
+            onProcessingError(ex, nextStep);
+          }
+        });
+  }
+
+  private void writeEvent() {
+    logStreamWriter.producerId(producerId).sourceRecordPosition(currentEvent.getPosition());
+
+    final ActorFuture<Boolean> retryFuture =
+        writeRetryStrategy.runWithRetry(
+            () -> {
+              eventPosition = eventProcessor.writeEvent(logStreamWriter);
+              return eventPosition >= 0;
+            },
+            abortCondition);
+
+    actor.runOnCompletion(
+        retryFuture,
+        (bool, t) -> {
+          if (t != null) {
+            LOG.error(ERROR_MESSAGE_WRITE_EVENT_ABORTED, currentEvent, t);
+            onProcessingError(t, this::writeEvent);
+          } else {
+            metrics.incrementEventsWrittenCount();
+            updateState();
+          }
+        });
+  }
+
+  private void updateState() {
+    final ActorFuture<Boolean> retryFuture =
+        updateStateRetryStrategy.runWithRetry(
+            () -> {
+              zeebeDbTransaction.commit();
+              return true;
+            },
+            abortCondition);
+
+    actor.runOnCompletion(
+        retryFuture,
+        (bool, throwable) -> {
+          if (throwable != null) {
+            LOG.error(
+                ERROR_MESSAGE_UPDATE_STATE_FAILED, currentEvent, streamProcessorName, throwable);
+            onProcessingError(throwable, this::updateState);
+          } else {
+
+            lastSuccessfulProcessedEventPosition = currentEvent.getPosition();
+            lastWrittenEventPosition = eventPosition;
+
+            executeSideEffects();
+          }
+        });
+  }
+
+  private void executeSideEffects() {
+    final ActorFuture<Boolean> retryFuture =
+        sideEffectsRetryStrategy.runWithRetry(eventProcessor::executeSideEffects, abortCondition);
+
+    actor.runOnCompletion(
+        retryFuture,
+        (bool, throwable) -> {
+          if (throwable != null) {
+            LOG.error(ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED, currentEvent, throwable);
+          }
+
+          // continue with next event
+          eventProcessor = null;
+          actor.submit(this::readNextEvent);
+        });
+  }
+
+  public long getLastSuccessfulProcessedEventPosition() {
+    return lastSuccessfulProcessedEventPosition;
+  }
+
+  public long getLastWrittenEventPosition() {
+    return lastWrittenEventPosition;
+  }
+
+  public static class ProcessingStateMachineBuilder {
+
+    private StreamProcessorMetrics metrics;
+    private StreamProcessor streamProcessor;
+
+    private StreamProcessorContext streamProcessorContext;
+    private ZeebeDb zeebeDb;
+    private BooleanSupplier shouldProcessNext;
+    private BooleanSupplier abortCondition;
+
+    public ProcessingStateMachineBuilder setMetrics(StreamProcessorMetrics metrics) {
+      this.metrics = metrics;
+      return this;
+    }
+
+    public ProcessingStateMachineBuilder setStreamProcessor(StreamProcessor streamProcessor) {
+      this.streamProcessor = streamProcessor;
+      return this;
+    }
+
+    public ProcessingStateMachineBuilder setStreamProcessorContext(StreamProcessorContext context) {
+      this.streamProcessorContext = context;
+      return this;
+    }
+
+    public ProcessingStateMachineBuilder setZeebeDb(ZeebeDb zeebeDb) {
+      this.zeebeDb = zeebeDb;
+      return this;
+    }
+
+    public ProcessingStateMachineBuilder setShouldProcessNext(BooleanSupplier shouldProcessNext) {
+      this.shouldProcessNext = shouldProcessNext;
+      return this;
+    }
+
+    public ProcessingStateMachineBuilder setAbortCondition(BooleanSupplier abortCondition) {
+      this.abortCondition = abortCondition;
+      return this;
+    }
+
+    public ProcessingStateMachine build() {
+      Objects.requireNonNull(streamProcessorContext);
+      Objects.requireNonNull(metrics);
+      Objects.requireNonNull(streamProcessor);
+      Objects.requireNonNull(zeebeDb);
+      Objects.requireNonNull(shouldProcessNext);
+      Objects.requireNonNull(abortCondition);
+      return new ProcessingStateMachine(
+          streamProcessorContext,
+          metrics,
+          streamProcessor,
+          zeebeDb,
+          shouldProcessNext,
+          abortCondition);
+    }
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/ReProcessingStateMachine.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/ReProcessingStateMachine.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.processor;
+
+import io.zeebe.db.ZeebeDb;
+import io.zeebe.db.ZeebeDbTransaction;
+import io.zeebe.logstreams.impl.Loggers;
+import io.zeebe.logstreams.log.LogStreamReader;
+import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.util.exception.RecoverableException;
+import io.zeebe.util.retry.RecoverableRetryStrategy;
+import io.zeebe.util.retry.RetryStrategy;
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+import org.slf4j.Logger;
+
+/**
+ * Represents the reprocessing state machine, which is executed on reprocessing.
+ *
+ * <pre>
+ *   +------------------+
+ *   |                  |
+ *   |  startRecover()  |
+ *   |                  |               +--------------------+
+ *   +------------------+               |                    |
+ *            |                   +---->|  reprocessEvent()  |--------+
+ *            v                   |     |                    |        |
+ * +------------------------+     |     +----+---------------+        | exception
+ * |                        |     |          |                        |
+ * |  reprocessNextEvent()  |-----+          |                        |
+ * |                        |                |                 +------v------+
+ * +------------------------+                |                 |             |-------+
+ *            ^                              |        +-------->  onError()  |       | exception
+ *            |                              |        |        |             |<------+
+ *            | hasNext                      |        |        +----------+--+
+ *            |                              |        |                   |
+ * +----------+--------------+               |        | exception         |
+ * |                         |               |        |                   |
+ * |  onRecordReprocessed()  <------+        |        |                   |
+ * |                         |      |        |        |                   |
+ * +-----------+-------------+      |   +----v--------+---+               |
+ *             |                    |   |                 |               |
+ *             |                    +---|  updateState()  |<--------------+
+ *             |                        |                 |
+ *             v                        +-----------------+
+ *    +-----------------+
+ *    |                 |
+ *    |  onRecovered()  |
+ *    |                 |
+ *    +-----------------+
+ * </pre>
+ *
+ * See https://textik.com/#773271ce7ea2096a
+ */
+public final class ReProcessingStateMachine {
+
+  private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
+
+  private static final String ERROR_MESSAGE_ROLLBACK_ABORTED =
+      "Expected to roll back the current transaction for event '{}' successfully, but exception was thrown.";
+  private static final String ERROR_MESSAGE_UPDATE_STATE_FAILED =
+      "Expected to successfully update state for event '{}' with processor '{}', but caught an exception. Retry.";
+  private static final String ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT =
+      "Expected to find event processor for event '{}' with processor '{}', but caught an exception. Skip this event.";
+
+  private static final String ERROR_MESSAGE_REPROCESSING_NO_SOURCE_EVENT =
+      "Expected to find last source event position '%d', but last position was '%d'. Failed to reprocess on processor '%s'";
+  private static final String ERROR_MESSAGE_REPROCESSING_NO_NEXT_EVENT =
+      "Expected to find last source event position '%d', but found no next event. Failed to reprocess on processor '%s'";
+  private static final String ERROR_MESSAGE_REPROCESSING_FAILED_SKIP_EVENT =
+      "Expected to successfully reprocess event '{}' on processor '{}', but caught an exception.";
+  private static final String ERROR_MESSAGE_REPROCESSING_FAILED_RETRY_REPROCESSING =
+      "Expected to reprocess event '{}' successfully on stream processor '{}', but caught recoverable exception. Retry reprocessing.";
+
+  private static final String LOG_STMT_REPROCESSING_FINISHED =
+      "Processor {} finished reprocessing at event position {}";
+
+  private static final Duration PROCESSING_RETRY_DELAY = Duration.ofMillis(250);
+
+  public static ProcessingStateMachineBuilder builder() {
+    return new ProcessingStateMachineBuilder();
+  }
+
+  private final ActorControl actor;
+  private final String streamProcessorName;
+  private final StreamProcessor streamProcessor;
+  private final EventFilter eventFilter;
+  private final LogStreamReader logStreamReader;
+
+  private final ZeebeDb zeebeDb;
+  private final RetryStrategy updateStateRetryStrategy;
+
+  private final BooleanSupplier abortCondition;
+
+  private ReProcessingStateMachine(
+      StreamProcessorContext context,
+      StreamProcessor streamProcessor,
+      ZeebeDb zeebeDb,
+      BooleanSupplier abortCondition) {
+    this.actor = context.getActorControl();
+    this.streamProcessorName = context.getName();
+    this.eventFilter = context.getEventFilter();
+    this.logStreamReader = context.getLogStreamReader();
+
+    this.streamProcessor = streamProcessor;
+    this.zeebeDb = zeebeDb;
+    this.updateStateRetryStrategy = new RecoverableRetryStrategy(actor);
+    this.abortCondition = abortCondition;
+  }
+
+  // current iteration
+  private long lastSourceEventPosition;
+  private ActorFuture<Void> recoveryFuture;
+
+  private LoggedEvent currentEvent;
+  private EventProcessor eventProcessor;
+  private ZeebeDbTransaction zeebeDbTransaction;
+
+  ActorFuture<Void> startRecover(long lastSourceEventPosition) {
+    this.lastSourceEventPosition = lastSourceEventPosition;
+    recoveryFuture = new CompletableActorFuture<>();
+    reprocessNextEvent();
+    return recoveryFuture;
+  }
+
+  private void reprocessNextEvent() {
+    try {
+      if (!logStreamReader.hasNext()) {
+        throw new IllegalStateException(
+            String.format(
+                ERROR_MESSAGE_REPROCESSING_NO_NEXT_EVENT,
+                lastSourceEventPosition,
+                streamProcessorName));
+      }
+
+      currentEvent = logStreamReader.next();
+      if (currentEvent.getPosition() > lastSourceEventPosition) {
+        throw new IllegalStateException(
+            String.format(
+                ERROR_MESSAGE_REPROCESSING_NO_SOURCE_EVENT,
+                lastSourceEventPosition,
+                currentEvent.getPosition(),
+                streamProcessorName));
+      }
+
+      if (eventFilter == null || eventFilter.applies(currentEvent)) {
+        reprocessEvent(currentEvent);
+      } else {
+        onRecordReprocessed(currentEvent);
+      }
+    } catch (final RuntimeException e) {
+      recoveryFuture.completeExceptionally(e);
+    }
+  }
+
+  private void reprocessEvent(final LoggedEvent currentEvent) {
+    try {
+      eventProcessor = streamProcessor.onEvent(currentEvent);
+    } catch (final Exception e) {
+      LOG.error(ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT, currentEvent, streamProcessorName, e);
+    }
+
+    if (eventProcessor == null) {
+      onRecordReprocessed(currentEvent);
+      return;
+    }
+
+    try {
+      // don't execute side effects or write events
+      zeebeDbTransaction = zeebeDb.transaction();
+      zeebeDbTransaction.run(eventProcessor::processEvent);
+      updateState();
+    } catch (final RecoverableException recoverableException) {
+      // recoverable
+      LOG.error(
+          ERROR_MESSAGE_REPROCESSING_FAILED_RETRY_REPROCESSING,
+          currentEvent,
+          streamProcessorName,
+          recoverableException);
+      actor.runDelayed(PROCESSING_RETRY_DELAY, () -> reprocessEvent(currentEvent));
+      return;
+    } catch (final Exception e) {
+      LOG.error(ERROR_MESSAGE_REPROCESSING_FAILED_SKIP_EVENT, currentEvent, streamProcessorName, e);
+      onProcessingError(e, this::updateState);
+    }
+  }
+
+  private void onRecordReprocessed(final LoggedEvent currentEvent) {
+    if (currentEvent.getPosition() == lastSourceEventPosition) {
+      LOG.info(LOG_STMT_REPROCESSING_FINISHED, streamProcessorName, currentEvent.getPosition());
+      onRecovered();
+    } else {
+      actor.submit(this::reprocessNextEvent);
+    }
+  }
+
+  private void onRecovered() {
+    recoveryFuture.complete(null);
+  }
+
+  private void onProcessingError(Throwable t, Runnable nextStep) {
+    final ActorFuture<Boolean> retryFuture =
+        updateStateRetryStrategy.runWithRetry(
+            () -> {
+              zeebeDbTransaction.rollback();
+              return true;
+            },
+            abortCondition);
+
+    actor.runOnCompletion(
+        retryFuture,
+        (bool, throwable) -> {
+          if (throwable != null) {
+            LOG.error(ERROR_MESSAGE_ROLLBACK_ABORTED, currentEvent, throwable);
+          }
+          try {
+            zeebeDbTransaction = zeebeDb.transaction();
+            zeebeDbTransaction.run(() -> eventProcessor.onError(t));
+            nextStep.run();
+          } catch (Exception ex) {
+            onProcessingError(ex, nextStep);
+          }
+        });
+  }
+
+  private void updateState() {
+    final ActorFuture<Boolean> retryFuture =
+        updateStateRetryStrategy.runWithRetry(
+            () -> {
+              zeebeDbTransaction.commit();
+              return true;
+            },
+            abortCondition);
+
+    actor.runOnCompletion(
+        retryFuture,
+        (bool, throwable) -> {
+          if (throwable != null) {
+            LOG.error(
+                ERROR_MESSAGE_UPDATE_STATE_FAILED, currentEvent, streamProcessorName, throwable);
+            onProcessingError(throwable, this::updateState);
+          } else {
+            onRecordReprocessed(currentEvent);
+          }
+        });
+  }
+
+  public static class ProcessingStateMachineBuilder {
+
+    private StreamProcessor streamProcessor;
+
+    private StreamProcessorContext streamProcessorContext;
+    private ZeebeDb zeebeDb;
+    private BooleanSupplier abortCondition;
+
+    public ProcessingStateMachineBuilder setStreamProcessor(StreamProcessor streamProcessor) {
+      this.streamProcessor = streamProcessor;
+      return this;
+    }
+
+    public ProcessingStateMachineBuilder setStreamProcessorContext(StreamProcessorContext context) {
+      this.streamProcessorContext = context;
+      return this;
+    }
+
+    public ProcessingStateMachineBuilder setZeebeDb(ZeebeDb zeebeDb) {
+      this.zeebeDb = zeebeDb;
+      return this;
+    }
+
+    public ProcessingStateMachineBuilder setAbortCondition(BooleanSupplier abortCondition) {
+      this.abortCondition = abortCondition;
+      return this;
+    }
+
+    public ReProcessingStateMachine build() {
+      Objects.requireNonNull(streamProcessorContext);
+      Objects.requireNonNull(streamProcessor);
+      Objects.requireNonNull(zeebeDb);
+      Objects.requireNonNull(abortCondition);
+      return new ReProcessingStateMachine(
+          streamProcessorContext, streamProcessor, zeebeDb, abortCondition);
+    }
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
@@ -24,7 +24,6 @@ import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.logstreams.spi.SnapshotController;
 import io.zeebe.logstreams.state.StateSnapshotMetadata;
 import io.zeebe.util.LangUtil;
-import io.zeebe.util.exception.RecoverableException;
 import io.zeebe.util.metrics.MetricsManager;
 import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.ActorCondition;
@@ -44,27 +43,6 @@ public class StreamProcessorController extends Actor {
 
   private static final String ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED =
       "Expected to find event with the snapshot position in log stream, but nothing was found. Failed to recover with processor '%s'.";
-  private static final String ERROR_MESSAGE_REPROCESSING_NO_SOURCE_EVENT =
-      "Expected to find last source event position '%d', but last position was '%d'. Failed to reprocess on processor '%s'";
-  private static final String ERROR_MESSAGE_REPROCESSING_NO_NEXT_EVENT =
-      "Expected to find last source event position '%d', but found no next event. Failed to reprocess on processor '%s'";
-  private static final String ERROR_MESSAGE_REPROCESSING_FAILED_SKIP_EVENT =
-      "Expected to successfully reprocess event '{}' on processor '{}', but caught an exception.";
-  private static final String ERROR_MESSAGE_REPROCESSING_FAILED_RETRY_REPROCESSING =
-      "Expected to reprocess event '{}' successfully on stream processor '{}', but caught recoverable exception. Retry reprocessing.";
-
-  private static final String ERROR_MESSAGE_WRITE_FAILED =
-      "Expected to successfully write event with processor '{}', but caught an exception. Stop processing further events.";
-  private static final String ERROR_MESSAGE_EXECUTE_SITE_EFFECTS_FAILED =
-      "Expected to successfully execute side effects with processor '{}', but caught an exception. Stop processing further events.";
-  private static final String ERROR_MESSAGE_UPDATE_STATE_FAILED =
-      "Expected to successfully update state with processor '{}', but caught an exception. Stop processing further events.";
-  private static final String ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT =
-      "Expected to successfully process event '{}' with processor '{}', but caught an exception. Skip this event.";
-  private static final String ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING =
-      "Expected to process event '{}' successfully on stream processor '{}', but caught recoverable exception. Retry processing.";
-
-  public static final Duration PROCESSING_RETRY_DELAY = Duration.ofMillis(250);
 
   private final StreamProcessorFactory streamProcessorFactory;
   private StreamProcessor streamProcessor;
@@ -81,25 +59,19 @@ public class StreamProcessorController extends Actor {
   private final AtomicBoolean isOpened = new AtomicBoolean(false);
   private Phase phase = Phase.REPROCESSING;
 
-  private final EventFilter eventFilter;
   private final boolean isReadOnlyProcessor;
-
-  private final Runnable readNextEvent = this::readNextEvent;
 
   private long snapshotPosition = -1L;
   private long lastSourceEventPosition = -1L;
-  private long eventPosition = -1L;
-  private long lastSuccessfulProcessedEventPosition = -1L;
-  private long lastWrittenEventPosition = -1L;
 
-  private LoggedEvent currentEvent;
-  private EventProcessor eventProcessor;
   private ActorCondition onCommitPositionUpdatedCondition;
 
   private boolean suspended = false;
 
   private StreamProcessorMetrics metrics;
   private ZeebeDb zeebeDb;
+  private ProcessingStateMachine processingStateMachine;
+  private ReProcessingStateMachine reProcessingStateMachine;
 
   public StreamProcessorController(final StreamProcessorContext context) {
     this.streamProcessorContext = context;
@@ -116,7 +88,6 @@ public class StreamProcessorController extends Actor {
     this.logStreamReader = context.getLogStreamReader();
     this.logStreamWriter = context.getLogStreamWriter();
     this.snapshotPeriod = context.getSnapshotPeriod();
-    this.eventFilter = context.getEventFilter();
     this.isReadOnlyProcessor = context.isReadOnlyProcessor();
   }
 
@@ -147,7 +118,6 @@ public class StreamProcessorController extends Actor {
     logStreamWriter.wrap(logStream);
 
     try {
-
       snapshotPosition = recoverFromSnapshot(logStream.getCommitPosition(), logStream.getTerm());
       LOG.info(
           "Recovering partition {} from snapshot at position {}", partitionId, snapshotPosition);
@@ -165,13 +135,43 @@ public class StreamProcessorController extends Actor {
       onFailure();
       LangUtil.rethrowUnchecked(e);
     }
+
+    processingStateMachine =
+        ProcessingStateMachine.builder()
+            .setStreamProcessorContext(streamProcessorContext)
+            .setMetrics(metrics)
+            .setStreamProcessor(streamProcessor)
+            .setZeebeDb(zeebeDb)
+            .setShouldProcessNext(() -> isOpened() && !isSuspended())
+            .setAbortCondition(this::isClosed)
+            .build();
+
+    reProcessingStateMachine =
+        ReProcessingStateMachine.builder()
+            .setStreamProcessorContext(streamProcessorContext)
+            .setStreamProcessor(streamProcessor)
+            .setZeebeDb(zeebeDb)
+            .setAbortCondition(this::isClosed)
+            .build();
   }
 
   @Override
   protected void onActorStarted() {
     try {
       if (lastSourceEventPosition > snapshotPosition) {
-        reprocessNextEvent();
+        final ActorFuture<Void> recoverFuture =
+            reProcessingStateMachine.startRecover(lastSourceEventPosition);
+
+        actor.runOnCompletion(
+            recoverFuture,
+            (v, throwable) -> {
+              if (throwable != null) {
+                LOG.error("Unexpected error on recovery happens.", throwable);
+                onFailure();
+              } else {
+                onRecovered();
+              }
+            });
       } else {
         onRecovered();
       }
@@ -238,78 +238,12 @@ public class StreamProcessorController extends Actor {
     return lastSourceEventPosition;
   }
 
-  private void reprocessNextEvent() {
-    try {
-      if (logStreamReader.hasNext()) {
-        currentEvent = logStreamReader.next();
-        if (currentEvent.getPosition() > lastSourceEventPosition) {
-          throw new IllegalStateException(
-              String.format(
-                  ERROR_MESSAGE_REPROCESSING_NO_SOURCE_EVENT,
-                  lastSourceEventPosition,
-                  currentEvent.getPosition(),
-                  getName()));
-        }
-
-        reprocessEvent(currentEvent);
-      } else {
-        throw new IllegalStateException(
-            String.format(
-                ERROR_MESSAGE_REPROCESSING_NO_NEXT_EVENT, lastSourceEventPosition, getName()));
-      }
-    } catch (final RuntimeException e) {
-      onFailure();
-      throw e;
-    }
-  }
-
-  private void reprocessEvent(final LoggedEvent currentEvent) {
-    if (eventFilter == null || eventFilter.applies(currentEvent)) {
-      try {
-        final EventProcessor eventProcessor = streamProcessor.onEvent(currentEvent);
-        if (eventProcessor != null) {
-          try {
-            // don't execute side effects or write events
-            zeebeDb.transaction(eventProcessor::processEvent);
-          } catch (final RecoverableException recoverableException) {
-            // recoverable
-            LOG.error(
-                ERROR_MESSAGE_REPROCESSING_FAILED_RETRY_REPROCESSING,
-                currentEvent,
-                getName(),
-                recoverableException);
-            actor.runDelayed(PROCESSING_RETRY_DELAY, () -> processEvent(currentEvent));
-            return;
-          } catch (final Exception e) {
-            LOG.error(ERROR_MESSAGE_REPROCESSING_FAILED_SKIP_EVENT, currentEvent, getName(), e);
-            zeebeDb.transaction(() -> eventProcessor.processingFailed(e));
-          }
-        }
-      } catch (final Exception e) {
-        LOG.error(ERROR_MESSAGE_REPROCESSING_FAILED_SKIP_EVENT, currentEvent, getName(), e);
-      }
-    }
-
-    onRecordReprocessed(currentEvent);
-  }
-
-  private void onRecordReprocessed(final LoggedEvent currentEvent) {
-    if (currentEvent.getPosition() == lastSourceEventPosition) {
-      LOG.info(
-          "Reprocessing partition {} finished at event position {}",
-          partitionId,
-          currentEvent.getPosition());
-      onRecovered();
-    } else {
-      actor.submit(this::reprocessNextEvent);
-    }
-  }
-
   private void onRecovered() {
     phase = Phase.PROCESSING;
 
     onCommitPositionUpdatedCondition =
-        actor.onCondition(getName() + "-on-commit-position-updated", readNextEvent);
+        actor.onCondition(
+            getName() + "-on-commit-position-updated", processingStateMachine::readNextEvent);
     streamProcessorContext.logStream.registerOnCommitPositionUpdatedCondition(
         onCommitPositionUpdatedCondition);
 
@@ -317,122 +251,7 @@ public class StreamProcessorController extends Actor {
 
     // start reading
     streamProcessor.onRecovered();
-    actor.submit(readNextEvent);
-  }
-
-  private void readNextEvent() {
-    if (isOpened() && !isSuspended() && logStreamReader.hasNext() && eventProcessor == null) {
-      currentEvent = logStreamReader.next();
-
-      if (eventFilter == null || eventFilter.applies(currentEvent)) {
-        processEvent(currentEvent);
-      } else {
-        skipRecord();
-      }
-    }
-  }
-
-  private void processEvent(final LoggedEvent event) {
-    try {
-      eventProcessor = streamProcessor.onEvent(event);
-
-      if (eventProcessor != null) {
-        try {
-          zeebeDb.transaction(eventProcessor::processEvent);
-          metrics.incrementEventsProcessedCount();
-          actor.runUntilDone(this::executeSideEffects);
-        } catch (final RecoverableException recoverableException) {
-          // recoverable
-          LOG.error(
-              ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING,
-              event,
-              getName(),
-              recoverableException);
-          actor.runDelayed(PROCESSING_RETRY_DELAY, () -> processEvent(currentEvent));
-        } catch (final Exception e) {
-          LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT, event, getName(), e);
-          zeebeDb.transaction(() -> eventProcessor.processingFailed(e));
-          // send rejection etc
-          actor.runUntilDone(this::executeSideEffects);
-        }
-      } else {
-        skipRecord();
-      }
-    } catch (final Exception e) {
-      LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT, event, getName(), e);
-      eventProcessor = null;
-      skipRecord();
-    }
-  }
-
-  private void skipRecord() {
-    actor.submit(readNextEvent);
-    metrics.incrementEventsSkippedCount();
-  }
-
-  private void executeSideEffects() {
-    try {
-      final boolean success = eventProcessor.executeSideEffects();
-      if (success) {
-        actor.done();
-
-        actor.runUntilDone(this::writeEvent);
-      } else if (isOpened()) {
-        // try again
-        actor.yield();
-      } else {
-        actor.done();
-      }
-    } catch (final Exception e) {
-      actor.done();
-      LOG.error(ERROR_MESSAGE_EXECUTE_SITE_EFFECTS_FAILED, getName(), e);
-      onFailure();
-    }
-  }
-
-  private void writeEvent() {
-    try {
-      logStreamWriter
-          .producerId(streamProcessorContext.getId())
-          .sourceRecordPosition(currentEvent.getPosition());
-
-      eventPosition = eventProcessor.writeEvent(logStreamWriter);
-
-      if (eventPosition >= 0) {
-        actor.done();
-
-        metrics.incrementEventsWrittenCount();
-
-        updateState();
-      } else if (isOpened()) {
-        // try again
-        actor.yield();
-      } else {
-        actor.done();
-      }
-    } catch (final Exception e) {
-      actor.done();
-      LOG.error(ERROR_MESSAGE_WRITE_FAILED, getName(), e);
-      onFailure();
-    }
-  }
-
-  private void updateState() {
-    try {
-      lastSuccessfulProcessedEventPosition = currentEvent.getPosition();
-
-      final boolean hasWrittenEvent = eventPosition > 0;
-      if (hasWrittenEvent) {
-        lastWrittenEventPosition = eventPosition;
-      }
-
-      // continue with next event
-      eventProcessor = null;
-      actor.submit(readNextEvent);
-    } catch (final Exception e) {
-      LOG.error(ERROR_MESSAGE_UPDATE_STATE_FAILED, getName(), e);
-      onFailure();
-    }
+    actor.submit(processingStateMachine::readNextEvent);
   }
 
   private void createSnapshot() {
@@ -446,21 +265,23 @@ public class StreamProcessorController extends Actor {
   }
 
   private void doCreateSnapshot() {
-    if (currentEvent != null) {
-      final long lastWrittenPosition =
-          lastWrittenEventPosition > lastSuccessfulProcessedEventPosition
-              ? lastWrittenEventPosition
-              : lastSuccessfulProcessedEventPosition;
 
-      final StateSnapshotMetadata metadata =
-          new StateSnapshotMetadata(
-              lastSuccessfulProcessedEventPosition,
-              lastWrittenPosition,
-              streamProcessorContext.getLogStream().getTerm(),
-              false);
+    final long lastWrittenEventPosition = processingStateMachine.getLastWrittenEventPosition();
+    final long lastSuccessfulProcessedEventPosition =
+        processingStateMachine.getLastSuccessfulProcessedEventPosition();
+    final long lastWrittenPosition =
+        lastWrittenEventPosition > lastSuccessfulProcessedEventPosition
+            ? lastWrittenEventPosition
+            : lastSuccessfulProcessedEventPosition;
 
-      writeSnapshot(metadata);
-    }
+    final StateSnapshotMetadata metadata =
+        new StateSnapshotMetadata(
+            lastSuccessfulProcessedEventPosition,
+            lastWrittenPosition,
+            streamProcessorContext.getLogStream().getTerm(),
+            false);
+
+    writeSnapshot(metadata);
 
     // reset to cpu bound
     actor.setSchedulingHints(SchedulingHints.cpuBound(ActorPriority.REGULAR));
@@ -481,7 +302,7 @@ public class StreamProcessorController extends Actor {
       LOG.info("Creation of snapshot {} took {} ms.", name, snapshotCreationTime);
       metrics.recordSnapshotCreationTime(snapshotCreationTime);
 
-      snapshotPosition = lastSuccessfulProcessedEventPosition;
+      snapshotPosition = processingStateMachine.getLastSuccessfulProcessedEventPosition();
     } catch (final Exception e) {
       LOG.error("Stream processor '{}' failed. Can not write snapshot.", getName(), e);
     }
@@ -537,6 +358,10 @@ public class StreamProcessorController extends Actor {
     return isOpened.get();
   }
 
+  public boolean isClosed() {
+    return !isOpened.get();
+  }
+
   public boolean isFailed() {
     return phase == Phase.FAILED;
   }
@@ -555,7 +380,7 @@ public class StreamProcessorController extends Actor {
     // if state is REPROCESSING, we do nothing, because
     // processing will be triggered once reprocessing is finished anyway
     if (phase == Phase.PROCESSING) {
-      actor.submit(readNextEvent);
+      actor.submit(processingStateMachine::readNextEvent);
     }
   }
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/ProcessingStateMachineTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/ProcessingStateMachineTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.processor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import io.zeebe.db.ZeebeDb;
+import io.zeebe.db.ZeebeDbTransaction;
+import io.zeebe.logstreams.log.LogStreamReader;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.testing.ControlledActorSchedulerRule;
+import java.util.concurrent.CountDownLatch;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+public class ProcessingStateMachineTest {
+
+  @Rule public ControlledActorSchedulerRule actorSchedulerRule = new ControlledActorSchedulerRule();
+
+  private ProcessingStateMachine processingStateMachine;
+
+  @Mock private StreamProcessor streamProcessor;
+  @Mock private LogStreamReader logStreamReader;
+  @Mock private LogStreamRecordWriter logStreamWriter;
+  @Mock private ZeebeDb zeebeDb;
+
+  private ZeebeDbTransaction zeebeDbTransaction;
+  private ActorControl actor;
+  private EventProcessor eventProcessor;
+
+  @Before
+  public void setup() {
+    initMocks(this);
+
+    final ControllableActor controllableActor = new ControllableActor();
+    actor = controllableActor.getActor();
+
+    when(logStreamReader.hasNext()).thenReturn(true, false);
+    when(logStreamReader.next()).thenReturn(mock(LoggedEvent.class));
+
+    when(logStreamWriter.producerId(anyInt())).thenReturn(logStreamWriter);
+
+    zeebeDbTransaction = mock(ZeebeDbTransaction.class);
+    when(zeebeDb.transaction()).thenReturn(zeebeDbTransaction);
+
+    eventProcessor = mock(EventProcessor.class);
+
+    when(eventProcessor.executeSideEffects()).thenReturn(true);
+    when(eventProcessor.writeEvent(any())).thenReturn(1L);
+
+    when(streamProcessor.onEvent(any())).thenReturn(eventProcessor);
+
+    final StreamProcessorContext streamProcessorContext = new StreamProcessorContext();
+    streamProcessorContext.setActorControl(actor);
+    streamProcessorContext.setLogStreamReader(logStreamReader);
+    streamProcessorContext.setLogStreamWriter(logStreamWriter);
+    streamProcessorContext.setName("testProcessor");
+
+    processingStateMachine =
+        ProcessingStateMachine.builder()
+            .setStreamProcessorContext(streamProcessorContext)
+            .setMetrics(mock(StreamProcessorMetrics.class))
+            .setStreamProcessor(streamProcessor)
+            .setZeebeDb(zeebeDb)
+            .setShouldProcessNext(() -> true)
+            .setAbortCondition(() -> false)
+            .build();
+
+    actorSchedulerRule.submitActor(controllableActor);
+  }
+
+  @Test
+  public void shouldRunLifecycle() throws Exception {
+    // given
+    final CountDownLatch latch = new CountDownLatch(1);
+    when(eventProcessor.executeSideEffects())
+        .then(
+            (invocationOnMock -> {
+              latch.countDown();
+              return true;
+            }));
+
+    // when
+    actor.call(() -> processingStateMachine.readNextEvent());
+    actorSchedulerRule.workUntilDone();
+
+    // then
+    latch.await();
+    final InOrder inOrder =
+        Mockito.inOrder(streamProcessor, eventProcessor, zeebeDb, zeebeDbTransaction);
+
+    // process
+    inOrder.verify(streamProcessor, times(1)).onEvent(any());
+    inOrder.verify(zeebeDb, times(1)).transaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+
+    // write event
+    inOrder.verify(eventProcessor, times(1)).writeEvent(any());
+
+    // update state
+    inOrder.verify(zeebeDbTransaction, times(1)).commit();
+
+    // execute side effects
+    inOrder.verify(eventProcessor, times(1)).executeSideEffects();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldRunLifecycleOnErrorInProcess() throws Exception {
+    // given
+    doThrow(new RuntimeException("expected")).doNothing().when(zeebeDbTransaction).run(any());
+    final CountDownLatch latch = new CountDownLatch(1);
+    when(eventProcessor.executeSideEffects())
+        .then(
+            (invocationOnMock -> {
+              latch.countDown();
+              return true;
+            }));
+
+    // when
+    actor.call(() -> processingStateMachine.readNextEvent());
+    actorSchedulerRule.workUntilDone();
+
+    // then
+    latch.await();
+    final InOrder inOrder =
+        Mockito.inOrder(streamProcessor, eventProcessor, zeebeDb, zeebeDbTransaction);
+
+    // process
+    inOrder.verify(streamProcessor, times(1)).onEvent(any());
+    inOrder.verify(zeebeDb, times(1)).transaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+
+    // on error
+    inOrder.verify(zeebeDbTransaction, times(1)).rollback();
+    inOrder.verify(zeebeDb, times(1)).transaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+
+    // write event
+    inOrder.verify(eventProcessor, times(1)).writeEvent(any());
+
+    // update state
+    inOrder.verify(zeebeDbTransaction, times(1)).commit();
+
+    // execute side effects
+    inOrder.verify(eventProcessor, times(1)).executeSideEffects();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldRunLifecycleOnErrorInWriteEvent() throws Exception {
+    // given
+    doThrow(new RuntimeException("expected")).doReturn(1L).when(eventProcessor).writeEvent(any());
+    final CountDownLatch latch = new CountDownLatch(1);
+    when(eventProcessor.executeSideEffects())
+        .then(
+            (invocationOnMock -> {
+              latch.countDown();
+              return true;
+            }));
+
+    // when
+    actor.call(() -> processingStateMachine.readNextEvent());
+    actorSchedulerRule.workUntilDone();
+
+    // then
+    latch.await();
+    final InOrder inOrder =
+        Mockito.inOrder(streamProcessor, eventProcessor, zeebeDb, zeebeDbTransaction);
+
+    // process
+    inOrder.verify(streamProcessor, times(1)).onEvent(any());
+    inOrder.verify(zeebeDb, times(1)).transaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+
+    // write event
+    inOrder.verify(eventProcessor, times(1)).writeEvent(any());
+
+    // on error
+    inOrder.verify(zeebeDbTransaction, times(1)).rollback();
+    inOrder.verify(zeebeDb, times(1)).transaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+
+    // write event
+    inOrder.verify(eventProcessor, times(1)).writeEvent(any());
+
+    // update state
+    inOrder.verify(zeebeDbTransaction, times(1)).commit();
+
+    // execute side effects
+    inOrder.verify(eventProcessor, times(1)).executeSideEffects();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldRunLifecycleOnErrorInUpdateState() throws Exception {
+    // given
+    doThrow(new RuntimeException("expected")).doNothing().when(zeebeDbTransaction).commit();
+    final CountDownLatch latch = new CountDownLatch(1);
+    when(eventProcessor.executeSideEffects())
+        .then(
+            (invocationOnMock -> {
+              latch.countDown();
+              return true;
+            }));
+
+    // when
+    actor.call(() -> processingStateMachine.readNextEvent());
+    actorSchedulerRule.workUntilDone();
+
+    // then
+    latch.await();
+    final InOrder inOrder =
+        Mockito.inOrder(streamProcessor, eventProcessor, zeebeDb, zeebeDbTransaction);
+
+    // process
+    inOrder.verify(streamProcessor, times(1)).onEvent(any());
+    inOrder.verify(zeebeDb, times(1)).transaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+
+    // write event
+    inOrder.verify(eventProcessor, times(1)).writeEvent(any());
+
+    // update state
+    inOrder.verify(zeebeDbTransaction, times(1)).commit();
+
+    // on error
+    inOrder.verify(zeebeDbTransaction, times(1)).rollback();
+    inOrder.verify(zeebeDb, times(1)).transaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+
+    // update state
+    inOrder.verify(zeebeDbTransaction, times(1)).commit();
+
+    // execute side effects
+    inOrder.verify(eventProcessor, times(1)).executeSideEffects();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldRunLifecycleOnErrorInExecuteSideEffects() throws Exception {
+    // given
+    final CountDownLatch latch = new CountDownLatch(1);
+    when(eventProcessor.executeSideEffects())
+        .then(
+            (invocationOnMock -> {
+              latch.countDown();
+              throw new RuntimeException("expected");
+            }));
+
+    // when
+    actor.call(() -> processingStateMachine.readNextEvent());
+    actorSchedulerRule.workUntilDone();
+
+    // then
+    latch.await();
+    final InOrder inOrder =
+        Mockito.inOrder(streamProcessor, eventProcessor, zeebeDb, zeebeDbTransaction);
+
+    // process
+    inOrder.verify(streamProcessor, times(1)).onEvent(any());
+    inOrder.verify(zeebeDb, times(1)).transaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+
+    // write event
+    inOrder.verify(eventProcessor, times(1)).writeEvent(any());
+
+    // update state
+    inOrder.verify(zeebeDbTransaction, times(1)).commit();
+
+    // execute side effects
+    inOrder.verify(eventProcessor, times(1)).executeSideEffects();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  private class ControllableActor extends Actor {
+
+    public ActorControl getActor() {
+      return actor;
+    }
+  }
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/ReProcessingStateMachineTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/ReProcessingStateMachineTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.processor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import io.zeebe.db.ZeebeDb;
+import io.zeebe.db.ZeebeDbTransaction;
+import io.zeebe.logstreams.log.LogStreamReader;
+import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.testing.ControlledActorSchedulerRule;
+import java.util.concurrent.CountDownLatch;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+public class ReProcessingStateMachineTest {
+
+  @Rule public ControlledActorSchedulerRule actorSchedulerRule = new ControlledActorSchedulerRule();
+
+  private ReProcessingStateMachine reProcessingStateMachine;
+
+  @Mock private StreamProcessor streamProcessor;
+  @Mock private LogStreamReader logStreamReader;
+  @Mock private ZeebeDb zeebeDb;
+
+  private ZeebeDbTransaction zeebeDbTransaction;
+  private ActorControl actor;
+
+  @Before
+  public void setup() {
+    initMocks(this);
+
+    final ControllableActor controllableActor = new ControllableActor();
+    actor = controllableActor.getActor();
+
+    when(logStreamReader.hasNext()).thenReturn(true, false);
+    when(logStreamReader.next()).thenReturn(mock(LoggedEvent.class));
+
+    zeebeDbTransaction = mock(ZeebeDbTransaction.class);
+    when(zeebeDb.transaction()).thenReturn(zeebeDbTransaction);
+
+    final EventProcessor eventProcessor = mock(EventProcessor.class);
+    when(streamProcessor.onEvent(any())).thenReturn(eventProcessor);
+
+    final StreamProcessorContext streamProcessorContext = new StreamProcessorContext();
+    streamProcessorContext.setActorControl(actor);
+    streamProcessorContext.setLogStreamReader(logStreamReader);
+    streamProcessorContext.setName("testProcessor");
+
+    reProcessingStateMachine =
+        ReProcessingStateMachine.builder()
+            .setStreamProcessorContext(streamProcessorContext)
+            .setStreamProcessor(streamProcessor)
+            .setZeebeDb(zeebeDb)
+            .setAbortCondition(() -> false)
+            .build();
+
+    actorSchedulerRule.submitActor(controllableActor);
+  }
+
+  @Test
+  public void shouldRunLifecycle() throws Exception {
+    // given
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    // when
+    actor.call(
+        () -> {
+          final ActorFuture<Void> recoverFuture = reProcessingStateMachine.startRecover(0);
+          actor.runOnCompletion(recoverFuture, (v, t) -> latch.countDown());
+        });
+    actorSchedulerRule.workUntilDone();
+
+    // then
+    latch.await();
+    final InOrder inOrder = Mockito.inOrder(streamProcessor, zeebeDb, zeebeDbTransaction);
+    inOrder.verify(streamProcessor, times(1)).onEvent(any());
+
+    // process
+    inOrder.verify(zeebeDb, times(1)).transaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+
+    // update state
+    inOrder.verify(zeebeDbTransaction, times(1)).commit();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldRunLifecycleOnErrorInProcess() throws Exception {
+    // given
+    doThrow(new RuntimeException("expected")).doNothing().when(zeebeDbTransaction).run(any());
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    // when
+    actor.call(
+        () -> {
+          final ActorFuture<Void> recoverFuture = reProcessingStateMachine.startRecover(0);
+          actor.runOnCompletion(recoverFuture, (v, t) -> latch.countDown());
+        });
+    actorSchedulerRule.workUntilDone();
+
+    // then
+    latch.await();
+    final InOrder inOrder = Mockito.inOrder(streamProcessor, zeebeDb, zeebeDbTransaction);
+    inOrder.verify(streamProcessor, times(1)).onEvent(any());
+    // process
+    inOrder.verify(zeebeDb, times(1)).transaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+
+    // on error
+    inOrder.verify(zeebeDbTransaction, times(1)).rollback();
+    inOrder.verify(zeebeDb, times(1)).transaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+    // update state
+    inOrder.verify(zeebeDbTransaction, times(1)).commit();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldRunLifecycleOnErrorOnUpdateState() throws Exception {
+    // given
+    doThrow(new RuntimeException("expected")).doNothing().when(zeebeDbTransaction).commit();
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    // when
+    actor.call(
+        () -> {
+          final ActorFuture<Void> recoverFuture = reProcessingStateMachine.startRecover(0);
+          actor.runOnCompletion(recoverFuture, (v, t) -> latch.countDown());
+        });
+    actorSchedulerRule.workUntilDone();
+
+    // then
+    latch.await();
+    final InOrder inOrder = Mockito.inOrder(streamProcessor, zeebeDb, zeebeDbTransaction);
+    inOrder.verify(streamProcessor, times(1)).onEvent(any());
+    // process
+    inOrder.verify(zeebeDb, times(1)).transaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+
+    // update state
+    inOrder.verify(zeebeDbTransaction, times(1)).commit();
+
+    // on error
+    inOrder.verify(zeebeDbTransaction, times(1)).rollback();
+    inOrder.verify(zeebeDb, times(1)).transaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+
+    // update state
+    inOrder.verify(zeebeDbTransaction, times(1)).commit();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  private class ControllableActor extends Actor {
+
+    public ActorControl getActor() {
+      return actor;
+    }
+  }
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
@@ -38,7 +38,7 @@ public class RecordingStreamProcessor implements StreamProcessor {
             }
 
             @Override
-            public void processingFailed(Exception exception) {
+            public void onError(Throwable exception) {
               failedEvents.incrementAndGet();
             }
           });

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorReprocessingTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorReprocessingTest.java
@@ -225,7 +225,7 @@ public class StreamProcessorReprocessingTest {
         .containsExactly(eventPosition1, eventPosition2, eventPosition3);
 
     verify(eventProcessor, times(3)).processEvent();
-    verify(eventProcessor, times(1)).processingFailed(any());
+    verify(eventProcessor, times(1)).onError(any());
     verify(eventProcessor, times(1)).executeSideEffects();
     verify(eventProcessor, times(1)).writeEvent(any());
   }
@@ -251,7 +251,7 @@ public class StreamProcessorReprocessingTest {
 
           doThrow(new RecoverableException("expected", new RuntimeException("expected")))
               .when(zeebeDb)
-              .transaction(any());
+              .transaction();
         });
     latch.await();
 
@@ -401,7 +401,7 @@ public class StreamProcessorReprocessingTest {
 
     verify(streamProcessor, times(1)).onRecovered();
     verify(eventProcessor, times(3)).processEvent();
-    verify(eventProcessor, times(3)).processingFailed(any());
+    verify(eventProcessor, times(3)).onError(any());
   }
 
   @Test

--- a/util/src/main/java/io/zeebe/util/exception/RecoverableException.java
+++ b/util/src/main/java/io/zeebe/util/exception/RecoverableException.java
@@ -21,6 +21,10 @@ package io.zeebe.util.exception;
  */
 public class RecoverableException extends RuntimeException {
 
+  public RecoverableException(String message) {
+    super(message);
+  }
+
   public RecoverableException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/util/src/main/java/io/zeebe/util/retry/AbortableRetryStrategy.java
+++ b/util/src/main/java/io/zeebe/util/retry/AbortableRetryStrategy.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.util.retry;
+
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
+import java.util.function.BooleanSupplier;
+
+public class AbortableRetryStrategy implements RetryStrategy {
+
+  private final ActorControl actor;
+  private final ActorRetryMechanism retryMechanism;
+  private CompletableActorFuture<Boolean> currentFuture;
+
+  public AbortableRetryStrategy(ActorControl actor) {
+    this.actor = actor;
+    this.retryMechanism = new ActorRetryMechanism(actor);
+  }
+
+  @Override
+  public ActorFuture<Boolean> runWithRetry(BooleanSupplier callable) {
+    return runWithRetry(callable, () -> false);
+  }
+
+  @Override
+  public ActorFuture<Boolean> runWithRetry(BooleanSupplier callable, BooleanSupplier condition) {
+    currentFuture = new CompletableActorFuture<>();
+    retryMechanism.wrap(callable, condition, currentFuture);
+
+    actor.runUntilDone(this::run);
+
+    return currentFuture;
+  }
+
+  private void run() {
+    try {
+      retryMechanism.run();
+    } catch (Exception exception) {
+      currentFuture.completeExceptionally(exception);
+      actor.done();
+    }
+  }
+}

--- a/util/src/main/java/io/zeebe/util/retry/ActorRetryMechanism.java
+++ b/util/src/main/java/io/zeebe/util/retry/ActorRetryMechanism.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.util.retry;
+
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.future.ActorFuture;
+import java.util.function.BooleanSupplier;
+
+public class ActorRetryMechanism {
+
+  private final ActorControl actor;
+
+  private BooleanSupplier currentCallable;
+  private BooleanSupplier currentTerminateCondition;
+  private ActorFuture<Boolean> currentFuture;
+
+  public ActorRetryMechanism(ActorControl actor) {
+    this.actor = actor;
+  }
+
+  void wrap(
+      BooleanSupplier callable, BooleanSupplier condition, ActorFuture<Boolean> resultFuture) {
+    currentCallable = callable;
+    currentTerminateCondition = condition;
+    currentFuture = resultFuture;
+  }
+
+  void run() {
+    if (currentCallable.getAsBoolean()) {
+      currentFuture.complete(true);
+      actor.done();
+    } else if (currentTerminateCondition.getAsBoolean()) {
+      currentFuture.complete(false);
+      actor.done();
+    } else {
+      actor.yield();
+    }
+  }
+}

--- a/util/src/main/java/io/zeebe/util/retry/RecoverableRetryStrategy.java
+++ b/util/src/main/java/io/zeebe/util/retry/RecoverableRetryStrategy.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.util.retry;
+
+import io.zeebe.util.exception.RecoverableException;
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
+import java.util.function.BooleanSupplier;
+
+public class RecoverableRetryStrategy implements RetryStrategy {
+
+  private final ActorControl actor;
+  private final ActorRetryMechanism retryMechanism;
+  private CompletableActorFuture<Boolean> currentFuture;
+  private BooleanSupplier terminateCondition;
+
+  public RecoverableRetryStrategy(ActorControl actor) {
+    this.actor = actor;
+    this.retryMechanism = new ActorRetryMechanism(actor);
+  }
+
+  @Override
+  public ActorFuture<Boolean> runWithRetry(BooleanSupplier callable) {
+    return runWithRetry(callable, () -> false);
+  }
+
+  @Override
+  public ActorFuture<Boolean> runWithRetry(BooleanSupplier callable, BooleanSupplier condition) {
+    currentFuture = new CompletableActorFuture<>();
+    terminateCondition = condition;
+    retryMechanism.wrap(callable, terminateCondition, currentFuture);
+
+    actor.runUntilDone(this::run);
+
+    return currentFuture;
+  }
+
+  private void run() {
+    try {
+      retryMechanism.run();
+    } catch (RecoverableException ex) {
+      if (terminateCondition.getAsBoolean()) {
+        actor.done();
+      } else {
+        actor.yield();
+      }
+    } catch (Exception exception) {
+      currentFuture.completeExceptionally(exception);
+      actor.done();
+    }
+  }
+}

--- a/util/src/main/java/io/zeebe/util/retry/RetryStrategy.java
+++ b/util/src/main/java/io/zeebe/util/retry/RetryStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.util.retry;
+
+import io.zeebe.util.sched.future.ActorFuture;
+import java.util.function.BooleanSupplier;
+
+public interface RetryStrategy {
+
+  /**
+   * Runs the given runnable with the defined retry strategy.
+   *
+   * <p>Returns an actor future, which will be completed when the callable was successfully executed
+   * and has returned true.
+   *
+   * @param callable the callable which should be executed
+   * @return a future, which is completed with true if the execution was successful
+   */
+  ActorFuture<Boolean> runWithRetry(BooleanSupplier callable);
+
+  /**
+   * Runs the given runnable with the defined retry strategy.
+   *
+   * <p>Returns an actor future, which will be completed when the callable was successfully executed
+   * and has returned true.
+   *
+   * @param callable the callable which should be executed
+   * @param terminateCondition condition is called when callable returns false, if terminate
+   *     condition returns true the retry strategy is aborted
+   * @return a future, which is completed with true if the execution was successful
+   */
+  ActorFuture<Boolean> runWithRetry(BooleanSupplier callable, BooleanSupplier terminateCondition);
+}

--- a/util/src/test/java/io/zeebe/util/retry/RecoverableRetryStrategyTest.java
+++ b/util/src/test/java/io/zeebe/util/retry/RecoverableRetryStrategyTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.util.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.util.exception.RecoverableException;
+import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.testing.ControlledActorSchedulerRule;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class RecoverableRetryStrategyTest {
+
+  @Rule public ControlledActorSchedulerRule schedulerRule = new ControlledActorSchedulerRule();
+
+  private RecoverableRetryStrategy recoverableRetryStrategy;
+  private ActorControl actorControl;
+  private ActorFuture<Boolean> resultFuture;
+
+  @Before
+  public void setUp() {
+    final ControllableActor actor = new ControllableActor();
+    this.actorControl = actor.getActor();
+    recoverableRetryStrategy = new RecoverableRetryStrategy(actorControl);
+
+    schedulerRule.submitActor(actor);
+  }
+
+  @Test
+  public void shouldRetryOnException() throws Exception {
+    // given
+    final AtomicInteger count = new AtomicInteger(0);
+    final AtomicBoolean toggle = new AtomicBoolean(false);
+
+    // when
+    actorControl.run(
+        () -> {
+          resultFuture =
+              recoverableRetryStrategy.runWithRetry(
+                  () -> {
+                    toggle.set(!toggle.get());
+                    if (toggle.get()) {
+                      throw new RecoverableException("expected");
+                    }
+                    return count.incrementAndGet() == 10;
+                  });
+        });
+
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(count.get()).isEqualTo(10);
+    assertThat(resultFuture.isDone()).isTrue();
+    assertThat(resultFuture.get()).isTrue();
+  }
+
+  private final class ControllableActor extends Actor {
+    public ActorControl getActor() {
+      return actor;
+    }
+  }
+}

--- a/util/src/test/java/io/zeebe/util/retry/RetryStrategyTest.java
+++ b/util/src/test/java/io/zeebe/util/retry/RetryStrategyTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.util.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.testing.ControlledActorSchedulerRule;
+import java.lang.reflect.Constructor;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class RetryStrategyTest {
+
+  @Rule public ControlledActorSchedulerRule schedulerRule = new ControlledActorSchedulerRule();
+
+  @Parameters(name = "{index}: {0}")
+  public static Object[][] reprocessingTriggers() {
+    return new Object[][] {
+      new Object[] {RecoverableRetryStrategy.class}, new Object[] {AbortableRetryStrategy.class}
+    };
+  }
+
+  @Parameter public Class<RetryStrategy> retryStrategyClass;
+
+  private RetryStrategy retryStrategy;
+  private ActorControl actorControl;
+  private ActorFuture<Boolean> resultFuture;
+
+  @Before
+  public void setUp() {
+    final ControllableActor actor = new ControllableActor();
+    this.actorControl = actor.getActor();
+
+    try {
+      final Constructor<RetryStrategy> constructor =
+          retryStrategyClass.getConstructor(ActorControl.class);
+      retryStrategy = constructor.newInstance(actorControl);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    schedulerRule.submitActor(actor);
+  }
+
+  @Test
+  public void shouldRunUntilDone() throws Exception {
+    // given
+    final AtomicInteger count = new AtomicInteger(0);
+
+    // when
+    actorControl.run(
+        () -> {
+          resultFuture = retryStrategy.runWithRetry(() -> count.incrementAndGet() == 10);
+        });
+
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(count.get()).isEqualTo(10);
+    assertThat(resultFuture.isDone()).isTrue();
+    assertThat(resultFuture.get()).isTrue();
+  }
+
+  @Test
+  public void shouldStopWhenAbortConditionReturnsTrue() throws Exception {
+    // given
+    final AtomicInteger count = new AtomicInteger(0);
+
+    // when
+    actorControl.run(
+        () -> {
+          resultFuture =
+              retryStrategy.runWithRetry(() -> false, () -> count.incrementAndGet() == 10);
+        });
+
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(count.get()).isEqualTo(10);
+    assertThat(resultFuture.isDone()).isTrue();
+    assertThat(resultFuture.get()).isFalse();
+  }
+
+  @Test
+  public void shouldAbortOnOtherException() {
+    // given
+    // when
+    actorControl.run(
+        () ->
+            resultFuture =
+                retryStrategy.runWithRetry(
+                    () -> {
+                      throw new RuntimeException("expected");
+                    }));
+
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(resultFuture.isDone()).isTrue();
+    assertThat(resultFuture.isCompletedExceptionally()).isTrue();
+    assertThat(resultFuture.getException()).isExactlyInstanceOf(RuntimeException.class);
+  }
+
+  private static final class ControllableActor extends Actor {
+    public ActorControl getActor() {
+      return actor;
+    }
+  }
+}

--- a/zb-db/src/main/java/io/zeebe/db/ZeebeDb.java
+++ b/zb-db/src/main/java/io/zeebe/db/ZeebeDb.java
@@ -37,11 +37,21 @@ public interface ZeebeDb<ColumnFamilyType extends Enum<ColumnFamilyType>> extend
    * <p>Reading key-value pairs via get or an iterator is also possible and will reflect changes,
    * which are made during the transaction.
    *
+   * <p><b>NOTE</b>: This will automatically commit the transaction and rollback on error
+   *
    * @param operations the operations
    * @throws ZeebeDbException is thrown on an unexpected error in the database layer
    * @throws RuntimeException is thrown on an unexpected error in executing the operations
    */
   void transaction(TransactionOperation operations);
+
+  /**
+   * This will return an transaction object, on which the caller can operate on. The caller is free
+   * to decide when to commit or rollback the transaction.
+   *
+   * @return the transaction object
+   */
+  ZeebeDbTransaction transaction();
 
   /**
    * Creates an instance of a specific column family to access and store key-value pairs in that

--- a/zb-db/src/main/java/io/zeebe/db/ZeebeDbTransaction.java
+++ b/zb-db/src/main/java/io/zeebe/db/ZeebeDbTransaction.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.db;
+
+/** Represents an Zeebe DB transaction, which can be committed or on error it can be rolled back. */
+public interface ZeebeDbTransaction {
+
+  /**
+   * Runs the commands like delete, put etc. in the current transaction. Access of different column
+   * families inside this transaction are possible.
+   *
+   * <p>Reading key-value pairs via get or an iterator is also possible and will reflect changes,
+   * which are made during the transaction.
+   *
+   * @param operations the operations
+   * @throws ZeebeDbException is thrown on an unexpected error in the database layer
+   * @throws RuntimeException is thrown on an unexpected error in executing the operations
+   */
+  void run(TransactionOperation operations);
+
+  /**
+   * Commits the transaction and writes the data into the database.
+   *
+   * @throws ZeebeDbException if the underlying database has a recoverable exception thrown
+   * @throws RuntimeException if the underlying database has a non recoverable exception thrown
+   */
+  void commit();
+
+  /**
+   * Rolls the transaction back to the latest commit, discards all changes in between.
+   *
+   * @throws ZeebeDbException if the underlying database has a recoverable exception thrown
+   * @throws RuntimeException if the underlying database has a non recoverable exception thrown
+   */
+  void rollback();
+}

--- a/zb-db/src/test/resources/log4j2-test.xml
+++ b/zb-db/src/test/resources/log4j2-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration status="WARN">
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout
+        pattern="%d{HH:mm:ss.SSS} [%t] [%X{actor-name}] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.zeebe" level="debug"/>
+    <!-- <Logger name="io.zeebe.db" level="trace"/> -->
+
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+
+</Configuration>


### PR DESCRIPTION
 * add endless retry strategy, which retries if return value is false or `RecoverableException`
 was thrown. Retrying is done until operation is successful or non recoverable exception is thrown
 * add limited retry strategy, which limits the retries on recoverable
 exceptions
 * use for` writeEvent` endless retry strategy
 * introduce new life cycle method `writeEventFailed`
 * use for `executeSideEffects` limited retry strategy
 * if `writeEventFailed` is called workflow instance is blacklisted

closes #2049
closes #2050 
closes #2051
closes #2052
closes #1988 
closes #2201 