### PR TITLE
chore(broker): extract key generation from stream writer

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/job/JobEventProcessors.java
+++ b/broker-core/src/main/java/io/zeebe/broker/job/JobEventProcessors.java
@@ -46,7 +46,9 @@ public class JobEventProcessors {
             ValueType.JOB_BATCH,
             JobBatchIntent.ACTIVATE,
             new JobBatchActivateProcessor(
-                jobState, workflowState.getElementInstanceState().getVariablesState()))
+                jobState,
+                workflowState.getElementInstanceState().getVariablesState(),
+                zeebeState.getKeyGenerator()))
         .withListener(new JobTimeoutTrigger(jobState));
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedCommandWriterImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedCommandWriterImpl.java
@@ -104,11 +104,7 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
     if (key >= 0) {
       event.key(key);
     } else {
-      if (type == RecordType.EVENT) {
-        event.positionAsKey();
-      } else {
-        event.keyNull();
-      }
+      event.keyNull();
     }
 
     event.metadataWriter(metadata).valueWriter(value).done();

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessor.java
@@ -86,7 +86,7 @@ public class TypedStreamProcessor implements StreamProcessor {
   @Override
   public void onOpen(final StreamProcessorContext context) {
     final LogStream logStream = context.getLogStream();
-    this.streamWriter = new TypedStreamWriterImpl(logStream, eventRegistry, getKeyGenerator());
+    this.streamWriter = new TypedStreamWriterImpl(logStream, eventRegistry);
 
     this.eventProcessorWrapper =
         new DelegatingEventProcessor(context.getId(), output, logStream, streamWriter, zeebeState);

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamWriter.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamWriter.java
@@ -34,13 +34,10 @@ public interface TypedStreamWriter extends TypedCommandWriter {
       String reason,
       Consumer<RecordMetadata> metadata);
 
-  /** @return the key of the event */
-  long appendNewEvent(Intent intent, UnpackedObject value);
+  void appendNewEvent(long key, Intent intent, UnpackedObject value);
 
   void appendFollowUpEvent(long key, Intent intent, UnpackedObject value);
 
   void appendFollowUpEvent(
       long key, Intent intent, UnpackedObject value, Consumer<RecordMetadata> metadata);
-
-  KeyGenerator getKeyGenerator();
 }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamWriterImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamWriterImpl.java
@@ -29,21 +29,14 @@ import java.util.function.Consumer;
 
 public class TypedStreamWriterImpl extends TypedCommandWriterImpl implements TypedStreamWriter {
 
-  private final KeyGenerator keyGenerator;
-
   public TypedStreamWriterImpl(
-      final LogStream stream,
-      final Map<ValueType, Class<? extends UnpackedObject>> eventRegistry,
-      final KeyGenerator keyGenerator) {
+      final LogStream stream, final Map<ValueType, Class<? extends UnpackedObject>> eventRegistry) {
     super(stream, eventRegistry);
-    this.keyGenerator = keyGenerator;
   }
 
   @Override
-  public long appendNewEvent(final Intent intent, final UnpackedObject value) {
-    final long key = keyGenerator.nextKey();
+  public void appendNewEvent(final long key, final Intent intent, final UnpackedObject value) {
     appendRecord(key, RecordType.EVENT, intent, value, noop);
-    return key;
   }
 
   @Override
@@ -89,10 +82,5 @@ public class TypedStreamWriterImpl extends TypedCommandWriterImpl implements Typ
         reason,
         command.getValue(),
         metadata);
-  }
-
-  @Override
-  public KeyGenerator getKeyGenerator() {
-    return keyGenerator;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageEventProcessors.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageEventProcessors.java
@@ -18,6 +18,7 @@
 package io.zeebe.broker.subscription.message.processor;
 
 import io.zeebe.broker.clustering.base.topology.TopologyManager;
+import io.zeebe.broker.logstreams.processor.KeyGenerator;
 import io.zeebe.broker.logstreams.processor.TypedEventStreamProcessorBuilder;
 import io.zeebe.broker.logstreams.state.ZeebeState;
 import io.zeebe.broker.subscription.command.SubscriptionCommandSender;
@@ -44,6 +45,7 @@ public class MessageEventProcessors {
         zeebeState.getMessageStartEventSubscriptionState();
     final EventScopeInstanceState eventScopeInstanceState =
         zeebeState.getWorkflowState().getEventScopeInstanceState();
+    final KeyGenerator keyGenerator = zeebeState.getKeyGenerator();
 
     typedProcessorBuilder
         .onCommand(
@@ -54,7 +56,8 @@ public class MessageEventProcessors {
                 subscriptionState,
                 startEventSubscriptionState,
                 eventScopeInstanceState,
-                subscriptionCommandSender))
+                subscriptionCommandSender,
+                keyGenerator))
         .onCommand(
             ValueType.MESSAGE, MessageIntent.DELETE, new DeleteMessageProcessor(messageState))
         .onCommand(

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/PublishMessageProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/PublishMessageProcessor.java
@@ -20,6 +20,7 @@ package io.zeebe.broker.subscription.message.processor;
 import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import io.zeebe.broker.Loggers;
+import io.zeebe.broker.logstreams.processor.KeyGenerator;
 import io.zeebe.broker.logstreams.processor.SideEffectProducer;
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedRecordProcessor;
@@ -54,6 +55,7 @@ public class PublishMessageProcessor implements TypedRecordProcessor<MessageReco
   private final MessageSubscriptionState subscriptionState;
   private final MessageStartEventSubscriptionState startEventSubscriptionState;
   private final SubscriptionCommandSender commandSender;
+  private final KeyGenerator keyGenerator;
   private final EventScopeInstanceState scopeEventInstanceState;
 
   private TypedResponseWriter responseWriter;
@@ -67,12 +69,14 @@ public class PublishMessageProcessor implements TypedRecordProcessor<MessageReco
       final MessageSubscriptionState subscriptionState,
       final MessageStartEventSubscriptionState startEventSubscriptionState,
       final EventScopeInstanceState scopeEventInstanceState,
-      final SubscriptionCommandSender commandSender) {
+      final SubscriptionCommandSender commandSender,
+      final KeyGenerator keyGenerator) {
     this.messageState = messageState;
     this.subscriptionState = subscriptionState;
     this.startEventSubscriptionState = startEventSubscriptionState;
     this.scopeEventInstanceState = scopeEventInstanceState;
     this.commandSender = commandSender;
+    this.keyGenerator = keyGenerator;
   }
 
   @Override
@@ -105,8 +109,9 @@ public class PublishMessageProcessor implements TypedRecordProcessor<MessageReco
       final TypedResponseWriter responseWriter,
       final TypedStreamWriter streamWriter,
       final Consumer<SideEffectProducer> sideEffect) {
+    final long key = keyGenerator.nextKey();
 
-    final long key = streamWriter.appendNewEvent(MessageIntent.PUBLISHED, command.getValue());
+    streamWriter.appendNewEvent(key, MessageIntent.PUBLISHED, command.getValue());
     responseWriter.writeEventOnCommand(key, MessageIntent.PUBLISHED, command.getValue(), command);
 
     correlatedWorkflowInstances.clear();
@@ -200,13 +205,13 @@ public class PublishMessageProcessor implements TypedRecordProcessor<MessageReco
             .setElementId(startEventId)
             .setBpmnElementType(BpmnElementType.START_EVENT);
 
-    final long eventKey = streamWriter.getKeyGenerator().nextKey();
+    final long eventKey = keyGenerator.nextKey();
     final boolean wasTriggered =
         scopeEventInstanceState.triggerEvent(
             workflowKey, eventKey, startEventId, command.getValue().getPayload());
 
     if (wasTriggered) {
-      streamWriter.appendNewEvent(WorkflowInstanceIntent.EVENT_OCCURRED, record);
+      streamWriter.appendNewEvent(eventKey, WorkflowInstanceIntent.EVENT_OCCURRED, record);
     } else {
       Loggers.WORKFLOW_PROCESSOR_LOGGER.error(
           String.format(ERROR_START_EVENT_NOT_TRIGGERED_MESSAGE, workflowKey));

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepHandlers.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepHandlers.java
@@ -131,8 +131,7 @@ public class BpmnStepHandlers {
         new ServiceTaskElementTerminatingHandler<>(state.getIncidentState(), state.getJobState()));
 
     stepHandlers.put(
-        BpmnStep.START_EVENT_EVENT_OCCURRED,
-        new StartEventEventOccurredHandler<>(state.getWorkflowState()));
+        BpmnStep.START_EVENT_EVENT_OCCURRED, new StartEventEventOccurredHandler<>(state));
 
     stepHandlers.put(
         BpmnStep.PARALLEL_MERGE_SEQUENCE_FLOW_TAKEN, new ParallelMergeSequenceFlowTaken<>());

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepProcessor.java
@@ -51,7 +51,7 @@ public class BpmnStepProcessor implements TypedRecordProcessor<WorkflowInstanceR
     this.workflowState = state.getWorkflowState();
     this.stepHandlers = new BpmnStepHandlers(zeebeState);
 
-    final EventOutput eventOutput = new EventOutput(state);
+    final EventOutput eventOutput = new EventOutput(state, zeebeState.getKeyGenerator());
     this.context = new BpmnStepContext<>(workflowState, eventOutput, catchEventBehavior);
   }
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowEventProcessors.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowEventProcessors.java
@@ -68,7 +68,7 @@ public class WorkflowEventProcessors {
     final WorkflowEngineState workflowEngineState = new WorkflowEngineState(workflowState);
     typedProcessorBuilder.withListener(workflowEngineState);
 
-    addWorkflowInstanceCommandProcessor(typedProcessorBuilder, workflowEngineState);
+    addWorkflowInstanceCommandProcessor(typedProcessorBuilder, workflowEngineState, zeebeState);
 
     final CatchEventBehavior catchEventOutput =
         new CatchEventBehavior(zeebeState, subscriptionCommandSender, partitionsCount);
@@ -81,8 +81,8 @@ public class WorkflowEventProcessors {
         subscriptionState,
         topologyManager,
         subscriptionCommandSender,
-        workflowState);
-    addTimerStreamProcessors(typedProcessorBuilder, timerChecker, workflowState, catchEventOutput);
+        zeebeState);
+    addTimerStreamProcessors(typedProcessorBuilder, timerChecker, zeebeState, catchEventOutput);
     addVariableDocumentStreamProcessors(typedProcessorBuilder, zeebeState);
     addWorkflowInstanceCreationStreamProcessors(typedProcessorBuilder, zeebeState);
 
@@ -90,10 +90,12 @@ public class WorkflowEventProcessors {
   }
 
   private static void addWorkflowInstanceCommandProcessor(
-      final TypedEventStreamProcessorBuilder builder, WorkflowEngineState workflowEngineState) {
+      final TypedEventStreamProcessorBuilder builder,
+      WorkflowEngineState workflowEngineState,
+      final ZeebeState zeebeState) {
 
     final WorkflowInstanceCommandProcessor commandProcessor =
-        new WorkflowInstanceCommandProcessor(workflowEngineState);
+        new WorkflowInstanceCommandProcessor(workflowEngineState, zeebeState.getKeyGenerator());
 
     WORKFLOW_INSTANCE_COMMANDS.forEach(
         intent -> builder.onCommand(ValueType.WORKFLOW_INSTANCE, intent, commandProcessor));
@@ -116,7 +118,7 @@ public class WorkflowEventProcessors {
       WorkflowInstanceSubscriptionState subscriptionState,
       TopologyManager topologyManager,
       SubscriptionCommandSender subscriptionCommandSender,
-      WorkflowState workflowState) {
+      ZeebeState zeebeState) {
     streamProcessorBuilder
         .onCommand(
             ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION,
@@ -126,7 +128,7 @@ public class WorkflowEventProcessors {
             ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION,
             WorkflowInstanceSubscriptionIntent.CORRELATE,
             new CorrelateWorkflowInstanceSubscription(
-                topologyManager, subscriptionState, subscriptionCommandSender, workflowState))
+                topologyManager, subscriptionState, subscriptionCommandSender, zeebeState))
         .onCommand(
             ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION,
             WorkflowInstanceSubscriptionIntent.CLOSE,
@@ -136,17 +138,17 @@ public class WorkflowEventProcessors {
   private static void addTimerStreamProcessors(
       final TypedEventStreamProcessorBuilder streamProcessorBuilder,
       DueDateTimerChecker timerChecker,
-      WorkflowState workflowState,
+      ZeebeState zeebeState,
       CatchEventBehavior catchEventOutput) {
+    final WorkflowState workflowState = zeebeState.getWorkflowState();
+
     streamProcessorBuilder
         .onCommand(
-            ValueType.TIMER,
-            TimerIntent.CREATE,
-            new CreateTimerProcessor(timerChecker, workflowState))
+            ValueType.TIMER, TimerIntent.CREATE, new CreateTimerProcessor(zeebeState, timerChecker))
         .onCommand(
             ValueType.TIMER,
             TimerIntent.TRIGGER,
-            new TriggerTimerProcessor(workflowState, catchEventOutput))
+            new TriggerTimerProcessor(zeebeState, catchEventOutput))
         .onCommand(ValueType.TIMER, TimerIntent.CANCEL, new CancelTimerProcessor(workflowState))
         .withListener(timerChecker);
   }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceCommandContext.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceCommandContext.java
@@ -17,7 +17,6 @@
  */
 package io.zeebe.broker.workflow.processor;
 
-import io.zeebe.broker.logstreams.processor.KeyGenerator;
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
 import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
@@ -68,10 +67,6 @@ public class WorkflowInstanceCommandContext {
 
   public void setResponseWriter(final TypedResponseWriter responseWriter) {
     this.responseWriter = responseWriter;
-  }
-
-  public KeyGenerator getKeyGenerator() {
-    return streamWriter.getKeyGenerator();
   }
 
   public void setStreamWriter(final TypedStreamWriter writer) {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceCommandProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceCommandProcessor.java
@@ -17,6 +17,7 @@
  */
 package io.zeebe.broker.workflow.processor;
 
+import io.zeebe.broker.logstreams.processor.KeyGenerator;
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedRecordProcessor;
 import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
@@ -32,10 +33,11 @@ public class WorkflowInstanceCommandProcessor
   private final WorkflowEngineState state;
   private final WorkflowInstanceCommandContext context;
 
-  public WorkflowInstanceCommandProcessor(WorkflowEngineState state) {
+  public WorkflowInstanceCommandProcessor(
+      WorkflowEngineState state, final KeyGenerator keyGenerator) {
     this.state = state;
     this.commandHandlers = new WorkflowInstanceCommandHandlers();
-    final EventOutput output = new EventOutput(state);
+    final EventOutput output = new EventOutput(state, keyGenerator);
     this.context = new WorkflowInstanceCommandContext(output);
   }
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/catchevent/StartEventEventOccurredHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/catchevent/StartEventEventOccurredHandler.java
@@ -18,6 +18,8 @@
 package io.zeebe.broker.workflow.processor.handlers.catchevent;
 
 import io.zeebe.broker.Loggers;
+import io.zeebe.broker.logstreams.processor.KeyGenerator;
+import io.zeebe.broker.logstreams.state.ZeebeState;
 import io.zeebe.broker.workflow.model.element.ExecutableCatchEventElement;
 import io.zeebe.broker.workflow.processor.BpmnStepContext;
 import io.zeebe.broker.workflow.processor.handlers.element.EventOccurredHandler;
@@ -36,14 +38,16 @@ public class StartEventEventOccurredHandler<T extends ExecutableCatchEventElemen
 
   private final WorkflowInstanceRecord record = new WorkflowInstanceRecord();
   private final WorkflowState state;
+  private KeyGenerator keyGenerator;
 
-  public StartEventEventOccurredHandler(WorkflowState state) {
-    this(null, state);
+  public StartEventEventOccurredHandler(ZeebeState zeebeState) {
+    this(null, zeebeState);
   }
 
-  public StartEventEventOccurredHandler(WorkflowInstanceIntent nextState, WorkflowState state) {
+  public StartEventEventOccurredHandler(WorkflowInstanceIntent nextState, ZeebeState zeebeState) {
     super(nextState);
-    this.state = state;
+    this.state = zeebeState.getWorkflowState();
+    keyGenerator = zeebeState.getKeyGenerator();
   }
 
   @Override
@@ -55,8 +59,7 @@ public class StartEventEventOccurredHandler<T extends ExecutableCatchEventElemen
     final WorkflowInstanceRecord event = context.getRecord().getValue();
     final long workflowKey = event.getWorkflowKey();
     final DeployedWorkflow workflow = state.getWorkflowByKey(workflowKey);
-    final long workflowInstanceKey =
-        context.getOutput().getStreamWriter().getKeyGenerator().nextKey();
+    final long workflowInstanceKey = keyGenerator.nextKey();
 
     // this should never happen because workflows are never deleted.
     if (workflow == null) {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/CorrelateWorkflowInstanceSubscription.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/message/CorrelateWorkflowInstanceSubscription.java
@@ -18,12 +18,14 @@
 package io.zeebe.broker.workflow.processor.message;
 
 import io.zeebe.broker.clustering.base.topology.TopologyManager;
+import io.zeebe.broker.logstreams.processor.KeyGenerator;
 import io.zeebe.broker.logstreams.processor.SideEffectProducer;
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedRecordProcessor;
 import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
 import io.zeebe.broker.logstreams.processor.TypedStreamProcessor;
 import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
+import io.zeebe.broker.logstreams.state.ZeebeState;
 import io.zeebe.broker.subscription.command.SubscriptionCommandSender;
 import io.zeebe.broker.subscription.message.data.WorkflowInstanceSubscriptionRecord;
 import io.zeebe.broker.subscription.message.state.WorkflowInstanceSubscriptionState;
@@ -58,6 +60,7 @@ public final class CorrelateWorkflowInstanceSubscription
   private final WorkflowInstanceSubscriptionState subscriptionState;
   private final SubscriptionCommandSender subscriptionCommandSender;
   private final WorkflowState workflowState;
+  private final KeyGenerator keyGenerator;
 
   private WorkflowInstanceSubscriptionRecord subscriptionRecord;
 
@@ -65,11 +68,12 @@ public final class CorrelateWorkflowInstanceSubscription
       final TopologyManager topologyManager,
       final WorkflowInstanceSubscriptionState subscriptionState,
       final SubscriptionCommandSender subscriptionCommandSender,
-      final WorkflowState workflowState) {
+      final ZeebeState zeebeState) {
     this.topologyManager = topologyManager;
     this.subscriptionState = subscriptionState;
     this.subscriptionCommandSender = subscriptionCommandSender;
-    this.workflowState = workflowState;
+    this.workflowState = zeebeState.getWorkflowState();
+    this.keyGenerator = zeebeState.getKeyGenerator();
   }
 
   @Override
@@ -127,7 +131,7 @@ public final class CorrelateWorkflowInstanceSubscription
 
     final ElementInstance elementInstance =
         workflowState.getElementInstanceState().getInstance(subscription.getElementInstanceKey());
-    final long eventKey = streamWriter.getKeyGenerator().nextKey();
+    final long eventKey = keyGenerator.nextKey();
     final boolean isOccurred =
         workflowState
             .getEventScopeInstanceState()

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/CreateTimerProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/CreateTimerProcessor.java
@@ -17,11 +17,13 @@
  */
 package io.zeebe.broker.workflow.processor.timer;
 
+import io.zeebe.broker.logstreams.processor.KeyGenerator;
 import io.zeebe.broker.logstreams.processor.SideEffectProducer;
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedRecordProcessor;
 import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
 import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
+import io.zeebe.broker.logstreams.state.ZeebeState;
 import io.zeebe.broker.workflow.state.TimerInstance;
 import io.zeebe.broker.workflow.state.WorkflowState;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
@@ -34,11 +36,12 @@ public class CreateTimerProcessor implements TypedRecordProcessor<TimerRecord> {
 
   private final WorkflowState workflowState;
   private final TimerInstance timerInstance = new TimerInstance();
+  private final KeyGenerator keyGenerator;
 
-  public CreateTimerProcessor(
-      final DueDateTimerChecker timerChecker, final WorkflowState workflowState) {
+  public CreateTimerProcessor(final ZeebeState zeebeState, final DueDateTimerChecker timerChecker) {
     this.timerChecker = timerChecker;
-    this.workflowState = workflowState;
+    this.workflowState = zeebeState.getWorkflowState();
+    this.keyGenerator = zeebeState.getKeyGenerator();
   }
 
   @Override
@@ -50,7 +53,7 @@ public class CreateTimerProcessor implements TypedRecordProcessor<TimerRecord> {
 
     final TimerRecord timer = record.getValue();
 
-    final long timerKey = streamWriter.getKeyGenerator().nextKey();
+    final long timerKey = keyGenerator.nextKey();
 
     timerInstance.setElementInstanceKey(timer.getElementInstanceKey());
     timerInstance.setDueDate(timer.getDueDate());

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/DueDateTimerChecker.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/timer/DueDateTimerChecker.java
@@ -108,9 +108,7 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
     this.actor = streamProcessor.getActor();
 
     final TypedStreamEnvironment env = streamProcessor.getEnvironment();
-    streamWriter =
-        new TypedStreamWriterImpl(
-            env.getStream(), env.getEventRegistry(), streamProcessor.getKeyGenerator());
+    streamWriter = new TypedStreamWriterImpl(env.getStream(), env.getEventRegistry());
   }
 
   @Override

--- a/broker-core/src/test/java/io/zeebe/broker/job/JobBatchActivateProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/job/JobBatchActivateProcessorTest.java
@@ -21,7 +21,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
@@ -63,8 +62,8 @@ public class JobBatchActivateProcessorTest {
                 .getZeebeState()
                 .getWorkflowState()
                 .getElementInstanceState()
-                .getVariablesState());
-    when(streamWriter.getKeyGenerator()).thenReturn(zeebeState.getZeebeState().getKeyGenerator());
+                .getVariablesState(),
+            zeebeState.getKeyGenerator());
   }
 
   @Test

--- a/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessorTest.java
@@ -247,14 +247,14 @@ public class TypedStreamProcessorTest {
     }
   }
 
-  protected static class BatchProcessor implements TypedRecordProcessor<DeploymentRecord> {
-
+  protected class BatchProcessor implements TypedRecordProcessor<DeploymentRecord> {
     @Override
     public void processRecord(
         final TypedRecord<DeploymentRecord> record,
         final TypedResponseWriter responseWriter,
         final TypedStreamWriter streamWriter) {
-      streamWriter.appendNewEvent(DeploymentIntent.CREATED, record.getValue());
+      streamWriter.appendNewEvent(
+          keyGenerator.nextKey(), DeploymentIntent.CREATED, record.getValue());
       streamWriter.flush();
     }
   }

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamBatchWriter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamBatchWriter.java
@@ -27,10 +27,9 @@ import org.agrona.DirectBuffer;
 public interface LogStreamBatchWriter extends LogStreamWriter {
   /** Builder to add a log entry to the batch. */
   interface LogEntryBuilder {
-    /** Use the log entry position as key. */
-    LogEntryBuilder positionAsKey();
     /** Use the default values as key. */
     LogEntryBuilder keyNull();
+
     /** Set the log entry key. */
     LogEntryBuilder key(long key);
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamBatchWriterTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamBatchWriterTest.java
@@ -119,7 +119,7 @@ public class LogStreamBatchWriterTest {
   @Test
   public void shouldReturnPositionOfSingleEvent() {
     // when
-    final long position = writer.event().positionAsKey().value(EVENT_VALUE_1).done().tryWrite();
+    final long position = writer.event().keyNull().value(EVENT_VALUE_1).done().tryWrite();
 
     // then
     assertThat(position).isGreaterThan(0);
@@ -135,11 +135,11 @@ public class LogStreamBatchWriterTest {
     final long position =
         writer
             .event()
-            .positionAsKey()
+            .key(1)
             .value(EVENT_VALUE_1)
             .done()
             .event()
-            .positionAsKey()
+            .key(2)
             .value(EVENT_VALUE_2)
             .done()
             .tryWrite();
@@ -158,11 +158,11 @@ public class LogStreamBatchWriterTest {
     final long position =
         writer
             .event()
-            .positionAsKey()
+            .key(1)
             .value(EVENT_VALUE_1)
             .done()
             .event()
-            .positionAsKey()
+            .key(2)
             .value(EVENT_VALUE_2)
             .done()
             .tryWrite();
@@ -179,11 +179,11 @@ public class LogStreamBatchWriterTest {
     final long position =
         writer
             .event()
-            .positionAsKey()
+            .key(1)
             .value(EVENT_VALUE_1, 1, 2)
             .done()
             .event()
-            .positionAsKey()
+            .key(2)
             .value(EVENT_VALUE_2, 1, 2)
             .done()
             .tryWrite();
@@ -200,11 +200,11 @@ public class LogStreamBatchWriterTest {
     final long position =
         writer
             .event()
-            .positionAsKey()
+            .key(1)
             .valueWriter(new DirectBufferWriter().wrap(EVENT_VALUE_1))
             .done()
             .event()
-            .positionAsKey()
+            .key(2)
             .valueWriter(new DirectBufferWriter().wrap(EVENT_VALUE_2))
             .done()
             .tryWrite();
@@ -221,12 +221,12 @@ public class LogStreamBatchWriterTest {
     final long position =
         writer
             .event()
-            .positionAsKey()
+            .key(1)
             .value(EVENT_VALUE_1)
             .metadata(EVENT_METADATA_1)
             .done()
             .event()
-            .positionAsKey()
+            .key(2)
             .value(EVENT_VALUE_2)
             .metadata(EVENT_METADATA_2)
             .done()
@@ -244,12 +244,12 @@ public class LogStreamBatchWriterTest {
     final long position =
         writer
             .event()
-            .positionAsKey()
+            .key(1)
             .value(EVENT_VALUE_1)
             .metadata(EVENT_METADATA_1, 1, 2)
             .done()
             .event()
-            .positionAsKey()
+            .key(2)
             .value(EVENT_VALUE_2)
             .metadata(EVENT_METADATA_2, 1, 2)
             .done()
@@ -269,12 +269,12 @@ public class LogStreamBatchWriterTest {
     final long position =
         writer
             .event()
-            .positionAsKey()
+            .key(1)
             .value(EVENT_VALUE_1)
             .metadataWriter(new DirectBufferWriter().wrap(EVENT_METADATA_1))
             .done()
             .event()
-            .positionAsKey()
+            .key(2)
             .value(EVENT_VALUE_2)
             .metadataWriter(new DirectBufferWriter().wrap(EVENT_METADATA_2))
             .done()
@@ -308,46 +308,17 @@ public class LogStreamBatchWriterTest {
   }
 
   @Test
-  public void shouldWriteEventWithPositionAsKey() {
-    // when
-    final long position =
-        writer
-            .event()
-            .positionAsKey()
-            .value(EVENT_VALUE_1)
-            .done()
-            .event()
-            .positionAsKey()
-            .value(EVENT_VALUE_2)
-            .done()
-            .tryWrite();
-
-    // then
-    final List<LoggedEvent> events = getWrittenEvents(position);
-    final LoggedEvent firstEvent = events.get(0);
-    final long positionEvent1 = firstEvent.getPosition();
-    final LoggedEvent secondEvent = events.get(1);
-    final long positionEvent2 = secondEvent.getPosition();
-
-    assertThat(positionEvent1).isGreaterThan(0);
-    assertThat(positionEvent2).isGreaterThan(0);
-    assertThat(positionEvent1).isLessThan(positionEvent2);
-    assertThat(firstEvent.getKey()).isEqualTo(firstEvent.getPosition());
-    assertThat(secondEvent.getKey()).isEqualTo(secondEvent.getPosition());
-  }
-
-  @Test
   public void shouldWriteEventWithSourceEvent() {
     // when
     final long position =
         writer
             .sourceRecordPosition(123L)
             .event()
-            .positionAsKey()
+            .key(1)
             .value(EVENT_VALUE_1)
             .done()
             .event()
-            .positionAsKey()
+            .key(2)
             .value(EVENT_VALUE_2)
             .done()
             .tryWrite();
@@ -365,11 +336,11 @@ public class LogStreamBatchWriterTest {
     final long position =
         writer
             .event()
-            .positionAsKey()
+            .key(1)
             .value(EVENT_VALUE_1)
             .done()
             .event()
-            .positionAsKey()
+            .key(2)
             .value(EVENT_VALUE_2)
             .done()
             .tryWrite();
@@ -388,11 +359,11 @@ public class LogStreamBatchWriterTest {
         writer
             .producerId(123)
             .event()
-            .positionAsKey()
+            .key(1)
             .value(EVENT_VALUE_1)
             .done()
             .event()
-            .positionAsKey()
+            .key(2)
             .value(EVENT_VALUE_2)
             .done()
             .tryWrite();
@@ -409,11 +380,11 @@ public class LogStreamBatchWriterTest {
     final long position =
         writer
             .event()
-            .positionAsKey()
+            .key(1)
             .value(EVENT_VALUE_1)
             .done()
             .event()
-            .positionAsKey()
+            .key(2)
             .value(EVENT_VALUE_2)
             .done()
             .tryWrite();
@@ -433,18 +404,17 @@ public class LogStreamBatchWriterTest {
     // when
     final ActorFuture<Long> position =
         writerScheduler.call(
-            () -> {
-              return writer
-                  .event()
-                  .positionAsKey()
-                  .value(EVENT_VALUE_1)
-                  .done()
-                  .event()
-                  .positionAsKey()
-                  .value(EVENT_VALUE_2)
-                  .done()
-                  .tryWrite();
-            });
+            () ->
+                writer
+                    .event()
+                    .key(1)
+                    .value(EVENT_VALUE_1)
+                    .done()
+                    .event()
+                    .key(2)
+                    .value(EVENT_VALUE_2)
+                    .done()
+                    .tryWrite());
     writerScheduler.workUntilDone();
 
     // then
@@ -462,11 +432,11 @@ public class LogStreamBatchWriterTest {
     final long position =
         writer
             .event()
-            .positionAsKey()
+            .key(1)
             .value(EVENT_VALUE_1)
             .done()
             .event()
-            .positionAsKey()
+            .key(2)
             .value(EVENT_VALUE_2)
             .done()
             .tryWrite();
@@ -483,7 +453,7 @@ public class LogStreamBatchWriterTest {
     final long position =
         writer
             .event()
-            .positionAsKey()
+            .keyNull()
             .value(EVENT_VALUE_1)
             .done()
             .event()
@@ -499,17 +469,8 @@ public class LogStreamBatchWriterTest {
   public void shouldFailToWriteEventWithoutValue() {
     // when
     assertThatThrownBy(
-            () -> {
-              writer
-                  .event()
-                  .positionAsKey()
-                  .value(EVENT_VALUE_1)
-                  .done()
-                  .event()
-                  .positionAsKey()
-                  .done()
-                  .tryWrite();
-            })
+            () ->
+                writer.event().key(1).value(EVENT_VALUE_1).done().event().key(2).done().tryWrite())
         .isInstanceOf(RuntimeException.class)
         .hasMessage("value must not be null");
   }


### PR DESCRIPTION
This PR extracts key generation from the stream writer and changes its API to require an explicit key. It also generates a new key as fallback instead of using the position as key.

closes #2047, #2016 