### PR TITLE
Prefix all maven artifacts with zeebe

### DIFF
--- a/bom/README.md
+++ b/bom/README.md
@@ -9,7 +9,7 @@ pom.
     <dependencies>
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-bom</artifactId>
+        <artifactId>zeebe-bom</artifactId>
         <version>X.Y.Z</version>
         <scope>import</scope>
         <type>pom</type>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe BOM</name>
   <groupId>io.zeebe</groupId>
-  <artifactId>zb-bom</artifactId>
+  <artifactId>zeebe-bom</artifactId>
   <version>0.17.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <inceptionYear>2017</inceptionYear>
@@ -48,97 +48,97 @@
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-bpmn-model</artifactId>
+        <artifactId>zeebe-bpmn-model</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-dispatcher</artifactId>
+        <artifactId>zeebe-dispatcher</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-logstreams</artifactId>
+        <artifactId>zeebe-logstreams</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-msgpack-core</artifactId>
+        <artifactId>zeebe-msgpack-core</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-msgpack-json-el</artifactId>
+        <artifactId>zeebe-msgpack-json-el</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-msgpack-json-path</artifactId>
+        <artifactId>zeebe-msgpack-json-path</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-msgpack-value</artifactId>
+        <artifactId>zeebe-msgpack-value</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-protocol</artifactId>
+        <artifactId>zeebe-protocol</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-protocol-impl</artifactId>
+        <artifactId>zeebe-protocol-impl</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-raft</artifactId>
+        <artifactId>zeebe-raft</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-gossip</artifactId>
+        <artifactId>zeebe-gossip</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-service-container</artifactId>
+        <artifactId>zeebe-service-container</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-transport</artifactId>
+        <artifactId>zeebe-transport</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-test-util</artifactId>
+        <artifactId>zeebe-test-util</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-util</artifactId>
+        <artifactId>zeebe-util</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-db</artifactId>
+        <artifactId>zeebe-db</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -150,7 +150,7 @@
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-build-tools</artifactId>
+        <artifactId>zeebe-build-tools</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -168,19 +168,19 @@
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-exporter-api</artifactId>
+        <artifactId>zeebe-exporter-api</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-elasticsearch-exporter</artifactId>
+        <artifactId>zeebe-elasticsearch-exporter</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>io.zeebe</groupId>
-        <artifactId>zb-exporter-asserts</artifactId>
+        <artifactId>zeebe-exporter-asserts</artifactId>
         <version>${project.version}</version>
       </dependency>
     </dependencies>

--- a/bpmn-model/pom.xml
+++ b/bpmn-model/pom.xml
@@ -2,13 +2,13 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe BPMN model API</name>
-  <artifactId>zb-bpmn-model</artifactId>
+  <artifactId>zeebe-bpmn-model</artifactId>
   <version>0.17.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>

--- a/broker-core/pom.xml
+++ b/broker-core/pom.xml
@@ -7,7 +7,7 @@
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -56,42 +56,42 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-logstreams</artifactId>
+      <artifactId>zeebe-logstreams</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol</artifactId>
+      <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol-impl</artifactId>
+      <artifactId>zeebe-protocol-impl</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-transport</artifactId>
+      <artifactId>zeebe-transport</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-service-container</artifactId>
+      <artifactId>zeebe-service-container</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-raft</artifactId>
+      <artifactId>zeebe-raft</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-gossip</artifactId>
+      <artifactId>zeebe-gossip</artifactId>
     </dependency>
 
     <dependency>
@@ -111,17 +111,17 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-core</artifactId>
+      <artifactId>zeebe-msgpack-core</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-json-el</artifactId>
+      <artifactId>zeebe-msgpack-json-el</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-exporter-api</artifactId>
+      <artifactId>zeebe-exporter-api</artifactId>
     </dependency>
 
     <dependency>
@@ -142,13 +142,13 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-exporter-asserts</artifactId>
+      <artifactId>zeebe-exporter-asserts</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -172,12 +172,12 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-json-path</artifactId>
+      <artifactId>zeebe-msgpack-json-path</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-value</artifactId>
+      <artifactId>zeebe-msgpack-value</artifactId>
     </dependency>
 
     <dependency>
@@ -188,7 +188,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-bpmn-model</artifactId>
+      <artifactId>zeebe-bpmn-model</artifactId>
     </dependency>
 
     <dependency>
@@ -198,12 +198,12 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-db</artifactId>
+      <artifactId>zeebe-db</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-dispatcher</artifactId>
+      <artifactId>zeebe-dispatcher</artifactId>
     </dependency>
 
     <dependency>
@@ -307,7 +307,7 @@
             <argument>${project.build.resources[0].directory}/subscription-schema.xml</argument>
           </arguments>
           <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
-          <!-- system properties defined in zb-parent -->
+          <!-- system properties defined in zeebe-parent -->
         </configuration>
         <dependencies>
           <dependency>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -2,12 +2,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Build Tools</name>
-  <artifactId>zb-build-tools</artifactId>
+  <artifactId>zeebe-build-tools</artifactId>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-bom</artifactId>
+    <artifactId>zeebe-bom</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../bom</relativePath>
   </parent>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../../parent</relativePath>
   </parent>
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-bpmn-model</artifactId>
+      <artifactId>zeebe-bpmn-model</artifactId>
     </dependency>
 
     <dependency>
@@ -46,7 +46,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
@@ -94,7 +94,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -2,12 +2,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Dispatcher</name>
-  <artifactId>zb-dispatcher</artifactId>
+  <artifactId>zeebe-dispatcher</artifactId>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -16,7 +16,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
@@ -31,7 +31,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -7,7 +7,7 @@
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -29,12 +29,12 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-elasticsearch-exporter</artifactId>
+      <artifactId>zeebe-elasticsearch-exporter</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
@@ -149,7 +149,7 @@
         <configuration>
           <!-- dependencies only packaged but not explicitly used -->
           <usedDependencies>
-            <dependency>io.zeebe:zb-elasticsearch-exporter</dependency>
+            <dependency>io.zeebe:zeebe-elasticsearch-exporter</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/exporter-api/pom.xml
+++ b/exporter-api/pom.xml
@@ -2,12 +2,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Exporter API</name>
-  <artifactId>zb-exporter-api</artifactId>
+  <artifactId>zeebe-exporter-api</artifactId>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -15,7 +15,7 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol</artifactId>
+      <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
     <dependency>

--- a/exporter-asserts/pom.xml
+++ b/exporter-asserts/pom.xml
@@ -2,12 +2,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Exporter AssertJ Assertions</name>
-  <artifactId>zb-exporter-asserts</artifactId>
+  <artifactId>zeebe-exporter-asserts</artifactId>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -15,12 +15,12 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-exporter-api</artifactId>
+      <artifactId>zeebe-exporter-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol</artifactId>
+      <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
     <dependency>

--- a/exporters/elasticsearch-exporter/pom.xml
+++ b/exporters/elasticsearch-exporter/pom.xml
@@ -3,11 +3,11 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Elasticsearch Exporter</name>
-  <artifactId>zb-elasticsearch-exporter</artifactId>
+  <artifactId>zeebe-elasticsearch-exporter</artifactId>
   <packaging>jar</packaging>
 
   <parent>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <groupId>io.zeebe</groupId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
@@ -21,12 +21,12 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-exporter-api</artifactId>
+      <artifactId>zeebe-exporter-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol</artifactId>
+      <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
     <dependency>
@@ -87,13 +87,13 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/gateway-protocol/pom.xml
+++ b/gateway-protocol/pom.xml
@@ -7,7 +7,7 @@
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -7,7 +7,7 @@
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -20,32 +20,32 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol</artifactId>
+      <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol-impl</artifactId>
+      <artifactId>zeebe-protocol-impl</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-value</artifactId>
+      <artifactId>zeebe-msgpack-value</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-dispatcher</artifactId>
+      <artifactId>zeebe-dispatcher</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-transport</artifactId>
+      <artifactId>zeebe-transport</artifactId>
     </dependency>
 
     <dependency>
@@ -55,7 +55,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-core</artifactId>
+      <artifactId>zeebe-msgpack-core</artifactId>
     </dependency>
 
     <dependency>
@@ -116,7 +116,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/gossip/pom.xml
+++ b/gossip/pom.xml
@@ -2,13 +2,13 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Gossip</name>
-  <artifactId>zb-gossip</artifactId>
+  <artifactId>zeebe-gossip</artifactId>
   <version>0.17.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -16,17 +16,17 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-dispatcher</artifactId>
+      <artifactId>zeebe-dispatcher</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-transport</artifactId>
+      <artifactId>zeebe-transport</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
@@ -41,7 +41,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/json-el/pom.xml
+++ b/json-el/pom.xml
@@ -1,12 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Msgpack Json Expression Language</name>
-  <artifactId>zb-msgpack-json-el</artifactId>
+  <artifactId>zeebe-msgpack-json-el</artifactId>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -14,17 +14,17 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-core</artifactId>
+      <artifactId>zeebe-msgpack-core</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-json-path</artifactId>
+      <artifactId>zeebe-msgpack-json-path</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
@@ -44,7 +44,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/json-path/pom.xml
+++ b/json-path/pom.xml
@@ -1,12 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Msgpack Json Path</name>
-  <artifactId>zb-msgpack-json-path</artifactId>
+  <artifactId>zeebe-msgpack-json-path</artifactId>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -14,13 +14,13 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-core</artifactId>
+      <artifactId>zeebe-msgpack-core</artifactId>
     </dependency>
 
     <!-- for CompactList -->
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>

--- a/logstreams/pom.xml
+++ b/logstreams/pom.xml
@@ -2,13 +2,13 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Logstreams</name>
-  <artifactId>zb-logstreams</artifactId>
+  <artifactId>zeebe-logstreams</artifactId>
   <version>0.17.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -16,17 +16,17 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-dispatcher</artifactId>
+      <artifactId>zeebe-dispatcher</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-service-container</artifactId>
+      <artifactId>zeebe-service-container</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
@@ -59,7 +59,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -71,12 +71,12 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol</artifactId>
+      <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-db</artifactId>
+      <artifactId>zeebe-db</artifactId>
     </dependency>
   </dependencies>
 

--- a/msgpack-core/pom.xml
+++ b/msgpack-core/pom.xml
@@ -1,12 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Msgpack Core</name>
-  <artifactId>zb-msgpack-core</artifactId>
+  <artifactId>zeebe-msgpack-core</artifactId>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -31,7 +31,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/msgpack-value/pom.xml
+++ b/msgpack-value/pom.xml
@@ -1,12 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Msgpack Value</name>
-  <artifactId>zb-msgpack-value</artifactId>
+  <artifactId>zeebe-msgpack-value</artifactId>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -19,12 +19,12 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-core</artifactId>
+      <artifactId>zeebe-msgpack-core</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
@@ -35,7 +35,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2,7 +2,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Parent</name>
-  <artifactId>zb-parent</artifactId>
+  <artifactId>zeebe-parent</artifactId>
   <version>0.17.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <inceptionYear>2017</inceptionYear>
@@ -10,7 +10,7 @@
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-bom</artifactId>
+    <artifactId>zeebe-bom</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../bom</relativePath>
   </parent>
@@ -425,7 +425,7 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-build-tools</artifactId>
+      <artifactId>zeebe-build-tools</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -495,7 +495,7 @@
           <dependencies>
             <dependency>
               <groupId>io.zeebe</groupId>
-              <artifactId>zb-build-tools</artifactId>
+              <artifactId>zeebe-build-tools</artifactId>
               <version>${project.version}</version>
             </dependency>
           </dependencies>
@@ -786,7 +786,7 @@
                 <ignoredUnusedDeclaredDependencies>
                   <dep>org.apache.logging.log4j:log4j-slf4j-impl</dep>
                   <dep>org.apache.logging.log4j:log4j-core</dep>
-                  <dep>io.zeebe:zb-build-tools</dep>
+                  <dep>io.zeebe:zeebe-build-tools</dep>
                 </ignoredUnusedDeclaredDependencies>
               </configuration>
             </execution>
@@ -950,7 +950,7 @@
             <dependencies>
               <dependency>
                 <groupId>io.zeebe</groupId>
-                <artifactId>zb-build-tools</artifactId>
+                <artifactId>zeebe-build-tools</artifactId>
                 <version>${project.version}</version>
               </dependency>
             </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>parent/</relativePath>
   </parent>

--- a/protocol-impl/pom.xml
+++ b/protocol-impl/pom.xml
@@ -3,11 +3,11 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Protocol Implementation</name>
-  <artifactId>zb-protocol-impl</artifactId>
+  <artifactId>zeebe-protocol-impl</artifactId>
   <version>0.17.0-SNAPSHOT</version>
 
   <parent>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <groupId>io.zeebe</groupId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
@@ -16,22 +16,22 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol</artifactId>
+      <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-core</artifactId>
+      <artifactId>zeebe-msgpack-core</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-value</artifactId>
+      <artifactId>zeebe-msgpack-value</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>

--- a/protocol-test-util/pom.xml
+++ b/protocol-test-util/pom.xml
@@ -7,7 +7,7 @@
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -15,32 +15,32 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol</artifactId>
+      <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol-impl</artifactId>
+      <artifactId>zeebe-protocol-impl</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-transport</artifactId>
+      <artifactId>zeebe-transport</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-exporter-api</artifactId>
+      <artifactId>zeebe-exporter-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-value</artifactId>
+      <artifactId>zeebe-msgpack-value</artifactId>
     </dependency>
 
     <dependency>
@@ -54,12 +54,12 @@
     </dependency>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-bpmn-model</artifactId>
+      <artifactId>zeebe-bpmn-model</artifactId>
     </dependency>
 
     <dependency>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -2,13 +2,13 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Protocol</name>
-  <artifactId>zb-protocol</artifactId>
+  <artifactId>zeebe-protocol</artifactId>
   <version>0.17.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -29,7 +29,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-raft</artifactId>
+      <artifactId>zeebe-raft</artifactId>
     </dependency>
 
     <dependency>
@@ -39,42 +39,42 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-exporter-api</artifactId>
+      <artifactId>zeebe-exporter-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-bpmn-model</artifactId>
+      <artifactId>zeebe-bpmn-model</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol-impl</artifactId>
+      <artifactId>zeebe-protocol-impl</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-value</artifactId>
+      <artifactId>zeebe-msgpack-value</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol</artifactId>
+      <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-service-container</artifactId>
+      <artifactId>zeebe-service-container</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-transport</artifactId>
+      <artifactId>zeebe-transport</artifactId>
     </dependency>
 
     <dependency>
@@ -94,7 +94,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -120,7 +120,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-exporter-asserts</artifactId>
+      <artifactId>zeebe-exporter-asserts</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -7,7 +7,7 @@
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>

--- a/raft/pom.xml
+++ b/raft/pom.xml
@@ -2,13 +2,13 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Raft</name>
-  <artifactId>zb-raft</artifactId>
+  <artifactId>zeebe-raft</artifactId>
   <version>0.17.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -16,47 +16,47 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-logstreams</artifactId>
+      <artifactId>zeebe-logstreams</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-value</artifactId>
+      <artifactId>zeebe-msgpack-value</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol</artifactId>
+      <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol-impl</artifactId>
+      <artifactId>zeebe-protocol-impl</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-dispatcher</artifactId>
+      <artifactId>zeebe-dispatcher</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-service-container</artifactId>
+      <artifactId>zeebe-service-container</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-msgpack-core</artifactId>
+      <artifactId>zeebe-msgpack-core</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-transport</artifactId>
+      <artifactId>zeebe-transport</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
@@ -71,7 +71,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -7,7 +7,7 @@
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>

--- a/service-container/pom.xml
+++ b/service-container/pom.xml
@@ -2,13 +2,13 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Service Container</name>
-  <artifactId>zb-service-container</artifactId>
+  <artifactId>zeebe-service-container</artifactId>
   <version>0.17.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -2,12 +2,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Test Util</name>
-  <artifactId>zb-test-util</artifactId>
+  <artifactId>zeebe-test-util</artifactId>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -15,17 +15,17 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol</artifactId>
+      <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-exporter-api</artifactId>
+      <artifactId>zeebe-exporter-api</artifactId>
     </dependency>
 
     <dependency>

--- a/test/README.md
+++ b/test/README.md
@@ -11,7 +11,7 @@ Add `zeebe-test` as test dependency to your project.
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-bom</artifactId>
+      <artifactId>zeebe-bom</artifactId>
       <version>${ZEEBE_VERSION}</version>
       <scope>import</scope>
       <type>pom</type>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -7,7 +7,7 @@
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath>../parent</relativePath>
@@ -26,17 +26,17 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-exporter-api</artifactId>
+      <artifactId>zeebe-exporter-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-bpmn-model</artifactId>
+      <artifactId>zeebe-bpmn-model</artifactId>
     </dependency>
 
     <dependency>
@@ -46,23 +46,23 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-service-container</artifactId>
+      <artifactId>zeebe-service-container</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-protocol</artifactId>
+      <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-transport</artifactId>
+      <artifactId>zeebe-transport</artifactId>
     </dependency>
 
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
     </dependency>
 
     <dependency>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -2,13 +2,13 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Transport</name>
-  <artifactId>zb-transport</artifactId>
+  <artifactId>zeebe-transport</artifactId>
   <version>0.17.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -17,12 +17,12 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-dispatcher</artifactId>
+      <artifactId>zeebe-dispatcher</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>
@@ -37,7 +37,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-test-util</artifactId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -2,12 +2,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Util</name>
-  <artifactId>zb-util</artifactId>
+  <artifactId>zeebe-util</artifactId>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>

--- a/zb-db/pom.xml
+++ b/zb-db/pom.xml
@@ -5,13 +5,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.zeebe</groupId>
-  <artifactId>zb-db</artifactId>
+  <artifactId>zeebe-db</artifactId>
   <name>Zeebe DB</name>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>io.zeebe</groupId>
-    <artifactId>zb-parent</artifactId>
+    <artifactId>zeebe-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
@@ -19,7 +19,7 @@
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zb-util</artifactId>
+      <artifactId>zeebe-util</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
closes #2231 

BREAKING CHANGE:
- some artifact ids changed from `zb-` to `zeebe-`

