### PR TITLE
Make reprocessing deterministic again

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/ErrorRecordValueImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/record/value/ErrorRecordValueImpl.java
@@ -1,0 +1,101 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.exporter.record.value;
+
+import io.zeebe.broker.exporter.ExporterObjectMapper;
+import io.zeebe.broker.exporter.record.RecordValueImpl;
+import io.zeebe.exporter.api.record.value.ErrorRecordValue;
+import java.util.Objects;
+
+public class ErrorRecordValueImpl extends RecordValueImpl implements ErrorRecordValue {
+
+  private final String exceptionMessage;
+  private final String stacktrace;
+  private final long errorEventPosition;
+
+  private final long workflowInstanceKey;
+
+  public ErrorRecordValueImpl(
+      ExporterObjectMapper objectMapper,
+      String exceptionMessage,
+      String stacktrace,
+      long errorEventPosition,
+      long workflowInstanceKey) {
+    super(objectMapper);
+    this.exceptionMessage = exceptionMessage;
+    this.stacktrace = stacktrace;
+    this.errorEventPosition = errorEventPosition;
+    this.workflowInstanceKey = workflowInstanceKey;
+  }
+
+  @Override
+  public String getExceptionMessage() {
+    return exceptionMessage;
+  }
+
+  @Override
+  public String getStacktrace() {
+    return stacktrace;
+  }
+
+  @Override
+  public long getErrorEventPosition() {
+    return errorEventPosition;
+  }
+
+  @Override
+  public long getWorkflowInstanceKey() {
+    return workflowInstanceKey;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ErrorRecordValueImpl that = (ErrorRecordValueImpl) o;
+    return errorEventPosition == that.errorEventPosition
+        && workflowInstanceKey == that.workflowInstanceKey
+        && Objects.equals(exceptionMessage, that.exceptionMessage)
+        && Objects.equals(stacktrace, that.stacktrace);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(exceptionMessage, stacktrace, errorEventPosition, workflowInstanceKey);
+  }
+
+  @Override
+  public String toString() {
+    return "ErrorRecordValueImpl{"
+        + "exceptionMessage='"
+        + exceptionMessage
+        + '\''
+        + ", stacktrace='"
+        + stacktrace
+        + '\''
+        + ", errorEventPosition="
+        + errorEventPosition
+        + ", workflowInstanceKey="
+        + workflowInstanceKey
+        + '}';
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamEnvironment.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamEnvironment.java
@@ -25,6 +25,7 @@ import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -60,6 +61,7 @@ public class TypedStreamEnvironment {
     EVENT_REGISTRY.put(ValueType.VARIABLE, VariableRecord.class);
     EVENT_REGISTRY.put(ValueType.VARIABLE_DOCUMENT, VariableDocumentRecord.class);
     EVENT_REGISTRY.put(ValueType.WORKFLOW_INSTANCE_CREATION, WorkflowInstanceCreationRecord.class);
+    EVENT_REGISTRY.put(ValueType.ERROR, ErrorRecord.class);
   }
 
   private TypedStreamReader reader;

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/state/ZeebeState.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/state/ZeebeState.java
@@ -106,14 +106,10 @@ public class ZeebeState {
     return keyState;
   }
 
-  public void blacklist(TypedRecord record) {
-    final UnpackedObject value = record.getValue();
-    if (value instanceof WorkflowInstanceRelated) {
-      final long workflowInstanceKey = ((WorkflowInstanceRelated) value).getWorkflowInstanceKey();
-      if (workflowInstanceKey >= 0) {
-        LOG.warn(BLACKLIST_INSTANCE_MESSAGE, workflowInstanceKey);
-        blackList.blacklist(workflowInstanceKey);
-      }
+  public void blacklist(long workflowInstanceKey) {
+    if (workflowInstanceKey >= 0) {
+      LOG.warn(BLACKLIST_INSTANCE_MESSAGE, workflowInstanceKey);
+      blackList.blacklist(workflowInstanceKey);
     }
   }
 

--- a/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/BlacklistInstanceTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/BlacklistInstanceTest.java
@@ -18,11 +18,14 @@
 package io.zeebe.broker.logstreams.processor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import io.zeebe.broker.logstreams.processor.TypedStreamProcessor.DelegatingEventProcessor;
 import io.zeebe.broker.util.ZeebeStateRule;
 import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.WorkflowInstanceRelated;
 import io.zeebe.protocol.clientapi.ValueType;
@@ -265,8 +268,10 @@ public class BlacklistInstanceTest {
     metadata.intent(recordIntent);
     metadata.valueType(recordValueType);
     final TypedEventImpl typedEvent = new TypedEventImpl();
+    final LoggedEvent loggedEvent = mock(LoggedEvent.class);
+    when(loggedEvent.getPosition()).thenReturn(1024L);
 
-    typedEvent.wrap(null, metadata, new Value());
+    typedEvent.wrap(loggedEvent, metadata, new Value());
     delegatingEventProcessor.wrap(processor, typedEvent, 1024);
 
     // when

--- a/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/SkipFailingEventsTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/logstreams/processor/SkipFailingEventsTest.java
@@ -19,6 +19,7 @@ package io.zeebe.broker.logstreams.processor;
 
 import static io.zeebe.broker.workflow.state.TimerInstance.NO_ELEMENT_INSTANCE;
 import static io.zeebe.test.util.TestUtil.doRepeatedly;
+import static io.zeebe.test.util.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.when;
 import io.zeebe.broker.logstreams.state.DefaultZeebeDbFactory;
 import io.zeebe.broker.logstreams.state.ZeebeState;
 import io.zeebe.broker.util.MockTypedRecord;
+import io.zeebe.broker.util.RecordStream;
 import io.zeebe.broker.util.Records;
 import io.zeebe.broker.util.StreamProcessorControl;
 import io.zeebe.broker.util.TestStreams;
@@ -36,9 +38,11 @@ import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.protocol.clientapi.RecordType;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.intent.ErrorIntent;
 import io.zeebe.protocol.intent.JobIntent;
 import io.zeebe.protocol.intent.TimerIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
@@ -49,6 +53,8 @@ import io.zeebe.util.buffer.BufferUtil;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Before;
 import org.junit.Rule;
@@ -97,6 +103,65 @@ public class SkipFailingEventsTest {
 
     final AtomicLong key = new AtomicLong();
     keyGenerator = () -> key.getAndIncrement();
+  }
+
+  @Test
+  public void shouldWriteErrorEvent() {
+    // given
+    final DumpProcessor dumpProcessor = spy(new DumpProcessor());
+    final ErrorProneProcessor processor = new ErrorProneProcessor();
+
+    streamProcessorControl =
+        streams.initStreamProcessor(
+            STREAM_NAME,
+            STREAM_PROCESSOR_ID,
+            DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+            (db, dbContext) -> {
+              zeebeState = new ZeebeState(db, dbContext);
+              return env.newStreamProcessor()
+                  .zeebeState(zeebeState)
+                  .onEvent(
+                      ValueType.WORKFLOW_INSTANCE,
+                      WorkflowInstanceIntent.ELEMENT_ACTIVATING,
+                      processor)
+                  .onEvent(
+                      ValueType.WORKFLOW_INSTANCE,
+                      WorkflowInstanceIntent.ELEMENT_ACTIVATED,
+                      dumpProcessor)
+                  .build();
+            });
+    streamProcessorControl.start();
+
+    final long failingEventPosition =
+        streams
+            .newRecord(STREAM_NAME)
+            .event(workflowInstance(1))
+            .recordType(RecordType.EVENT)
+            .intent(WorkflowInstanceIntent.ELEMENT_ACTIVATING)
+            .key(keyGenerator.nextKey())
+            .write();
+
+    // when
+    streamProcessorControl.unblock();
+
+    doRepeatedly(
+            () ->
+                streams
+                    .events(STREAM_NAME)
+                    .filter(e -> Records.isEvent(e, ValueType.ERROR, ErrorIntent.CREATED))
+                    .findFirst())
+        .until(o -> o.isPresent())
+        .get();
+
+    // then
+    assertThat(processor.getProcessCount()).isEqualTo(1);
+
+    final ErrorRecord errorRecord =
+        new RecordStream(streams.events(STREAM_NAME)).onlyErrorRecords().getFirst().getValue();
+
+    assertThat(errorRecord.getErrorEventPosition()).isEqualTo(failingEventPosition);
+    assertThat(BufferUtil.bufferAsString(errorRecord.getExceptionMessage())).isEqualTo("expected");
+    assertThat(errorRecord.getWorkflowInstanceKey()).isEqualTo(1);
   }
 
   @Test
@@ -177,6 +242,63 @@ public class SkipFailingEventsTest {
 
     verify(dumpProcessor, times(1)).processRecord(any(), any(), any(), any());
     assertThat(dumpProcessor.processedInstances).containsExactly(2L);
+  }
+
+  @Test
+  public void shouldFindFailedEventsOnReprocessing() throws Exception {
+    // given
+    when(output.sendResponse(any())).thenReturn(true);
+
+    final long failedPos =
+        streams
+            .newRecord(STREAM_NAME)
+            .event(job(1))
+            .recordType(RecordType.EVENT)
+            .intent(JobIntent.ACTIVATED)
+            .producerId(STREAM_PROCESSOR_ID)
+            .key(keyGenerator.nextKey())
+            .write();
+    streams
+        .newRecord(STREAM_NAME)
+        .event(error(1, failedPos))
+        .recordType(RecordType.EVENT)
+        .producerId(STREAM_PROCESSOR_ID)
+        .sourceRecordPosition(failedPos)
+        .intent(ErrorIntent.CREATED)
+        .key(keyGenerator.nextKey())
+        .write();
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    streamProcessorControl =
+        streams.initStreamProcessor(
+            STREAM_NAME,
+            STREAM_PROCESSOR_ID,
+            DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+            (db, dbContext) -> {
+              zeebeState = new ZeebeState(db, dbContext);
+              return env.newStreamProcessor()
+                  .zeebeState(zeebeState)
+                  .withListener(
+                      new StreamProcessorLifecycleAware() {
+                        @Override
+                        public void onRecovered(TypedStreamProcessor streamProcessor) {
+                          latch.countDown();
+                        }
+                      })
+                  .onEvent(ValueType.JOB, JobIntent.ACTIVATED, new DumpProcessor())
+                  .build();
+            });
+
+    // when
+    streamProcessorControl.start();
+    latch.await(2000, TimeUnit.MILLISECONDS);
+
+    // then
+    final RecordMetadata metadata = new RecordMetadata();
+    metadata.valueType(ValueType.WORKFLOW_INSTANCE);
+    final MockTypedRecord<WorkflowInstanceRecord> mockTypedRecord =
+        new MockTypedRecord<>(0, metadata, workflowInstance(1));
+    waitUntil(() -> zeebeState.isOnBlacklist(mockTypedRecord));
   }
 
   @Test
@@ -346,6 +468,13 @@ public class SkipFailingEventsTest {
 
   protected WorkflowInstanceRecord workflowInstance(final int instanceKey) {
     final WorkflowInstanceRecord event = new WorkflowInstanceRecord();
+    event.setWorkflowInstanceKey(instanceKey);
+    return event;
+  }
+
+  protected ErrorRecord error(final int instanceKey, final long pos) {
+    final ErrorRecord event = new ErrorRecord();
+    event.initErrorRecord(new Exception("expected"), pos);
     event.setWorkflowInstanceKey(instanceKey);
     return event;
   }

--- a/broker-core/src/test/java/io/zeebe/broker/util/RecordStream.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/RecordStream.java
@@ -22,6 +22,7 @@ import io.zeebe.broker.subscription.message.data.MessageSubscriptionRecord;
 import io.zeebe.broker.subscription.message.data.WorkflowInstanceSubscriptionRecord;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
@@ -108,6 +109,12 @@ public class RecordStream extends StreamWrapper<LoggedEvent, RecordStream> {
     return new TypedRecordStream<>(
         filter(Records::isWorkflowInstanceCreationRecord)
             .map(e -> CopiedTypedEvent.toTypedEvent(e, WorkflowInstanceCreationRecord.class)));
+  }
+
+  public TypedRecordStream<ErrorRecord> onlyErrorRecords() {
+    return new TypedRecordStream<>(
+        filter(Records::isErrorRecord)
+            .map(e -> CopiedTypedEvent.toTypedEvent(e, ErrorRecord.class)));
   }
 
   /**

--- a/broker-core/src/test/java/io/zeebe/broker/util/Records.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/Records.java
@@ -89,6 +89,10 @@ public class Records {
     return isRecordOfType(event, ValueType.WORKFLOW_INSTANCE_CREATION);
   }
 
+  public static boolean isErrorRecord(final LoggedEvent event) {
+    return isRecordOfType(event, ValueType.ERROR);
+  }
+
   public static boolean hasIntent(final LoggedEvent event, final Intent intent) {
     if (event == null) {
       return false;

--- a/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
@@ -48,6 +48,7 @@ import io.zeebe.protocol.clientapi.RecordType;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -96,6 +97,7 @@ public class TestStreams {
     VALUE_TYPES.put(VariableRecord.class, ValueType.VARIABLE);
     VALUE_TYPES.put(VariableDocumentRecord.class, ValueType.VARIABLE_DOCUMENT);
     VALUE_TYPES.put(WorkflowInstanceCreationRecord.class, ValueType.WORKFLOW_INSTANCE_CREATION);
+    VALUE_TYPES.put(ErrorRecord.class, ValueType.ERROR);
 
     VALUE_TYPES.put(UnpackedObject.class, ValueType.NOOP);
   }
@@ -421,6 +423,8 @@ public class TestStreams {
     protected AtomicReference<Predicate<LoggedEvent>> blockAfterCondition =
         new AtomicReference<>(null);
 
+    private final RecordMetadata metadata = new RecordMetadata();
+    private final ErrorRecord errorRecord = new ErrorRecord();
     protected boolean blockAfterCurrentEvent;
     private StreamProcessorContext context;
 
@@ -497,6 +501,18 @@ public class TestStreams {
     public void onClose() {
       wrappedProcessor.onClose();
     }
+
+    @Override
+    public long getFailedPosition(LoggedEvent currentEvent) {
+      metadata.reset();
+      currentEvent.readMetadata(metadata);
+
+      if (metadata.getValueType() == ValueType.ERROR) {
+        currentEvent.readValue(errorRecord);
+        return errorRecord.getErrorEventPosition();
+      }
+      return -1;
+    }
   }
 
   public static class FluentLogWriter {
@@ -505,6 +521,8 @@ public class TestStreams {
     protected UnpackedObject value;
     protected LogStream logStream;
     protected long key = -1;
+    private long sourceRecordPosition = -1;
+    private int producerId = -1;
 
     public FluentLogWriter(final LogStream logStream) {
       this.logStream = logStream;
@@ -519,6 +537,16 @@ public class TestStreams {
 
     public FluentLogWriter requestId(final long requestId) {
       this.metadata.requestId(requestId);
+      return this;
+    }
+
+    public FluentLogWriter producerId(final int producerId) {
+      this.producerId = producerId;
+      return this;
+    }
+
+    public FluentLogWriter sourceRecordPosition(final long sourceRecordPosition) {
+      this.sourceRecordPosition = sourceRecordPosition;
       return this;
     }
 
@@ -550,6 +578,9 @@ public class TestStreams {
 
     public long write() {
       final LogStreamRecordWriter writer = new LogStreamWriterImpl(logStream);
+
+      writer.sourceRecordPosition(sourceRecordPosition);
+      writer.producerId(producerId);
 
       if (key >= 0) {
         writer.key(key);

--- a/exporter-api/src/main/java/io/zeebe/exporter/api/record/value/ErrorRecordValue.java
+++ b/exporter-api/src/main/java/io/zeebe/exporter/api/record/value/ErrorRecordValue.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.api.record.value;
+
+import io.zeebe.exporter.api.record.RecordValue;
+
+/** Error records are written on unexpected errors during the processing phase. */
+public interface ErrorRecordValue extends RecordValue {
+
+  /** @return the exception message, which causes this error record. */
+  String getExceptionMessage();
+
+  /** @return the stacktrace, which belongs to the exception */
+  String getStacktrace();
+
+  /** @return the position of the event, which causes this error */
+  long getErrorEventPosition();
+
+  /**
+   * @return the workflow instance key, which is related to the failed event. If the event is not
+   *     workflow instance related, then this will return -1
+   */
+  long getWorkflowInstanceKey();
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessor.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessor.java
@@ -51,4 +51,8 @@ public interface StreamProcessor {
   default void onClose() {
     // no nothing
   }
+
+  default long getFailedPosition(LoggedEvent currentEvent) {
+    return -1;
+  }
 }

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/ReProcessingStateMachineTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/ReProcessingStateMachineTest.java
@@ -18,11 +18,13 @@ package io.zeebe.logstreams.processor;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import io.zeebe.db.DbContext;
+import io.zeebe.db.TransactionOperation;
 import io.zeebe.db.ZeebeDbTransaction;
 import io.zeebe.logstreams.log.LogStreamReader;
 import io.zeebe.logstreams.log.LoggedEvent;
@@ -50,6 +52,8 @@ public class ReProcessingStateMachineTest {
 
   private ZeebeDbTransaction zeebeDbTransaction;
   private ActorControl actor;
+  private EventProcessor eventProcessor;
+  private LoggedEvent loggedEvent;
 
   @Before
   public void setup() {
@@ -58,14 +62,17 @@ public class ReProcessingStateMachineTest {
     final ControllableActor controllableActor = new ControllableActor();
     actor = controllableActor.getActor();
 
-    when(logStreamReader.hasNext()).thenReturn(true, false);
-    when(logStreamReader.next()).thenReturn(mock(LoggedEvent.class));
+    when(logStreamReader.hasNext()).thenReturn(true, true, false, true, false);
+    loggedEvent = mock(LoggedEvent.class);
+    when(loggedEvent.getSourceEventPosition()).thenReturn(1L);
+    when(logStreamReader.next()).thenReturn(loggedEvent);
 
-    zeebeDbTransaction = mock(ZeebeDbTransaction.class);
+    zeebeDbTransaction = spy(new Transaction());
     when(dbContext.getCurrentTransaction()).thenReturn(zeebeDbTransaction);
 
-    final EventProcessor eventProcessor = mock(EventProcessor.class);
+    eventProcessor = mock(EventProcessor.class);
     when(streamProcessor.onEvent(any())).thenReturn(eventProcessor);
+    when(streamProcessor.getFailedPosition(any())).thenReturn(-1L);
 
     final StreamProcessorContext streamProcessorContext = new StreamProcessorContext();
     streamProcessorContext.setActorControl(actor);
@@ -91,19 +98,21 @@ public class ReProcessingStateMachineTest {
     // when
     actor.call(
         () -> {
-          final ActorFuture<Void> recoverFuture = reProcessingStateMachine.startRecover(0);
+          final ActorFuture<Void> recoverFuture = reProcessingStateMachine.startRecover(0L);
           actor.runOnCompletion(recoverFuture, (v, t) -> latch.countDown());
         });
     actorSchedulerRule.workUntilDone();
 
     // then
     latch.await();
-    final InOrder inOrder = Mockito.inOrder(streamProcessor, dbContext, zeebeDbTransaction);
+    final InOrder inOrder =
+        Mockito.inOrder(streamProcessor, eventProcessor, dbContext, zeebeDbTransaction);
     inOrder.verify(streamProcessor, times(1)).onEvent(any());
 
     // process
     inOrder.verify(dbContext, times(1)).getCurrentTransaction();
     inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+    inOrder.verify(eventProcessor, times(1)).processEvent();
 
     // update state
     inOrder.verify(zeebeDbTransaction, times(1)).commit();
@@ -111,68 +120,112 @@ public class ReProcessingStateMachineTest {
   }
 
   @Test
-  public void shouldRunLifecycleOnErrorInProcess() throws Exception {
+  public void shouldRunLifecycleWithFailedEvent() throws Exception {
     // given
-    doThrow(new RuntimeException("expected")).doNothing().when(zeebeDbTransaction).run(any());
     final CountDownLatch latch = new CountDownLatch(1);
+    when(streamProcessor.getFailedPosition(any())).thenReturn(1L);
+    when(loggedEvent.getPosition()).thenReturn(1L);
 
     // when
     actor.call(
         () -> {
-          final ActorFuture<Void> recoverFuture = reProcessingStateMachine.startRecover(0);
+          final ActorFuture<Void> recoverFuture = reProcessingStateMachine.startRecover(0L);
           actor.runOnCompletion(recoverFuture, (v, t) -> latch.countDown());
         });
     actorSchedulerRule.workUntilDone();
 
     // then
     latch.await();
-    final InOrder inOrder = Mockito.inOrder(streamProcessor, dbContext, zeebeDbTransaction);
+    final InOrder inOrder =
+        Mockito.inOrder(streamProcessor, eventProcessor, dbContext, zeebeDbTransaction);
     inOrder.verify(streamProcessor, times(1)).onEvent(any());
-    // process
-    inOrder.verify(dbContext, times(1)).getCurrentTransaction();
-    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
 
-    // on error
-    inOrder.verify(zeebeDbTransaction, times(1)).rollback();
+    // event on error
     inOrder.verify(dbContext, times(1)).getCurrentTransaction();
     inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+    inOrder.verify(eventProcessor, times(1)).onError(any());
+
     // update state
     inOrder.verify(zeebeDbTransaction, times(1)).commit();
     inOrder.verifyNoMoreInteractions();
   }
 
   @Test
-  public void shouldRunLifecycleOnErrorOnUpdateState() throws Exception {
+  public void shouldRetryProcessingUntilSuccess() throws Exception {
     // given
-    doThrow(new RuntimeException("expected")).doNothing().when(zeebeDbTransaction).commit();
+    doThrow(new RuntimeException("expected"))
+        .doThrow(new RuntimeException("expected"))
+        .doCallRealMethod()
+        .when(zeebeDbTransaction)
+        .run(any());
     final CountDownLatch latch = new CountDownLatch(1);
 
     // when
     actor.call(
         () -> {
-          final ActorFuture<Void> recoverFuture = reProcessingStateMachine.startRecover(0);
+          final ActorFuture<Void> recoverFuture = reProcessingStateMachine.startRecover(0L);
           actor.runOnCompletion(recoverFuture, (v, t) -> latch.countDown());
         });
     actorSchedulerRule.workUntilDone();
 
     // then
     latch.await();
-    final InOrder inOrder = Mockito.inOrder(streamProcessor, dbContext, zeebeDbTransaction);
+    final InOrder inOrder =
+        Mockito.inOrder(streamProcessor, eventProcessor, dbContext, zeebeDbTransaction);
     inOrder.verify(streamProcessor, times(1)).onEvent(any());
     // process
     inOrder.verify(dbContext, times(1)).getCurrentTransaction();
     inOrder.verify(zeebeDbTransaction, times(1)).run(any());
 
-    // update state
-    inOrder.verify(zeebeDbTransaction, times(1)).commit();
-
-    // on error
+    // first - retry
     inOrder.verify(zeebeDbTransaction, times(1)).rollback();
     inOrder.verify(dbContext, times(1)).getCurrentTransaction();
     inOrder.verify(zeebeDbTransaction, times(1)).run(any());
 
+    // second - retry
+    inOrder.verify(zeebeDbTransaction, times(1)).rollback();
+    inOrder.verify(dbContext, times(1)).getCurrentTransaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+    inOrder.verify(eventProcessor, times(1)).processEvent();
+
     // update state
     inOrder.verify(zeebeDbTransaction, times(1)).commit();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldRetryUpdateStateUntilSuccess() throws Exception {
+    // given
+    doThrow(new RuntimeException("expected"))
+        .doThrow(new RuntimeException("expected"))
+        .doNothing()
+        .when(zeebeDbTransaction)
+        .commit();
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    // when
+    actor.call(
+        () -> {
+          final ActorFuture<Void> recoverFuture = reProcessingStateMachine.startRecover(-1L);
+          actor.runOnCompletion(recoverFuture, (v, t) -> latch.countDown());
+        });
+    actorSchedulerRule.workUntilDone();
+
+    // then
+    latch.await();
+    final InOrder inOrder =
+        Mockito.inOrder(streamProcessor, eventProcessor, dbContext, zeebeDbTransaction);
+    inOrder.verify(streamProcessor, times(1)).getFailedPosition(any());
+    inOrder.verify(streamProcessor, times(1)).onEvent(any());
+
+    // process
+    inOrder.verify(dbContext, times(1)).getCurrentTransaction();
+    inOrder.verify(zeebeDbTransaction, times(1)).run(any());
+    inOrder.verify(eventProcessor, times(1)).processEvent();
+
+    // update state with 2 retries
+    inOrder.verify(zeebeDbTransaction, times(3)).commit();
+
     inOrder.verifyNoMoreInteractions();
   }
 
@@ -181,5 +234,23 @@ public class ReProcessingStateMachineTest {
     public ActorControl getActor() {
       return actor;
     }
+  }
+
+  private class Transaction implements ZeebeDbTransaction {
+
+    @Override
+    public void run(TransactionOperation operations) {
+      try {
+        operations.run();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public void commit() {}
+
+    @Override
+    public void rollback() {}
   }
 }

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
@@ -44,6 +44,7 @@ public class RecordingStreamProcessor implements StreamProcessor {
           });
 
   private StreamProcessorContext context = null;
+  private long failedEventPosition;
 
   public RecordingStreamProcessor(ZeebeDb zeebeDb) {
     this.zeebeDb = zeebeDb;
@@ -68,6 +69,14 @@ public class RecordingStreamProcessor implements StreamProcessor {
     }
 
     return eventProcessor;
+  }
+
+  @Override
+  public long getFailedPosition(LoggedEvent currentEvent) {
+    if (currentEvent.getPosition() == failedEventPosition) {
+      return failedEventPosition;
+    }
+    return -1;
   }
 
   public static RecordingStreamProcessor createSpy(ZeebeDb db) {
@@ -100,5 +109,9 @@ public class RecordingStreamProcessor implements StreamProcessor {
 
   public int getProcessingFailedCount() {
     return failedEvents.get();
+  }
+
+  public void setFailedEventPosition(long failedEventPosition) {
+    this.failedEventPosition = failedEventPosition;
   }
 }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/error/ErrorRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/error/ErrorRecord.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.protocol.impl.record.value.error;
+
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.msgpack.property.LongProperty;
+import io.zeebe.msgpack.property.StringProperty;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.agrona.DirectBuffer;
+
+public class ErrorRecord extends UnpackedObject {
+  private final StringProperty exceptionMessageProp = new StringProperty("exceptionMessage");
+  private final StringProperty stacktraceProp = new StringProperty("stacktrace", "");
+  private final LongProperty errorEventPositionProp = new LongProperty("errorEventPosition");
+
+  private final LongProperty workflowInstanceKeyProp = new LongProperty("workflowInstanceKey", -1L);
+
+  public ErrorRecord() {
+    this.declareProperty(exceptionMessageProp)
+        .declareProperty(stacktraceProp)
+        .declareProperty(errorEventPositionProp)
+        .declareProperty(workflowInstanceKeyProp);
+  }
+
+  public void initErrorRecord(Throwable throwable, long position) {
+    reset();
+
+    final StringWriter stringWriter = new StringWriter();
+    final PrintWriter pw = new PrintWriter(stringWriter);
+    throwable.printStackTrace(pw);
+
+    stacktraceProp.setValue(stringWriter.toString());
+    exceptionMessageProp.setValue(throwable.getMessage());
+    errorEventPositionProp.setValue(position);
+  }
+
+  public DirectBuffer getExceptionMessage() {
+    return exceptionMessageProp.getValue();
+  }
+
+  public DirectBuffer getStacktrace() {
+    return stacktraceProp.getValue();
+  }
+
+  public long getErrorEventPosition() {
+    return errorEventPositionProp.getValue();
+  }
+
+  public long getWorkflowInstanceKey() {
+    return workflowInstanceKeyProp.getValue();
+  }
+
+  public ErrorRecord setWorkflowInstanceKey(long workflowInstanceKey) {
+    this.workflowInstanceKeyProp.setValue(workflowInstanceKey);
+    return this;
+  }
+}

--- a/protocol/src/main/java/io/zeebe/protocol/intent/ErrorIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/ErrorIntent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.protocol.intent;
+
+public enum ErrorIntent implements Intent {
+  CREATED((short) 0);
+
+  private final short value;
+
+  ErrorIntent(short value) {
+    this.value = value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(short value) {
+    switch (value) {
+      case 0:
+        return CREATED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+}

--- a/protocol/src/main/java/io/zeebe/protocol/intent/Intent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/Intent.java
@@ -34,7 +34,8 @@ public interface Intent {
           TimerIntent.class,
           VariableIntent.class,
           VariableDocumentIntent.class,
-          WorkflowInstanceCreationIntent.class);
+          WorkflowInstanceCreationIntent.class,
+          ErrorIntent.class);
 
   Intent UNKNOWN =
       new Intent() {
@@ -89,6 +90,8 @@ public interface Intent {
         return VariableDocumentIntent.from(intent);
       case WORKFLOW_INSTANCE_CREATION:
         return WorkflowInstanceCreationIntent.from(intent);
+      case ERROR:
+        return ErrorIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -134,6 +137,8 @@ public interface Intent {
         return VariableDocumentIntent.valueOf(intent);
       case WORKFLOW_INSTANCE_CREATION:
         return WorkflowInstanceCreationIntent.valueOf(intent);
+      case ERROR:
+        return ErrorIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -47,6 +47,7 @@
       <validValue name="VARIABLE">17</validValue>
       <validValue name="VARIABLE_DOCUMENT">18</validValue>
       <validValue name="WORKFLOW_INSTANCE_CREATION">19</validValue>
+      <validValue name="ERROR">20</validValue>
     </enum>
 
     <enum name="ControlMessageType" encodingType="uint8"

--- a/util/src/main/java/io/zeebe/util/retry/AbortableRetryStrategy.java
+++ b/util/src/main/java/io/zeebe/util/retry/AbortableRetryStrategy.java
@@ -32,12 +32,12 @@ public class AbortableRetryStrategy implements RetryStrategy {
   }
 
   @Override
-  public ActorFuture<Boolean> runWithRetry(BooleanSupplier callable) {
+  public ActorFuture<Boolean> runWithRetry(OperationToRetry callable) {
     return runWithRetry(callable, () -> false);
   }
 
   @Override
-  public ActorFuture<Boolean> runWithRetry(BooleanSupplier callable, BooleanSupplier condition) {
+  public ActorFuture<Boolean> runWithRetry(OperationToRetry callable, BooleanSupplier condition) {
     currentFuture = new CompletableActorFuture<>();
     retryMechanism.wrap(callable, condition, currentFuture);
 

--- a/util/src/main/java/io/zeebe/util/retry/ActorRetryMechanism.java
+++ b/util/src/main/java/io/zeebe/util/retry/ActorRetryMechanism.java
@@ -23,7 +23,7 @@ public class ActorRetryMechanism {
 
   private final ActorControl actor;
 
-  private BooleanSupplier currentCallable;
+  private OperationToRetry currentCallable;
   private BooleanSupplier currentTerminateCondition;
   private ActorFuture<Boolean> currentFuture;
 
@@ -32,14 +32,14 @@ public class ActorRetryMechanism {
   }
 
   void wrap(
-      BooleanSupplier callable, BooleanSupplier condition, ActorFuture<Boolean> resultFuture) {
+      OperationToRetry callable, BooleanSupplier condition, ActorFuture<Boolean> resultFuture) {
     currentCallable = callable;
     currentTerminateCondition = condition;
     currentFuture = resultFuture;
   }
 
-  void run() {
-    if (currentCallable.getAsBoolean()) {
+  void run() throws Exception {
+    if (currentCallable.run()) {
       currentFuture.complete(true);
       actor.done();
     } else if (currentTerminateCondition.getAsBoolean()) {

--- a/util/src/main/java/io/zeebe/util/retry/OperationToRetry.java
+++ b/util/src/main/java/io/zeebe/util/retry/OperationToRetry.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.util.retry;
+
+@FunctionalInterface
+public interface OperationToRetry {
+
+  boolean run() throws Exception;
+}

--- a/util/src/main/java/io/zeebe/util/retry/RetryStrategy.java
+++ b/util/src/main/java/io/zeebe/util/retry/RetryStrategy.java
@@ -29,7 +29,7 @@ public interface RetryStrategy {
    * @param callable the callable which should be executed
    * @return a future, which is completed with true if the execution was successful
    */
-  ActorFuture<Boolean> runWithRetry(BooleanSupplier callable);
+  ActorFuture<Boolean> runWithRetry(OperationToRetry callable);
 
   /**
    * Runs the given runnable with the defined retry strategy.
@@ -42,5 +42,5 @@ public interface RetryStrategy {
    *     condition returns true the retry strategy is aborted
    * @return a future, which is completed with true if the execution was successful
    */
-  ActorFuture<Boolean> runWithRetry(BooleanSupplier callable, BooleanSupplier terminateCondition);
+  ActorFuture<Boolean> runWithRetry(OperationToRetry callable, BooleanSupplier terminateCondition);
 }

--- a/util/src/test/java/io/zeebe/util/retry/EndlessRetryStrategyTest.java
+++ b/util/src/test/java/io/zeebe/util/retry/EndlessRetryStrategyTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.util.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.testing.ControlledActorSchedulerRule;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class EndlessRetryStrategyTest {
+
+  @Rule public ControlledActorSchedulerRule schedulerRule = new ControlledActorSchedulerRule();
+
+  private EndlessRetryStrategy retryStrategy;
+  private ActorControl actorControl;
+  private ActorFuture<Boolean> resultFuture;
+
+  @Before
+  public void setUp() {
+    final ControllableActor actor = new ControllableActor();
+    this.actorControl = actor.getActor();
+    retryStrategy = new EndlessRetryStrategy(actorControl);
+
+    schedulerRule.submitActor(actor);
+  }
+
+  @Test
+  public void shouldRunUntilDone() throws Exception {
+    // given
+    final AtomicInteger count = new AtomicInteger(0);
+
+    // when
+    actorControl.run(
+        () -> {
+          resultFuture = retryStrategy.runWithRetry(() -> count.incrementAndGet() == 10);
+        });
+
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(count.get()).isEqualTo(10);
+    assertThat(resultFuture.isDone()).isTrue();
+    assertThat(resultFuture.get()).isTrue();
+  }
+
+  @Test
+  public void shouldStopWhenAbortConditionReturnsTrue() throws Exception {
+    // given
+    final AtomicInteger count = new AtomicInteger(0);
+
+    // when
+    actorControl.run(
+        () -> {
+          resultFuture =
+              retryStrategy.runWithRetry(() -> false, () -> count.incrementAndGet() == 10);
+        });
+
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(count.get()).isEqualTo(10);
+    assertThat(resultFuture.isDone()).isTrue();
+    assertThat(resultFuture.get()).isFalse();
+  }
+
+  @Test
+  public void shouldRetryOnExceptionAndAbortWhenConditionReturnsTrue() throws Exception {
+    // given
+    final AtomicInteger count = new AtomicInteger(0);
+
+    // when
+    actorControl.run(
+        () -> {
+          resultFuture =
+              retryStrategy.runWithRetry(
+                  () -> {
+                    throw new RuntimeException();
+                  },
+                  () -> count.incrementAndGet() == 10);
+        });
+
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(count.get()).isEqualTo(10);
+    assertThat(resultFuture.isDone()).isTrue();
+    assertThat(resultFuture.get()).isFalse();
+  }
+
+  @Test
+  public void shouldRetryOnException() throws Exception {
+    // given
+    final AtomicInteger count = new AtomicInteger(0);
+    final AtomicBoolean toggle = new AtomicBoolean(false);
+
+    // when
+    actorControl.run(
+        () -> {
+          resultFuture =
+              retryStrategy.runWithRetry(
+                  () -> {
+                    toggle.set(!toggle.get());
+                    if (toggle.get()) {
+                      throw new RuntimeException("expected");
+                    }
+                    return count.incrementAndGet() == 10;
+                  });
+        });
+
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(count.get()).isEqualTo(10);
+    assertThat(resultFuture.isDone()).isTrue();
+    assertThat(resultFuture.get()).isTrue();
+  }
+
+  private final class ControllableActor extends Actor {
+    public ActorControl getActor() {
+      return actor;
+    }
+  }
+}

--- a/zb-db/src/main/java/io/zeebe/db/ZeebeDbTransaction.java
+++ b/zb-db/src/main/java/io/zeebe/db/ZeebeDbTransaction.java
@@ -29,7 +29,7 @@ public interface ZeebeDbTransaction {
    * @throws ZeebeDbException is thrown on an unexpected error in the database layer
    * @throws RuntimeException is thrown on an unexpected error in executing the operations
    */
-  void run(TransactionOperation operations);
+  void run(TransactionOperation operations) throws Exception;
 
   /**
    * Commits the transaction and writes the data into the database.

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
@@ -72,12 +72,15 @@ public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
   }
 
   @Override
-  public void run(TransactionOperation operations) {
+  public void run(TransactionOperation operations) throws Exception {
     try {
       operations.run();
-    } catch (Exception ex) {
-      throw new RuntimeException(
-          "Unexpected error occurred during zeebe db transaction operation.", ex);
+    } catch (RocksDBException rdbex) {
+      final String errorMessage = "Unexpected error occurred during RocksDB transaction commit.";
+      if (isRocksDbExceptionRecoverable(rdbex)) {
+        throw new ZeebeDbException(errorMessage, rdbex);
+      }
+      throw rdbex;
     }
   }
 

--- a/zb-db/src/test/java/io/zeebe/db/impl/DbTransactionTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/DbTransactionTest.java
@@ -105,7 +105,7 @@ public class DbTransactionTest {
   }
 
   @Test
-  public void shouldStartNewTransaction() {
+  public void shouldStartNewTransaction() throws Exception {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
@@ -134,7 +134,7 @@ public class DbTransactionTest {
   }
 
   @Test
-  public void shouldAccessOnOpenTransaction() {
+  public void shouldAccessOnOpenTransaction() throws Exception {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);
@@ -164,7 +164,7 @@ public class DbTransactionTest {
   }
 
   @Test
-  public void shouldNotReopenTransaction() {
+  public void shouldNotReopenTransaction() throws Exception {
     // given
     final ZeebeDbTransaction transaction = dbContext.getCurrentTransaction();
 
@@ -219,7 +219,7 @@ public class DbTransactionTest {
   }
 
   @Test
-  public void shouldRollbackTransaction() {
+  public void shouldRollbackTransaction() throws Exception {
     // given
     oneKey.wrapLong(1);
     oneValue.wrapLong(-1);


### PR DESCRIPTION
 * introduce a new error record
 * error record is written when an error happens on: `#processEvent`, `#writeEvent` or `#updateState`
 * processing will continue after error event is committed
 * on reprocessing error records are collected in a blacklist
 * when event which should be reprocessed is on blacklist than `#onError` is instead of `#processEvent` is called
 * This means even if the exception will not appear for this event on `#processEvent` again, the `#onError` is called which makes the event/error handling for reprocessing deterministic again
 * If an event is not blacklisted, the normal `#processEvent` method is called, when an exception is thrown the processing will be retried. Because, the event have been processed before successfully, on normal processing, otherwise it had been on the blacklist

closes #2228 
