### PR TITLE
chore(broker-core): get element instance only when necessary

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepContext.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/BpmnStepContext.java
@@ -43,9 +43,6 @@ public class BpmnStepContext<T extends ExecutableFlowElement> {
   private ExecutableFlowElement element;
   private TypedCommandWriter commandWriter;
 
-  private ElementInstance flowScopeInstance;
-  private ElementInstance elementInstance;
-
   public BpmnStepContext(WorkflowState stateDb, EventOutput eventOutput) {
     this.stateDb = stateDb;
     this.eventOutput = eventOutput;
@@ -94,11 +91,8 @@ public class BpmnStepContext<T extends ExecutableFlowElement> {
   }
 
   public ElementInstance getFlowScopeInstance() {
-    return flowScopeInstance;
-  }
-
-  public void setFlowScopeInstance(final ElementInstance flowScopeInstance) {
-    this.flowScopeInstance = flowScopeInstance;
+    final WorkflowInstanceRecord value = getValue();
+    return stateDb.getElementInstanceState().getInstance(value.getFlowScopeKey());
   }
 
   /**
@@ -107,11 +101,12 @@ public class BpmnStepContext<T extends ExecutableFlowElement> {
    * @return
    */
   public ElementInstance getElementInstance() {
-    return elementInstance;
-  }
-
-  public void setElementInstance(final ElementInstance elementInstance) {
-    this.elementInstance = elementInstance;
+    final TypedRecord<WorkflowInstanceRecord> record = getRecord();
+    if (record != null) {
+      final long key = record.getKey();
+      return stateDb.getElementInstanceState().getInstance(key);
+    }
+    return null;
   }
 
   public SideEffectQueue getSideEffect() {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceCommandProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/WorkflowInstanceCommandProcessor.java
@@ -48,7 +48,6 @@ public class WorkflowInstanceCommandProcessor
       TypedStreamWriter streamWriter) {
     populateCommandContext(record, responseWriter, streamWriter);
     commandHandlers.handle(context);
-    state.getElementInstanceState().flushDirtyState();
   }
 
   private void populateCommandContext(

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/AbstractHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/AbstractHandler.java
@@ -104,12 +104,13 @@ public abstract class AbstractHandler<T extends ExecutableFlowElement>
   }
 
   protected void transitionTo(BpmnStepContext<T> context, WorkflowInstanceIntent nextState) {
-    final WorkflowInstanceIntent state = context.getElementInstance().getState();
+    final ElementInstance elementInstance = context.getElementInstance();
+    final WorkflowInstanceIntent state = elementInstance.getState();
 
     assert WorkflowInstanceLifecycle.canTransition(state, nextState)
         : String.format("cannot transition from '%s' to '%s'", state, nextState);
 
-    context.getElementInstance().setState(nextState);
+    elementInstance.setState(nextState);
     context
         .getOutput()
         .appendFollowUpEvent(context.getRecord().getKey(), nextState, context.getValue());
@@ -125,5 +126,6 @@ public abstract class AbstractHandler<T extends ExecutableFlowElement>
           .getEventScopeInstanceState()
           .shutdownInstance(context.getRecord().getKey());
     }
+    context.getElementInstanceState().updateInstance(elementInstance);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/AbstractTerminalStateHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/AbstractTerminalStateHandler.java
@@ -49,6 +49,7 @@ public class AbstractTerminalStateHandler<T extends ExecutableFlowElement>
     final ElementInstance flowScopeInstance = context.getFlowScopeInstance();
     if (flowScopeInstance != null) {
       flowScopeInstance.consumeToken();
+      context.getStateDb().getElementInstanceState().updateInstance(flowScopeInstance);
     }
 
     return true;
@@ -66,6 +67,7 @@ public class AbstractTerminalStateHandler<T extends ExecutableFlowElement>
           .appendFollowUpEvent(record.getKey(), record.getState(), record.getValue());
       flowScopeInstance.spawnToken();
     }
+    context.getStateDb().getElementInstanceState().updateInstance(flowScopeInstance);
   }
 
   protected boolean isLastActiveExecutionPathInScope(BpmnStepContext<T> context) {

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/container/ContainerElementActivatedHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/container/ContainerElementActivatedHandler.java
@@ -21,6 +21,7 @@ import io.zeebe.broker.workflow.model.element.ExecutableCatchEventElement;
 import io.zeebe.broker.workflow.model.element.ExecutableFlowElementContainer;
 import io.zeebe.broker.workflow.processor.BpmnStepContext;
 import io.zeebe.broker.workflow.processor.handlers.element.ElementActivatedHandler;
+import io.zeebe.broker.workflow.state.ElementInstance;
 import io.zeebe.broker.workflow.state.IndexedRecord;
 import io.zeebe.broker.workflow.state.StoredRecord.Purpose;
 import io.zeebe.broker.workflow.state.WorkflowState;
@@ -60,7 +61,9 @@ public class ContainerElementActivatedHandler<T extends ExecutableFlowElementCon
       publishDeferredRecord(context);
     }
 
-    context.getElementInstance().spawnToken();
+    final ElementInstance elementInstance = context.getElementInstance();
+    elementInstance.spawnToken();
+    context.getStateDb().getElementInstanceState().updateInstance(elementInstance);
     return true;
   }
 

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/element/EventOccurredHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/element/EventOccurredHandler.java
@@ -20,6 +20,7 @@ package io.zeebe.broker.workflow.processor.handlers.element;
 import io.zeebe.broker.workflow.model.element.ExecutableFlowElement;
 import io.zeebe.broker.workflow.processor.BpmnStepContext;
 import io.zeebe.broker.workflow.processor.handlers.AbstractHandler;
+import io.zeebe.broker.workflow.state.ElementInstance;
 import io.zeebe.broker.workflow.state.EventTrigger;
 import io.zeebe.protocol.BpmnElementType;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
@@ -102,7 +103,9 @@ public class EventOccurredHandler<T extends ExecutableFlowElement> extends Abstr
     final long eventInstanceKey =
         context.getOutput().appendNewEvent(WorkflowInstanceIntent.ELEMENT_ACTIVATING, record);
     processEventTrigger(context, eventScopeKey, eventInstanceKey, event);
-    context.getFlowScopeInstance().spawnToken();
+    final ElementInstance flowScopeInstance = context.getFlowScopeInstance();
+    flowScopeInstance.spawnToken();
+    context.getStateDb().getElementInstanceState().updateInstance(flowScopeInstance);
 
     return eventInstanceKey;
   }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/seqflow/FlowOutElementCompletedHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/seqflow/FlowOutElementCompletedHandler.java
@@ -21,6 +21,7 @@ import io.zeebe.broker.workflow.model.element.ExecutableFlowNode;
 import io.zeebe.broker.workflow.model.element.ExecutableSequenceFlow;
 import io.zeebe.broker.workflow.processor.BpmnStepContext;
 import io.zeebe.broker.workflow.processor.handlers.element.ElementCompletedHandler;
+import io.zeebe.broker.workflow.state.ElementInstance;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import java.util.List;
 
@@ -51,6 +52,8 @@ public class FlowOutElementCompletedHandler<T extends ExecutableFlowNode>
     context
         .getOutput()
         .appendNewEvent(WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN, context.getValue(), flow);
-    context.getFlowScopeInstance().spawnToken();
+    final ElementInstance flowScopeInstance = context.getFlowScopeInstance();
+    flowScopeInstance.spawnToken();
+    context.getStateDb().getElementInstanceState().updateInstance(flowScopeInstance);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/seqflow/ParallelMergeSequenceFlowTaken.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/handlers/seqflow/ParallelMergeSequenceFlowTaken.java
@@ -60,13 +60,14 @@ public class ParallelMergeSequenceFlowTaken<T extends ExecutableSequenceFlow>
       mergeableRecords.forEach(
           r -> {
             eventOutput.removeDeferredEvent(scopeInstance.getKey(), r.getKey());
-            context.getFlowScopeInstance().consumeToken();
+            scopeInstance.consumeToken();
           });
 
       context
           .getOutput()
           .appendNewEvent(WorkflowInstanceIntent.ELEMENT_ACTIVATING, context.getValue(), gateway);
-      context.getFlowScopeInstance().spawnToken();
+      scopeInstance.spawnToken();
+      context.getStateDb().getElementInstanceState().updateInstance(scopeInstance);
     }
 
     return true;

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/instance/CreateWorkflowInstanceProcessor.java
@@ -90,8 +90,7 @@ public class CreateWorkflowInstanceProcessor
       return;
     }
 
-    final ElementInstance workflowInstance =
-        createElementInstance(workflow, workflowInstanceKey, record.getVariables());
+    final ElementInstance workflowInstance = createElementInstance(workflow, workflowInstanceKey);
     streamWriter.appendFollowUpEvent(
         workflowInstanceKey,
         WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -136,7 +135,7 @@ public class CreateWorkflowInstanceProcessor
   }
 
   private ElementInstance createElementInstance(
-      DeployedWorkflow workflow, long workflowInstanceKey, DirectBuffer variables) {
+      DeployedWorkflow workflow, long workflowInstanceKey) {
     newWorkflowInstance.reset();
     newWorkflowInstance.setBpmnProcessId(workflow.getBpmnProcessId());
     newWorkflowInstance.setVersion(workflow.getVersion());
@@ -149,7 +148,6 @@ public class CreateWorkflowInstanceProcessor
     final ElementInstance instance =
         elementInstanceState.newInstance(
             workflowInstanceKey, newWorkflowInstance, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
-    elementInstanceState.flushDirtyState();
 
     return instance;
   }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/job/JobCompletedEventProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/job/JobCompletedEventProcessor.java
@@ -57,6 +57,7 @@ public final class JobCompletedEventProcessor implements TypedRecordProcessor<Jo
       elementInstance.setState(WorkflowInstanceIntent.ELEMENT_COMPLETING);
       elementInstance.setJobKey(-1);
       elementInstance.setValue(value);
+      workflowState.getElementInstanceState().updateInstance(elementInstance);
 
       workflowState.getEventScopeInstanceState().shutdownInstance(elementInstanceKey);
       workflowState

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/processor/job/JobCreatedProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/processor/job/JobCreatedProcessor.java
@@ -22,6 +22,7 @@ import io.zeebe.broker.logstreams.processor.TypedRecordProcessor;
 import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
 import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
 import io.zeebe.broker.workflow.state.ElementInstance;
+import io.zeebe.broker.workflow.state.ElementInstanceState;
 import io.zeebe.broker.workflow.state.WorkflowState;
 import io.zeebe.protocol.impl.record.value.job.JobHeaders;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -43,11 +44,12 @@ public final class JobCreatedProcessor implements TypedRecordProcessor<JobRecord
     final JobHeaders jobHeaders = record.getValue().getHeaders();
     final long elementInstanceKey = jobHeaders.getElementInstanceKey();
     if (elementInstanceKey > 0) {
-      final ElementInstance elementInstance =
-          workflowState.getElementInstanceState().getInstance(elementInstanceKey);
+      final ElementInstanceState elementInstanceState = workflowState.getElementInstanceState();
+      final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);
 
       if (elementInstance != null) {
         elementInstance.setJobKey(record.getKey());
+        elementInstanceState.updateInstance(elementInstance);
       }
     }
   }

--- a/broker-core/src/main/java/io/zeebe/broker/workflow/state/WorkflowEngineState.java
+++ b/broker-core/src/main/java/io/zeebe/broker/workflow/state/WorkflowEngineState.java
@@ -103,6 +103,7 @@ public class WorkflowEngineState implements StreamProcessorLifecycleAware {
 
     scopeInstance.setState(state);
     scopeInstance.setValue(value);
+    elementInstanceState.updateInstance(scopeInstance);
   }
 
   private void removeElementInstance(long key, WorkflowInstanceRecord value) {

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementActivatedHandlerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementActivatedHandlerTest.java
@@ -42,7 +42,6 @@ public class ElementActivatedHandlerTest extends ElementHandlerTestCase<Executab
   @Test
   public void shouldNotHandleStateIfNoElementGiven() {
     // given
-    context.setElementInstance(null);
 
     // when - then
     assertThat(handler.shouldHandleState(context)).isFalse();
@@ -54,6 +53,7 @@ public class ElementActivatedHandlerTest extends ElementHandlerTestCase<Executab
     final ElementInstance instance =
         createAndSetContextElementInstance(WorkflowInstanceIntent.ELEMENT_ACTIVATED);
     instance.setState(WorkflowInstanceIntent.ELEMENT_TERMINATED);
+    elementInstanceState.updateInstance(instance);
 
     // when - then
     assertThat(handler.shouldHandleState(context)).isFalse();

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementActivatingHandlerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementActivatingHandlerTest.java
@@ -53,7 +53,6 @@ public class ElementActivatingHandlerTest extends ElementHandlerTestCase<Executa
   @Test
   public void shouldNotHandleStateIfNoElementGiven() {
     // given
-    context.setElementInstance(null);
 
     // when - then
     assertThat(handler.shouldHandleState(context)).isFalse();
@@ -65,6 +64,7 @@ public class ElementActivatingHandlerTest extends ElementHandlerTestCase<Executa
     final ElementInstance instance =
         createAndSetContextElementInstance(WorkflowInstanceIntent.ELEMENT_ACTIVATING);
     instance.setState(WorkflowInstanceIntent.ELEMENT_TERMINATED);
+    elementInstanceState.updateInstance(instance);
 
     // when - then
     assertThat(handler.shouldHandleState(context)).isFalse();

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementCompletedHandlerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementCompletedHandlerTest.java
@@ -48,7 +48,6 @@ public class ElementCompletedHandlerTest extends ElementHandlerTestCase<Executab
   @Test
   public void shouldNotHandleStateIfNoElementGiven() {
     // given
-    context.setElementInstance(null);
 
     // when - then
     assertThat(handler.shouldHandleState(context)).isFalse();
@@ -60,6 +59,7 @@ public class ElementCompletedHandlerTest extends ElementHandlerTestCase<Executab
     final ElementInstance instance =
         createAndSetContextElementInstance(WorkflowInstanceIntent.ELEMENT_COMPLETED);
     instance.setState(WorkflowInstanceIntent.ELEMENT_TERMINATED);
+    elementInstanceState.updateInstance(instance);
 
     // when - then
     assertThat(handler.shouldHandleState(context)).isFalse();

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementCompletingHandlerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementCompletingHandlerTest.java
@@ -49,7 +49,6 @@ public class ElementCompletingHandlerTest extends ElementHandlerTestCase<Executa
   @Test
   public void shouldNotHandleStateIfNoElementGiven() {
     // given
-    context.setElementInstance(null);
 
     // when - then
     assertThat(handler.shouldHandleState(context)).isFalse();
@@ -61,6 +60,7 @@ public class ElementCompletingHandlerTest extends ElementHandlerTestCase<Executa
     final ElementInstance instance =
         createAndSetContextElementInstance(WorkflowInstanceIntent.ELEMENT_COMPLETING);
     instance.setState(WorkflowInstanceIntent.ELEMENT_TERMINATED);
+    elementInstanceState.updateInstance(instance);
 
     // when - then
     assertThat(handler.shouldHandleState(context)).isFalse();

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementHandlerTestCase.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementHandlerTestCase.java
@@ -29,6 +29,7 @@ import io.zeebe.broker.workflow.model.element.ExecutableFlowNode;
 import io.zeebe.broker.workflow.processor.BpmnStepContext;
 import io.zeebe.broker.workflow.processor.EventOutput;
 import io.zeebe.broker.workflow.state.ElementInstance;
+import io.zeebe.broker.workflow.state.ElementInstanceState;
 import io.zeebe.broker.workflow.state.IndexedRecord;
 import io.zeebe.broker.workflow.state.StoredRecord;
 import io.zeebe.broker.workflow.state.StoredRecord.Purpose;
@@ -53,10 +54,13 @@ public abstract class ElementHandlerTestCase<T extends ExecutableFlowNode> {
   @Captor public ArgumentCaptor<IncidentRecord> incidentCaptor;
 
   protected BpmnStepContext<T> context;
+  protected ElementInstanceState elementInstanceState;
 
   @Before
   public void setUp() {
     context = new BpmnStepContext<>(zeebeStateRule.getZeebeState().getWorkflowState(), eventOutput);
+    elementInstanceState =
+        zeebeStateRule.getZeebeState().getWorkflowState().getElementInstanceState();
     context.setStreamWriter(streamWriter);
   }
 
@@ -91,13 +95,11 @@ public abstract class ElementHandlerTestCase<T extends ExecutableFlowNode> {
       WorkflowInstanceIntent state, ElementInstance flowScope) {
     final ElementInstance instance = newElementInstance(state, flowScope);
     setContextElementInstance(instance);
-    context.setFlowScopeInstance(flowScope);
 
     return instance;
   }
 
   protected void setContextElementInstance(ElementInstance instance) {
-    context.setElementInstance(instance);
     context.setRecord(newRecordFor(instance));
   }
 

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementTerminatedHandlerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementTerminatedHandlerTest.java
@@ -53,7 +53,6 @@ public class ElementTerminatedHandlerTest extends ElementHandlerTestCase {
   @Test
   public void shouldNotHandleStateIfNoElementGiven() {
     // given
-    context.setElementInstance(null);
 
     // when - then
     assertThat(handler.shouldHandleState(context)).isFalse();
@@ -65,6 +64,7 @@ public class ElementTerminatedHandlerTest extends ElementHandlerTestCase {
     final ElementInstance instance =
         createAndSetContextElementInstance(WorkflowInstanceIntent.ELEMENT_TERMINATED);
     instance.setState(WorkflowInstanceIntent.ELEMENT_COMPLETING);
+    elementInstanceState.updateInstance(instance);
 
     // when - then
     assertThat(handler.shouldHandleState(context)).isFalse();

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementTerminatingHandlerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/ElementTerminatingHandlerTest.java
@@ -19,6 +19,7 @@ package io.zeebe.broker.workflow.processor.handlers.element;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.zeebe.broker.incident.processor.IncidentState;
 import io.zeebe.broker.workflow.model.element.ExecutableFlowNode;
 import io.zeebe.broker.workflow.state.ElementInstance;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
@@ -30,6 +31,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class ElementTerminatingHandlerTest extends ElementHandlerTestCase<ExecutableFlowNode> {
   private ElementTerminatingHandler<ExecutableFlowNode> handler;
+  private final IncidentState incidentState = zeebeStateRule.getZeebeState().getIncidentState();
 
   @Override
   @Before
@@ -41,7 +43,6 @@ public class ElementTerminatingHandlerTest extends ElementHandlerTestCase<Execut
   @Test
   public void shouldNotHandleStateIfNoElementGiven() {
     // given
-    context.setElementInstance(null);
 
     // when - then
     assertThat(handler.shouldHandleState(context)).isFalse();
@@ -53,6 +54,7 @@ public class ElementTerminatingHandlerTest extends ElementHandlerTestCase<Execut
     final ElementInstance instance =
         createAndSetContextElementInstance(WorkflowInstanceIntent.ELEMENT_TERMINATING);
     instance.setState(WorkflowInstanceIntent.ELEMENT_COMPLETING);
+    elementInstanceState.updateInstance(instance);
 
     // when - then
     assertThat(handler.shouldHandleState(context)).isFalse();

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/EventOccurredHandlerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/handlers/element/EventOccurredHandlerTest.java
@@ -46,7 +46,6 @@ public class EventOccurredHandlerTest extends ElementHandlerTestCase<ExecutableF
     final ElementInstance instance =
         createAndSetContextElementInstance(WorkflowInstanceIntent.ELEMENT_ACTIVATED);
     instance.getValue().setWorkflowInstanceKey(zeebeStateRule.getKeyGenerator().nextKey());
-    context.setElementInstance(null);
     zeebeStateRule
         .getZeebeState()
         .getWorkflowState()

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/state/ElementInstanceStateTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/state/ElementInstanceStateTest.java
@@ -181,7 +181,6 @@ public class ElementInstanceStateTest {
     workflowInstanceRecord.setElementId("subProcess");
     elementInstanceState.newInstance(
         parentInstance, 101, workflowInstanceRecord, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
-    elementInstanceState.flushDirtyState();
     elementInstanceState.removeInstance(101L);
 
     // when
@@ -211,7 +210,6 @@ public class ElementInstanceStateTest {
     workflowInstanceRecord.setElementId("subProcess2");
     elementInstanceState.newInstance(
         parentInstance, 102, workflowInstanceRecord, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
-    elementInstanceState.flushDirtyState();
 
     // when
     elementInstanceState.removeInstance(101L);
@@ -242,7 +240,7 @@ public class ElementInstanceStateTest {
     instance.spawnToken();
     instance.setState(WorkflowInstanceIntent.ELEMENT_ACTIVATING);
     instance.setJobKey(5);
-    elementInstanceState.flushDirtyState();
+    elementInstanceState.updateInstance(instance);
 
     // then
     final ElementInstance updatedInstance = elementInstanceState.getInstance(100);
@@ -261,7 +259,7 @@ public class ElementInstanceStateTest {
   }
 
   @Test
-  public void shouldUpdateElementInstanceInCache() {
+  public void shouldNotUpdateElementInstance() {
     // given
     final WorkflowInstanceRecord workflowInstanceRecord = createWorkflowInstanceRecord();
     final ElementInstance instance =
@@ -277,13 +275,13 @@ public class ElementInstanceStateTest {
     final ElementInstance updatedInstance = elementInstanceState.getInstance(100);
 
     assertThat(updatedInstance.getKey()).isEqualTo(100);
-    assertThat(updatedInstance.getState()).isEqualTo(WorkflowInstanceIntent.ELEMENT_ACTIVATING);
-    assertThat(updatedInstance.getJobKey()).isEqualTo(5);
+    assertThat(updatedInstance.getState()).isEqualTo(WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+    assertThat(updatedInstance.getJobKey()).isEqualTo(0L);
     assertThat(updatedInstance.canTerminate()).isTrue();
 
     assertThat(updatedInstance.getNumberOfActiveElementInstances()).isEqualTo(0);
-    assertThat(updatedInstance.getNumberOfActiveExecutionPaths()).isEqualTo(1);
-    assertThat(updatedInstance.getNumberOfActiveTokens()).isEqualTo(1);
+    assertThat(updatedInstance.getNumberOfActiveExecutionPaths()).isEqualTo(0);
+    assertThat(updatedInstance.getNumberOfActiveTokens()).isEqualTo(0);
 
     final WorkflowInstanceRecord record = updatedInstance.getValue();
     assertWorkflowInstanceRecord(record);
@@ -296,7 +294,6 @@ public class ElementInstanceStateTest {
     final ElementInstance instance =
         elementInstanceState.newInstance(
             100, workflowInstanceRecord, WorkflowInstanceIntent.ELEMENT_ACTIVATED);
-    elementInstanceState.flushDirtyState();
 
     // when
     instance.spawnToken();
@@ -322,7 +319,6 @@ public class ElementInstanceStateTest {
     workflowInstanceRecord.setElementId("subProcess2");
     elementInstanceState.newInstance(
         parentInstance, 102, workflowInstanceRecord, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
-    elementInstanceState.flushDirtyState();
 
     // when
     final List<ElementInstance> children = elementInstanceState.getChildren(100L);
@@ -413,8 +409,6 @@ public class ElementInstanceStateTest {
     elementInstanceState.newInstance(
         parentInstance, child, workflowInstanceRecord, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
     setVariableLocal(child, BufferUtil.wrapString("b"), MsgPackUtil.asMsgPack("2"));
-
-    elementInstanceState.flushDirtyState();
 
     // when
     elementInstanceState.removeInstance(101);

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/state/VariableStateTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/state/VariableStateTest.java
@@ -665,7 +665,6 @@ public class VariableStateTest {
     final TypedRecord<WorkflowInstanceRecord> record = mockTypedRecord(key, parentKey);
     elementInstanceState.newInstance(
         parent, key, record.getValue(), WorkflowInstanceIntent.ELEMENT_ACTIVATING);
-    elementInstanceState.flushDirtyState();
   }
 
   private TypedRecord<WorkflowInstanceRecord> mockTypedRecord(long key, long parentKey) {


### PR DESCRIPTION
Removes unnecessary usage of cache and flushing behavior. Only requests element instance from db and only updates the state if necessary.

Before that change, the corresponding element instance and the flow scope instance was requested 
and then the step processing was executed, even if the instances are not used. There are exist also look ups on element instances, which checks some properties but not updates the element instance. These
element instances where then added to the cache and flushed unnecessary.

closes #2131 
