### PR TITLE
fix(exporters/elasticsearch-exporter): migrates ES to pkg io.zeebe.exporter

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.exporter.api;
+package io.zeebe.exporter;
 
 import io.zeebe.exporter.api.record.Record;
 import io.zeebe.protocol.clientapi.ValueType;

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.exporter.api;
+package io.zeebe.exporter;
 
-import io.zeebe.exporter.api.ElasticsearchExporterConfiguration.IndexConfiguration;
+import io.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
 import io.zeebe.exporter.api.context.Context;
 import io.zeebe.exporter.api.context.Controller;
 import io.zeebe.exporter.api.record.Record;

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.exporter.api;
+package io.zeebe.exporter;
 
 import io.zeebe.exporter.api.record.Record;
 import io.zeebe.exporter.api.record.RecordMetadata;

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterException.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterException.java
@@ -13,23 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.exporter.api.util;
+package io.zeebe.exporter;
 
-import org.apache.http.HttpHost;
+public class ElasticsearchExporterException extends RuntimeException {
 
-public interface ElasticsearchNode<SELF extends ElasticsearchNode> {
+  public ElasticsearchExporterException(String message) {
+    super(message);
+  }
 
-  void start();
-
-  void stop();
-
-  SELF withXpack();
-
-  SELF withUser(String username, String password);
-
-  SELF withJavaOptions(String... options);
-
-  SELF withKeyStore(String keyStore);
-
-  HttpHost getRestHttpHost();
+  public ElasticsearchExporterException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.exporter.api;
+package io.zeebe.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,8 +21,8 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.zeebe.exporter.api.record.Record;
-import io.zeebe.exporter.api.util.ElasticsearchForkedJvm;
-import io.zeebe.exporter.api.util.ElasticsearchNode;
+import io.zeebe.exporter.util.ElasticsearchForkedJvm;
+import io.zeebe.exporter.util.ElasticsearchNode;
 import io.zeebe.test.exporter.ExporterIntegrationRule;
 import io.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.zeebe.util.ZbLogger;

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterFaultToleranceIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterFaultToleranceIT.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.exporter.api;
+package io.zeebe.exporter;
 
 import io.zeebe.exporter.api.record.Record;
 import io.zeebe.test.util.TestUtil;

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterIT.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.exporter.api;
+package io.zeebe.exporter;
 
-import io.zeebe.exporter.api.util.ElasticsearchNode;
+import io.zeebe.exporter.util.ElasticsearchNode;
 import java.util.function.Consumer;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.exporter.api;
+package io.zeebe.exporter;
 
-import static io.zeebe.exporter.api.ElasticsearchExporter.ZEEBE_RECORD_TEMPLATE_JSON;
+import static io.zeebe.exporter.ElasticsearchExporter.ZEEBE_RECORD_TEMPLATE_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/util/ElasticsearchForkedJvm.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/util/ElasticsearchForkedJvm.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.exporter.api.util;
+package io.zeebe.exporter.util;
 
 import java.io.File;
 import java.io.IOException;

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/util/ElasticsearchNode.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/util/ElasticsearchNode.java
@@ -13,15 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.exporter.api;
+package io.zeebe.exporter.util;
 
-public class ElasticsearchExporterException extends RuntimeException {
+import org.apache.http.HttpHost;
 
-  public ElasticsearchExporterException(String message) {
-    super(message);
-  }
+public interface ElasticsearchNode<SELF extends ElasticsearchNode> {
 
-  public ElasticsearchExporterException(String message, Throwable cause) {
-    super(message, cause);
-  }
+  void start();
+
+  void stop();
+
+  SELF withXpack();
+
+  SELF withUser(String username, String password);
+
+  SELF withJavaOptions(String... options);
+
+  SELF withKeyStore(String keyStore);
+
+  HttpHost getRestHttpHost();
 }


### PR DESCRIPTION
- reverts change of #2018 which accidentally migrated ES exporter from package `io.zeebe.exporter` to package `io.zeebe.exporter.api`

closes #2253 
