### PR TITLE
Fix NPE in error record

### DIFF
--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/error/ErrorRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/error/ErrorRecord.java
@@ -20,9 +20,13 @@ import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Objects;
 import org.agrona.DirectBuffer;
 
 public class ErrorRecord extends UnpackedObject {
+
+  private static final String NULL_MESSAGE = "Without exception message.";
+
   private final StringProperty exceptionMessageProp = new StringProperty("exceptionMessage");
   private final StringProperty stacktraceProp = new StringProperty("stacktrace", "");
   private final LongProperty errorEventPositionProp = new LongProperty("errorEventPosition");
@@ -37,6 +41,7 @@ public class ErrorRecord extends UnpackedObject {
   }
 
   public void initErrorRecord(Throwable throwable, long position) {
+    Objects.requireNonNull(throwable);
     reset();
 
     final StringWriter stringWriter = new StringWriter();
@@ -44,7 +49,8 @@ public class ErrorRecord extends UnpackedObject {
     throwable.printStackTrace(pw);
 
     stacktraceProp.setValue(stringWriter.toString());
-    exceptionMessageProp.setValue(throwable.getMessage());
+    final String exceptionMessage = throwable.getMessage();
+    exceptionMessageProp.setValue(exceptionMessage == null ? NULL_MESSAGE : exceptionMessage);
     errorEventPositionProp.setValue(position);
   }
 

--- a/zb-db/src/main/java/io/zeebe/db/ZeebeDbTransaction.java
+++ b/zb-db/src/main/java/io/zeebe/db/ZeebeDbTransaction.java
@@ -35,15 +35,15 @@ public interface ZeebeDbTransaction {
    * Commits the transaction and writes the data into the database.
    *
    * @throws ZeebeDbException if the underlying database has a recoverable exception thrown
-   * @throws RuntimeException if the underlying database has a non recoverable exception thrown
+   * @throws Exception if the underlying database has a non recoverable exception thrown
    */
-  void commit();
+  void commit() throws Exception;
 
   /**
    * Rolls the transaction back to the latest commit, discards all changes in between.
    *
    * @throws ZeebeDbException if the underlying database has a recoverable exception thrown
-   * @throws RuntimeException if the underlying database has a non recoverable exception thrown
+   * @throws Exception if the underlying database has a non recoverable exception thrown
    */
-  void rollback();
+  void rollback() throws Exception;
 }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/DefaultDbContext.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/DefaultDbContext.java
@@ -38,7 +38,7 @@ import org.rocksdb.Status;
 public class DefaultDbContext implements DbContext {
   private static final byte[] ZERO_SIZE_ARRAY = new byte[0];
 
-  private ZeebeTransaction transaction;
+  private final ZeebeTransaction transaction;
 
   // we can also simply use one buffer
   private final ExpandableArrayBuffer keyBuffer = new ExpandableArrayBuffer();

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
@@ -90,16 +90,15 @@ public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
   }
 
   @Override
-  public void commit() {
+  public void commit() throws RocksDBException {
     try {
       commitInternal();
     } catch (RocksDBException rdbex) {
       final String errorMessage = "Unexpected error occurred during RocksDB transaction commit.";
       if (isRocksDbExceptionRecoverable(rdbex)) {
         throw new ZeebeDbException(errorMessage, rdbex);
-      } else {
-        throw new RuntimeException(errorMessage, rdbex);
       }
+      throw rdbex;
     }
   }
 
@@ -109,16 +108,15 @@ public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
   }
 
   @Override
-  public void rollback() {
+  public void rollback() throws RocksDBException {
     try {
       rollbackInternal();
     } catch (RocksDBException rdbex) {
       final String errorMessage = "Unexpected error occurred during RocksDB transaction rollback.";
       if (isRocksDbExceptionRecoverable(rdbex)) {
         throw new ZeebeDbException(errorMessage, rdbex);
-      } else {
-        throw new RuntimeException(errorMessage, rdbex);
       }
+      throw rdbex;
     }
   }
 

--- a/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbTransactionTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbTransactionTest.java
@@ -15,10 +15,15 @@
  */
 package io.zeebe.db.impl.rocksdb.transaction;
 
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
 import io.zeebe.db.DbContext;
 import io.zeebe.db.ZeebeDb;
 import io.zeebe.db.ZeebeDbException;
 import io.zeebe.db.ZeebeDbFactory;
+import io.zeebe.db.ZeebeDbTransaction;
 import io.zeebe.db.impl.DefaultColumnFamily;
 import io.zeebe.db.impl.DefaultZeebeDbFactory;
 import java.io.File;
@@ -60,7 +65,7 @@ public class ZeebeRocksDbTransactionTest {
   }
 
   @Test(expected = RuntimeException.class)
-  public void shouldThrowNonRecoverableException() {
+  public void shouldWrapExceptionInRuntimeException() {
     // given
     final Status status = new Status(Code.NotSupported, SubCode.None, "");
 
@@ -69,5 +74,127 @@ public class ZeebeRocksDbTransactionTest {
         () -> {
           throw new RocksDBException("expected", status);
         });
+  }
+
+  @Test(expected = ZeebeDbException.class)
+  public void shouldThrowRecoverableExceptionOnCommit() throws Exception {
+    // given
+    final ZeebeTransaction transaction = mock(ZeebeTransaction.class);
+    final DbContext newContext = new DefaultDbContext(transaction);
+    final Status status = new Status(Code.IOError, SubCode.None, "");
+    doThrow(new RocksDBException("expected", status)).when(transaction).commitInternal();
+
+    // when
+    newContext.runInTransaction(() -> {});
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void shouldWrapExceptionInRuntimeExceptionOnCommit() throws Exception {
+    // given
+    final ZeebeTransaction transaction = mock(ZeebeTransaction.class);
+    final DbContext newContext = new DefaultDbContext(transaction);
+    final Status status = new Status(Code.NotSupported, SubCode.None, "");
+    doThrow(new RocksDBException("expected", status)).when(transaction).commitInternal();
+
+    // when
+    newContext.runInTransaction(() -> {});
+  }
+
+  @Test(expected = ZeebeDbException.class)
+  public void shouldThrowRecoverableExceptionOnRollback() throws Exception {
+    // given
+    final ZeebeTransaction transaction = mock(ZeebeTransaction.class);
+    final DbContext newContext = new DefaultDbContext(transaction);
+    final Status status = new Status(Code.IOError, SubCode.None, "");
+    doThrow(new RocksDBException("expected", status)).when(transaction).rollbackInternal();
+
+    // when
+    newContext.runInTransaction(() -> {});
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void shouldWrapExceptionInRuntimeExceptionOnRollback() throws Exception {
+    // given
+    final ZeebeTransaction transaction = mock(ZeebeTransaction.class);
+    final DbContext newContext = new DefaultDbContext(transaction);
+    final Status status = new Status(Code.NotSupported, SubCode.None, "");
+    doThrow(new RocksDBException("expected", status)).when(transaction).rollbackInternal();
+
+    // when
+    newContext.runInTransaction(() -> {});
+  }
+
+  @Test(expected = ZeebeDbException.class)
+  public void shouldThrowRecoverableExceptionInTransactionRun() throws Exception {
+    // given
+    final Status status = new Status(Code.IOError, SubCode.None, "");
+
+    // when
+    final ZeebeDbTransaction currentTransaction = dbContext.getCurrentTransaction();
+    currentTransaction.run(
+        () -> {
+          throw new RocksDBException("expected", status);
+        });
+  }
+
+  @Test(expected = RocksDBException.class)
+  public void shouldReThrowExceptionFromTransactionRun() throws Exception {
+    // given
+    final Status status = new Status(Code.NotSupported, SubCode.None, "");
+
+    // when
+    final ZeebeDbTransaction currentTransaction = dbContext.getCurrentTransaction();
+    currentTransaction.run(
+        () -> {
+          throw new RocksDBException("expected", status);
+        });
+  }
+
+  @Test(expected = ZeebeDbException.class)
+  public void shouldThrowRecoverableExceptionInTransactionCommit() throws Exception {
+    // given
+    final Status status = new Status(Code.IOError, SubCode.None, "");
+    final ZeebeTransaction currentTransaction =
+        spy((ZeebeTransaction) dbContext.getCurrentTransaction());
+    doThrow(new RocksDBException("expected", status)).when(currentTransaction).commitInternal();
+
+    // when
+    currentTransaction.commit();
+  }
+
+  @Test(expected = RocksDBException.class)
+  public void shouldReThrowExceptionFromTransactionCommit() throws Exception {
+    // given
+    final Status status = new Status(Code.NotSupported, SubCode.None, "");
+    final ZeebeTransaction currentTransaction =
+        spy((ZeebeTransaction) dbContext.getCurrentTransaction());
+    doThrow(new RocksDBException("expected", status)).when(currentTransaction).commitInternal();
+
+    // when
+    currentTransaction.commit();
+  }
+
+  @Test(expected = ZeebeDbException.class)
+  public void shouldThrowRecoverableExceptionInTransactionRollback() throws Exception {
+    // given
+    final Status status = new Status(Code.IOError, SubCode.None, "");
+    final ZeebeTransaction currentTransaction =
+        spy((ZeebeTransaction) dbContext.getCurrentTransaction());
+    doThrow(new RocksDBException("expected", status)).when(currentTransaction).rollbackInternal();
+
+    // when
+    currentTransaction.rollback();
+  }
+
+  @Test(expected = RocksDBException.class)
+  public void shouldReThrowExceptionFromTransactionRollback() throws Exception {
+    // given
+    final Status status = new Status(Code.NotSupported, SubCode.None, "");
+    final ZeebeTransaction currentTransaction =
+        spy((ZeebeTransaction) dbContext.getCurrentTransaction());
+    doThrow(new RocksDBException("expected", status)).when(currentTransaction).rollbackInternal();
+
+    // when
+    currentTransaction.rollback();
   }
 }


### PR DESCRIPTION
Fixes possible a NullpointerException in the error record and add test to ensure that the expected exceptions are thrown by the current ZeebeDB implementation

closes #2266 
closes #2251
