### PR TITLE
chore(broker): refactor open/close message start subscriptions

### DIFF
--- a/broker-core/src/test/java/io/zeebe/broker/util/StreamProcessorControl.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/StreamProcessorControl.java
@@ -18,6 +18,7 @@
 package io.zeebe.broker.util;
 
 import io.zeebe.broker.logstreams.processor.TypedRecord;
+import io.zeebe.broker.subscription.message.data.MessageStartEventSubscriptionRecord;
 import io.zeebe.broker.subscription.message.data.MessageSubscriptionRecord;
 import io.zeebe.broker.subscription.message.data.WorkflowInstanceSubscriptionRecord;
 import io.zeebe.logstreams.log.LoggedEvent;
@@ -56,6 +57,9 @@ public interface StreamProcessorControl {
       Predicate<TypedRecord<WorkflowInstanceSubscriptionRecord>> test);
 
   void blockAfterTimerEvent(Predicate<TypedRecord<TimerRecord>> test);
+
+  void blockAfterMessageStartEventSubscriptionRecord(
+      final Predicate<TypedRecord<MessageStartEventSubscriptionRecord>> test);
 
   /**
    * @return true if the event to block on has been processed and the stream processor won't handle

--- a/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
@@ -340,6 +340,16 @@ public class TestStreams {
     }
 
     @Override
+    public void blockAfterMessageStartEventSubscriptionRecord(
+        final Predicate<TypedRecord<MessageStartEventSubscriptionRecord>> test) {
+      blockAfterEvent(
+          e ->
+              Records.isMessageStartEventSubscriptionRecord(e)
+                  && test.test(
+                      CopiedTypedEvent.toTypedEvent(e, MessageStartEventSubscriptionRecord.class)));
+    }
+
+    @Override
     public void close() {
       if (currentController != null && currentController.isOpened()) {
         currentStreamProcessorService.close();

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/DeploymentCreatedProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/DeploymentCreatedProcessorTest.java
@@ -21,7 +21,9 @@ import static io.zeebe.test.util.TestUtil.waitUntil;
 import static io.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.zeebe.broker.logstreams.processor.TypedRecord;
 import io.zeebe.broker.logstreams.state.ZeebeState;
+import io.zeebe.broker.subscription.message.data.MessageStartEventSubscriptionRecord;
 import io.zeebe.broker.util.StreamProcessorControl;
 import io.zeebe.broker.util.StreamProcessorRule;
 import io.zeebe.broker.workflow.processor.deployment.DeploymentCreatedProcessor;
@@ -35,14 +37,15 @@ import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.impl.record.value.deployment.ResourceType;
 import io.zeebe.protocol.intent.DeploymentIntent;
 import io.zeebe.protocol.intent.MessageStartEventSubscriptionIntent;
+import io.zeebe.util.buffer.BufferUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class DeploymentCreatedProcessorTest {
-
   public static final String PROCESS_ID = "process";
   public static final String RESOURCE_ID = "process.bpmn";
+  public static final String MESSAGE_NAME = "msg";
 
   @Rule
   public StreamProcessorRule rule = new StreamProcessorRule(Protocol.DEPLOYMENT_PARTITION + 1);
@@ -110,6 +113,102 @@ public class DeploymentCreatedProcessorTest {
         .isEqualTo(MessageStartEventSubscriptionIntent.OPEN);
   }
 
+  @Test
+  public void shouldCloseSubscriptionWhenInCorrectOrder() {
+    // given
+    streamProcessor.start();
+
+    // when
+    writeMessageStartRecord(3, 1);
+    writeNoneStartRecord(7, 2);
+
+    // then
+    waitUntil(() -> rule.events().onlyMessageStartEventSubscriptionRecords().count() == 2);
+
+    final TypedRecord<MessageStartEventSubscriptionRecord> closeRecord =
+        rule.events()
+            .onlyMessageStartEventSubscriptionRecords()
+            .withIntent(MessageStartEventSubscriptionIntent.CLOSE)
+            .getFirst();
+
+    assertThat(closeRecord.getValue().getWorkflowKey()).isEqualTo(3);
+  }
+
+  @Test
+  public void shouldIgnoreOutdatedDeployment() {
+    // given
+    streamProcessor.start();
+
+    // when
+    streamProcessor.blockAfterMessageStartEventSubscriptionRecord(
+        r ->
+            r.getValue().getWorkflowKey() == 5
+                && r.getMetadata().getIntent() == MessageStartEventSubscriptionIntent.OPEN);
+    writeMessageStartRecord(5, 2);
+    waitUntil(() -> streamProcessor.isBlocked());
+
+    streamProcessor.blockAfterDeploymentEvent(
+        r -> r.getKey() == 3 && r.getMetadata().getIntent() == DeploymentIntent.CREATED);
+    writeMessageStartRecord(3, 1);
+    streamProcessor.unblock();
+    waitUntil(() -> streamProcessor.isBlocked());
+
+    // then
+    assertThat(
+            rule.getZeebeState()
+                .getWorkflowState()
+                .getLatestWorkflowVersionByProcessId(BufferUtil.wrapString(PROCESS_ID))
+                .getVersion())
+        .isEqualTo(2);
+    assertThat(
+            rule.events()
+                .onlyMessageStartEventSubscriptionRecords()
+                .withIntent(MessageStartEventSubscriptionIntent.OPEN)
+                .count())
+        .isEqualTo(1);
+    assertThat(
+            rule.events()
+                .onlyMessageStartEventSubscriptionRecords()
+                .withIntent(MessageStartEventSubscriptionIntent.CLOSE))
+        .isNullOrEmpty();
+  }
+
+  @Test
+  public void shouldCloseSubscriptionEvenIfNotNextVersion() {
+    // given
+    streamProcessor.start();
+
+    // when
+    streamProcessor.blockAfterMessageStartEventSubscriptionRecord(
+        r ->
+            r.getValue().getWorkflowKey() == 3
+                && r.getMetadata().getIntent() == MessageStartEventSubscriptionIntent.OPEN);
+    writeMessageStartRecord(3, 1);
+    waitUntil(() -> streamProcessor.isBlocked());
+
+    streamProcessor.blockAfterMessageStartEventSubscriptionRecord(
+        r ->
+            r.getValue().getWorkflowKey() == 3
+                && r.getMetadata().getIntent() == MessageStartEventSubscriptionIntent.CLOSE);
+    writeNoneStartRecord(7, 3);
+    streamProcessor.unblock();
+    waitUntil(() -> streamProcessor.isBlocked());
+
+    streamProcessor.blockAfterDeploymentEvent(
+        r -> r.getKey() == 5 && r.getMetadata().getIntent() == DeploymentIntent.CREATED);
+    writeMessageStartRecord(5, 2);
+    streamProcessor.unblock();
+    waitUntil(() -> streamProcessor.isBlocked());
+
+    // then
+    assertThat(
+            rule.events()
+                .onlyMessageStartEventSubscriptionRecords()
+                .withIntent(MessageStartEventSubscriptionIntent.CLOSE)
+                .count())
+        .isEqualTo(1);
+  }
+
   private void writeNoneStartRecord(final long key, final int version) {
     writeNoneStartRecord(PROCESS_ID, RESOURCE_ID, key, version);
   }
@@ -136,7 +235,11 @@ public class DeploymentCreatedProcessorTest {
   private static DeploymentRecord createMessageStartDeploymentRecord(
       final String processId, final String resourceId, final long key, final int version) {
     final BpmnModelInstance modelInstance =
-        Bpmn.createExecutableProcess(processId).startEvent().message("msg").endEvent().done();
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .message(MESSAGE_NAME)
+            .endEvent()
+            .done();
     return createDeploymentRecord(modelInstance, processId, resourceId, key, version);
   }
 


### PR DESCRIPTION
I decided not to go with the approach of ensuring that the deployments are always distributed in order because the tests were being more time-consuming to write than what I initially thought. Instead, this PR makes the DeploymentCreatedProcessor resilient to reordered deployments and also introduces some minor improvements (e.g., reused objects, etc). With these changes, outdated deployments are ignored and new deployments close any subscriptions in effect (even if they're not from the previous version). The WorkflowState was always updating the latest workflow even if the version number was smaller than the one stored. I'm not sure if this was intended but I didn't see anything that depended on that behavior so I added a check to only update if the version increases. 

closes #2288 
