### PR TITLE
chore(logstreams): make number of snapshots configurable

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/partitions/PartitionInstallService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/partitions/PartitionInstallService.java
@@ -112,6 +112,7 @@ public class PartitionInstallService implements Service<Void>, RaftStateListener
             .logDirectory(logDirectoryPath)
             .logName(logName)
             .indexStateStorage(stateStorage)
+            .maxSnapshots(brokerCfg.getData().getMaxSnapshots())
             .buildWith(partitionInstall);
 
     final StateStorageFactoryService stateStorageFactoryService =

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/LogStreamsComponent.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/LogStreamsComponent.java
@@ -45,8 +45,10 @@ public class LogStreamsComponent implements Component {
 
     final Duration snapshotPeriod =
         DurationUtil.parse(brokerConfiguration.getData().getSnapshotPeriod());
+    final int maxSnapshots = brokerConfiguration.getData().getMaxSnapshots();
+
     final StreamProcessorServiceFactory streamProcessorFactory =
-        new StreamProcessorServiceFactory(serviceContainer, snapshotPeriod);
+        new StreamProcessorServiceFactory(serviceContainer, snapshotPeriod, maxSnapshots);
     serviceContainer
         .createService(STREAM_PROCESSOR_SERVICE_FACTORY, streamProcessorFactory)
         .install();

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/StreamProcessorServiceFactory.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/StreamProcessorServiceFactory.java
@@ -42,11 +42,14 @@ import java.util.List;
 public class StreamProcessorServiceFactory implements Service<StreamProcessorServiceFactory> {
   private final ServiceContainer serviceContainer;
   private final Duration snapshotPeriod;
+  private final int maxSnapshots;
   private ActorScheduler actorScheduler;
 
-  public StreamProcessorServiceFactory(ServiceContainer serviceContainer, Duration snapshotPeriod) {
+  public StreamProcessorServiceFactory(
+      ServiceContainer serviceContainer, Duration snapshotPeriod, int maxSnapshots) {
     this.serviceContainer = serviceContainer;
     this.snapshotPeriod = snapshotPeriod;
+    this.maxSnapshots = maxSnapshots;
   }
 
   @Override
@@ -122,6 +125,7 @@ public class StreamProcessorServiceFactory implements Service<StreamProcessorSer
           .serviceContainer(serviceContainer)
           .snapshotController(snapshotController)
           .snapshotPeriod(snapshotPeriod)
+          .maxSnapshots(maxSnapshots)
           .logStream(logStream)
           .eventFilter(eventFilter)
           .readOnly(readOnly)

--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -33,6 +33,8 @@ public class DataCfg implements ConfigurationEntry {
 
   private String snapshotReplicationPeriod = "5m";
 
+  private int maxSnapshots = 1;
+
   @Override
   public void init(BrokerCfg globalConfig, String brokerBase, Environment environment) {
     applyEnvironment(environment);
@@ -75,6 +77,14 @@ public class DataCfg implements ConfigurationEntry {
     this.snapshotReplicationPeriod = snapshotReplicationPeriod;
   }
 
+  public void setMaxSnapshots(final int maxSnapshots) {
+    this.maxSnapshots = maxSnapshots;
+  }
+
+  public int getMaxSnapshots() {
+    return maxSnapshots;
+  }
+
   @Override
   public String toString() {
     return "DataCfg{"
@@ -88,6 +98,9 @@ public class DataCfg implements ConfigurationEntry {
         + '\''
         + ", snapshotReplicationPeriod='"
         + snapshotReplicationPeriod
+        + '\''
+        + ", maxSnapshots='"
+        + maxSnapshots
         + '\''
         + '}';
   }

--- a/dist/src/main/config/zeebe.cfg.toml
+++ b/dist/src/main/config/zeebe.cfg.toml
@@ -189,6 +189,10 @@
 # How often we take snapshots of streams (time unit)
 # snapshotPeriod = "15m"
 
+# The maximum number of snapshots kept (must be a positive integer). When this 
+# limit is passed the oldest snapshot is deleted.
+# maxSnapshots = "1"
+#
 # How often follower partitions will check for new snapshots to replicate from
 # the leader partitions. Snapshot replication enables faster failover by
 # reducing how many log entries must be reprocessed in case of leader change.

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/LogBlockIndexWriter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/LogBlockIndexWriter.java
@@ -93,6 +93,7 @@ public class LogBlockIndexWriter extends Actor {
 
   private final Duration snapshotInterval;
   private long snapshotEventPosition = -1;
+  private final int maxSnapshots;
 
   private Metric snapshotsCreated;
 
@@ -112,6 +113,7 @@ public class LogBlockIndexWriter extends Actor {
     this.deviation = builder.getDeviation();
     this.indexBlockSize = (int) (builder.getIndexBlockSize() * (1f - deviation));
     this.snapshotInterval = builder.getSnapshotPeriod();
+    this.maxSnapshots = builder.getMaxSnapshots();
     this.bufferSize = builder.getReadBlockSize();
 
     this.allocatedBuffer = BufferAllocators.allocateDirect(bufferSize);
@@ -278,7 +280,7 @@ public class LogBlockIndexWriter extends Actor {
         logStorage.flush();
 
         snapshotEventPosition = lastBlockEventPosition;
-        blockIndex.writeSnapshot(snapshotEventPosition);
+        blockIndex.writeSnapshot(snapshotEventPosition, maxSnapshots);
 
         LOG.trace("Created snapshot of block index {}.", name);
         snapshotsCreated.incrementOrdered();

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/LogStreamBuilder.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/LogStreamBuilder.java
@@ -62,6 +62,7 @@ public class LogStreamBuilder {
   protected int indexBlockSize = 1024 * 1024 * 4;
   protected float deviation = LogBlockIndexWriter.DEFAULT_DEVIATION;
   protected int readBlockSize = 1024;
+  protected int maxSnapshots = 1;
 
   protected Duration snapshotPeriod = Duration.ofMinutes(1);
 
@@ -140,6 +141,11 @@ public class LogStreamBuilder {
     return this;
   }
 
+  public LogStreamBuilder maxSnapshots(final int maxSnapshots) {
+    this.maxSnapshots = maxSnapshots;
+    return this;
+  }
+
   public LogStreamBuilder readBlockSize(final int readBlockSize) {
     this.readBlockSize = readBlockSize;
     return this;
@@ -184,6 +190,10 @@ public class LogStreamBuilder {
 
   public StateStorage getStateStorage() {
     return stateStorage;
+  }
+
+  public int getMaxSnapshots() {
+    return maxSnapshots;
   }
 
   public float getDeviation() {

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogBlockIndexService.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogBlockIndexService.java
@@ -21,6 +21,7 @@ import io.zeebe.db.ZeebeDbFactory;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.zeebe.logstreams.impl.log.index.LogBlockColumnFamilies;
 import io.zeebe.logstreams.impl.log.index.LogBlockIndex;
+import io.zeebe.logstreams.state.StateSnapshotController;
 import io.zeebe.logstreams.state.StateStorage;
 import io.zeebe.servicecontainer.Service;
 import io.zeebe.servicecontainer.ServiceStartContext;
@@ -38,8 +39,10 @@ public class LogBlockIndexService implements Service<LogBlockIndex> {
   public void start(ServiceStartContext startContext) {
     final ZeebeDbFactory<LogBlockColumnFamilies> dbFactory =
         ZeebeRocksDbFactory.newFactory(LogBlockColumnFamilies.class);
+    final StateSnapshotController snapshotController =
+        new StateSnapshotController(dbFactory, stateStorage);
 
-    logBlockIndex = new LogBlockIndex(dbFactory, stateStorage);
+    logBlockIndex = new LogBlockIndex(snapshotController);
   }
 
   @Override

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorBuilder.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorBuilder.java
@@ -54,6 +54,7 @@ public class StreamProcessorBuilder {
   protected ServiceContainer serviceContainer;
   private List<ServiceName<?>> additionalDependencies;
   private StreamProcessorFactory streamProcessorFactory;
+  private int maxSnapshots;
 
   public StreamProcessorBuilder(int id, String name) {
     this.id = id;
@@ -84,6 +85,11 @@ public class StreamProcessorBuilder {
 
   public StreamProcessorBuilder snapshotPeriod(Duration snapshotPeriod) {
     this.snapshotPeriod = snapshotPeriod;
+    return this;
+  }
+
+  public StreamProcessorBuilder maxSnapshots(int maxSnapshots) {
+    this.maxSnapshots = maxSnapshots;
     return this;
   }
 
@@ -161,6 +167,7 @@ public class StreamProcessorBuilder {
     }
 
     ctx.setSnapshotPeriod(snapshotPeriod);
+    ctx.setMaxSnapshots(maxSnapshots);
     ctx.setSnapshotController(snapshotController);
 
     logStreamReader = new BufferedLogStreamReader();

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorContext.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorContext.java
@@ -44,6 +44,7 @@ public class StreamProcessorContext {
 
   private Runnable suspendRunnable;
   private Runnable resumeRunnable;
+  private int maxSnapshots;
 
   public LogStream getLogStream() {
     return logStream;
@@ -165,5 +166,13 @@ public class StreamProcessorContext {
 
   public StreamProcessorFactory getStreamProcessorFactory() {
     return streamProcessorFactory;
+  }
+
+  public void setMaxSnapshots(final int maxSnapshots) {
+    this.maxSnapshots = maxSnapshots;
+  }
+
+  public int getMaxSnapshots() {
+    return maxSnapshots;
   }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
@@ -62,6 +62,7 @@ public class StreamProcessorController extends Actor {
   private DbContext dbContext;
   private ProcessingStateMachine processingStateMachine;
   private AsyncSnapshotDirector asyncSnapshotDirector;
+  private final int maxSnapshots;
 
   public StreamProcessorController(final StreamProcessorContext context) {
     this.streamProcessorContext = context;
@@ -77,6 +78,7 @@ public class StreamProcessorController extends Actor {
 
     this.logStreamReader = context.getLogStreamReader();
     this.logStreamWriter = context.getLogStreamWriter();
+    this.maxSnapshots = context.getMaxSnapshots();
   }
 
   @Override
@@ -196,7 +198,8 @@ public class StreamProcessorController extends Actor {
             logStream::registerOnCommitPositionUpdatedCondition,
             logStream::removeOnCommitPositionUpdatedCondition,
             logStream::getCommitPosition,
-            metrics);
+            metrics,
+            maxSnapshots);
 
     actorScheduler.submitActor(asyncSnapshotDirector);
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/StateSnapshotController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/StateSnapshotController.java
@@ -36,7 +36,7 @@ public class StateSnapshotController implements SnapshotController {
   private ZeebeDb db;
 
   public StateSnapshotController(final ZeebeDbFactory rocksDbFactory, final StateStorage storage) {
-    zeebeDbFactory = rocksDbFactory;
+    this.zeebeDbFactory = rocksDbFactory;
     this.storage = storage;
   }
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogBlockIndexTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogBlockIndexTest.java
@@ -22,6 +22,7 @@ import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.zeebe.logstreams.impl.log.index.LogBlockColumnFamilies;
 import io.zeebe.logstreams.impl.log.index.LogBlockIndex;
 import io.zeebe.logstreams.impl.log.index.LogBlockIndexContext;
+import io.zeebe.logstreams.state.StateSnapshotController;
 import io.zeebe.logstreams.state.StateStorage;
 import org.junit.After;
 import org.junit.Before;
@@ -53,11 +54,11 @@ public class LogBlockIndexTest {
   private void startBlockIndexDb() {
     final ZeebeDbFactory<LogBlockColumnFamilies> dbFactory =
         ZeebeRocksDbFactory.newFactory(LogBlockColumnFamilies.class);
-
     final StateStorage stateStorage =
         new StateStorage(runtimeDirectory.getRoot(), snapshotDirectory.getRoot());
+    final StateSnapshotController controller = new StateSnapshotController(dbFactory, stateStorage);
 
-    blockIndex = new LogBlockIndex(dbFactory, stateStorage);
+    blockIndex = new LogBlockIndex(controller);
     indexContext = blockIndex.createLogBlockIndexContext();
   }
 
@@ -219,7 +220,7 @@ public class LogBlockIndexTest {
     // given
     final int numBlocks = 10;
     final long snapshotPosition = addBlocks(numBlocks);
-    blockIndex.writeSnapshot(snapshotPosition);
+    blockIndex.writeSnapshot(snapshotPosition, 1);
 
     // when
     blockIndex.closeDb(); // close and reopen DB

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/AsyncSnapshotingTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/AsyncSnapshotingTest.java
@@ -45,8 +45,9 @@ import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 public class AsyncSnapshotingTest {
-
   private static final long TIMEOUT = 2_000L;
+  private static final int MAX_SNAPSHOTS = 3;
+
   private final TemporaryFolder tempFolderRule = new TemporaryFolder();
   private final AutoCloseableRule autoCloseableRule = new AutoCloseableRule();
   private final LogStreamRule logStreamRule = new LogStreamRule(tempFolderRule);
@@ -95,7 +96,8 @@ public class AsyncSnapshotingTest {
             actorCondition -> logStream.registerOnCommitPositionUpdatedCondition(actorCondition),
             actorCondition -> logStream.removeOnCommitPositionUpdatedCondition(actorCondition),
             () -> logStream.getCommitPosition(),
-            mock(StreamProcessorMetrics.class));
+            mock(StreamProcessorMetrics.class),
+            MAX_SNAPSHOTS);
     actorScheduler.submitActor(asyncSnapshotDirector).join();
   }
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
@@ -72,6 +72,7 @@ public class StreamProcessorControllerTest {
   private static final String PROCESSOR_NAME = "testProcessor";
   private static final int PROCESSOR_ID = 1;
   private static final Duration SNAPSHOT_INTERVAL = Duration.ofMinutes(1);
+  private static final int MAX_SNAPSHOTS = 3;
 
   private static final DirectBuffer EVENT_1 = wrapString("FOO");
   private static final DirectBuffer EVENT_2 = wrapString("BAR");
@@ -782,6 +783,7 @@ public class StreamProcessorControllerTest {
             .eventFilter(eventFilter)
             .serviceContainer(logStreamRule.getServiceContainer())
             .snapshotController(snapshotController)
+            .maxSnapshots(MAX_SNAPSHOTS)
             .streamProcessorFactory(this::createStreamProcessor)
             .snapshotPeriod(SNAPSHOT_INTERVAL)
             .build()

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.CompactionPriority;
 import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
@@ -103,10 +104,8 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
   }
 
   private static ColumnFamilyOptions createColumnFamilyOptions() {
-
     // Options which are used on all column families
-    final ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();
-
-    return columnFamilyOptions;
+    return new ColumnFamilyOptions()
+        .setCompactionPriority(CompactionPriority.OldestSmallestSeqFirst);
   }
 }


### PR DESCRIPTION
I opted for the "OldestSmallestSeqFirst" compaction priority which compacts files whose range hasn't been compacted in the longest time. This seems to fit our use case because it deletes and merges old SST files. Since in Zeebe the most recent keys are the "hotter" ones (e.g., keys from new instances, timers, messages, etc), it makes sense to compact SST files with the most stable key ranges. In my small local tests, this strategy seemed to provide the best results in terms of space efficiency. 

closes #2296, closes #2303 
