### PR TITLE
chore(logstreams): fix race condition

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/index/LogBlockIndex.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/index/LogBlockIndex.java
@@ -145,11 +145,11 @@ public class LogBlockIndex {
       throw new IllegalArgumentException(errorMessage);
     }
 
-    lastVirtualPosition = blockPosition;
     final DbLong dbBlockPosition = indexContext.writeKeyInstance(blockPosition);
     final DbLong dbBlockAddress = indexContext.writeValueInstance(blockAddress);
 
     indexColumnFamily.put(indexContext.getDbContext(), dbBlockPosition, dbBlockAddress);
+    lastVirtualPosition = blockPosition;
   }
 
   /**


### PR DESCRIPTION
 * last position was updated before the state was changed
 * the tests assumed that if they see the position change the state has the change as well
   here we had a race condition


closes #2282 
