### PR TITLE
chore(logstreams): add snapshot replication

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/Loggers.java
+++ b/broker-core/src/main/java/io/zeebe/broker/Loggers.java
@@ -25,9 +25,10 @@ public class Loggers {
   public static final Logger SERVICES_LOGGER = new ZbLogger("io.zeebe.broker.services");
   public static final Logger SYSTEM_LOGGER = new ZbLogger("io.zeebe.broker.system");
   public static final Logger TRANSPORT_LOGGER = new ZbLogger("io.zeebe.broker.transport");
-  public static final Logger STREAM_PROCESSING = new ZbLogger("io.zeebe.broker.streamProcessing");
+  public static final Logger STREAM_PROCESSING = new ZbLogger("io.zeebe.logstreams");
   public static final Logger WORKFLOW_REPOSITORY_LOGGER =
       new ZbLogger("io.zeebe.broker.workflow.repository");
+
   public static final Logger EXPORTER_LOGGER = new ZbLogger("io.zeebe.broker.exporter");
   public static final Logger WORKFLOW_PROCESSOR_LOGGER = new ZbLogger("io.zeebe.broker.workflow");
 }

--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/gossip/AtomixService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/gossip/AtomixService.java
@@ -158,7 +158,7 @@ public class AtomixService implements Service<Atomix> {
 
           final Node node =
               Node.builder().withAddress(Address.from(address[0], memberPort)).build();
-          LOG.info("Member {} will contact node: {}", localMemberId, node.address());
+          LOG.debug("Member {} will contact node: {}", localMemberId, node.address());
           nodes.add(node);
         });
     return builder.withNodes(nodes).build();

--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/partitions/BootstrapPartitions.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/partitions/BootstrapPartitions.java
@@ -26,7 +26,6 @@ import io.atomix.primitive.partition.Partition;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.protocols.raft.partition.RaftPartitionGroup;
 import io.zeebe.broker.system.configuration.BrokerCfg;
-import io.zeebe.broker.system.configuration.ClusterCfg;
 import io.zeebe.distributedlog.StorageConfiguration;
 import io.zeebe.distributedlog.StorageConfigurationManager;
 import io.zeebe.servicecontainer.Injector;
@@ -54,7 +53,6 @@ public class BootstrapPartitions implements Service<Void> {
 
   public BootstrapPartitions(final BrokerCfg brokerCfg) {
     this.brokerCfg = brokerCfg;
-    final ClusterCfg cluster = brokerCfg.getCluster();
   }
 
   @Override
@@ -103,7 +101,7 @@ public class BootstrapPartitions implements Service<Void> {
         partitionInstallServiceName(partitionName);
 
     final PartitionInstallService partitionInstallService =
-        new PartitionInstallService(configuration);
+        new PartitionInstallService(atomix.getEventService(), configuration);
 
     startContext.createService(partitionInstallServiceName, partitionInstallService).install();
   }

--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/TopologyManagerImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/TopologyManagerImpl.java
@@ -107,7 +107,7 @@ public class TopologyManagerImpl extends Actor
   @Override
   public void event(ClusterMembershipEvent clusterMembershipEvent) {
     final Member eventSource = clusterMembershipEvent.subject();
-    LOG.info(
+    LOG.debug(
         "Member {} received event {}", topology.getLocal().getNodeId(), clusterMembershipEvent);
     final BrokerInfo brokerInfo = readBrokerInfo(eventSource);
 

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/ExporterManagerService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/ExporterManagerService.java
@@ -26,12 +26,9 @@ import io.zeebe.broker.exporter.stream.ExporterColumnFamilies;
 import io.zeebe.broker.exporter.stream.ExporterStreamProcessor;
 import io.zeebe.broker.exporter.stream.ExporterStreamProcessorState;
 import io.zeebe.broker.logstreams.processor.StreamProcessorServiceFactory;
-import io.zeebe.broker.logstreams.state.DefaultZeebeDbFactory;
 import io.zeebe.broker.system.configuration.ExporterCfg;
 import io.zeebe.db.ZeebeDb;
 import io.zeebe.logstreams.spi.SnapshotController;
-import io.zeebe.logstreams.state.StateSnapshotController;
-import io.zeebe.logstreams.state.StateStorage;
 import io.zeebe.servicecontainer.Injector;
 import io.zeebe.servicecontainer.Service;
 import io.zeebe.servicecontainer.ServiceGroupReference;
@@ -82,12 +79,7 @@ public class ExporterManagerService implements Service<ExporterManagerService> {
   }
 
   private void startExporter(ServiceName<Partition> partitionName, Partition partition) {
-    final StateStorage stateStorage =
-        partition.getStateStorageFactory().create(EXPORTER_PROCESSOR_ID, PROCESSOR_NAME);
-
-    final SnapshotController snapshotController =
-        new StateSnapshotController(
-            DefaultZeebeDbFactory.defaultFactory(ExporterColumnFamilies.class), stateStorage);
+    final SnapshotController snapshotController = partition.getExporterSnapshotController();
 
     if (exporterRepository.getExporters().isEmpty()) {
       clearExporterState(snapshotController);

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/LogStreamsComponent.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/LogStreamsComponent.java
@@ -23,8 +23,6 @@ import static io.zeebe.broker.clustering.base.ClusterBaseLayerServiceNames.TOPOL
 import static io.zeebe.broker.logstreams.LogStreamServiceNames.STREAM_PROCESSOR_SERVICE_FACTORY;
 import static io.zeebe.broker.logstreams.LogStreamServiceNames.ZB_STREAM_PROCESSOR_SERVICE_NAME;
 import static io.zeebe.broker.transport.TransportServiceNames.CLIENT_API_SERVER_NAME;
-import static io.zeebe.broker.transport.TransportServiceNames.MANAGEMENT_API_CLIENT_NAME;
-import static io.zeebe.broker.transport.TransportServiceNames.clientTransport;
 import static io.zeebe.broker.transport.TransportServiceNames.serverTransport;
 
 import io.zeebe.broker.logstreams.processor.StreamProcessorServiceFactory;
@@ -60,9 +58,6 @@ public class LogStreamsComponent implements Component {
             serverTransport(CLIENT_API_SERVER_NAME),
             streamProcessorService.getClientApiTransportInjector())
         .dependency(TOPOLOGY_MANAGER_SERVICE, streamProcessorService.getTopologyManagerInjector())
-        .dependency(
-            clientTransport(MANAGEMENT_API_CLIENT_NAME),
-            streamProcessorService.getManagementApiClientInjector())
         .dependency(
             STREAM_PROCESSOR_SERVICE_FACTORY,
             streamProcessorService.getStreamProcessorServiceFactoryInjector())

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/state/SnapshotChunkImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/state/SnapshotChunkImpl.java
@@ -1,0 +1,126 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.logstreams.state;
+
+import static io.zeebe.clustering.management.SnapshotChunkDecoder.snapshotPositionNullValue;
+import static io.zeebe.clustering.management.SnapshotChunkDecoder.totalCountNullValue;
+import static io.zeebe.clustering.management.SnapshotChunkEncoder.chunkNameHeaderLength;
+import static io.zeebe.clustering.management.SnapshotChunkEncoder.contentHeaderLength;
+
+import io.zeebe.broker.util.SbeBufferWriterReader;
+import io.zeebe.clustering.management.SnapshotChunkDecoder;
+import io.zeebe.clustering.management.SnapshotChunkEncoder;
+import io.zeebe.logstreams.processor.SnapshotChunk;
+import io.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public class SnapshotChunkImpl
+    extends SbeBufferWriterReader<SnapshotChunkEncoder, SnapshotChunkDecoder>
+    implements SnapshotChunk {
+
+  private final SnapshotChunkEncoder encoder = new SnapshotChunkEncoder();
+  private final SnapshotChunkDecoder decoder = new SnapshotChunkDecoder();
+
+  private long snapshotPosition;
+  private int totalCount;
+  private String chunkName;
+
+  private final DirectBuffer content = new UnsafeBuffer(0, 0);
+
+  public SnapshotChunkImpl() {}
+
+  public SnapshotChunkImpl(SnapshotChunk chunk) {
+    snapshotPosition = chunk.getSnapshotPosition();
+    totalCount = chunk.getTotalCount();
+    chunkName = chunk.getChunkName();
+    content.wrap(chunk.getContent());
+  }
+
+  @Override
+  public int getLength() {
+    return super.getLength()
+        + chunkNameHeaderLength()
+        + chunkName.length()
+        + contentHeaderLength()
+        + content.capacity();
+  }
+
+  @Override
+  protected SnapshotChunkEncoder getBodyEncoder() {
+    return encoder;
+  }
+
+  @Override
+  protected SnapshotChunkDecoder getBodyDecoder() {
+    return decoder;
+  }
+
+  @Override
+  public void write(MutableDirectBuffer buffer, int offset) {
+    super.write(buffer, offset);
+
+    encoder
+        .snapshotPosition(snapshotPosition)
+        .totalCount(totalCount)
+        .chunkName(chunkName)
+        .putContent(content, 0, content.capacity());
+  }
+
+  @Override
+  public void wrap(DirectBuffer buffer, int offset, int length) {
+    super.wrap(buffer, offset, length);
+
+    snapshotPosition = decoder.snapshotPosition();
+    totalCount = decoder.totalCount();
+    chunkName = decoder.chunkName();
+    decoder.wrapContent(content);
+  }
+
+  @Override
+  public void reset() {
+    super.reset();
+
+    snapshotPosition = snapshotPositionNullValue();
+    totalCount = totalCountNullValue();
+
+    chunkName = "";
+    content.wrap(0, 0);
+  }
+
+  @Override
+  public long getSnapshotPosition() {
+    return snapshotPosition;
+  }
+
+  @Override
+  public int getTotalCount() {
+    return totalCount;
+  }
+
+  @Override
+  public String getChunkName() {
+    return chunkName;
+  }
+
+  @Override
+  public byte[] getContent() {
+    return BufferUtil.bufferAsArray(content);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/state/StateReplication.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/state/StateReplication.java
@@ -1,0 +1,92 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.logstreams.state;
+
+import static io.zeebe.broker.Loggers.STREAM_PROCESSING;
+
+import io.atomix.cluster.messaging.ClusterEventService;
+import io.zeebe.logstreams.processor.SnapshotChunk;
+import io.zeebe.logstreams.processor.SnapshotReplication;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.slf4j.Logger;
+
+public class StateReplication implements SnapshotReplication {
+
+  public static final String REPLICATION_TOPIC_FORMAT = "replication-%d-%s";
+  private static final Logger LOG = STREAM_PROCESSING;
+
+  private final String replicationTopic;
+
+  private final DirectBuffer readBuffer = new UnsafeBuffer(0, 0);
+  private final ClusterEventService eventService;
+  private ExecutorService executorService;
+
+  public StateReplication(ClusterEventService eventService, int partitionId, String name) {
+    this.eventService = eventService;
+    this.replicationTopic = String.format(REPLICATION_TOPIC_FORMAT, partitionId, name);
+  }
+
+  @Override
+  public void replicate(SnapshotChunk snapshot) {
+    eventService.broadcast(
+        replicationTopic,
+        snapshot,
+        (s) -> {
+          LOG.debug(
+              "Replicate on topic {} snapshot chunk {} for snapshot pos {}.",
+              replicationTopic,
+              s.getChunkName(),
+              s.getSnapshotPosition());
+
+          final SnapshotChunkImpl chunkImpl = new SnapshotChunkImpl(s);
+          return chunkImpl.toBytes();
+        });
+  }
+
+  @Override
+  public void consume(Consumer<SnapshotChunk> consumer) {
+    executorService = Executors.newSingleThreadExecutor((r) -> new Thread(r, replicationTopic));
+    eventService.subscribe(
+        replicationTopic,
+        (bytes -> {
+          readBuffer.wrap(bytes);
+          final SnapshotChunkImpl chunk = new SnapshotChunkImpl();
+          chunk.wrap(readBuffer, 0, bytes.length);
+          LOG.debug(
+              "Received on topic {} replicated snapshot chunk {} for snapshot pos {}.",
+              replicationTopic,
+              chunk.getChunkName(),
+              chunk.getSnapshotPosition());
+          return chunk;
+        }),
+        consumer,
+        executorService);
+  }
+
+  @Override
+  public void close() {
+    if (executorService != null) {
+      executorService.shutdownNow();
+      executorService = null;
+    }
+  }
+}

--- a/broker-core/src/main/resources/log4j2.xml
+++ b/broker-core/src/main/resources/log4j2.xml
@@ -3,12 +3,14 @@
 
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout
+        pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n"/>
     </Console>
   </Appenders>
 
   <Loggers>
     <Logger name="io.zeebe" level="debug"/>
+    <Logger name="io.atomix" level="warn"/>
 
     <Root level="info">
       <AppenderRef ref="Console"/>

--- a/broker-core/src/main/resources/management-schema.xml
+++ b/broker-core/src/main/resources/management-schema.xml
@@ -19,7 +19,7 @@
     </composite>
 
     <composite name="blob">
-      <type name="length" primitiveType="uint32" maxValue="524288"/>
+      <type name="length" primitiveType="uint32" maxValue="2147483647"/>
       <type name="varData" primitiveType="uint8" length="0"/>
     </composite>
 
@@ -53,6 +53,13 @@
   <sbe:message name="PushDeploymentResponse" id="14">
     <field name="partitionId" id="0" type="uint16"/>
     <field name="deploymentKey" id="1" type="uint64"/>
+  </sbe:message>
+
+  <sbe:message name="SnapshotChunk" id="15">
+    <field name="snapshotPosition" id="0" type="uint64"/>
+    <field name="totalCount" id="1" type="int32"/>
+    <data name="chunkName" id="2" type="varDataEncoding"/>
+    <data name="content" id="3" type="blob"/>
   </sbe:message>
 
 </sbe:messageSchema>

--- a/broker-core/src/test/java/io/zeebe/broker/transport/clientapi/ClientApiMessageHandlerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/transport/clientapi/ClientApiMessageHandlerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
+import io.atomix.cluster.messaging.ClusterEventService;
 import io.zeebe.broker.clustering.base.partitions.Partition;
 import io.zeebe.broker.clustering.base.partitions.RaftState;
 import io.zeebe.distributedlog.DistributedLogstreamService;
@@ -185,7 +186,7 @@ public class ClientApiMessageHandlerTest {
     messageHandler = new ClientApiMessageHandler();
 
     final Partition partition =
-        new Partition(LOG_STREAM_PARTITION_ID, RaftState.LEADER) {
+        new Partition(mock(ClusterEventService.class), LOG_STREAM_PARTITION_ID, RaftState.LEADER) {
           @Override
           public LogStream getLogStream() {
             return logStream;

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
@@ -60,7 +60,7 @@ public class BrokerTopologyManagerImpl extends Actor
     final Member subject = event.subject();
     final Type eventType = event.type();
     final BrokerInfo brokerInfo = BrokerInfo.fromProperties(subject.properties());
-    LOG.info("Got membership event {}", brokerInfo);
+    LOG.debug("Got membership event {}", brokerInfo);
 
     if (brokerInfo != null) {
       actor.call(

--- a/logstreams/src/main/java/io/zeebe/distributedlog/impl/DistributedLogstreamPartition.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/impl/DistributedLogstreamPartition.java
@@ -94,7 +94,10 @@ public class DistributedLogstreamPartition implements Service<DistributedLogstre
         .whenComplete(
             (r, error) -> {
               if (error == null) {
-                LOG.info("Claimed leadership successfully");
+                LOG.info(
+                    "Node {} claimed leadership for partition {} successfully",
+                    memberId,
+                    partitionId);
                 startFuture.complete(null);
               } else {
                 startFuture.completeExceptionally(error);

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/SnapshotChunk.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/SnapshotChunk.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.processor;
+
+public interface SnapshotChunk {
+
+  /** @return the lower bound snapshot position, identifies the corresponding snapshot */
+  long getSnapshotPosition();
+
+  /** @return the total count of snapshot chunks, which correspond to the same snapshot */
+  int getTotalCount();
+
+  /** @return the name of the current chunk (e.g. file name) */
+  String getChunkName();
+
+  /** @return the content of the current chunk */
+  byte[] getContent();
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/SnapshotReplication.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/SnapshotReplication.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.processor;
+
+import java.util.function.Consumer;
+
+public interface SnapshotReplication {
+
+  /**
+   * Replicates the given snapshot chunk.
+   *
+   * @param snapshot the chunk to replicate
+   */
+  void replicate(SnapshotChunk snapshot);
+
+  /**
+   * Registers an consumer, which should be called when an snapshot chunk was received.
+   *
+   * @param consumer the consumer which should be called
+   */
+  void consume(Consumer<SnapshotChunk> consumer);
+
+  /** Closes the snapshot replication. */
+  void close();
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/spi/SnapshotController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/spi/SnapshotController.java
@@ -17,6 +17,7 @@ package io.zeebe.logstreams.spi;
 
 import io.zeebe.db.ZeebeDb;
 import java.io.IOException;
+import java.util.function.Consumer;
 
 public interface SnapshotController extends AutoCloseable {
   /**
@@ -38,6 +39,18 @@ public interface SnapshotController extends AutoCloseable {
    * @throws IOException thrown if moving the snapshot fails
    */
   void moveValidSnapshot(long lowerBoundSnapshotPosition) throws IOException;
+
+  /**
+   * Replicates the latest valid snapshot. The given executor is called for each snapshot chunk in
+   * the latest snapshot. The executor should execute/run the given Runnable in a specific
+   * environment (e.g. ActorThread).
+   *
+   * @param executor executor which executed the given Runnable
+   */
+  void replicateLatestSnapshot(Consumer<Runnable> executor);
+
+  /** Registers to consumes replicated snapshots. */
+  void consumeReplicatedSnapshots();
 
   /**
    * Recovers the state from the latest snapshot and returns the lower bound snapshot position.

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/NoneSnapshotReplication.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/NoneSnapshotReplication.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.state;
+
+import io.zeebe.logstreams.processor.SnapshotChunk;
+import io.zeebe.logstreams.processor.SnapshotReplication;
+import java.util.function.Consumer;
+
+public class NoneSnapshotReplication implements SnapshotReplication {
+
+  @Override
+  public void replicate(SnapshotChunk snapshot) {}
+
+  @Override
+  public void consume(Consumer<SnapshotChunk> consumer) {}
+
+  @Override
+  public void close() {}
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/StateStorage.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/StateStorage.java
@@ -61,6 +61,12 @@ public class StateStorage {
     return snapshotsDirectory;
   }
 
+  public File getTmpSnapshotDirectoryFor(String position) {
+    final String path = String.format("%s-%s", position, TEMP_SNAPSHOT_DIRECTORY);
+
+    return new File(snapshotsDirectory, path);
+  }
+
   public File getSnapshotDirectoryFor(long position) {
     final String path = String.format("%d", position);
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
@@ -96,9 +96,9 @@ public class StreamProcessorControllerTest {
 
   private ZeebeDb zeebeDb;
   private DbContext dbContext;
-  private StateStorage stateStorage;
   private ActorFuture<Void> openedFuture;
   private CountDownLatch processorCreated;
+  private StateStorage stateStorage;
 
   @Before
   public void setup() throws Exception {

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/ReplicateSnapshotControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/ReplicateSnapshotControllerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.zeebe.db.impl.DefaultColumnFamily;
+import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.zeebe.logstreams.processor.SnapshotChunk;
+import io.zeebe.logstreams.processor.SnapshotReplication;
+import io.zeebe.logstreams.util.RocksDBWrapper;
+import io.zeebe.test.util.AutoCloseableRule;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ReplicateSnapshotControllerTest {
+
+  private static final int VALUE = 0xCAFE;
+  private static final String KEY = "test";
+
+  @Rule public TemporaryFolder tempFolderRule = new TemporaryFolder();
+  @Rule public AutoCloseableRule autoCloseableRule = new AutoCloseableRule();
+
+  private StateSnapshotController replicatorSnapshotController;
+  private StateSnapshotController receiverSnapshotController;
+  private Replicator replicator;
+
+  @Before
+  public void setup() throws IOException {
+    final File runtimeDirectory = tempFolderRule.newFolder("runtime");
+    final File snapshotsDirectory = tempFolderRule.newFolder("snapshots");
+    final StateStorage storage = new StateStorage(runtimeDirectory, snapshotsDirectory);
+
+    final File receiverRuntimeDirectory = tempFolderRule.newFolder("runtime-receiver");
+    final File receiverSnapshotsDirectory = tempFolderRule.newFolder("snapshots-receiver");
+    final StateStorage receiverStorage =
+        new StateStorage(receiverRuntimeDirectory, receiverSnapshotsDirectory);
+
+    replicator = new Replicator();
+    replicatorSnapshotController =
+        new StateSnapshotController(
+            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class), storage, replicator);
+    receiverSnapshotController =
+        new StateSnapshotController(
+            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class), receiverStorage, replicator);
+
+    autoCloseableRule.manage(replicatorSnapshotController);
+    autoCloseableRule.manage(receiverSnapshotController);
+
+    final RocksDBWrapper wrapper = new RocksDBWrapper();
+    wrapper.wrap(replicatorSnapshotController.openDb());
+    wrapper.putInt(KEY, VALUE);
+  }
+
+  @Test
+  public void shouldReplicateSnapshotChunks() {
+    // given
+    replicatorSnapshotController.takeSnapshot(1);
+
+    // when
+    replicatorSnapshotController.replicateLatestSnapshot(Runnable::run);
+
+    // then
+    final List<SnapshotChunk> replicatedChunks = replicator.replicatedChunks;
+    final int totalCount = replicatedChunks.size();
+    assertThat(totalCount).isGreaterThan(0);
+
+    final SnapshotChunk firstChunk = replicatedChunks.get(0);
+    final int chunkTotalCount = firstChunk.getTotalCount();
+    assertThat(totalCount).isEqualTo(chunkTotalCount);
+
+    assertThat(replicatedChunks)
+        .extracting(SnapshotChunk::getSnapshotPosition, SnapshotChunk::getTotalCount)
+        .containsOnly(tuple(1L, totalCount));
+  }
+
+  @Test
+  public void shouldNotReplicateWithoutSnapshot() {
+    // given
+
+    // when
+    replicatorSnapshotController.replicateLatestSnapshot(Runnable::run);
+
+    // then
+    final List<SnapshotChunk> replicatedChunks = replicator.replicatedChunks;
+    final int totalCount = replicatedChunks.size();
+    assertThat(totalCount).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldReceiveSnapshotChunks() throws Exception {
+    // given
+    receiverSnapshotController.consumeReplicatedSnapshots();
+    replicatorSnapshotController.takeSnapshot(1);
+
+    // when
+    replicatorSnapshotController.replicateLatestSnapshot(Runnable::run);
+
+    // then
+    final RocksDBWrapper wrapper = new RocksDBWrapper();
+    final long recoveredSnapshot = receiverSnapshotController.recover();
+    assertThat(recoveredSnapshot).isEqualTo(1);
+
+    wrapper.wrap(receiverSnapshotController.openDb());
+    final int valueFromSnapshot = wrapper.getInt(KEY);
+    assertThat(valueFromSnapshot).isEqualTo(VALUE);
+  }
+
+  @Test
+  public void shouldNotFailOnReplicatingAndReceivingTwice() throws Exception {
+    // given
+    receiverSnapshotController.consumeReplicatedSnapshots();
+    replicatorSnapshotController.takeSnapshot(1);
+    replicatorSnapshotController.replicateLatestSnapshot(Runnable::run);
+
+    // when
+    replicatorSnapshotController.replicateLatestSnapshot(Runnable::run);
+
+    // then
+    final RocksDBWrapper wrapper = new RocksDBWrapper();
+    final long recoveredSnapshot = receiverSnapshotController.recover();
+    assertThat(recoveredSnapshot).isEqualTo(1);
+
+    wrapper.wrap(receiverSnapshotController.openDb());
+    final int valueFromSnapshot = wrapper.getInt(KEY);
+    assertThat(valueFromSnapshot).isEqualTo(VALUE);
+  }
+
+  private final class Replicator implements SnapshotReplication {
+
+    final List<SnapshotChunk> replicatedChunks = new ArrayList<>();
+    private Consumer<SnapshotChunk> chunkConsumer;
+
+    @Override
+    public void replicate(SnapshotChunk snapshot) {
+      replicatedChunks.add(snapshot);
+      if (chunkConsumer != null) {
+        chunkConsumer.accept(snapshot);
+      }
+    }
+
+    @Override
+    public void consume(Consumer<SnapshotChunk> consumer) {
+      chunkConsumer = consumer;
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.broker.it.clustering;
+
+import static io.zeebe.test.util.TestUtil.waitUntil;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.Broker;
+import io.zeebe.broker.Loggers;
+import io.zeebe.broker.it.GrpcClientRule;
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.Adler32;
+import java.util.zip.CheckedInputStream;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
+
+public class SnapshotReplicationTest {
+
+  private static final int PARTITION_COUNT = 1;
+
+  private static final BpmnModelInstance WORKFLOW =
+      Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
+
+  public ClusteringRule clusteringRule =
+      new ClusteringRule(
+          PARTITION_COUNT,
+          3,
+          3,
+          brokerCfg -> {
+            brokerCfg.getData().setSnapshotPeriod("1s");
+          });
+  public GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
+
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(clusteringRule).around(clientRule);
+
+  @Rule public ExpectedException expectedException = ExpectedException.none();
+
+  private ZeebeClient client;
+
+  @Before
+  public void init() {
+    client = clientRule.getClient();
+  }
+
+  @Test
+  public void shouldReplicateSnapshots() throws Exception {
+    // given
+    client.newDeployCommand().addWorkflowModel(WORKFLOW, "workflow.bpmn").send().join();
+    final int leaderNodeId = clusteringRule.getLeaderForPartition(1).getNodeId();
+    final Broker leader = clusteringRule.getBroker(leaderNodeId);
+
+    // when - snapshot
+    waitForValidSnapshotAtBroker(leader);
+
+    final List<Broker> otherBrokers = clusteringRule.getOtherBrokerObjects(leaderNodeId);
+    for (Broker broker : otherBrokers) {
+      waitForValidSnapshotAtBroker(broker);
+    }
+
+    // then - replicated
+    final Collection<Broker> brokers = clusteringRule.getBrokers();
+    final Map<Integer, Map<String, Long>> brokerSnapshotChecksums = new HashMap<>();
+    for (Broker broker : brokers) {
+      final Map<String, Long> checksums = createSnapshotDirectoryChecksums(broker);
+      brokerSnapshotChecksums.put(broker.getConfig().getCluster().getNodeId(), checksums);
+    }
+
+    final Map<String, Long> checksumFirstNode = brokerSnapshotChecksums.get(0);
+    assertThat(checksumFirstNode).isEqualTo(brokerSnapshotChecksums.get(1));
+    assertThat(checksumFirstNode).isEqualTo(brokerSnapshotChecksums.get(2));
+  }
+
+  private File getSnapshotsDirectory(Broker broker) {
+    final String dataDir = broker.getConfig().getData().getDirectories().get(0);
+    return new File(dataDir, "partition-1/state/1_zb-stream-processor/snapshots");
+  }
+
+  private void waitForValidSnapshotAtBroker(Broker broker) {
+    final File snapshotsDir = getSnapshotsDirectory(broker);
+
+    waitUntil(
+        () -> Arrays.stream(snapshotsDir.listFiles()).anyMatch(f -> !f.getName().contains("tmp")));
+  }
+
+  private Map<String, Long> createSnapshotDirectoryChecksums(Broker broker) throws Exception {
+    final File snapshotsDir = getSnapshotsDirectory(broker);
+
+    final Map<String, Long> checksums = createChecksumsForSnapshotDirectory(snapshotsDir);
+
+    assertThat(checksums.size()).isGreaterThan(0);
+    return checksums;
+  }
+
+  private Map<String, Long> createChecksumsForSnapshotDirectory(File snapshotDirectory) {
+    final Map<String, Long> checksums = new HashMap<>();
+    final File[] snapshotDirs = snapshotDirectory.listFiles();
+    if (snapshotDirs != null) {
+      Arrays.stream(snapshotDirs)
+          .filter(f -> !f.getName().contains("tmp"))
+          .forEach(
+              validSnapshotDir -> {
+                final File[] snapshotFiles = validSnapshotDir.listFiles();
+                if (snapshotFiles != null) {
+                  for (File snapshotFile : snapshotFiles) {
+                    final long checksum = createCheckSumForFile(snapshotFile);
+
+                    Loggers.STREAM_PROCESSING.debug(
+                        "Created checksum {} for file {}", checksum, snapshotFile);
+                    checksums.put(snapshotFile.getName(), checksum);
+                  }
+                }
+              });
+    }
+
+    return checksums;
+  }
+
+  private long createCheckSumForFile(File snapshotFile) {
+    try (CheckedInputStream checkedInputStream =
+        new CheckedInputStream(Files.newInputStream(snapshotFile.toPath()), new Adler32())) {
+      while (checkedInputStream.skip(512) > 0) {}
+
+      return checkedInputStream.getChecksum().getValue();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/qa/integration-tests/src/test/resources/log4j2-test.xml
+++ b/qa/integration-tests/src/test/resources/log4j2-test.xml
@@ -3,14 +3,14 @@
 
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout
+        pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n"/>
     </Console>
   </Appenders>
 
   <Loggers>
     <Logger name="io.zeebe" level="info"/>
-    <Logger name="io.atomix" level="info"/>
-    <!--<Logger name="io.zeebe.raft" level="debug"/>-->
+    <Logger name="io.atomix" level="warn"/>
 
     <Root level="info">
       <AppenderRef ref="Console"/>


### PR DESCRIPTION
 * snapshort director calls snapshot replication after snapshot is
 marked as valid
 * snapshot controller replicates chunks of snapshots
 * snapshot controller can also consume replicated snapshot chunks
 * implementation of snapshot replication is done in broker via atomix
 pub-sub mechanics


closes #2344 
