### PR TITLE
chore(logstreams): fix sigsegv

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/index/LogBlockIndex.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/index/LogBlockIndex.java
@@ -70,6 +70,7 @@ public class LogBlockIndex {
     if (zeebeDb != null) {
       stateSnapshotController.close();
       zeebeDb = null;
+      indexColumnFamily = null;
     }
   }
 


### PR DESCRIPTION
### TL;DR:

  * reduce starting phase time on StreamProcessorController
   this causes problems on closing the service/actor

----

Problem was that the starting phase (`#onActorStarting`) from the `StreamProcessorController` takes quite a bit of time and the `StreamProcessorService#start` uses `startContext#async` to start the controller.
This means the `StreamProcessorService` is successfully installed when the `#onActorStarting` of the `StreamProcessorController` is completed. 

Some tests have a short execution time, which means the `StreamProcessorService` is not completely installed  when `broker#close` is called. This also means that the `#stop` method is not called of the `StreamProcessorService`, since the installation is not yet done. So it will access resources like the LogBlockIndex even if they already closed.

One way to solve this is to mark the service interruptable, but this solves only one problem. The next problem is that we can't interrupt actor jobs, which means if the actor is submitted it will execute `actor#onActorStarting`, even if the `actor#close` is called in the meantime. The actor can only interrupted between the phase callbacks. That is the reason why I moved the snapshot recovery into the `#onActorStarted` method. There is also no real reason why it was in the `#onActorStarting` callback. 

**So keep in mind**: `onActorStarting` only for setup code like assign fields etc. 


closes #2369 
closes #2324 
