### PR TITLE
fix(msgpack): Fix for wrapping values that are at edge of buffer capacity and has zero-length

### DIFF
--- a/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgPackToken.java
+++ b/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgPackToken.java
@@ -62,7 +62,17 @@ public class MsgPackToken {
   }
 
   public void setValue(DirectBuffer buffer, int offset, int length) {
-    this.valueBuffer.wrap(buffer, offset, length);
+    if (length == 0) {
+      valueBuffer.wrap(0, 0);
+    } else if (offset + length <= buffer.capacity()) {
+      this.valueBuffer.wrap(buffer, offset, length);
+    } else {
+      final int result = offset + length;
+      throw new MsgpackReaderException(
+          String.format(
+              "Reading %d bytes past buffer capacity(%d) in range [%d:%d]",
+              result - buffer.capacity(), buffer.capacity(), offset, result));
+    }
   }
 
   public void setValue(double value) {

--- a/msgpack-core/src/test/java/io/zeebe/msgpack/spec/MsgPackReadTokenTest.java
+++ b/msgpack-core/src/test/java/io/zeebe/msgpack/spec/MsgPackReadTokenTest.java
@@ -218,7 +218,13 @@ public class MsgPackReadTokenTest {
             given((b) -> b.add(0xe0)),
             INTEGER,
             doAssert((t) -> assertThat(t.getIntegerValue()).isEqualTo(-32))
-          }
+          },
+          {
+            "zero length fixstr",
+            given((b) -> b.add(0xa0)),
+            STRING,
+            doAssert((t) -> assertThatBuffer(t.getValueBuffer()).hasCapacity(0))
+          },
         });
   }
 

--- a/msgpack-core/src/test/java/io/zeebe/msgpack/spec/MsgPackReadingTest.java
+++ b/msgpack-core/src/test/java/io/zeebe/msgpack/spec/MsgPackReadingTest.java
@@ -188,7 +188,12 @@ public class MsgPackReadingTest {
             "negative fixint",
             given((b) -> b.add(0xe0)),
             doAssert((r) -> assertThat(r.readInteger()).isEqualTo(-32))
-          }
+          },
+          {
+            "zero length fixstr",
+            given((b) -> b.add(0xa0)),
+            doAssert((r) -> assertThat(r.readStringLength()).isEqualTo(0))
+          },
         });
   }
 


### PR DESCRIPTION
Fixes edge-case, when wrapped value offset is equal to buffer capacity, but length is zero, so no error should be thrown.

The critical part is not to ask buffer of anything >= capacity(), which throws, even when length is zero, use some dummy zero-length buffer to wrap instead.

closes #2371 