### PR TITLE
chore(logstreams): add checksums to the snapshot chunks

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/partitions/BootstrapPartitions.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/partitions/BootstrapPartitions.java
@@ -101,7 +101,7 @@ public class BootstrapPartitions implements Service<Void> {
         partitionInstallServiceName(partitionName);
 
     final PartitionInstallService partitionInstallService =
-        new PartitionInstallService(atomix.getEventService(), configuration);
+        new PartitionInstallService(atomix.getEventService(), configuration, brokerCfg);
 
     startContext.createService(partitionInstallServiceName, partitionInstallService).install();
   }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/state/SnapshotChunkImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/state/SnapshotChunkImpl.java
@@ -17,6 +17,7 @@
  */
 package io.zeebe.broker.logstreams.state;
 
+import static io.zeebe.clustering.management.SnapshotChunkDecoder.checksumNullValue;
 import static io.zeebe.clustering.management.SnapshotChunkDecoder.snapshotPositionNullValue;
 import static io.zeebe.clustering.management.SnapshotChunkDecoder.totalCountNullValue;
 import static io.zeebe.clustering.management.SnapshotChunkEncoder.chunkNameHeaderLength;
@@ -41,6 +42,7 @@ public class SnapshotChunkImpl
   private long snapshotPosition;
   private int totalCount;
   private String chunkName;
+  private long checksum;
 
   private final DirectBuffer content = new UnsafeBuffer(0, 0);
 
@@ -50,6 +52,7 @@ public class SnapshotChunkImpl
     snapshotPosition = chunk.getSnapshotPosition();
     totalCount = chunk.getTotalCount();
     chunkName = chunk.getChunkName();
+    checksum = chunk.getChecksum();
     content.wrap(chunk.getContent());
   }
 
@@ -80,6 +83,7 @@ public class SnapshotChunkImpl
         .snapshotPosition(snapshotPosition)
         .totalCount(totalCount)
         .chunkName(chunkName)
+        .checksum(checksum)
         .putContent(content, 0, content.capacity());
   }
 
@@ -90,6 +94,7 @@ public class SnapshotChunkImpl
     snapshotPosition = decoder.snapshotPosition();
     totalCount = decoder.totalCount();
     chunkName = decoder.chunkName();
+    checksum = decoder.checksum();
     decoder.wrapContent(content);
   }
 
@@ -99,6 +104,7 @@ public class SnapshotChunkImpl
 
     snapshotPosition = snapshotPositionNullValue();
     totalCount = totalCountNullValue();
+    checksum = checksumNullValue();
 
     chunkName = "";
     content.wrap(0, 0);
@@ -117,6 +123,11 @@ public class SnapshotChunkImpl
   @Override
   public String getChunkName() {
     return chunkName;
+  }
+
+  @Override
+  public long getChecksum() {
+    return checksum;
   }
 
   @Override

--- a/broker-core/src/main/resources/management-schema.xml
+++ b/broker-core/src/main/resources/management-schema.xml
@@ -58,8 +58,9 @@
   <sbe:message name="SnapshotChunk" id="15">
     <field name="snapshotPosition" id="0" type="uint64"/>
     <field name="totalCount" id="1" type="int32"/>
-    <data name="chunkName" id="2" type="varDataEncoding"/>
-    <data name="content" id="3" type="blob"/>
+    <field name="checksum" id="2" type="uint64"/>
+    <data name="chunkName" id="3" type="varDataEncoding"/>
+    <data name="content" id="4" type="blob"/>
   </sbe:message>
 
 </sbe:messageSchema>

--- a/broker-core/src/test/java/io/zeebe/broker/transport/clientapi/ClientApiMessageHandlerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/transport/clientapi/ClientApiMessageHandlerTest.java
@@ -186,7 +186,8 @@ public class ClientApiMessageHandlerTest {
     messageHandler = new ClientApiMessageHandler();
 
     final Partition partition =
-        new Partition(mock(ClusterEventService.class), LOG_STREAM_PARTITION_ID, RaftState.LEADER) {
+        new Partition(
+            null, mock(ClusterEventService.class), LOG_STREAM_PARTITION_ID, RaftState.LEADER) {
           @Override
           public LogStream getLogStream() {
             return logStream;

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/SnapshotChunk.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/SnapshotChunk.java
@@ -26,6 +26,9 @@ public interface SnapshotChunk {
   /** @return the name of the current chunk (e.g. file name) */
   String getChunkName();
 
+  /** @return the checksum of the content, can be use to verify the integrity of the content */
+  long getChecksum();
+
   /** @return the content of the current chunk */
   byte[] getContent();
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/ReplicationController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/ReplicationController.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.state;
+
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+
+import io.zeebe.logstreams.impl.Loggers;
+import io.zeebe.logstreams.processor.SnapshotChunk;
+import io.zeebe.logstreams.processor.SnapshotReplication;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.zip.CRC32;
+import org.agrona.collections.Long2LongHashMap;
+import org.slf4j.Logger;
+
+final class ReplicationController {
+
+  private static final Logger LOG = Loggers.SNAPSHOT_LOGGER;
+
+  private static final long START_VALUE = 0L;
+  private static final long INVALID_SNAPSHOT = -1;
+  private static final long MISSING_SNAPSHOT = Long.MIN_VALUE;
+
+  private final SnapshotReplication replication;
+  private final Long2LongHashMap receivedSnapshots = new Long2LongHashMap(MISSING_SNAPSHOT);
+  private final StateStorage storage;
+  private final Runnable ensureMaxSnapshotCount;
+
+  ReplicationController(
+      SnapshotReplication replication, StateStorage storage, Runnable ensureMaxSnapshotCount) {
+    this.replication = replication;
+    this.storage = storage;
+    this.ensureMaxSnapshotCount = ensureMaxSnapshotCount;
+  }
+
+  private static long createChecksum(byte[] content) {
+    final CRC32 crc32 = new CRC32();
+    crc32.update(content);
+    return crc32.getValue();
+  }
+
+  public void replicate(long snapshotPosition, int totalCount, File snapshotChunkFile) {
+    try {
+      final byte[] content = Files.readAllBytes(snapshotChunkFile.toPath());
+      final long checksum = createChecksum(content);
+
+      replication.replicate(
+          new SnapshotChunkImpl(
+              snapshotPosition, totalCount, snapshotChunkFile.getName(), checksum, content));
+    } catch (IOException ioe) {
+      LOG.error(
+          "Unexpected error on reading snapshot chunk from file '{}'.", snapshotChunkFile, ioe);
+    }
+  }
+
+  /** Registering for consuming snapshot chunks. */
+  public void consumeReplicatedSnapshots() {
+    replication.consume((this::consumeSnapshotChunk));
+  }
+
+  /**
+   * This is called by the snapshot replication implementation on each snapshot chunk
+   *
+   * @param snapshotChunk the chunk to consume
+   */
+  private void consumeSnapshotChunk(SnapshotChunk snapshotChunk) {
+    final long snapshotPosition = snapshotChunk.getSnapshotPosition();
+    final String snapshotName = Long.toString(snapshotPosition);
+    final String chunkName = snapshotChunk.getChunkName();
+
+    if (storage.existSnapshot(snapshotPosition)) {
+      LOG.debug("Ignore snapshot chunk {}, snapshot {} already exist.", chunkName, snapshotName);
+      return;
+    }
+
+    final long snapshotCounter =
+        receivedSnapshots.computeIfAbsent(snapshotPosition, k -> START_VALUE);
+    if (snapshotCounter == INVALID_SNAPSHOT) {
+      LOG.debug(
+          "Ignore snapshot chunk {}, because snapshot {} is marked as invalid.",
+          chunkName,
+          snapshotName);
+      return;
+    }
+
+    final long expectedChecksum = snapshotChunk.getChecksum();
+    final long actualChecksum = createChecksum(snapshotChunk.getContent());
+
+    if (expectedChecksum != actualChecksum) {
+      markSnapshotAsInvalid(snapshotChunk);
+      LOG.warn(
+          "Expected to have checksum {} for snapshot chunk file {} ({}), but calculated {}",
+          expectedChecksum,
+          chunkName,
+          snapshotName,
+          actualChecksum);
+      return;
+    }
+
+    final File tmpSnapshotDirectory = storage.getTmpSnapshotDirectoryFor(snapshotName);
+    if (!tmpSnapshotDirectory.exists()) {
+      tmpSnapshotDirectory.mkdirs();
+    }
+
+    final File snapshotFile = new File(tmpSnapshotDirectory, chunkName);
+    if (snapshotFile.exists()) {
+      LOG.debug("Received a snapshot file which already exist '{}'.", snapshotFile);
+      return;
+    }
+
+    LOG.debug("Consume snapshot chunk {}", chunkName);
+    writeReceivedSnapshotChunk(snapshotChunk, tmpSnapshotDirectory, snapshotFile);
+  }
+
+  private void writeReceivedSnapshotChunk(
+      SnapshotChunk snapshotChunk, File tmpSnapshotDirectory, File snapshotFile) {
+    try {
+      Files.write(
+          snapshotFile.toPath(), snapshotChunk.getContent(), CREATE_NEW, StandardOpenOption.WRITE);
+      LOG.debug("Wrote replicated snapshot chunk to file {}", snapshotFile.toPath());
+
+      validateWhenReceivedAllChunks(snapshotChunk, tmpSnapshotDirectory);
+    } catch (IOException ioe) {
+      markSnapshotAsInvalid(snapshotChunk);
+      LOG.error(
+          "Unexpected error occurred on writing an snapshot chunk to '{}'.", snapshotFile, ioe);
+    }
+  }
+
+  private void markSnapshotAsInvalid(SnapshotChunk chunk) {
+    receivedSnapshots.put(chunk.getSnapshotPosition(), INVALID_SNAPSHOT);
+  }
+
+  private void validateWhenReceivedAllChunks(
+      SnapshotChunk snapshotChunk, File tmpSnapshotDirectory) {
+    final int totalChunkCount = snapshotChunk.getTotalCount();
+    final long currentChunks = incrementAndGetChunkCount(snapshotChunk);
+
+    if (currentChunks == totalChunkCount) {
+      final File validSnapshotDirectory =
+          storage.getSnapshotDirectoryFor(snapshotChunk.getSnapshotPosition());
+      LOG.debug(
+          "Received all snapshot chunks ({}/{}), snapshot is valid. Move to {}",
+          currentChunks,
+          totalChunkCount,
+          validSnapshotDirectory.toPath());
+      tryToMarkSnapshotAsValid(snapshotChunk, tmpSnapshotDirectory, validSnapshotDirectory);
+    } else {
+      LOG.debug(
+          "Waiting for more snapshot chunks, currently have {}/{}.",
+          currentChunks,
+          totalChunkCount);
+    }
+  }
+
+  private long incrementAndGetChunkCount(SnapshotChunk snapshotChunk) {
+    final long snapshotPosition = snapshotChunk.getSnapshotPosition();
+    final long oldCount = receivedSnapshots.get(snapshotPosition);
+    final long newCount = oldCount + 1;
+    receivedSnapshots.put(snapshotPosition, newCount);
+    return newCount;
+  }
+
+  private void tryToMarkSnapshotAsValid(
+      SnapshotChunk snapshotChunk, File tmpSnapshotDirectory, File validSnapshotDirectory) {
+    try {
+      Files.move(tmpSnapshotDirectory.toPath(), validSnapshotDirectory.toPath());
+      receivedSnapshots.remove(snapshotChunk.getSnapshotPosition());
+
+      ensureMaxSnapshotCount.run();
+    } catch (IOException ioe) {
+      markSnapshotAsInvalid(snapshotChunk);
+      LOG.error(
+          "Unexpected error occurred on moving replicated snapshot from '{}'.",
+          tmpSnapshotDirectory.toPath(),
+          ioe);
+    }
+  }
+
+  private final class SnapshotChunkImpl implements SnapshotChunk {
+    private final long snapshotPosition;
+    private final int totalCount;
+    private final String chunkName;
+    private final byte[] content;
+    private final long checksum;
+
+    SnapshotChunkImpl(
+        long snapshotPosition, int totalCount, String chunkName, long checksum, byte[] content) {
+      this.snapshotPosition = snapshotPosition;
+      this.totalCount = totalCount;
+      this.chunkName = chunkName;
+      this.checksum = checksum;
+      this.content = content;
+    }
+
+    public long getSnapshotPosition() {
+      return snapshotPosition;
+    }
+
+    @Override
+    public String getChunkName() {
+      return chunkName;
+    }
+
+    @Override
+    public int getTotalCount() {
+      return totalCount;
+    }
+
+    public long getChecksum() {
+      return checksum;
+    }
+
+    public byte[] getContent() {
+      return content;
+    }
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/StateStorage.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/StateStorage.java
@@ -18,6 +18,7 @@ package io.zeebe.logstreams.state;
 import io.zeebe.logstreams.impl.Loggers;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -65,6 +66,15 @@ public class StateStorage {
     final String path = String.format("%s-%s", position, TEMP_SNAPSHOT_DIRECTORY);
 
     return new File(snapshotsDirectory, path);
+  }
+
+  public boolean existSnapshot(long snapshotPosition) {
+    final File[] files = snapshotsDirectory.listFiles();
+    if (files != null && files.length > 0) {
+      final String snapshotDirName = Long.toString(snapshotPosition);
+      return Arrays.stream(files).anyMatch(f -> f.getName().equalsIgnoreCase(snapshotDirName));
+    }
+    return false;
   }
 
   public File getSnapshotDirectoryFor(long position) {

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/FailingSnapshotChunkReplicationTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/FailingSnapshotChunkReplicationTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.db.impl.DefaultColumnFamily;
+import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.zeebe.logstreams.processor.SnapshotChunk;
+import io.zeebe.logstreams.processor.SnapshotReplication;
+import io.zeebe.test.util.AutoCloseableRule;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class FailingSnapshotChunkReplicationTest {
+
+  @Rule public TemporaryFolder tempFolderRule = new TemporaryFolder();
+  @Rule public AutoCloseableRule autoCloseableRule = new AutoCloseableRule();
+
+  private StateSnapshotController replicatorSnapshotController;
+  private StateSnapshotController receiverSnapshotController;
+  private StateStorage receiverStorage;
+
+  public void setup(SnapshotReplication replicator) throws IOException {
+    final File runtimeDirectory = tempFolderRule.newFolder("runtime");
+    final File snapshotsDirectory = tempFolderRule.newFolder("snapshots");
+    final StateStorage storage = new StateStorage(runtimeDirectory, snapshotsDirectory);
+
+    final File receiverRuntimeDirectory = tempFolderRule.newFolder("runtime-receiver");
+    final File receiverSnapshotsDirectory = tempFolderRule.newFolder("snapshots-receiver");
+    receiverStorage = new StateStorage(receiverRuntimeDirectory, receiverSnapshotsDirectory);
+
+    replicatorSnapshotController =
+        new StateSnapshotController(
+            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class), storage, replicator, 1);
+    receiverSnapshotController =
+        new StateSnapshotController(
+            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class),
+            receiverStorage,
+            replicator,
+            1);
+
+    autoCloseableRule.manage(replicatorSnapshotController);
+    autoCloseableRule.manage(receiverSnapshotController);
+    replicatorSnapshotController.openDb();
+  }
+
+  @Test
+  public void shouldNotWriteChunksAfterReceivingInvalidChunk() throws Exception {
+    // given
+    final EvilReplicator replicator = new EvilReplicator();
+    setup(replicator);
+
+    receiverSnapshotController.consumeReplicatedSnapshots();
+    replicatorSnapshotController.takeSnapshot(1);
+
+    // when
+    replicatorSnapshotController.replicateLatestSnapshot(Runnable::run);
+
+    // then
+    final List<SnapshotChunk> replicatedChunks = replicator.replicatedChunks;
+    assertThat(replicatedChunks.size()).isGreaterThan(0);
+
+    final File snapshotDirectory = receiverStorage.getTmpSnapshotDirectoryFor("1");
+    assertThat(snapshotDirectory).exists();
+
+    final File[] files = snapshotDirectory.listFiles();
+    assertThat(files).hasSize(1);
+    assertThat(files[0].getName()).isEqualTo(replicatedChunks.get(0).getChunkName());
+
+    assertThat(receiverStorage.existSnapshot(1)).isFalse();
+  }
+
+  @Test
+  public void shouldNotMarkSnapshotAsValidIfNotReceivedAllChunks() throws Exception {
+    // given
+    final FlakyReplicator replicator = new FlakyReplicator();
+    setup(replicator);
+
+    receiverSnapshotController.consumeReplicatedSnapshots();
+    replicatorSnapshotController.takeSnapshot(1);
+
+    // when
+    replicatorSnapshotController.replicateLatestSnapshot(Runnable::run);
+
+    // then
+    final List<SnapshotChunk> replicatedChunks = replicator.replicatedChunks;
+    assertThat(replicatedChunks.size()).isGreaterThan(0);
+
+    final File snapshotDirectory = receiverStorage.getTmpSnapshotDirectoryFor("1");
+    assertThat(snapshotDirectory).exists();
+    final File[] files = snapshotDirectory.listFiles();
+    assertThat(files)
+        .extracting(File::getName)
+        .containsExactlyInAnyOrder(
+            replicatedChunks.subList(0, 2).stream()
+                .map(SnapshotChunk::getChunkName)
+                .toArray(String[]::new));
+    assertThat(receiverStorage.existSnapshot(1)).isFalse();
+  }
+
+  private final class FlakyReplicator implements SnapshotReplication {
+
+    final List<SnapshotChunk> replicatedChunks = new ArrayList<>();
+    private Consumer<SnapshotChunk> chunkConsumer;
+
+    @Override
+    public void replicate(SnapshotChunk snapshot) {
+      replicatedChunks.add(snapshot);
+      if (chunkConsumer != null) {
+        if (replicatedChunks.size() < 3) {
+          chunkConsumer.accept(snapshot);
+        }
+      }
+    }
+
+    @Override
+    public void consume(Consumer<SnapshotChunk> consumer) {
+      chunkConsumer = consumer;
+    }
+
+    @Override
+    public void close() {}
+  }
+
+  private final class EvilReplicator implements SnapshotReplication {
+
+    final List<SnapshotChunk> replicatedChunks = new ArrayList<>();
+    private Consumer<SnapshotChunk> chunkConsumer;
+
+    @Override
+    public void replicate(SnapshotChunk snapshot) {
+      replicatedChunks.add(snapshot);
+      if (chunkConsumer != null) {
+        chunkConsumer.accept(
+            replicatedChunks.size() > 1 ? new DisruptedSnapshotChunk(snapshot) : snapshot);
+      }
+    }
+
+    @Override
+    public void consume(Consumer<SnapshotChunk> consumer) {
+      chunkConsumer = consumer;
+    }
+
+    @Override
+    public void close() {}
+  }
+
+  private final class DisruptedSnapshotChunk implements SnapshotChunk {
+    private final SnapshotChunk snapshotChunk;
+
+    DisruptedSnapshotChunk(SnapshotChunk snapshotChunk) {
+      this.snapshotChunk = snapshotChunk;
+    }
+
+    @Override
+    public long getSnapshotPosition() {
+      return snapshotChunk.getSnapshotPosition();
+    }
+
+    @Override
+    public int getTotalCount() {
+      return snapshotChunk.getTotalCount();
+    }
+
+    @Override
+    public String getChunkName() {
+      return snapshotChunk.getChunkName();
+    }
+
+    @Override
+    public long getChecksum() {
+      return 0;
+    }
+
+    @Override
+    public byte[] getContent() {
+      return snapshotChunk.getContent();
+    }
+  }
+}

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.zip.Adler32;
+import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
 import org.junit.Before;
 import org.junit.Rule;
@@ -143,7 +143,7 @@ public class SnapshotReplicationTest {
 
   private long createCheckSumForFile(File snapshotFile) {
     try (CheckedInputStream checkedInputStream =
-        new CheckedInputStream(Files.newInputStream(snapshotFile.toPath()), new Adler32())) {
+        new CheckedInputStream(Files.newInputStream(snapshotFile.toPath()), new CRC32())) {
       while (checkedInputStream.skip(512) > 0) {}
 
       return checkedInputStream.getChecksum().getValue();


### PR DESCRIPTION
* checksums are created before the chunk is replicated
 * checksum is validated on receiving chunk
 * if sum is not equal we will mark this snapshot as invalid
 * we count the received chunks with a in mem map
 * we ensure max snapshot count after marking snapshot as valid 

closes #2345
closes #2378

follow up issue https://github.com/zeebe-io/zeebe/issues/2387