### PR TITLE
chore(broker-core): fix flaky DeploymentProcessor test

### DIFF
--- a/broker-core/src/test/java/io/zeebe/broker/util/LogStreamPrinter.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/LogStreamPrinter.java
@@ -114,6 +114,8 @@ public class LogStreamPrinter {
   private static void writeRecordHeader(final LoggedEvent event, final StringBuilder sb) {
     sb.append("Position: ");
     sb.append(event.getPosition());
+    sb.append(" Key: ");
+    sb.append(event.getKey());
   }
 
   private static void writeWorkflowInstanceBody(

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/DeploymentCreatedProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/DeploymentCreatedProcessorTest.java
@@ -120,6 +120,8 @@ public class DeploymentCreatedProcessorTest {
 
     // when
     writeMessageStartRecord(3, 1);
+    waitUntil(
+        () -> rule.events().onlyDeploymentRecords().withIntent(DeploymentIntent.CREATED).exists());
     writeNoneStartRecord(7, 2);
 
     // then


### PR DESCRIPTION
* fix race condition in test
 * it could happen that deployment CREATE event was directly processed
   after another - this means state was updated and on CREATED no
   subscription was opened since already a new deployment with not
   subscription was deployed


closes #2392