### PR TITLE
chore(logstreams): wait for deletion

### DIFF
--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
@@ -421,11 +421,11 @@ public class StreamProcessorControllerTest {
     }
 
     // then
-    verify(snapshotController, timeout(5000).times(5)).moveValidSnapshot(anyLong());
-    verify(snapshotController, timeout(5000).times(5)).ensureMaxSnapshotCount(3);
+    verify(snapshotController, timeout(5000).atLeast(4)).moveValidSnapshot(anyLong());
+    verify(snapshotController, timeout(5000).atLeast(4)).ensureMaxSnapshotCount(3);
 
+    waitUntil(() -> stateStorage.list().size() == 3);
     assertThat(stateStorage.listByPositionAsc()).hasSize(3);
-    assertThat(stateStorage.list()).hasSize(3);
   }
 
   @Test


### PR DESCRIPTION
* Files.delete is not atomic and this means the main threads can see the file even if it is already deleted


closes #2396