### PR TITLE
chore(logstreams): remove orphaned tmp snapshots

### DIFF
--- a/logstreams/src/test/java/io/zeebe/logstreams/state/ReplicateSnapshotControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/ReplicateSnapshotControllerTest.java
@@ -195,7 +195,7 @@ public class ReplicateSnapshotControllerTest {
     assertThat(receiverStorage.existSnapshot(2)).isTrue();
   }
 
-  private final class Replicator implements SnapshotReplication {
+  protected static final class Replicator implements SnapshotReplication {
 
     final List<SnapshotChunk> replicatedChunks = new ArrayList<>();
     private Consumer<SnapshotChunk> chunkConsumer;

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/StateStorageTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/StateStorageTest.java
@@ -70,7 +70,7 @@ public class StateStorageTest {
     // given
     createSnapshotDirectory("no");
     createSnapshotDirectory("bad");
-    createSnapshotDirectory(StateStorage.TEMP_SNAPSHOT_DIRECTORY);
+    createSnapshotDirectory(StateStorage.TMP_SNAPSHOT_DIRECTORY);
     createSnapshotDirectory("1");
     createSnapshotDirectory("0");
     final File[] expected =
@@ -87,6 +87,30 @@ public class StateStorageTest {
   }
 
   @Test
+  public void shouldFindAllTemporaryFoldersWhichAreBelowGivenPosition() {
+    // given
+    createSnapshotDirectory("no");
+    createSnapshotDirectory("bad");
+    createSnapshotDirectory(StateStorage.TMP_SNAPSHOT_DIRECTORY);
+    createSnapshotDirectory("121-tmp");
+    createSnapshotDirectory("not-tmp");
+    createSnapshotDirectory("3-tmp");
+    createSnapshotDirectory("3");
+    createSnapshotDirectory("310-tmp");
+    final File[] expected =
+        new File[] {
+          new File(storage.getSnapshotsDirectory(), "3-tmp"),
+          new File(storage.getSnapshotsDirectory(), "121-tmp")
+        };
+
+    // when
+    final List<File> valid = storage.findTmpDirectoriesBelowPosition(128L);
+
+    // then
+    assertThat(valid).containsExactlyInAnyOrder(expected);
+  }
+
+  @Test
   public void shouldListAllFoldersInOrder() {
     // given
     createSnapshotDirectory("no");
@@ -94,7 +118,7 @@ public class StateStorageTest {
     createSnapshotDirectory("bad");
     createSnapshotDirectory("256");
     createSnapshotDirectory("131");
-    createSnapshotDirectory(StateStorage.TEMP_SNAPSHOT_DIRECTORY);
+    createSnapshotDirectory(StateStorage.TMP_SNAPSHOT_DIRECTORY);
     createSnapshotDirectory("1");
     createSnapshotDirectory("0");
 


### PR DESCRIPTION
* it can happen that snapshots are not completely replicated, because what ever reason
 * might that validation fail or file can't be written to the file system etc. this means they will never become valid
 * in that case they become stale/orphaned - we can delete them after we ensure the max snapshot count
 * since we deleting valid snapshots and keep at max X snapshots we know that all snapshots before the position
 * of the oldes valid snapshots are no longer valuable so we can delete them as well

closes #2387