### PR TITLE
chore(logstreams): delete data on followers

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/exporter/ExporterManagerService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/ExporterManagerService.java
@@ -111,8 +111,7 @@ public class ExporterManagerService implements Service<ExporterManagerService> {
                         exporterRepository.getExporters().values());
                 partition
                     .getLogStream()
-                    .setExporterPositionSupplier(
-                        exporterStreamProcessor::getPositionToRecoveryFrom);
+                    .setExporterPositionSupplier(exporterStreamProcessor::getPositionToRecoverFrom);
                 return exporterStreamProcessor;
               })
           .deleteDataOnSnapshot(false)

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/processor/TypedStreamProcessor.java
@@ -111,7 +111,7 @@ public class TypedStreamProcessor implements StreamProcessor {
   }
 
   @Override
-  public long getPositionToRecoveryFrom() {
+  public long getPositionToRecoverFrom() {
     return zeebeState.getLastSuccessfuProcessedRecordPosition();
   }
 

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterStateTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterStateTest.java
@@ -164,4 +164,14 @@ public class ExporterStateTest {
     // then
     assertThat(positions).hasSize(2).contains(entry("e1", 1L), entry("e2", 2L));
   }
+
+  @Test
+  public void shouldGetLowestPosition() {
+    // given
+    state.setPosition("e2", -1L);
+    state.setPosition("e1", 1L);
+
+    // when/then
+    assertThat(state.getLowestPosition()).isEqualTo(-1L);
+  }
 }

--- a/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/TestStreams.java
@@ -524,8 +524,8 @@ public class TestStreams {
     }
 
     @Override
-    public long getPositionToRecoveryFrom() {
-      return wrappedProcessor.getPositionToRecoveryFrom();
+    public long getPositionToRecoverFrom() {
+      return wrappedProcessor.getPositionToRecoverFrom();
     }
 
     @Override

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogStreamService.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogStreamService.java
@@ -238,8 +238,8 @@ public class LogStreamService implements LogStream, Service<LogStream> {
       return;
     }
 
-    final long minExportedPosition = exporterPositionSupplier.get();
-    position = Math.min(position, minExportedPosition);
+    final long lowestExportedPosition = exporterPositionSupplier.get();
+    position = Math.min(position, lowestExportedPosition);
 
     final long blockAddress = logBlockIndex.lookupBlockAddress(logBlockIndexContext, position);
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/AsyncSnapshotDirector.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/AsyncSnapshotDirector.java
@@ -222,7 +222,7 @@ public class AsyncSnapshotDirector extends Actor {
         try {
           snapshotController.ensureMaxSnapshotCount(maxSnapshots);
           if (snapshotController.getValidSnapshotsCount() == maxSnapshots) {
-            oldDataRemover.accept(lowerBoundSnapshotPosition);
+            oldDataRemover.accept(snapshotController.getPositionToDelete(maxSnapshots));
           }
 
         } catch (Exception ex) {

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessor.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessor.java
@@ -60,7 +60,7 @@ public interface StreamProcessor {
    *
    * @return the last successful processed event position from the state
    */
-  default long getPositionToRecoveryFrom() {
+  default long getPositionToRecoverFrom() {
     return NO_EVENTS_PROCESSED;
   }
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
@@ -168,7 +168,7 @@ public class StreamProcessorController extends Actor {
     dbContext = zeebeDb.createContext();
     streamProcessor = streamProcessorFactory.createProcessor(zeebeDb, dbContext);
 
-    final long snapshotPosition = streamProcessor.getPositionToRecoveryFrom();
+    final long snapshotPosition = streamProcessor.getPositionToRecoverFrom();
     logStreamReader.seekToFirstEvent(); // reset seek position
     if (lowerBoundSnapshotPosition > -1 && snapshotPosition > -1) {
       final boolean found = logStreamReader.seek(snapshotPosition);

--- a/logstreams/src/main/java/io/zeebe/logstreams/spi/SnapshotController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/spi/SnapshotController.java
@@ -50,7 +50,7 @@ public interface SnapshotController extends AutoCloseable {
   void replicateLatestSnapshot(Consumer<Runnable> executor);
 
   /** Registers to consumes replicated snapshots. */
-  void consumeReplicatedSnapshots();
+  void consumeReplicatedSnapshots(Consumer<Long> dataDeleteCallback);
 
   /**
    * Recovers the state from the latest snapshot and returns the lower bound snapshot position.
@@ -67,6 +67,16 @@ public interface SnapshotController extends AutoCloseable {
    * @param maxSnapshotCount the maximum count of snapshots which should be kept
    */
   void ensureMaxSnapshotCount(int maxSnapshotCount) throws Exception;
+
+  /**
+   * Returns the highest position that is considered to be safe to delete, which is the position of
+   * the oldest of the required snapshots. If maxSnapshotCount hasn't been reached, returns -1,
+   * since it's not safe to delete data.
+   *
+   * @param maxSnapshotCount the required number of snapshots
+   * @return the position to delete
+   */
+  long getPositionToDelete(int maxSnapshotCount);
 
   /**
    * Returns the current number of valid snapshots.

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/AsyncSnapshotingTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/AsyncSnapshotingTest.java
@@ -17,7 +17,13 @@ package io.zeebe.logstreams.processor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.zeebe.db.impl.DefaultColumnFamily;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
@@ -214,7 +220,7 @@ public class AsyncSnapshotingTest {
     verify(snapshotController, TIMEOUT.times(1)).moveValidSnapshot(32);
 
     // then
-    verify(mockDeleteCallback, TIMEOUT).noop(eq(32L));
+    verify(mockDeleteCallback, TIMEOUT).noop(eq(25L));
   }
 
   @Test

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/RecordingStreamProcessor.java
@@ -100,7 +100,7 @@ public class RecordingStreamProcessor implements StreamProcessor {
   }
 
   @Override
-  public long getPositionToRecoveryFrom() {
+  public long getPositionToRecoverFrom() {
     final DbLong value = lastProcessedPositionColumnFamily.get(keyInstance);
     return value == null ? NO_EVENTS_PROCESSED : value.getValue();
   }

--- a/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/processor/StreamProcessorControllerTest.java
@@ -497,7 +497,7 @@ public class StreamProcessorControllerTest {
 
     // when
     changeRecordingStreamProcessor =
-        (processor) -> doReturn(-1L).when(processor).getPositionToRecoveryFrom();
+        (processor) -> doReturn(-1L).when(processor).getPositionToRecoverFrom();
     streamProcessorController.openAsync().join();
     final long secondEventPosition = writeEventAndWaitUntilProcessed(EVENT_2);
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/FailingSnapshotChunkReplicationTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/FailingSnapshotChunkReplicationTest.java
@@ -79,7 +79,7 @@ public class FailingSnapshotChunkReplicationTest {
     final EvilReplicator replicator = new EvilReplicator();
     setup(replicator);
 
-    receiverSnapshotController.consumeReplicatedSnapshots();
+    receiverSnapshotController.consumeReplicatedSnapshots(pos -> {});
     replicatorSnapshotController.takeSnapshot(1);
 
     // when
@@ -105,7 +105,7 @@ public class FailingSnapshotChunkReplicationTest {
     final FlakyReplicator replicator = new FlakyReplicator();
     setup(replicator);
 
-    receiverSnapshotController.consumeReplicatedSnapshots();
+    receiverSnapshotController.consumeReplicatedSnapshots(pos -> {});
     replicatorSnapshotController.takeSnapshot(1);
 
     // when
@@ -132,14 +132,14 @@ public class FailingSnapshotChunkReplicationTest {
     // given
     final FlakyReplicator flakyReplicator = new FlakyReplicator();
     setup(flakyReplicator);
-    receiverSnapshotController.consumeReplicatedSnapshots();
+    receiverSnapshotController.consumeReplicatedSnapshots(pos -> {});
     replicatorSnapshotController.takeSnapshot(1);
     replicatorSnapshotController.replicateLatestSnapshot(Runnable::run);
     replicatorSnapshotController.close();
 
     final Replicator workingReplicator = new Replicator();
     setupReplication(workingReplicator);
-    receiverSnapshotController.consumeReplicatedSnapshots();
+    receiverSnapshotController.consumeReplicatedSnapshots(pos -> {});
     replicatorSnapshotController.takeSnapshot(2);
     replicatorSnapshotController.replicateLatestSnapshot(Runnable::run);
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -48,6 +48,7 @@ import io.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.zeebe.transport.SocketAddress;
 import io.zeebe.transport.impl.util.SocketUtil;
 import io.zeebe.util.FileUtil;
+import io.zeebe.util.sched.clock.ControlledActorClock;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
@@ -88,6 +89,7 @@ public class ClusteringRule extends ExternalResource {
   private final Map<Integer, File> brokerBases;
   private final List<Integer> partitionIds;
   private final String clusterName;
+  private final ControlledActorClock controlledClock = new ControlledActorClock();
   // cluster
   private ZeebeClient client;
   private Gateway gateway;
@@ -197,7 +199,7 @@ public class ClusteringRule extends ExternalResource {
   private Broker createBroker(int nodeId) {
     final File brokerBase = getBrokerBase(nodeId);
     final BrokerCfg brokerCfg = getBrokerCfg(nodeId);
-    final Broker broker = new Broker(brokerCfg, brokerBase.getAbsolutePath(), null);
+    final Broker broker = new Broker(brokerCfg, brokerBase.getAbsolutePath(), controlledClock);
     closables.manage(broker);
     return broker;
   }
@@ -536,6 +538,10 @@ public class ClusteringRule extends ExternalResource {
 
   public ZeebeClient getClient() {
     return client;
+  }
+
+  public ControlledActorClock getClock() {
+    return controlledClock;
   }
 
   public List<Integer> getPartitionIds() {

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -20,18 +20,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.zeebe.broker.Broker;
 import io.zeebe.broker.Loggers;
+import io.zeebe.broker.it.DataDeleteTest;
 import io.zeebe.broker.it.GrpcClientRule;
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.intent.MessageIntent;
+import io.zeebe.test.util.TestUtil;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
 import org.junit.Before;
@@ -47,14 +53,10 @@ public class SnapshotReplicationTest {
   private static final BpmnModelInstance WORKFLOW =
       Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
 
+  // NOTE: the configuration removes the RecordingExporter from the broker's configuration to enable
+  // data deletion so it can't be used in tests
   public ClusteringRule clusteringRule =
-      new ClusteringRule(
-          PARTITION_COUNT,
-          3,
-          3,
-          brokerCfg -> {
-            brokerCfg.getData().setSnapshotPeriod("1s");
-          });
+      new ClusteringRule(PARTITION_COUNT, 3, 3, DataDeleteTest::configureForDeletionTest);
   public GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 
   @Rule public RuleChain ruleChain = RuleChain.outerRule(clusteringRule).around(clientRule);
@@ -74,6 +76,7 @@ public class SnapshotReplicationTest {
     client.newDeployCommand().addWorkflowModel(WORKFLOW, "workflow.bpmn").send().join();
     final int leaderNodeId = clusteringRule.getLeaderForPartition(1).getNodeId();
     final Broker leader = clusteringRule.getBroker(leaderNodeId);
+    clusteringRule.getClock().addTime(Duration.ofSeconds(DataDeleteTest.SNAPSHOT_PERIOD_SECONDS));
 
     // when - snapshot
     waitForValidSnapshotAtBroker(leader);
@@ -96,9 +99,72 @@ public class SnapshotReplicationTest {
     assertThat(checksumFirstNode).isEqualTo(brokerSnapshotChecksums.get(2));
   }
 
+  @Test
+  public void shouldDeleteDataOnFollowersWithExporter() {
+    // given
+    final int leaderNodeId = clusteringRule.getLeaderForPartition(1).getNodeId();
+    final List<Broker> followers =
+        clusteringRule.getBrokers().stream()
+            .filter(b -> b.getConfig().getCluster().getNodeId() != leaderNodeId)
+            .collect(Collectors.toList());
+
+    // when
+    final AtomicInteger messagesSent = new AtomicInteger();
+    while (followers.stream()
+        .map(this::getSegmentsDirectory)
+        .allMatch(dir -> dir.listFiles().length <= 2)) {
+      clientRule
+          .getClient()
+          .newPublishMessageCommand()
+          .messageName("msg")
+          .correlationKey("key")
+          .send()
+          .join();
+      messagesSent.incrementAndGet();
+    }
+
+    // when
+    TestUtil.waitUntil(
+        () ->
+            DataDeleteTest.TestExporter.records.stream()
+                    .filter(r -> r.getMetadata().getIntent() == MessageIntent.PUBLISHED)
+                    .limit(messagesSent.get())
+                    .count()
+                == messagesSent.get());
+
+    // then
+    takeSnapshotAndAssertDataWasDeleted(followers);
+  }
+
+  private void takeSnapshotAndAssertDataWasDeleted(final List<Broker> followers) {
+    final HashMap<Integer, Integer> followerSegmentCounts = new HashMap();
+    followers.forEach(
+        b -> {
+          final int nodeId = b.getConfig().getCluster().getNodeId();
+          followerSegmentCounts.put(nodeId, getSegmentsDirectory(b).list().length);
+        });
+
+    clusteringRule.getClock().addTime(Duration.ofSeconds(DataDeleteTest.SNAPSHOT_PERIOD_SECONDS));
+    followers.forEach(this::waitForValidSnapshotAtBroker);
+
+    // then
+    TestUtil.waitUntil(
+        () ->
+            followers.stream()
+                .allMatch(
+                    b ->
+                        getSegmentsDirectory(b).listFiles().length
+                            < followerSegmentCounts.get(b.getConfig().getCluster().getNodeId())));
+  }
+
   private File getSnapshotsDirectory(Broker broker) {
     final String dataDir = broker.getConfig().getData().getDirectories().get(0);
     return new File(dataDir, "partition-1/state/1_zb-stream-processor/snapshots");
+  }
+
+  private File getSegmentsDirectory(Broker broker) {
+    final String dataDir = broker.getConfig().getData().getDirectories().get(0);
+    return new File(dataDir, "/partition-1/segments");
   }
 
   private void waitForValidSnapshotAtBroker(Broker broker) {


### PR DESCRIPTION
One noteworthy detail is that, from the followers perspective, the situation where no exporter state snapshot is sent by the leader (for instance, because there are no exporters configured) is indistinguishable from the situation where the snapshot is in transit and simply hasn't arrived. In that situation we don't delete data to avoid deleting something that an exporter might need. We don't need to implement a better solution because when we have a unified RocksDb instance, this problem will be solved by default.

closes #2346 

