### PR TITLE
check returned error of leader election service

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/partitions/PartitionInstallService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/partitions/PartitionInstallService.java
@@ -145,7 +145,14 @@ public class PartitionInstallService extends Actor
   @Override
   protected void onActorStarted() {
     actor.runOnCompletion(
-        leaderElectionInstallFuture, (leaderElection, e) -> leaderElection.addListener(this));
+        leaderElectionInstallFuture,
+        (leaderElection, e) -> {
+          if (e == null) {
+            leaderElection.addListener(this);
+          } else {
+            LOG.error("Could not install leader election for partition {}", partitionId, e);
+          }
+        });
   }
 
   public void onTransitionToLeader(int partitionId, long term) {


### PR DESCRIPTION
closes #2404 

This PR handles the null pointer exception which can happen if the leader election service did not start successfully. 
