### PR TITLE
chore(logstreams): don't create snapshot if already exists

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/processor/StreamProcessorController.java
@@ -241,11 +241,10 @@ public class StreamProcessorController extends Actor {
           () -> {
             final LogStream logStream = streamProcessorContext.logStream;
             if (asyncSnapshotDirector != null) {
-              LOG.info("On closing, will try to enforce snapshot creation.");
               actor.runOnCompletionBlockingCurrentPhase(
                   asyncSnapshotDirector.enforceSnapshotCreation(
                       processingStateMachine.getLastWrittenEventPosition(),
-                      logStream.getCommitPosition()),
+                      processingStateMachine.getLastSuccessfulProcessedEventPosition()),
                   (v, ex) -> {
                     try {
                       asyncSnapshotDirector.close();

--- a/logstreams/src/main/java/io/zeebe/logstreams/spi/SnapshotController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/spi/SnapshotController.java
@@ -74,4 +74,11 @@ public interface SnapshotController extends AutoCloseable {
    * @return valid snapshots count
    */
   int getValidSnapshotsCount();
+
+  /**
+   * Returns the position of the last valid snapshot. Or, -1 if no valid snapshot exists.
+   *
+   * @return the snapshot position
+   */
+  long getLastValidSnapshotPosition();
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/StateSnapshotController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/StateSnapshotController.java
@@ -244,8 +244,18 @@ public class StateSnapshotController implements SnapshotController {
     }
   }
 
+  @Override
   public int getValidSnapshotsCount() {
     return storage.list().size();
+  }
+
+  @Override
+  public long getLastValidSnapshotPosition() {
+    return storage.listByPositionDesc().stream()
+        .map(File::getName)
+        .mapToLong(Long::parseLong)
+        .findFirst()
+        .orElse(-1L);
   }
 
   @Override

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/StateSnapshotControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/StateSnapshotControllerTest.java
@@ -222,6 +222,38 @@ public class StateSnapshotControllerTest {
         .hasMessage("Failed to recover from snapshots");
   }
 
+  @Test
+  public void shouldGetValidSnapshotCount() {
+    // given
+    snapshotController.openDb();
+
+    assertThat(snapshotController.getValidSnapshotsCount()).isEqualTo(0);
+
+    snapshotController.takeSnapshot(1L);
+    snapshotController.takeSnapshot(3L);
+    snapshotController.takeSnapshot(5L);
+    snapshotController.takeTempSnapshot();
+
+    // when/then
+    assertThat(snapshotController.getValidSnapshotsCount()).isEqualTo(3);
+  }
+
+  @Test
+  public void shouldGetLastValidSnapshot() {
+    // given
+    snapshotController.openDb();
+
+    assertThat(snapshotController.getLastValidSnapshotPosition()).isEqualTo(-1L);
+
+    snapshotController.takeSnapshot(1L);
+    snapshotController.takeSnapshot(3L);
+    snapshotController.takeSnapshot(5L);
+    snapshotController.takeTempSnapshot();
+
+    // when/then
+    assertThat(snapshotController.getLastValidSnapshotPosition()).isEqualTo(5L);
+  }
+
   private void corruptSnapshot(long position) throws IOException {
     final File snapshot = storage.getSnapshotDirectoryFor(position);
     assertThat(snapshot).isNotNull();


### PR DESCRIPTION
* on forcing snapshot creation, check if the snapshot already exists
* on forcing snapshot creation, use the last processed position for the snapshot
* on startup, initialize the last valid snapshot position

closes #2389 
