### PR TITLE
fix(broker): fix lost messages on rejected correlation

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionApiCommandMessageHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionApiCommandMessageHandler.java
@@ -25,6 +25,7 @@ import io.zeebe.broker.subscription.CorrelateWorkflowInstanceSubscriptionDecoder
 import io.zeebe.broker.subscription.MessageHeaderDecoder;
 import io.zeebe.broker.subscription.OpenMessageSubscriptionDecoder;
 import io.zeebe.broker.subscription.OpenWorkflowInstanceSubscriptionDecoder;
+import io.zeebe.broker.subscription.RejectCorrelateMessageSubscriptionDecoder;
 import io.zeebe.broker.subscription.message.data.MessageSubscriptionRecord;
 import io.zeebe.broker.subscription.message.data.WorkflowInstanceSubscriptionRecord;
 import io.zeebe.logstreams.log.LogStreamRecordWriter;
@@ -67,6 +68,9 @@ public class SubscriptionApiCommandMessageHandler
 
   private final CloseWorkflowInstanceSubscriptionCommand closeWorkflowInstanceSubscriptionCommand =
       new CloseWorkflowInstanceSubscriptionCommand();
+
+  private final RejectCorrelateMessageSubscriptionCommand resetMessageCorrelationCommand =
+      new RejectCorrelateMessageSubscriptionCommand();
 
   private final LogStreamRecordWriter logStreamWriter = new LogStreamWriterImpl();
   private final RecordMetadata recordMetadata = new RecordMetadata();
@@ -117,6 +121,9 @@ public class SubscriptionApiCommandMessageHandler
               case CloseWorkflowInstanceSubscriptionDecoder.TEMPLATE_ID:
                 onCloseWorkflowInstanceSubscription(buffer, offset, length);
                 break;
+              case RejectCorrelateMessageSubscriptionDecoder.TEMPLATE_ID:
+                onRejectCorrelateMessageSubscription(buffer, offset, length);
+                break;
               default:
                 break;
             }
@@ -132,6 +139,7 @@ public class SubscriptionApiCommandMessageHandler
     messageSubscriptionRecord
         .setWorkflowInstanceKey(openMessageSubscriptionCommand.getWorkflowInstanceKey())
         .setElementInstanceKey(openMessageSubscriptionCommand.getElementInstanceKey())
+        .setMessageKey(-1)
         .setMessageName(openMessageSubscriptionCommand.getMessageName())
         .setCorrelationKey(openMessageSubscriptionCommand.getCorrelationKey())
         .setCloseOnCorrelate(openMessageSubscriptionCommand.shouldCloseOnCorrelate());
@@ -156,6 +164,7 @@ public class SubscriptionApiCommandMessageHandler
             openWorkflowInstanceSubscriptionCommand.getSubscriptionPartitionId())
         .setWorkflowInstanceKey(workflowInstanceKey)
         .setElementInstanceKey(openWorkflowInstanceSubscriptionCommand.getElementInstanceKey())
+        .setMessageKey(-1)
         .setMessageName(openWorkflowInstanceSubscriptionCommand.getMessageName())
         .setCloseOnCorrelate(openWorkflowInstanceSubscriptionCommand.shouldCloseOnCorrelate());
 
@@ -179,6 +188,7 @@ public class SubscriptionApiCommandMessageHandler
             correlateWorkflowInstanceSubscriptionCommand.getSubscriptionPartitionId())
         .setWorkflowInstanceKey(workflowInstanceKey)
         .setElementInstanceKey(correlateWorkflowInstanceSubscriptionCommand.getElementInstanceKey())
+        .setMessageKey(correlateWorkflowInstanceSubscriptionCommand.getMessageKey())
         .setMessageName(correlateWorkflowInstanceSubscriptionCommand.getMessageName())
         .setVariables(correlateWorkflowInstanceSubscriptionCommand.getVariables());
 
@@ -196,6 +206,7 @@ public class SubscriptionApiCommandMessageHandler
     messageSubscriptionRecord
         .setWorkflowInstanceKey(correlateMessageSubscriptionCommand.getWorkflowInstanceKey())
         .setElementInstanceKey(correlateMessageSubscriptionCommand.getElementInstanceKey())
+        .setMessageKey(-1)
         .setMessageName(correlateMessageSubscriptionCommand.getMessageName());
 
     return writeCommand(
@@ -212,6 +223,7 @@ public class SubscriptionApiCommandMessageHandler
     messageSubscriptionRecord
         .setWorkflowInstanceKey(closeMessageSubscriptionCommand.getWorkflowInstanceKey())
         .setElementInstanceKey(closeMessageSubscriptionCommand.getElementInstanceKey())
+        .setMessageKey(-1L)
         .setMessageName(closeMessageSubscriptionCommand.getMessageName());
 
     return writeCommand(
@@ -234,6 +246,7 @@ public class SubscriptionApiCommandMessageHandler
             closeWorkflowInstanceSubscriptionCommand.getSubscriptionPartitionId())
         .setWorkflowInstanceKey(workflowInstanceKey)
         .setElementInstanceKey(closeWorkflowInstanceSubscriptionCommand.getElementInstanceKey())
+        .setMessageKey(-1)
         .setMessageName(closeWorkflowInstanceSubscriptionCommand.getMessageName());
 
     return writeCommand(
@@ -241,6 +254,28 @@ public class SubscriptionApiCommandMessageHandler
         ValueType.WORKFLOW_INSTANCE_SUBSCRIPTION,
         WorkflowInstanceSubscriptionIntent.CLOSE,
         workflowInstanceSubscriptionRecord);
+  }
+
+  private boolean onRejectCorrelateMessageSubscription(
+      DirectBuffer buffer, int offset, int length) {
+    resetMessageCorrelationCommand.wrap(buffer, offset, length);
+
+    final long workflowInstanceKey = resetMessageCorrelationCommand.getWorkflowInstanceKey();
+
+    messageSubscriptionRecord.reset();
+    messageSubscriptionRecord
+        .setWorkflowInstanceKey(workflowInstanceKey)
+        .setElementInstanceKey(-1L)
+        .setMessageName(resetMessageCorrelationCommand.getMessageName())
+        .setCorrelationKey(resetMessageCorrelationCommand.getCorrelationKey())
+        .setMessageKey(resetMessageCorrelationCommand.getMessageKey())
+        .setCloseOnCorrelate(false);
+
+    return writeCommand(
+        resetMessageCorrelationCommand.getSubscriptionPartitionId(),
+        ValueType.MESSAGE_SUBSCRIPTION,
+        MessageSubscriptionIntent.REJECT,
+        messageSubscriptionRecord);
   }
 
   private boolean writeCommand(

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionCommandSender.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/command/SubscriptionCommandSender.java
@@ -73,6 +73,9 @@ public class SubscriptionCommandSender {
   private final CloseWorkflowInstanceSubscriptionCommand closeWorkflowInstanceSubscriptionCommand =
       new CloseWorkflowInstanceSubscriptionCommand();
 
+  private final RejectCorrelateMessageSubscriptionCommand
+      rejectCorrelateMessageSubscriptionCommand = new RejectCorrelateMessageSubscriptionCommand();
+
   private final Atomix atomix;
 
   private int partitionId;
@@ -129,6 +132,7 @@ public class SubscriptionCommandSender {
       final long workflowInstanceKey,
       final long elementInstanceKey,
       final DirectBuffer messageName,
+      final long messageKey,
       final DirectBuffer variables) {
 
     final int workflowInstancePartitionId = Protocol.decodePartitionId(workflowInstanceKey);
@@ -136,6 +140,7 @@ public class SubscriptionCommandSender {
     correlateWorkflowInstanceSubscriptionCommand.setSubscriptionPartitionId(partitionId);
     correlateWorkflowInstanceSubscriptionCommand.setWorkflowInstanceKey(workflowInstanceKey);
     correlateWorkflowInstanceSubscriptionCommand.setElementInstanceKey(elementInstanceKey);
+    correlateWorkflowInstanceSubscriptionCommand.setMessageKey(messageKey);
     correlateWorkflowInstanceSubscriptionCommand.getMessageName().wrap(messageName);
     correlateWorkflowInstanceSubscriptionCommand.getVariables().wrap(variables);
 
@@ -185,6 +190,25 @@ public class SubscriptionCommandSender {
 
     return sendSubscriptionCommand(
         workflowInstancePartitionId, closeWorkflowInstanceSubscriptionCommand);
+  }
+
+  public boolean rejectCorrelateMessageSubscription(
+      final long workflowInstanceKey,
+      final long elementInstanceKey,
+      final long messageKey,
+      final DirectBuffer messageName,
+      final DirectBuffer correlationKey) {
+
+    final int workflowInstancePartitionId = Protocol.decodePartitionId(workflowInstanceKey);
+
+    rejectCorrelateMessageSubscriptionCommand.setSubscriptionPartitionId(partitionId);
+    rejectCorrelateMessageSubscriptionCommand.setWorkflowInstanceKey(workflowInstanceKey);
+    rejectCorrelateMessageSubscriptionCommand.setMessageKey(messageKey);
+    rejectCorrelateMessageSubscriptionCommand.getMessageName().wrap(messageName);
+    rejectCorrelateMessageSubscriptionCommand.getCorrelationKey().wrap(correlationKey);
+
+    return sendSubscriptionCommand(
+        workflowInstancePartitionId, rejectCorrelateMessageSubscriptionCommand);
   }
 
   private boolean sendSubscriptionCommand(

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/MessageSubscriptionRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/MessageSubscriptionRecord.java
@@ -28,6 +28,7 @@ public class MessageSubscriptionRecord extends UnpackedObject implements Workflo
 
   private final LongProperty workflowInstanceKeyProp = new LongProperty("workflowInstanceKey");
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey");
+  private final LongProperty messageKeyProp = new LongProperty("messageKey");
   private final StringProperty messageNameProp = new StringProperty("messageName", "");
   private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
   private final BooleanProperty closeOnCorrelateProp =
@@ -36,6 +37,7 @@ public class MessageSubscriptionRecord extends UnpackedObject implements Workflo
   public MessageSubscriptionRecord() {
     this.declareProperty(workflowInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
+        .declareProperty(messageKeyProp)
         .declareProperty(messageNameProp)
         .declareProperty(correlationKeyProp)
         .declareProperty(closeOnCorrelateProp);
@@ -83,6 +85,15 @@ public class MessageSubscriptionRecord extends UnpackedObject implements Workflo
 
   public MessageSubscriptionRecord setCloseOnCorrelate(boolean closeOnCorrelate) {
     this.closeOnCorrelateProp.setValue(closeOnCorrelate);
+    return this;
+  }
+
+  public long getMessageKey() {
+    return messageKeyProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setMessageKey(long messageKey) {
+    this.messageKeyProp.setValue(messageKey);
     return this;
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/WorkflowInstanceSubscriptionRecord.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/data/WorkflowInstanceSubscriptionRecord.java
@@ -33,6 +33,7 @@ public class WorkflowInstanceSubscriptionRecord extends UnpackedObject
       new IntegerProperty("subscriptionPartitionId");
   private final LongProperty workflowInstanceKeyProp = new LongProperty("workflowInstanceKey");
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey");
+  private final LongProperty messageKeyProp = new LongProperty("messageKey");
   private final StringProperty messageNameProp = new StringProperty("messageName", "");
   private final DocumentProperty variablesProp = new DocumentProperty("variables");
   private final BooleanProperty closeOnCorrelateProp =
@@ -42,6 +43,7 @@ public class WorkflowInstanceSubscriptionRecord extends UnpackedObject
     this.declareProperty(subscriptionPartitionIdProp)
         .declareProperty(workflowInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
+        .declareProperty(messageKeyProp)
         .declareProperty(messageNameProp)
         .declareProperty(variablesProp)
         .declareProperty(closeOnCorrelateProp);
@@ -71,6 +73,15 @@ public class WorkflowInstanceSubscriptionRecord extends UnpackedObject
 
   public WorkflowInstanceSubscriptionRecord setElementInstanceKey(long key) {
     elementInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  public long getMessageKey() {
+    return messageKeyProp.getValue();
+  }
+
+  public WorkflowInstanceSubscriptionRecord setMessageKey(long messageKey) {
+    messageKeyProp.setValue(messageKey);
     return this;
   }
 

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageEventProcessors.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/MessageEventProcessors.java
@@ -75,6 +75,11 @@ public class MessageEventProcessors {
             MessageSubscriptionIntent.CLOSE,
             new CloseMessageSubscriptionProcessor(subscriptionState, subscriptionCommandSender))
         .onCommand(
+            ValueType.MESSAGE_SUBSCRIPTION,
+            MessageSubscriptionIntent.REJECT,
+            new RejectMessageCorrelationProcessor(
+                messageState, subscriptionState, subscriptionCommandSender))
+        .onCommand(
             ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
             MessageStartEventSubscriptionIntent.OPEN,
             new OpenMessageStartEventSubscriptionProcessor(

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/PendingMessageSubscriptionChecker.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/PendingMessageSubscriptionChecker.java
@@ -23,7 +23,6 @@ import io.zeebe.broker.subscription.message.state.MessageSubscriptionState;
 import io.zeebe.util.sched.clock.ActorClock;
 
 public class PendingMessageSubscriptionChecker implements Runnable {
-
   private final SubscriptionCommandSender commandSender;
   private final MessageSubscriptionState subscriptionState;
 
@@ -50,6 +49,7 @@ public class PendingMessageSubscriptionChecker implements Runnable {
             subscription.getWorkflowInstanceKey(),
             subscription.getElementInstanceKey(),
             subscription.getMessageName(),
+            subscription.getMessageKey(),
             subscription.getMessageVariables());
 
     if (success) {

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/RejectMessageCorrelationProcessor.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/processor/RejectMessageCorrelationProcessor.java
@@ -1,0 +1,130 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.subscription.message.processor;
+
+import io.zeebe.broker.logstreams.processor.SideEffectProducer;
+import io.zeebe.broker.logstreams.processor.TypedRecord;
+import io.zeebe.broker.logstreams.processor.TypedRecordProcessor;
+import io.zeebe.broker.logstreams.processor.TypedResponseWriter;
+import io.zeebe.broker.logstreams.processor.TypedStreamWriter;
+import io.zeebe.broker.subscription.command.SubscriptionCommandSender;
+import io.zeebe.broker.subscription.message.data.MessageSubscriptionRecord;
+import io.zeebe.broker.subscription.message.state.Message;
+import io.zeebe.broker.subscription.message.state.MessageState;
+import io.zeebe.broker.subscription.message.state.MessageSubscription;
+import io.zeebe.broker.subscription.message.state.MessageSubscriptionState;
+import io.zeebe.protocol.clientapi.RejectionType;
+import io.zeebe.protocol.intent.MessageSubscriptionIntent;
+import io.zeebe.util.sched.clock.ActorClock;
+import java.util.function.Consumer;
+
+public class RejectMessageCorrelationProcessor
+    implements TypedRecordProcessor<MessageSubscriptionRecord> {
+
+  private final MessageState messageState;
+  private final MessageSubscriptionState subscriptionState;
+  private final SubscriptionCommandSender commandSender;
+
+  public RejectMessageCorrelationProcessor(
+      final MessageState messageState,
+      final MessageSubscriptionState subscriptionState,
+      final SubscriptionCommandSender commandSender) {
+    this.messageState = messageState;
+    this.subscriptionState = subscriptionState;
+    this.commandSender = commandSender;
+  }
+
+  @Override
+  public void processRecord(
+      final TypedRecord<MessageSubscriptionRecord> record,
+      final TypedResponseWriter responseWriter,
+      final TypedStreamWriter streamWriter,
+      final Consumer<SideEffectProducer> sideEffect) {
+
+    final MessageSubscriptionRecord subscriptionRecord = record.getValue();
+    final long messageKey = subscriptionRecord.getMessageKey();
+    final long workflowInstanceKey = subscriptionRecord.getWorkflowInstanceKey();
+
+    if (!messageState.existMessageCorrelation(messageKey, workflowInstanceKey)) {
+      streamWriter.appendRejection(
+          record,
+          RejectionType.INVALID_STATE,
+          String.format(
+              "Expected message %d to be correlated in workflow instance %d but no correlation was found",
+              messageKey, workflowInstanceKey));
+      return;
+    }
+    messageState.removeMessageCorrelation(messageKey, workflowInstanceKey);
+
+    findSubscriptionToCorrelate(
+        record, streamWriter, sideEffect, subscriptionRecord, messageKey, workflowInstanceKey);
+
+    streamWriter.appendFollowUpEvent(
+        record.getKey(), MessageSubscriptionIntent.REJECTED, record.getValue());
+  }
+
+  private void findSubscriptionToCorrelate(
+      final TypedRecord<MessageSubscriptionRecord> record,
+      final TypedStreamWriter streamWriter,
+      final Consumer<SideEffectProducer> sideEffect,
+      final MessageSubscriptionRecord subscriptionRecord,
+      final long messageKey,
+      final long workflowInstanceKey) {
+
+    // the message TTL may expire after the previous correlation attempt
+    final Message message = messageState.getMessage(messageKey);
+    if (message == null) {
+      return;
+    }
+
+    subscriptionState.visitSubscriptions(
+        subscriptionRecord.getMessageName(),
+        subscriptionRecord.getCorrelationKey(),
+        subscription -> {
+          if (subscription.getWorkflowInstanceKey() == workflowInstanceKey
+              && !subscription.isCorrelating()) {
+            subscription.setMessageKey(messageKey);
+            subscription.setMessageVariables(message.getVariables());
+
+            correlateMessage(streamWriter, subscription, sideEffect);
+            return false;
+          }
+          return true;
+        });
+  }
+
+  private void correlateMessage(
+      final TypedStreamWriter streamWriter,
+      final MessageSubscription subscription,
+      final Consumer<SideEffectProducer> sideEffect) {
+    subscriptionState.updateToCorrelatingState(
+        subscription,
+        subscription.getMessageVariables(),
+        ActorClock.currentTimeMillis(),
+        subscription.getMessageKey());
+    messageState.putMessageCorrelation(
+        subscription.getMessageKey(), subscription.getWorkflowInstanceKey());
+
+    commandSender.correlateWorkflowInstanceSubscription(
+        subscription.getWorkflowInstanceKey(),
+        subscription.getElementInstanceKey(),
+        subscription.getMessageName(),
+        subscription.getMessageKey(),
+        subscription.getMessageVariables());
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageState.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageState.java
@@ -144,6 +144,13 @@ public class MessageState {
     return correlatedMessageColumnFamily.exists(messageWorkflowKey);
   }
 
+  public void removeMessageCorrelation(long messageKey, long workflowInstanceKey) {
+    this.messageKey.wrapLong(messageKey);
+    this.workflowInstanceKey.wrapLong(workflowInstanceKey);
+
+    correlatedMessageColumnFamily.delete(messageWorkflowKey);
+  }
+
   public void visitMessages(
       final DirectBuffer name, final DirectBuffer correlationKey, final MessageVisitor visitor) {
 
@@ -159,7 +166,7 @@ public class MessageState {
         });
   }
 
-  private Message getMessage(long messageKey) {
+  public Message getMessage(long messageKey) {
     this.messageKey.wrapLong(messageKey);
     return messageColumnFamily.get(this.messageKey);
   }

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageSubscription.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageSubscription.java
@@ -34,6 +34,7 @@ public class MessageSubscription implements DbValue {
 
   private long workflowInstanceKey;
   private long elementInstanceKey;
+  private long messageKey;
   private long commandSentTime;
   private boolean closeOnCorrelate;
 
@@ -81,6 +82,14 @@ public class MessageSubscription implements DbValue {
     return elementInstanceKey;
   }
 
+  public long getMessageKey() {
+    return messageKey;
+  }
+
+  public void setMessageKey(final long messageKey) {
+    this.messageKey = messageKey;
+  }
+
   public long getCommandSentTime() {
     return commandSentTime;
   }
@@ -109,6 +118,9 @@ public class MessageSubscription implements DbValue {
     this.elementInstanceKey = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
     offset += Long.BYTES;
 
+    this.messageKey = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
+    offset += Long.BYTES;
+
     this.commandSentTime = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
     offset += Long.BYTES;
 
@@ -123,7 +135,7 @@ public class MessageSubscription implements DbValue {
   @Override
   public int getLength() {
     return 1
-        + Long.BYTES * 3
+        + Long.BYTES * 4
         + Integer.BYTES * 3
         + messageName.capacity()
         + correlationKey.capacity()
@@ -136,6 +148,9 @@ public class MessageSubscription implements DbValue {
     offset += Long.BYTES;
 
     buffer.putLong(offset, elementInstanceKey, ZB_DB_BYTE_ORDER);
+    offset += Long.BYTES;
+
+    buffer.putLong(offset, messageKey, ZB_DB_BYTE_ORDER);
     offset += Long.BYTES;
 
     buffer.putLong(offset, commandSentTime, ZB_DB_BYTE_ORDER);

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageSubscriptionState.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/MessageSubscriptionState.java
@@ -136,8 +136,12 @@ public class MessageSubscriptionState {
   }
 
   public void updateToCorrelatingState(
-      final MessageSubscription subscription, DirectBuffer messageVariables, long sentTime) {
+      final MessageSubscription subscription,
+      DirectBuffer messageVariables,
+      long sentTime,
+      long messageKey) {
     subscription.setMessageVariables(messageVariables);
+    subscription.setMessageKey(messageKey);
     updateSentTime(subscription, sentTime);
   }
 

--- a/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/WorkflowInstanceSubscriptionState.java
+++ b/broker-core/src/main/java/io/zeebe/broker/subscription/message/state/WorkflowInstanceSubscriptionState.java
@@ -84,10 +84,7 @@ public class WorkflowInstanceSubscriptionState {
       long elementInstanceKey, DirectBuffer messageName) {
     wrapSubscriptionKeys(elementInstanceKey, messageName);
 
-    final WorkflowInstanceSubscription workflowInstanceSubscription =
-        subscriptionColumnFamily.get(elementKeyAndMessageName);
-
-    return workflowInstanceSubscription;
+    return subscriptionColumnFamily.get(elementKeyAndMessageName);
   }
 
   public void visitElementSubscriptions(

--- a/broker-core/src/main/resources/subscription-schema.xml
+++ b/broker-core/src/main/resources/subscription-schema.xml
@@ -52,8 +52,9 @@
     <field name="subscriptionPartitionId" id="0" type="uint16"/>
     <field name="workflowInstanceKey" id="1" type="uint64"/>
     <field name="elementInstanceKey" id="2" type="uint64"/>
-    <data name="messageName" id="3" type="varDataEncoding"/>
-    <data name="variables" id="4" type="varDataEncoding"/>
+    <field name="messageKey" id="3" type="uint64"/>
+    <data name="messageName" id="4" type="varDataEncoding"/>
+    <data name="variables" id="5" type="varDataEncoding"/>
   </sbe:message>
 
   <sbe:message name="CorrelateMessageSubscription" id="3">
@@ -76,6 +77,14 @@
     <field name="workflowInstanceKey" id="1" type="uint64"/>
     <field name="elementInstanceKey" id="2" type="uint64"/>
     <data name="messageName" id="3" type="varDataEncoding"/>
+  </sbe:message>
+
+  <sbe:message name="RejectCorrelateMessageSubscription" id="6">
+    <field name="subscriptionPartitionId" id="0" type="uint16"/>
+    <field name="workflowInstanceKey" id="1" type="uint64"/>
+    <field name="messageKey" id="2" type="uint64"/>
+    <data name="messageName" id="3" type="varDataEncoding"/>
+    <data name="correlationKey" id="4" type="varDataEncoding"/>
   </sbe:message>
 
 </sbe:messageSchema>

--- a/broker-core/src/test/java/io/zeebe/broker/subscription/message/MessageStreamProcessorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/subscription/message/MessageStreamProcessorTest.java
@@ -42,6 +42,7 @@ import io.zeebe.protocol.clientapi.RejectionType;
 import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.intent.MessageIntent;
 import io.zeebe.protocol.intent.MessageSubscriptionIntent;
+import io.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 import org.junit.Before;
 import org.junit.Rule;
@@ -68,7 +69,7 @@ public class MessageStreamProcessorTest {
         .thenReturn(true);
 
     when(mockSubscriptionCommandSender.correlateWorkflowInstanceSubscription(
-            anyLong(), anyLong(), any(), any()))
+            anyLong(), anyLong(), any(), anyLong(), any()))
         .thenReturn(true);
 
     when(mockSubscriptionCommandSender.closeWorkflowInstanceSubscription(
@@ -137,11 +138,14 @@ public class MessageStreamProcessorTest {
     streamProcessor.unblock();
 
     // then
+    final long messageKey =
+        rule.events().onlyMessageRecords().withIntent(MessageIntent.PUBLISHED).getFirst().getKey();
     verify(mockSubscriptionCommandSender, timeout(5_000).times(2))
         .correlateWorkflowInstanceSubscription(
             subscription.getWorkflowInstanceKey(),
             subscription.getElementInstanceKey(),
             subscription.getMessageName(),
+            messageKey,
             message.getVariables());
   }
 
@@ -167,11 +171,15 @@ public class MessageStreamProcessorTest {
     streamProcessor.unblock();
 
     // then
+    final long messageKey =
+        rule.events().onlyMessageRecords().withIntent(MessageIntent.PUBLISHED).getFirst().getKey();
+
     verify(mockSubscriptionCommandSender, timeout(5_000).times(2))
         .correlateWorkflowInstanceSubscription(
             subscription.getWorkflowInstanceKey(),
             subscription.getElementInstanceKey(),
             subscription.getMessageName(),
+            messageKey,
             message.getVariables());
   }
 
@@ -257,11 +265,15 @@ public class MessageStreamProcessorTest {
     streamProcessor.unblock();
 
     // then
+    final long messageKey =
+        rule.events().onlyMessageRecords().withIntent(MessageIntent.PUBLISHED).getFirst().getKey();
+
     verify(mockSubscriptionCommandSender, timeout(5_000).times(1))
         .correlateWorkflowInstanceSubscription(
             subscription.getWorkflowInstanceKey(),
             subscription.getElementInstanceKey(),
             subscription.getMessageName(),
+            messageKey,
             message.getVariables());
   }
 
@@ -286,11 +298,34 @@ public class MessageStreamProcessorTest {
     streamProcessor.unblock();
 
     // then
-    verify(mockSubscriptionCommandSender, timeout(5_000).times(2))
+    waitUntil(
+        () ->
+            rule.events().onlyMessageRecords().withIntent(MessageIntent.PUBLISHED).limit(2).count()
+                == 2);
+    final long firstMessageKey =
+        rule.events().onlyMessageRecords().withIntent(MessageIntent.PUBLISHED).getFirst().getKey();
+    final long lastMessageKey =
+        rule.events()
+            .onlyMessageRecords()
+            .withIntent(MessageIntent.PUBLISHED)
+            .skip(1)
+            .getFirst()
+            .getKey();
+
+    verify(mockSubscriptionCommandSender, timeout(5_000))
         .correlateWorkflowInstanceSubscription(
             subscription.getWorkflowInstanceKey(),
             subscription.getElementInstanceKey(),
             subscription.getMessageName(),
+            firstMessageKey,
+            message.getVariables());
+
+    verify(mockSubscriptionCommandSender, timeout(5_000))
+        .correlateWorkflowInstanceSubscription(
+            subscription.getWorkflowInstanceKey(),
+            subscription.getElementInstanceKey(),
+            subscription.getMessageName(),
+            lastMessageKey,
             message.getVariables());
   }
 
@@ -340,20 +375,91 @@ public class MessageStreamProcessorTest {
     assertAllMessagesReceived(subscription, first, second);
   }
 
+  @Test
+  public void shouldCorrelateToFirstSubscriptionAfterRejection() {
+    // given
+    final MessageRecord message = message();
+    final MessageSubscriptionRecord firstSubscription =
+        messageSubscription().setElementInstanceKey(5L);
+    final MessageSubscriptionRecord secondSubscription =
+        messageSubscription().setElementInstanceKey(10L);
+    streamProcessor.blockAfterMessageSubscriptionEvent(
+        r ->
+            r.getMetadata().getIntent() == MessageSubscriptionIntent.OPENED
+                && r.getValue().getElementInstanceKey()
+                    == secondSubscription.getElementInstanceKey());
+
+    // when
+    rule.writeCommand(MessageIntent.PUBLISH, message);
+    rule.writeCommand(MessageSubscriptionIntent.OPEN, firstSubscription);
+    rule.writeCommand(MessageSubscriptionIntent.OPEN, secondSubscription);
+    waitUntil(streamProcessor::isBlocked);
+
+    final long messageKey =
+        rule.events().onlyMessageRecords().withIntent(MessageIntent.PUBLISHED).getFirst().getKey();
+    firstSubscription.setMessageKey(messageKey);
+    rule.writeCommand(MessageSubscriptionIntent.REJECT, firstSubscription);
+    streamProcessor.unblock();
+
+    // then
+    verify(mockSubscriptionCommandSender, timeout(5_000))
+        .correlateWorkflowInstanceSubscription(
+            eq(firstSubscription.getWorkflowInstanceKey()),
+            eq(firstSubscription.getElementInstanceKey()),
+            any(DirectBuffer.class),
+            eq(messageKey),
+            any(DirectBuffer.class));
+
+    verify(mockSubscriptionCommandSender, timeout(5_000))
+        .correlateWorkflowInstanceSubscription(
+            eq(secondSubscription.getWorkflowInstanceKey()),
+            eq(secondSubscription.getElementInstanceKey()),
+            any(DirectBuffer.class),
+            eq(messageKey),
+            any(DirectBuffer.class));
+  }
+
   private void assertAllMessagesReceived(
       MessageSubscriptionRecord subscription, MessageRecord first, MessageRecord second) {
     final ArgumentCaptor<DirectBuffer> nameCaptor = ArgumentCaptor.forClass(DirectBuffer.class);
     final ArgumentCaptor<DirectBuffer> variablesCaptor =
         ArgumentCaptor.forClass(DirectBuffer.class);
-    verify(mockSubscriptionCommandSender, timeout(5_000).times(2))
+
+    waitUntil(
+        () ->
+            rule.events().onlyMessageRecords().withIntent(MessageIntent.PUBLISHED).limit(2).count()
+                == 2);
+    final long firstMessageKey =
+        rule.events().onlyMessageRecords().withIntent(MessageIntent.PUBLISHED).getFirst().getKey();
+    final long lastMessageKey =
+        rule.events()
+            .onlyMessageRecords()
+            .withIntent(MessageIntent.PUBLISHED)
+            .skip(1)
+            .getFirst()
+            .getKey();
+
+    verify(mockSubscriptionCommandSender, timeout(5_000))
         .correlateWorkflowInstanceSubscription(
             eq(subscription.getWorkflowInstanceKey()),
             eq(subscription.getElementInstanceKey()),
             nameCaptor.capture(),
+            eq(firstMessageKey),
             variablesCaptor.capture());
-    assertThat(nameCaptor.getValue()).isEqualTo(subscription.getMessageName());
+
+    verify(mockSubscriptionCommandSender, timeout(5_000))
+        .correlateWorkflowInstanceSubscription(
+            eq(subscription.getWorkflowInstanceKey()),
+            eq(subscription.getElementInstanceKey()),
+            nameCaptor.capture(),
+            eq(lastMessageKey),
+            variablesCaptor.capture());
+
     assertThat(variablesCaptor.getAllValues().get(0)).isEqualTo(first.getVariables());
-    assertThat(variablesCaptor.getAllValues().get(1)).isEqualTo(second.getVariables());
+    assertThat(nameCaptor.getValue()).isEqualTo(subscription.getMessageName());
+    assertThat(BufferUtil.equals(nameCaptor.getAllValues().get(1), second.getName())).isTrue();
+    assertThat(BufferUtil.equals(variablesCaptor.getAllValues().get(1), second.getVariables()))
+        .isTrue();
   }
 
   private MessageSubscriptionRecord messageSubscription() {
@@ -361,6 +467,7 @@ public class MessageStreamProcessorTest {
     subscription
         .setWorkflowInstanceKey(1L)
         .setElementInstanceKey(2L)
+        .setMessageKey(-1L)
         .setMessageName(wrapString("order canceled"))
         .setCorrelationKey(wrapString("order-123"))
         .setCloseOnCorrelate(true);

--- a/broker-core/src/test/java/io/zeebe/broker/subscription/message/PublishMessageTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/subscription/message/PublishMessageTest.java
@@ -38,8 +38,10 @@ import io.zeebe.test.broker.protocol.clientapi.ExecuteCommandRequestBuilder;
 import io.zeebe.test.broker.protocol.clientapi.ExecuteCommandResponse;
 import io.zeebe.test.broker.protocol.clientapi.PartitionTestClient;
 import io.zeebe.test.util.MsgPackUtil;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
@@ -50,6 +52,8 @@ public class PublishMessageTest {
 
   @ClassRule
   public static final RuleChain RULE_CHAIN = RuleChain.outerRule(BROKER_RULE).around(API_RULE);
+
+  @Rule public RecordingExporterTestWatcher testWatcher = new RecordingExporterTestWatcher();
 
   private PartitionTestClient testClient;
 

--- a/broker-core/src/test/java/io/zeebe/broker/subscription/message/state/MessageStateTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/subscription/message/state/MessageStateTest.java
@@ -383,6 +383,20 @@ public class MessageStateTest {
     assertThat(messageState.existMessageCorrelation(1L, 3L)).isFalse();
   }
 
+  @Test
+  public void shouldRemoveMessageCorrelation() {
+    // given
+    final long messageKey = 6L;
+    final long workflowInstanceKey = 9L;
+    messageState.putMessageCorrelation(messageKey, workflowInstanceKey);
+
+    // when
+    messageState.removeMessageCorrelation(messageKey, workflowInstanceKey);
+
+    // then
+    assertThat(messageState.existMessageCorrelation(messageKey, workflowInstanceKey)).isFalse();
+  }
+
   private Message createMessage(long key, String name, String correlationKey) {
     return new Message(
         key,

--- a/broker-core/src/test/java/io/zeebe/broker/subscription/message/state/MessageSubscriptionStateTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/subscription/message/state/MessageSubscriptionStateTest.java
@@ -254,7 +254,7 @@ public class MessageSubscriptionStateTest {
     assertThat(subscription.isCorrelating()).isFalse();
 
     // when
-    state.updateToCorrelatingState(subscription, wrapString("{\"foo\":\"bar\"}"), 1_000);
+    state.updateToCorrelatingState(subscription, wrapString("{\"foo\":\"bar\"}"), 1_000, 5);
 
     // then
     assertThat(subscription.isCorrelating()).isTrue();
@@ -267,6 +267,7 @@ public class MessageSubscriptionStateTest {
     assertThat(subscriptions).hasSize(1);
     assertThat(subscriptions.get(0).getMessageVariables())
         .isEqualTo(subscription.getMessageVariables());
+    assertThat(subscriptions.get(0).getMessageKey()).isEqualTo(subscription.getMessageKey());
 
     // and
     final List<Long> keys = new ArrayList<>();

--- a/broker-core/src/test/java/io/zeebe/broker/util/RecordStream.java
+++ b/broker-core/src/test/java/io/zeebe/broker/util/RecordStream.java
@@ -25,6 +25,7 @@ import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
@@ -77,6 +78,12 @@ public class RecordStream extends StreamWrapper<LoggedEvent, RecordStream> {
     return new TypedRecordStream<>(
         filter(Records::isWorkflowInstanceRecord)
             .map(e -> CopiedTypedEvent.toTypedEvent(e, WorkflowInstanceRecord.class)));
+  }
+
+  public TypedRecordStream<MessageRecord> onlyMessageRecords() {
+    return new TypedRecordStream<>(
+        filter(Records::isMessageRecord)
+            .map(e -> CopiedTypedEvent.toTypedEvent(e, MessageRecord.class)));
   }
 
   public TypedRecordStream<MessageSubscriptionRecord> onlyMessageSubscriptionRecords() {

--- a/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorRule.java
+++ b/broker-core/src/test/java/io/zeebe/broker/workflow/processor/WorkflowInstanceStreamProcessorRule.java
@@ -100,7 +100,7 @@ public class WorkflowInstanceStreamProcessorRule extends ExternalResource
   }
 
   @Override
-  protected void before() throws Exception {
+  protected void before() {
     mockSubscriptionCommandSender = mock(SubscriptionCommandSender.class);
     mockTopologyManager = mock(TopologyManager.class);
 
@@ -112,6 +112,9 @@ public class WorkflowInstanceStreamProcessorRule extends ExternalResource
         .thenReturn(true);
     when(mockSubscriptionCommandSender.closeMessageSubscription(
             anyInt(), anyLong(), anyLong(), any(DirectBuffer.class)))
+        .thenReturn(true);
+    when(mockSubscriptionCommandSender.rejectCorrelateMessageSubscription(
+            anyLong(), anyLong(), anyLong(), any(), any()))
         .thenReturn(true);
 
     streamProcessor =

--- a/protocol/src/main/java/io/zeebe/protocol/intent/MessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/intent/MessageSubscriptionIntent.java
@@ -22,8 +22,11 @@ public enum MessageSubscriptionIntent implements WorkflowInstanceRelatedIntent {
   CORRELATE((short) 2),
   CORRELATED((short) 3),
 
-  CLOSE((short) 4),
-  CLOSED((short) 5);
+  REJECT((short) 4),
+  REJECTED((short) 5),
+
+  CLOSE((short) 6),
+  CLOSED((short) 7);
 
   private final short value;
   private final boolean shouldBlacklist;
@@ -53,8 +56,12 @@ public enum MessageSubscriptionIntent implements WorkflowInstanceRelatedIntent {
       case 3:
         return CORRELATED;
       case 4:
-        return CLOSE;
+        return REJECT;
       case 5:
+        return REJECTED;
+      case 6:
+        return CLOSE;
+      case 7:
         return CLOSED;
       default:
         return Intent.UNKNOWN;


### PR DESCRIPTION
Sends a reset command which removes the message's correlation from the state, allowing it to be correlated again.

closes #1811 
