### PR TITLE
Migrates IO threads to cpu bound

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/ThreadsCfg.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/ThreadsCfg.java
@@ -19,7 +19,7 @@ package io.zeebe.broker.system.configuration;
 
 public class ThreadsCfg implements ConfigurationEntry {
   private int cpuThreadCount = 2;
-  private int ioThreadCount = 2;
+  private int ioThreadCount = 0;
 
   public int getCpuThreadCount() {
     return cpuThreadCount;

--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/ThreadsCfg.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/ThreadsCfg.java
@@ -19,7 +19,6 @@ package io.zeebe.broker.system.configuration;
 
 public class ThreadsCfg implements ConfigurationEntry {
   private int cpuThreadCount = 2;
-  private int ioThreadCount = 0;
 
   public int getCpuThreadCount() {
     return cpuThreadCount;
@@ -29,21 +28,8 @@ public class ThreadsCfg implements ConfigurationEntry {
     this.cpuThreadCount = cpuThreads;
   }
 
-  public int getIoThreadCount() {
-    return ioThreadCount;
-  }
-
-  public void setIoThreadCount(int ioThreads) {
-    this.ioThreadCount = ioThreads;
-  }
-
   @Override
   public String toString() {
-    return "ThreadsCfg{"
-        + "cpuThreadCount="
-        + cpuThreadCount
-        + ", ioThreadCount="
-        + ioThreadCount
-        + '}';
+    return "ThreadsCfg{" + "cpuThreadCount=" + cpuThreadCount + '}';
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/system/metrics/MetricsFileWriterService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/metrics/MetricsFileWriterService.java
@@ -23,11 +23,10 @@ import io.zeebe.servicecontainer.ServiceStartContext;
 import io.zeebe.servicecontainer.ServiceStopContext;
 import io.zeebe.util.metrics.MetricsManager;
 import io.zeebe.util.sched.ActorScheduler;
-import io.zeebe.util.sched.SchedulingHints;
 
 public class MetricsFileWriterService implements Service<MetricsFileWriter> {
   private MetricsFileWriter metricsFileWriter;
-  private MetricsCfg configuration;
+  private final MetricsCfg configuration;
 
   public MetricsFileWriterService(MetricsCfg cfg) {
     this.configuration = cfg;
@@ -43,7 +42,7 @@ public class MetricsFileWriterService implements Service<MetricsFileWriter> {
     metricsFileWriter =
         new MetricsFileWriter(
             configuration.getReportingIntervalDuration(), metricsFileName, metricsManager);
-    startContext.async(scheduler.submitActor(metricsFileWriter, true, SchedulingHints.ioBound()));
+    startContext.async(scheduler.submitActor(metricsFileWriter, true));
   }
 
   @Override

--- a/dist/src/main/config/zeebe.cfg.toml
+++ b/dist/src/main/config/zeebe.cfg.toml
@@ -214,19 +214,12 @@
 
 # Controls the number of non-blocking CPU threads to be used. WARNING: You
 # should never specify a value that is larger than the number of physical cores
-# available. Good practice is to leave 1-2 cores for ioThreads and the operating
+# available. Good practice is to leave at least one for the operating
 # system (it has to run somewhere). For example, when running Zeebe on a machine
 # which has 4 cores, a good value would be 2.
 #
 # The default value is 2.
 #cpuThreadCount = 2
-
-# Controls the number of io threads to be used. These threads are used for
-# workloads that write data to disk. While writing, these threads are blocked
-# which means that they yield the CPU.
-#
-# The default value is 2.
-#ioThreadCount = 2
 
 [metrics]
 

--- a/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotDirector.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotDirector.java
@@ -21,7 +21,6 @@ import io.zeebe.logstreams.impl.Loggers;
 import io.zeebe.logstreams.spi.SnapshotController;
 import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.ActorCondition;
-import io.zeebe.util.sched.SchedulingHints;
 import io.zeebe.util.sched.future.ActorFuture;
 import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.time.Duration;
@@ -104,7 +103,6 @@ public class AsyncSnapshotDirector extends Actor {
 
   @Override
   protected void onActorStarting() {
-    actor.setSchedulingHints(SchedulingHints.ioBound());
     actor.runAtFixedRate(snapshotRate, prepareTakingSnapshot);
 
     commitCondition = actor.onCondition(getConditionNameForPosition(), this::onCommitCheck);

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogBlockIndexWriterService.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogBlockIndexWriterService.java
@@ -24,14 +24,13 @@ import io.zeebe.servicecontainer.Service;
 import io.zeebe.servicecontainer.ServiceStartContext;
 import io.zeebe.servicecontainer.ServiceStopContext;
 import io.zeebe.util.sched.ActorScheduler;
-import io.zeebe.util.sched.SchedulingHints;
 
 public class LogBlockIndexWriterService implements Service<LogBlockIndexWriter> {
   private final Injector<LogBlockIndex> logBlockIndexInjector = new Injector<>();
   private final Injector<LogStorage> logStorageInjector = new Injector<>();
 
   private LogBlockIndexWriter logBlockIndexWriter;
-  private LogStreamBuilder logStreamBuilder;
+  private final LogStreamBuilder logStreamBuilder;
 
   public LogBlockIndexWriterService(LogStreamBuilder logStreamBuilder) {
     this.logStreamBuilder = logStreamBuilder;
@@ -51,7 +50,7 @@ public class LogBlockIndexWriterService implements Service<LogBlockIndexWriter> 
             logBlockIndex,
             scheduler.getMetricsManager());
 
-    startContext.async(scheduler.submitActor(logBlockIndexWriter, true, SchedulingHints.ioBound()));
+    startContext.async(scheduler.submitActor(logBlockIndexWriter, true));
   }
 
   @Override

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogStorageAppenderService.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogStorageAppenderService.java
@@ -22,7 +22,6 @@ import io.zeebe.servicecontainer.Injector;
 import io.zeebe.servicecontainer.Service;
 import io.zeebe.servicecontainer.ServiceStartContext;
 import io.zeebe.servicecontainer.ServiceStopContext;
-import io.zeebe.util.sched.SchedulingHints;
 
 public class LogStorageAppenderService implements Service<LogStorageAppender> {
   private final Injector<Subscription> appenderSubscriptionInjector = new Injector<>();
@@ -48,8 +47,7 @@ public class LogStorageAppenderService implements Service<LogStorageAppender> {
             subscription,
             maxAppendBlockSize);
 
-    startContext.async(
-        startContext.getScheduler().submitActor(service, true, SchedulingHints.ioBound()));
+    startContext.async(startContext.getScheduler().submitActor(service, true));
   }
 
   @Override

--- a/util/src/main/java/io/zeebe/util/sched/ActorExecutor.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorExecutor.java
@@ -55,6 +55,9 @@ public class ActorExecutor {
   }
 
   public ActorFuture<Void> submitIoBoundTask(ActorTask task, boolean collectTaskMetrics) {
+    assert ioBoundThreads.numOfThreads > 0
+        : "Expected to have at least one IO Thread configured to submit an IO bound task to it, but there were none.";
+
     return submitTask(task, collectTaskMetrics, ioBoundThreads);
   }
 

--- a/util/src/main/java/io/zeebe/util/sched/ActorScheduler.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorScheduler.java
@@ -142,7 +142,7 @@ public class ActorScheduler {
     private ActorThreadGroup cpuBoundActorGroup;
     private final double[] priorityQuotas = new double[] {0.60, 0.30, 0.10};
 
-    private int ioBoundThreadsCount = 2;
+    private int ioBoundThreadsCount = 0;
     private ActorThreadGroup ioBoundActorGroup;
 
     private ActorThreadFactory actorThreadFactory;


### PR DESCRIPTION
Migrated the IO bounded threads to the CPU bounded scheduler.  With this change we get more CPU time to execute the processing part and avoid unnecessary idling of the IO Threads.

See the attached profiles 
[io-profiling.zip](https://github.com/zeebe-io/zeebe/files/3202630/io-profiling.zip)


closes #2470 
