### PR TITLE
chore(Dockerfile): add ZEEBE_STANDALONE_GATEWAY env to start standalo…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ ARG DISTBALL
 ENV ZB_HOME=/usr/local/zeebe \
     ZEEBE_LOG_LEVEL=info \
     ZEEBE_GATEWAY_HOST=0.0.0.0 \
-    DEPLOY_ON_KUBERNETES=false \
-    BOOTSTRAP=1
+    ZEEBE_STANDALONE_GATEWAY=false
 ENV PATH "${ZB_HOME}/bin:${PATH}"
 ENV JAVA_OPTS -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
 

--- a/docker/utils/startup.sh
+++ b/docker/utils/startup.sh
@@ -4,8 +4,8 @@ configFile=/usr/local/zeebe/conf/zeebe.cfg.toml
 
 export ZEEBE_HOST=${ZEEBE_HOST:-$(hostname -i)}
 
-if [[ "$DEPLOY_ON_KUBERNETES" == "true" ]]; then
-    ZEEBE_HOST="${HOST}.${DNS}"
+if [ "$ZEEBE_STANDALONE_GATEWAY" = "true" ]; then
+    exec /usr/local/zeebe/bin/gateway
+else
+    exec /usr/local/zeebe/bin/broker
 fi
-
-exec /usr/local/zeebe/bin/broker


### PR DESCRIPTION
…ne gateway

- add ZEEBE_STANDALONE_GATEWAY to start container as standalone gateway without
  a broker (default: false)
- remove outdated DEPLOY_ON_KUBERNETES env variable
- remove outdated BOOTSTRAP env variable


closes #
