### PR TITLE
Migrate ParallelGateway tests

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/engine/EngineService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/engine/EngineService.java
@@ -30,23 +30,9 @@ import io.zeebe.broker.transport.clientapi.CommandResponseWriterImpl;
 import io.zeebe.engine.processor.ProcessingContext;
 import io.zeebe.engine.processor.StreamProcessor;
 import io.zeebe.engine.processor.TypedRecordProcessors;
-import io.zeebe.engine.processor.workflow.BpmnStepProcessor;
-import io.zeebe.engine.processor.workflow.CatchEventBehavior;
-import io.zeebe.engine.processor.workflow.WorkflowEventProcessors;
-import io.zeebe.engine.processor.workflow.deployment.DeploymentCreatedProcessor;
-import io.zeebe.engine.processor.workflow.deployment.DeploymentEventProcessors;
-import io.zeebe.engine.processor.workflow.deployment.distribute.DeploymentDistributeProcessor;
-import io.zeebe.engine.processor.workflow.incident.IncidentEventProcessors;
-import io.zeebe.engine.processor.workflow.job.JobEventProcessors;
-import io.zeebe.engine.processor.workflow.message.MessageEventProcessors;
-import io.zeebe.engine.processor.workflow.timer.DueDateTimerChecker;
+import io.zeebe.engine.processor.workflow.EngineProcessors;
 import io.zeebe.engine.state.ZeebeState;
-import io.zeebe.engine.state.deployment.WorkflowState;
 import io.zeebe.logstreams.log.LogStream;
-import io.zeebe.logstreams.log.LogStreamWriterImpl;
-import io.zeebe.protocol.Protocol;
-import io.zeebe.protocol.clientapi.ValueType;
-import io.zeebe.protocol.intent.DeploymentIntent;
 import io.zeebe.servicecontainer.Injector;
 import io.zeebe.servicecontainer.Service;
 import io.zeebe.servicecontainer.ServiceContainer;
@@ -114,47 +100,15 @@ public class EngineService implements Service<EngineService> {
             (processingContext) -> {
               final ActorControl actor = processingContext.getActor();
               final ZeebeState zeebeState = processingContext.getZeebeState();
-              return createTypedStreamProcessor(actor, partitionId, zeebeState, processingContext);
+              return createTypedStreamProcessor(actor, zeebeState, processingContext);
             })
         .deleteDataOnSnapshot(true)
         .build();
   }
 
   public TypedRecordProcessors createTypedStreamProcessor(
-      ActorControl actor,
-      int partitionId,
-      ZeebeState zeebeState,
-      ProcessingContext processingContext) {
-    final TypedRecordProcessors typedRecordProcessors = TypedRecordProcessors.processors();
+      ActorControl actor, ZeebeState zeebeState, ProcessingContext processingContext) {
     final LogStream stream = processingContext.getLogStream();
-
-    addDistributeDeploymentProcessors(actor, zeebeState, stream, typedRecordProcessors);
-
-    final SubscriptionCommandSenderImpl subscriptionCommandSender =
-        new SubscriptionCommandSenderImpl(atomix);
-    subscriptionCommandSender.init(topologyManager, actor, stream);
-    final CatchEventBehavior catchEventBehavior =
-        new CatchEventBehavior(
-            zeebeState, subscriptionCommandSender, clusterCfg.getPartitionsCount());
-
-    addDeploymentRelatedProcessorAndServices(
-        catchEventBehavior, partitionId, zeebeState, typedRecordProcessors);
-    addMessageProcessors(subscriptionCommandSender, zeebeState, typedRecordProcessors);
-
-    final BpmnStepProcessor stepProcessor =
-        addWorkflowProcessors(
-            zeebeState, typedRecordProcessors, subscriptionCommandSender, catchEventBehavior);
-    addIncidentProcessors(zeebeState, stepProcessor, typedRecordProcessors);
-    addJobProcessors(zeebeState, typedRecordProcessors);
-
-    return typedRecordProcessors;
-  }
-
-  private void addDistributeDeploymentProcessors(
-      ActorControl actor,
-      ZeebeState zeebeState,
-      LogStream stream,
-      TypedRecordProcessors typedRecordProcessors) {
 
     final TopologyPartitionListenerImpl partitionListener =
         new TopologyPartitionListenerImpl(actor);
@@ -163,68 +117,16 @@ public class EngineService implements Service<EngineService> {
     final DeploymentDistributorImpl deploymentDistributor =
         new DeploymentDistributorImpl(
             clusterCfg, atomix, partitionListener, zeebeState.getDeploymentState(), actor);
-    final DeploymentDistributeProcessor deploymentDistributeProcessor =
-        new DeploymentDistributeProcessor(
-            zeebeState.getDeploymentState(),
-            new LogStreamWriterImpl(stream),
-            deploymentDistributor);
 
-    typedRecordProcessors.onCommand(
-        ValueType.DEPLOYMENT, DeploymentIntent.DISTRIBUTE, deploymentDistributeProcessor);
-  }
+    final SubscriptionCommandSenderImpl subscriptionCommandSender =
+        new SubscriptionCommandSenderImpl(atomix);
+    subscriptionCommandSender.init(topologyManager, actor, stream);
 
-  private BpmnStepProcessor addWorkflowProcessors(
-      ZeebeState zeebeState,
-      TypedRecordProcessors typedRecordProcessors,
-      SubscriptionCommandSenderImpl subscriptionCommandSender,
-      CatchEventBehavior catchEventBehavior) {
-    final DueDateTimerChecker timerChecker = new DueDateTimerChecker(zeebeState.getWorkflowState());
-    return WorkflowEventProcessors.addWorkflowProcessors(
-        zeebeState,
-        typedRecordProcessors,
+    return EngineProcessors.createEngineProcessors(
+        processingContext,
+        clusterCfg.getPartitionsCount(),
         subscriptionCommandSender,
-        catchEventBehavior,
-        timerChecker);
-  }
-
-  public void addDeploymentRelatedProcessorAndServices(
-      CatchEventBehavior catchEventBehavior,
-      int partitionId,
-      ZeebeState zeebeState,
-      TypedRecordProcessors typedRecordProcessors) {
-    final WorkflowState workflowState = zeebeState.getWorkflowState();
-    final boolean isDeploymentPartition = partitionId == Protocol.DEPLOYMENT_PARTITION;
-    if (isDeploymentPartition) {
-      DeploymentEventProcessors.addTransformingDeploymentProcessor(
-          typedRecordProcessors, zeebeState, catchEventBehavior);
-    } else {
-      DeploymentEventProcessors.addDeploymentCreateProcessor(typedRecordProcessors, workflowState);
-    }
-
-    typedRecordProcessors.onEvent(
-        ValueType.DEPLOYMENT,
-        DeploymentIntent.CREATED,
-        new DeploymentCreatedProcessor(workflowState, isDeploymentPartition));
-  }
-
-  private void addIncidentProcessors(
-      ZeebeState zeebeState,
-      BpmnStepProcessor stepProcessor,
-      TypedRecordProcessors typedRecordProcessors) {
-    IncidentEventProcessors.addProcessors(typedRecordProcessors, zeebeState, stepProcessor);
-  }
-
-  private void addJobProcessors(
-      ZeebeState zeebeState, TypedRecordProcessors typedRecordProcessors) {
-    JobEventProcessors.addJobProcessors(typedRecordProcessors, zeebeState);
-  }
-
-  private void addMessageProcessors(
-      SubscriptionCommandSenderImpl subscriptionCommandSender,
-      ZeebeState zeebeState,
-      TypedRecordProcessors typedRecordProcessors) {
-    MessageEventProcessors.addMessageProcessors(
-        typedRecordProcessors, zeebeState, subscriptionCommandSender);
+        deploymentDistributor);
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/EngineProcessors.java
@@ -1,0 +1,140 @@
+/*
+ * Zeebe Workflow Engine
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.engine.processor.workflow;
+
+import io.zeebe.engine.processor.ProcessingContext;
+import io.zeebe.engine.processor.TypedRecordProcessors;
+import io.zeebe.engine.processor.workflow.deployment.DeploymentCreatedProcessor;
+import io.zeebe.engine.processor.workflow.deployment.DeploymentEventProcessors;
+import io.zeebe.engine.processor.workflow.deployment.distribute.DeploymentDistributeProcessor;
+import io.zeebe.engine.processor.workflow.deployment.distribute.DeploymentDistributor;
+import io.zeebe.engine.processor.workflow.incident.IncidentEventProcessors;
+import io.zeebe.engine.processor.workflow.job.JobEventProcessors;
+import io.zeebe.engine.processor.workflow.message.MessageEventProcessors;
+import io.zeebe.engine.processor.workflow.message.command.SubscriptionCommandSender;
+import io.zeebe.engine.processor.workflow.timer.DueDateTimerChecker;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.deployment.WorkflowState;
+import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.logstreams.log.LogStreamWriterImpl;
+import io.zeebe.protocol.Protocol;
+import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.intent.DeploymentIntent;
+
+public class EngineProcessors {
+
+  public static TypedRecordProcessors createEngineProcessors(
+      ProcessingContext processingContext,
+      int partitionsCount,
+      SubscriptionCommandSender subscriptionCommandSender,
+      DeploymentDistributor deploymentDistributor) {
+
+    final TypedRecordProcessors typedRecordProcessors = TypedRecordProcessors.processors();
+    final LogStream stream = processingContext.getLogStream();
+    final int partitionId = stream.getPartitionId();
+    final ZeebeState zeebeState = processingContext.getZeebeState();
+
+    addDistributeDeploymentProcessors(
+        zeebeState, stream, typedRecordProcessors, deploymentDistributor);
+
+    final CatchEventBehavior catchEventBehavior =
+        new CatchEventBehavior(zeebeState, subscriptionCommandSender, partitionsCount);
+
+    addDeploymentRelatedProcessorAndServices(
+        catchEventBehavior, partitionId, zeebeState, typedRecordProcessors);
+    addMessageProcessors(subscriptionCommandSender, zeebeState, typedRecordProcessors);
+
+    final BpmnStepProcessor stepProcessor =
+        addWorkflowProcessors(
+            zeebeState, typedRecordProcessors, subscriptionCommandSender, catchEventBehavior);
+    addIncidentProcessors(zeebeState, stepProcessor, typedRecordProcessors);
+    addJobProcessors(zeebeState, typedRecordProcessors);
+
+    return typedRecordProcessors;
+  }
+
+  private static void addDistributeDeploymentProcessors(
+      ZeebeState zeebeState,
+      LogStream stream,
+      TypedRecordProcessors typedRecordProcessors,
+      DeploymentDistributor deploymentDistributor) {
+
+    final DeploymentDistributeProcessor deploymentDistributeProcessor =
+        new DeploymentDistributeProcessor(
+            zeebeState.getDeploymentState(),
+            new LogStreamWriterImpl(stream),
+            deploymentDistributor);
+
+    typedRecordProcessors.onCommand(
+        ValueType.DEPLOYMENT, DeploymentIntent.DISTRIBUTE, deploymentDistributeProcessor);
+  }
+
+  private static BpmnStepProcessor addWorkflowProcessors(
+      ZeebeState zeebeState,
+      TypedRecordProcessors typedRecordProcessors,
+      SubscriptionCommandSender subscriptionCommandSender,
+      CatchEventBehavior catchEventBehavior) {
+    final DueDateTimerChecker timerChecker = new DueDateTimerChecker(zeebeState.getWorkflowState());
+    return WorkflowEventProcessors.addWorkflowProcessors(
+        zeebeState,
+        typedRecordProcessors,
+        subscriptionCommandSender,
+        catchEventBehavior,
+        timerChecker);
+  }
+
+  private static void addDeploymentRelatedProcessorAndServices(
+      CatchEventBehavior catchEventBehavior,
+      int partitionId,
+      ZeebeState zeebeState,
+      TypedRecordProcessors typedRecordProcessors) {
+    final WorkflowState workflowState = zeebeState.getWorkflowState();
+    final boolean isDeploymentPartition = partitionId == Protocol.DEPLOYMENT_PARTITION;
+    if (isDeploymentPartition) {
+      DeploymentEventProcessors.addTransformingDeploymentProcessor(
+          typedRecordProcessors, zeebeState, catchEventBehavior);
+    } else {
+      DeploymentEventProcessors.addDeploymentCreateProcessor(typedRecordProcessors, workflowState);
+    }
+
+    typedRecordProcessors.onEvent(
+        ValueType.DEPLOYMENT,
+        DeploymentIntent.CREATED,
+        new DeploymentCreatedProcessor(workflowState, isDeploymentPartition));
+  }
+
+  private static void addIncidentProcessors(
+      ZeebeState zeebeState,
+      BpmnStepProcessor stepProcessor,
+      TypedRecordProcessors typedRecordProcessors) {
+    IncidentEventProcessors.addProcessors(typedRecordProcessors, zeebeState, stepProcessor);
+  }
+
+  private static void addJobProcessors(
+      ZeebeState zeebeState, TypedRecordProcessors typedRecordProcessors) {
+    JobEventProcessors.addJobProcessors(typedRecordProcessors, zeebeState);
+  }
+
+  private static void addMessageProcessors(
+      SubscriptionCommandSender subscriptionCommandSender,
+      ZeebeState zeebeState,
+      TypedRecordProcessors typedRecordProcessors) {
+    MessageEventProcessors.addMessageProcessors(
+        typedRecordProcessors, zeebeState, subscriptionCommandSender);
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/EngineRule.java
@@ -1,0 +1,289 @@
+/*
+ * Zeebe Workflow Engine
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.engine.processor.workflow;
+
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.zeebe.engine.processor.TypedEventImpl;
+import io.zeebe.engine.processor.TypedRecord;
+import io.zeebe.engine.processor.workflow.deployment.distribute.DeploymentDistributor;
+import io.zeebe.engine.processor.workflow.deployment.distribute.PendingDeploymentDistribution;
+import io.zeebe.engine.processor.workflow.message.command.SubscriptionCommandSender;
+import io.zeebe.engine.util.CopiedTypedEvent;
+import io.zeebe.engine.util.RecordStream;
+import io.zeebe.engine.util.Records;
+import io.zeebe.engine.util.StreamProcessorRule;
+import io.zeebe.engine.util.TypedRecordStream;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.protocol.BpmnElementType;
+import io.zeebe.protocol.Protocol;
+import io.zeebe.protocol.clientapi.ValueType;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.zeebe.protocol.impl.record.value.deployment.ResourceType;
+import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.intent.DeploymentIntent;
+import io.zeebe.protocol.intent.Intent;
+import io.zeebe.protocol.intent.JobIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceCreationIntent;
+import io.zeebe.protocol.intent.WorkflowInstanceIntent;
+import io.zeebe.test.util.TestUtil;
+import io.zeebe.util.sched.future.CompletableActorFuture;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class EngineRule extends ExternalResource {
+
+  private final StreamProcessorRule environmentRule =
+      new StreamProcessorRule(Protocol.DEPLOYMENT_PARTITION);
+
+  private SubscriptionCommandSender mockSubscriptionCommandSender;
+  private DeploymentDistributor mockDeploymentDistributor;
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    final Statement statement = super.apply(base, description);
+    return environmentRule.apply(statement, description);
+  }
+
+  @Override
+  protected void before() {
+    mockSubscriptionCommandSender = mock(SubscriptionCommandSender.class);
+
+    when(mockSubscriptionCommandSender.openMessageSubscription(
+            anyInt(), anyLong(), anyLong(), any(), any(), anyBoolean()))
+        .thenReturn(true);
+    when(mockSubscriptionCommandSender.correlateMessageSubscription(
+            anyInt(), anyLong(), anyLong(), any()))
+        .thenReturn(true);
+    when(mockSubscriptionCommandSender.closeMessageSubscription(
+            anyInt(), anyLong(), anyLong(), any(DirectBuffer.class)))
+        .thenReturn(true);
+    when(mockSubscriptionCommandSender.rejectCorrelateMessageSubscription(
+            anyLong(), anyLong(), anyLong(), any(), any()))
+        .thenReturn(true);
+
+    mockDeploymentDistributor = mock(DeploymentDistributor.class);
+
+    when(mockDeploymentDistributor.pushDeployment(anyLong(), anyLong(), any()))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    final DeploymentRecord deploymentRecord = new DeploymentRecord();
+    final UnsafeBuffer deploymentBuffer = new UnsafeBuffer(new byte[deploymentRecord.getLength()]);
+    deploymentRecord.write(deploymentBuffer, 0);
+
+    final PendingDeploymentDistribution deploymentDistribution =
+        mock(PendingDeploymentDistribution.class);
+    when(deploymentDistribution.getDeployment()).thenReturn(deploymentBuffer);
+    when(mockDeploymentDistributor.removePendingDeployment(anyLong()))
+        .thenReturn(deploymentDistribution);
+
+    environmentRule.startTypedStreamProcessor(
+        (processingContext) ->
+            EngineProcessors.createEngineProcessors(
+                processingContext, 1, mockSubscriptionCommandSender, mockDeploymentDistributor));
+  }
+
+  public TypedRecord<DeploymentRecord> deploy(final BpmnModelInstance modelInstance) {
+    final DeploymentRecord deploymentRecord = new DeploymentRecord();
+    deploymentRecord
+        .resources()
+        .add()
+        .setResourceName(wrapString("process.bpmn"))
+        .setResource(wrapString(Bpmn.convertToString(modelInstance)))
+        .setResourceType(ResourceType.BPMN_XML);
+
+    environmentRule.writeCommand(DeploymentIntent.CREATE, deploymentRecord);
+
+    return awaitRecord(ValueType.DEPLOYMENT, DeploymentIntent.CREATED, DeploymentRecord.class);
+  }
+
+  public TypedRecord<WorkflowInstanceCreationRecord> createWorkflowInstance(
+      Function<WorkflowInstanceCreationRecord, WorkflowInstanceCreationRecord> transformer) {
+    final long position =
+        environmentRule.writeCommand(
+            WorkflowInstanceCreationIntent.CREATE,
+            transformer.apply(new WorkflowInstanceCreationRecord()));
+
+    return awaitRecord(
+        ValueType.WORKFLOW_INSTANCE_CREATION,
+        WorkflowInstanceCreationIntent.CREATED,
+        (e) -> ((TypedEventImpl) e).getSourceEventPosition() == position,
+        WorkflowInstanceCreationRecord.class);
+  }
+
+  public RecordStream events() {
+    return environmentRule.events();
+  }
+
+  public void completeJobOfType(String type) {
+    final TypedRecord<JobRecord> createdEvent = awaitJobInState(type, JobIntent.CREATED);
+
+    environmentRule.writeCommand(
+        createdEvent.getKey(), JobIntent.COMPLETE, createdEvent.getValue());
+    awaitJobInState(type, JobIntent.COMPLETED);
+  }
+
+  private TypedRecord<JobRecord> awaitJobInState(final String type, final JobIntent state) {
+    return awaitRecord(ValueType.JOB, state, withJobType(wrapString(type)), JobRecord.class);
+  }
+
+  public TypedRecord<WorkflowInstanceRecord> awaitWorkflowInstanceRecord(
+      String elementId, Intent intent) {
+    return awaitRecord(
+        ValueType.WORKFLOW_INSTANCE,
+        intent,
+        withElementId(wrapString(elementId)),
+        WorkflowInstanceRecord.class);
+  }
+
+  public List<TypedRecord<WorkflowInstanceRecord>> collectWorkflowInstanceRecords(
+      WorkflowInstanceIntent intent, BpmnElementType elementType, int amount) {
+    return collectWorkflowInstanceRecords(intent, withBpmElementType(elementType), amount);
+  }
+
+  public List<TypedRecord<WorkflowInstanceRecord>> collectWorkflowInstanceRecords(
+      Intent intent, Predicate<TypedRecord<WorkflowInstanceRecord>> matcher, int amount) {
+    return collectRecords(
+        ValueType.WORKFLOW_INSTANCE, intent, matcher, WorkflowInstanceRecord.class, amount);
+  }
+
+  public List<TypedRecord<WorkflowInstanceRecord>> collectWorkflowInstanceRecordsUntilCompletion() {
+    return collectRecords(
+        ValueType.WORKFLOW_INSTANCE,
+        r ->
+            r.getMetadata().getIntent() == WorkflowInstanceIntent.ELEMENT_COMPLETED
+                && r.getKey() == r.getValue().getWorkflowInstanceKey(),
+        WorkflowInstanceRecord.class);
+  }
+
+  public List<TypedRecord<WorkflowInstanceRecord>> collectWorkflowInstanceRecordsUntil(
+      Predicate<TypedRecord<WorkflowInstanceRecord>> abortCondition) {
+    return collectRecords(
+        ValueType.WORKFLOW_INSTANCE, abortCondition, WorkflowInstanceRecord.class);
+  }
+
+  public List<TypedRecord<WorkflowInstanceRecord>> collectWorkflowInstanceRecords(
+      Intent intent, Predicate<TypedRecord<WorkflowInstanceRecord>> abortCondition) {
+    return collectRecords(
+        ValueType.WORKFLOW_INSTANCE, intent, abortCondition, WorkflowInstanceRecord.class);
+  }
+
+  private <T extends UnpackedObject> List<TypedRecord<T>> collectRecords(
+      ValueType valueType, Predicate<TypedRecord<T>> abortCondition, Class<T> valueClass) {
+    return TestUtil.doRepeatedly(
+            () ->
+                new TypedRecordStream<T>(
+                        environmentRule
+                            .events()
+                            .filter(r -> Records.isRecordOfType(r, valueType))
+                            .map(e -> CopiedTypedEvent.toTypedEvent(e, valueClass)))
+                    .limit(abortCondition)
+                    .collect(Collectors.toList()))
+        .until(typedRecords -> typedRecords.stream().anyMatch(abortCondition));
+  }
+
+  private <T extends UnpackedObject> List<TypedRecord<T>> collectRecords(
+      ValueType valueType,
+      Intent intent,
+      Predicate<TypedRecord<T>> abortCondition,
+      Class<T> valueClass) {
+    return TestUtil.doRepeatedly(
+            () ->
+                new TypedRecordStream<T>(
+                        environmentRule
+                            .events()
+                            .filter(r -> Records.isEvent(r, valueType, intent))
+                            .map(e -> CopiedTypedEvent.toTypedEvent(e, valueClass)))
+                    .limit(abortCondition)
+                    .collect(Collectors.toList()))
+        .until(typedRecords -> typedRecords.stream().anyMatch(abortCondition));
+  }
+
+  private <T extends UnpackedObject> List<TypedRecord<T>> collectRecords(
+      ValueType valueType,
+      Intent intent,
+      Predicate<TypedRecord<T>> matcher,
+      Class<T> valueClass,
+      int amount) {
+    return TestUtil.doRepeatedly(
+            () ->
+                environmentRule
+                    .events()
+                    .filter(r -> Records.isEvent(r, valueType, intent))
+                    .map(e -> CopiedTypedEvent.toTypedEvent(e, valueClass))
+                    .filter(matcher)
+                    .limit(amount)
+                    .collect(Collectors.toList()))
+        .until(typedRecords -> typedRecords.size() >= amount);
+  }
+
+  private <T extends UnpackedObject> TypedRecord<T> awaitRecord(
+      ValueType valueType, Intent intent, Class<T> recordClass) {
+    return awaitRecord(valueType, intent, (r) -> true, recordClass);
+  }
+
+  private <T extends UnpackedObject> TypedRecord<T> awaitRecord(
+      ValueType valueType, Intent intent, Predicate<TypedRecord<T>> matcher, Class<T> valueClass) {
+    return TestUtil.doRepeatedly(
+            () ->
+                environmentRule
+                    .events()
+                    .filter(r -> Records.isEvent(r, valueType, intent))
+                    .map(e -> CopiedTypedEvent.toTypedEvent(e, valueClass))
+                    .filter(matcher)
+                    .findFirst())
+        .until(Optional::isPresent)
+        .orElse(null);
+  }
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+  //////////////////////////////////////// PREDICATES /////////////////////////////////////////////
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+
+  private Predicate<TypedRecord<JobRecord>> withJobType(DirectBuffer type) {
+    return r -> r.getValue().getType().equals(type);
+  }
+
+  private static Predicate<TypedRecord<WorkflowInstanceRecord>> withBpmElementType(
+      BpmnElementType bpmElementType) {
+    return r -> r.getValue().getBpmnElementType() == bpmElementType;
+  }
+
+  private static Predicate<TypedRecord<WorkflowInstanceRecord>> withElementId(
+      DirectBuffer elementId) {
+    return r -> r.getValue().getElementId().equals(elementId);
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/CopiedTypedEvent.java
+++ b/engine/src/test/java/io/zeebe/engine/util/CopiedTypedEvent.java
@@ -37,7 +37,7 @@ public class CopiedTypedEvent extends TypedEventImpl {
     this.sourcePosition = event.getSourceEventPosition();
     this.metadata = new RecordMetadata();
     event.readMetadata(metadata);
-    value.wrap(event.getValueBuffer(), event.getValueOffset(), event.getValueLength());
+    event.readValue(object);
   }
 
   @Override

--- a/engine/src/test/java/io/zeebe/engine/util/LogStreamPrinter.java
+++ b/engine/src/test/java/io/zeebe/engine/util/LogStreamPrinter.java
@@ -17,17 +17,22 @@
  */
 package io.zeebe.engine.util;
 
+import static io.zeebe.engine.processor.TypedEventRegistry.EVENT_REGISTRY;
+
 import io.zeebe.logstreams.log.BufferedLogStreamReader;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
 import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.protocol.impl.record.RecordMetadata;
-import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.servicecontainer.Injector;
 import io.zeebe.servicecontainer.Service;
 import io.zeebe.servicecontainer.ServiceName;
 import io.zeebe.servicecontainer.ServiceStartContext;
+import io.zeebe.util.ReflectUtil;
+import java.util.EnumMap;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +41,7 @@ public class LogStreamPrinter {
   private static final ServiceName<Object> PRINTER_SERVICE_NAME =
       ServiceName.newServiceName("printer", Object.class);
 
-  private static final String HEADER_INDENTATION = "\t";
+  private static final String HEADER_INDENTATION = "\t\t\t";
   private static final String ENTRY_INDENTATION = HEADER_INDENTATION + "\t";
 
   private static final Logger LOGGER = LoggerFactory.getLogger("io.zeebe.broker.test");
@@ -47,19 +52,26 @@ public class LogStreamPrinter {
     sb.append(logStream.getPartitionId());
     sb.append(":\n");
 
+    final EnumMap<ValueType, UnpackedObject> eventCache = new EnumMap<>(ValueType.class);
+    EVENT_REGISTRY.forEach((t, c) -> eventCache.put(t, ReflectUtil.newInstance(c)));
+
     try (LogStreamReader streamReader = new BufferedLogStreamReader(logStream)) {
       streamReader.seekToFirstEvent();
 
       while (streamReader.hasNext()) {
         final LoggedEvent event = streamReader.next();
-        writeRecord(event, sb);
+
+        writeRecord(eventCache, event, sb);
       }
     }
 
     LOGGER.info(sb.toString());
   }
 
-  private static void writeRecord(final LoggedEvent event, final StringBuilder sb) {
+  private static void writeRecord(
+      final Map<ValueType, UnpackedObject> eventCache,
+      final LoggedEvent event,
+      final StringBuilder sb) {
     sb.append(HEADER_INDENTATION);
     writeRecordHeader(event, sb);
     sb.append("\n");
@@ -69,20 +81,11 @@ public class LogStreamPrinter {
     writeMetadata(metadata, sb);
     sb.append("\n");
 
-    sb.append(ENTRY_INDENTATION);
-    writeRecordBody(sb, event, metadata);
+    final UnpackedObject unpackedObject = eventCache.get(metadata.getValueType());
+    event.readValue(unpackedObject);
+    sb.append(ENTRY_INDENTATION).append("Value:\n");
+    unpackedObject.writeJSON(sb);
     sb.append("\n");
-  }
-
-  private static void writeRecordBody(
-      final StringBuilder sb, final LoggedEvent event, final RecordMetadata metadata) {
-    if (metadata.getValueType() == ValueType.WORKFLOW_INSTANCE) {
-      final WorkflowInstanceRecord record = new WorkflowInstanceRecord();
-      event.readValue(record);
-      writeWorkflowInstanceBody(record, sb);
-    } else {
-      sb.append("<getValue>");
-    }
   }
 
   private static void writeRecordHeader(final LoggedEvent event, final StringBuilder sb) {
@@ -90,11 +93,6 @@ public class LogStreamPrinter {
     sb.append(event.getPosition());
     sb.append(" Key: ");
     sb.append(event.getKey());
-  }
-
-  private static void writeWorkflowInstanceBody(
-      final WorkflowInstanceRecord record, final StringBuilder sb) {
-    record.writeJSON(sb);
   }
 
   private static void writeMetadata(final RecordMetadata metadata, final StringBuilder sb) {

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/RecordMetadata.java
@@ -25,6 +25,7 @@ import io.zeebe.protocol.clientapi.RejectionType;
 import io.zeebe.protocol.clientapi.ValueType;
 import io.zeebe.protocol.intent.Intent;
 import io.zeebe.util.buffer.BufferReader;
+import io.zeebe.util.buffer.BufferUtil;
 import io.zeebe.util.buffer.BufferWriter;
 import java.nio.charset.StandardCharsets;
 import org.agrona.DirectBuffer;
@@ -218,10 +219,6 @@ public class RecordMetadata implements BufferWriter, BufferReader {
         && requestStreamId != RecordMetadataEncoder.requestStreamIdNullValue();
   }
 
-  public void copyRequestMetadata(RecordMetadata target) {
-    target.requestId(requestId).requestStreamId(requestStreamId);
-  }
-
   @Override
   public String toString() {
     return "RecordMetadata{"
@@ -235,8 +232,14 @@ public class RecordMetadata implements BufferWriter, BufferReader {
         + requestStreamId
         + ", requestId="
         + requestId
+        + ", protocolVersion="
+        + protocolVersion
         + ", valueType="
         + valueType
+        + ", rejectionType="
+        + rejectionType
+        + ", rejectionReason="
+        + BufferUtil.bufferAsString(rejectionReason)
         + '}';
   }
 }


### PR DESCRIPTION
 * adds a factory method, which can be used in our broker and in our engine tests to install all processors
 * adds a first version of a EngineRule, which I would like to discuss. Contains functionallity to deploy, create instances, complete jobs and to await an certain event/state. 
* migrated the ParallelGatewayTests as an example how it could look like, test execution time decreased from 40s to 7 seconds

   