### PR TITLE
chore(broker-core): capture injected service before removing accessor service

### DIFF
--- a/broker-core/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker-core/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -312,9 +312,12 @@ public class EmbeddedBrokerRule extends ExternalResource {
       throw new RuntimeException(e);
     }
 
+    // capture value before removing the service as it will uninject the value on stop
+    final S value = injector.getValue();
+
     serviceContainer.removeService(accessorServiceName);
 
-    return injector.getValue();
+    return value;
   }
 
   public <T> void installService(


### PR DESCRIPTION
- on service stop the injector values are "uninjected" which allows a race
  condition where the service is stopped before we access the injector value

closes #2534 
