### PR TITLE
Refactor data deletion

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/partitions/Partition.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/partitions/Partition.java
@@ -20,14 +20,18 @@ package io.zeebe.broker.clustering.base.partitions;
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.zeebe.broker.Loggers;
 import io.zeebe.broker.engine.EngineService;
+import io.zeebe.broker.engine.EngineServiceNames;
 import io.zeebe.broker.engine.impl.StateReplication;
-import io.zeebe.broker.exporter.stream.ExportersState;
+import io.zeebe.broker.exporter.ExporterServiceNames;
+import io.zeebe.broker.logstreams.delete.FollowerLogStreamDeletionService;
+import io.zeebe.broker.logstreams.delete.LeaderLogStreamDeletionService;
 import io.zeebe.broker.logstreams.restore.BrokerRestoreServer;
 import io.zeebe.broker.system.configuration.BrokerCfg;
 import io.zeebe.db.ZeebeDb;
 import io.zeebe.distributedlog.StorageConfiguration;
 import io.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.zeebe.engine.state.StateStorageFactory;
+import io.zeebe.logstreams.impl.delete.DeletionService;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.state.NoneSnapshotReplication;
 import io.zeebe.logstreams.state.SnapshotReplication;
@@ -82,14 +86,29 @@ public class Partition implements Service<Partition> {
   public void start(final ServiceStartContext startContext) {
     final CompletableActorFuture<Void> startedFuture = new CompletableActorFuture<>();
     logStream = logStreamInjector.getValue();
-
-    logStream = logStreamInjector.getValue();
     snapshotController = createSnapshotController();
 
+    final DeletionService deletionService;
     if (state == RaftState.FOLLOWER) {
-      logStream.setExporterPositionSupplier(this::getLowestReplicatedExportedPosition);
-      snapshotController.consumeReplicatedSnapshots(logStream::delete);
+      deletionService =
+          new FollowerLogStreamDeletionService(
+              logStream, snapshotController, brokerCfg.getCluster().getNodeId());
+
+      snapshotController.setDeletionService(deletionService);
+      snapshotController.consumeReplicatedSnapshots();
     } else {
+      final LeaderLogStreamDeletionService leaderDeletionService =
+          new LeaderLogStreamDeletionService(logStream);
+      startContext
+          .createService(
+              EngineServiceNames.leaderLogStreamDeletionService(partitionId), leaderDeletionService)
+          .dependency(
+              ExporterServiceNames.EXPORTER_MANAGER,
+              leaderDeletionService.getExporterManagerInjector())
+          .install();
+      deletionService = leaderDeletionService;
+      snapshotController.setDeletionService(deletionService);
+
       try {
         snapshotController.recover();
         zeebeDb = snapshotController.openDb();
@@ -117,40 +136,6 @@ public class Partition implements Service<Partition> {
                 startedFuture.complete(null);
               }
             });
-  }
-
-  private long getLowestReplicatedExportedPosition() {
-    try {
-      if (snapshotController.getValidSnapshotsCount() > 0) {
-        snapshotController.recover();
-        final ZeebeDb zeebeDb = snapshotController.openDb();
-        final ExportersState exporterState = new ExportersState(zeebeDb, zeebeDb.createContext());
-
-        final long lowestPosition = exporterState.getLowestPosition();
-
-        LOG.debug(
-            "The lowest exported position at follower {} is {}.",
-            brokerCfg.getCluster().getNodeId(),
-            lowestPosition);
-        return lowestPosition;
-      } else {
-        LOG.info(
-            "Follower {} has no exporter snapshot so it can't delete data.",
-            brokerCfg.getCluster().getNodeId());
-      }
-    } catch (Exception e) {
-      LOG.error(
-          "Unexpected error occurred while obtaining the lowest exported position at a follower.",
-          e);
-    } finally {
-      try {
-        snapshotController.close();
-      } catch (Exception e) {
-        LOG.error("Unexpected error occurred while closing the DB.", e);
-      }
-    }
-
-    return -1;
   }
 
   public StorageConfiguration getConfiguration() {

--- a/broker-core/src/main/java/io/zeebe/broker/engine/EngineService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/engine/EngineService.java
@@ -58,7 +58,6 @@ public class EngineService implements Service<EngineService> {
   private final ClusterCfg clusterCfg;
   private final ServiceContainer serviceContainer;
   private final Duration snapshotPeriod;
-  private final int maxSnapshots;
   private ServiceStartContext serviceContext;
 
   private ServerTransport clientApiTransport;
@@ -73,7 +72,6 @@ public class EngineService implements Service<EngineService> {
     this.serviceContainer = serviceContainer;
     final DataCfg dataCfg = brokerCfg.getData();
     this.snapshotPeriod = DurationUtil.parse(dataCfg.getSnapshotPeriod());
-    this.maxSnapshots = dataCfg.getMaxSnapshots();
   }
 
   @Override
@@ -115,8 +113,7 @@ public class EngineService implements Service<EngineService> {
             partition.getPartitionId(),
             partition.getLogStream(),
             partition.getSnapshotController(),
-            snapshotPeriod,
-            maxSnapshots);
+            snapshotPeriod);
 
     final ServiceName<AsyncSnapshotingDirectorService> snapshotDirectorServiceName =
         StreamProcessorServiceNames.asyncSnapshotingDirectorService(logName, PROCESSOR_NAME);

--- a/broker-core/src/main/java/io/zeebe/broker/engine/EngineServiceNames.java
+++ b/broker-core/src/main/java/io/zeebe/broker/engine/EngineServiceNames.java
@@ -19,6 +19,7 @@ package io.zeebe.broker.engine;
 
 import io.zeebe.engine.processor.workflow.message.command.SubscriptionCommandMessageHandler;
 import io.zeebe.engine.state.StateStorageFactory;
+import io.zeebe.logstreams.impl.delete.DeletionService;
 import io.zeebe.servicecontainer.ServiceName;
 
 public class EngineServiceNames {
@@ -35,4 +36,9 @@ public class EngineServiceNames {
       SUBSCRIPTION_API_MESSAGE_HANDLER_SERVICE_NAME =
           ServiceName.newServiceName(
               "broker.subscriptionApi.messageHandler", SubscriptionCommandMessageHandler.class);
+
+  public static final ServiceName<DeletionService> leaderLogStreamDeletionService(int partitionId) {
+    return ServiceName.newServiceName(
+        String.format("logstream.%d.deletion", partitionId), DeletionService.class);
+  }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExportersState.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExportersState.java
@@ -99,4 +99,8 @@ public class ExportersState {
     exporterId.wrapString(exporter);
     exporterPositionColumnFamily.delete(exporterId);
   }
+
+  public boolean hasExporters() {
+    return !exporterPositionColumnFamily.isEmpty();
+  }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/delete/FollowerLogStreamDeletionService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/delete/FollowerLogStreamDeletionService.java
@@ -1,0 +1,93 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.logstreams.delete;
+
+import static io.zeebe.broker.clustering.base.partitions.Partition.LOG;
+
+import io.zeebe.broker.exporter.ExporterManagerService;
+import io.zeebe.broker.exporter.stream.ExportersState;
+import io.zeebe.db.ZeebeDb;
+import io.zeebe.logstreams.impl.delete.DeletionService;
+import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.logstreams.state.StateSnapshotController;
+import io.zeebe.servicecontainer.Injector;
+
+public class FollowerLogStreamDeletionService implements DeletionService {
+  private final Injector<ExporterManagerService> exporterManagerInjector = new Injector<>();
+  private final LogStream logStream;
+  private final StateSnapshotController snapshotController;
+  private final int partitionId;
+  private final int brokerId;
+
+  private ExporterManagerService exporterManagerService;
+
+  public FollowerLogStreamDeletionService(
+      LogStream logStream, StateSnapshotController snapshotController, int brokerId) {
+    this.logStream = logStream;
+    this.snapshotController = snapshotController;
+    this.partitionId = logStream.getPartitionId();
+    this.brokerId = brokerId;
+  }
+
+  @Override
+  public void delete(final long position) {
+    final long minPosition = Math.min(position, getMinimumExportedPosition());
+    logStream.delete(minPosition);
+  }
+
+  private long getMinimumExportedPosition() {
+    try {
+      if (snapshotController.getValidSnapshotsCount() > 0) {
+        snapshotController.recover();
+        final ZeebeDb zeebeDb = snapshotController.openDb();
+        final ExportersState exporterState = new ExportersState(zeebeDb, zeebeDb.createContext());
+
+        if (exporterState.hasExporters()) {
+          final long lowestPosition = exporterState.getLowestPosition();
+
+          LOG.debug(
+              "The lowest exported position for partition {} at broker {} is {}.",
+              partitionId,
+              brokerId,
+              lowestPosition);
+          return lowestPosition;
+        } else {
+          LOG.debug(
+              "No exporters present in snapshot for partition {} at broker {}.",
+              partitionId,
+              brokerId);
+          return Long.MAX_VALUE;
+        }
+      }
+    } catch (Exception e) {
+      LOG.error(
+          "Unexpected error occurred while obtaining the lowest exported position at follower {} for partition {}.",
+          brokerId,
+          partitionId,
+          e);
+    } finally {
+      try {
+        snapshotController.close();
+      } catch (Exception e) {
+        LOG.error("Unexpected error occurred while closing the DB.", e);
+      }
+    }
+
+    return -1;
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/delete/LeaderLogStreamDeletionService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/delete/LeaderLogStreamDeletionService.java
@@ -1,0 +1,63 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.logstreams.delete;
+
+import io.zeebe.broker.exporter.ExporterManagerService;
+import io.zeebe.logstreams.impl.delete.DeletionService;
+import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.servicecontainer.Injector;
+import io.zeebe.servicecontainer.Service;
+import io.zeebe.servicecontainer.ServiceStartContext;
+import io.zeebe.servicecontainer.ServiceStopContext;
+
+public class LeaderLogStreamDeletionService implements DeletionService, Service {
+  private final Injector<ExporterManagerService> exporterManagerInjector = new Injector<>();
+  private final LogStream logStream;
+  private ExporterManagerService exporterManagerService;
+
+  public LeaderLogStreamDeletionService(LogStream logStream) {
+    this.logStream = logStream;
+  }
+
+  @Override
+  public void start(final ServiceStartContext startContext) {
+    exporterManagerService = exporterManagerInjector.getValue();
+  }
+
+  @Override
+  public void delete(final long position) {
+    final long minPosition = Math.min(position, getMinimumExportedPosition());
+    logStream.delete(minPosition);
+  }
+
+  private long getMinimumExportedPosition() {
+    return exporterManagerService.getLowestExporterPosition();
+  }
+
+  @Override
+  public void stop(final ServiceStopContext stopContext) {}
+
+  @Override
+  public LeaderLogStreamDeletionService get() {
+    return this;
+  }
+
+  public Injector<ExporterManagerService> getExporterManagerInjector() {
+    return exporterManagerInjector;
+  }
+}

--- a/broker-core/src/test/java/io/zeebe/broker/logstreams/delete/LeaderLogStreamDeletionTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/logstreams/delete/LeaderLogStreamDeletionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.logstreams.delete;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.zeebe.broker.engine.EngineServiceNames;
+import io.zeebe.broker.exporter.ExporterManagerService;
+import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.servicecontainer.Injector;
+import io.zeebe.servicecontainer.ServiceStartContext;
+import io.zeebe.servicecontainer.testing.ServiceContainerRule;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.mockito.Mock;
+
+public class LeaderLogStreamDeletionTest {
+  private static final int PARTITION_ID = 0;
+  private final ActorSchedulerRule actorScheduler = new ActorSchedulerRule();
+  private final ServiceContainerRule serviceContainer = new ServiceContainerRule(actorScheduler);
+
+  @Rule public RuleChain chain = RuleChain.outerRule(actorScheduler).around(serviceContainer);
+
+  @Mock ExporterManagerService mockExporterManagerService;
+  @Mock LogStream mockLogStream = mock(LogStream.class);
+
+  private LeaderLogStreamDeletionService deletionService;
+
+  private static final long POSITION_TO_DELETE = 6L;
+  private static final long ADDRESS_TO_DELETE = 55L;
+
+  @Before
+  public void setup() {
+    deletionService = new LeaderLogStreamDeletionService(mockLogStream);
+    serviceContainer
+        .get()
+        .createService(
+            EngineServiceNames.leaderLogStreamDeletionService(PARTITION_ID), deletionService)
+        .install()
+        .join();
+    final Injector<ExporterManagerService> exporterManagerInjector =
+        deletionService.getExporterManagerInjector();
+
+    mockExporterManagerService = mock(ExporterManagerService.class);
+    exporterManagerInjector.inject(mockExporterManagerService);
+    deletionService.start(mock(ServiceStartContext.class));
+  }
+
+  @Test
+  public void shouldDeleteWithDelayedExporter() {
+    // given
+    when(mockExporterManagerService.getLowestExporterPosition()).thenReturn(POSITION_TO_DELETE);
+
+    // when
+    deletionService.delete(POSITION_TO_DELETE + 2);
+
+    // then
+    verify(mockLogStream, times(1)).delete(POSITION_TO_DELETE);
+  }
+
+  @Test
+  public void shouldDeleteWithNoExporter() {
+    // given
+    when(mockExporterManagerService.getLowestExporterPosition()).thenReturn(Long.MAX_VALUE);
+
+    // when
+    deletionService.delete(POSITION_TO_DELETE);
+
+    // then
+    verify(mockLogStream, times(1)).delete(POSITION_TO_DELETE);
+  }
+
+  @Test
+  public void shouldNotDeleteOnNegativePosition() {
+    // given
+    when(mockExporterManagerService.getLowestExporterPosition()).thenReturn(Long.MAX_VALUE);
+
+    // when
+    deletionService.delete(-1);
+
+    // then
+    verify(mockLogStream, never()).delete(POSITION_TO_DELETE);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotingDirectorService.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotingDirectorService.java
@@ -32,39 +32,31 @@ public class AsyncSnapshotingDirectorService implements Service<AsyncSnapshoting
   private final LogStream logStream;
   private final StateSnapshotController snapshotController;
   private final Duration snapshotPeriod;
-  private final int maxSnapshots;
   private AsyncSnapshotDirector asyncSnapshotDirector;
 
   public AsyncSnapshotingDirectorService(
       final int partitionId,
       final LogStream logStream,
       final StateSnapshotController snapshotController,
-      Duration snapshotPeriod,
-      int maxSnapshots) {
+      Duration snapshotPeriod) {
     this.partitionId = partitionId;
     this.logStream = logStream;
     this.snapshotController = snapshotController;
     this.snapshotPeriod = snapshotPeriod;
-    this.maxSnapshots = maxSnapshots;
   }
 
   @Override
   public void start(final ServiceStartContext startContext) {
-    final StreamProcessor controller = streamProcessorInjector.getValue();
+    final StreamProcessor streamProcessor = streamProcessorInjector.getValue();
     final SnapshotMetrics snapshotMetrics =
         new SnapshotMetrics(
             startContext.getScheduler().getMetricsManager(),
-            controller.getName(),
+            streamProcessor.getName(),
             String.valueOf(partitionId));
 
     asyncSnapshotDirector =
         new AsyncSnapshotDirector(
-            controller,
-            snapshotController,
-            logStream,
-            snapshotPeriod,
-            maxSnapshots,
-            snapshotMetrics);
+            streamProcessor, snapshotController, logStream, snapshotPeriod, snapshotMetrics);
 
     startContext.getScheduler().submitActor(asyncSnapshotDirector);
   }

--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
@@ -516,7 +516,7 @@ public class StreamProcessorTest {
     inOrder.verify(stateSnapshotController, TIMEOUT.times(1)).openDb();
     inOrder.verify(stateSnapshotController, TIMEOUT.times(1)).takeTempSnapshot();
     inOrder.verify(stateSnapshotController, TIMEOUT.times(1)).moveValidSnapshot(position);
-    inOrder.verify(stateSnapshotController, TIMEOUT.times(1)).ensureMaxSnapshotCount(MAX_SNAPSHOTS);
+    inOrder.verify(stateSnapshotController, TIMEOUT.times(1)).ensureMaxSnapshotCount();
   }
 
   @Test
@@ -605,7 +605,7 @@ public class StreamProcessorTest {
 
     inOrder.verify(stateSnapshotController, never()).takeTempSnapshot();
     inOrder.verify(stateSnapshotController, never()).moveValidSnapshot(position);
-    inOrder.verify(stateSnapshotController, never()).ensureMaxSnapshotCount(1);
+    inOrder.verify(stateSnapshotController, never()).ensureMaxSnapshotCount();
   }
 
   @Test
@@ -632,7 +632,7 @@ public class StreamProcessorTest {
 
     inOrder.verify(stateSnapshotController, never()).takeTempSnapshot();
     inOrder.verify(stateSnapshotController, never()).moveValidSnapshot(anyLong());
-    inOrder.verify(stateSnapshotController, never()).ensureMaxSnapshotCount(1);
+    inOrder.verify(stateSnapshotController, never()).ensureMaxSnapshotCount();
   }
 
   @Test

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -295,7 +295,7 @@ public class TestStreams {
     final StateStorage stateStorage =
         getStateStorageFactory(stream).create(streamProcessorId, PROCESSOR_NAME);
     final StateSnapshotController currentSnapshotController =
-        spy(new StateSnapshotController(zeebeDbFactory, stateStorage));
+        spy(new StateSnapshotController(zeebeDbFactory, stateStorage, maxSnapshot));
     snapshotControllerMap.put(stream.getLogName(), currentSnapshotController);
 
     final ActorFuture<Void> openFuture = new CompletableActorFuture<>();
@@ -328,12 +328,7 @@ public class TestStreams {
         new SnapshotMetrics(actorScheduler.getMetricsManager(), PROCESSOR_NAME, "1");
     asyncSnapshotDirector =
         new AsyncSnapshotDirector(
-            processorService,
-            currentSnapshotController,
-            stream,
-            snapshotInterval,
-            maxSnapshot,
-            metrics);
+            processorService, currentSnapshotController, stream, snapshotInterval, metrics);
     actorScheduler.submitActor(asyncSnapshotDirector);
 
     return processorService;

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/LogBlockIndexWriter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/LogBlockIndexWriter.java
@@ -93,7 +93,6 @@ public class LogBlockIndexWriter extends Actor {
 
   private final Duration snapshotInterval;
   private long snapshotEventPosition = -1;
-  private final int maxSnapshots;
 
   private Metric snapshotsCreated;
 
@@ -113,7 +112,6 @@ public class LogBlockIndexWriter extends Actor {
     this.deviation = builder.getDeviation();
     this.indexBlockSize = (int) (builder.getIndexBlockSize() * (1f - deviation));
     this.snapshotInterval = builder.getSnapshotPeriod();
-    this.maxSnapshots = builder.getMaxSnapshots();
     this.bufferSize = builder.getReadBlockSize();
 
     this.allocatedBuffer = BufferAllocators.allocateDirect(bufferSize);
@@ -280,7 +278,7 @@ public class LogBlockIndexWriter extends Actor {
         logStorage.flush();
 
         snapshotEventPosition = lastBlockEventPosition;
-        blockIndex.writeSnapshot(snapshotEventPosition, maxSnapshots);
+        blockIndex.writeSnapshot(snapshotEventPosition);
 
         LOG.trace("Created snapshot of block index {}.", name);
         snapshotsCreated.incrementOrdered();

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/LogStreamBuilder.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/LogStreamBuilder.java
@@ -245,7 +245,8 @@ public class LogStreamBuilder {
         new FsLogStorageService(storageConfig, partitionId, logStorageStubber);
     installOperation.createService(logStorageServiceName, logStorageService).install();
 
-    final LogBlockIndexService logBlockIndexService = new LogBlockIndexService(stateStorage);
+    final LogBlockIndexService logBlockIndexService =
+        new LogBlockIndexService(stateStorage, maxSnapshots);
     installOperation.createService(logBlockIndexServiceName, logBlockIndexService).install();
 
     final LogBlockIndexWriterService logBlockIndexWriterService =

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/delete/DeletionService.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/delete/DeletionService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.impl.delete;
+
+public interface DeletionService {
+  /**
+   * Triggers deletion of data from the log stream, where the given position is used as upper bound.
+   *
+   * @param position the position as upper bound
+   */
+  void delete(long position);
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/delete/NoopDeletionService.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/delete/NoopDeletionService.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.impl.delete;
+
+public class NoopDeletionService implements DeletionService {
+
+  @Override
+  public void delete(final long position) {}
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/index/LogBlockIndex.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/index/LogBlockIndex.java
@@ -205,11 +205,11 @@ public class LogBlockIndex {
    *
    * @param snapshotEventPosition last written position
    */
-  public void writeSnapshot(final long snapshotEventPosition, final int maxSnapshots) {
+  public void writeSnapshot(final long snapshotEventPosition) {
     stateSnapshotController.takeSnapshot(snapshotEventPosition);
 
     try {
-      stateSnapshotController.ensureMaxSnapshotCount(maxSnapshots);
+      stateSnapshotController.ensureMaxSnapshotCount();
     } catch (Exception e) {
       Loggers.SNAPSHOT_LOGGER.error(ERROR_MSG_ENSURING_MAX_SNAPSHOT_COUNT, e);
     }

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogBlockIndexService.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogBlockIndexService.java
@@ -28,11 +28,14 @@ import io.zeebe.servicecontainer.ServiceStartContext;
 import io.zeebe.servicecontainer.ServiceStopContext;
 
 public class LogBlockIndexService implements Service<LogBlockIndex> {
+
+  private final int maxSnapshotCount;
   private LogBlockIndex logBlockIndex;
   private final StateStorage stateStorage;
 
-  public LogBlockIndexService(StateStorage stateStorage) {
+  public LogBlockIndexService(StateStorage stateStorage, int maxSnapshotCount) {
     this.stateStorage = stateStorage;
+    this.maxSnapshotCount = maxSnapshotCount;
   }
 
   @Override
@@ -40,7 +43,7 @@ public class LogBlockIndexService implements Service<LogBlockIndex> {
     final ZeebeDbFactory<LogBlockColumnFamilies> dbFactory =
         ZeebeRocksDbFactory.newFactory(LogBlockColumnFamilies.class);
     final StateSnapshotController snapshotController =
-        new StateSnapshotController(dbFactory, stateStorage);
+        new StateSnapshotController(dbFactory, stateStorage, maxSnapshotCount);
 
     logBlockIndex = new LogBlockIndex(snapshotController);
   }

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStream.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStream.java
@@ -22,7 +22,6 @@ import io.zeebe.logstreams.impl.log.index.LogBlockIndex;
 import io.zeebe.logstreams.spi.LogStorage;
 import io.zeebe.util.sched.ActorCondition;
 import io.zeebe.util.sched.future.ActorFuture;
-import java.util.function.Supplier;
 
 /**
  * Represents a stream of events from a log storage.
@@ -122,6 +121,4 @@ public interface LogStream extends AutoCloseable {
   void registerOnCommitPositionUpdatedCondition(ActorCondition condition);
 
   void removeOnCommitPositionUpdatedCondition(ActorCondition condition);
-
-  void setExporterPositionSupplier(Supplier<Long> supplier);
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/spi/SnapshotController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/spi/SnapshotController.java
@@ -51,7 +51,7 @@ public interface SnapshotController extends AutoCloseable {
   void replicateLatestSnapshot(Consumer<Runnable> executor);
 
   /** Registers to consumes replicated snapshots. */
-  void consumeReplicatedSnapshots(Consumer<Long> dataDeleteCallback);
+  void consumeReplicatedSnapshots();
 
   /**
    * Recovers the state from the latest snapshot and returns the lower bound snapshot position.
@@ -61,13 +61,6 @@ public interface SnapshotController extends AutoCloseable {
   long recover() throws Exception;
 
   ZeebeDb openDb();
-
-  /**
-   * Ensures that only the given maximum of snapshots are kept, the rest will be purged.
-   *
-   * @param maxSnapshotCount the maximum count of snapshots which should be kept
-   */
-  void ensureMaxSnapshotCount(int maxSnapshotCount) throws Exception;
 
   /**
    * Returns the highest position that is considered to be safe to delete, which is the position of

--- a/logstreams/src/main/java/io/zeebe/logstreams/spi/ValidSnapshotListener.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/spi/ValidSnapshotListener.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.spi;
+
+@FunctionalInterface
+public interface ValidSnapshotListener {
+
+  void onNewValidSnapshot();
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/NoopSnapshotController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/NoopSnapshotController.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.logstreams.state;
+
+import io.zeebe.db.ZeebeDb;
+import io.zeebe.logstreams.spi.SnapshotController;
+import java.io.IOException;
+import java.util.function.Consumer;
+
+public class NoopSnapshotController implements SnapshotController {
+
+  @Override
+  public void takeSnapshot(final long lowerBoundSnapshotPosition) {}
+
+  @Override
+  public void close() throws Exception {}
+
+  @Override
+  public void takeTempSnapshot() {}
+
+  @Override
+  public void moveValidSnapshot(final long lowerBoundSnapshotPosition) throws IOException {}
+
+  @Override
+  public void replicateLatestSnapshot(final Consumer<Runnable> executor) {}
+
+  @Override
+  public void consumeReplicatedSnapshots() {}
+
+  @Override
+  public long recover() throws Exception {
+    return 0;
+  }
+
+  @Override
+  public ZeebeDb openDb() {
+    return null;
+  }
+
+  @Override
+  public long getPositionToDelete(final int maxSnapshotCount) {
+    return 0;
+  }
+
+  @Override
+  public int getValidSnapshotsCount() {
+    return 0;
+  }
+
+  @Override
+  public long getLastValidSnapshotPosition() {
+    return 0;
+  }
+
+  @Override
+  public void addListener(final SnapshotReplicationListener listener) {}
+
+  @Override
+  public void removeListener(final SnapshotReplicationListener listener) {}
+
+  @Override
+  public void enableRetrySnapshot(final long snapshotPosition) {}
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogBlockIndexTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogBlockIndexTest.java
@@ -216,7 +216,7 @@ public class LogBlockIndexTest {
     // given
     final int numBlocks = 10;
     final long snapshotPosition = addBlocks(numBlocks);
-    blockIndex.writeSnapshot(snapshotPosition, 1);
+    blockIndex.writeSnapshot(snapshotPosition);
 
     // when
     blockIndex.closeDb(); // close and reopen DB

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamDeleteTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamDeleteTest.java
@@ -182,7 +182,6 @@ public class LogStreamDeleteTest {
   public void shouldDeleteFromLogStream() {
     // given
     final LogStream logStream = prepareLogstream();
-    logStream.setExporterPositionSupplier(() -> Long.MAX_VALUE);
 
     // when
     logStream.delete(fourthPosition);
@@ -202,7 +201,6 @@ public class LogStreamDeleteTest {
   public void shouldDeleteUntilLastBlockIndexAddress() {
     // given
     final LogStream logStream = prepareLogstream();
-    logStream.setExporterPositionSupplier(() -> Long.MAX_VALUE);
 
     // when
     logStream.delete(Long.MAX_VALUE);
@@ -238,47 +236,6 @@ public class LogStreamDeleteTest {
         .isNotEmpty();
     assertThat(events(logStream).filter(e -> e.getPosition() == fourthPosition).findAny())
         .isNotEmpty();
-  }
-
-  @Test
-  public void shouldDeleteMinExportedPosition() {
-    // given
-    final LogStream logStream = prepareLogstream();
-
-    // when
-    logStream.setExporterPositionSupplier(() -> thirdPosition);
-    logStream.delete(fourthPosition);
-
-    // then
-    assertThat(events(logStream).count()).isEqualTo(3);
-
-    assertThat(events(logStream).filter(e -> e.getPosition() == firstPosition).findAny()).isEmpty();
-    assertThat(events(logStream).filter(e -> e.getPosition() == secondPosition).findAny())
-        .isNotEmpty();
-    assertThat(events(logStream).filter(e -> e.getPosition() == thirdPosition).findAny())
-        .isNotEmpty();
-    assertThat(events(logStream).filter(e -> e.getPosition() == fourthPosition).findAny())
-        .isNotEmpty();
-  }
-
-  @Test
-  public void shouldNotDeleteWithoutSupplierConfigured() {
-    // given
-    final LogStream logStream = prepareLogstream();
-
-    // when
-    logStream.delete(Long.MAX_VALUE);
-
-    // then
-    assertThat(events(logStream).count()).isEqualTo(4);
-    assertThat(
-        events(logStream)
-            .allMatch(
-                e ->
-                    e.getPosition() == firstPosition
-                        || e.getPosition() == secondPosition
-                        || e.getPosition() == thirdPosition
-                        || e.getPosition() == fourthPosition));
   }
 
   private LogStream prepareLogstream() {

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/FailingSnapshotChunkReplicationTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/FailingSnapshotChunkReplicationTest.java
@@ -77,7 +77,7 @@ public class FailingSnapshotChunkReplicationTest {
     final EvilReplicator replicator = new EvilReplicator();
     setup(replicator);
 
-    receiverSnapshotController.consumeReplicatedSnapshots(pos -> {});
+    receiverSnapshotController.consumeReplicatedSnapshots();
     replicatorSnapshotController.takeSnapshot(1);
 
     // when
@@ -103,7 +103,7 @@ public class FailingSnapshotChunkReplicationTest {
     final FlakyReplicator replicator = new FlakyReplicator();
     setup(replicator);
 
-    receiverSnapshotController.consumeReplicatedSnapshots(pos -> {});
+    receiverSnapshotController.consumeReplicatedSnapshots();
     replicatorSnapshotController.takeSnapshot(1);
 
     // when
@@ -130,14 +130,14 @@ public class FailingSnapshotChunkReplicationTest {
     // given
     final FlakyReplicator flakyReplicator = new FlakyReplicator();
     setup(flakyReplicator);
-    receiverSnapshotController.consumeReplicatedSnapshots(pos -> {});
+    receiverSnapshotController.consumeReplicatedSnapshots();
     replicatorSnapshotController.takeSnapshot(1);
     replicatorSnapshotController.replicateLatestSnapshot(Runnable::run);
     replicatorSnapshotController.close();
 
     final Replicator workingReplicator = new Replicator();
     setupReplication(workingReplicator);
-    receiverSnapshotController.consumeReplicatedSnapshots(pos -> {});
+    receiverSnapshotController.consumeReplicatedSnapshots();
     replicatorSnapshotController.takeSnapshot(2);
     replicatorSnapshotController.replicateLatestSnapshot(Runnable::run);
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/StateSnapshotControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/StateSnapshotControllerTest.java
@@ -48,7 +48,7 @@ public class StateSnapshotControllerTest {
 
     snapshotController =
         new StateSnapshotController(
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class), storage);
+            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class), storage, 2);
 
     autoCloseableRule.manage(snapshotController);
   }
@@ -148,7 +148,7 @@ public class StateSnapshotControllerTest {
     snapshotController.takeSnapshot(34);
 
     // when
-    snapshotController.ensureMaxSnapshotCount(2);
+    snapshotController.ensureMaxSnapshotCount();
 
     // then
     assertThat(storage.list()).hasSize(2);
@@ -169,7 +169,7 @@ public class StateSnapshotControllerTest {
     createSnapshotDirectory("132-tmp");
 
     // when
-    snapshotController.ensureMaxSnapshotCount(2);
+    snapshotController.ensureMaxSnapshotCount();
 
     // then
     assertThat(storage.getSnapshotsDirectory().listFiles())

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/DataDeleteTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/DataDeleteTest.java
@@ -41,13 +41,13 @@ public class DataDeleteTest {
   public static final int MAX_SNAPSHOTS = 1;
 
   public EmbeddedBrokerRule brokerRule =
-      new EmbeddedBrokerRule(DataDeleteTest::configureForDeletionTest);
+      new EmbeddedBrokerRule(DataDeleteTest::configureCustomExporter);
   public GrpcClientRule clientRule = new GrpcClientRule(brokerRule);
 
   @Rule public RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(clientRule);
   @Rule public Timeout timeout = new Timeout(60, TimeUnit.SECONDS);
 
-  public static void configureForDeletionTest(final BrokerCfg brokerCfg) {
+  public static void configureCustomExporter(final BrokerCfg brokerCfg) {
     final DataCfg data = brokerCfg.getData();
     data.setMaxSnapshots(MAX_SNAPSHOTS);
     data.setSnapshotPeriod(SNAPSHOT_PERIOD_SECONDS + "s");

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
@@ -63,14 +63,14 @@ public class GrpcClientRule extends ExternalResource {
   }
 
   @Override
-  protected void before() {
+  public void before() {
     final ZeebeClientBuilder builder = ZeebeClient.newClientBuilder();
     configurator.accept(builder);
     client = builder.build();
   }
 
   @Override
-  protected void after() {
+  public void after() {
     client.close();
     client = null;
   }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.broker.it.clustering;
+
+import static io.zeebe.test.util.TestUtil.waitUntil;
+
+import io.zeebe.broker.Broker;
+import io.zeebe.broker.it.DataDeleteTest;
+import io.zeebe.broker.system.configuration.BrokerCfg;
+import io.zeebe.broker.system.configuration.DataCfg;
+import io.zeebe.test.util.TestUtil;
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class ClusteredDataDeletionTest {
+  private static final int SNAPSHOT_PERIOD_SECONDS = 30;
+  private static final int MAX_SNAPSHOTS = 1;
+
+  private ClusteringRule clusteringRule;
+
+  @Parameters(name = "{index}: {1}")
+  public static Object[][] configurators() {
+    return new Object[][] {
+      new Object[] {
+        (Consumer<BrokerCfg>) ClusteredDataDeletionTest::configureNoExporters, "no-exporter"
+      },
+      new Object[] {
+        (Consumer<BrokerCfg>) DataDeleteTest::configureCustomExporter, "updating-exporter"
+      }
+    };
+  }
+
+  @Parameter public Consumer<BrokerCfg> configurator;
+
+  @Parameter(1)
+  public String name;
+
+  @Before
+  public void setup() throws IOException {
+    clusteringRule = new ClusteringRule(1, 3, 3, configurator);
+    clusteringRule.before();
+  }
+
+  @After
+  public void tearDown() {
+    clusteringRule.after();
+  }
+
+  private static void configureNoExporters(final BrokerCfg brokerCfg) {
+    final DataCfg data = brokerCfg.getData();
+    data.setMaxSnapshots(MAX_SNAPSHOTS);
+    data.setSnapshotPeriod(SNAPSHOT_PERIOD_SECONDS + "s");
+    data.setDefaultLogSegmentSize("8k");
+    data.setIndexBlockSize("2K");
+
+    brokerCfg.setExporters(Collections.EMPTY_LIST);
+  }
+
+  @Test
+  public void shouldDeleteDataOnLeader() {
+    // given
+    final int leaderNodeId = clusteringRule.getLeaderForPartition(1).getNodeId();
+    final Broker leader = clusteringRule.getBroker(leaderNodeId);
+
+    while (getSegmentsDirectory(leader).listFiles().length <= 2) {
+      clusteringRule
+          .getClient()
+          .newPublishMessageCommand()
+          .messageName("msg")
+          .correlationKey("key")
+          .send()
+          .join();
+    }
+
+    // when
+    final HashMap<Integer, Integer> segmentCount =
+        takeSnapshotAndWaitForReplication(Collections.singletonList(leader), clusteringRule);
+
+    // then
+    TestUtil.waitUntil(
+        () -> getSegmentsDirectory(leader).listFiles().length < segmentCount.get(leaderNodeId));
+  }
+
+  @Test
+  public void shouldDeleteDataOnFollowers() {
+    // given
+    final int leaderNodeId = clusteringRule.getLeaderForPartition(1).getNodeId();
+    final List<Broker> followers =
+        clusteringRule.getBrokers().stream()
+            .filter(b -> b.getConfig().getCluster().getNodeId() != leaderNodeId)
+            .collect(Collectors.toList());
+
+    while (followers.stream()
+        .map(this::getSegmentsDirectory)
+        .allMatch(dir -> dir.listFiles().length <= 2)) {
+      clusteringRule
+          .getClient()
+          .newPublishMessageCommand()
+          .messageName("msg")
+          .correlationKey("key")
+          .send()
+          .join();
+    }
+
+    // when
+    final HashMap<Integer, Integer> followerSegmentCounts =
+        takeSnapshotAndWaitForReplication(followers, clusteringRule);
+
+    // then
+    TestUtil.waitUntil(
+        () ->
+            followers.stream()
+                .allMatch(
+                    b ->
+                        getSegmentsDirectory(b).listFiles().length
+                            < followerSegmentCounts.get(b.getConfig().getCluster().getNodeId())));
+  }
+
+  private HashMap<Integer, Integer> takeSnapshotAndWaitForReplication(
+      final List<Broker> brokers, ClusteringRule clusteringRule) {
+    final HashMap<Integer, Integer> segmentCounts = new HashMap();
+    brokers.forEach(
+        b -> {
+          final int nodeId = b.getConfig().getCluster().getNodeId();
+          segmentCounts.put(nodeId, getSegmentsDirectory(b).list().length);
+        });
+
+    clusteringRule.getClock().addTime(Duration.ofSeconds(DataDeleteTest.SNAPSHOT_PERIOD_SECONDS));
+    brokers.forEach(this::waitForValidSnapshotAtBroker);
+    return segmentCounts;
+  }
+
+  private File getSnapshotsDirectory(Broker broker) {
+    final String dataDir = broker.getConfig().getData().getDirectories().get(0);
+    return new File(dataDir, "partition-1/state/1_zb-stream-processor/snapshots");
+  }
+
+  private File getSegmentsDirectory(Broker broker) {
+    final String dataDir = broker.getConfig().getData().getDirectories().get(0);
+    return new File(dataDir, "/partition-1/segments");
+  }
+
+  private void waitForValidSnapshotAtBroker(Broker broker) {
+    final File snapshotsDir = getSnapshotsDirectory(broker);
+
+    waitUntil(
+        () -> Arrays.stream(snapshotsDir.listFiles()).anyMatch(f -> !f.getName().contains("tmp")));
+  }
+}

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -27,8 +27,6 @@ import io.zeebe.client.ZeebeClient;
 import io.zeebe.engine.Loggers;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
-import io.zeebe.protocol.intent.MessageIntent;
-import io.zeebe.test.util.TestUtil;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -38,8 +36,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
 import org.junit.Before;
@@ -58,7 +54,7 @@ public class SnapshotReplicationTest {
   // NOTE: the configuration removes the RecordingExporter from the broker's configuration to enable
   // data deletion so it can't be used in tests
   public ClusteringRule clusteringRule =
-      new ClusteringRule(PARTITION_COUNT, 3, 3, DataDeleteTest::configureForDeletionTest);
+      new ClusteringRule(PARTITION_COUNT, 3, 3, DataDeleteTest::configureCustomExporter);
   public GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 
   @Rule public RuleChain ruleChain = RuleChain.outerRule(clusteringRule).around(clientRule);
@@ -73,7 +69,7 @@ public class SnapshotReplicationTest {
   }
 
   @Test
-  public void shouldReplicateSnapshots() throws Exception {
+  public void shouldReplicateSnapshots() {
     // given
     client.newDeployCommand().addWorkflowModel(WORKFLOW, "workflow.bpmn").send().join();
     final int leaderNodeId = clusteringRule.getLeaderForPartition(1).getNodeId();
@@ -99,43 +95,6 @@ public class SnapshotReplicationTest {
     final Map<String, Long> checksumFirstNode = brokerSnapshotChecksums.get(0);
     assertThat(checksumFirstNode).isEqualTo(brokerSnapshotChecksums.get(1));
     assertThat(checksumFirstNode).isEqualTo(brokerSnapshotChecksums.get(2));
-  }
-
-  @Test
-  public void shouldDeleteDataOnFollowersWithExporter() {
-    // given
-    final int leaderNodeId = clusteringRule.getLeaderForPartition(1).getNodeId();
-    final List<Broker> followers =
-        clusteringRule.getBrokers().stream()
-            .filter(b -> b.getConfig().getCluster().getNodeId() != leaderNodeId)
-            .collect(Collectors.toList());
-
-    // when
-    final AtomicInteger messagesSent = new AtomicInteger();
-    while (followers.stream()
-        .map(this::getSegmentsDirectory)
-        .allMatch(dir -> dir.listFiles().length <= 2)) {
-      clientRule
-          .getClient()
-          .newPublishMessageCommand()
-          .messageName("msg")
-          .correlationKey("key")
-          .send()
-          .join();
-      messagesSent.incrementAndGet();
-    }
-
-    // when
-    TestUtil.waitUntil(
-        () ->
-            DataDeleteTest.TestExporter.records.stream()
-                    .filter(r -> r.getMetadata().getIntent() == MessageIntent.PUBLISHED)
-                    .limit(messagesSent.get())
-                    .count()
-                == messagesSent.get());
-
-    // then
-    takeSnapshotAndAssertDataWasDeleted(followers);
   }
 
   @Test
@@ -167,45 +126,7 @@ public class SnapshotReplicationTest {
     waitForValidSnapshotAtBroker(stoppedBroker);
   }
 
-  private void takeSnapshotAndAssertDataWasDeleted(final List<Broker> followers) {
-    final HashMap<Integer, Integer> followerSegmentCounts = new HashMap();
-    followers.forEach(
-        b -> {
-          final int nodeId = b.getConfig().getCluster().getNodeId();
-          followerSegmentCounts.put(nodeId, getSegmentsDirectory(b).list().length);
-        });
-
-    clusteringRule.getClock().addTime(Duration.ofSeconds(DataDeleteTest.SNAPSHOT_PERIOD_SECONDS));
-    followers.forEach(this::waitForValidSnapshotAtBroker);
-
-    // then
-    TestUtil.waitUntil(
-        () ->
-            followers.stream()
-                .allMatch(
-                    b ->
-                        getSegmentsDirectory(b).listFiles().length
-                            < followerSegmentCounts.get(b.getConfig().getCluster().getNodeId())));
-  }
-
-  private File getSnapshotsDirectory(Broker broker) {
-    final String dataDir = broker.getConfig().getData().getDirectories().get(0);
-    return new File(dataDir, "partition-1/state/1_zb-stream-processor/snapshots");
-  }
-
-  private File getSegmentsDirectory(Broker broker) {
-    final String dataDir = broker.getConfig().getData().getDirectories().get(0);
-    return new File(dataDir, "/partition-1/segments");
-  }
-
-  private void waitForValidSnapshotAtBroker(Broker broker) {
-    final File snapshotsDir = getSnapshotsDirectory(broker);
-
-    waitUntil(
-        () -> Arrays.stream(snapshotsDir.listFiles()).anyMatch(f -> !f.getName().contains("tmp")));
-  }
-
-  private Map<String, Long> createSnapshotDirectoryChecksums(Broker broker) throws Exception {
+  private Map<String, Long> createSnapshotDirectoryChecksums(Broker broker) {
     final File snapshotsDir = getSnapshotsDirectory(broker);
 
     final Map<String, Long> checksums = createChecksumsForSnapshotDirectory(snapshotsDir);
@@ -247,5 +168,17 @@ public class SnapshotReplicationTest {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private File getSnapshotsDirectory(Broker broker) {
+    final String dataDir = broker.getConfig().getData().getDirectories().get(0);
+    return new File(dataDir, "partition-1/state/1_zb-stream-processor/snapshots");
+  }
+
+  protected void waitForValidSnapshotAtBroker(Broker broker) {
+    final File snapshotsDir = getSnapshotsDirectory(broker);
+
+    waitUntil(
+        () -> Arrays.stream(snapshotsDir.listFiles()).anyMatch(f -> !f.getName().contains("tmp")));
   }
 }


### PR DESCRIPTION
This PR refactors the data deletion to the DeletionService and related classes. The second commit is related to #2420 and adds deletion tests for followers and leader with and without exporters. I'm not sure if the issue #2420 is closed by the second commit but I wasn't sure what else to test at the integration level. 

closes #2452
closes #2420 
