### PR TITLE
fix(engine): fix invalid state when cancelling with pending job

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobCompletedEventProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobCompletedEventProcessor.java
@@ -49,21 +49,26 @@ public final class JobCompletedEventProcessor implements TypedRecordProcessor<Jo
         workflowState.getElementInstanceState().getInstance(elementInstanceKey);
 
     if (elementInstance != null) {
+      final long scopeKey = elementInstance.getValue().getFlowScopeKey();
+      final ElementInstance scopeInstance =
+          workflowState.getElementInstanceState().getInstance(scopeKey);
 
-      final WorkflowInstanceRecord value = elementInstance.getValue();
+      if (scopeInstance.isActive()) {
+        final WorkflowInstanceRecord value = elementInstance.getValue();
 
-      streamWriter.appendFollowUpEvent(
-          elementInstanceKey, WorkflowInstanceIntent.ELEMENT_COMPLETING, value);
-      elementInstance.setState(WorkflowInstanceIntent.ELEMENT_COMPLETING);
-      elementInstance.setJobKey(-1);
-      elementInstance.setValue(value);
-      workflowState.getElementInstanceState().updateInstance(elementInstance);
+        streamWriter.appendFollowUpEvent(
+            elementInstanceKey, WorkflowInstanceIntent.ELEMENT_COMPLETING, value);
+        elementInstance.setState(WorkflowInstanceIntent.ELEMENT_COMPLETING);
+        elementInstance.setJobKey(-1);
+        elementInstance.setValue(value);
+        workflowState.getElementInstanceState().updateInstance(elementInstance);
 
-      workflowState.getEventScopeInstanceState().shutdownInstance(elementInstanceKey);
-      workflowState
-          .getElementInstanceState()
-          .getVariablesState()
-          .setTemporaryVariables(elementInstanceKey, jobEvent.getVariablesBuffer());
+        workflowState.getEventScopeInstanceState().shutdownInstance(elementInstanceKey);
+        workflowState
+            .getElementInstanceState()
+            .getVariablesState()
+            .setTemporaryVariables(elementInstanceKey, jobEvent.getVariablesBuffer());
+      }
     }
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorTest.java
@@ -49,7 +49,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -187,7 +186,6 @@ public class WorkflowInstanceStreamProcessorTest {
   }
 
   @Test
-  @Ignore("https://github.com/zeebe-io/zeebe/issues/2542")
   public void shouldCancelAndCompleteJobConcurrentlyInSubProcess() {
     // given
     streamProcessorRule.deploy(SUB_PROCESS_WORKFLOW);


### PR DESCRIPTION
The problem was that when job completed was written after the subprocess terminating but before the service task terminating, the job completed processor would set the task's state to completing. After this the ELEMENT_TERMINATING record was skipped because the element's state didn't match and the ELEMENT_COMPLETING record was skipped because the subprocess element was no longer active. To fix this I just added a check to the job completed processor so it doesn't set the task to completing if the subprocess is not active. Also, I didn't add a rejection to the job completed because it didn't seem correct semantically and also the user can also see that the instance was cancelled so I don't think there's an issue there but let me know if you disagree.

closes #2542 