### PR TITLE
Allow to enable debug exporter by environment variable

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
@@ -18,6 +18,7 @@
 package io.zeebe.broker.system.configuration;
 
 import com.google.gson.GsonBuilder;
+import io.zeebe.broker.exporter.debug.DebugLogExporter;
 import io.zeebe.util.Environment;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,7 @@ public class BrokerCfg {
   }
 
   public void init(final String brokerBase, final Environment environment) {
+    applyEnvironment(environment);
     network.init(this, brokerBase, environment);
     cluster.init(this, brokerBase, environment);
     threads.init(this, brokerBase, environment);
@@ -44,6 +46,14 @@ public class BrokerCfg {
     data.init(this, brokerBase, environment);
     exporters.forEach(e -> e.init(this, brokerBase, environment));
     gateway.init(this, brokerBase, environment);
+  }
+
+  private void applyEnvironment(final Environment environment) {
+    environment
+        .get(EnvironmentConstants.ENV_DEBUG_EXPORTER)
+        .ifPresent(
+            value ->
+                exporters.add(DebugLogExporter.defaultConfig("pretty".equalsIgnoreCase(value))));
   }
 
   public NetworkCfg getNetwork() {

--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
@@ -30,4 +30,5 @@ public class EnvironmentConstants {
   public static final String ENV_CLUSTER_NAME = "ZEEBE_CLUSTER_NAME";
   public static final String ENV_EMBED_GATEWAY = "ZEEBE_EMBED_GATEWAY";
   public static final String ENV_METRICS_HTTP_SERVER = "ZEEBE_METRICS_HTTP_SERVER";
+  public static final String ENV_DEBUG_EXPORTER = "ZEEBE_DEBUG";
 }

--- a/broker-core/src/test/java/io/zeebe/broker/system/ConfigurationTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/system/ConfigurationTest.java
@@ -25,6 +25,7 @@ import static io.zeebe.broker.system.configuration.ClusterCfg.DEFAULT_REPLICATIO
 import static io.zeebe.broker.system.configuration.DataCfg.DEFAULT_DIRECTORY;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_CLUSTER_NAME;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_CLUSTER_SIZE;
+import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_DEBUG_EXPORTER;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_DIRECTORIES;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_EMBED_GATEWAY;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_HOST;
@@ -38,6 +39,7 @@ import static io.zeebe.broker.system.configuration.NetworkCfg.DEFAULT_HOST;
 import static io.zeebe.protocol.Protocol.START_PARTITION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.zeebe.broker.exporter.debug.DebugLogExporter;
 import io.zeebe.broker.system.configuration.BrokerCfg;
 import io.zeebe.broker.system.configuration.ClusterCfg;
 import io.zeebe.broker.system.configuration.DataCfg;
@@ -184,6 +186,36 @@ public class ConfigurationTest {
         .is(new Condition<>(ExporterCfg::isExternal, "is external"));
     assertThat(config.getExporters().get(1).isExternal()).isFalse();
     assertThat(config.getExporters().get(2).isExternal()).isFalse();
+  }
+
+  @Test
+  public void shouldEnableDebugLogExporter() {
+    // given
+    final ExporterCfg exporterCfg = DebugLogExporter.defaultConfig(false);
+    environment.put(ENV_DEBUG_EXPORTER, "true");
+
+    // when
+    final BrokerCfg brokerCfg = readConfig("default");
+
+    // then
+    assertThat(brokerCfg.getExporters())
+        .usingRecursiveFieldByFieldElementComparator()
+        .contains(exporterCfg);
+  }
+
+  @Test
+  public void shouldEnableDebugLogExporterWithPrettyOption() {
+    // given
+    final ExporterCfg exporterCfg = DebugLogExporter.defaultConfig(true);
+    environment.put(ENV_DEBUG_EXPORTER, "pretty");
+
+    // when
+    final BrokerCfg brokerCfg = readConfig("default");
+
+    // then
+    assertThat(brokerCfg.getExporters())
+        .usingRecursiveFieldByFieldElementComparator()
+        .contains(exporterCfg);
   }
 
   @Test

--- a/dist/src/main/config/zeebe.cfg.toml
+++ b/dist/src/main/config/zeebe.cfg.toml
@@ -267,6 +267,8 @@
 # class through the use of annotations.
 #
 # Enable the following debug exporter to log the exported records to console
+# This exporter can also be enabled using the environment variable ZEEBE_DEBUG, the pretty print
+# option will be enabled if the variable is set to "pretty".
 #
 # [[exporters]]
 # id = "debug-log"


### PR DESCRIPTION
- set environment variable `ZEEBE_DEBUG` to any value to enable the exporter
- set `ZEEBE_DEBUG=pretty` to enable pretty print
- the variable value is checked case insensitive


closes #2579 
