### PR TITLE
Update dirtySegmentId on FS segement delete

### DIFF
--- a/logstreams/src/test/java/io/zeebe/logstreams/fs/log/FsLogStorageTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/fs/log/FsLogStorageTest.java
@@ -664,6 +664,23 @@ public class FsLogStorageTest {
     fsLogStorage.close();
   }
 
+  @Test
+  public void shouldIgnoreDeletedSegmentsOnFlush() throws Exception {
+    // given
+    fsLogStorage.open();
+    final int remainingCapacity = SEGMENT_SIZE - FsLogSegmentDescriptor.METADATA_LENGTH;
+    final byte[] largeBlock = new byte[remainingCapacity];
+
+    fsLogStorage.append(ByteBuffer.wrap(largeBlock));
+    final long address = fsLogStorage.append(ByteBuffer.wrap(largeBlock));
+
+    // when
+    fsLogStorage.delete(address);
+
+    // then
+    fsLogStorage.flush();
+  }
+
   private byte[] readLogFile(final String logFilePath, final long address, final int capacity) {
     final ByteBuffer buffer = ByteBuffer.allocate(capacity);
 


### PR DESCRIPTION
- update dirtySegmentId in case it is below the remaining segments after
  deletion
- add null check before segment flush to be sure


closes #2529 
