### PR TITLE
Wait for deployment distribution to prevent rejection

### DIFF
--- a/broker-core/src/test/java/io/zeebe/broker/exporter/ExporterManagerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/ExporterManagerTest.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.zeebe.broker.exporter.debug.DebugLogExporter;
 import io.zeebe.broker.system.configuration.ExporterCfg;
 import io.zeebe.broker.test.EmbeddedBrokerRule;
-import io.zeebe.engine.processor.StreamProcessorServiceNames;
 import io.zeebe.exporter.api.context.Controller;
 import io.zeebe.exporter.api.record.Record;
 import io.zeebe.model.bpmn.Bpmn;
@@ -32,7 +31,6 @@ import io.zeebe.msgpack.value.DocumentValue;
 import io.zeebe.protocol.intent.DeploymentIntent;
 import io.zeebe.test.broker.protocol.clientapi.ClientApiRule;
 import io.zeebe.test.broker.protocol.clientapi.PartitionTestClient;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.Before;
@@ -54,7 +52,7 @@ public class ExporterManagerTest {
             exporterCfg.setClassName(TestExporter.class.getName());
             exporterCfg.setId("test-exporter");
 
-            brokerCfg.setExporters(Collections.singletonList(exporterCfg));
+            brokerCfg.getExporters().add(exporterCfg);
           });
 
   public ClientApiRule clientRule = new ClientApiRule(brokerRule::getAtomix);
@@ -94,16 +92,15 @@ public class ExporterManagerTest {
     waitUntil(() -> isDeploymentExported(deploymentKey1));
 
     // when
-    brokerRule.getBrokerCfg().setExporters(Collections.emptyList());
+    brokerRule.getBrokerCfg().getExporters().remove(exporterCfg);
     brokerRule.restartBroker();
 
     // TODO: remove workaround to force new snapshot by publishing new record
     // (https://github.com/zeebe-io/zeebe/issues/2490)
-    final long msgKey =
-        testClient.publishMessage("msg", "123", DocumentValue.EMPTY_DOCUMENT).getKey();
+    testClient.publishMessage("msg", "123", DocumentValue.EMPTY_DOCUMENT).getKey();
 
     TestExporter.records.clear();
-    brokerRule.getBrokerCfg().setExporters(Collections.singletonList(exporterCfg));
+    brokerRule.getBrokerCfg().getExporters().add(exporterCfg);
     brokerRule.restartBroker();
 
     // then
@@ -113,12 +110,6 @@ public class ExporterManagerTest {
     assertThat(TestExporter.records)
         .extracting(Record::getKey)
         .contains(deploymentKey1, deploymentKey2);
-  }
-
-  private void waitForStreamProcessor() {
-    brokerRule.getService(
-        StreamProcessorServiceNames.asyncSnapshotingDirectorService(
-            "raft-atomix-partition-1", "zb-stream-processor"));
   }
 
   private boolean isDeploymentExported(long deploymentKey1) {

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/PartitionTestClient.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/clientapi/PartitionTestClient.java
@@ -53,6 +53,7 @@ import io.zeebe.protocol.intent.VariableDocumentIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceCreationIntent;
 import io.zeebe.protocol.intent.WorkflowInstanceIntent;
 import io.zeebe.test.util.MsgPackUtil;
+import io.zeebe.test.util.TestUtil;
 import io.zeebe.test.util.record.DeploymentRecordStream;
 import io.zeebe.test.util.record.IncidentRecordStream;
 import io.zeebe.test.util.record.JobBatchRecordStream;
@@ -104,7 +105,15 @@ public class PartitionTestClient {
         .withFailMessage("Deployment failed: %s", response.getRejectionReason())
         .isEqualTo(RecordType.EVENT);
 
-    return response.getKey();
+    final long key = response.getKey();
+
+    TestUtil.waitUntil(
+        () ->
+            RecordingExporter.deploymentRecords(DeploymentIntent.DISTRIBUTED)
+                .withRecordKey(key)
+                .exists());
+
+    return key;
   }
 
   public ExecuteCommandResponse deployWithResponse(final byte[] resource) {


### PR DESCRIPTION
- sometimes test fail with a command rejection because the workflow is not
  deployed on all partitions

