### PR TITLE
fix(engine): fix NPE if StreamProcessor doesn't initialize before close

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -272,11 +272,25 @@ public class StreamProcessor extends Actor implements Service<StreamProcessor> {
   }
 
   public ActorFuture<Long> getLastProcessedPositionAsync() {
-    return actor.call(processingStateMachine::getLastSuccessfulProcessedEventPosition);
+    return actor.call(
+        () -> {
+          if (processingStateMachine != null) {
+            return processingStateMachine.getLastSuccessfulProcessedEventPosition();
+          }
+
+          throw new IllegalStateException("Stream processor actor hasn't started.");
+        });
   }
 
   public ActorFuture<Long> getLastWrittenPositionAsync() {
-    return actor.call(processingStateMachine::getLastWrittenEventPosition);
+    return actor.call(
+        () -> {
+          if (processingStateMachine != null) {
+            return processingStateMachine.getLastWrittenEventPosition();
+          }
+
+          throw new IllegalStateException("Stream processor actor hasn't started.");
+        });
   }
 
   public StreamProcessorMetrics getMetrics() {


### PR DESCRIPTION
The StreamProcessor returns null instead of throwing an NPE and the AsyncSnapshotingDirector logs a warning

closes #2590 