### PR TITLE
consolidate duplicated logic in snapshot restore and replication

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/gossip/AtomixService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/gossip/AtomixService.java
@@ -136,7 +136,6 @@ public class AtomixService implements Service<Atomix> {
     final BrokerRestoreFactory restoreFactory =
         new BrokerRestoreFactory(
             atomix.getCommunicationService(),
-            atomix.getEventService(),
             atomix.getPartitionService(),
             raftPartitionGroupName,
             localMemberId);

--- a/broker-core/src/main/java/io/zeebe/broker/logstreams/state/StatePositionSupplier.java
+++ b/broker-core/src/main/java/io/zeebe/broker/logstreams/state/StatePositionSupplier.java
@@ -1,0 +1,124 @@
+/*
+ * Zeebe Broker Core
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.broker.logstreams.state;
+
+import io.zeebe.broker.exporter.stream.ExportersState;
+import io.zeebe.db.ZeebeDb;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.logstreams.spi.SnapshotController;
+import io.zeebe.util.collection.Tuple;
+import org.slf4j.Logger;
+
+public class StatePositionSupplier {
+
+  private final SnapshotController snapshotController;
+  private final int partitionId;
+  private final String brokerId;
+  private final Logger logger;
+
+  public StatePositionSupplier(
+      SnapshotController snapshotController, int partitionId, String brokerId, Logger log) {
+    this.snapshotController = snapshotController;
+    this.partitionId = partitionId;
+    this.brokerId = brokerId;
+    this.logger = log;
+  }
+
+  public Tuple<Long, Long> getLatestPositions() {
+    long processedPosition = -1;
+    long exportedPosition = -1;
+    try {
+      if (snapshotController.getValidSnapshotsCount() > 0) {
+        snapshotController.recover();
+        final ZeebeDb zeebeDb = snapshotController.openDb();
+        processedPosition = getLastProcessedPosition(zeebeDb);
+        exportedPosition = getMinimumExportedPosition(zeebeDb);
+      }
+    } catch (Exception e) {
+      logger.error(
+          "Unexpected error occurred while obtaining the processed and exported position at broker {} for partition {}.",
+          brokerId,
+          partitionId,
+          e);
+    } finally {
+      try {
+        snapshotController.close();
+      } catch (Exception e) {
+        logger.error("Unexpected error occurred while closing the DB.", e);
+      }
+    }
+
+    return new Tuple(exportedPosition, processedPosition);
+  }
+
+  public long getMinimumExportedPosition() {
+    try {
+      if (snapshotController.getValidSnapshotsCount() > 0) {
+        snapshotController.recover();
+        final ZeebeDb zeebeDb = snapshotController.openDb();
+        return getMinimumExportedPosition(zeebeDb);
+      }
+    } catch (Exception e) {
+      logger.error(
+          "Unexpected error occurred while obtaining the minimum exported position at broker {} for partition {}.",
+          brokerId,
+          partitionId,
+          e);
+    } finally {
+      try {
+        snapshotController.close();
+      } catch (Exception e) {
+        logger.error("Unexpected error occurred while closing the DB.", e);
+      }
+    }
+    return -1;
+  }
+
+  private long getMinimumExportedPosition(ZeebeDb zeebeDb) {
+    final ExportersState exporterState = new ExportersState(zeebeDb, zeebeDb.createContext());
+
+    if (exporterState.hasExporters()) {
+      final long lowestPosition = exporterState.getLowestPosition();
+
+      logger.debug(
+          "The lowest exported position for partition {} at broker {} is {}.",
+          partitionId,
+          brokerId,
+          lowestPosition);
+
+      return lowestPosition;
+    } else {
+      logger.debug(
+          "No exporters present in snapshot for partition {} at broker {}.", partitionId, brokerId);
+      return Long.MAX_VALUE;
+    }
+  }
+
+  private long getLastProcessedPosition(ZeebeDb zeebeDb) {
+    final ZeebeState processorState = new ZeebeState(partitionId, zeebeDb, zeebeDb.createContext());
+    final long lowestPosition = processorState.getLastSuccessfulProcessedRecordPosition();
+
+    logger.debug(
+        "The last processed position for partition {} at broker {} is {}.",
+        partitionId,
+        brokerId,
+        lowestPosition);
+
+    return lowestPosition;
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/distributedlog/restore/RestoreFactory.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/restore/RestoreFactory.java
@@ -16,6 +16,7 @@
 package io.zeebe.distributedlog.restore;
 
 import io.zeebe.distributedlog.restore.snapshot.SnapshotRestoreContext;
+import org.slf4j.Logger;
 
 public interface RestoreFactory {
 
@@ -29,5 +30,5 @@ public interface RestoreFactory {
   RestoreClient createClient(int partitionId);
 
   /** @return a {@link SnapshotRestoreContext} */
-  SnapshotRestoreContext createSnapshotRestoreContext();
+  SnapshotRestoreContext createSnapshotRestoreContext(int partitionId, Logger logger);
 }

--- a/logstreams/src/main/java/io/zeebe/distributedlog/restore/snapshot/SnapshotRestoreContext.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/restore/snapshot/SnapshotRestoreContext.java
@@ -16,19 +16,17 @@
 package io.zeebe.distributedlog.restore.snapshot;
 
 import io.zeebe.logstreams.state.StateStorage;
+import io.zeebe.util.collection.Tuple;
 import java.util.function.Supplier;
 
 public interface SnapshotRestoreContext {
 
   /** @return state storage of processor */
-  StateStorage getStateStorage(int partitionId);
-
-  /** @return a supplier that supplies the latest exported position by reading exporterStorage */
-  Supplier<Long> getExporterPositionSupplier(int partitionId);
+  StateStorage getStateStorage();
 
   /**
-   * @return a supplier that supplies the latest processed position by reading snapshots in the
-   *     processorStorage
+   * @return a supplier that supplies the minimum exported and latest processed position in the
+   *     latest snapshot
    */
-  Supplier<Long> getProcessorPositionSupplier(int partitionId);
+  Supplier<Tuple<Long, Long>> getSnapshotPositionSupplier();
 }

--- a/logstreams/src/main/java/io/zeebe/distributedlog/restore/snapshot/SnapshotRestoreStrategy.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/restore/snapshot/SnapshotRestoreStrategy.java
@@ -69,9 +69,6 @@ public class SnapshotRestoreStrategy implements RestoreStrategy {
   }
 
   private long getFirstEventToBeReplicated(long exporterPosition, long processedPosition) {
-    if (exporterPosition > 0) {
-      return Math.min(processedPosition, exporterPosition);
-    }
-    return processedPosition;
+    return Math.min(processedPosition, exporterPosition);
   }
 }

--- a/logstreams/src/main/java/io/zeebe/distributedlog/restore/snapshot/impl/DefaultSnapshotRequestHandler.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/restore/snapshot/impl/DefaultSnapshotRequestHandler.java
@@ -21,6 +21,7 @@ import io.zeebe.distributedlog.restore.snapshot.SnapshotRestoreResponse;
 import io.zeebe.logstreams.impl.Loggers;
 import io.zeebe.logstreams.spi.SnapshotController;
 import io.zeebe.logstreams.state.SnapshotChunk;
+import io.zeebe.logstreams.state.SnapshotChunkUtil;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotChunkUtil.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotChunkUtil.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.distributedlog.restore.snapshot.impl;
+package io.zeebe.logstreams.state;
 
-import io.zeebe.logstreams.state.SnapshotChunk;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotConsumer.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotConsumer.java
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.distributedlog.restore.snapshot;
-
-import io.zeebe.logstreams.state.SnapshotChunk;
+package io.zeebe.logstreams.state;
 
 public interface SnapshotConsumer {
   boolean consumeSnapshotChunk(SnapshotChunk chunk);
 
-  boolean moveValidSnapshot(long snapshotPosition);
+  boolean completeSnapshot(long snapshotPosition);
 
-  void clearTmpSnapshot(long snapshotPosition);
+  void invalidateSnapshot(long snapshotPosition);
 }

--- a/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/ControllableSnapshotRestoreContext.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/ControllableSnapshotRestoreContext.java
@@ -17,44 +17,34 @@ package io.zeebe.distributedlog.restore.impl;
 
 import io.zeebe.distributedlog.restore.snapshot.SnapshotRestoreContext;
 import io.zeebe.logstreams.state.StateStorage;
+import io.zeebe.util.collection.Tuple;
 import java.util.function.Supplier;
 
 public class ControllableSnapshotRestoreContext implements SnapshotRestoreContext {
 
   private StateStorage processorStateStorage;
-  private Supplier<Long> exporterPositionSupplier;
-  private Supplier<Long> processorPositionSupplier;
+  private Supplier<Tuple<Long, Long>> positionSupplier;
 
   public void setProcessorStateStorage(StateStorage processorStateStorage) {
     this.processorStateStorage = processorStateStorage;
   }
 
-  public void setExporterPositionSupplier(Supplier<Long> exporterPositionSupplier) {
-    this.exporterPositionSupplier = exporterPositionSupplier;
-  }
-
-  public void setProcessorPositionSupplier(Supplier<Long> processorPositionSupplier) {
-    this.processorPositionSupplier = processorPositionSupplier;
+  public void setPositionSupplier(Supplier<Tuple<Long, Long>> exporterPositionSupplier) {
+    this.positionSupplier = exporterPositionSupplier;
   }
 
   @Override
-  public StateStorage getStateStorage(int partitionId) {
+  public StateStorage getStateStorage() {
     return processorStateStorage;
   }
 
   @Override
-  public Supplier<Long> getExporterPositionSupplier(int partitionId) {
-    return exporterPositionSupplier;
-  }
-
-  @Override
-  public Supplier<Long> getProcessorPositionSupplier(int partitionId) {
-    return processorPositionSupplier;
+  public Supplier<Tuple<Long, Long>> getSnapshotPositionSupplier() {
+    return positionSupplier;
   }
 
   public void reset() {
     processorStateStorage = null;
-    exporterPositionSupplier = null;
-    processorPositionSupplier = null;
+    positionSupplier = null;
   }
 }

--- a/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/ReplicatingRestoreClientProvider.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/ReplicatingRestoreClientProvider.java
@@ -20,6 +20,7 @@ import io.zeebe.distributedlog.restore.RestoreClient;
 import io.zeebe.distributedlog.restore.RestoreFactory;
 import io.zeebe.distributedlog.restore.RestoreNodeProvider;
 import io.zeebe.distributedlog.restore.snapshot.SnapshotRestoreContext;
+import org.slf4j.Logger;
 
 public class ReplicatingRestoreClientProvider implements RestoreFactory {
 
@@ -43,7 +44,7 @@ public class ReplicatingRestoreClientProvider implements RestoreFactory {
   }
 
   @Override
-  public SnapshotRestoreContext createSnapshotRestoreContext() {
+  public SnapshotRestoreContext createSnapshotRestoreContext(int partitionId, Logger logger) {
     return this.snapshotRestoreContext;
   }
 }

--- a/logstreams/src/test/java/io/zeebe/distributedlog/restore/snapshot/RecordingSnapshotConsumer.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/restore/snapshot/RecordingSnapshotConsumer.java
@@ -16,6 +16,7 @@
 package io.zeebe.distributedlog.restore.snapshot;
 
 import io.zeebe.logstreams.state.SnapshotChunk;
+import io.zeebe.logstreams.state.SnapshotConsumer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,13 +35,13 @@ public class RecordingSnapshotConsumer implements SnapshotConsumer {
   }
 
   @Override
-  public boolean moveValidSnapshot(long snapshotPosition) {
+  public boolean completeSnapshot(long snapshotPosition) {
     snapshots.put(snapshotPosition, true);
     return true;
   }
 
   @Override
-  public void clearTmpSnapshot(long snapshotPosition) {
+  public void invalidateSnapshot(long snapshotPosition) {
     consumedChunks.clear();
   }
 

--- a/logstreams/src/test/java/io/zeebe/distributedlog/restore/snapshot/RestoreSnapshotReplicatorTest.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/restore/snapshot/RestoreSnapshotReplicatorTest.java
@@ -35,7 +35,7 @@ public class RestoreSnapshotReplicatorTest {
       new ControllableSnapshotRestoreContext();
   private RecordingSnapshotConsumer snapshotConsumer = new RecordingSnapshotConsumer();
   private RestoreSnapshotReplicator snapshotReplicator =
-      new RestoreSnapshotReplicator(client, restoreContext, snapshotConsumer, 1, Runnable::run);
+      new RestoreSnapshotReplicator(client, restoreContext, snapshotConsumer, Runnable::run);
   private MemberId server = MemberId.anonymous();
   private final ControllableSnapshotChunk responseChunk = new ControllableSnapshotChunk();
 
@@ -53,8 +53,7 @@ public class RestoreSnapshotReplicatorTest {
     final long snapshotId = 10;
     final int numChunks = 5;
 
-    restoreContext.setExporterPositionSupplier(() -> 5L);
-    restoreContext.setProcessorPositionSupplier(() -> 10L);
+    restoreContext.setPositionSupplier(() -> new Tuple(5L, 10L));
 
     for (int i = 0; i < numChunks; i++) {
       client.completeRequestSnapshotChunk(
@@ -80,8 +79,7 @@ public class RestoreSnapshotReplicatorTest {
     final long snapshotId = 10;
     final int numChunks = 5;
 
-    restoreContext.setExporterPositionSupplier(() -> 5L);
-    restoreContext.setProcessorPositionSupplier(() -> 10L);
+    restoreContext.setPositionSupplier(() -> new Tuple(5L, 10L));
 
     client.completeRequestSnapshotChunk(0, new InvalidSnapshotRestoreResponse());
 
@@ -99,8 +97,7 @@ public class RestoreSnapshotReplicatorTest {
     final long snapshotId = 10;
     final int numChunks = 5;
 
-    restoreContext.setExporterPositionSupplier(() -> 5L);
-    restoreContext.setProcessorPositionSupplier(() -> 10L);
+    restoreContext.setPositionSupplier(() -> new Tuple(5L, 10L));
 
     final CompletableFuture<Tuple<Long, Long>> replicate =
         snapshotReplicator.restore(server, snapshotId, numChunks);


### PR DESCRIPTION
 - added a `StatePositionSupplier` that is used by both deletion service and snapshot restore
 - `ReplicationController` and snapshot restore  uses a common `SnapshotConsumer` to process received snapshot chunks.

closes #2592 
closes #2522 
