### PR TITLE
chore(protocol): IncidentRecord return ErrorType instead of String

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/boundary/BoundaryEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/boundary/BoundaryEventTest.java
@@ -394,7 +394,7 @@ public class BoundaryEventTest {
             .getFirst();
 
     Assertions.assertThat(incidentRecord.getValue())
-        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR.name())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasWorkflowInstanceKey(workflowInstanceKey)
         .hasElementId("task")
         .hasElementInstanceKey(failureEvent.getKey())

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/handlers/element/ElementActivatingHandlerTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/handlers/element/ElementActivatingHandlerTest.java
@@ -116,7 +116,7 @@ public class ElementActivatingHandlerTest extends ElementHandlerTestCase<Executa
     final IncidentRecord raisedIncident = getRaisedIncident();
     assertThat(handled).isFalse();
     assertThat(raisedIncident)
-        .extracting(IncidentRecord::getErrorTypeEnum, IncidentRecord::getErrorMessageBuffer)
+        .extracting(IncidentRecord::getErrorType, IncidentRecord::getErrorMessageBuffer)
         .containsExactly(ErrorType.IO_MAPPING_ERROR, BufferUtil.wrapString("fail"));
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/EventSubscriptionIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/EventSubscriptionIncidentTest.java
@@ -278,7 +278,7 @@ public class EventSubscriptionIncidentTest {
             .getFirst();
 
     Assertions.assertThat(incidentRecord.getValue())
-        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR.name())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             "Failed to extract the correlation-key by '"
                 + CORRELATION_VARIABLE_2
@@ -313,7 +313,7 @@ public class EventSubscriptionIncidentTest {
             .getFirst();
 
     Assertions.assertThat(incidentRecord.getValue())
-        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR.name())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             "Failed to extract the correlation-key by '"
                 + CORRELATION_VARIABLE_2

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/ExpressionIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/ExpressionIncidentTest.java
@@ -118,7 +118,7 @@ public class ExpressionIncidentTest {
     assertThat(incidentCommand.getSourceRecordPosition()).isEqualTo(failingEvent.getPosition());
 
     Assertions.assertThat(incidentEvent.getValue())
-        .hasErrorType(ErrorType.CONDITION_ERROR.name())
+        .hasErrorType(ErrorType.CONDITION_ERROR)
         .hasErrorMessage(
             "Expected at least one condition to evaluate to true, or to have a default flow")
         .hasBpmnProcessId("workflow")
@@ -144,7 +144,7 @@ public class ExpressionIncidentTest {
             .getFirst();
 
     Assertions.assertThat(incidentEvent.getValue())
-        .hasErrorType(ErrorType.CONDITION_ERROR.name())
+        .hasErrorType(ErrorType.CONDITION_ERROR)
         .hasErrorMessage(
             "Expected to evaluate condition 'foo >= 5 && foo < 10' successfully, but failed because: Cannot compare values of different types: STRING and INTEGER")
         .hasBpmnProcessId("workflow")
@@ -351,7 +351,7 @@ public class ExpressionIncidentTest {
 
     assertThat(incidentEvent.getKey()).isGreaterThan(0);
     Assertions.assertThat(incidentEvent.getValue())
-        .hasErrorType(ErrorType.CONDITION_ERROR.name())
+        .hasErrorType(ErrorType.CONDITION_ERROR)
         .hasErrorMessage(
             "Expected to evaluate condition 'foo >= 5 && foo < 10' successfully, but failed because: Cannot compare values of different types: STRING and INTEGER")
         .hasBpmnProcessId("workflow")

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/JobFailIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/JobFailIncidentTest.java
@@ -125,7 +125,7 @@ public class JobFailIncidentTest {
     assertThat(incidentEvent.getKey()).isGreaterThan(0);
 
     assertThat(incidentEvent.getValue())
-        .hasErrorType(ErrorType.JOB_NO_RETRIES.name())
+        .hasErrorType(ErrorType.JOB_NO_RETRIES)
         .hasErrorMessage("No more retries left.")
         .hasBpmnProcessId("process")
         .hasWorkflowKey(workflowKey)
@@ -174,7 +174,7 @@ public class JobFailIncidentTest {
     assertThat(incidentCommand.getSourceRecordPosition()).isEqualTo(failedEvent.getPosition());
     assertThat(incidentEvent.getKey()).isGreaterThan(0);
     assertThat(incidentEvent.getValue())
-        .hasErrorType(ErrorType.JOB_NO_RETRIES.name())
+        .hasErrorType(ErrorType.JOB_NO_RETRIES)
         .hasErrorMessage("failed job")
         .hasBpmnProcessId("process")
         .hasWorkflowKey(workflowKey)
@@ -211,7 +211,7 @@ public class JobFailIncidentTest {
             .getFirst();
 
     assertThat(incidentEvent.getValue())
-        .hasErrorType(ErrorType.JOB_NO_RETRIES.name())
+        .hasErrorType(ErrorType.JOB_NO_RETRIES)
         .hasErrorMessage("second message")
         .hasBpmnProcessId("process")
         .hasWorkflowKey(workflowKey)
@@ -267,7 +267,7 @@ public class JobFailIncidentTest {
     assertThat(resolvedIncident.getSourceRecordPosition()).isEqualTo(lastPos);
 
     assertThat(resolvedIncident.getValue())
-        .hasErrorType(ErrorType.JOB_NO_RETRIES.name())
+        .hasErrorType(ErrorType.JOB_NO_RETRIES)
         .hasErrorMessage("No more retries left.")
         .hasBpmnProcessId("process")
         .hasWorkflowKey(workflowKey)
@@ -355,7 +355,7 @@ public class JobFailIncidentTest {
     assertThat(jobCancelCommand.getSourceRecordPosition()).isEqualTo(terminatingTask.getPosition());
 
     assertThat(resolvedIncidentEvent.getValue())
-        .hasErrorType(ErrorType.JOB_NO_RETRIES.name())
+        .hasErrorType(ErrorType.JOB_NO_RETRIES)
         .hasErrorMessage("No more retries left.")
         .hasBpmnProcessId("process")
         .hasWorkflowKey(workflowKey)

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/MappingIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/MappingIncidentTest.java
@@ -113,7 +113,7 @@ public class MappingIncidentTest {
 
     final IncidentRecordValue incidentEventValue = incidentEvent.getValue();
     Assertions.assertThat(incidentEventValue)
-        .hasErrorType(ErrorType.IO_MAPPING_ERROR.name())
+        .hasErrorType(ErrorType.IO_MAPPING_ERROR)
         .hasErrorMessage("No data found for query foo.")
         .hasBpmnProcessId("process")
         .hasWorkflowKey(workflowKey)
@@ -163,7 +163,7 @@ public class MappingIncidentTest {
     assertThat(incidentEvent.getValue().getVariableScopeKey()).isEqualTo(failureEvent.getKey());
 
     Assertions.assertThat(incidentEvent.getValue())
-        .hasErrorType(ErrorType.IO_MAPPING_ERROR.name())
+        .hasErrorType(ErrorType.IO_MAPPING_ERROR)
         .hasErrorMessage("No data found for query notExisting.")
         .hasBpmnProcessId("process")
         .hasWorkflowInstanceKey(workflowInstanceKey)
@@ -212,7 +212,7 @@ public class MappingIncidentTest {
         .isEqualTo(createIncidentEvent.getPosition());
 
     Assertions.assertThat(incidentEvent.getValue())
-        .hasErrorType(ErrorType.IO_MAPPING_ERROR.name())
+        .hasErrorType(ErrorType.IO_MAPPING_ERROR)
         .hasErrorMessage("No data found for query foo.")
         .hasBpmnProcessId("process")
         .hasWorkflowInstanceKey(workflowInstanceKey)
@@ -271,7 +271,7 @@ public class MappingIncidentTest {
         .isEqualTo(incidentResolvedEvent.getSourceRecordPosition());
 
     Assertions.assertThat(incidentResolvedEvent.getValue())
-        .hasErrorType(ErrorType.IO_MAPPING_ERROR.name())
+        .hasErrorType(ErrorType.IO_MAPPING_ERROR)
         .hasErrorMessage("No data found for query foo.")
         .hasBpmnProcessId("process")
         .hasWorkflowInstanceKey(workflowInstanceKey)
@@ -332,7 +332,7 @@ public class MappingIncidentTest {
         .isEqualTo(incidentResolvedEvent.getSourceRecordPosition());
 
     Assertions.assertThat(incidentResolvedEvent.getValue())
-        .hasErrorType(ErrorType.IO_MAPPING_ERROR.name())
+        .hasErrorType(ErrorType.IO_MAPPING_ERROR)
         .hasErrorMessage("No data found for query foo.")
         .hasBpmnProcessId("process")
         .hasWorkflowInstanceKey(workflowInstanceKey)
@@ -387,7 +387,7 @@ public class MappingIncidentTest {
             .getFirst();
 
     Assertions.assertThat(secondIncidentEvent.getValue())
-        .hasErrorType(ErrorType.IO_MAPPING_ERROR.name())
+        .hasErrorType(ErrorType.IO_MAPPING_ERROR)
         .hasErrorMessage("No data found for query bar.")
         .hasBpmnProcessId("process")
         .hasWorkflowInstanceKey(workflowInstanceKey)
@@ -439,7 +439,7 @@ public class MappingIncidentTest {
     // then
     assertThat(secondResolvedIncident.getKey()).isGreaterThan(firstIncident.getKey());
     Assertions.assertThat(secondResolvedIncident.getValue())
-        .hasErrorType(ErrorType.IO_MAPPING_ERROR.name())
+        .hasErrorType(ErrorType.IO_MAPPING_ERROR)
         .hasErrorMessage("No data found for query foo.")
         .hasBpmnProcessId("process")
         .hasWorkflowInstanceKey(workflowInstanceKey)
@@ -524,7 +524,7 @@ public class MappingIncidentTest {
         .isEqualTo(incidentResolvedEvent.getSourceRecordPosition());
 
     Assertions.assertThat(incidentResolvedEvent.getValue())
-        .hasErrorType(ErrorType.IO_MAPPING_ERROR.name())
+        .hasErrorType(ErrorType.IO_MAPPING_ERROR)
         .hasErrorMessage("No data found for query foo.")
         .hasBpmnProcessId("process")
         .hasWorkflowInstanceKey(workflowInstanceKey)
@@ -568,7 +568,7 @@ public class MappingIncidentTest {
     assertThat(incidentEvent.getKey()).isEqualTo(incidentCreatedEvent.getKey());
 
     Assertions.assertThat(incidentEvent.getValue())
-        .hasErrorType(ErrorType.IO_MAPPING_ERROR.name())
+        .hasErrorType(ErrorType.IO_MAPPING_ERROR)
         .hasErrorMessage("No data found for query foo.")
         .hasBpmnProcessId("process")
         .hasWorkflowInstanceKey(workflowInstanceKey)

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/MessageIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/MessageIncidentTest.java
@@ -79,7 +79,7 @@ public class MessageIncidentTest {
             .getFirst();
 
     Assertions.assertThat(incidentRecord.getValue())
-        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR.name())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage("Failed to extract the correlation-key by 'orderId': no value found")
         .hasBpmnProcessId(PROCESS_ID)
         .hasWorkflowInstanceKey(workflowInstanceKey)
@@ -112,7 +112,7 @@ public class MessageIncidentTest {
             .getFirst();
 
     Assertions.assertThat(incidentRecord.getValue())
-        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR.name())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             "Failed to extract the correlation-key by 'orderId': the value must be either a string or a number")
         .hasBpmnProcessId(PROCESS_ID)

--- a/engine/src/test/java/io/zeebe/engine/state/instance/IncidentStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/instance/IncidentStateTest.java
@@ -206,6 +206,6 @@ public class IncidentStateTest {
 
     assertThat(expectedRecord.getErrorMessageBuffer())
         .isEqualTo(storedRecord.getErrorMessageBuffer());
-    assertThat(expectedRecord.getErrorTypeEnum()).isEqualTo(storedRecord.getErrorTypeEnum());
+    assertThat(expectedRecord.getErrorType()).isEqualTo(storedRecord.getErrorType());
   }
 }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -112,8 +112,8 @@ public class IncidentRecord extends UnifiedRecordValue
   }
 
   @Override
-  public String getErrorType() {
-    return errorTypeProp.getValue().name();
+  public ErrorType getErrorType() {
+    return errorTypeProp.getValue();
   }
 
   @Override
@@ -145,11 +145,6 @@ public class IncidentRecord extends UnifiedRecordValue
 
   public long getVariableScopeKey() {
     return variableScopeKeyProp.getValue();
-  }
-
-  @JsonIgnore
-  public ErrorType getErrorTypeEnum() {
-    return errorTypeProp.getValue();
   }
 
   public long getWorkflowInstanceKey() {

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/IncidentRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/IncidentRecordValue.java
@@ -28,7 +28,7 @@ public interface IncidentRecordValue extends RecordValue {
    * @return the type of error this incident is caused by. Can be <code>UNKNOWN</code> if the
    *     incident record is part of a {@link IncidentIntent#RESOLVE} command.
    */
-  String getErrorType();
+  ErrorType getErrorType();
 
   /**
    * @return the description of the error this incident is caused by. Can be empty if the incident

--- a/test-util/src/main/java/io/zeebe/test/util/record/IncidentRecordStream.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/IncidentRecordStream.java
@@ -16,6 +16,7 @@
 package io.zeebe.test.util.record;
 
 import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.value.ErrorType;
 import io.zeebe.protocol.record.value.IncidentRecordValue;
 import java.util.stream.Stream;
 
@@ -31,7 +32,7 @@ public class IncidentRecordStream
     return new IncidentRecordStream(wrappedStream);
   }
 
-  public IncidentRecordStream withErrorType(final String errorType) {
+  public IncidentRecordStream withErrorType(final ErrorType errorType) {
     return valueFilter(v -> errorType.equals(v.getErrorType()));
   }
 


### PR DESCRIPTION
BREAKING CHANGE: IncidentRecord#getErrorType now returns ErrorType
instead of String


closes #2627 
