### PR TITLE
Use -1 as deadline default

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterRecordMapper.java
@@ -36,7 +36,6 @@ import io.zeebe.broker.exporter.record.value.deployment.DeploymentResourceImpl;
 import io.zeebe.broker.exporter.record.value.job.HeadersImpl;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.msgpack.value.LongValue;
-import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.impl.record.value.deployment.Workflow;
@@ -184,7 +183,7 @@ public class ExporterRecordMapper {
             jobHeaders.getWorkflowDefinitionVersion());
 
     final Instant deadline;
-    if (record.getDeadlineLong() != Protocol.INSTANT_NULL_VALUE) {
+    if (record.getDeadlineLong() > 0) {
       deadline = Instant.ofEpochMilli(record.getDeadlineLong());
     } else {
       deadline = null;

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
@@ -25,7 +25,6 @@ import io.zeebe.msgpack.property.StringProperty;
 import io.zeebe.msgpack.value.LongValue;
 import io.zeebe.msgpack.value.StringValue;
 import io.zeebe.msgpack.value.ValueArray;
-import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.zeebe.protocol.record.value.JobRecordValue;
@@ -41,8 +40,9 @@ public class JobBatchRecord extends UnifiedRecordValue implements JobBatchRecord
 
   private final StringProperty typeProp = new StringProperty("type");
   private final StringProperty workerProp = new StringProperty("worker", "");
-  private final LongProperty timeoutProp = new LongProperty("timeout", Protocol.INSTANT_NULL_VALUE);
-  private final IntegerProperty maxJobsToActivateProp = new IntegerProperty("maxJobsToActivate", 1);
+  private final LongProperty timeoutProp = new LongProperty("timeout", -1);
+  private final IntegerProperty maxJobsToActivateProp =
+      new IntegerProperty("maxJobsToActivate", -1);
   private final ArrayProperty<LongValue> jobKeysProp =
       new ArrayProperty<>("jobKeys", new LongValue());
   private final ArrayProperty<JobRecord> jobsProp = new ArrayProperty<>("jobs", new JobRecord());

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -24,7 +24,6 @@ import io.zeebe.msgpack.property.ObjectProperty;
 import io.zeebe.msgpack.property.PackedProperty;
 import io.zeebe.msgpack.property.StringProperty;
 import io.zeebe.msgpack.spec.MsgPackHelper;
-import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.intent.WorkflowInstanceRelated;
@@ -46,8 +45,7 @@ public class JobRecord extends UnifiedRecordValue
   private static final String VARIABLES = "variables";
   private static final String ERROR_MESSAGE = "errorMessage";
 
-  private final LongProperty deadlineProp =
-      new LongProperty("deadline", Protocol.INSTANT_NULL_VALUE);
+  private final LongProperty deadlineProp = new LongProperty("deadline", -1);
   private final StringProperty workerProp = new StringProperty("worker", "");
   private final IntegerProperty retriesProp = new IntegerProperty(RETRIES, -1);
   private final StringProperty typeProp = new StringProperty(TYPE, "");
@@ -121,7 +119,8 @@ public class JobRecord extends UnifiedRecordValue
   @Override
   @JsonIgnore
   public Instant getDeadline() {
-    return Instant.ofEpochMilli(deadlineProp.getValue());
+    final long deadline = deadlineProp.getValue();
+    return deadline > 0 ? Instant.ofEpochMilli(deadline) : null;
   }
 
   @Override

--- a/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -212,6 +212,17 @@ public class JsonSerializableToJsonTest {
         "{'resources':[{'resourceType':'BPMN_XML','resourceName':'resource','resource':'Y29udGVudHM='}],'deployedWorkflows':[{'bpmnProcessId':'testProcess','version':12,'workflowKey':123,'resourceName':'resource'}]}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////// Empty DeploymentRecord /////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      new Object[] {
+        "Empty DeploymentRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              return new DeploymentRecord();
+            },
+        "{'resources':[],'deployedWorkflows':[]}"
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////////// ErrorRecord ///////////////////////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
       new Object[] {
@@ -226,6 +237,21 @@ public class JsonSerializableToJsonTest {
         "{'exceptionMessage':'test','stacktrace':"
             + JSONParser.quote(STACK_TRACE)
             + ",'errorEventPosition':123,'workflowInstanceKey':4321}"
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////////// Empty ErrorRecord /////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      new Object[] {
+        "Empty ErrorRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final ErrorRecord record = new ErrorRecord();
+              record.initErrorRecord(RUNTIME_EXCEPTION, 123);
+              return record;
+            },
+        "{'exceptionMessage':'test','stacktrace':"
+            + JSONParser.quote(STACK_TRACE)
+            + ",'errorEventPosition':123,'workflowInstanceKey':-1}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       //////////////////////////////////// IncidentRecord /////////////////////////////////////////
@@ -257,6 +283,18 @@ public class JsonSerializableToJsonTest {
               return record;
             },
         "{'errorType':'IO_MAPPING_ERROR','errorMessage':'error','bpmnProcessId':'process','workflowKey':134,'workflowInstanceKey':10,'elementId':'activity','elementInstanceKey':34,'jobKey':123,'variableScopeKey':34}"
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////// Empty IncidentRecord ///////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      new Object[] {
+        "Empty IncidentRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final IncidentRecord record = new IncidentRecord();
+              return record;
+            },
+        "{'errorType':'UNKNOWN','errorMessage':'','bpmnProcessId':'','workflowKey':-1,'workflowInstanceKey':-1,'elementId':'','elementInstanceKey':-1,'jobKey':-1,'variableScopeKey':-1}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -310,7 +348,18 @@ public class JsonSerializableToJsonTest {
             },
         "{'maxJobsToActivate':1,'type':'type','worker':'worker','truncated':true,'jobKeys':[3],'jobs':[{'headers':{'bpmnProcessId':'test-process','workflowKey':13,'workflowDefinitionVersion':12,'workflowInstanceKey':1234,'elementId':'activity','elementInstanceKey':123},'type':'type','worker':'worker','variables':'{\"foo\":\"bar\"}','retries':3,'errorMessage':'failed message','customHeaders':{},'deadline':1000}],'timeout':2}"
       },
-
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty JobBatchRecord //////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty JobBatchRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final String type = "type";
+              return new JobBatchRecord().setType(type);
+            },
+        "{'worker':'','type':'type','maxJobsToActivate':-1,'truncated':false,'jobKeys':[],'jobs':[],'timeout':-1}"
+      },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////////// JobRecord /////////////////////////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -357,6 +406,14 @@ public class JsonSerializableToJsonTest {
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////////// Empty JobRecord ///////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty JobRecord",
+        (Supplier<UnifiedRecordValue>) () -> new JobRecord(),
+        "{'type':'','headers':{'workflowDefinitionVersion':-1,'elementId':'','bpmnProcessId':'','workflowKey':-1,'workflowInstanceKey':-1,'elementInstanceKey':-1},'variables':'{}','worker':'','retries':-1,'errorMessage':'','customHeaders':{},'deadline':-1}"
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////// MessageRecord /////////////////////////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
@@ -378,6 +435,26 @@ public class JsonSerializableToJsonTest {
               return record;
             },
         "{'timeToLive':12,'correlationKey':'test-key','variables':'{\"foo\":\"bar\"}','messageId':'test-id','name':'test-message'}"
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty MessageRecord ///////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty MessageRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final String correlationKey = "test-key";
+              final String messageName = "test-message";
+              final long timeToLive = 12;
+
+              final MessageRecord record =
+                  new MessageRecord()
+                      .setTimeToLive(timeToLive)
+                      .setCorrelationKey(correlationKey)
+                      .setName(messageName);
+              return record;
+            },
+        "{'timeToLive':12,'correlationKey':'test-key','variables':'{}','messageId':'','name':'test-message'}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -403,6 +480,20 @@ public class JsonSerializableToJsonTest {
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty MessageStartEventSubscriptionRecord /////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty MessageStartEventSubscriptionRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final int workflowKey = 22334;
+
+              return new MessageStartEventSubscriptionRecord().setWorkflowKey(workflowKey);
+            },
+        "{'workflowKey':22334,'messageName':'','startEventId':''}"
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////// MessageSubscriptionRecord /////////////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
@@ -425,6 +516,23 @@ public class JsonSerializableToJsonTest {
               return record;
             },
         "{'workflowInstanceKey':1,'elementInstanceKey':1,'messageName':'name','correlationKey':'key'}"
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty MessageSubscriptionRecord
+      // /////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty MessageSubscriptionRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final long elementInstanceKey = 13L;
+              final long workflowInstanceKey = 1L;
+
+              return new MessageSubscriptionRecord()
+                  .setWorkflowInstanceKey(workflowInstanceKey)
+                  .setElementInstanceKey(elementInstanceKey);
+            },
+        "{'workflowInstanceKey':1,'elementInstanceKey':13,'messageName':'','correlationKey':''}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -452,6 +560,23 @@ public class JsonSerializableToJsonTest {
               return record;
             },
         "{'elementInstanceKey':123,'messageName':'test-message','workflowInstanceKey':1345,'variables':'{\"foo\":\"bar\"}'}"
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////// Empty WorkflowInstanceSubscriptionRecord ///////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty WorkflowInstanceSubscriptionRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final long elementInstanceKey = 123;
+              final long workflowInstanceKey = 1345;
+
+              return new WorkflowInstanceSubscriptionRecord()
+                  .setWorkflowInstanceKey(workflowInstanceKey)
+                  .setElementInstanceKey(elementInstanceKey);
+            },
+        "{'elementInstanceKey':123,'messageName':'','workflowInstanceKey':1345,'variables':'{}'}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -529,6 +654,20 @@ public class JsonSerializableToJsonTest {
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty VariableDocumentRecord //////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty VariableDocumentRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final long scopeKey = 3;
+
+              return new VariableDocumentRecord().setScopeKey(scopeKey);
+            },
+        "{'updateSemantics':'PROPAGATE','document':{},'scopeKey':3}"
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////// WorkflowInstanceCreationRecord ////////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
@@ -553,6 +692,18 @@ public class JsonSerializableToJsonTest {
               return record;
             },
         "{'variables':{'foo':'bar','baz':'boz'},'bpmnProcessId':'process','key':1,'version':1,'instanceKey':2}"
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty WorkflowInstanceCreationRecord //////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty WorkflowInstanceCreationRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              return new WorkflowInstanceCreationRecord();
+            },
+        "{'variables':{},'bpmnProcessId':'','key':-1,'version':-1,'instanceKey':-1}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -582,6 +733,18 @@ public class JsonSerializableToJsonTest {
               return record;
             },
         "{'bpmnProcessId':'test-process','version':12,'workflowKey':13,'workflowInstanceKey':1234,'elementId':'activity','flowScopeKey':123,'bpmnElementType':'SERVICE_TASK'}"
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// Empty WorkflowInstanceRecord //////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty WorkflowInstanceRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              return new WorkflowInstanceRecord();
+            },
+        "{'bpmnProcessId':'','version':-1,'workflowKey':-1,'workflowInstanceKey':-1,'elementId':'','flowScopeKey':-1,'bpmnElementType':'UNSPECIFIED'}"
       },
     };
     return contents;

--- a/protocol/src/main/java/io/zeebe/protocol/Protocol.java
+++ b/protocol/src/main/java/io/zeebe/protocol/Protocol.java
@@ -28,9 +28,6 @@ public class Protocol {
    */
   public static final ByteOrder ENDIANNESS = ByteOrder.LITTLE_ENDIAN;
 
-  /** The null value of an instant property which indicates that it is not set. */
-  public static final long INSTANT_NULL_VALUE = Long.MIN_VALUE;
-
   /** By convention, the partition to deploy to */
   public static final int DEPLOYMENT_PARTITION = 1;
 


### PR DESCRIPTION
 * job record and job batch record used Long.MIN_VALUE which was replaced with -1 to be consistent with other properties
* added tests for empty record serialization 

 BREAKING CHANGE:

  * deadline and timeout is no longer null if not set (default value is -1)


closes #2658 
