### PR TITLE
Disable indexing of deployment resource in elasticsearch

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -31,7 +31,7 @@
             "resources": {
               "properties": {
                 "resource": {
-                  "type": "text"
+                  "enabled": false
                 },
                 "resourceName": {
                   "type": "text"


### PR DESCRIPTION
BREAKING CHANGE:
- deployment resource bytes will not be indexed anymore by elasticsearch

closes #2694 
