### PR TITLE
Error handling on append

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogStreamService.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogStreamService.java
@@ -90,6 +90,7 @@ public class LogStreamService implements LogStream, Service<LogStream> {
 
   @Override
   public ActorFuture<LogStorageAppender> openAppender() {
+    final String logName = getLogName();
     final ServiceName<Void> logStorageAppenderRootService = logStorageAppenderRootService(logName);
     final ServiceName<Dispatcher> logWriteBufferServiceName = logWriteBufferServiceName(logName);
     final ServiceName<Subscription> appenderSubscriptionServiceName =
@@ -141,6 +142,7 @@ public class LogStreamService implements LogStream, Service<LogStream> {
     appender = null;
     writeBuffer = null;
 
+    final String logName = getLogName();
     return serviceContext.removeService(logStorageAppenderRootService(logName));
   }
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/spi/LogStorage.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/spi/LogStorage.java
@@ -15,6 +15,7 @@
  */
 package io.zeebe.logstreams.spi;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /** Log structured storage abstraction */
@@ -61,8 +62,11 @@ public interface LogStorage {
    *
    * @param blockBuffer the buffer containing a block of log entries to be written into storage
    * @return the address at which the block has been written or error status code
+   * @throws IOException on I/O error during the append operation
+   * @throws IllegalArgumentException when block size is to large
+   * @throws IllegalStateException when logstorage was not opened and not initialized
    */
-  long append(ByteBuffer blockBuffer);
+  long append(ByteBuffer blockBuffer) throws IOException;
 
   /**
    * Deletes from the log storage, uses the given address as upper limit.
@@ -129,8 +133,12 @@ public interface LogStorage {
    */
   boolean isByteAddressable();
 
-  /** Open the storage. Called in the log conductor thread. */
-  void open();
+  /**
+   * Open the storage. Called in the log conductor thread.
+   *
+   * @throws IOException on I/O errors during allocating the first segments
+   */
+  void open() throws IOException;
 
   /** Close the storage. Called in the log conductor thread. */
   void close();

--- a/logstreams/src/test/java/io/zeebe/distributedlog/DefaultDistributedLogStreamServiceTest.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/DefaultDistributedLogStreamServiceTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.distributedlog;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import io.zeebe.distributedlog.impl.LogstreamConfig;
+import io.zeebe.logstreams.LogStreams;
+import io.zeebe.logstreams.impl.service.LogStreamServiceNames;
+import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.logstreams.spi.LogStorage;
+import io.zeebe.servicecontainer.Service;
+import io.zeebe.servicecontainer.ServiceContainer;
+import io.zeebe.servicecontainer.ServiceName;
+import io.zeebe.servicecontainer.testing.ServiceContainerRule;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+
+public class DefaultDistributedLogStreamServiceTest {
+
+  private static final ServiceName<LogStream> LOG_STREAM_SERVICE_NAME =
+      LogStreamServiceNames.logStreamServiceName("raft-atomix-partition-1");
+
+  private final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
+  private final ServiceContainerRule serviceContainerRule =
+      new ServiceContainerRule(actorSchedulerRule);
+
+  private final LogInstallRule installRule = new LogInstallRule();
+
+  private static final List<String> MEMBERS = Arrays.asList("1");
+
+  private final DistributedLogRule distributedLogRule =
+      new DistributedLogRule(serviceContainerRule, 1, 1, 1, MEMBERS, null);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(actorSchedulerRule)
+          .around(serviceContainerRule)
+          .around(temporaryFolder)
+          .around(installRule)
+          .around(distributedLogRule);
+
+  @Test
+  public void shouldAppendBlock() throws Exception {
+    // given
+    distributedLogRule.waitUntilNodesJoined();
+    distributedLogRule.becomeLeader(1);
+    final LogStream logStreamSpy = installRule.getService().getLogStreamMock();
+
+    // when
+    distributedLogRule.writeEvent(1, "message");
+
+    // then
+    verify(logStreamSpy.getLogStorage(), timeout(5_000).times(1)).append(any(ByteBuffer.class));
+  }
+
+  @Test
+  public void shouldRetryAppendBlock() throws Exception {
+    // given
+    distributedLogRule.waitUntilNodesJoined();
+    distributedLogRule.becomeLeader(1);
+    final LogStream logStreamSpy = installRule.getService().getLogStreamMock();
+    final LogStorage logStorage = logStreamSpy.getLogStorage();
+    doThrow(IOException.class).when(logStorage).append(any());
+
+    // when
+    distributedLogRule.writeEvent(1, "message");
+
+    // then
+    verify(logStreamSpy.getLogStorage(), timeout(5_000).atLeast(2)).append(any(ByteBuffer.class));
+  }
+
+  @Test
+  public void shouldBlockPrimitive() throws Exception {
+    // given
+    distributedLogRule.waitUntilNodesJoined();
+    distributedLogRule.becomeLeader(1);
+    final LogStream logStreamSpy = installRule.getService().getLogStreamMock();
+    final LogStorage logStorage = logStreamSpy.getLogStorage();
+    doThrow(IllegalStateException.class).when(logStorage).append(any());
+
+    // when
+    distributedLogRule.writeEvent(1, "message");
+    distributedLogRule.writeEvent(1, "message");
+
+    // then
+    verify(logStreamSpy.getLogStorage(), timeout(5_000).times(1)).append(any(ByteBuffer.class));
+  }
+
+  private class LogInstallRule extends ExternalResource {
+
+    private LogService service;
+
+    @Override
+    protected void before() {
+      final ServiceContainer serviceContainer = serviceContainerRule.get();
+      final LogStream logStream =
+          LogStreams.createFsLogStream(1)
+              .logDirectory(temporaryFolder.getRoot().getAbsolutePath())
+              .logSegmentSize(512 * 1024 * 1024)
+              .serviceContainer(serviceContainer)
+              .build()
+              .join();
+
+      service = new LogService(logStream);
+      serviceContainer.createService(LOG_STREAM_SERVICE_NAME, service).install().join();
+
+      LogstreamConfig.putLogStream("1", 1, service.logStreamMock);
+    }
+
+    public LogService getService() {
+      return service;
+    }
+
+    @Override
+    protected void after() {
+      serviceContainerRule.get().removeService(LOG_STREAM_SERVICE_NAME);
+    }
+  }
+
+  private class LogService implements Service<LogStream> {
+
+    private final LogStream logStreamMock;
+
+    LogService(LogStream logStream) {
+      this.logStreamMock = spy(logStream);
+      final LogStorage logStorageSpy = spy(logStreamMock.getLogStorage());
+      doReturn(logStorageSpy).when(logStreamMock).getLogStorage();
+      doReturn("raft-atomix-partition-1").when(logStreamMock).getLogName();
+    }
+
+    @Override
+    public LogStream get() {
+      return logStreamMock;
+    }
+
+    public LogStream getLogStreamMock() {
+      return logStreamMock;
+    }
+  }
+}

--- a/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/RestoreControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/RestoreControllerTest.java
@@ -55,15 +55,15 @@ public class RestoreControllerTest {
   private static final String KEY = "test";
   private static final DirectBuffer EVENT = wrapString("FOO");
 
-  private TemporaryFolder temporaryFolderClient = new TemporaryFolder();
-  private LogStreamRule logStreamRuleClient = new LogStreamRule(temporaryFolderClient);
-  private LogStreamWriterRule writerClient = new LogStreamWriterRule(logStreamRuleClient);
-  private LogStreamReaderRule readerClient = new LogStreamReaderRule(logStreamRuleClient);
+  private final TemporaryFolder temporaryFolderClient = new TemporaryFolder();
+  private final LogStreamRule logStreamRuleClient = new LogStreamRule(temporaryFolderClient);
+  private final LogStreamWriterRule writerClient = new LogStreamWriterRule(logStreamRuleClient);
+  private final LogStreamReaderRule readerClient = new LogStreamReaderRule(logStreamRuleClient);
 
-  private TemporaryFolder temporaryFolderServer = new TemporaryFolder();
-  private LogStreamRule logStreamRuleServer = new LogStreamRule(temporaryFolderServer);
-  private LogStreamWriterRule writerServer = new LogStreamWriterRule(logStreamRuleServer);
-  private LogStreamReaderRule readerServer = new LogStreamReaderRule(logStreamRuleServer);
+  private final TemporaryFolder temporaryFolderServer = new TemporaryFolder();
+  private final LogStreamRule logStreamRuleServer = new LogStreamRule(temporaryFolderServer);
+  private final LogStreamWriterRule writerServer = new LogStreamWriterRule(logStreamRuleServer);
+  private final LogStreamReaderRule readerServer = new LogStreamReaderRule(logStreamRuleServer);
 
   @Rule
   public RuleChain ruleChain =
@@ -122,10 +122,14 @@ public class RestoreControllerTest {
         new LogReplicator(
             (commitPosition, blockBuffer) -> {
               logStreamRuleClient.getLogStream().setCommitPosition(commitPosition);
-              return logStreamRuleClient
-                  .getLogStream()
-                  .getLogStorage()
-                  .append(ByteBuffer.wrap(blockBuffer));
+              try {
+                return logStreamRuleClient
+                    .getLogStream()
+                    .getLogStorage()
+                    .append(ByteBuffer.wrap(blockBuffer));
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
             },
             restoreClient,
             restoreThreadContext,

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/CompleteInBlockProcessorTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/CompleteInBlockProcessorTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.zeebe.logstreams.impl.CompleteEventsInBlockProcessor;
 import io.zeebe.logstreams.impl.log.fs.FsLogStorage;
 import io.zeebe.logstreams.impl.log.fs.FsLogStorageConfiguration;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -56,11 +57,11 @@ public class CompleteInBlockProcessorTest {
   private long appendedAddress;
 
   @Before
-  public void init() {
+  public void init() throws IOException {
     processor = new CompleteEventsInBlockProcessor();
     logPath = tempFolder.getRoot().getAbsolutePath();
     fsStorageConfig = new FsLogStorageConfiguration(SEGMENT_SIZE, logPath, 0, false);
-    fsLogStorage = new FsLogStorage(fsStorageConfig, 0);
+    fsLogStorage = new FsLogStorage(fsStorageConfig);
 
     final ByteBuffer writeBuffer = ByteBuffer.allocate(192);
     final MutableDirectBuffer directBuffer = new UnsafeBuffer(0, 0);
@@ -201,7 +202,8 @@ public class CompleteInBlockProcessorTest {
   }
 
   @Test
-  public void shouldInsufficientBufferCapacityIfPosWasSetAndNewEventCantReadCompletely() {
+  public void shouldInsufficientBufferCapacityIfPosWasSetAndNewEventCantReadCompletely()
+      throws IOException {
     // given
     final int largeEventMetadataSize = 8;
     final int writeBufferLength = (3 * ALIGNED_LEN) + largeEventMetadataSize;

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStorageAppenderTest.java
@@ -84,7 +84,7 @@ public class LogStorageAppenderTest {
 
   @Test
   @Ignore // TODO: handle failures in append
-  public void shouldDiscardEventsIfFailToAppend() {
+  public void shouldDiscardEventsIfFailToAppend() throws Exception {
     final Subscription subscription = logStream.getWriteBuffer().openSubscription("test");
 
     final LogStorageAppender logStorageAppender = logStream.getLogStorageAppender();

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/StateSnapshotControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/StateSnapshotControllerTest.java
@@ -54,7 +54,7 @@ public class StateSnapshotControllerTest {
   }
 
   @Test
-  public void shouldThrowExceptionOnTakeSnapshotIfClosed() throws Exception {
+  public void shouldThrowExceptionOnTakeSnapshotIfClosed() {
     // given
 
     // then

--- a/util/src/main/java/io/zeebe/util/FileUtil.java
+++ b/util/src/main/java/io/zeebe/util/FileUtil.java
@@ -76,15 +76,11 @@ public class FileUtil {
         });
   }
 
-  public static long getAvailableSpace(File logLocation) {
+  public static long getAvailableSpace(File logLocation) throws IOException {
     long usableSpace = -1;
 
-    try {
-      final FileStore fileStore = Files.getFileStore(logLocation.toPath());
-      usableSpace = fileStore.getUsableSpace();
-    } catch (IOException e) {
-      LangUtil.rethrowUnchecked(e);
-    }
+    final FileStore fileStore = Files.getFileStore(logLocation.toPath());
+    usableSpace = fileStore.getUsableSpace();
 
     return usableSpace;
   }


### PR DESCRIPTION
 * replace confusing return values with appropriate exceptions
 * primitive will retry on IOException, which are recoverable
 * primitive will go in fail state and block, when non recoverable
 exception appears


closes #2298 
closes https://github.com/zeebe-io/zeebe/issues/2309
closes https://github.com/zeebe-io/zeebe/issues/2673