### PR TITLE
feat(broker-core): add exporter back off retry strategy

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/Loggers.java
+++ b/broker-core/src/main/java/io/zeebe/broker/Loggers.java
@@ -22,14 +22,11 @@ import org.slf4j.Logger;
 
 public class Loggers {
   public static final Logger CLUSTERING_LOGGER = new ZbLogger("io.zeebe.broker.clustering");
-  public static final Logger SERVICES_LOGGER = new ZbLogger("io.zeebe.broker.services");
   public static final Logger SYSTEM_LOGGER = new ZbLogger("io.zeebe.broker.system");
   public static final Logger TRANSPORT_LOGGER = new ZbLogger("io.zeebe.broker.transport");
-  public static final Logger STREAM_PROCESSING = new ZbLogger("io.zeebe.broker.logstreams");
   public static final Logger WORKFLOW_REPOSITORY_LOGGER =
       new ZbLogger("io.zeebe.broker.workflow.repository");
 
-  public static final Logger WORKFLOW_PROCESSOR_LOGGER = new ZbLogger("io.zeebe.broker.workflow");
   public static final Logger EXPORTER_LOGGER = new ZbLogger("io.zeebe.broker.exporter");
 
   public static final Logger getExporterLogger(String exporterId) {

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -17,6 +17,7 @@
  */
 package io.zeebe.broker.exporter.stream;
 
+import static io.zeebe.test.util.TestUtil.doRepeatedly;
 import static io.zeebe.test.util.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
@@ -232,7 +233,8 @@ public class ExporterDirectorTest {
     final long eventPosition2 = writeEvent();
 
     // then
-    waitUntil(() -> failCount.get() <= -2);
+    doRepeatedly(() -> rule.getClock().addTime(Duration.ofSeconds(1)))
+        .until((r) -> failCount.get() <= -2);
     assertThat(exporters.get(0).getExportedRecords())
         .extracting(Record::getPosition)
         .containsExactly(eventPosition1, eventPosition2);
@@ -357,7 +359,7 @@ public class ExporterDirectorTest {
     // then
     final ExportersState exportersState = rule.getExportersState();
     assertThat(exportersState.getPosition(EXPORTER_ID_1)).isEqualTo(eventPosition);
-    assertThat(exportersState.getPosition(EXPORTER_ID_2)).isEqualTo(-1);
+    waitUntil(() -> exportersState.getPosition(EXPORTER_ID_2) == -1);
   }
 
   @Test

--- a/util/src/main/java/io/zeebe/util/retry/BackOffRetryStrategy.java
+++ b/util/src/main/java/io/zeebe/util/retry/BackOffRetryStrategy.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.util.retry;
+
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
+import java.time.Duration;
+import java.util.function.BooleanSupplier;
+
+public class BackOffRetryStrategy implements RetryStrategy {
+
+  private final ActorControl actor;
+  private final Duration maxBackOff;
+
+  private Duration backOffDuration;
+  private CompletableActorFuture<Boolean> currentFuture;
+  private BooleanSupplier currentTerminateCondition;
+  private OperationToRetry currentCallable;
+
+  public BackOffRetryStrategy(ActorControl actor, Duration maxBackOff) {
+    this.actor = actor;
+    this.maxBackOff = maxBackOff;
+  }
+
+  @Override
+  public ActorFuture<Boolean> runWithRetry(OperationToRetry callable) {
+    return runWithRetry(callable, () -> false);
+  }
+
+  @Override
+  public ActorFuture<Boolean> runWithRetry(
+      OperationToRetry callable, BooleanSupplier terminateCondition) {
+    currentFuture = new CompletableActorFuture<>();
+    this.currentTerminateCondition = terminateCondition;
+    currentCallable = callable;
+    backOffDuration = Duration.ofSeconds(1);
+
+    actor.run(this::run);
+
+    return currentFuture;
+  }
+
+  private void run() {
+    try {
+      if (currentCallable.run()) {
+        currentFuture.complete(true);
+      } else if (currentTerminateCondition.getAsBoolean()) {
+        currentFuture.complete(false);
+      } else {
+        backOff();
+      }
+    } catch (Exception exception) {
+      if (currentTerminateCondition.getAsBoolean()) {
+        currentFuture.complete(false);
+      } else {
+        backOff();
+      }
+    }
+  }
+
+  private void backOff() {
+    final boolean notReachedMaxBackOff = !backOffDuration.equals(maxBackOff);
+    if (notReachedMaxBackOff) {
+      final Duration nextBackOff = backOffDuration.multipliedBy(2);
+      backOffDuration = nextBackOff.compareTo(maxBackOff) < 0 ? nextBackOff : maxBackOff;
+    }
+    actor.runDelayed(backOffDuration, this::run);
+  }
+}

--- a/util/src/test/java/io/zeebe/util/retry/BackOffRetryStrategyTest.java
+++ b/util/src/test/java/io/zeebe/util/retry/BackOffRetryStrategyTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.util.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.clock.ActorClock;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.testing.ControlledActorSchedulerRule;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class BackOffRetryStrategyTest {
+
+  @Rule public ControlledActorSchedulerRule schedulerRule = new ControlledActorSchedulerRule();
+
+  private BackOffRetryStrategy retryStrategy;
+  private ActorControl actorControl;
+  private ActorFuture<Boolean> resultFuture;
+
+  @Before
+  public void setUp() {
+    final ControllableActor actor = new ControllableActor();
+    this.actorControl = actor.getActor();
+    retryStrategy = new BackOffRetryStrategy(actorControl, Duration.ofSeconds(10));
+
+    schedulerRule.submitActor(actor);
+  }
+
+  @Test
+  public void shouldRunWithoutDelay() throws Exception {
+    // given
+    final List<Long> callRecorder = new ArrayList<>();
+
+    // when
+    final long startTime = schedulerRule.getClock().getCurrentTimeInMillis();
+    actorControl.run(
+        () -> {
+          resultFuture =
+              retryStrategy.runWithRetry(
+                  () -> {
+                    callRecorder.add(ActorClock.current().getTimeMillis());
+                    return true;
+                  });
+        });
+
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(callRecorder.size()).isEqualTo(1);
+    assertThat(resultFuture.isDone()).isTrue();
+    assertThat(resultFuture.get()).isTrue();
+
+    assertThat(callRecorder.get(0) - startTime).isLessThan(500);
+  }
+
+  @Test
+  public void shouldRunWithBackOff() throws Exception {
+    // given
+    final AtomicInteger count = new AtomicInteger(0);
+    final List<Long> callRecorder = new ArrayList<>();
+
+    // when
+    actorControl.run(
+        () -> {
+          resultFuture =
+              retryStrategy.runWithRetry(
+                  () -> {
+                    callRecorder.add(ActorClock.current().getTimeMillis());
+                    return count.incrementAndGet() == 10;
+                  });
+        });
+
+    while (count.get() != 10) {
+      schedulerRule.workUntilDone();
+      schedulerRule.getClock().addTime(Duration.ofSeconds(1));
+    }
+
+    // then
+    assertThat(count.get()).isEqualTo(10);
+    assertThat(resultFuture.isDone()).isTrue();
+    assertThat(resultFuture.get()).isTrue();
+
+    final long beforeLastCall = callRecorder.get(callRecorder.size() - 2);
+    final long lastCall = callRecorder.get(callRecorder.size() - 1);
+    assertThat(lastCall - beforeLastCall).isBetween(10_000L, 10_500L);
+  }
+
+  @Test
+  public void shouldStopWhenAbortConditionReturnsTrue() throws Exception {
+    // given
+
+    // when
+    actorControl.run(
+        () -> {
+          resultFuture = retryStrategy.runWithRetry(() -> false, () -> true);
+        });
+
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(resultFuture.isDone()).isTrue();
+    assertThat(resultFuture.get()).isFalse();
+  }
+
+  @Test
+  public void shouldRetryOnExceptionAndAbortWhenConditionReturnsTrue() throws Exception {
+    // given
+    final AtomicInteger count = new AtomicInteger(0);
+
+    // when
+    actorControl.run(
+        () -> {
+          resultFuture =
+              retryStrategy.runWithRetry(
+                  () -> {
+                    throw new RuntimeException();
+                  },
+                  () -> count.incrementAndGet() == 2);
+        });
+
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(count.get()).isEqualTo(1);
+    assertThat(resultFuture.isDone()).isFalse();
+
+    schedulerRule.getClock().addTime(Duration.ofSeconds(2));
+    schedulerRule.workUntilDone();
+
+    // then
+    assertThat(count.get()).isEqualTo(2);
+    assertThat(resultFuture.isDone()).isTrue();
+    assertThat(resultFuture.get()).isFalse();
+  }
+
+  @Test
+  public void shouldRetryOnExceptionWithMaxBackOff() throws Exception {
+    // given
+    final AtomicInteger count = new AtomicInteger(0);
+    final AtomicBoolean toggle = new AtomicBoolean(false);
+    final List<Long> callRecorder = new ArrayList<>();
+
+    // when
+    actorControl.run(
+        () -> {
+          resultFuture =
+              retryStrategy.runWithRetry(
+                  () -> {
+                    callRecorder.add(ActorClock.current().getTimeMillis());
+                    toggle.set(!toggle.get());
+                    if (toggle.get()) {
+                      throw new RuntimeException("expected");
+                    }
+                    return count.incrementAndGet() == 10;
+                  });
+        });
+
+    while (count.get() != 10) {
+      schedulerRule.workUntilDone();
+      schedulerRule.getClock().addTime(Duration.ofSeconds(1));
+    }
+
+    // then
+    assertThat(count.get()).isEqualTo(10);
+    assertThat(resultFuture.isDone()).isTrue();
+    assertThat(resultFuture.get()).isTrue();
+
+    final long beforeLastCall = callRecorder.get(callRecorder.size() - 2);
+    final long lastCall = callRecorder.get(callRecorder.size() - 1);
+    assertThat(lastCall - beforeLastCall).isBetween(10_000L, 10_500L);
+  }
+
+  private final class ControllableActor extends Actor {
+    public ActorControl getActor() {
+      return actor;
+    }
+  }
+}


### PR DESCRIPTION
 * when the exporting fails the exporting is endless retried with a back off strategy
 * back off starts with 1 second and increases with power of 2 until max back off is reached
 * this avoids unnecessary immediately retries and filling the log with stack traces

closes #2661 
