### PR TITLE
Fix dependency problems

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/engine/EngineService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/engine/EngineService.java
@@ -90,6 +90,7 @@ public class EngineService implements Service<EngineService> {
         .logStream(logStream)
         .actorScheduler(serviceContext.getScheduler())
         .additionalDependencies(partitionServiceName)
+        .additionalDependencies(serviceContext.getServiceName())
         .zeebeDb(partition.getZeebeDb())
         .serviceContainer(serviceContainer)
         .commandResponseWriter(new CommandResponseWriterImpl(commandApiTransport.getOutput()))

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerReprocessingTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerReprocessingTest.java
@@ -144,6 +144,16 @@ public class BrokerReprocessingTest {
   private Runnable restartAction = () -> {};
 
   @Test
+  public void shouldDirectlyRestart() {
+    // given
+
+    // when
+    reprocessingTrigger.accept(this);
+
+    // then - no error
+  }
+
+  @Test
   public void shouldCreateWorkflowInstanceAfterRestart() {
     // given
     deploy(WORKFLOW, "workflow.bpmn");

--- a/service-container/src/main/java/io/zeebe/servicecontainer/impl/ServiceDependencyResolver.java
+++ b/service-container/src/main/java/io/zeebe/servicecontainer/impl/ServiceDependencyResolver.java
@@ -131,12 +131,9 @@ public class ServiceDependencyResolver {
       final List<ServiceController> dependents = dependentServices.get(dependency);
 
       if (dependents != null) {
+        dependents.remove(controller);
         if (stoppingServices.contains(dependency)) {
-          boolean allStopped = true;
-          for (int i = 0; i < dependents.size() && allStopped; i++) {
-            allStopped &= !startedServices.contains(dependents.get(i).getServiceName());
-          }
-
+          final boolean allStopped = dependents.isEmpty();
           if (allStopped) {
             dependency.fireEvent(ServiceEventType.DEPENDENTS_STOPPED);
           }
@@ -148,8 +145,6 @@ public class ServiceDependencyResolver {
               controller,
               dependency.getServiceName());
         }
-
-        dependents.remove(controller);
       }
     }
 

--- a/service-container/src/test/resources/log4j2-test.xml
+++ b/service-container/src/test/resources/log4j2-test.xml
@@ -8,7 +8,7 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="io.zeebe" level="debug"/>
+    <Logger name="io.zeebe.servicecontainer" level="trace"/>
 
     <Root level="info">
       <AppenderRef ref="Console"/>


### PR DESCRIPTION
fix to early open and close:

 * stream processor start future was completed to early
   which causes problems regarding to dependents access resources
   even if the processor was not completed started

refactor service container:

* remove only root services on close
 * use fireevent instead of direct channel
 * log events on trace https://github.com/zeebe-io/zeebe/issues/2505

fix dependency removing bug:

 * dependencies have been removed before the depenents
   which causes a lot of problems including SIGSEG

closes #2637
closes #2742
closes #2741
closes https://github.com/zeebe-io/zeebe/issues/2505

