### PR TITLE
chore(broker-core): log brokerInfo with membership events

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/TopologyManagerImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/TopologyManagerImpl.java
@@ -100,9 +100,13 @@ public class TopologyManagerImpl extends Actor
   @Override
   public void event(ClusterMembershipEvent clusterMembershipEvent) {
     final Member eventSource = clusterMembershipEvent.subject();
-    LOG.debug(
-        "Member {} received event {}", topology.getLocal().getNodeId(), clusterMembershipEvent);
+
     final BrokerInfo brokerInfo = readBrokerInfo(eventSource);
+    LOG.debug(
+        "Member {} received event {} with {}",
+        topology.getLocal().getNodeId(),
+        clusterMembershipEvent,
+        brokerInfo);
 
     if (brokerInfo != null && brokerInfo.getNodeId() != topology.getLocal().getNodeId()) {
       actor.call(

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
@@ -60,12 +60,12 @@ public class BrokerTopologyManagerImpl extends Actor
     final Member subject = event.subject();
     final Type eventType = event.type();
     final BrokerInfo brokerInfo = BrokerInfo.fromProperties(subject.properties());
-    LOG.debug("Got membership event {}", brokerInfo);
 
     if (brokerInfo != null) {
       actor.call(
           () -> {
-            Loggers.GATEWAY_LOGGER.debug("Received membership event: {}", event);
+            Loggers.GATEWAY_LOGGER.debug(
+                "Received membership event: {} with {} ", event, brokerInfo);
             final BrokerClusterStateImpl newTopology = new BrokerClusterStateImpl(topology.get());
 
             switch (eventType) {


### PR DESCRIPTION
Added decoded BrokerInfo to the logs. It still logs the unreadable properties in the event.

closes #2759 
