### PR TITLE
chore(engine): do not reprocess last event in the snapshot

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
@@ -144,8 +144,6 @@ public final class ReProcessingStateMachine {
   ActorFuture<Void> startRecover(final long snapshotPosition) {
     recoveryFuture = new CompletableActorFuture<>();
 
-    final long startPosition = logStreamReader.getPosition();
-
     LOG.info("Start scanning the log for error events.");
     lastSourceEventPosition = scanLog(snapshotPosition);
     LOG.info("Finished scanning the log for error events.");
@@ -154,7 +152,7 @@ public final class ReProcessingStateMachine {
       LOG.info(
           "Processor starts reprocessing, until last source event position {}",
           lastSourceEventPosition);
-      logStreamReader.seek(startPosition);
+      logStreamReader.seekToNextEvent(snapshotPosition);
       reprocessNextEvent();
     } else {
       recoveryFuture.complete(null);


### PR DESCRIPTION
closes #2768 
closes #2618
