### PR TITLE
chore(bom): import netty bom in Zeebe bom to enforce downstream version

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -24,6 +24,8 @@
     </nexus.snapshot.repository>
     <nexus.release.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io/
     </nexus.release.repository>
+
+    <version.netty>4.1.37.Final</version.netty>
   </properties>
 
   <dependencyManagement>
@@ -176,6 +178,14 @@
         <groupId>io.zeebe</groupId>
         <artifactId>zeebe-protocol-asserts</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -324,14 +324,6 @@
       </dependency>
 
       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${version.netty}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-netty</artifactId>
         <version>${version.grpc}</version>


### PR DESCRIPTION
I decided to do the unusual step to import netty in the Zeebe BOM as otherwise there are to many edge cases which are hard to manage with at least 3 other dependencies using netty. With this we enforce in all dependencies the same netty version even in third party apps. For now I assume this is our safest bet to not run it to this problem again.

closes #2775
