### PR TITLE
Export error events by default in elasticsearch exporter

### DIFF
--- a/dist/src/main/config/zeebe.cfg.toml
+++ b/dist/src/main/config/zeebe.cfg.toml
@@ -291,6 +291,7 @@
 #  rejection = false
 #
 #  deployment = true
+#  error = true
 #  incident = true
 #  job = true
 #  jobBatch = false

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
@@ -114,6 +114,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.deployment) {
         createValueIndexTemplate(ValueType.DEPLOYMENT);
       }
+      if (index.error) {
+        createValueIndexTemplate(ValueType.ERROR);
+      }
       if (index.incident) {
         createValueIndexTemplate(ValueType.INCIDENT);
       }

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -57,6 +57,7 @@ public class ElasticsearchExporterConfiguration {
 
     // value types to export
     public boolean deployment = true;
+    public boolean error = true;
     public boolean incident = true;
     public boolean job = true;
     public boolean jobBatch = false;
@@ -82,6 +83,8 @@ public class ElasticsearchExporterConfiguration {
           + event
           + ", rejection="
           + rejection
+          + ", error="
+          + error
           + ", deployment="
           + deployment
           + ", incident="
@@ -141,6 +144,8 @@ public class ElasticsearchExporterConfiguration {
     switch (valueType) {
       case DEPLOYMENT:
         return index.deployment;
+      case ERROR:
+        return index.error;
       case INCIDENT:
         return index.incident;
       case JOB:

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-error-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-error-template.json
@@ -1,0 +1,32 @@
+{
+  "index_patterns": [
+    "zeebe-record-error_*"
+  ],
+  "order": 20,
+  "aliases": {
+    "zeebe-record-error": {}
+  },
+  "mappings": {
+    "_doc": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "exceptionMessage": {
+              "type": "text"
+            },
+            "stacktrace": {
+              "type": "text"
+            },
+            "errorEventPosition": {
+              "type": "long"
+            },
+            "workflowInstanceKey": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
@@ -132,6 +132,7 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
     configuration.index.event = true;
     configuration.index.rejection = true;
     configuration.index.deployment = true;
+    configuration.index.error = true;
     configuration.index.incident = true;
     configuration.index.job = true;
     configuration.index.jobBatch = true;

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
@@ -29,7 +29,9 @@ import io.zeebe.exporter.api.context.Context;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.value.ErrorRecordValue;
 import io.zeebe.test.exporter.ExporterTestHarness;
+import io.zeebe.test.exporter.record.MockRecordValue;
 import io.zeebe.util.ZbLogger;
 import java.time.Duration;
 import java.util.Arrays;
@@ -69,6 +71,7 @@ public class ElasticsearchExporterTest {
     config.index.prefix = "foo-bar";
     config.index.createTemplate = true;
     config.index.deployment = true;
+    config.index.error = true;
     config.index.incident = true;
     config.index.job = true;
     config.index.jobBatch = true;
@@ -88,6 +91,7 @@ public class ElasticsearchExporterTest {
     verify(esClient).putIndexTemplate("foo-bar", ZEEBE_RECORD_TEMPLATE_JSON, "-");
 
     verify(esClient).putIndexTemplate(ValueType.DEPLOYMENT);
+    verify(esClient).putIndexTemplate(ValueType.ERROR);
     verify(esClient).putIndexTemplate(ValueType.INCIDENT);
     verify(esClient).putIndexTemplate(ValueType.JOB);
     verify(esClient).putIndexTemplate(ValueType.JOB_BATCH);
@@ -105,6 +109,7 @@ public class ElasticsearchExporterTest {
     // given
     config.index.event = true;
     config.index.deployment = true;
+    config.index.error = true;
     config.index.incident = true;
     config.index.job = true;
     config.index.jobBatch = true;
@@ -121,6 +126,7 @@ public class ElasticsearchExporterTest {
     final ValueType[] valueTypes =
         new ValueType[] {
           ValueType.DEPLOYMENT,
+          ValueType.ERROR,
           ValueType.INCIDENT,
           ValueType.JOB,
           ValueType.JOB_BATCH,
@@ -144,6 +150,7 @@ public class ElasticsearchExporterTest {
     // given
     config.index.event = true;
     config.index.deployment = false;
+    config.index.error = false;
     config.index.incident = false;
     config.index.job = false;
     config.index.jobBatch = false;
@@ -160,6 +167,7 @@ public class ElasticsearchExporterTest {
     final ValueType[] valueTypes =
         new ValueType[] {
           ValueType.DEPLOYMENT,
+          ValueType.ERROR,
           ValueType.INCIDENT,
           ValueType.JOB,
           ValueType.JOB_BATCH,
@@ -331,5 +339,33 @@ public class ElasticsearchExporterTest {
     when(client.putIndexTemplate(any(ValueType.class))).thenReturn(true);
     when(client.putIndexTemplate(anyString(), anyString(), anyString())).thenReturn(true);
     return client;
+  }
+
+  static class ErrorMockRecord extends MockRecordValue implements ErrorRecordValue {
+
+    static final String EXCEPTION_MESSAGE = "Expected Exception Message";
+    static final String STACKTRACE = "Expected Stacktrace";
+    static final long ERROR_EVENT_POSITION = 123;
+    static final long WORKFLOW_INSTANCE_KEY = 456;
+
+    @Override
+    public String getExceptionMessage() {
+      return EXCEPTION_MESSAGE;
+    }
+
+    @Override
+    public String getStacktrace() {
+      return STACKTRACE;
+    }
+
+    @Override
+    public long getErrorEventPosition() {
+      return ERROR_EVENT_POSITION;
+    }
+
+    @Override
+    public long getWorkflowInstanceKey() {
+      return WORKFLOW_INSTANCE_KEY;
+    }
   }
 }


### PR DESCRIPTION
The export is enabled by default as it is a important record type and should not be missed. Sorry no real test case but I promise I tested it manually.

closes #2773
