### PR TITLE
chore(ci): Remove "kind: Pod" from all the podSpecs

### DIFF
--- a/.ci/pipelines/docker_zeebe.groovy
+++ b/.ci/pipelines/docker_zeebe.groovy
@@ -6,8 +6,6 @@ pipeline {
       label "zeebe-ci-build_${env.JOB_BASE_NAME}-${env.BUILD_ID}"
       defaultContainer 'jnlp'
       yaml '''\
-apiVersion: v1
-kind: Pod
 metadata:
   labels:
     agent: zeebe-ci-build

--- a/.ci/pipelines/docs_zeebe_io.groovy
+++ b/.ci/pipelines/docs_zeebe_io.groovy
@@ -5,8 +5,6 @@ pipeline {
                 label "zeebe-ci-build_${env.JOB_BASE_NAME}-${env.BUILD_ID}"
                 defaultContainer 'jnlp'
                 yaml '''\
-apiVersion: v1
-kind: Pod
 metadata:
   labels:
     agent: zeebe-ci-build

--- a/.ci/pipelines/release_zeebe.groovy
+++ b/.ci/pipelines/release_zeebe.groovy
@@ -10,8 +10,6 @@ pipeline {
         label "zeebe-ci-release_${buildName}"
         defaultContainer 'jnlp'
         yaml '''\
-apiVersion: v1
-kind: Pod
 metadata:
   labels:
     agent: zeebe-ci-build

--- a/.ci/podSpecs/distribution.yml
+++ b/.ci/podSpecs/distribution.yml
@@ -1,6 +1,3 @@
----
-apiVersion: v1
-kind: Pod
 metadata:
   labels:
     agent: zeebe-ci-build


### PR DESCRIPTION
I am currently working on SRE-594 to update the zeebe-ci with the latest Jenkins plugins

In order to support correctly we need to remove `kind: Pod` from the podSpecs that we are using since that's not necessary anymore and the plugin injects it dynamically.
