### PR TITLE
docs(README): Landing page edits

### DIFF
--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -22,9 +22,7 @@ Using Camunda Operate, or anything that integrates with Zeebe's streaming export
 
 ## Deploy to Kubernetes.
 
-Run your workloads on any cloud provider.
-
-![](cloud-providers.png)
+Run your workloads on any cloud provider or on-premises.
 
 ## Scalable. Fault-tolerant. Distributed.
 

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -1,29 +1,17 @@
 ![Zeebe Logo](/zeebe-logo.png)
 
-# Zeebe: Cloud-Native Workflow Engine for Microservices Orchestration.
+### Zeebe is a cloud-native workflow engine for microservices orchestration
 
-## Graphically model your workflows.
+* Define workflows graphically in BPMN 2.0
+* Choose any gRPC-supported programming language
+* Deploy with Docker and Kubernetes (in the cloud or on-premises)
+* Build workflows that react to events from Apache Kafka and other messaging platforms
+* Scale horizontally to handle very high throughput
+* Fault tolerance (no relational database required)
+* Export workflow data for monitoring and analysis
+* Engage with an active community
 
-Using industry-standard BPMN.
-
-![BPMN](workflows-data-based-conditions.png)
-
-## Write light-weight services to handle tasks.
-
-In any programming language that supports gRPC: Java, Go, JavaScript, C#, Ruby, Python, Rust....
-
-![](lightweight-workers.png)
-
-## Inspect the running state of your system.
-
-Using Camunda Operate, or anything that integrates with Zeebe's streaming exporter.
-
-![](Operate-Batch-Cancel-Or-Retry.png)
-
-## Deploy to Kubernetes.
-
-Run your workloads on any cloud provider or on-premises.
-
-## Scalable. Fault-tolerant. Distributed.
-
-Choose three.
+**First Steps**
+* [Read up on Zeebe's core concepts](/basics/README.html)
+* [Run Zeebe with Docker or download a distribution](/introduction/install.html)
+* [Try the Getting Started tutorial](/getting-started/README.html)


### PR DESCRIPTION
closes #2814 

After looking at the landing page again, I propose a couple edits:
* Remove cloud provider logos: use of a company's logo is almost always restricted by "brand guidelines" or needs explicit approval; I'd rather not test the limits here. Also, I am concerned by any implication that Zeebe offers some sort of "special" support for these 3 providers. 
* Add "or on-premises". Many Zeebe users do not want to run in the cloud and will deploy Zeebe on-prem instead. Would prefer to make it clear that this is possible and that Zeebe isn't a cloud-only software. 

LMK what you think!
