### PR TITLE
Fix race condition between cancel and activate

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/CancelProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/CancelProcessor.java
@@ -37,9 +37,8 @@ public class CancelProcessor implements CommandProcessor<JobRecord> {
   @Override
   public void onCommand(TypedRecord<JobRecord> command, CommandControl<JobRecord> commandControl) {
     final long jobKey = command.getKey();
-    final JobRecord job = command.getValue();
-
-    if (state.exists(jobKey)) {
+    final JobRecord job = state.getJob(jobKey);
+    if (job != null) {
       state.cancel(jobKey, job);
       commandControl.accept(JobIntent.CANCELED, job);
     } else {

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/BpmnElementTypeTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/BpmnElementTypeTest.java
@@ -46,7 +46,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class BpmnElementTypeTest {
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/activity/ActivityTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/activity/ActivityTest.java
@@ -68,7 +68,7 @@ public class ActivityTest {
           .endEvent("taskEnd")
           .done();
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/boundary/BoundaryEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/boundary/BoundaryEventTest.java
@@ -76,7 +76,7 @@ public class BoundaryEventTest {
           .endEvent()
           .done();
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/CreateDeploymentMultiplePartitionsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/CreateDeploymentMultiplePartitionsTest.java
@@ -56,7 +56,7 @@ public class CreateDeploymentMultiplePartitionsTest {
   public static final int PARTITION_ID = DEPLOYMENT_PARTITION;
   public static final int PARTITION_COUNT = 3;
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule(PARTITION_COUNT);
+  @ClassRule public static final EngineRule ENGINE = EngineRule.multiplePartition(PARTITION_COUNT);
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/CreateDeploymentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/CreateDeploymentTest.java
@@ -63,7 +63,7 @@ public class CreateDeploymentTest {
   private static final BpmnModelInstance WORKFLOW_2_V2 =
       Bpmn.createExecutableProcess(PROCESS_ID_2).startEvent("v2").endEvent().done();
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/gateway/EventbasedGatewayTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/gateway/EventbasedGatewayTest.java
@@ -105,7 +105,7 @@ public class EventbasedGatewayTest {
           .endEvent("end2")
           .done();
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/gateway/ExclusiveGatewayTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/gateway/ExclusiveGatewayTest.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 
 public class ExclusiveGatewayTest {
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/gateway/ParallelGatewayTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/gateway/ParallelGatewayTest.java
@@ -61,7 +61,7 @@ public class ParallelGatewayTest {
           .connectTo("join")
           .done();
 
-  @Rule public EngineRule engine = new EngineRule();
+  @Rule public EngineRule engine = EngineRule.singlePartition();
 
   @Test
   public void shouldActivateTasksOnParallelBranches() {

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/EventSubscriptionIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/EventSubscriptionIncidentTest.java
@@ -163,7 +163,7 @@ public class EventSubscriptionIncidentTest {
           .endEvent()
           .done();
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/ExpressionIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/ExpressionIncidentTest.java
@@ -47,7 +47,7 @@ import org.junit.Test;
 
 public class ExpressionIncidentTest {
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/JobFailIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/JobFailIncidentTest.java
@@ -50,7 +50,7 @@ import org.junit.Test;
 
 public class JobFailIncidentTest {
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/MappingIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/MappingIncidentTest.java
@@ -46,7 +46,7 @@ import org.junit.Test;
 
 public class MappingIncidentTest {
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/MessageIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/MessageIncidentTest.java
@@ -50,7 +50,7 @@ public class MessageIncidentTest {
               "catch", e -> e.message(m -> m.name("cancel").zeebeCorrelationKey("orderId")))
           .done();
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/CancelWorkflowInstanceTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/CancelWorkflowInstanceTest.java
@@ -80,7 +80,7 @@ public class CancelWorkflowInstanceTest {
         builder.serviceTask("task2", b -> b.zeebeTaskType("type2")).endEvent("end2").done();
   }
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/WorkflowInstanceFunctionalTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/WorkflowInstanceFunctionalTest.java
@@ -49,7 +49,7 @@ import org.junit.Test;
 
 public class WorkflowInstanceFunctionalTest {
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/WorkflowInstanceTokenTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/WorkflowInstanceTokenTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 
 public class WorkflowInstanceTokenTest {
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/job/ActivateJobsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/job/ActivateJobsTest.java
@@ -68,7 +68,7 @@ public class ActivateJobsTest {
 
   private String taskType;
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/job/CompleteJobTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/job/CompleteJobTest.java
@@ -43,7 +43,7 @@ public class CompleteJobTest {
   private static final String PROCESS_ID = "process";
   private static String jobType;
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/job/FailJobTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/job/FailJobTest.java
@@ -48,7 +48,7 @@ public class FailJobTest {
   private static final String PROCESS_ID = "process";
   private static String jobType;
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/job/JobEventSequenceTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/job/JobEventSequenceTest.java
@@ -1,0 +1,75 @@
+/*
+ * Zeebe Workflow Engine
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.engine.processor.workflow.job;
+
+import static io.zeebe.engine.util.RecordToWrite.command;
+import static io.zeebe.engine.util.RecordToWrite.event;
+import static io.zeebe.protocol.record.intent.JobBatchIntent.ACTIVATE;
+import static io.zeebe.protocol.record.intent.JobIntent.ACTIVATED;
+import static io.zeebe.protocol.record.intent.JobIntent.CANCEL;
+import static io.zeebe.protocol.record.intent.JobIntent.CANCELED;
+import static io.zeebe.protocol.record.intent.JobIntent.CREATE;
+import static io.zeebe.protocol.record.intent.JobIntent.CREATED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.RecordValue;
+import io.zeebe.protocol.record.intent.JobBatchIntent;
+import io.zeebe.protocol.record.value.JobRecordValue;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class JobEventSequenceTest {
+
+  @Rule public final EngineRule engine = EngineRule.explicitStart();
+
+  @Test
+  public void shouldUseJobStateOnCancelCommand() {
+    // given
+    engine.writeRecords(
+        command().job(CREATE),
+        event().job(CREATED).causedBy(0),
+        command().jobBatch(ACTIVATE),
+        command().job(CANCEL));
+
+    // when
+    engine.start();
+
+    // then
+    final Record<JobRecordValue> canceled =
+        RecordingExporter.jobRecords().withIntent(CANCELED).getFirst();
+
+    final Record<JobRecordValue> activated =
+        RecordingExporter.jobRecords().withIntent(ACTIVATED).getFirst();
+
+    assertThat(activated.getValue().getDeadline()).isEqualTo(canceled.getValue().getDeadline());
+
+    final List<Record<RecordValue>> records =
+        RecordingExporter.records()
+            .limit(r -> r.getIntent() == CANCELED)
+            .collect(Collectors.toList());
+    assertThat(records)
+        .extracting(Record::getIntent)
+        .containsExactly(
+            CREATE, CREATED, ACTIVATE, CANCEL, ACTIVATED, JobBatchIntent.ACTIVATED, CANCELED);
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/job/JobTimeOutTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/job/JobTimeOutTest.java
@@ -42,7 +42,7 @@ public class JobTimeOutTest {
   private static final String PROCESS_ID = "process";
   private static String jobType;
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/job/JobUpdateRetriesTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/job/JobUpdateRetriesTest.java
@@ -40,7 +40,7 @@ public class JobUpdateRetriesTest {
 
   private static String jobType;
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageCatchElementTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageCatchElementTest.java
@@ -101,7 +101,8 @@ public class MessageCatchElementTest {
           .endEvent()
           .done();
 
-  @ClassRule public static final EngineRule ENGINE_RULE = new EngineRule(PARTITION_COUNT);
+  @ClassRule
+  public static final EngineRule ENGINE_RULE = EngineRule.multiplePartition(PARTITION_COUNT);
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageCorrelationMultiplePartitionsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageCorrelationMultiplePartitionsTest.java
@@ -59,7 +59,7 @@ public class MessageCorrelationMultiplePartitionsTest {
           .endEvent("end")
           .done();
 
-  @Rule public EngineRule engine = new EngineRule(3);
+  @Rule public EngineRule engine = EngineRule.multiplePartition(3);
 
   @Before
   public void init() {

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageCorrelationTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageCorrelationTest.java
@@ -88,7 +88,7 @@ public class MessageCorrelationTest {
           .endEvent("taskEnd")
           .done();
 
-  @Rule public EngineRule engine = new EngineRule();
+  @Rule public EngineRule engine = EngineRule.singlePartition();
 
   @Test
   public void shouldCorrelateMessageIfEnteredBefore() {

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageMappingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageMappingTest.java
@@ -117,7 +117,7 @@ public class MessageMappingTest {
     };
   }
 
-  @ClassRule public static final EngineRule ENGINE_RULE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStartEventSubscriptionMultiplePartitionsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStartEventSubscriptionMultiplePartitionsTest.java
@@ -35,7 +35,7 @@ public class MessageStartEventSubscriptionMultiplePartitionsTest {
   private static final String MESSAGE_NAME1 = "startMessage1";
   private static final String EVENT_ID1 = "startEventId1";
 
-  public @Rule EngineRule engine = new EngineRule(3);
+  public @Rule EngineRule engine = EngineRule.multiplePartition(3);
 
   @Test
   public void shouldOpenMessageStartEventSubscriptionOnAllPartitions() {

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStartEventSubscriptionTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStartEventSubscriptionTest.java
@@ -41,7 +41,7 @@ public class MessageStartEventSubscriptionTest {
   private static final String MESSAGE_NAME2 = "startMessage2";
   private static final String EVENT_ID2 = "startEventId2";
 
-  @Rule public EngineRule engine = new EngineRule();
+  @Rule public EngineRule engine = EngineRule.singlePartition();
 
   @Test
   public void shouldOpenMessageSubscriptionOnDeployment() {

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStartEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStartEventTest.java
@@ -46,7 +46,7 @@ public class MessageStartEventTest {
   private static final String MESSAGE_NAME2 = "startMessage2";
   private static final String EVENT_ID2 = "startEventId2";
 
-  @Rule public EngineRule engine = new EngineRule();
+  @Rule public EngineRule engine = EngineRule.singlePartition();
 
   @Test
   public void shouldCorrelateMessageToStartEvent() {

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/PublishMessageTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/PublishMessageTest.java
@@ -22,7 +22,11 @@ import static org.assertj.core.api.Assertions.entry;
 
 import io.zeebe.engine.util.EngineRule;
 import io.zeebe.engine.util.client.PublishMessageClient;
-import io.zeebe.protocol.record.*;
+import io.zeebe.protocol.record.Assertions;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.RejectionType;
+import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.MessageIntent;
 import io.zeebe.protocol.record.value.MessageRecordValue;
 import io.zeebe.test.util.record.RecordingExporter;
@@ -34,7 +38,7 @@ import org.junit.Test;
 
 public class PublishMessageTest {
 
-  @ClassRule public static final EngineRule ENGINE_RULE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/subprocess/EmbeddedSubProcessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/subprocess/EmbeddedSubProcessTest.java
@@ -60,7 +60,7 @@ public class EmbeddedSubProcessTest {
           .endEvent("end")
           .done();
 
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/timer/TimerCatchEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/timer/TimerCatchEventTest.java
@@ -39,7 +39,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class TimerCatchEventTest {
-  @ClassRule public static final EngineRule ENGINE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/timer/TimerStartEventTest.java
@@ -67,7 +67,7 @@ public class TimerStartEventTest {
 
   private static final BpmnModelInstance MULTI_TIMER_START_MODEL = createMultipleTimerStartModel();
 
-  @Rule public final EngineRule engine = new EngineRule();
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
 
   private static BpmnModelInstance createTimerAndMessageStartEventsModel() {
     final ProcessBuilder builder = Bpmn.createExecutableProcess("process");

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/UpdateVariableDocumentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/UpdateVariableDocumentTest.java
@@ -44,7 +44,7 @@ import org.junit.Test;
 
 public class UpdateVariableDocumentTest {
 
-  @ClassRule public static final EngineRule ENGINE_RULE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/WorkflowInstanceVariableTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/WorkflowInstanceVariableTest.java
@@ -47,7 +47,7 @@ public class WorkflowInstanceVariableTest {
           .endEvent()
           .done();
 
-  @ClassRule public static final EngineRule ENGINE_RULE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/WorkflowInstanceVariableTypeTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/WorkflowInstanceVariableTypeTest.java
@@ -44,7 +44,7 @@ public class WorkflowInstanceVariableTypeTest {
   private static final BpmnModelInstance WORKFLOW =
       Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done();
 
-  @ClassRule public static final EngineRule ENGINE_RULE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/mapping/ActivityInputMappingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/mapping/ActivityInputMappingTest.java
@@ -45,7 +45,7 @@ public class ActivityInputMappingTest {
 
   private static final String PROCESS_ID = "process";
 
-  @ClassRule public static final EngineRule ENGINE_RULE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/mapping/ActivityOutputMappingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/mapping/ActivityOutputMappingTest.java
@@ -47,7 +47,7 @@ public class ActivityOutputMappingTest {
 
   private static final String PROCESS_ID = "process";
 
-  @ClassRule public static final EngineRule ENGINE_RULE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/mapping/JobInputMappingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/mapping/JobInputMappingTest.java
@@ -42,7 +42,7 @@ public class JobInputMappingTest {
 
   private static final String PROCESS_ID = "process";
 
-  @ClassRule public static final EngineRule ENGINE_RULE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/mapping/JobOutputMappingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/mapping/JobOutputMappingTest.java
@@ -50,7 +50,7 @@ public class JobOutputMappingTest {
 
   private static final String PROCESS_ID = "process";
 
-  @ClassRule public static final EngineRule ENGINE_RULE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/mapping/MessageOutputMappingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/variable/mapping/MessageOutputMappingTest.java
@@ -54,7 +54,7 @@ public class MessageOutputMappingTest {
   private static final String MESSAGE_NAME = "message";
   private static final String CORRELATION_VARIABLE = "key";
 
-  @ClassRule public static final EngineRule ENGINE_RULE = new EngineRule();
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/engine/src/test/java/io/zeebe/engine/state/instance/JobBatchActivateProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/instance/JobBatchActivateProcessorTest.java
@@ -81,7 +81,7 @@ public class JobBatchActivateProcessorTest {
     processor.processRecord(record, responseWriter, streamWriter);
 
     // then
-    verify(jobState, times(expectedIterations)).visitJob(anyLong(), any());
+    verify(jobState, times(expectedIterations)).visitJob(anyLong(), any(), any());
   }
 
   @Test
@@ -98,7 +98,7 @@ public class JobBatchActivateProcessorTest {
     processor.processRecord(record, responseWriter, streamWriter);
 
     // then
-    verify(jobState, times(expectedIterations)).visitJob(anyLong(), any());
+    verify(jobState, times(expectedIterations)).visitJob(anyLong(), any(), any());
   }
 
   private void createJobs(int amount, String type) {

--- a/engine/src/test/java/io/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/instance/JobStateTest.java
@@ -344,6 +344,28 @@ public class JobStateTest {
   }
 
   @Test
+  public void shouldCleanUpOnForEachTimedOutAndVisitNext() {
+    // given
+    createAndActivateJobRecord(1, newJobRecord().setDeadline(1L));
+    jobState.cancel(1, newJobRecord());
+    createAndActivateJobRecord(2, newJobRecord().setDeadline(256L));
+
+    // when
+    final List<Long> timedOutKeys = new ArrayList<>();
+    final long since = 65536L;
+    jobState.forEachTimedOutEntry(
+        since,
+        (k, e) -> {
+          timedOutKeys.add(k);
+          return true;
+        });
+
+    // then
+    assertThat(timedOutKeys).hasSize(1);
+    assertThat(timedOutKeys).containsExactly(2L);
+  }
+
+  @Test
   public void shouldDoNothingIfNotTimedOutJobs() {
     // given
     jobState.create(5, newJobRecord().setDeadline(512L));

--- a/engine/src/test/java/io/zeebe/engine/util/RecordToWrite.java
+++ b/engine/src/test/java/io/zeebe/engine/util/RecordToWrite.java
@@ -1,0 +1,94 @@
+/*
+ * Zeebe Workflow Engine
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.zeebe.engine.util;
+
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.intent.JobBatchIntent;
+import io.zeebe.protocol.record.intent.JobIntent;
+
+public final class RecordToWrite {
+
+  private static final int DEFAULT_KEY = 1;
+  private final RecordMetadata recordMetadata;
+  private UnifiedRecordValue unifiedRecordValue;
+  private int sourceIndex = -1;
+
+  public static RecordToWrite command() {
+    final RecordMetadata recordMetadata = new RecordMetadata();
+    return new RecordToWrite(recordMetadata.recordType(RecordType.COMMAND));
+  }
+
+  public static RecordToWrite event() {
+    final RecordMetadata recordMetadata = new RecordMetadata();
+    return new RecordToWrite(recordMetadata.recordType(RecordType.EVENT));
+  }
+
+  private RecordToWrite(RecordMetadata recordMetadata) {
+    this.recordMetadata = recordMetadata;
+  }
+
+  public RecordToWrite job(JobIntent intent) {
+    recordMetadata.valueType(ValueType.JOB).intent(intent);
+
+    final JobRecord jobRecord = new JobRecord();
+    jobRecord.setType("type").setRetries(3).setWorker("worker");
+
+    unifiedRecordValue = jobRecord;
+    return this;
+  }
+
+  public RecordToWrite jobBatch(JobBatchIntent intent) {
+    recordMetadata.valueType(ValueType.JOB_BATCH).intent(intent);
+
+    final JobBatchRecord jobBatchRecord =
+        new JobBatchRecord()
+            .setWorker("worker")
+            .setTimeout(10_000L)
+            .setType("type")
+            .setMaxJobsToActivate(1);
+
+    unifiedRecordValue = jobBatchRecord;
+    return this;
+  }
+
+  public RecordToWrite causedBy(int index) {
+    sourceIndex = index;
+    return this;
+  }
+
+  public long getKey() {
+    return DEFAULT_KEY;
+  }
+
+  public RecordMetadata getRecordMetadata() {
+    return recordMetadata;
+  }
+
+  public UnifiedRecordValue getUnifiedRecordValue() {
+    return unifiedRecordValue;
+  }
+
+  public int getSourceIndex() {
+    return sourceIndex;
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -254,6 +254,10 @@ public class StreamProcessorRule implements TestRule {
         .write();
   }
 
+  public long writeBatch(RecordToWrite... recordToWrites) {
+    return streams.writeBatch(getLogName(startPartitionId), recordToWrites);
+  }
+
   public long writeCommandOnPartition(int partition, Intent intent, UnpackedObject value) {
     return streams
         .newRecord(getLogName(partition))

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamBatchWriter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamBatchWriter.java
@@ -33,6 +33,13 @@ public interface LogStreamBatchWriter extends LogStreamWriter {
     /** Set the log entry key. */
     LogEntryBuilder key(long key);
 
+    /**
+     * Can be used if command and event, which is caused by this command is written in batch.
+     *
+     * @param index the index in this batch
+     */
+    LogEntryBuilder sourceIndex(int index);
+
     /** Set the log entry metadata. */
     LogEntryBuilder metadata(DirectBuffer buffer, int offset, int length);
 


### PR DESCRIPTION
* cancel processor uses current state instead of written value
 * state will clean up and not fail if detects a missing job
 * add new possibility to write tests
   * we can now write batch of records (atomically)
   * we can write this batch before the engine starts to trigger reprocessing

I decided against iterating over column family on delete/cancel job, since this will cause some performance issues if we have many jobs.

closes #2784