### PR TITLE
fix(broker): avoid overwriting previous pending distribution

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/system/management/deployment/PushDeploymentRequestHandler.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/management/deployment/PushDeploymentRequestHandler.java
@@ -110,7 +110,7 @@ public class PushDeploymentRequestHandler
     final String topic = DeploymentDistributorImpl.getDeploymentResponseTopic(deploymentKey);
 
     atomix.getEventService().broadcast(topic, deploymentResponse.toBytes());
-    LOG.trace("Send deployment response on topic {}", topic);
+    LOG.trace("Send deployment response on topic {} for partition {}", topic, partitionId);
   }
 
   private void handleValidRequest(
@@ -153,7 +153,10 @@ public class PushDeploymentRequestHandler
           final boolean success =
               writeCreatingDeployment(partition, deploymentKey, deploymentRecord);
           if (success) {
-            LOG.debug("Deployment CREATE command was written on partition {}", partitionId);
+            LOG.debug(
+                "Deployment CREATE command for deployment {} was written on partition {}",
+                deploymentKey,
+                partitionId);
             actor.done();
 
             sendResponse(responseFuture, deploymentKey, partitionId);

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/distribute/PendingDeploymentDistribution.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/distribute/PendingDeploymentDistribution.java
@@ -27,23 +27,21 @@ import org.agrona.MutableDirectBuffer;
 
 public class PendingDeploymentDistribution implements DbValue {
 
-  private static final int DEPLOYMENT_LENGTH_OFFSET = SIZE_OF_LONG;
+  private static final int DEPLOYMENT_LENGTH_OFFSET = SIZE_OF_LONG + SIZE_OF_INT;
   private static final int DEPLOYMENT_OFFSET = DEPLOYMENT_LENGTH_OFFSET + SIZE_OF_INT;
 
   private final DirectBuffer deployment;
   private long sourcePosition;
-  private long distributionCount;
+  private int distributionCount;
 
-  public PendingDeploymentDistribution(DirectBuffer deployment, long sourcePosition) {
+  public PendingDeploymentDistribution(
+      DirectBuffer deployment, long sourcePosition, int distributionCount) {
     this.deployment = deployment;
     this.sourcePosition = sourcePosition;
-  }
-
-  public void setDistributionCount(long distributionCount) {
     this.distributionCount = distributionCount;
   }
 
-  public long decrementCount() {
+  public int decrementCount() {
     return --distributionCount;
   }
 
@@ -59,6 +57,9 @@ public class PendingDeploymentDistribution implements DbValue {
   public void wrap(DirectBuffer buffer, int offset, int length) {
     this.sourcePosition = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
     offset += Long.BYTES;
+
+    this.distributionCount = buffer.getInt(offset, ZB_DB_BYTE_ORDER);
+    offset += Integer.BYTES;
 
     final int deploymentSize = buffer.getInt(offset, ZB_DB_BYTE_ORDER);
     offset += Integer.BYTES;
@@ -78,6 +79,9 @@ public class PendingDeploymentDistribution implements DbValue {
     final int startOffset = offset;
     buffer.putLong(offset, sourcePosition, ZB_DB_BYTE_ORDER);
     offset += Long.BYTES;
+
+    buffer.putInt(offset, distributionCount, ZB_DB_BYTE_ORDER);
+    offset += Integer.BYTES;
 
     final int deploymentSize = deployment.capacity();
     buffer.putInt(offset, deploymentSize, ZB_DB_BYTE_ORDER);

--- a/engine/src/main/java/io/zeebe/engine/state/deployment/DeploymentsState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/deployment/DeploymentsState.java
@@ -35,7 +35,8 @@ public class DeploymentsState {
   public DeploymentsState(ZeebeDb<ZbColumnFamilies> zeebeDb, DbContext dbContext) {
 
     deploymentKey = new DbLong();
-    pendingDeploymentDistribution = new PendingDeploymentDistribution(new UnsafeBuffer(0, 0), -1);
+    pendingDeploymentDistribution =
+        new PendingDeploymentDistribution(new UnsafeBuffer(0, 0), -1, 0);
     pendingDeploymentColumnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.PENDING_DEPLOYMENT,

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -255,7 +255,7 @@ public final class EngineRule extends ExternalResource {
     @Override
     public ActorFuture<Void> pushDeployment(long key, long position, DirectBuffer buffer) {
       final PendingDeploymentDistribution pendingDeployment =
-          new PendingDeploymentDistribution(buffer, position);
+          new PendingDeploymentDistribution(buffer, position, partitionCount);
       pendingDeployments.put(key, pendingDeployment);
 
       forEachPartition(


### PR DESCRIPTION
The issue was that the distribution count in the PendingDeploymentDistribution object wasn't written to or from the DB, it was always the value set when the object was created. Meaning that every deployment response would decrement the same value. Therefore, only one DISTRIBUTED would be written because the counter would only pass through 0 once. This PR fixes the object `wrap` and `write` methods to store and read the value from RocksDb. Additionally, some parts of the response handling logic were incorrect (like the leader mismatch handling) and had log statements that were misleading, so I also did some refactoring to improve that.  

closes #2818, closes #2764