### PR TITLE
chore(engine): notify when jobs are available

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/engine/EngineService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/engine/EngineService.java
@@ -12,6 +12,7 @@ import io.zeebe.broker.clustering.base.partitions.Partition;
 import io.zeebe.broker.clustering.base.topology.TopologyManager;
 import io.zeebe.broker.clustering.base.topology.TopologyPartitionListenerImpl;
 import io.zeebe.broker.engine.impl.DeploymentDistributorImpl;
+import io.zeebe.broker.engine.impl.LongPollingJobNotification;
 import io.zeebe.broker.engine.impl.PartitionCommandSenderImpl;
 import io.zeebe.broker.system.configuration.BrokerCfg;
 import io.zeebe.broker.system.configuration.ClusterCfg;
@@ -139,12 +140,16 @@ public class EngineService implements Service<EngineService> {
     final PushDeploymentRequestHandler deploymentRequestHandler =
         leaderManagementRequestHandlerInjector.getValue().getPushDeploymentRequestHandler();
 
+    final LongPollingJobNotification jobsAvailableNotification =
+        new LongPollingJobNotification(atomix.getEventService());
+
     return EngineProcessors.createEngineProcessors(
         processingContext,
         clusterCfg.getPartitionsCount(),
         subscriptionCommandSender,
         deploymentDistributor,
-        deploymentRequestHandler);
+        deploymentRequestHandler,
+        jobsAvailableNotification::onJobsAvailable);
   }
 
   @Override

--- a/broker-core/src/main/java/io/zeebe/broker/engine/impl/LongPollingJobNotification.java
+++ b/broker-core/src/main/java/io/zeebe/broker/engine/impl/LongPollingJobNotification.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.engine.impl;
+
+import io.atomix.cluster.messaging.ClusterEventService;
+
+public class LongPollingJobNotification {
+  private static final String TOPIC = "jobsAvailable";
+  private final ClusterEventService eventService;
+
+  public LongPollingJobNotification(ClusterEventService eventService) {
+    this.eventService = eventService;
+  }
+
+  public void onJobsAvailable(String jobType) {
+    eventService.broadcast(TOPIC, jobType);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/EngineProcessors.java
@@ -25,6 +25,7 @@ import io.zeebe.logstreams.log.LogStreamWriterImpl;
 import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.DeploymentIntent;
+import java.util.function.Consumer;
 
 public class EngineProcessors {
 
@@ -33,7 +34,8 @@ public class EngineProcessors {
       int partitionsCount,
       SubscriptionCommandSender subscriptionCommandSender,
       DeploymentDistributor deploymentDistributor,
-      DeploymentResponder deploymentResponder) {
+      DeploymentResponder deploymentResponder,
+      Consumer<String> onJobsAvailableCallback) {
 
     final TypedRecordProcessors typedRecordProcessors = TypedRecordProcessors.processors();
     final LogStream stream = processingContext.getLogStream();
@@ -54,7 +56,7 @@ public class EngineProcessors {
         addWorkflowProcessors(
             zeebeState, typedRecordProcessors, subscriptionCommandSender, catchEventBehavior);
     addIncidentProcessors(zeebeState, stepProcessor, typedRecordProcessors);
-    addJobProcessors(zeebeState, typedRecordProcessors);
+    addJobProcessors(zeebeState, typedRecordProcessors, onJobsAvailableCallback);
 
     return typedRecordProcessors;
   }
@@ -119,8 +121,10 @@ public class EngineProcessors {
   }
 
   private static void addJobProcessors(
-      ZeebeState zeebeState, TypedRecordProcessors typedRecordProcessors) {
-    JobEventProcessors.addJobProcessors(typedRecordProcessors, zeebeState);
+      ZeebeState zeebeState,
+      TypedRecordProcessors typedRecordProcessors,
+      Consumer<String> onJobsAvailableCallback) {
+    JobEventProcessors.addJobProcessors(typedRecordProcessors, zeebeState, onJobsAvailableCallback);
   }
 
   private static void addMessageProcessors(

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorRule.java
@@ -110,7 +110,7 @@ public class WorkflowInstanceStreamProcessorRule extends ExternalResource
               new CatchEventBehavior(zeebeState, mockSubscriptionCommandSender, 1),
               new DueDateTimerChecker(workflowState));
 
-          JobEventProcessors.addJobProcessors(typedRecordProcessors, zeebeState);
+          JobEventProcessors.addJobProcessors(typedRecordProcessors, zeebeState, type -> {});
           typedRecordProcessors.withListener(this);
           return typedRecordProcessors;
         });

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/IncidentStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/IncidentStreamProcessorRule.java
@@ -87,7 +87,7 @@ public class IncidentStreamProcessorRule extends ExternalResource {
                   mockTimerEventScheduler);
 
           IncidentEventProcessors.addProcessors(typedRecordProcessors, zeebeState, stepProcessor);
-          JobEventProcessors.addJobProcessors(typedRecordProcessors, zeebeState);
+          JobEventProcessors.addJobProcessors(typedRecordProcessors, zeebeState, type -> {});
           return typedRecordProcessors;
         });
   }

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/job/ActivatableJobsNotificationTests.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/job/ActivatableJobsNotificationTests.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.job;
+
+import static io.zeebe.protocol.record.intent.JobIntent.TIMED_OUT;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.zeebe.protocol.record.value.JobRecordValue;
+import io.zeebe.test.util.Strings;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ActivatableJobsNotificationTests {
+
+  private static final String PROCESS_ID = "process";
+  private static final Function<String, BpmnModelInstance> MODEL_SUPPLIER =
+      (type) ->
+          Bpmn.createExecutableProcess(PROCESS_ID)
+              .startEvent("start")
+              .serviceTask("task", b -> b.zeebeTaskType(type).done())
+              .endEvent("end")
+              .done();
+
+  private String taskType;
+
+  private static Consumer<String> jobAvailableCallback =
+      (Consumer<String>) Mockito.spy(Consumer.class);
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition().withJobsAvailableCallback(jobAvailableCallback);
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Before
+  public void setup() {
+    taskType = Strings.newRandomValidBpmnId();
+    ENGINE.deployment().withXmlResource(PROCESS_ID, MODEL_SUPPLIER.apply(taskType)).deploy();
+  }
+
+  @Test
+  public void shouldNotifyWhenFirstJobCreated() {
+    // when
+    createWorkflowInstanceAndJobs(1);
+
+    // then
+    Mockito.verify(jobAvailableCallback, times(1)).accept(taskType);
+  }
+
+  @Test
+  public void shouldNotNotifyWhenSecondJobCreated() {
+    // when
+    createWorkflowInstanceAndJobs(2);
+
+    // then
+    Mockito.verify(jobAvailableCallback, times(1)).accept(taskType);
+  }
+
+  @Test
+  public void shouldNotifyWhenJobsAvailableAgain() {
+    // given
+    createWorkflowInstanceAndJobs(2);
+    final Record<JobBatchRecordValue> jobs = activateJobs(2);
+
+    // when
+    createWorkflowInstanceAndJobs(1);
+
+    // then
+    Mockito.verify(jobAvailableCallback, times(2)).accept(taskType);
+  }
+
+  @Test
+  public void shouldNotifyWhenJobCanceled() {
+    // given
+    final List<Long> instanceKeys = createWorkflowInstanceAndJobs(1);
+    ENGINE.workflowInstance().withInstanceKey(instanceKeys.get(0)).cancel();
+
+    // when
+    createWorkflowInstanceAndJobs(1);
+
+    // then
+    Mockito.verify(jobAvailableCallback, times(2)).accept(taskType);
+  }
+
+  @Test
+  public void shouldNotNotifyWhenActivatedJobCanceled() {
+    // given
+    final List<Long> instanceKeys = createWorkflowInstanceAndJobs(2);
+    activateJobs(1);
+    ENGINE.workflowInstance().withInstanceKey(instanceKeys.get(0)).cancel();
+
+    // when
+    createWorkflowInstanceAndJobs(1);
+
+    // then
+    Mockito.verify(jobAvailableCallback, times(1)).accept(taskType);
+  }
+
+  @Test
+  public void shouldNotifyWhenJobsAvailableAfterTimeOut() {
+    // given
+    createWorkflowInstanceAndJobs(1);
+    activateJobs(1, Duration.ofMillis(10));
+
+    // when
+    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+    RecordingExporter.jobRecords(TIMED_OUT).withType(taskType).getFirst();
+
+    // then
+    Mockito.verify(jobAvailableCallback, times(2)).accept(taskType);
+  }
+
+  @Test
+  public void shouldNotifyWhenJobAvailableAfterNotActivatedJobCompleted() {
+    // given
+    createWorkflowInstanceAndJobs(1);
+    final long jobKey = activateJobs(1, Duration.ofMillis(10)).getValue().getJobKeys().get(0);
+    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+    RecordingExporter.jobRecords(TIMED_OUT).withType(taskType).getFirst();
+
+    // when
+    ENGINE.job().withKey(jobKey).complete();
+    createWorkflowInstanceAndJobs(1);
+
+    // then
+    Mockito.verify(jobAvailableCallback, times(3)).accept(taskType);
+  }
+
+  @Test
+  public void shouldNotifyWhenJobsFailWithRetryAvailable() {
+    // given
+    createWorkflowInstanceAndJobs(1);
+    final Record<JobBatchRecordValue> jobs = activateJobs(1);
+    final long jobKey = jobs.getValue().getJobKeys().get(0);
+
+    // when
+    ENGINE.job().withKey(jobKey).withRetries(10).fail();
+
+    // then
+    Mockito.verify(jobAvailableCallback, times(2)).accept(taskType);
+  }
+
+  @Test
+  public void shouldNotifyWhenFailedJobsResolved() {
+    // given
+    createWorkflowInstanceAndJobs(1);
+    final Record<JobBatchRecordValue> jobs = activateJobs(1);
+    final JobRecordValue job = jobs.getValue().getJobs().get(0);
+
+    ENGINE.job().withType(taskType).ofInstance(job.getWorkflowInstanceKey()).fail();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(job.getWorkflowInstanceKey())
+        .withType(taskType)
+        .withRetries(1)
+        .updateRetries();
+    ENGINE.incident().ofInstance(job.getWorkflowInstanceKey()).resolve();
+
+    // then
+    Mockito.verify(jobAvailableCallback, times(2)).accept(taskType);
+  }
+
+  @Test
+  public void shouldNotifyForMultipleJobTypes() {
+    // given
+    final String firstType = Strings.newRandomValidBpmnId();
+    final String secondType = Strings.newRandomValidBpmnId();
+
+    // when
+    ENGINE.createJob(firstType, PROCESS_ID);
+    ENGINE.createJob(secondType, PROCESS_ID);
+
+    // then
+    Mockito.verify(jobAvailableCallback, times(1)).accept(firstType);
+    Mockito.verify(jobAvailableCallback, times(1)).accept(secondType);
+  }
+
+  private List<Long> createWorkflowInstanceAndJobs(int amount) {
+    return IntStream.range(0, amount)
+        .mapToObj(i -> ENGINE.createJob(taskType, PROCESS_ID))
+        .map(r -> r.getValue().getWorkflowInstanceKey())
+        .collect(Collectors.toList());
+  }
+
+  private Record<JobBatchRecordValue> activateJobs(int amount) {
+    final Duration timeout = Duration.ofMinutes(12);
+    return activateJobs(amount, timeout);
+  }
+
+  private Record<JobBatchRecordValue> activateJobs(int amount, Duration timeout) {
+    final String worker = "myTestWorker";
+    return ENGINE
+        .jobs()
+        .withType(taskType)
+        .byWorker(worker)
+        .withTimeout(timeout.toMillis())
+        .withMaxJobsToActivate(amount)
+        .activate();
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -74,6 +74,7 @@ public final class EngineRule extends ExternalResource {
 
   private final int partitionCount;
   private final boolean explicitStart;
+  private Consumer<String> jobsAvailableCallback = type -> {};
 
   public static EngineRule singlePartition() {
     return new EngineRule(1);
@@ -117,6 +118,11 @@ public final class EngineRule extends ExternalResource {
     startProcessors();
   }
 
+  public EngineRule withJobsAvailableCallback(Consumer<String> callback) {
+    this.jobsAvailableCallback = callback;
+    return this;
+  }
+
   private void startProcessors() {
     final DeploymentRecord deploymentRecord = new DeploymentRecord();
     final UnsafeBuffer deploymentBuffer = new UnsafeBuffer(new byte[deploymentRecord.getLength()]);
@@ -138,7 +144,8 @@ public final class EngineRule extends ExternalResource {
                           new SubscriptionCommandSender(
                               currentPartitionId, new PartitionCommandSenderImpl()),
                           new DeploymentDistributionImpl(),
-                          (key, partition) -> {})
+                          (key, partition) -> {},
+                          jobsAvailableCallback)
                       .withListener(new ProcessingExporterTransistor()));
         });
   }

--- a/zb-db/src/main/java/io/zeebe/db/ColumnFamily.java
+++ b/zb-db/src/main/java/io/zeebe/db/ColumnFamily.java
@@ -159,6 +159,14 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue> 
   boolean exists(KeyType key);
 
   /**
+   * Checks if a key with prefix keyPrefix exists in the column family.
+   *
+   * @param keyPrefix the prefix to look for
+   * @return true if atleast one key exists in this column family with the prefix, false otherwise
+   */
+  boolean existsPrefix(DbKey keyPrefix);
+
+  /**
    * Checks if the column family has any entry.
    *
    * @return <code>true</code> if the column family has no entry

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -149,6 +149,11 @@ class TransactionalColumnFamily<
   }
 
   @Override
+  public boolean existsPrefix(DbKey keyPrefix) {
+    return transactionDb.existsPrefix(handle, context, keyPrefix, keyInstance, valueInstance);
+  }
+
+  @Override
   public boolean isEmpty() {
     return isEmpty(context);
   }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -192,6 +192,18 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
             transaction.delete(columnFamilyHandle, context.getKeyBufferArray(), key.getLength()));
   }
 
+  public boolean existsPrefix(
+      long columnFamilyHandle,
+      DbContext context,
+      DbKey keyPrefix,
+      DbKey keyInstance,
+      DbValue valueInstance) {
+    context.wrapValueView(new byte[0]);
+    whileEqualPrefix(
+        columnFamilyHandle, context, keyPrefix, keyInstance, valueInstance, (key, value) -> false);
+    return !context.isValueViewEmpty();
+  }
+
   ////////////////////////////////////////////////////////////////////
   //////////////////////////// ITERATION /////////////////////////////
   ////////////////////////////////////////////////////////////////////

--- a/zb-db/src/test/java/io/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
@@ -375,6 +375,30 @@ public class DbCompositeKeyColumnFamilyTest {
     assertThat(secondKeyParts).containsExactly(34L, 37426L, 923113L, 255L);
   }
 
+  @Test
+  public void shouldExistsPrefixTrue() {
+    // given
+    firstKey.wrapString("foo");
+    assertThat(columnFamily.existsPrefix(firstKey)).isFalse();
+
+    // then
+    putKeyValuePair("foo", 12, "baring");
+
+    // then
+    assertThat(columnFamily.existsPrefix(firstKey)).isTrue();
+  }
+
+  @Test
+  public void shouldExistsPrefixFalseWhenDelete() {
+    // given
+    firstKey.wrapString("foo");
+    putKeyValuePair("foo", 12, "baring");
+    columnFamily.delete(compositeKey);
+
+    // then
+    assertThat(columnFamily.existsPrefix(firstKey)).isFalse();
+  }
+
   private void putKeyValuePair(String firstKey, long secondKey, String value) {
     this.firstKey.wrapString(firstKey);
     this.secondKey.wrapLong(secondKey);


### PR DESCRIPTION
# Description
`ActivatableJobsCount` maintains an in-memory map of jobtype to activatable job count. When stream processor is opened and recovered, the map is initialized by iterating over the RocksDB state. After that `JobState` notifies when a job is created or marked not activatable. When the count is updated from 0 to 1, `onJobsAvailableCallback` is invoked which broadcasts `jobType`.

# Related issues
Related to #2828

closes #2824

# Pull Request Checklist

- [x] I have signed the Camunda CLA
- [x] I followed the [contributor guidelines](/CONTRIBUTING.md)
- [x] All commit messages match our [commit message guidelines](/CONTRIBUTING.md#commit-message-guidelines)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally
