### PR TITLE
chore(build-tools): add EmptyCatchBlock rule

### DIFF
--- a/build-tools/src/main/resources/check/.checkstyle.xml
+++ b/build-tools/src/main/resources/check/.checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
     <module name="SeverityMatchFilter">
         <property name="severity" value="info"/>
@@ -111,7 +111,13 @@
         </module>
 
         <module name="DefaultComesLast" />
+
         <module name="InterfaceIsType" />
+
         <module name="MutableException" />
+
+        <module name="EmptyCatchBlock">
+          <property name="commentFormat" value="^.+$" />
+        </module>
     </module>
 </module>

--- a/logstreams/src/test/java/io/zeebe/distributedlog/DistributedLogRule.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/DistributedLogRule.java
@@ -85,7 +85,8 @@ public class DistributedLogRule extends ExternalResource {
     this.otherNodes = otherNodes;
     try {
       rootDirectory = Files.createTempDirectory("dl-test-" + nodeId + "-");
-    } catch (Exception e) {
+    } catch (Exception ignored) {
+      // ignored
     }
     config =
         new StorageConfigurationManager(

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
@@ -233,6 +233,7 @@ public class RecordingExporter implements Exporter {
           try {
             IS_EMPTY.await(waitTime, TimeUnit.MILLISECONDS);
           } catch (final InterruptedException ignored) {
+            // ignored
           }
           now = System.currentTimeMillis();
         }


### PR DESCRIPTION
# Description

Enforces that empty catch blocks contain at least a one line comment.

# Related issues

Part of #2650 

# Pull Request Checklist

- [x] I have signed the Camunda CLA
- [x] I followed the [contributor guidelines](/CONTRIBUTING.md)
- [x] All commit messages match our [commit message guidelines](/CONTRIBUTING.md#commit-message-guidelines)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally
