### PR TITLE
chore(build-tools): add EqualsAvoidNull checkstyle rule

### DIFF
--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/instance/TimerEventDefinitionTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/instance/TimerEventDefinitionTest.java
@@ -40,11 +40,11 @@ public class TimerEventDefinitionTest extends AbstractEventDefinitionTest {
     for (final TimerEventDefinition eventDefinition : eventDefinitions) {
       final String id = eventDefinition.getId();
       String textContent = null;
-      if (id.equals("date")) {
+      if ("date".equals(id)) {
         textContent = eventDefinition.getTimeDate().getTextContent();
-      } else if (id.equals("duration")) {
+      } else if ("duration".equals(id)) {
         textContent = eventDefinition.getTimeDuration().getTextContent();
-      } else if (id.equals("cycle")) {
+      } else if ("cycle".equals(id)) {
         textContent = eventDefinition.getTimeCycle().getTextContent();
       }
 

--- a/build-tools/src/main/resources/check/.checkstyle.xml
+++ b/build-tools/src/main/resources/check/.checkstyle.xml
@@ -121,5 +121,7 @@
         </module>
 
         <module name="InnerAssignment" />
+
+        <module name="EqualsAvoidNull" />
     </module>
 </module>


### PR DESCRIPTION
# Description

- adds [EqualsAvoidNull](https://checkstyle.org/config_coding.html#EqualsAvoidNull) checkstyle rule
- checks that any combination of String literals is on the left side of an equals() comparison
- helps avoid NPEs when comparing string literals

# Related issues

Part of #2650

# Pull Request Checklist

- [x] I have signed the Camunda CLA
- [x] I followed the [contributor guidelines](/CONTRIBUTING.md)
- [x] All commit messages match our [commit message guidelines](/CONTRIBUTING.md#commit-message-guidelines)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally
