### PR TITLE
chore(build-tools): add InnerAssignment check

### DIFF
--- a/build-tools/src/main/resources/check/.checkstyle.xml
+++ b/build-tools/src/main/resources/check/.checkstyle.xml
@@ -119,5 +119,7 @@
         <module name="EmptyCatchBlock">
           <property name="commentFormat" value="^.+$" />
         </module>
+
+        <module name="InnerAssignment" />
     </module>
 </module>

--- a/engine/src/main/java/io/zeebe/engine/state/instance/VariablesState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/VariablesState.java
@@ -202,12 +202,15 @@ public class VariablesState {
   public void setVariablesFromDocument(long scopeKey, long workflowKey, DirectBuffer document) {
     // 1. index entries in the document
     indexedDocument.index(document);
+    if (!indexedDocument.hasEntries()) {
+      return;
+    }
 
     long currentScope = scopeKey;
     long parentScope;
 
     // 2. overwrite any variables in the scope hierarchy
-    while (indexedDocument.hasEntries() && (parentScope = getParent(currentScope)) > 0) {
+    while ((parentScope = getParent(currentScope)) > 0) {
       final DocumentEntryIterator entryIterator = indexedDocument.iterator();
 
       while (entryIterator.hasNext()) {
@@ -238,22 +241,20 @@ public class VariablesState {
     }
 
     // 3. set remaining variables on top scope
-    if (indexedDocument.hasEntries()) {
-      final DocumentEntryIterator entryIterator = indexedDocument.iterator();
+    final DocumentEntryIterator entryIterator = indexedDocument.iterator();
 
-      while (entryIterator.hasNext()) {
-        entryIterator.next();
+    while (entryIterator.hasNext()) {
+      entryIterator.next();
 
-        setVariableLocal(
-            currentScope,
-            workflowKey,
-            document,
-            entryIterator.getNameOffset(),
-            entryIterator.getNameLength(),
-            document,
-            entryIterator.getValueOffset(),
-            entryIterator.getValueLength());
-      }
+      setVariableLocal(
+          currentScope,
+          workflowKey,
+          document,
+          entryIterator.getNameOffset(),
+          entryIterator.getNameLength(),
+          document,
+          entryIterator.getValueOffset(),
+          entryIterator.getValueLength());
     }
   }
 

--- a/util/src/main/java/io/zeebe/util/BoundedArrayQueue.java
+++ b/util/src/main/java/io/zeebe/util/BoundedArrayQueue.java
@@ -29,19 +29,23 @@ public class BoundedArrayQueue<P> implements Iterable<P>, Queue<P> {
     this.capacity = findNextPositivePowerOfTwo(capacity);
     this.mask = this.capacity - 1;
 
-    head = tail = 0;
+    head = 0;
+    tail = 0;
 
     array = new Object[this.capacity];
   }
 
+  @Override
   public void clear() {
-    head = tail = 0;
+    head = 0;
+    tail = 0;
     for (int i = 0; i < array.length; i++) {
       array[i] = null;
     }
     iterator.reset();
   }
 
+  @Override
   public boolean offer(P object) {
     final int remainingSpace = capacity - size();
 
@@ -58,6 +62,7 @@ public class BoundedArrayQueue<P> implements Iterable<P>, Queue<P> {
     }
   }
 
+  @Override
   @SuppressWarnings("unchecked")
   public P poll() {
     final int size = size();
@@ -76,6 +81,7 @@ public class BoundedArrayQueue<P> implements Iterable<P>, Queue<P> {
     return (P) object;
   }
 
+  @Override
   @SuppressWarnings("unchecked")
   public P peek() {
     final int size = size();
@@ -91,6 +97,7 @@ public class BoundedArrayQueue<P> implements Iterable<P>, Queue<P> {
     return (P) object;
   }
 
+  @Override
   public int size() {
     return (int) (tail - head);
   }


### PR DESCRIPTION
# Description

Adds the [InnerAssignment](https://checkstyle.org/config_coding.html#InnerAssignment) checkstyle module, which checks for assignments in subexpressions, such as in `String s = Integer.toString(i = 2)`, but allows for common idioms such as:

```java
while ((line = input.readLine()) != null) { 
  // ...
}
```

The rational is, with the exception of for iterators and assignment in while idiom, all assignments should occur in their own top-level statement to increase readability. With inner assignments like the one given above, it is difficult to see all places where a variable is set. 

Updated `VariablesState`, where although the condition was in the while, it didn't really make sense and could be simplified into a guard clause instead of checking every step.

# Related issues

Part of #2650

# Pull Request Checklist

- [x] I have signed the Camunda CLA
- [x] I followed the [contributor guidelines](/CONTRIBUTING.md)
- [x] All commit messages match our [commit message guidelines](/CONTRIBUTING.md#commit-message-guidelines)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally
