### PR TITLE
chore(build-tools): add MissingSwitchDefault check

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/Topology.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/Topology.java
@@ -154,6 +154,10 @@ public class Topology {
           member.removeLeader(partitionId);
           member.addFollower(partitionId);
           break;
+
+        default:
+          LOG.warn("Unexpected raft state {}", state);
+          break;
       }
     }
   }

--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/TopologyManagerImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/topology/TopologyManagerImpl.java
@@ -114,6 +114,10 @@ public class TopologyManagerImpl extends Actor
               case MEMBER_REMOVED:
                 onMemberRemoved(brokerInfo);
                 break;
+
+              case REACHABILITY_CHANGED:
+              default:
+                break;
             }
           });
     }

--- a/build-tools/src/main/resources/check/.checkstyle.xml
+++ b/build-tools/src/main/resources/check/.checkstyle.xml
@@ -135,5 +135,7 @@
         <module name="NestedIfDepth">
           <property name="max" value="2" />
         </module>
+
+        <module name="MissingSwitchDefault" />
     </module>
 </module>

--- a/engine/src/main/java/io/zeebe/engine/state/instance/WorkflowEngineState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/WorkflowEngineState.java
@@ -101,6 +101,8 @@ public class WorkflowEngineState implements StreamProcessorLifecycleAware {
       case ELEMENT_TERMINATED:
         metrics.elementInstanceTerminated(value.getBpmnElementType());
         break;
+      default:
+        break;
     }
   }
 

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
@@ -73,6 +73,10 @@ public class BrokerTopologyManagerImpl extends Actor
               case MEMBER_REMOVED:
                 newTopology.removeBroker(brokerInfo.getNodeId());
                 break;
+
+              case REACHABILITY_CHANGED:
+              default:
+                break;
             }
 
             topology.set(newTopology);

--- a/json-path/src/main/java/io/zeebe/msgpack/mapping/MsgPackDocumentIndexer.java
+++ b/json-path/src/main/java/io/zeebe/msgpack/mapping/MsgPackDocumentIndexer.java
@@ -139,6 +139,9 @@ public final class MsgPackDocumentIndexer implements MsgPackTokenVisitor {
             mapEntryContext.currentKey = "";
             mapEntryContext.parsingMode = MapEntryParsingMode.KEY;
             break;
+          default:
+            throw new IllegalStateException(
+                "Unexpected map entry parsing mode " + mapEntryContext.parsingMode.name());
         }
         break;
       case ARRAY_ENTRY:
@@ -148,6 +151,9 @@ public final class MsgPackDocumentIndexer implements MsgPackTokenVisitor {
         parseValue(tokenContext, key, position, currentValue);
 
         break;
+      default:
+        throw new IllegalStateException(
+            "Unknown token parsing mode " + tokenContext.parsingMode.name());
     }
   }
 

--- a/logstreams/src/main/java/io/zeebe/distributedlog/restore/impl/RestoreController.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/restore/impl/RestoreController.java
@@ -106,8 +106,12 @@ public class RestoreController {
                     server, request.getLatestLocalPosition(), request.getBackupPosition()));
         break;
       case NONE:
+      default:
         logger.debug(
-            "Restore server {} reports nothing to replicate for request {}", server, request);
+            "Restore server {} reports {} as restore info for request {}",
+            server,
+            response.getReplicationTarget(),
+            request);
         result.complete(() -> CompletableFuture.completedFuture(request.getLatestLocalPosition()));
         break;
     }

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/BufferedLogStreamReader.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/BufferedLogStreamReader.java
@@ -179,6 +179,8 @@ public class BufferedLogStreamReader implements LogStreamReader {
   @Override
   public boolean hasNext() {
     switch (state) {
+      case EVENT_AVAILABLE:
+        return true;
       case EMPTY_LOG_STREAM:
         seekToFirstEvent();
         break;
@@ -190,6 +192,8 @@ public class BufferedLogStreamReader implements LogStreamReader {
         break;
       case WRAP_NOT_CALLED:
         throw new IllegalStateException("Iterator not initialized");
+      default:
+        throw new IllegalStateException("Unknown reader state " + state.name());
     }
 
     return state == IteratorState.EVENT_AVAILABLE;

--- a/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgPackReader.java
+++ b/msgpack-core/src/main/java/io/zeebe/msgpack/spec/MsgPackReader.java
@@ -328,6 +328,7 @@ public class MsgPackReader {
         break;
       case EXTENSION:
       case NEVER_USED:
+      default:
         throw new MsgpackReaderException(
             String.format("Unknown token format '%s'", format.getType().name()));
     }
@@ -451,6 +452,7 @@ public class MsgPackReader {
           offset += 4;
           break;
         case NEVER_USED:
+        default:
           throw new MsgpackReaderException("Encountered 0xC1 \"NEVER_USED\" byte");
       }
 

--- a/msgpack-value/src/main/java/io/zeebe/msgpack/value/ArrayValue.java
+++ b/msgpack-value/src/main/java/io/zeebe/msgpack/value/ArrayValue.java
@@ -203,9 +203,10 @@ public class ArrayValue<T extends BaseValue> extends BaseValue implements Iterat
       case Insert:
       case Modify:
         return innerValue.getEncodedLength();
+      case Uninitialized:
+      default:
+        return 0;
     }
-
-    return 0;
   }
 
   private void readInnerValue() {
@@ -223,6 +224,9 @@ public class ArrayValue<T extends BaseValue> extends BaseValue implements Iterat
         break;
       case Modify:
         updateInnerValue();
+        break;
+      case Uninitialized:
+      default:
         break;
     }
 

--- a/util/src/main/java/io/zeebe/util/sched/ActorTask.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorTask.java
@@ -250,6 +250,10 @@ public class ActorTask {
           onClosed();
           resubmit = false;
           break;
+
+        default:
+          throw new IllegalStateException(
+              "Unexpected actor lifecycle phase " + lifecyclePhase.name());
       }
     } else {
       if (lifecyclePhase != ActorLifecyclePhase.CLOSED) {


### PR DESCRIPTION
## Description

Adds [MissingSwitchDefault]() module to checkstyle configuration, which ensures all switch statements have a default case; the rationale is to ensure that in cases where we must handle all cases, we do so (or fail on default), and in cases where not it is still explicit that we don't.

This also updates instances of switch statements in our code without a default case. The only case I wasn't sure if it is safe to fail is in the `ActorTask`, but closing the task may not be what is expected either, and I felt throwing an exception is "better" than performing unexpected behaviour.

## Related issues

Related to #2650 

## Pull Request Checklist

- [x] I have signed the [Camunda CLA](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#sign-the-contributor-license-agreement)
- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
