### PR TITLE
chore(build-tools): add NestedFor/If/TryDepth checks

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
@@ -343,27 +343,8 @@ public abstract class AbstractBaseElementBuilder<
       x = sourceX + sourceWidth + SPACE;
 
       if (element instanceof FlowNode) {
-
         final FlowNode flowNode = (FlowNode) element;
-        final Collection<SequenceFlow> outgoing = flowNode.getOutgoing();
-
-        if (outgoing.size() == 0) {
-          final double sourceY = sourceBounds.getY();
-          final double sourceHeight = sourceBounds.getHeight();
-          final double targetHeight = shapeBounds.getHeight();
-          y = sourceY + sourceHeight / 2 - targetHeight / 2;
-        } else {
-          final SequenceFlow[] sequenceFlows = outgoing.toArray(new SequenceFlow[outgoing.size()]);
-          final SequenceFlow last = sequenceFlows[outgoing.size() - 1];
-
-          final BpmnShape targetShape = findBpmnShape(last.getTarget());
-          if (targetShape != null) {
-            final Bounds targetBounds = targetShape.getBounds();
-            final double lastY = targetBounds.getY();
-            final double lastHeight = targetBounds.getHeight();
-            y = lastY + lastHeight + SPACE;
-          }
-        }
+        y = getFlowNodeYCoordinate(flowNode, shapeBounds, sourceBounds);
       }
     }
 
@@ -542,5 +523,31 @@ public abstract class AbstractBaseElementBuilder<
         break;
       }
     }
+  }
+
+  private double getFlowNodeYCoordinate(
+      FlowNode flowNode, Bounds shapeBounds, Bounds sourceBounds) {
+    final Collection<SequenceFlow> outgoing = flowNode.getOutgoing();
+    double y = 0;
+
+    if (outgoing.size() == 0) {
+      final double sourceY = sourceBounds.getY();
+      final double sourceHeight = sourceBounds.getHeight();
+      final double targetHeight = shapeBounds.getHeight();
+      y = sourceY + sourceHeight / 2 - targetHeight / 2;
+    } else {
+      final SequenceFlow[] sequenceFlows = outgoing.toArray(new SequenceFlow[outgoing.size()]);
+      final SequenceFlow last = sequenceFlows[outgoing.size() - 1];
+      final BpmnShape targetShape = findBpmnShape(last.getTarget());
+
+      if (targetShape != null) {
+        final Bounds targetBounds = targetShape.getBounds();
+        final double lastY = targetBounds.getY();
+        final double lastHeight = targetBounds.getHeight();
+        y = lastY + lastHeight + SPACE;
+      }
+    }
+
+    return y;
   }
 }

--- a/build-tools/src/main/resources/check/.checkstyle.xml
+++ b/build-tools/src/main/resources/check/.checkstyle.xml
@@ -123,5 +123,17 @@
         <module name="InnerAssignment" />
 
         <module name="EqualsAvoidNull" />
+
+        <module name="NestedForDepth">
+          <property name="max" value="2" />
+        </module>
+
+        <module name="NestedTryDepth">
+          <property name="max" value="2" />
+        </module>
+
+        <module name="NestedIfDepth">
+          <property name="max" value="2" />
+        </module>
     </module>
 </module>


### PR DESCRIPTION
## Description

Adds [NestedForDepth](https://checkstyle.org/config_coding.html#NestedForDepth), [NestedIfDepth](https://checkstyle.org/config_coding.html#NestedIfDepth), and [NestedTryDepth](https://checkstyle.org/config_coding.html#NestedTryDepth), each with a maximum depth level of 2. This required only a single code change in the `bpmn-model` scope, where we had a method with a 4 `if-else` nested.

I'm not 100% sure 2 is ideal; I can imagine some cases where 3 makes sense (i.e. stuff with quarternions) but none that apply to us imo. I think 2 is a good balance.

## Related issues

related to #2650 

## Pull Request Checklist

- [x] I have signed the [Camunda CLA](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#sign-the-contributor-license-agreement)
- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
