### PR TITLE
chore(clients/java): simplify Java Tls configuration

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
@@ -15,7 +15,6 @@
  */
 package io.zeebe.client;
 
-import io.netty.handler.ssl.SslContext;
 import io.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
 import java.time.Duration;
 import java.util.Properties;
@@ -73,9 +72,10 @@ public interface ZeebeClientBuilder {
   ZeebeClientBuilder useSecureConnection();
 
   /**
-   * SSL/TLS context provided by {@link * GrpcSslContexts} to be used instead of the system default.
+   * Path to a root CA certificate to be used instead of the certificate in the default default
+   * store.
    */
-  ZeebeClientBuilder sslContext(SslContext sslContext);
+  ZeebeClientBuilder caCertificatePath(String certificatePath);
 
   /** @return a new {@link ZeebeClient} with the provided configuration options. */
   ZeebeClient build();

--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientConfiguration.java
@@ -15,7 +15,6 @@
  */
 package io.zeebe.client;
 
-import io.netty.handler.ssl.SslContext;
 import java.time.Duration;
 
 public interface ZeebeClientConfiguration {
@@ -46,6 +45,6 @@ public interface ZeebeClientConfiguration {
   /** @see ZeebeClientBuilder#useSecureConnection() */
   boolean isSecureConnectionEnabled();
 
-  /** @see ZeebeClientBuilder#sslContext(SslContext) */
-  SslContext getSslContext();
+  /** @see ZeebeClientBuilder#caCertificatePath(String) */
+  String getCaCertificatePath();
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -18,7 +18,6 @@ package io.zeebe.client.impl;
 import static io.zeebe.client.ClientProperties.DEFAULT_MESSAGE_TIME_TO_LIVE;
 import static io.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
 
-import io.netty.handler.ssl.SslContext;
 import io.zeebe.client.ClientProperties;
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.ZeebeClientBuilder;
@@ -37,7 +36,7 @@ public class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientCo
   private Duration defaultMessageTimeToLive = Duration.ofHours(1);
   private Duration defaultRequestTimeout = Duration.ofSeconds(20);
   private boolean useSecureConnection = false;
-  private SslContext sslContext;
+  private String certificatePath;
 
   @Override
   public String getBrokerContactPoint() {
@@ -85,8 +84,8 @@ public class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientCo
   }
 
   @Override
-  public SslContext getSslContext() {
-    return sslContext;
+  public String getCaCertificatePath() {
+    return certificatePath;
   }
 
   @Override
@@ -184,8 +183,8 @@ public class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientCo
   }
 
   @Override
-  public ZeebeClientBuilder sslContext(final SslContext sslContext) {
-    this.sslContext = sslContext;
+  public ZeebeClientBuilder caCertificatePath(final String certificatePath) {
+    this.certificatePath = certificatePath;
     return this;
   }
 

--- a/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
@@ -16,12 +16,17 @@
 package io.zeebe.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.zeebe.client.util.ClientTest;
+import java.io.FileNotFoundException;
 import java.time.Duration;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class ZeebeClientTest extends ClientTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void shouldNotFailIfClosedTwice() {
@@ -46,5 +51,24 @@ public class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
       assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(20));
     }
+  }
+
+  @Test
+  public void shouldFailIfCertificateDoesNotExist() {
+    assertThatThrownBy(
+            () ->
+                ZeebeClient.newClientBuilder()
+                    .useSecureConnection()
+                    .caCertificatePath("/wrong/path")
+                    .build())
+        .hasCauseInstanceOf(FileNotFoundException.class);
+  }
+
+  @Test
+  public void shouldFailWithEmptyCertificatePath() {
+    assertThatThrownBy(
+            () ->
+                ZeebeClient.newClientBuilder().useSecureConnection().caCertificatePath("").build())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -105,17 +105,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-handler</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-netty</artifactId>
-    </dependency>
-
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/SecurityTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/SecurityTest.java
@@ -9,13 +9,10 @@ package io.zeebe.broker.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.grpc.netty.GrpcSslContexts;
-import io.netty.handler.ssl.SslContext;
 import io.zeebe.broker.it.clustering.ClusteringRule;
 import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.api.response.Topology;
 import io.zeebe.gateway.impl.configuration.GatewayCfg;
-import javax.net.ssl.SSLException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -47,21 +44,14 @@ public class SecurityTest {
     assertThat(topology.getBrokers().size()).isEqualTo(1);
   }
 
-  private SslContext createContext() {
-    try {
-      return GrpcSslContexts.forClient()
-          .trustManager(
-              io.zeebe.broker.it.clustering.DeploymentClusteredTest.class
-                  .getClassLoader()
-                  .getResourceAsStream("security/ca.cert.pem"))
-          .build();
-    } catch (SSLException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   private ZeebeClientBuilder configureClientForTls(final ZeebeClientBuilder clientBuilder) {
-    return clientBuilder.useSecureConnection().sslContext(createContext());
+    return clientBuilder
+        .useSecureConnection()
+        .caCertificatePath(
+            io.zeebe.broker.it.clustering.DeploymentClusteredTest.class
+                .getClassLoader()
+                .getResource("security/ca.cert.pem")
+                .getPath());
   }
 
   private void configureGatewayForTls(final GatewayCfg gatewayCfg) {


### PR DESCRIPTION
## Description
Modifies the Java client API to be consistent with the proposed Go client API, namely instead of allowing an SslContext to be passed we allow a certificate path to be specified which is used to build the context. This also allows us to validate that this path is valid (non-empty, points to existent file).

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
