### PR TITLE
chore(clients): change clients to use TLS by default

### DIFF
--- a/clients/go/zbc/client.go
+++ b/clients/go/zbc/client.go
@@ -36,9 +36,9 @@ type ZBClientImpl struct {
 }
 
 type ZBClientConfig struct {
-	GatewayAddress      string
-	UseSecureConnection bool
-	CaCertificatePath   string
+	GatewayAddress         string
+	UsePlaintextConnection bool
+	CaCertificatePath      string
 }
 
 type ZBError string
@@ -109,7 +109,7 @@ func (client *ZBClientImpl) Close() error {
 func NewZBClient(config *ZBClientConfig) (ZBClient, error) {
 	var opts []grpc.DialOption
 
-	if config.UseSecureConnection {
+	if !config.UsePlaintextConnection {
 		var creds credentials.TransportCredentials
 
 		if config.CaCertificatePath == "" {

--- a/clients/go/zbc/client_test.go
+++ b/clients/go/zbc/client_test.go
@@ -38,9 +38,8 @@ func TestNewZBClientWithTls(t *testing.T) {
 
 	parts := strings.Split(lis.Addr().String(), ":")
 	client, e := NewZBClient(&ZBClientConfig{
-		GatewayAddress:      fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
-		UseSecureConnection: true,
-		CaCertificatePath:   "../resources/ca.cert.pem",
+		GatewayAddress:    fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
+		CaCertificatePath: "../resources/ca.cert.pem",
 	})
 
 	require.NoError(t, e)
@@ -67,9 +66,9 @@ func TestNewZBClientWithoutTls(t *testing.T) {
 
 	parts := strings.Split(lis.Addr().String(), ":")
 	client, e := NewZBClient(&ZBClientConfig{
-		GatewayAddress:      fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
-		UseSecureConnection: false,
-		CaCertificatePath:   "../resources/ca.cert.pem",
+		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
+		UsePlaintextConnection: true,
+		CaCertificatePath:      "../resources/ca.cert.pem",
 	})
 
 	require.NoError(t, e)
@@ -94,8 +93,7 @@ func TestNewZBClientWithDefaultRootCa(t *testing.T) {
 
 	parts := strings.Split(lis.Addr().String(), ":")
 	client, e := NewZBClient(&ZBClientConfig{
-		GatewayAddress:      fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
-		UseSecureConnection: true,
+		GatewayAddress: fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 	})
 
 	require.NoError(t, e)
@@ -120,9 +118,8 @@ func TestNewZBClientWithPathToNonExistingFile(t *testing.T) {
 
 	parts := strings.Split(lis.Addr().String(), ":")
 	_, e := NewZBClient(&ZBClientConfig{
-		GatewayAddress:      fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
-		UseSecureConnection: true,
-		CaCertificatePath:   "../resources/non.existing",
+		GatewayAddress:    fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
+		CaCertificatePath: "../resources/non.existing",
 	})
 
 	require.Equal(t, NonExistingFileError, e)

--- a/clients/java/src/main/java/io/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/zeebe/client/ClientProperties.java
@@ -41,4 +41,10 @@ public class ClientProperties {
 
   /** @see ZeebeClientBuilder#defaultRequestTimeout(Duration) */
   public static final String DEFAULT_REQUEST_TIMEOUT = "zeebe.client.requestTimeout";
+
+  /** @see ZeebeClientBuilder#usePlaintext() */
+  public static final String USE_PLAINTEXT_CONNECTION = "zeebe.client.security.plaintext";
+
+  /** @see ZeebeClientBuilder#caCertificatePath(String) */
+  public static final String CA_CERTIFICATE_PATH = "zeebe.client.security.certpath";
 }

--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
@@ -68,8 +68,8 @@ public interface ZeebeClientBuilder {
   /** The request timeout used if not overridden by the command. Default is 20 seconds. */
   ZeebeClientBuilder defaultRequestTimeout(Duration requestTimeout);
 
-  /** Use a secure connection between the client and the gateway. */
-  ZeebeClientBuilder useSecureConnection();
+  /** Use a plaintext connection between the client and the gateway. */
+  ZeebeClientBuilder usePlaintext();
 
   /**
    * Path to a root CA certificate to be used instead of the certificate in the default default

--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientConfiguration.java
@@ -42,8 +42,8 @@ public interface ZeebeClientConfiguration {
   /** @see ZeebeClientBuilder#defaultRequestTimeout(Duration) */
   Duration getDefaultRequestTimeout();
 
-  /** @see ZeebeClientBuilder#useSecureConnection() */
-  boolean isSecureConnectionEnabled();
+  /** @see ZeebeClientBuilder#usePlaintext() */
+  boolean isPlaintextConnectionEnabled();
 
   /** @see ZeebeClientBuilder#caCertificatePath(String) */
   String getCaCertificatePath();

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -15,8 +15,10 @@
  */
 package io.zeebe.client.impl;
 
+import static io.zeebe.client.ClientProperties.CA_CERTIFICATE_PATH;
 import static io.zeebe.client.ClientProperties.DEFAULT_MESSAGE_TIME_TO_LIVE;
 import static io.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
+import static io.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 
 import io.zeebe.client.ClientProperties;
 import io.zeebe.client.ZeebeClient;
@@ -35,7 +37,7 @@ public class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientCo
   private Duration defaultJobPollInterval = Duration.ofMillis(100);
   private Duration defaultMessageTimeToLive = Duration.ofHours(1);
   private Duration defaultRequestTimeout = Duration.ofSeconds(20);
-  private boolean useSecureConnection = false;
+  private boolean usePlaintextConnection = false;
   private String certificatePath;
 
   @Override
@@ -79,8 +81,8 @@ public class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientCo
   }
 
   @Override
-  public boolean isSecureConnectionEnabled() {
-    return useSecureConnection;
+  public boolean isPlaintextConnectionEnabled() {
+    return usePlaintextConnection;
   }
 
   @Override
@@ -123,6 +125,12 @@ public class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientCo
     if (properties.containsKey(DEFAULT_REQUEST_TIMEOUT)) {
       defaultRequestTimeout(
           Duration.ofMillis(Long.parseLong(properties.getProperty(DEFAULT_REQUEST_TIMEOUT))));
+    }
+    if (properties.containsKey(USE_PLAINTEXT_CONNECTION)) {
+      usePlaintext();
+    }
+    if (properties.containsKey(CA_CERTIFICATE_PATH)) {
+      caCertificatePath(properties.getProperty(CA_CERTIFICATE_PATH));
     }
 
     return this;
@@ -177,8 +185,8 @@ public class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientCo
   }
 
   @Override
-  public ZeebeClientBuilder useSecureConnection() {
-    this.useSecureConnection = true;
+  public ZeebeClientBuilder usePlaintext() {
+    this.usePlaintextConnection = true;
     return this;
   }
 

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
@@ -109,7 +109,7 @@ public class ZeebeClientImpl implements ZeebeClient {
     final NettyChannelBuilder channelBuilder =
         NettyChannelBuilder.forAddress(address.getHost(), address.getPort());
 
-    if (config.isSecureConnectionEnabled()) {
+    if (!config.isPlaintextConnectionEnabled()) {
       final String certificatePath = config.getCaCertificatePath();
       SslContext sslContext = null;
 

--- a/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
@@ -18,6 +18,7 @@ package io.zeebe.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.zeebe.client.util.ClientTest;
 import java.io.FileNotFoundException;
 import java.time.Duration;
@@ -56,19 +57,18 @@ public class ZeebeClientTest extends ClientTest {
   @Test
   public void shouldFailIfCertificateDoesNotExist() {
     assertThatThrownBy(
-            () ->
-                ZeebeClient.newClientBuilder()
-                    .useSecureConnection()
-                    .caCertificatePath("/wrong/path")
-                    .build())
+            () -> ZeebeClient.newClientBuilder().caCertificatePath("/wrong/path").build())
         .hasCauseInstanceOf(FileNotFoundException.class);
   }
 
   @Test
   public void shouldFailWithEmptyCertificatePath() {
-    assertThatThrownBy(
-            () ->
-                ZeebeClient.newClientBuilder().useSecureConnection().caCertificatePath("").build())
+    assertThatThrownBy(() -> ZeebeClient.newClientBuilder().caCertificatePath("").build())
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void shouldHaveTlsEnabledByDefault() {
+    assertThat(new ZeebeClientBuilderImpl().isPlaintextConnectionEnabled()).isFalse();
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
@@ -41,13 +41,17 @@ public class GrpcClientRule extends ExternalResource {
       final EmbeddedBrokerRule brokerRule, final Consumer<ZeebeClientBuilder> configurator) {
     this(
         config -> {
-          config.brokerContactPoint(brokerRule.getGatewayAddress().toString());
+          config.brokerContactPoint(brokerRule.getGatewayAddress().toString()).usePlaintext();
           configurator.accept(config);
         });
   }
 
   public GrpcClientRule(final ClusteringRule clusteringRule) {
-    this(config -> config.brokerContactPoint(clusteringRule.getGatewayAddress().toString()));
+    this(
+        config ->
+            config
+                .brokerContactPoint(clusteringRule.getGatewayAddress().toString())
+                .usePlaintext());
   }
 
   public GrpcClientRule(final Consumer<ZeebeClientBuilder> configurator) {

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/SecurityTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/SecurityTest.java
@@ -45,13 +45,11 @@ public class SecurityTest {
   }
 
   private ZeebeClientBuilder configureClientForTls(final ZeebeClientBuilder clientBuilder) {
-    return clientBuilder
-        .useSecureConnection()
-        .caCertificatePath(
-            io.zeebe.broker.it.clustering.DeploymentClusteredTest.class
-                .getClassLoader()
-                .getResource("security/ca.cert.pem")
-                .getPath());
+    return clientBuilder.caCertificatePath(
+        io.zeebe.broker.it.clustering.DeploymentClusteredTest.class
+            .getClassLoader()
+            .getResource("security/ca.cert.pem")
+            .getPath());
   }
 
   private void configureGatewayForTls(final GatewayCfg gatewayCfg) {

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -102,6 +102,11 @@ public class ClusteringRule extends ExternalResource {
   }
 
   public ClusteringRule(
+      final int partitionCount, final int replicationFactor, final int clusterSize) {
+    this(partitionCount, replicationFactor, clusterSize, cfg -> {});
+  }
+
+  public ClusteringRule(
       final int partitionCount,
       final int replicationFactor,
       final int clusterSize,
@@ -112,18 +117,7 @@ public class ClusteringRule extends ExternalResource {
         clusterSize,
         configurator,
         gatewayCfg -> {},
-        clientCfg -> {});
-  }
-
-  public ClusteringRule(
-      final int partitionCount, final int replicationFactor, final int clusterSize) {
-    this(
-        partitionCount,
-        replicationFactor,
-        clusterSize,
-        cfg -> {},
-        gatewayCfg -> {},
-        clientCfg -> {});
+        ZeebeClientBuilder::usePlaintext);
   }
 
   public ClusteringRule(

--- a/test/src/main/java/io/zeebe/test/exporter/ExporterIntegrationRule.java
+++ b/test/src/main/java/io/zeebe/test/exporter/ExporterIntegrationRule.java
@@ -374,6 +374,7 @@ public class ExporterIntegrationRule extends ExternalResource {
     properties.put(
         ClientProperties.BROKER_CONTACTPOINT,
         getBrokerConfig().getGateway().getNetwork().toSocketAddress().toString());
+    properties.put(ClientProperties.USE_PLAINTEXT_CONNECTION, "");
 
     return properties;
   }

--- a/test/src/test/java/io/zeebe/test/WorkflowTest.java
+++ b/test/src/test/java/io/zeebe/test/WorkflowTest.java
@@ -7,18 +7,28 @@
  */
 package io.zeebe.test;
 
+import io.zeebe.client.ClientProperties;
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.api.response.WorkflowInstanceEvent;
 import io.zeebe.protocol.record.intent.DeploymentIntent;
 import io.zeebe.test.util.record.RecordingExporter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class WorkflowTest {
-  @Rule public final ZeebeTestRule testRule = new ZeebeTestRule();
+  @Rule
+  public final ZeebeTestRule testRule =
+      new ZeebeTestRule(
+          EmbeddedBrokerRule.DEFAULT_CONFIG_FILE,
+          () -> {
+            final Properties properties = new Properties();
+            properties.setProperty(ClientProperties.USE_PLAINTEXT_CONNECTION, "");
+            return properties;
+          });
 
   private ZeebeClient client;
 


### PR DESCRIPTION
## Description
Change the clients to use TLS by default. 

## Related issues
closes #2886 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
