### PR TITLE
block activate job requests for long polling

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/clustering/base/EmbeddedGatewayService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/clustering/base/EmbeddedGatewayService.java
@@ -36,7 +36,8 @@ public class EmbeddedGatewayService implements Service<Gateway> {
     final AtomixCluster atomix = atomixClusterInjector.getValue();
     final Function<GatewayCfg, BrokerClient> brokerClientFactory =
         cfg -> new BrokerClientImpl(cfg, atomix, startContext.getScheduler(), false);
-    gateway = new Gateway(configuration.getGateway(), brokerClientFactory);
+    gateway =
+        new Gateway(configuration.getGateway(), brokerClientFactory, startContext.getScheduler());
     startContext.run(this::startGateway);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
@@ -238,11 +238,6 @@ public class JobState {
         }));
   }
 
-  public void forEachActivatableJobEntry(Consumer<DirectBuffer> callback) {
-    activatableColumnFamily.forEach(
-        (compositeKey, zbNil) -> callback.accept(compositeKey.getFirst().getBuffer()));
-  }
-
   boolean visitJob(
       long jobKey, BiFunction<Long, JobRecord, Boolean> callback, Runnable cleanupRunnable) {
     final JobRecord job = getJob(jobKey);

--- a/gateway/src/main/java/io/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/zeebe/gateway/Gateway.java
@@ -16,6 +16,8 @@ import io.zeebe.gateway.impl.broker.BrokerClient;
 import io.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.zeebe.gateway.impl.configuration.SecurityCfg;
+import io.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
+import io.zeebe.util.sched.ActorScheduler;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -41,28 +43,36 @@ public class Gateway {
   private final Function<GatewayCfg, ServerBuilder> serverBuilderFactory;
   private final Function<GatewayCfg, BrokerClient> brokerClientFactory;
   private final GatewayCfg gatewayCfg;
+  private final ActorScheduler actorScheduler;
 
   private Server server;
   private BrokerClient brokerClient;
 
-  public Gateway(GatewayCfg gatewayCfg, AtomixCluster atomixCluster) {
+  public Gateway(
+      GatewayCfg gatewayCfg, AtomixCluster atomixCluster, ActorScheduler actorScheduler) {
     this(
         gatewayCfg,
         cfg -> new BrokerClientImpl(cfg, atomixCluster),
-        DEFAULT_SERVER_BUILDER_FACTORY);
-  }
-
-  public Gateway(GatewayCfg gatewayCfg, Function<GatewayCfg, BrokerClient> brokerClientFactory) {
-    this(gatewayCfg, brokerClientFactory, DEFAULT_SERVER_BUILDER_FACTORY);
+        DEFAULT_SERVER_BUILDER_FACTORY,
+        actorScheduler);
   }
 
   public Gateway(
       GatewayCfg gatewayCfg,
       Function<GatewayCfg, BrokerClient> brokerClientFactory,
-      Function<GatewayCfg, ServerBuilder> serverBuilderFactory) {
+      ActorScheduler actorScheduler) {
+    this(gatewayCfg, brokerClientFactory, DEFAULT_SERVER_BUILDER_FACTORY, actorScheduler);
+  }
+
+  public Gateway(
+      GatewayCfg gatewayCfg,
+      Function<GatewayCfg, BrokerClient> brokerClientFactory,
+      Function<GatewayCfg, ServerBuilder> serverBuilderFactory,
+      ActorScheduler actorScheduler) {
     this.gatewayCfg = gatewayCfg;
     this.brokerClientFactory = brokerClientFactory;
     this.serverBuilderFactory = serverBuilderFactory;
+    this.actorScheduler = actorScheduler;
   }
 
   public GatewayCfg getGatewayCfg() {
@@ -79,7 +89,11 @@ public class Gateway {
 
     brokerClient = buildBrokerClient();
 
-    final EndpointManager endpointManager = new EndpointManager(brokerClient);
+    final LongPollingActivateJobsHandler longPollingHandler =
+        new LongPollingActivateJobsHandler(brokerClient);
+    actorScheduler.submitActor(longPollingHandler);
+
+    final EndpointManager endpointManager = new EndpointManager(brokerClient, longPollingHandler);
 
     final ServerBuilder serverBuilder = serverBuilderFactory.apply(gatewayCfg);
 

--- a/gateway/src/main/java/io/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/zeebe/gateway/Gateway.java
@@ -161,7 +161,7 @@ public class Gateway {
 
   public void stop() {
     if (server != null && !server.isShutdown()) {
-      server.shutdown();
+      server.shutdownNow();
       try {
         server.awaitTermination();
       } catch (InterruptedException e) {

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClient.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClient.java
@@ -25,4 +25,6 @@ public interface BrokerClient extends AutoCloseable {
       Consumer<Throwable> throwableConsumer);
 
   BrokerTopologyManager getTopologyManager();
+
+  void subscribeJobAvailableNotification(String topic, Consumer<String> handler);
 }

--- a/gateway/src/main/java/io/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.impl.job;
+
+import io.grpc.stub.StreamObserver;
+import io.zeebe.gateway.Loggers;
+import io.zeebe.gateway.impl.broker.BrokerClient;
+import io.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.ScheduledTimer;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import org.slf4j.Logger;
+
+public class LongPollingActivateJobsHandler extends Actor {
+
+  public static final Duration DEFAULT_LONG_POLLING_TIMEOUT = Duration.ofSeconds(10);
+  private static final String JOBS_AVAILABLE_TOPIC = "jobsAvailable";
+  private static final int NO_JOBS_RESPONSE_THRESHOLD = 3;
+  private static final Logger LOG = Loggers.GATEWAY_LOGGER;
+
+  private final ActivateJobsHandler activateJobsHandler;
+  private final BrokerClient brokerClient;
+  private final Map<String, Integer> zeroResponses = new HashMap<>();
+  private final Map<String, Queue<LongPollingActivateJobsRequest>> blockedRequests =
+      new HashMap<>();
+
+  public LongPollingActivateJobsHandler(BrokerClient brokerClient) {
+    this.brokerClient = brokerClient;
+    this.activateJobsHandler = new ActivateJobsHandler(brokerClient);
+  }
+
+  public void activateJobs(
+      ActivateJobsRequest request, StreamObserver<ActivateJobsResponse> responseObserver) {
+    final LongPollingActivateJobsRequest longPollingRequest =
+        new LongPollingActivateJobsRequest(request, responseObserver);
+    activateJobs(longPollingRequest);
+  }
+
+  public void activateJobs(LongPollingActivateJobsRequest request) {
+    actor.run(
+        () -> {
+          if (isJobAvailable(request.getType())) {
+            final BrokerClusterState topology = brokerClient.getTopologyManager().getTopology();
+            if (topology != null) {
+              final int partitionsCount = topology.getPartitionsCount();
+              activateJobsHandler.activateJobs(
+                  partitionsCount,
+                  request.getRequest(),
+                  request.getMaxJobsToActivate(),
+                  request.getType(),
+                  response -> onResponse(request, response),
+                  remainingAmount -> onCompleted(request, remainingAmount));
+            }
+          } else {
+            block(request);
+          }
+        });
+  }
+
+  @Override
+  protected void onActorStarting() {
+    brokerClient.subscribeJobAvailableNotification(JOBS_AVAILABLE_TOPIC, this::onNotification);
+  }
+
+  private void onNotification(String jobType) {
+    LOG.trace("Received jobs available notification for type {}.", jobType);
+    actor.call(() -> jobsAvailable(jobType));
+  }
+
+  private void onCompleted(LongPollingActivateJobsRequest request, Integer remainingAmount) {
+    if (remainingAmount == request.getMaxJobsToActivate()) {
+      actor.submit(() -> jobsNotAvailable(request));
+    } else {
+      actor.submit(() -> request.complete());
+    }
+  }
+
+  private void onResponse(
+      LongPollingActivateJobsRequest request, ActivateJobsResponse activateJobsResponse) {
+    actor.submit(
+        () -> {
+          request.onResponse(activateJobsResponse);
+          jobsAvailable(request.getType());
+        });
+  }
+
+  private void jobsNotAvailable(LongPollingActivateJobsRequest request) {
+    zeroResponses.compute(request.getType(), (t, count) -> count == null ? 1 : count + 1);
+    block(request);
+  }
+
+  private void jobsAvailable(String jobType) {
+    zeroResponses.remove(jobType);
+    unblock(jobType);
+  }
+
+  private void unblock(String jobType) {
+    final Queue<LongPollingActivateJobsRequest> requests = blockedRequests.remove(jobType);
+    if (requests == null) {
+      return;
+    }
+    requests.forEach(
+        request -> {
+          LOG.trace("Unblocking ActivateJobsRequest {}", request.getRequest());
+          activateJobs(request);
+        });
+  }
+
+  private boolean isJobAvailable(String jobType) {
+    final Integer notAvailableResponses = zeroResponses.get(jobType);
+    return notAvailableResponses == null || notAvailableResponses < NO_JOBS_RESPONSE_THRESHOLD;
+  }
+
+  private void block(LongPollingActivateJobsRequest request) {
+    if (!request.isTimedOut()) {
+      LOG.trace(
+          "Jobs of type {} not available. Blocking request {}",
+          request.getType(),
+          request.getRequest());
+      blockedRequests.computeIfAbsent(request.getType(), t -> new LinkedList<>()).offer(request);
+      if (!request.hasScheduledTimer()) {
+        addTimeOut(request);
+      }
+    }
+  }
+
+  private void addTimeOut(LongPollingActivateJobsRequest request) {
+    final ScheduledTimer timeout =
+        actor.runDelayed(
+            DEFAULT_LONG_POLLING_TIMEOUT,
+            () -> {
+              try {
+                final Queue<LongPollingActivateJobsRequest> requests =
+                    blockedRequests.get(request.getType());
+                if (requests != null) {
+                  requests.remove(request);
+                }
+                request.timeout();
+              } catch (Exception e) {
+                e.printStackTrace();
+              }
+            });
+    request.setScheduledTimer(timeout);
+  }
+}

--- a/gateway/src/main/java/io/zeebe/gateway/impl/job/LongPollingActivateJobsRequest.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/job/LongPollingActivateJobsRequest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.impl.job;
+
+import io.grpc.stub.StreamObserver;
+import io.zeebe.gateway.RequestMapper;
+import io.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import io.zeebe.util.sched.ScheduledTimer;
+
+public class LongPollingActivateJobsRequest {
+  private final BrokerActivateJobsRequest request;
+  private final StreamObserver<ActivateJobsResponse> responseObserver;
+  private final String jobType;
+  private final int maxJobsToActivate;
+
+  private ScheduledTimer scheduledTimer;
+  private boolean isTimedOut;
+  private boolean isCompleted;
+
+  public LongPollingActivateJobsRequest(
+      ActivateJobsRequest request, StreamObserver<ActivateJobsResponse> responseObserver) {
+    this(
+        RequestMapper.toActivateJobsRequest(request),
+        responseObserver,
+        request.getType(),
+        request.getMaxJobsToActivate());
+  }
+
+  private LongPollingActivateJobsRequest(
+      BrokerActivateJobsRequest request,
+      StreamObserver<ActivateJobsResponse> responseObserver,
+      String jobType,
+      int maxJobstoActivate) {
+    this.request = request;
+    this.responseObserver = responseObserver;
+    this.jobType = jobType;
+    this.maxJobsToActivate = maxJobstoActivate;
+  }
+
+  public void complete() {
+    if (isCompleted()) {
+      return;
+    }
+    if (scheduledTimer != null) {
+      scheduledTimer.cancel();
+    }
+    responseObserver.onCompleted();
+    this.isCompleted = true;
+  }
+
+  public boolean isCompleted() {
+    return this.isCompleted;
+  }
+
+  public void onResponse(ActivateJobsResponse grpcResponse) {
+    if (!isCompleted) {
+      responseObserver.onNext(grpcResponse);
+    }
+  }
+
+  public void timeout() {
+    complete();
+    this.isTimedOut = true;
+  }
+
+  public BrokerActivateJobsRequest getRequest() {
+    return request;
+  }
+
+  public StreamObserver<ActivateJobsResponse> getResponseObserver() {
+    return responseObserver;
+  }
+
+  public String getType() {
+    return jobType;
+  }
+
+  public int getMaxJobsToActivate() {
+    return maxJobsToActivate;
+  }
+
+  public void setScheduledTimer(ScheduledTimer scheduledTimer) {
+    this.scheduledTimer = scheduledTimer;
+  }
+
+  public boolean hasScheduledTimer() {
+    return scheduledTimer != null;
+  }
+
+  public boolean isTimedOut() {
+    return isTimedOut;
+  }
+}

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/ActivateJobsTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/ActivateJobsTest.java
@@ -48,6 +48,8 @@ public class ActivateJobsTest extends GatewayTest {
             .addAllFetchVariable(fetchVariables)
             .build();
 
+    stub.addAvailableJobs(jobType, maxJobsToActivate);
+
     // when
     final Iterator<ActivateJobsResponse> responses = client.activateJobs(request);
 
@@ -93,10 +95,16 @@ public class ActivateJobsTest extends GatewayTest {
     final ActivateJobsStub stub = new ActivateJobsStub();
     stub.registerWith(gateway);
 
+    final String type = "test";
+    final int maxJobsToActivate = 2;
     final ActivateJobsRequest request =
-        ActivateJobsRequest.newBuilder().setType("test").setMaxJobsToActivate(2).build();
+        ActivateJobsRequest.newBuilder()
+            .setType(type)
+            .setMaxJobsToActivate(maxJobsToActivate)
+            .build();
 
     for (int partitionOffset = 0; partitionOffset < 3; partitionOffset++) {
+      stub.addAvailableJobs(type, maxJobsToActivate);
       // when
       final Iterator<ActivateJobsResponse> responses = client.activateJobs(request);
 

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.api.job;
+
+import static io.zeebe.test.util.TestUtil.waitUntil;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.grpc.stub.StreamObserver;
+import io.zeebe.gateway.api.util.GatewayTest;
+import io.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
+import io.zeebe.gateway.impl.job.LongPollingActivateJobsRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import java.util.stream.IntStream;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LongPollingActivateJobsTest extends GatewayTest {
+
+  private static final String TYPE = "test";
+  private LongPollingActivateJobsHandler handler;
+  private ActivateJobsStub stub;
+  private int partitionsCount;
+
+  @Before
+  public void setup() {
+    handler = new LongPollingActivateJobsHandler(brokerClient);
+    actorSchedulerRule.submitActor(handler);
+    stub = spy(new ActivateJobsStub());
+    stub.registerWith(gateway);
+    partitionsCount = brokerClient.getTopologyManager().getTopology().getPartitionsCount();
+  }
+
+  @Test
+  public void shouldBlockRequestsWhenResponseHasNoJobs() {
+    // given
+    final LongPollingActivateJobsRequest request = getLongPollingActivateJobsRequest();
+    stub.addAvailableJobs(TYPE, 0);
+
+    // when
+    handler.activateJobs(request);
+
+    // then
+    waitUntil(() -> request.hasScheduledTimer());
+    verify(request.getResponseObserver(), times(0)).onCompleted();
+  }
+
+  @Test
+  public void shouldUnblockRequestWhenJobsAvailable() {
+    // given
+    final LongPollingActivateJobsRequest request = getLongPollingActivateJobsRequest();
+    final StreamObserver<ActivateJobsResponse> responseSpy = request.getResponseObserver();
+    stub.addAvailableJobs(TYPE, 0);
+
+    handler.activateJobs(request);
+
+    // when
+    waitUntil(() -> request.hasScheduledTimer());
+    stub.addAvailableJobs(TYPE, 1);
+    verify(responseSpy, times(0)).onCompleted();
+    gateway.notifyJobsAvailable(TYPE);
+
+    // then
+    verify(responseSpy, timeout(1000).times(1)).onNext(any());
+    verify(responseSpy, times(1)).onCompleted();
+  }
+
+  @Test
+  public void shouldBlockOnlyAfterForwardingUntilThreshold() throws Exception {
+    // when
+    final int threshold = 3;
+    IntStream.range(0, threshold)
+        .forEach(
+            i -> {
+              final LongPollingActivateJobsRequest request = getLongPollingActivateJobsRequest();
+              handler.activateJobs(request);
+              waitUntil(() -> request.hasScheduledTimer());
+            });
+
+    // then
+    verify(stub, times(threshold * partitionsCount)).handle(any());
+  }
+
+  @Test
+  public void shouldBlockImmediatelyAfterThreshold() throws Exception {
+    // given
+    final int threshold = 3;
+    IntStream.range(0, threshold)
+        .forEach(
+            i -> {
+              final LongPollingActivateJobsRequest request = getLongPollingActivateJobsRequest();
+              handler.activateJobs(request);
+              waitUntil(() -> request.hasScheduledTimer());
+            });
+
+    // when
+    final LongPollingActivateJobsRequest request = getLongPollingActivateJobsRequest();
+    handler.activateJobs(request);
+    waitUntil(() -> request.hasScheduledTimer());
+
+    // then
+    verify(stub, times(threshold * partitionsCount)).handle(any());
+  }
+
+  @Test
+  public void shouldUnblockAllRequestsWhenJobsAvailable() throws Exception {
+    // given
+    final int numRequests = 3;
+    IntStream.range(0, numRequests)
+        .forEach(
+            i -> {
+              final LongPollingActivateJobsRequest request = getLongPollingActivateJobsRequest();
+              handler.activateJobs(request);
+              waitUntil(() -> request.hasScheduledTimer());
+            });
+
+    verify(stub, times(numRequests * partitionsCount)).handle(any());
+
+    // when
+    stub.addAvailableJobs(TYPE, 1);
+    gateway.notifyJobsAvailable(TYPE);
+
+    // then
+    verify(stub, timeout(1000).times(2 * numRequests * partitionsCount)).handle(any());
+  }
+
+  @Test
+  public void shouldUnblockAfterRequestTimeout() {
+    // given
+
+    final LongPollingActivateJobsRequest longPollingRequest = getLongPollingActivateJobsRequest();
+    stub.addAvailableJobs(TYPE, 0);
+
+    // when
+    handler.activateJobs(longPollingRequest);
+    waitUntil(() -> longPollingRequest.hasScheduledTimer());
+    actorClock.addTime(LongPollingActivateJobsHandler.DEFAULT_LONG_POLLING_TIMEOUT);
+    waitUntil(() -> longPollingRequest.isTimedOut(), 200);
+
+    // then
+    verify(longPollingRequest.getResponseObserver(), times(1)).onCompleted();
+  }
+
+  @Test
+  public void shouldCompleteFollowingRequestsAfterTimeout() {
+
+    final LongPollingActivateJobsRequest timeoutRequest1 = getLongPollingActivateJobsRequest();
+    handler.activateJobs(timeoutRequest1);
+    final LongPollingActivateJobsRequest timeoutRequest2 = getLongPollingActivateJobsRequest();
+    handler.activateJobs(timeoutRequest2);
+    final LongPollingActivateJobsRequest timeoutRequest3 = getLongPollingActivateJobsRequest();
+    handler.activateJobs(timeoutRequest3);
+    waitUntil(() -> timeoutRequest3.hasScheduledTimer());
+    actorClock.addTime(LongPollingActivateJobsHandler.DEFAULT_LONG_POLLING_TIMEOUT);
+    waitUntil(() -> timeoutRequest1.isTimedOut(), 200);
+    waitUntil(() -> timeoutRequest2.isTimedOut(), 200);
+    waitUntil(() -> timeoutRequest3.isTimedOut(), 200);
+
+    // when
+    final LongPollingActivateJobsRequest successRequest = getLongPollingActivateJobsRequest();
+    stub.addAvailableJobs(TYPE, 1);
+    gateway.notifyJobsAvailable(TYPE);
+    handler.activateJobs(successRequest);
+
+    // then
+    verify(successRequest.getResponseObserver(), timeout(1000).times(1)).onNext(any());
+    verify(successRequest.getResponseObserver(), times(1)).onCompleted();
+  }
+
+  private LongPollingActivateJobsRequest getLongPollingActivateJobsRequest() {
+    final int maxJobsToActivate = 2;
+    final ActivateJobsRequest request =
+        ActivateJobsRequest.newBuilder()
+            .setType(TYPE)
+            .setMaxJobsToActivate(maxJobsToActivate)
+            .build();
+    final StreamObserver responseSpy = spy(StreamObserver.class);
+
+    return new LongPollingActivateJobsRequest(request, responseSpy);
+  }
+}

--- a/gateway/src/test/java/io/zeebe/gateway/api/util/GatewayTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/util/GatewayTest.java
@@ -9,22 +9,26 @@ package io.zeebe.gateway.api.util;
 
 import io.zeebe.gateway.impl.broker.BrokerClient;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
-import java.io.IOException;
+import io.zeebe.util.sched.clock.ControlledActorClock;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.rules.RuleChain;
 
 public class GatewayTest {
 
-  @Rule public StubbedGatewayRule gatewayRule = new StubbedGatewayRule();
-
+  protected ControlledActorClock actorClock = new ControlledActorClock();
+  public ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule(actorClock);
+  public StubbedGatewayRule gatewayRule = new StubbedGatewayRule(actorSchedulerRule);
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(actorSchedulerRule).around(gatewayRule);
   protected StubbedGateway gateway;
   protected GatewayBlockingStub client;
   protected BrokerClient brokerClient;
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() {
     gateway = gatewayRule.getGateway();
     client = gatewayRule.getClient();
-    brokerClient = gateway.buildBrokerClient();
+    brokerClient = gateway.getBrokerClient();
   }
 }

--- a/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedGatewayRule.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedGatewayRule.java
@@ -8,16 +8,22 @@
 package io.zeebe.gateway.api.util;
 
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import org.junit.rules.ExternalResource;
 
 public class StubbedGatewayRule extends ExternalResource {
 
+  private final ActorSchedulerRule actorSchedulerRule;
   protected StubbedGateway gateway;
   protected GatewayBlockingStub client;
 
+  public StubbedGatewayRule(ActorSchedulerRule actorSchedulerRule) {
+    this.actorSchedulerRule = actorSchedulerRule;
+  }
+
   @Override
   protected void before() throws Throwable {
-    gateway = new StubbedGateway();
+    gateway = new StubbedGateway(actorSchedulerRule.get());
     gateway.start();
     client = gateway.buildClient();
   }

--- a/gateway/src/test/java/io/zeebe/gateway/security/SecurityTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/security/SecurityTest.java
@@ -12,6 +12,7 @@ import io.zeebe.gateway.Gateway;
 import io.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.zeebe.gateway.impl.configuration.SecurityCfg;
+import io.zeebe.util.sched.ActorScheduler;
 import java.io.IOException;
 import org.junit.After;
 import org.junit.Rule;
@@ -46,7 +47,9 @@ public class SecurityTest {
             cfg.getSecurity().getCertificateChainPath()));
 
     // when
-    gateway = new Gateway(cfg, AtomixCluster.builder().build());
+    gateway =
+        new Gateway(
+            cfg, AtomixCluster.builder().build(), ActorScheduler.newActorScheduler().build());
     gateway.start();
   }
 
@@ -66,7 +69,9 @@ public class SecurityTest {
             cfg.getSecurity().getPrivateKeyPath()));
 
     // when
-    gateway = new Gateway(cfg, AtomixCluster.builder().build());
+    gateway =
+        new Gateway(
+            cfg, AtomixCluster.builder().build(), ActorScheduler.newActorScheduler().build());
     gateway.start();
   }
 
@@ -83,7 +88,9 @@ public class SecurityTest {
             + "Edit the gateway configuration file to provide one or to disable TLS.");
 
     // when
-    gateway = new Gateway(cfg, AtomixCluster.builder().build());
+    gateway =
+        new Gateway(
+            cfg, AtomixCluster.builder().build(), ActorScheduler.newActorScheduler().build());
     gateway.start();
   }
 
@@ -100,7 +107,9 @@ public class SecurityTest {
             + "Edit the gateway configuration file to provide one or to disable TLS.");
 
     // when
-    gateway = new Gateway(cfg, AtomixCluster.builder().build());
+    gateway =
+        new Gateway(
+            cfg, AtomixCluster.builder().build(), ActorScheduler.newActorScheduler().build());
     gateway.start();
   }
 


### PR DESCRIPTION
## Description
Implemented support for long polling in the gateway. Gateway can now block activate jobs requests if no jobs are available. Requests will be blocked until a job is available to activate or until a default timeout. (Timeout will be configurable per request in another issue).  

## Related issues

closes #2825 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
