### PR TITLE
feat(clients/java): support credentials in Java client

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -121,6 +121,14 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/clients/java/src/main/java/io/zeebe/client/CredentialsProvider.java
+++ b/clients/java/src/main/java/io/zeebe/client/CredentialsProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client;
+
+import io.grpc.Metadata;
+import io.zeebe.client.impl.ZeebeClientCredentialsProvider;
+
+public interface CredentialsProvider {
+
+  /**
+   * Adds credentials to the headers. For an example of this, see {@link
+   * ZeebeClientCredentialsProvider#applyCredentials(Metadata)}
+   *
+   * @param headers gRPC headers to be modified
+   */
+  void applyCredentials(Metadata headers);
+}

--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
@@ -77,6 +77,12 @@ public interface ZeebeClientBuilder {
    */
   ZeebeClientBuilder caCertificatePath(String certificatePath);
 
+  /**
+   * A custom {@link CredentialsProvider} which will be used to apply authentication credentials to
+   * requests.
+   */
+  ZeebeClientBuilder credentialsProvider(CredentialsProvider credentialsProvider);
+
   /** @return a new {@link ZeebeClient} with the provided configuration options. */
   ZeebeClient build();
 }

--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientConfiguration.java
@@ -47,4 +47,7 @@ public interface ZeebeClientConfiguration {
 
   /** @see ZeebeClientBuilder#caCertificatePath(String) */
   String getCaCertificatePath();
+
+  /** @see ZeebeClientBuilder#credentialsProvider(CredentialsProvider) */
+  CredentialsProvider getCredentialsProvider();
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeCallCredentials.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeCallCredentials.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl;
+
+import io.grpc.Metadata;
+import io.grpc.SecurityLevel;
+import io.zeebe.client.CredentialsProvider;
+import io.zeebe.util.ZbLogger;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+
+public class ZeebeCallCredentials extends io.grpc.CallCredentials {
+  private static final Logger LOG = new ZbLogger(ZeebeCallCredentials.class);
+
+  private final CredentialsProvider credentialsProvider;
+
+  ZeebeCallCredentials(final CredentialsProvider credentialsProvider) {
+    this.credentialsProvider = credentialsProvider;
+  }
+
+  @Override
+  public void applyRequestMetadata(
+      final RequestInfo requestInfo, final Executor appExecutor, final MetadataApplier applier) {
+
+    if (requestInfo.getSecurityLevel().ordinal() < SecurityLevel.PRIVACY_AND_INTEGRITY.ordinal()) {
+      LOG.warn(
+          "The request's security level does not guarantee that the credentials will be confidential.");
+    }
+
+    final Metadata headers = new Metadata();
+    credentialsProvider.applyCredentials(headers);
+    applier.apply(headers);
+  }
+
+  @Override
+  public void thisUsesUnstableApi() {}
+}

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientAuthInfo.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientAuthInfo.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ZeebeClientAuthInfo {
+
+  @JsonProperty("credentials")
+  private ZeebeClientCredentials credentials;
+
+  public ZeebeClientCredentials getCredentials() {
+    return credentials;
+  }
+}

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -21,6 +21,7 @@ import static io.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
 import static io.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 
 import io.zeebe.client.ClientProperties;
+import io.zeebe.client.CredentialsProvider;
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.ZeebeClientConfiguration;
@@ -39,6 +40,7 @@ public class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientCo
   private Duration defaultRequestTimeout = Duration.ofSeconds(20);
   private boolean usePlaintextConnection = false;
   private String certificatePath;
+  private CredentialsProvider credentialsProvider;
 
   @Override
   public String getBrokerContactPoint() {
@@ -88,6 +90,11 @@ public class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientCo
   @Override
   public String getCaCertificatePath() {
     return certificatePath;
+  }
+
+  @Override
+  public CredentialsProvider getCredentialsProvider() {
+    return credentialsProvider;
   }
 
   @Override
@@ -193,6 +200,12 @@ public class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientCo
   @Override
   public ZeebeClientBuilder caCertificatePath(final String certificatePath) {
     this.certificatePath = certificatePath;
+    return this;
+  }
+
+  @Override
+  public ZeebeClientBuilder credentialsProvider(CredentialsProvider credentialsProvider) {
+    this.credentialsProvider = credentialsProvider;
     return this;
   }
 

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientCredentials.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientCredentials.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ZeebeClientCredentials {
+
+  @JsonProperty("access_token")
+  private String accessToken;
+
+  @JsonProperty("expires_in")
+  private String expiresIn;
+
+  @JsonProperty("token_type")
+  private String tokenType;
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  public String getTokenType() {
+    return tokenType;
+  }
+}

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientCredentialsProvider.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientCredentialsProvider.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.zeebe.client.CredentialsProvider;
+import java.io.File;
+import java.io.IOException;
+
+public class ZeebeClientCredentialsProvider implements CredentialsProvider {
+
+  public static final String INVALID_PATH_ERROR_MSG =
+      "Expected valid path to Zeebe credentials but '%s' is either invalid or does not point to a file.";
+  private static final TypeReference<ZeebeClientAuthInfo> TYPE_REF =
+      new TypeReference<ZeebeClientAuthInfo>() {};
+  private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
+  private static final Key<String> HEADER_AUTH_KEY =
+      Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+  private final String zeebeCredentialsPath;
+
+  public ZeebeClientCredentialsProvider(String zeebeCredentialsPath) {
+    if (!isValidCredentialsPath(zeebeCredentialsPath)) {
+      throw new IllegalArgumentException(
+          String.format(INVALID_PATH_ERROR_MSG, zeebeCredentialsPath));
+    }
+
+    this.zeebeCredentialsPath = zeebeCredentialsPath;
+  }
+
+  private boolean isValidCredentialsPath(String zeebeCredentialsPath) {
+    if (zeebeCredentialsPath == null || zeebeCredentialsPath.isEmpty()) {
+      return false;
+    }
+
+    final File credentialsFile = new File(zeebeCredentialsPath);
+    return credentialsFile.exists();
+  }
+
+  /**
+   * Adds a JSON Web Token (JWT) to the Authorization header of a gRPC call. The JWT is obtained
+   * from a provided Zeebe credentials YAML file.
+   */
+  @Override
+  public void applyCredentials(Metadata headers) {
+    try {
+      final ZeebeClientCredentials credentials = getAccessCredentials();
+
+      headers.put(
+          HEADER_AUTH_KEY,
+          String.format(
+              "%s %s", credentials.getTokenType().trim(), credentials.getAccessToken().trim()));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private ZeebeClientCredentials getAccessCredentials() throws IOException {
+    JsonNode node = MAPPER.readTree(new File(zeebeCredentialsPath));
+
+    // NOTE: currently the token structure doesn't have other fields but when it does this could be
+    // improved
+    node = node.get("endpoint").get("auth");
+    final ZeebeClientAuthInfo clientAuthInfo = MAPPER.readValue(node.traverse(), TYPE_REF);
+
+    return clientAuthInfo.getCredentials();
+  }
+}

--- a/clients/java/src/test/java/io/zeebe/client/CredentialsTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/CredentialsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.ServerInterceptors;
+import io.grpc.testing.GrpcServerRule;
+import io.zeebe.client.impl.ZeebeClientBuilderImpl;
+import io.zeebe.client.impl.ZeebeClientImpl;
+import io.zeebe.client.util.RecordingGatewayService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CredentialsTest {
+  @Rule public final GrpcServerRule serverRule = new GrpcServerRule();
+
+  private final RecordingInterceptor recordingInterceptor = new RecordingInterceptor();
+  private final RecordingGatewayService gatewayService = new RecordingGatewayService();
+  private ZeebeClient client;
+
+  @Before
+  public void setUp() {
+    serverRule
+        .getServiceRegistry()
+        .addService(ServerInterceptors.intercept(gatewayService, recordingInterceptor));
+  }
+
+  @After
+  public void tearDown() {
+    if (client != null) {
+      client.close();
+      client = null;
+    }
+
+    recordingInterceptor.reset();
+  }
+
+  @Test
+  public void shouldModifyCallMetadata() {
+    // given
+    final Key<String> key = Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+    final String bearerToken = "Bearer someToken";
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+
+    builder.usePlaintext().credentialsProvider(headers -> headers.put(key, bearerToken));
+    client = new ZeebeClientImpl(builder, serverRule.getChannel());
+
+    // when
+    client.newTopologyRequest().send().join();
+
+    // then
+    assertThat(recordingInterceptor.getCapturedHeaders().get(key)).isEqualTo(bearerToken);
+  }
+}

--- a/clients/java/src/test/java/io/zeebe/client/RecordingInterceptor.java
+++ b/clients/java/src/test/java/io/zeebe/client/RecordingInterceptor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+public class RecordingInterceptor implements ServerInterceptor {
+  private Metadata capturedHeaders;
+
+  @Override
+  public <ReqT, RespT> Listener<ReqT> interceptCall(
+      final ServerCall<ReqT, RespT> call,
+      final Metadata headers,
+      final ServerCallHandler<ReqT, RespT> next) {
+
+    capturedHeaders = headers;
+    return next.startCall(call, headers);
+  }
+
+  public Metadata getCapturedHeaders() {
+    return capturedHeaders;
+  }
+
+  public void reset() {
+    capturedHeaders = null;
+  }
+}

--- a/clients/java/src/test/java/io/zeebe/client/ZeebeClientCredentialsProviderTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/ZeebeClientCredentialsProviderTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client;
+
+import static io.zeebe.client.impl.ZeebeClientCredentialsProvider.INVALID_PATH_ERROR_MSG;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.ServerInterceptors;
+import io.grpc.testing.GrpcServerRule;
+import io.zeebe.client.impl.ZeebeClientBuilderImpl;
+import io.zeebe.client.impl.ZeebeClientCredentialsProvider;
+import io.zeebe.client.impl.ZeebeClientImpl;
+import io.zeebe.client.util.RecordingGatewayService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ZeebeClientCredentialsProviderTest {
+
+  @Rule public final GrpcServerRule serverRule = new GrpcServerRule();
+
+  private final RecordingInterceptor recordingInterceptor = new RecordingInterceptor();
+  private final RecordingGatewayService gatewayService = new RecordingGatewayService();
+  private ZeebeClient client;
+
+  @Before
+  public void setUp() {
+    serverRule
+        .getServiceRegistry()
+        .addService(ServerInterceptors.intercept(gatewayService, recordingInterceptor));
+  }
+
+  @After
+  public void tearDown() {
+    if (client != null) {
+      client.close();
+      client = null;
+    }
+  }
+
+  @Test
+  public void shouldModifyCallHeaders() {
+    // given
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+
+    builder
+        .usePlaintext()
+        .credentialsProvider(
+            new ZeebeClientCredentialsProvider(
+                this.getClass().getClassLoader().getResource("creds").getPath()));
+    client = new ZeebeClientImpl(builder, serverRule.getChannel());
+
+    // when
+    client.newTopologyRequest().send().join();
+
+    // then
+    final Key<String> key = Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+    assertThat(recordingInterceptor.getCapturedHeaders().get(key)).isEqualTo("Bearer someToken");
+  }
+
+  @Test
+  public void shouldFailWithNullPath() {
+    // when/then
+    assertThatThrownBy(() -> new ZeebeClientCredentialsProvider(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(INVALID_PATH_ERROR_MSG.replaceFirst("%s", "null"));
+  }
+
+  @Test
+  public void shouldFailWithEmptyPath() {
+    // when/then
+    assertThatThrownBy(() -> new ZeebeClientCredentialsProvider(""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageMatching(INVALID_PATH_ERROR_MSG.replaceFirst("%s", ""));
+  }
+
+  @Test
+  public void shouldFailWithNonExistingFile() {
+    // given
+    final String badCredentialsPath =
+        this.getClass().getClassLoader().getResource("creds").getPath() + "_fail";
+
+    // when/then
+    assertThatThrownBy(() -> new ZeebeClientCredentialsProvider(badCredentialsPath))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageMatching(INVALID_PATH_ERROR_MSG.replaceFirst("%s", badCredentialsPath));
+  }
+}

--- a/clients/java/src/test/java/io/zeebe/client/util/TestEnvironmentRule.java
+++ b/clients/java/src/test/java/io/zeebe/client/util/TestEnvironmentRule.java
@@ -63,7 +63,7 @@ public class TestEnvironmentRule extends ExternalResource {
     final ManagedChannel channel = serverRule.getChannel();
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
     clientConfigurator.accept(builder);
-    gatewayStub = spy(ZeebeClientImpl.buildGatewayStub(channel));
+    gatewayStub = spy(ZeebeClientImpl.buildGatewayStub(channel, builder));
     client = new ZeebeClientImpl(builder, channel, gatewayStub);
   }
 

--- a/clients/java/src/test/resources/creds
+++ b/clients/java/src/test/resources/creds
@@ -1,0 +1,5 @@
+endpoint:
+  auth:
+    credentials:
+      access_token: someToken
+      token_type: Bearer


### PR DESCRIPTION
## Description
Allows the user to specify a CredentialsProvider which in turn can modify request headers to contain a token. There's a default BearerTokenCredentialsProvider which takes a path to a yaml file with the following spec:
```
endpoint:
  auth:
    credentials:
      access_token: <JWT>
      expires_in: YY-MM-DDTHH-mm-ssZ,
      token_type: Bearer
```

Currently the expiration date isn't being used to preemptively refresh as this PR doesn't deal with the refresh after rejection situation either.  

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2839 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
