### PR TITLE
feat(broker): distinguish multi-instance body records

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/multiinstance/MultiInstanceBodyActivatedHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/multiinstance/MultiInstanceBodyActivatedHandler.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.processor.workflow.handlers.multiinstance;
 import io.zeebe.engine.processor.workflow.BpmnStepContext;
 import io.zeebe.engine.processor.workflow.BpmnStepHandler;
 import io.zeebe.engine.processor.workflow.deployment.model.BpmnStep;
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableActivity;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableMultiInstanceBody;
 import io.zeebe.engine.state.instance.VariablesState;
 import io.zeebe.msgpack.query.MsgPackQueryProcessor;
@@ -43,10 +44,13 @@ public class MultiInstanceBodyActivatedHandler extends AbstractMultiInstanceBody
     final WorkflowInstanceRecord instanceRecord = context.getValue();
     instanceRecord.setFlowScopeKey(context.getKey());
 
+    final ExecutableActivity innerActivity = context.getElement().getInnerActivity();
+
     final long elementInstanceKey =
         context
             .getOutput()
-            .appendNewEvent(WorkflowInstanceIntent.ELEMENT_ACTIVATING, instanceRecord);
+            .appendNewEvent(
+                WorkflowInstanceIntent.ELEMENT_ACTIVATING, instanceRecord, innerActivity);
 
     // need to spawn token for child instance
     context.getElementInstanceState().spawnToken(context.getKey());

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/multiinstance/MultiInstanceActivityTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/multiinstance/MultiInstanceActivityTest.java
@@ -133,7 +133,7 @@ public class MultiInstanceActivityTest {
             .getFirst();
 
     Assertions.assertThat(multiInstanceBody.getValue())
-        .hasBpmnElementType(expectedElementType)
+        .hasBpmnElementType(BpmnElementType.MULTI_INSTANCE_BODY)
         .hasFlowScopeKey(workflowInstanceKey);
 
     assertThat(
@@ -189,12 +189,12 @@ public class MultiInstanceActivityTest {
                 .withWorkflowInstanceKey(workflowInstanceKey)
                 .withElementId(ELEMENT_ID)
                 .limit(4))
-        .extracting(Record::getIntent)
+        .extracting(r -> tuple(r.getIntent(), r.getValue().getBpmnElementType()))
         .containsExactly(
-            WorkflowInstanceIntent.ELEMENT_ACTIVATING,
-            WorkflowInstanceIntent.ELEMENT_ACTIVATED,
-            WorkflowInstanceIntent.ELEMENT_COMPLETING,
-            WorkflowInstanceIntent.ELEMENT_COMPLETED);
+            tuple(WorkflowInstanceIntent.ELEMENT_ACTIVATING, BpmnElementType.MULTI_INSTANCE_BODY),
+            tuple(WorkflowInstanceIntent.ELEMENT_ACTIVATED, BpmnElementType.MULTI_INSTANCE_BODY),
+            tuple(WorkflowInstanceIntent.ELEMENT_COMPLETING, BpmnElementType.MULTI_INSTANCE_BODY),
+            tuple(WorkflowInstanceIntent.ELEMENT_COMPLETED, BpmnElementType.MULTI_INSTANCE_BODY));
 
     assertThat(
             RecordingExporter.workflowInstanceRecords()
@@ -238,16 +238,40 @@ public class MultiInstanceActivityTest {
                 .withElementId(ELEMENT_ID)
                 .skipUntil(r -> r.getPosition() > innerInstances.get(2).getPosition())
                 .limit(elementInstanceCount * 2))
-        .extracting(r -> tuple(r.getKey(), r.getIntent()))
+        .extracting(r -> tuple(r.getKey(), r.getIntent(), r.getValue().getBpmnElementType()))
         .containsExactly(
-            tuple(multiInstanceBody.getKey(), WorkflowInstanceIntent.ELEMENT_TERMINATING),
-            tuple(innerInstances.get(0).getKey(), WorkflowInstanceIntent.ELEMENT_TERMINATING),
-            tuple(innerInstances.get(1).getKey(), WorkflowInstanceIntent.ELEMENT_TERMINATING),
-            tuple(innerInstances.get(2).getKey(), WorkflowInstanceIntent.ELEMENT_TERMINATING),
-            tuple(innerInstances.get(0).getKey(), WorkflowInstanceIntent.ELEMENT_TERMINATED),
-            tuple(innerInstances.get(1).getKey(), WorkflowInstanceIntent.ELEMENT_TERMINATED),
-            tuple(innerInstances.get(2).getKey(), WorkflowInstanceIntent.ELEMENT_TERMINATED),
-            tuple(multiInstanceBody.getKey(), WorkflowInstanceIntent.ELEMENT_TERMINATED));
+            tuple(
+                multiInstanceBody.getKey(),
+                WorkflowInstanceIntent.ELEMENT_TERMINATING,
+                BpmnElementType.MULTI_INSTANCE_BODY),
+            tuple(
+                innerInstances.get(0).getKey(),
+                WorkflowInstanceIntent.ELEMENT_TERMINATING,
+                expectedElementType),
+            tuple(
+                innerInstances.get(1).getKey(),
+                WorkflowInstanceIntent.ELEMENT_TERMINATING,
+                expectedElementType),
+            tuple(
+                innerInstances.get(2).getKey(),
+                WorkflowInstanceIntent.ELEMENT_TERMINATING,
+                expectedElementType),
+            tuple(
+                innerInstances.get(0).getKey(),
+                WorkflowInstanceIntent.ELEMENT_TERMINATED,
+                expectedElementType),
+            tuple(
+                innerInstances.get(1).getKey(),
+                WorkflowInstanceIntent.ELEMENT_TERMINATED,
+                expectedElementType),
+            tuple(
+                innerInstances.get(2).getKey(),
+                WorkflowInstanceIntent.ELEMENT_TERMINATED,
+                expectedElementType),
+            tuple(
+                multiInstanceBody.getKey(),
+                WorkflowInstanceIntent.ELEMENT_TERMINATED,
+                BpmnElementType.MULTI_INSTANCE_BODY));
 
     assertThat(
             RecordingExporter.workflowInstanceRecords()

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/multiinstance/MultiInstanceServiceTaskTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/multiinstance/MultiInstanceServiceTaskTest.java
@@ -17,6 +17,7 @@ import io.zeebe.model.bpmn.builder.MultiInstanceLoopCharacteristicsBuilder;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.protocol.record.value.JobRecordValue;
 import io.zeebe.test.util.record.RecordingExporter;
 import io.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -125,7 +126,13 @@ public class MultiInstanceServiceTaskTest {
                 .withWorkflowInstanceKey(workflowInstanceKey)
                 .limitToWorkflowInstanceCompleted()
                 .withElementId(ELEMENT_ID))
-        .hasSize(4);
+        .hasSize(4)
+        .extracting(r -> r.getValue().getBpmnElementType())
+        .containsExactly(
+            BpmnElementType.SERVICE_TASK,
+            BpmnElementType.SERVICE_TASK,
+            BpmnElementType.SERVICE_TASK,
+            BpmnElementType.MULTI_INSTANCE_BODY);
 
     assertThat(
             RecordingExporter.workflowInstanceRecords()

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/BpmnElementType.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/BpmnElementType.java
@@ -40,9 +40,10 @@ public enum BpmnElementType {
   EVENT_BASED_GATEWAY,
 
   // Other
-  SEQUENCE_FLOW;
+  SEQUENCE_FLOW,
+  MULTI_INSTANCE_BODY;
 
-  public static BpmnElementType bpmnElementTypeFor(String elementTypeName) {
+  public static BpmnElementType bpmnElementTypeFor(final String elementTypeName) {
     switch (elementTypeName) {
       case "process":
         return BpmnElementType.PROCESS;


### PR DESCRIPTION
## Description

* the multi-instance body has the BPMN element type `MULTI_INSTANCE_BODY`
* the inner instances have the BPMN element type of the element itself (e.g. `SERVICE_TASK`)

## Related issues

closes #2892 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
