### PR TITLE
chore(gateway): periodically probe broker for activatable jobs

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/zeebe/gateway/Gateway.java
@@ -90,7 +90,7 @@ public class Gateway {
     brokerClient = buildBrokerClient();
 
     final LongPollingActivateJobsHandler longPollingHandler =
-        new LongPollingActivateJobsHandler(brokerClient);
+        LongPollingActivateJobsHandler.newBuilder().setBrokerClient(brokerClient).build();
     actorScheduler.submitActor(longPollingHandler);
 
     final EndpointManager endpointManager = new EndpointManager(brokerClient, longPollingHandler);

--- a/gateway/src/main/java/io/zeebe/gateway/impl/job/JobTypeAvailabilityState.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/job/JobTypeAvailabilityState.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.impl.job;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class JobTypeAvailabilityState {
+
+  private final Queue<LongPollingActivateJobsRequest> blockedRequests = new LinkedList<>();
+  private int emptyResponses;
+  private long lastUpdatedTime;
+
+  public void incrementEmptyResponses(long lastUpdatedTime) {
+    emptyResponses++;
+    this.lastUpdatedTime = lastUpdatedTime;
+  }
+
+  public void resetEmptyResponses(int value) {
+    this.emptyResponses = value;
+  }
+
+  public int getEmptyResponses() {
+    return emptyResponses;
+  }
+
+  public long getLastUpdatedTime() {
+    return lastUpdatedTime;
+  }
+
+  public void blockRequest(LongPollingActivateJobsRequest request) {
+    blockedRequests.offer(request);
+  }
+
+  public void clearBlockedRequests() {
+    blockedRequests.clear();
+  }
+
+  public void removeBlockedRequest(LongPollingActivateJobsRequest request) {
+    blockedRequests.remove(request);
+  }
+
+  public LongPollingActivateJobsRequest pollBlockedRequests() {
+    return blockedRequests.poll();
+  }
+
+  public Queue<LongPollingActivateJobsRequest> getBlockedRequests() {
+    return blockedRequests;
+  }
+}


### PR DESCRIPTION
## Description
Gateway periodically probes the broker by unblocking one long polling activate jobs request to prevent requests from blocking for ever in case gateway lost notifications from the broker.

## Related issues
#2828 

closes #2826 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
