### PR TITLE
chore(broker-core): records are not copied for exporters

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -7,14 +7,13 @@
  */
 package io.zeebe.broker.exporter.stream;
 
-import static io.zeebe.engine.processor.TypedEventRegistry.EVENT_REGISTRY;
-
 import io.zeebe.broker.Loggers;
 import io.zeebe.broker.exporter.context.ExporterContext;
 import io.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.zeebe.db.ZeebeDb;
-import io.zeebe.engine.processor.CopiedRecords;
 import io.zeebe.engine.processor.EventFilter;
+import io.zeebe.engine.processor.RecordValues;
+import io.zeebe.engine.processor.TypedEventImpl;
 import io.zeebe.exporter.api.Exporter;
 import io.zeebe.exporter.api.context.Context;
 import io.zeebe.exporter.api.context.Controller;
@@ -22,7 +21,7 @@ import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.protocol.impl.record.RecordMetadata;
-import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.servicecontainer.Service;
@@ -306,25 +305,28 @@ public class ExporterDirector extends Actor implements Service<ExporterDirector>
 
   private static class RecordExporter {
 
+    private final RecordValues recordValues = new RecordValues();
     private final RecordMetadata rawMetadata = new RecordMetadata();
     private final List<ExporterContainer> containers;
-    private final int partitionId;
+    private final TypedEventImpl typedEvent;
 
-    private Record record;
     private boolean shouldExport;
     private int exporterIndex;
 
     RecordExporter(List<ExporterContainer> containers, int partitionId) {
       this.containers = containers;
-      this.partitionId = partitionId;
+      typedEvent = new TypedEventImpl(partitionId);
     }
 
     void wrap(LoggedEvent rawEvent) {
       rawEvent.readMetadata(rawMetadata);
 
-      shouldExport = EVENT_REGISTRY.containsKey(rawMetadata.getValueType());
+      final UnifiedRecordValue recordValue =
+          recordValues.readRecordValue(rawEvent, rawMetadata.getValueType());
+
+      shouldExport = recordValue != null;
       if (shouldExport) {
-        record = CopiedRecords.createCopiedRecord(partitionId, rawEvent);
+        typedEvent.wrap(rawEvent, rawMetadata, recordValue);
         exporterIndex = 0;
       }
     }
@@ -342,8 +344,9 @@ public class ExporterDirector extends Actor implements Service<ExporterDirector>
         final ExporterContainer container = containers.get(exporterIndex);
 
         try {
-          if (container.position < record.getPosition() && container.acceptRecord(rawMetadata)) {
-            container.exporter.export(record);
+          if (container.position < typedEvent.getPosition()
+              && container.acceptRecord(rawMetadata)) {
+            container.exporter.export(typedEvent);
           }
 
           exporterIndex++;
@@ -351,7 +354,7 @@ public class ExporterDirector extends Actor implements Service<ExporterDirector>
           container
               .context
               .getLogger()
-              .error("Error on exporting record with key {}", record.getKey(), ex);
+              .error("Error on exporting record with key {}", typedEvent.getKey(), ex);
           return false;
         }
       }

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/util/ControlledTestExporter.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/util/ControlledTestExporter.java
@@ -99,14 +99,15 @@ public class ControlledTestExporter implements Exporter {
 
   @Override
   public void export(final Record record) {
+    final Record copiedRecord = record.clone();
     if (onExport != null) {
-      onExport.accept(record);
+      onExport.accept(copiedRecord);
     }
 
-    exportedRecords.add(record);
+    exportedRecords.add(copiedRecord);
 
     if (shouldAutoUpdatePosition) {
-      getController().updateLastExportedRecordPosition(record.getPosition());
+      getController().updateLastExportedRecordPosition(copiedRecord.getPosition());
     }
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/ProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ProcessingContext.java
@@ -11,10 +11,7 @@ import io.zeebe.db.DbContext;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
-import io.zeebe.protocol.impl.record.UnifiedRecordValue;
-import io.zeebe.protocol.record.ValueType;
 import io.zeebe.util.sched.ActorControl;
-import java.util.Map;
 import java.util.function.BooleanSupplier;
 
 public class ProcessingContext implements ReadonlyProcessingContext {
@@ -26,7 +23,7 @@ public class ProcessingContext implements ReadonlyProcessingContext {
   private TypedStreamWriter logStreamWriter;
   private CommandResponseWriter commandResponseWriter;
 
-  private Map<ValueType, UnifiedRecordValue> eventCache;
+  private RecordValues recordValues;
   private RecordProcessorMap recordProcessorMap;
   private ZeebeState zeebeState;
   private DbContext dbContext;
@@ -53,8 +50,8 @@ public class ProcessingContext implements ReadonlyProcessingContext {
     return this;
   }
 
-  public ProcessingContext eventCache(Map<ValueType, UnifiedRecordValue> eventCache) {
-    this.eventCache = eventCache;
+  public ProcessingContext eventCache(RecordValues recordValues) {
+    this.recordValues = recordValues;
     return this;
   }
 
@@ -108,8 +105,8 @@ public class ProcessingContext implements ReadonlyProcessingContext {
     return logStreamWriter;
   }
 
-  public Map<ValueType, UnifiedRecordValue> getEventCache() {
-    return eventCache;
+  public RecordValues getRecordValues() {
+    return recordValues;
   }
 
   public RecordProcessorMap getRecordProcessorMap() {

--- a/engine/src/main/java/io/zeebe/engine/processor/ReadonlyProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ReadonlyProcessingContext.java
@@ -11,10 +11,7 @@ import io.zeebe.db.DbContext;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
-import io.zeebe.protocol.impl.record.UnifiedRecordValue;
-import io.zeebe.protocol.record.ValueType;
 import io.zeebe.util.sched.ActorControl;
-import java.util.Map;
 import java.util.function.BooleanSupplier;
 
 public interface ReadonlyProcessingContext {
@@ -34,8 +31,8 @@ public interface ReadonlyProcessingContext {
   /** @return the writer, which is used by the processor to write follow up events */
   TypedStreamWriter getLogStreamWriter();
 
-  /** @return the cache, which contains the mapping from ValueType to UnpackedObject (record) */
-  Map<ValueType, UnifiedRecordValue> getEventCache();
+  /** @return the pool, which contains the mapping from ValueType to UnpackedObject (record) */
+  RecordValues getRecordValues();
 
   /** @return the map of processors, which are executed during processing */
   RecordProcessorMap getRecordProcessorMap();

--- a/engine/src/main/java/io/zeebe/engine/processor/RecordValues.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/RecordValues.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor;
+
+import static io.zeebe.engine.processor.TypedEventRegistry.EVENT_REGISTRY;
+
+import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.util.ReflectUtil;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+public class RecordValues {
+
+  private final Map<ValueType, UnifiedRecordValue> eventCache;
+
+  public RecordValues() {
+    final EnumMap<ValueType, UnifiedRecordValue> cache = new EnumMap<>(ValueType.class);
+    EVENT_REGISTRY.forEach((t, c) -> cache.put(t, ReflectUtil.newInstance(c)));
+
+    eventCache = Collections.unmodifiableMap(cache);
+  }
+
+  public UnifiedRecordValue readRecordValue(LoggedEvent event, ValueType valueType) {
+    final UnifiedRecordValue value = eventCache.get(valueType);
+    if (value != null) {
+      value.reset();
+      event.readValue(value);
+    }
+    return value;
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -7,28 +7,21 @@
  */
 package io.zeebe.engine.processor;
 
-import static io.zeebe.engine.processor.TypedEventRegistry.EVENT_REGISTRY;
-
 import io.zeebe.db.DbContext;
 import io.zeebe.db.ZeebeDb;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.logstreams.impl.Loggers;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
-import io.zeebe.protocol.impl.record.UnifiedRecordValue;
-import io.zeebe.protocol.record.ValueType;
 import io.zeebe.servicecontainer.Service;
 import io.zeebe.servicecontainer.ServiceStartContext;
 import io.zeebe.servicecontainer.ServiceStopContext;
 import io.zeebe.util.LangUtil;
-import io.zeebe.util.ReflectUtil;
 import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.ActorCondition;
 import io.zeebe.util.sched.ActorScheduler;
 import io.zeebe.util.sched.future.ActorFuture;
 import io.zeebe.util.sched.future.CompletableActorFuture;
-import java.util.Collections;
-import java.util.EnumMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
@@ -66,13 +59,10 @@ public class StreamProcessor extends Actor implements Service<StreamProcessor> {
     this.typedRecordProcessorFactory = context.getTypedRecordProcessorFactory();
     this.zeebeDb = context.getZeebeDb();
 
-    final EnumMap<ValueType, UnifiedRecordValue> eventCache = new EnumMap<>(ValueType.class);
-    EVENT_REGISTRY.forEach((t, c) -> eventCache.put(t, ReflectUtil.newInstance(c)));
-
     processingContext =
         context
             .getProcessingContext()
-            .eventCache(Collections.unmodifiableMap(eventCache))
+            .eventCache(new RecordValues())
             .actor(actor)
             .abortCondition(this::isClosed);
     this.logStreamReader = processingContext.getLogStreamReader();

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedEventImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedEventImpl.java
@@ -7,10 +7,12 @@
  */
 package io.zeebe.engine.processor;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.zeebe.logstreams.log.LoggedEvent;
-import io.zeebe.protocol.Protocol;
+import io.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.ValueType;
@@ -18,9 +20,15 @@ import io.zeebe.protocol.record.intent.Intent;
 
 @SuppressWarnings({"rawtypes"})
 public class TypedEventImpl implements TypedRecord {
+  private final int partitionId;
+
   protected LoggedEvent rawEvent;
   protected RecordMetadata metadata;
   protected UnifiedRecordValue value;
+
+  public TypedEventImpl(int partitionId) {
+    this.partitionId = partitionId;
+  }
 
   public void wrap(LoggedEvent rawEvent, RecordMetadata metadata, UnifiedRecordValue value) {
     this.rawEvent = rawEvent;
@@ -49,7 +57,7 @@ public class TypedEventImpl implements TypedRecord {
 
   @Override
   public int getPartitionId() {
-    return Protocol.decodePartitionId(getKey());
+    return partitionId;
   }
 
   @Override
@@ -83,28 +91,34 @@ public class TypedEventImpl implements TypedRecord {
   }
 
   @Override
+  @JsonIgnore
   public int getRequestStreamId() {
     return metadata.getRequestStreamId();
   }
 
   @Override
+  @JsonIgnore
   public long getRequestId() {
     return metadata.getRequestId();
   }
 
+  @JsonIgnore
   public int getMaxValueLength() {
     return this.rawEvent.getMaxValueLength();
   }
 
   @Override
-  public String toString() {
-    return "TypedEventImpl{" + "metadata=" + metadata + ", value=" + value + '}';
+  public String toJson() {
+    return MsgPackConverter.convertJsonSerializableObjectToJson(this);
   }
 
   @Override
-  public String toJson() {
-    final StringBuilder builder = new StringBuilder();
-    value.writeJSON(builder);
-    return builder.toString();
+  public Record clone() {
+    return CopiedRecords.createCopiedRecord(getPartitionId(), rawEvent);
+  }
+
+  @Override
+  public String toString() {
+    return "TypedEventImpl{" + "metadata=" + metadata + ", value=" + value + '}';
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processor/TypedEventSerializationTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/TypedEventSerializationTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor;
+
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.protocol.impl.record.CopiedRecord;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.RejectionType;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.intent.DeploymentIntent;
+import io.zeebe.protocol.record.value.deployment.ResourceType;
+import io.zeebe.test.util.JsonUtil;
+import io.zeebe.util.collection.Tuple;
+import org.agrona.DirectBuffer;
+import org.junit.Test;
+
+public class TypedEventSerializationTest {
+
+  private static Tuple<TypedRecord, CopiedRecord> createRecordTuple() {
+    final RecordMetadata recordMetadata = new RecordMetadata();
+
+    final DeploymentIntent intent = DeploymentIntent.CREATE;
+    final int protocolVersion = 1;
+    final ValueType valueType = ValueType.DEPLOYMENT;
+
+    final RecordType recordType = RecordType.COMMAND;
+    final String rejectionReason = "fails";
+    final RejectionType rejectionType = RejectionType.INVALID_ARGUMENT;
+    final int requestId = 23;
+    final int requestStreamId = 1;
+
+    recordMetadata
+        .intent(intent)
+        .protocolVersion(protocolVersion)
+        .valueType(valueType)
+        .recordType(recordType)
+        .rejectionReason(rejectionReason)
+        .rejectionType(rejectionType)
+        .requestId(requestId)
+        .requestStreamId(requestStreamId);
+
+    final String resourceName = "resource";
+    final ResourceType resourceType = ResourceType.BPMN_XML;
+    final DirectBuffer resource = wrapString("contents");
+    final String bpmnProcessId = "testProcess";
+    final long workflowKey = 123;
+    final int workflowVersion = 12;
+    final DeploymentRecord record = new DeploymentRecord();
+    record
+        .resources()
+        .add()
+        .setResourceName(wrapString(resourceName))
+        .setResourceType(resourceType)
+        .setResource(resource);
+    record
+        .workflows()
+        .add()
+        .setBpmnProcessId(wrapString(bpmnProcessId))
+        .setKey(workflowKey)
+        .setResourceName(wrapString(resourceName))
+        .setVersion(workflowVersion);
+
+    final long key = 1234;
+    final long position = 4321;
+    final long sourcePosition = 231;
+    final long timestamp = 2191L;
+
+    final LoggedEvent loggedEvent = mock(LoggedEvent.class);
+    when(loggedEvent.getPosition()).thenReturn(position);
+    when(loggedEvent.getKey()).thenReturn(key);
+    when(loggedEvent.getSourceEventPosition()).thenReturn(sourcePosition);
+    when(loggedEvent.getTimestamp()).thenReturn(timestamp);
+
+    final TypedEventImpl typedEvent = new TypedEventImpl(0);
+    typedEvent.wrap(loggedEvent, recordMetadata, record);
+
+    final CopiedRecord copiedRecord =
+        new CopiedRecord<>(record, recordMetadata, key, 0, position, sourcePosition, timestamp);
+
+    return new Tuple<>(typedEvent, copiedRecord);
+  }
+
+  @Test
+  public void shouldCreateSameJson() {
+    // given
+    final Tuple<TypedRecord, CopiedRecord> records = createRecordTuple();
+    final String expectedJson = records.getRight().toJson();
+
+    // when
+    final String actualJson = records.getLeft().toJson();
+
+    // then
+    JsonUtil.assertEquality(actualJson, expectedJson);
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/BlacklistInstanceTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/BlacklistInstanceTest.java
@@ -221,7 +221,7 @@ public class BlacklistInstanceTest {
     final RecordMetadata metadata = new RecordMetadata();
     metadata.intent(recordIntent);
     metadata.valueType(recordValueType);
-    final TypedEventImpl typedEvent = new TypedEventImpl();
+    final TypedEventImpl typedEvent = new TypedEventImpl(1);
     final LoggedEvent loggedEvent = mock(LoggedEvent.class);
     when(loggedEvent.getPosition()).thenReturn(1024L);
 

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -11,9 +11,10 @@ import static io.zeebe.test.util.record.RecordingExporter.jobRecords;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.zeebe.engine.processor.CopiedRecords;
 import io.zeebe.engine.processor.ReadonlyProcessingContext;
+import io.zeebe.engine.processor.RecordValues;
 import io.zeebe.engine.processor.StreamProcessorLifecycleAware;
+import io.zeebe.engine.processor.TypedEventImpl;
 import io.zeebe.engine.processor.workflow.EngineProcessors;
 import io.zeebe.engine.processor.workflow.deployment.distribute.DeploymentDistributor;
 import io.zeebe.engine.processor.workflow.deployment.distribute.PendingDeploymentDistribution;
@@ -33,7 +34,8 @@ import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.protocol.Protocol;
-import io.zeebe.protocol.impl.record.CopiedRecord;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.intent.DeploymentIntent;
@@ -242,14 +244,22 @@ public final class EngineRule extends ExternalResource {
     environmentRule.writeBatch(records);
   }
 
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+  //////////////////////////////// PROCESSOR EXPORTER CROSSOVER ///////////////////////////////////
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+
   private static class ProcessingExporterTransistor implements StreamProcessorLifecycleAware {
 
+    private final RecordValues recordValues = new RecordValues();
+    private final RecordMetadata metadata = new RecordMetadata();
+
     private BufferedLogStreamReader logStreamReader;
-    private int partitionId;
+    private TypedEventImpl typedEvent;
 
     @Override
     public void onOpen(ReadonlyProcessingContext context) {
-      partitionId = context.getLogStream().getPartitionId();
+      final int partitionId = context.getLogStream().getPartitionId();
+      typedEvent = new TypedEventImpl(partitionId);
       final ActorControl actor = context.getActor();
 
       final ActorCondition onCommitCondition =
@@ -263,10 +273,14 @@ public final class EngineRule extends ExternalResource {
     private void onNewEventCommitted() {
       while (logStreamReader.hasNext()) {
         final LoggedEvent rawEvent = logStreamReader.next();
+        metadata.reset();
+        rawEvent.readMetadata(metadata);
 
-        final CopiedRecord typedRecord = CopiedRecords.createCopiedRecord(partitionId, rawEvent);
+        final UnifiedRecordValue recordValue =
+            recordValues.readRecordValue(rawEvent, metadata.getValueType());
+        typedEvent.wrap(rawEvent, metadata, recordValue);
 
-        RECORDING_EXPORTER.export(typedRecord);
+        RECORDING_EXPORTER.export(typedEvent);
       }
     }
   }
@@ -302,10 +316,6 @@ public final class EngineRule extends ExternalResource {
       return pendingDeployments.remove(key);
     }
   }
-
-  /////////////////////////////////////////////////////////////////////////////////////////////////
-  //////////////////////////////// PROCESSOR EXPORTER CROSSOVER ///////////////////////////////////
-  /////////////////////////////////////////////////////////////////////////////////////////////////
 
   private class PartitionCommandSenderImpl implements PartitionCommandSender {
 

--- a/engine/src/test/java/io/zeebe/engine/util/MockTypedRecord.java
+++ b/engine/src/test/java/io/zeebe/engine/util/MockTypedRecord.java
@@ -11,6 +11,7 @@ import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.ValueType;
@@ -109,6 +110,11 @@ public class MockTypedRecord<T extends UnifiedRecordValue> implements TypedRecor
 
   @Override
   public String toJson() {
+    throw new UnsupportedOperationException("not yet implemented");
+  }
+
+  @Override
+  public Record<T> clone() {
     throw new UnsupportedOperationException("not yet implemented");
   }
 }

--- a/exporter-api/src/main/java/io/zeebe/exporter/api/Exporter.java
+++ b/exporter-api/src/main/java/io/zeebe/exporter/api/Exporter.java
@@ -58,13 +58,17 @@ public interface Exporter {
   default void close() {}
 
   /**
-   * Called at least once for every record to be exporter. Once a record is guaranteed to have been
+   * Called at least once for every record to be exported. Once a record is guaranteed to have been
    * exported, implementations should call {@link Controller#updateLastExportedRecordPosition(long)}
    * to signal that this record should not be received here ever again.
    *
    * <p>Should the export method throw an unexpected {@link RuntimeException}, the method will be
    * called indefinitely until it terminates without any exception. It is up to the implementation
    * to handle errors properly, to implement retry strategies, etc.
+   *
+   * <p>Given Record just wraps the underlying internal buffer. This means if the implementation
+   * needs to collect multiple records it either has to call {@link Record#toJson()} to get the
+   * serialized version of the record or {@link Record#clone()} to get a deep copy.
    *
    * @param record the record to export
    */

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/CopiedRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/CopiedRecord.java
@@ -13,6 +13,7 @@ import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.Intent;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public class CopiedRecord<T extends UnifiedRecordValue> implements Record<T> {
 
@@ -50,6 +51,37 @@ public class CopiedRecord<T extends UnifiedRecordValue> implements Record<T> {
     this.rejectionType = metadata.getRejectionType();
     this.rejectionReason = metadata.getRejectionReason();
     this.valueType = metadata.getValueType();
+  }
+
+  private CopiedRecord(CopiedRecord<T> copiedRecord) {
+    final UnifiedRecordValue value = copiedRecord.getValue();
+    final byte[] bytes = new byte[value.getLength()];
+    final UnsafeBuffer buffer = new UnsafeBuffer(bytes);
+    value.write(buffer, 0);
+
+    final Class<? extends UnifiedRecordValue> recordValueClass = value.getClass();
+    try {
+      final T recordValue = (T) recordValueClass.newInstance();
+      recordValue.wrap(buffer);
+      this.recordValue = recordValue;
+    } catch (Exception e) {
+      throw new RuntimeException(
+          String.format(
+              "Expected to instantiate %s, but has no default ctor.", recordValueClass.getName()),
+          e);
+    }
+
+    key = copiedRecord.key;
+    position = copiedRecord.position;
+    sourcePosition = copiedRecord.sourcePosition;
+    timestamp = copiedRecord.timestamp;
+
+    this.intent = copiedRecord.intent;
+    this.recordType = copiedRecord.recordType;
+    this.partitionId = copiedRecord.partitionId;
+    this.rejectionType = copiedRecord.rejectionType;
+    this.rejectionReason = copiedRecord.rejectionReason;
+    this.valueType = copiedRecord.valueType;
   }
 
   @Override
@@ -115,5 +147,10 @@ public class CopiedRecord<T extends UnifiedRecordValue> implements Record<T> {
   @Override
   public String toString() {
     return toJson();
+  }
+
+  @Override
+  public Record<T> clone() {
+    return new CopiedRecord<>(this);
   }
 }

--- a/protocol/src/main/java/io/zeebe/protocol/record/Record.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/Record.java
@@ -18,7 +18,7 @@ package io.zeebe.protocol.record;
 import io.zeebe.protocol.record.intent.Intent;
 
 /** Represents a record published to the log stream. */
-public interface Record<T extends RecordValue> extends JsonSerializable {
+public interface Record<T extends RecordValue> extends JsonSerializable, Cloneable {
   /**
    * Retrieves the position of the record. Positions are locally unique to the partition, and
    * monotonically increasing. Records are then ordered on the partition by their positions, i.e.
@@ -84,4 +84,11 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
    * @return record value
    */
   T getValue();
+
+  /**
+   * Creates a deep copy of the current record. Can be used to collect records.
+   *
+   * @return a deep copy of this record
+   */
+  Record<T> clone();
 }

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
@@ -62,7 +62,7 @@ public class RecordingExporter implements Exporter {
   public void export(final Record record) {
     LOCK.lock();
     try {
-      RECORDS.add(record);
+      RECORDS.add(record.clone());
       IS_EMPTY.signal();
     } finally {
       LOCK.unlock();

--- a/test-util/src/test/java/io/zeebe/test/util/record/RecordingExporterTest.java
+++ b/test-util/src/test/java/io/zeebe/test/util/record/RecordingExporterTest.java
@@ -113,6 +113,11 @@ public class RecordingExporterTest {
     public String toJson() {
       return null;
     }
+
+    @Override
+    public Record<TestValue> clone() {
+      return this;
+    }
   }
 
   public static class TestValue implements RecordValue {

--- a/test/src/main/java/io/zeebe/test/exporter/record/MockRecord.java
+++ b/test/src/main/java/io/zeebe/test/exporter/record/MockRecord.java
@@ -159,7 +159,7 @@ public class MockRecord extends ExporterMappedObject implements Record, Cloneabl
   }
 
   @Override
-  public Object clone() {
+  public Record clone() {
     try {
       final MockRecord cloned = (MockRecord) super.clone();
       cloned.metadata = (MockRecordMetadata) metadata.clone();


### PR DESCRIPTION
## Description

Exporters get no longer a deep copy of the record.
Records are wrapping internal buffer, if the exporter wants to collect records he has to call either `toJson` or `clone` to get a copy of it. This should improve the exporting performance.

## Related issues

closes #2728 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
