### PR TITLE
configure long polling time out in activate jobs request

### DIFF
--- a/clients/java/src/test/java/io/zeebe/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/job/ActivateJobsTest.java
@@ -190,8 +190,8 @@ public class ActivateJobsTest extends ClientTest {
     assertThat(request.getTimeout())
         .isEqualTo(client.getConfiguration().getDefaultJobTimeout().toMillis());
     assertThat(request.getWorker()).isEqualTo(client.getConfiguration().getDefaultJobWorkerName());
-
-    rule.verifyDefaultRequestTimeout();
+    assertThat(request.getRequestTimeout())
+        .isEqualTo(client.getConfiguration().getDefaultRequestTimeout().toMillis());
   }
 
   @Test
@@ -220,8 +220,9 @@ public class ActivateJobsTest extends ClientTest {
         .requestTimeout(requestTimeout)
         .send()
         .join();
+    final ActivateJobsRequest request = gatewayService.getLastRequest();
 
     // then
-    rule.verifyRequestTimeout(requestTimeout);
+    assertThat(request.getRequestTimeout()).isEqualTo(requestTimeout.toMillis());
   }
 }

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -22,6 +22,10 @@ message ActivateJobsRequest {
   // a list of variables to fetch as the job variables; if empty, all visible variables at
   // the time of activation for the scope of the job will be returned
   repeated string fetchVariable = 5;
+  // The request will be completed when at least one job is activated or after the requestTimeout.
+  // if the requestTimeout = 0, a default timeout is used.
+  // if the requestTimeout < 0, long polling is disabled and the request is completed immediately, even when no job is activated.
+  int64 requestTimeout = 6;
 }
 
 message ActivateJobsResponse {

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -62,6 +62,11 @@
                 "name": "fetchVariable",
                 "type": "string",
                 "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "requestTimeout",
+                "type": "int64"
               }
             ]
           },

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
@@ -22,6 +22,7 @@ import io.zeebe.model.bpmn.builder.ServiceTaskBuilder;
 import io.zeebe.protocol.record.intent.DeploymentIntent;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -60,7 +61,8 @@ public class GrpcClientRule extends ExternalResource {
 
   @Override
   public void before() {
-    final ZeebeClientBuilder builder = ZeebeClient.newClientBuilder();
+    final ZeebeClientBuilder builder =
+        ZeebeClient.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(10));
     configurator.accept(builder);
     client = builder.build();
   }

--- a/test/src/main/java/io/zeebe/test/ClientRule.java
+++ b/test/src/main/java/io/zeebe/test/ClientRule.java
@@ -8,12 +8,14 @@
 package io.zeebe.test;
 
 import io.zeebe.client.ZeebeClient;
+import java.time.Duration;
 import java.util.Properties;
 import java.util.function.Supplier;
 import org.junit.rules.ExternalResource;
 
 public class ClientRule extends ExternalResource {
 
+  private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(2);
   protected final Supplier<Properties> properties;
   protected ZeebeClient client;
 
@@ -40,7 +42,11 @@ public class ClientRule extends ExternalResource {
   }
 
   public void createClient() {
-    client = ZeebeClient.newClientBuilder().withProperties(properties.get()).build();
+    client =
+        ZeebeClient.newClientBuilder()
+            .defaultRequestTimeout(DEFAULT_REQUEST_TIMEOUT)
+            .withProperties(properties.get())
+            .build();
   }
 
   public void destroyClient() {


### PR DESCRIPTION
## Description

* Added a parameter `requestTimeout` to the grpc ActivateJobsRequest to specify long polling timeout per request.
* The default value 0 for `requestTimeout` indicates to use the default timeout configured in the broker (which is 10s). To turn of longpolling for this request, set the timeout to be -1.
* Updated java client to configure `requestTimeout`.

## Related issues

closes #2827 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
