### PR TITLE
chore(clients/go): improve Go errors

### DIFF
--- a/clients/go/zbc/client.go
+++ b/clients/go/zbc/client.go
@@ -17,8 +17,8 @@ package zbc
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/credentials"
 	"log"
 	"os"
@@ -44,6 +44,9 @@ type ZBClientConfig struct {
 	CaCertificatePath      string
 	CredentialsProvider    CredentialsProvider
 }
+
+const FileNotFoundError = ZBError("file not found")
+const InvalidPathError = ZBError("invalid path")
 
 type ZBError string
 
@@ -147,7 +150,7 @@ func configureConnectionSecurity(config *ZBClientConfig, opts *[]grpc.DialOption
 		if config.CaCertificatePath == "" {
 			creds = credentials.NewTLS(&tls.Config{})
 		} else if _, err := os.Stat(config.CaCertificatePath); os.IsNotExist(err) {
-			return newNoSuchFileError("CA certificate", config.CaCertificatePath)
+			return fileNotFoundError("CA certificate", config.CaCertificatePath)
 		} else {
 			creds, err = credentials.NewClientTLSFromFile(config.CaCertificatePath, "")
 			if err != nil {
@@ -163,11 +166,11 @@ func configureConnectionSecurity(config *ZBClientConfig, opts *[]grpc.DialOption
 	return nil
 }
 
-func newNoSuchFileError(fileDescription, path string) error {
-	return errors.New(fmt.Sprintf("expected to find %s but there was no such file at '%s'", fileDescription, path))
+func fileNotFoundError(fileDescription, path string) error {
+	return errors.Wrap(FileNotFoundError, fmt.Sprintf("expected to find %s but there was no such file at path '%s'", fileDescription, path))
 }
 
-func newEmptyPathError(fileDescription string) error {
-	return errors.New(fmt.Sprintf("expected valid path to %s but path was empty", fileDescription))
+func invalidPathError(fileDescription string) error {
+	return errors.Wrap(FileNotFoundError, fmt.Sprintf("expected valid path to %s but path was empty", fileDescription))
 
 }

--- a/clients/go/zbc/client_test.go
+++ b/clients/go/zbc/client_test.go
@@ -16,6 +16,7 @@ package zbc
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/zeebe-io/zeebe/clients/go/pb"
 	"google.golang.org/grpc"
@@ -136,7 +137,7 @@ func TestNewZBClientWithPathToNonExistingFile(t *testing.T) {
 	})
 
 	// then
-	require.EqualError(t, err, newNoSuchFileError("CA certificate", wrongPath).Error())
+	require.Error(t, errors.Cause(err), FileNotFoundError)
 }
 
 func createSecureServer() (net.Listener, *grpc.Server) {

--- a/clients/go/zbc/credentialsProvider.go
+++ b/clients/go/zbc/credentialsProvider.go
@@ -92,11 +92,11 @@ func (provider *ZeebeClientCredentialsProvider) ApplyCredentials(headers map[str
 // Creates a ZeebeClientCredentialsProvider with a path to the Zeebe credentials YAML file.
 func NewZeebeClientCredentialsProvider(zeebeCredentialsPath string) (*ZeebeClientCredentialsProvider, error) {
 	if zeebeCredentialsPath == "" {
-		return nil, newEmptyPathError("Zeebe credentials file")
+		return nil, invalidPathError("Zeebe credentials file")
 	}
 
 	if _, err := os.Stat(zeebeCredentialsPath); err != nil {
-		return nil, newNoSuchFileError("Zeebe credentials file", zeebeCredentialsPath)
+		return nil, fileNotFoundError("Zeebe credentials file", zeebeCredentialsPath)
 
 	}
 

--- a/clients/go/zbc/credentialsProvider_test.go
+++ b/clients/go/zbc/credentialsProvider_test.go
@@ -16,8 +16,8 @@ package zbc
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/zeebe-io/zeebe/clients/go/pb"
 	"google.golang.org/grpc"
@@ -68,7 +68,7 @@ func TestZeebeClientCredentialsProviderWithEmptyPath(t *testing.T) {
 	_, err := NewZeebeClientCredentialsProvider("")
 
 	// then
-	require.EqualError(t, err, newEmptyPathError("Zeebe credentials file").Error())
+	require.Error(t, errors.Cause(err), InvalidPathError)
 }
 
 func TestZeebeClientCredentialsProviderWithWrongPath(t *testing.T) {
@@ -77,7 +77,7 @@ func TestZeebeClientCredentialsProviderWithWrongPath(t *testing.T) {
 	_, err := NewZeebeClientCredentialsProvider(wrongPath)
 
 	// then
-	require.EqualError(t, err, newNoSuchFileError("Zeebe credentials file", wrongPath).Error())
+	require.Error(t, errors.Cause(err), FileNotFoundError)
 }
 
 type CustomCredentialsProvider struct {


### PR DESCRIPTION
## Description
Improves the errors returned by our Go client to be descriptive but also based on comparable constants.

## Related issues
closes #2938 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
