### PR TITLE
Extend exporter metrics to contain valueType info

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -231,8 +231,8 @@ public class ExporterDirector extends Actor implements Service<ExporterDirector>
     actor.submit(this::readNextEvent);
   }
 
-  private void skipRecord() {
-    metrics.eventSkipped();
+  private void skipRecord(String valueType) {
+    metrics.eventSkipped(valueType);
     actor.submit(this::readNextEvent);
   }
 
@@ -243,7 +243,9 @@ public class ExporterDirector extends Actor implements Service<ExporterDirector>
         inExportingPhase = true;
         exportEvent(currentEvent);
       } else {
-        skipRecord();
+        final RecordMetadata metadata = new RecordMetadata();
+        currentEvent.readMetadata(metadata);
+        skipRecord(metadata.getValueType().toString());
       }
     }
   }
@@ -272,7 +274,7 @@ public class ExporterDirector extends Actor implements Service<ExporterDirector>
                   LOG.error(ERROR_MESSAGE_EXPORTING_ABORTED, event, throwable);
                   onFailure();
                 } else {
-                  metrics.eventExported();
+                  metrics.eventExported(recordExporter.getTypedEvent().getValueType().toString());
                   inExportingPhase = false;
                   actor.submit(this::readNextEvent);
                 }
@@ -360,6 +362,10 @@ public class ExporterDirector extends Actor implements Service<ExporterDirector>
       }
 
       return true;
+    }
+
+    public TypedEventImpl getTypedEvent() {
+      return typedEvent;
     }
   }
 

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -16,7 +16,7 @@ public class ExporterMetrics {
           .namespace("zeebe")
           .name("exporter_events_total")
           .help("Number of events processed by exporter")
-          .labelNames("action", "partition")
+          .labelNames("action", "partition", "valueType")
           .register();
 
   private final String partitionIdLabel;
@@ -25,15 +25,15 @@ public class ExporterMetrics {
     partitionIdLabel = String.valueOf(partitionId);
   }
 
-  private void event(String action) {
-    EXPORTER_EVENTS.labels(action, partitionIdLabel).inc();
+  private void event(String action, String valueType) {
+    EXPORTER_EVENTS.labels(action, partitionIdLabel, valueType).inc();
   }
 
-  public void eventExported() {
-    event("exported");
+  public void eventExported(String valueType) {
+    event("exported", valueType);
   }
 
-  public void eventSkipped() {
-    event("skipped");
+  public void eventSkipped(String valueType) {
+    event("skipped", valueType);
   }
 }

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -8,6 +8,7 @@
 package io.zeebe.broker.exporter.stream;
 
 import io.prometheus.client.Counter;
+import io.zeebe.protocol.record.ValueType;
 
 public class ExporterMetrics {
 
@@ -25,15 +26,15 @@ public class ExporterMetrics {
     partitionIdLabel = String.valueOf(partitionId);
   }
 
-  private void event(String action, String valueType) {
-    EXPORTER_EVENTS.labels(action, partitionIdLabel, valueType).inc();
+  private void event(String action, ValueType valueType) {
+    EXPORTER_EVENTS.labels(action, partitionIdLabel, valueType.name()).inc();
   }
 
-  public void eventExported(String valueType) {
+  public void eventExported(ValueType valueType) {
     event("exported", valueType);
   }
 
-  public void eventSkipped(String valueType) {
+  public void eventSkipped(ValueType valueType) {
     event("skipped", valueType);
   }
 }


### PR DESCRIPTION
## Description

Exporter writes some Prometheus metrics, now metric entries contain valueType information

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
