### PR TITLE
Enforce declaration order

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -43,11 +43,10 @@ public class SystemContext implements AutoCloseable {
   protected final List<Component> components = new ArrayList<>();
   protected final BrokerCfg brokerCfg;
   protected final List<ActorFuture<?>> requiredStartActions = new ArrayList<>();
-  private final List<Closeable> closeablesToReleaseResources = new ArrayList<>();
   protected ServiceContainer serviceContainer;
   protected Map<String, String> diagnosticContext;
   protected ActorScheduler scheduler;
-
+  private final List<Closeable> closeablesToReleaseResources = new ArrayList<>();
   private Duration closeTimeout;
 
   public SystemContext(String configFileLocation, final String basePath, final ActorClock clock) {

--- a/broker-core/src/main/java/io/zeebe/broker/transport/BufferingServerTransportService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/transport/BufferingServerTransportService.java
@@ -29,9 +29,8 @@ public class BufferingServerTransportService implements Service<BufferingServerT
 
   protected final String readableName;
   protected final InetSocketAddress bindAddress;
-  private final ByteValue sendBufferSize;
-
   protected BufferingServerTransport serverTransport;
+  private final ByteValue sendBufferSize;
 
   public BufferingServerTransportService(
       String readableName, InetSocketAddress bindAddress, ByteValue sendBufferSize) {

--- a/broker-core/src/main/java/io/zeebe/broker/transport/ClientTransportService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/transport/ClientTransportService.java
@@ -24,10 +24,9 @@ import java.util.Collection;
 public class ClientTransportService implements Service<ClientTransport> {
 
   protected final Collection<IntTuple<SocketAddress>> defaultEndpoints;
+  protected ClientTransport transport;
   private final String name;
   private final ByteValue messageBufferSize;
-
-  protected ClientTransport transport;
 
   public ClientTransportService(
       String name,

--- a/broker-core/src/main/java/io/zeebe/broker/transport/ServerTransportService.java
+++ b/broker-core/src/main/java/io/zeebe/broker/transport/ServerTransportService.java
@@ -31,9 +31,8 @@ public class ServerTransportService implements Service<ServerTransport> {
 
   protected final String readableName;
   protected final InetSocketAddress bindAddress;
-  private final ByteValue sendBufferSize;
-
   protected ServerTransport serverTransport;
+  private final ByteValue sendBufferSize;
 
   public ServerTransportService(
       String readableName, InetSocketAddress bindAddress, ByteValue sendBufferSize) {

--- a/broker-core/src/main/java/io/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
+++ b/broker-core/src/main/java/io/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
@@ -33,10 +33,10 @@ public class CommandResponseWriterImpl implements CommandResponseWriter, BufferW
       new ExecuteCommandResponseEncoder();
   protected final ServerResponse response = new ServerResponse();
   protected final ServerOutput output;
-  private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
   protected int partitionId = partitionIdNullValue();
   protected long key = keyNullValue();
   protected BufferWriter valueWriter;
+  private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
   private RecordType recordType = RecordType.NULL_VAL;
   private ValueType valueType = ValueType.NULL_VAL;
   private short intent = Intent.NULL_VAL;

--- a/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -55,9 +55,9 @@ public class ExporterDirectorTest {
   private static final String EXPORTER_ID_2 = "exporter-2";
 
   private static final VerificationWithTimeout TIMEOUT = timeout(5_000);
+  @Rule public ExporterRule rule = new ExporterRule(PARTITION_ID);
   private final List<ControlledTestExporter> exporters = new ArrayList<>();
   private final List<ExporterDescriptor> exporterDescriptors = new ArrayList<>();
-  @Rule public ExporterRule rule = new ExporterRule(PARTITION_ID);
   private ExportersState state;
 
   @Before

--- a/broker-core/src/test/java/io/zeebe/broker/logstreams/delete/LeaderLogStreamDeletionTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/logstreams/delete/LeaderLogStreamDeletionTest.java
@@ -30,11 +30,11 @@ public class LeaderLogStreamDeletionTest {
   private static final int PARTITION_ID = 0;
   private static final long POSITION_TO_DELETE = 6L;
   private static final long ADDRESS_TO_DELETE = 55L;
+  @Mock ExporterManagerService mockExporterManagerService;
+  @Mock LogStream mockLogStream = mock(LogStream.class);
   private final ActorSchedulerRule actorScheduler = new ActorSchedulerRule();
   private final ServiceContainerRule serviceContainer = new ServiceContainerRule(actorScheduler);
   @Rule public RuleChain chain = RuleChain.outerRule(actorScheduler).around(serviceContainer);
-  @Mock ExporterManagerService mockExporterManagerService;
-  @Mock LogStream mockLogStream = mock(LogStream.class);
   private LeaderLogStreamDeletionService deletionService;
 
   @Before

--- a/broker-core/src/test/java/io/zeebe/broker/transport/commandapi/CommandApiMessageHandlerTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/transport/commandapi/CommandApiMessageHandlerTest.java
@@ -69,10 +69,6 @@ public class CommandApiMessageHandlerTest {
     JOB_EVENT = buffer.byteArray();
   }
 
-  protected final UnsafeBuffer buffer = new UnsafeBuffer(new byte[1024 * 1024]);
-  protected final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
-  protected final ExecuteCommandRequestEncoder commandRequestEncoder =
-      new ExecuteCommandRequestEncoder();
   public TemporaryFolder tempFolder = new TemporaryFolder();
   public ActorSchedulerRule agentRunnerService = new ActorSchedulerRule();
   public ServiceContainerRule serviceContainerRule = new ServiceContainerRule(agentRunnerService);
@@ -81,6 +77,10 @@ public class CommandApiMessageHandlerTest {
   public RuleChain ruleChain =
       RuleChain.outerRule(tempFolder).around(agentRunnerService).around(serviceContainerRule);
 
+  protected final UnsafeBuffer buffer = new UnsafeBuffer(new byte[1024 * 1024]);
+  protected final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  protected final ExecuteCommandRequestEncoder commandRequestEncoder =
+      new ExecuteCommandRequestEncoder();
   protected BufferingServerOutput serverOutput;
   private LogStream logStream;
   private CommandApiMessageHandler messageHandler;

--- a/build-tools/src/main/resources/check/.checkstyle.xml
+++ b/build-tools/src/main/resources/check/.checkstyle.xml
@@ -142,6 +142,8 @@
 
     <module name="ModifierOrder"/>
 
+    <module name="DeclarationOrder" />
+
     <module name="CustomImportOrder">
       <property name="sortImportsInGroupAlphabetically" value="true"/>
       <property name="separateLineBetweenGroups" value="true"/>

--- a/build-tools/src/main/resources/intellij/ZeebeStyle.xml
+++ b/build-tools/src/main/resources/intellij/ZeebeStyle.xml
@@ -38,6 +38,9 @@
     <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
     <option name="JD_KEEP_EMPTY_RETURN" value="false" />
   </JavaCodeStyleSettings>
+  <MarkdownNavigatorCodeStyleSettings>
+    <option name="RIGHT_MARGIN" value="72" />
+  </MarkdownNavigatorCodeStyleSettings>
   <XML>
     <option name="XML_ALIGN_ATTRIBUTES" value="false" />
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
@@ -120,54 +123,6 @@
             <match>
               <AND>
                 <FIELD>true</FIELD>
-                <FINAL>true</FINAL>
-                <PUBLIC>true</PUBLIC>
-                <STATIC>true</STATIC>
-              </AND>
-            </match>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <FIELD>true</FIELD>
-                <FINAL>true</FINAL>
-                <PROTECTED>true</PROTECTED>
-                <STATIC>true</STATIC>
-              </AND>
-            </match>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <FIELD>true</FIELD>
-                <FINAL>true</FINAL>
-                <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
-                <STATIC>true</STATIC>
-              </AND>
-            </match>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <FIELD>true</FIELD>
-                <FINAL>true</FINAL>
-                <PRIVATE>true</PRIVATE>
-                <STATIC>true</STATIC>
-              </AND>
-            </match>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <FIELD>true</FIELD>
                 <PUBLIC>true</PUBLIC>
                 <STATIC>true</STATIC>
               </AND>
@@ -213,50 +168,6 @@
               <AND>
                 <INITIALIZER_BLOCK>true</INITIALIZER_BLOCK>
                 <STATIC>true</STATIC>
-              </AND>
-            </match>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <FIELD>true</FIELD>
-                <FINAL>true</FINAL>
-                <PUBLIC>true</PUBLIC>
-              </AND>
-            </match>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <FIELD>true</FIELD>
-                <FINAL>true</FINAL>
-                <PROTECTED>true</PROTECTED>
-              </AND>
-            </match>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <FIELD>true</FIELD>
-                <FINAL>true</FINAL>
-                <PACKAGE_PRIVATE>true</PACKAGE_PRIVATE>
-              </AND>
-            </match>
-          </rule>
-        </section>
-        <section>
-          <rule>
-            <match>
-              <AND>
-                <FIELD>true</FIELD>
-                <FINAL>true</FINAL>
-                <PRIVATE>true</PRIVATE>
               </AND>
             </match>
           </rule>

--- a/dispatcher/src/main/java/io/zeebe/dispatcher/Dispatcher.java
+++ b/dispatcher/src/main/java/io/zeebe/dispatcher/Dispatcher.java
@@ -43,9 +43,9 @@ public class Dispatcher extends Actor implements AutoCloseable {
   protected final String name;
   protected final int mode;
   protected Subscription[] subscriptions;
-  private final Runnable onClaimComplete = this::signalSubsciptions;
   protected int logWindowLength;
   protected volatile boolean isClosed = false;
+  private final Runnable onClaimComplete = this::signalSubsciptions;
   private final Runnable backgroundTask = this::runBackgroundTask;
   private ActorCondition dataConsumed;
 

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedEventImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedEventImpl.java
@@ -20,11 +20,10 @@ import io.zeebe.protocol.record.intent.Intent;
 
 @SuppressWarnings({"rawtypes"})
 public class TypedEventImpl implements TypedRecord {
-  private final int partitionId;
-
   protected LoggedEvent rawEvent;
   protected RecordMetadata metadata;
   protected UnifiedRecordValue value;
+  private final int partitionId;
 
   public TypedEventImpl(int partitionId) {
     this.partitionId = partitionId;

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedResponseWriterImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedResponseWriterImpl.java
@@ -18,9 +18,9 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public class TypedResponseWriterImpl implements TypedResponseWriter, SideEffectProducer {
 
-  private final UnsafeBuffer stringWrapper = new UnsafeBuffer(0, 0);
   protected CommandResponseWriter writer;
   protected int partitionId;
+  private final UnsafeBuffer stringWrapper = new UnsafeBuffer(0, 0);
   private long requestId;
   private int requestStreamId;
   private boolean isResponseStaged;

--- a/engine/src/test/java/io/zeebe/engine/processor/TypedStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/TypedStreamProcessorTest.java
@@ -43,10 +43,9 @@ import org.mockito.MockitoAnnotations;
 public class TypedStreamProcessorTest {
   private static final String STREAM_NAME = "foo";
   private static final int STREAM_PROCESSOR_ID = 144144;
-
+  protected LogStream stream;
   private final TemporaryFolder tempFolder = new TemporaryFolder();
   private final AutoCloseableRule closeables = new AutoCloseableRule();
-
   private final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
   private final ServiceContainerRule serviceContainerRule =
       new ServiceContainerRule(actorSchedulerRule);
@@ -58,7 +57,6 @@ public class TypedStreamProcessorTest {
           .around(serviceContainerRule)
           .around(closeables);
 
-  protected LogStream stream;
   private TestStreams streams;
   private KeyGenerator keyGenerator;
   private CommandResponseWriter mockCommandResponseWriter;

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/BlacklistInstanceTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/BlacklistInstanceTest.java
@@ -47,8 +47,8 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class BlacklistInstanceTest {
 
-  private static final AtomicLong KEY_GENERATOR = new AtomicLong(0);
   @ClassRule public static ZeebeStateRule zeebeStateRule = new ZeebeStateRule();
+  private static final AtomicLong KEY_GENERATOR = new AtomicLong(0);
 
   @Parameter(0)
   public ValueType recordValueType;

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorRule.java
@@ -66,8 +66,8 @@ public class WorkflowInstanceStreamProcessorRule extends ExternalResource
   public static final int VERSION = 1;
   public static final int WORKFLOW_KEY = 123;
   public static final int DEPLOYMENT_KEY = 1;
-  private final StreamProcessorRule environmentRule;
   @Rule public TemporaryFolder folder = new TemporaryFolder();
+  private final StreamProcessorRule environmentRule;
   private SubscriptionCommandSender mockSubscriptionCommandSender;
 
   private WorkflowState workflowState;

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorTest.java
@@ -85,10 +85,10 @@ public class WorkflowInstanceStreamProcessorTest {
           .moveToActivity("task1")
           .endEvent("end")
           .done();
+  @Rule public Timeout timeoutRule = new Timeout(2, TimeUnit.MINUTES);
   private final StreamProcessorRule envRule = new StreamProcessorRule();
   private final WorkflowInstanceStreamProcessorRule streamProcessorRule =
       new WorkflowInstanceStreamProcessorRule(envRule);
-  @Rule public Timeout timeoutRule = new Timeout(2, TimeUnit.MINUTES);
   @Rule public RuleChain chain = RuleChain.outerRule(envRule).around(streamProcessorRule);
 
   @Test

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/handlers/element/ElementActivatingHandlerTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/handlers/element/ElementActivatingHandlerTest.java
@@ -29,8 +29,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class ElementActivatingHandlerTest extends ElementHandlerTestCase<ExecutableFlowNode> {
-  private final WorkflowInstanceIntent nextState = WorkflowInstanceIntent.ELEMENT_ACTIVATED;
   @Mock public IOMappingHelper ioMappingHelper;
+  private final WorkflowInstanceIntent nextState = WorkflowInstanceIntent.ELEMENT_ACTIVATED;
   private ElementActivatingHandler<ExecutableFlowNode> handler;
 
   @Override

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/IncidentStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/IncidentStreamProcessorRule.java
@@ -46,8 +46,8 @@ import org.junit.rules.TemporaryFolder;
 
 public class IncidentStreamProcessorRule extends ExternalResource {
 
-  private final StreamProcessorRule environmentRule;
   @Rule public TemporaryFolder folder = new TemporaryFolder();
+  private final StreamProcessorRule environmentRule;
   private SubscriptionCommandSender mockSubscriptionCommandSender;
   private DueDateTimerChecker mockTimerEventScheduler;
 

--- a/engine/src/test/java/io/zeebe/engine/state/instance/VariableStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/instance/VariableStateTest.java
@@ -36,13 +36,11 @@ import org.junit.Test;
 
 public class VariableStateTest {
 
+  @ClassRule public static ZeebeStateRule stateRule = new ZeebeStateRule();
   private static final long WORKFLOW_KEY = 123;
   private static final AtomicLong PARENT_KEY = new AtomicLong(0);
   private static final AtomicLong CHILD_KEY = new AtomicLong(1);
   private static final AtomicLong SECOND_CHILD_KEY = new AtomicLong(2);
-
-  @ClassRule public static ZeebeStateRule stateRule = new ZeebeStateRule();
-
   private static ElementInstanceState elementInstanceState;
   private static VariablesState variablesState;
   private static RecordingVariableListener listener;

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClientImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClientImpl.java
@@ -43,11 +43,11 @@ public class BrokerClientImpl implements BrokerClient {
   protected final ActorScheduler actorScheduler;
   protected final ClientTransport transport;
   protected final BrokerTopologyManagerImpl topologyManager;
+  protected boolean isClosed;
   private final AtomixCluster atomixCluster;
   private final boolean ownsActorScheduler;
   private final Dispatcher dataFrameReceiveBuffer;
   private final BrokerRequestManager requestManager;
-  protected boolean isClosed;
   private Subscription jobAvailableSubscription;
 
   public BrokerClientImpl(final GatewayCfg configuration, final AtomixCluster atomixCluster) {

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/ActivateJobsStub.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/ActivateJobsStub.java
@@ -43,6 +43,7 @@ public class ActivateJobsStub
       new UnsafeBuffer(MsgPackConverter.convertToMsgPack(CUSTOM_HEADERS));
   public static final DirectBuffer VARIABLES_MSGPACK =
       new UnsafeBuffer(MsgPackConverter.convertToMsgPack(VARIABLES));
+  private Map<String, Integer> availableJobs = new HashMap<>();
 
   public long getJobBatchKey() {
     return JOB_BATCH_KEY;
@@ -87,8 +88,6 @@ public class ActivateJobsStub
   public long getElementInstanceKey() {
     return ELEMENT_INSTANCE_KEY;
   }
-
-  private Map<String, Integer> availableJobs = new HashMap<>();
 
   @Override
   public BrokerResponse<JobBatchRecord> handle(BrokerActivateJobsRequest request) throws Exception {

--- a/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedGatewayRule.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedGatewayRule.java
@@ -13,9 +13,9 @@ import org.junit.rules.ExternalResource;
 
 public class StubbedGatewayRule extends ExternalResource {
 
-  private final ActorSchedulerRule actorSchedulerRule;
   protected StubbedGateway gateway;
   protected GatewayBlockingStub client;
+  private final ActorSchedulerRule actorSchedulerRule;
 
   public StubbedGatewayRule(ActorSchedulerRule actorSchedulerRule) {
     this.actorSchedulerRule = actorSchedulerRule;

--- a/json-el/src/test/java/io/zeebe/msgpack/el/JsonConditionInterpreterTest.java
+++ b/json-el/src/test/java/io/zeebe/msgpack/el/JsonConditionInterpreterTest.java
@@ -21,8 +21,6 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class JsonConditionInterpreterTest {
 
-  private final JsonConditionInterpreter interpreter = new JsonConditionInterpreter();
-
   @Parameter(0)
   public String expression;
 
@@ -31,6 +29,8 @@ public class JsonConditionInterpreterTest {
 
   @Parameter(2)
   public boolean isFulfilled;
+
+  private final JsonConditionInterpreter interpreter = new JsonConditionInterpreter();
 
   @Parameters(name = "{index}: expression = {0}")
   public static Iterable<Object[]> data() {

--- a/json-el/src/test/java/io/zeebe/msgpack/el/JsonConditionTest.java
+++ b/json-el/src/test/java/io/zeebe/msgpack/el/JsonConditionTest.java
@@ -19,8 +19,8 @@ import org.junit.rules.ExpectedException;
 
 public class JsonConditionTest {
 
-  private final JsonConditionInterpreter interpreter = new JsonConditionInterpreter();
   @Rule public ExpectedException thrown = ExpectedException.none();
+  private final JsonConditionInterpreter interpreter = new JsonConditionInterpreter();
 
   @Test
   public void shouldEvaluateConditionWithLiteral() {

--- a/json-path/src/test/java/io/zeebe/msgpack/mapping/MappingTestUtil.java
+++ b/json-path/src/test/java/io/zeebe/msgpack/mapping/MappingTestUtil.java
@@ -30,6 +30,7 @@ import org.msgpack.jackson.dataformat.MessagePackFactory;
 
 public class MappingTestUtil {
   public static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+  public static Path jsonDocumentPath;
   protected static final String NODE_JSON_OBJECT_KEY = "jsonObject";
   protected static final String NODE_TEST_ATTR_KEY = "testAttr";
   protected static final String NODE_STRING_KEY = "string";
@@ -49,11 +50,8 @@ public class MappingTestUtil {
   protected static final Map<String, Object> JSON_PAYLOAD = new HashMap<>();
   protected static final ObjectMapper MSGPACK_MAPPER = new ObjectMapper(new MessagePackFactory());
   protected static final byte[] MSG_PACK_BYTES;
-
   private static final MutableDirectBuffer WRITE_BUFFER = new UnsafeBuffer(new byte[256]);
   private static final MsgPackWriter WRITER = new MsgPackWriter();
-
-  public static Path jsonDocumentPath;
 
   static {
     JSON_MAPPER.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/fs/FsLogSegment.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/fs/FsLogSegment.java
@@ -43,8 +43,8 @@ public class FsLogSegment {
       "Expected to allocate new segment of size %d, but not enough space available (%d)";
   private static final String ERROR_MSG_INSUFFICIENT_CAPACITY =
       "Expected to append block with size %d, but actual capacity is insufficient %d.";
-  private final String fileName;
   protected volatile short state;
+  private final String fileName;
   private FileChannel fileChannel;
   private final Rater rater =
       new Rater(

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/fs/FsLogStorage.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/fs/FsLogStorage.java
@@ -39,8 +39,8 @@ public class FsLogStorage implements LogStorage {
       "Expected to append block with smaller block size then %d, but actual block size was %d.";
 
   protected final FsLogStorageConfiguration config;
-  private final ReadResultProcessor defaultReadResultProcessor = (buffer, readResult) -> readResult;
   protected volatile int state = STATE_CREATED;
+  private final ReadResultProcessor defaultReadResultProcessor = (buffer, readResult) -> readResult;
   /** Readable log segments */
   private FsLogSegments logSegments;
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogWriteBufferService.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogWriteBufferService.java
@@ -19,10 +19,9 @@ import io.zeebe.servicecontainer.ServiceStartContext;
 import io.zeebe.servicecontainer.ServiceStopContext;
 
 public class LogWriteBufferService implements Service<Dispatcher> {
-  private final Injector<LogStorage> logStorageInjector = new Injector<>();
-
   protected DispatcherBuilder dispatcherBuilder;
   protected Dispatcher dispatcher;
+  private final Injector<LogStorage> logStorageInjector = new Injector<>();
 
   public LogWriteBufferService(DispatcherBuilder builder) {
     this.dispatcherBuilder = builder;

--- a/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/ControllableRestoreClient.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/ControllableRestoreClient.java
@@ -22,12 +22,11 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class ControllableRestoreClient implements RestoreClient {
+  public List<LogReplicationRequest> requestLog = new ArrayList<>();
   private final Map<Long, CompletableFuture<LogReplicationResponse>> logReplicationRequests =
       new HashMap<>();
-
   private final Map<Integer, CompletableFuture<SnapshotRestoreResponse>>
       snapshotReplicationRequests = new HashMap<>();
-  public List<LogReplicationRequest> requestLog = new ArrayList<>();
 
   @Override
   public CompletableFuture<SnapshotRestoreResponse> requestSnapshotChunk(

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamReaderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamReaderTest.java
@@ -32,10 +32,7 @@ public class LogStreamReaderTest {
   private static final UnsafeBuffer EVENT_VALUE = new UnsafeBuffer(getBytes("test"));
   private static final UnsafeBuffer BIG_EVENT_VALUE =
       new UnsafeBuffer(new byte[BufferedLogStreamReader.DEFAULT_INITIAL_BUFFER_CAPACITY * 2]);
-  private final Random random = new Random();
-
   @Rule public ExpectedException expectedException = ExpectedException.none();
-
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
   public LogStreamRule logStreamRule = new LogStreamRule(temporaryFolder);
   public LogStreamWriterRule writer = new LogStreamWriterRule(logStreamRule);
@@ -45,6 +42,7 @@ public class LogStreamReaderTest {
   public RuleChain ruleChain =
       RuleChain.outerRule(temporaryFolder).around(logStreamRule).around(readerRule).around(writer);
 
+  private final Random random = new Random();
   private LogStreamReader reader;
   private long eventKey;
 

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/CopiedRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/CopiedRecord.java
@@ -17,19 +17,17 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public class CopiedRecord<T extends UnifiedRecordValue> implements Record<T> {
 
+  protected ValueType valueType;
   private final T recordValue;
-
   private final long key;
   private final long position;
   private final long sourcePosition;
   private final long timestamp;
-
   private final RecordType recordType;
   private final Intent intent;
   private final int partitionId;
   private final RejectionType rejectionType;
   private final String rejectionReason;
-  protected ValueType valueType;
 
   public CopiedRecord(
       T recordValue,
@@ -145,12 +143,12 @@ public class CopiedRecord<T extends UnifiedRecordValue> implements Record<T> {
   }
 
   @Override
-  public String toString() {
-    return toJson();
+  public Record<T> clone() {
+    return new CopiedRecord<>(this);
   }
 
   @Override
-  public Record<T> clone() {
-    return new CopiedRecord<>(this);
+  public String toString() {
+    return toJson();
   }
 }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/RecordMetadata.java
@@ -30,11 +30,11 @@ public class RecordMetadata implements BufferWriter, BufferReader {
 
   protected final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
   protected final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
-  private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
   protected RecordMetadataEncoder encoder = new RecordMetadataEncoder();
   protected RecordMetadataDecoder decoder = new RecordMetadataDecoder();
   protected long requestId;
   protected ValueType valueType = ValueType.NULL_VAL;
+  private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
   private RecordType recordType = RecordType.NULL_VAL;
   private short intentValue = Intent.NULL_VAL;
   private Intent intent = null;

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/brokerapi/StubBrokerRule.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/brokerapi/StubBrokerRule.java
@@ -29,15 +29,13 @@ public class StubBrokerRule extends ExternalResource {
   public static final int TEST_PARTITION_ID = DEPLOYMENT_PARTITION;
   protected final int nodeId;
   protected final SocketAddress socketAddress;
-  private final ControlledActorClock clock = new ControlledActorClock();
-  private final int partitionCount;
   protected ActorScheduler scheduler;
   protected ServerTransport transport;
-
   protected StubResponseChannelHandler channelHandler;
   protected MsgPackHelper msgPackHelper;
-
   protected AtomicReference<Topology> currentTopology = new AtomicReference<>();
+  private final ControlledActorClock clock = new ControlledActorClock();
+  private final int partitionCount;
 
   public StubBrokerRule() {
     this(0);

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/commandapi/CommandApiRule.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/commandapi/CommandApiRule.java
@@ -64,13 +64,13 @@ public class CommandApiRule extends ExternalResource {
   protected final int nodeId;
   protected final Supplier<AtomixCluster> atomixSupplier;
   protected final int partitionCount;
-  private final Int2ObjectHashMap<PartitionTestClient> testPartitionClients =
-      new Int2ObjectHashMap<>();
-  private final ControlledActorClock controlledActorClock = new ControlledActorClock();
   protected int nextPartitionId = 0;
   protected MsgPackHelper msgPackHelper;
   protected ClientTransport transport;
   protected int defaultPartitionId = -1;
+  private final Int2ObjectHashMap<PartitionTestClient> testPartitionClients =
+      new Int2ObjectHashMap<>();
+  private final ControlledActorClock controlledActorClock = new ControlledActorClock();
   private AtomixCluster atomix;
   private ActorScheduler scheduler;
 

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/commandapi/ErrorResponse.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/commandapi/ErrorResponse.java
@@ -16,9 +16,9 @@ import org.agrona.DirectBuffer;
 
 public class ErrorResponse implements BufferReader {
   protected final MsgPackHelper msgPackHelper;
+  protected String errorData;
   private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
   private final ErrorResponseDecoder bodyDecoder = new ErrorResponseDecoder();
-  protected String errorData;
 
   public ErrorResponse(MsgPackHelper msgPackHelper) {
     this.msgPackHelper = msgPackHelper;

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/commandapi/ExecuteCommandResponse.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/commandapi/ExecuteCommandResponse.java
@@ -27,10 +27,10 @@ import org.agrona.io.DirectBufferInputStream;
 public class ExecuteCommandResponse implements BufferReader {
   protected final ErrorResponse errorResponse;
   protected final MsgPackHelper msgPackHelper;
+  protected Map<String, Object> value;
   private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
   private final ExecuteCommandResponseDecoder responseDecoder = new ExecuteCommandResponseDecoder();
   private final DirectBuffer responseBuffer = new UnsafeBuffer();
-  protected Map<String, Object> value;
   private int valueLengthOffset;
   private String rejectionReason;
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
@@ -30,9 +30,8 @@ import org.junit.rules.ExternalResource;
 
 public class GrpcClientRule extends ExternalResource {
 
-  private final Consumer<ZeebeClientBuilder> configurator;
-
   protected ZeebeClient client;
+  private final Consumer<ZeebeClientBuilder> configurator;
 
   public GrpcClientRule(final EmbeddedBrokerRule brokerRule) {
     this(brokerRule, config -> {});

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/job/ActivateJobsTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/job/ActivateJobsTest.java
@@ -53,15 +53,11 @@ public class ActivateJobsTest {
   private static final Map<String, Object> CUSTOM_HEADERS = Collections.singletonMap("foo", "bar");
   private static final Map<String, Object> VARIABLES = Collections.singletonMap("hello", "world");
   private static final int PARTITION_COUNT = 3;
-
+  @Rule public Timeout timeout = Timeout.seconds(120);
   private final EmbeddedBrokerRule embeddedBrokerRule =
       new EmbeddedBrokerRule(setPartitionCount(PARTITION_COUNT));
   public GrpcClientRule clientRule = new GrpcClientRule(embeddedBrokerRule);
-
   @Rule public RuleChain ruleChain = RuleChain.outerRule(embeddedBrokerRule).around(clientRule);
-
-  @Rule public Timeout timeout = Timeout.seconds(120);
-
   private ZeebeClient client;
 
   @Before

--- a/service-container/src/main/java/io/zeebe/servicecontainer/impl/ServiceContainerImpl.java
+++ b/service-container/src/main/java/io/zeebe/servicecontainer/impl/ServiceContainerImpl.java
@@ -35,8 +35,8 @@ public class ServiceContainerImpl extends Actor implements ServiceContainer {
       new ConcurrentQueueChannel<>(new ManyToOneConcurrentLinkedQueue<>());
   protected final ActorScheduler actorScheduler;
   protected final AtomicBoolean isOpenend = new AtomicBoolean(false);
-  private final CompletableActorFuture<Void> containerCloseFuture = new CompletableActorFuture<>();
   protected ContainerState state = ContainerState.NEW;
+  private final CompletableActorFuture<Void> containerCloseFuture = new CompletableActorFuture<>();
 
   public ServiceContainerImpl(ActorScheduler scheduler) {
     actorScheduler = scheduler;

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
@@ -51,12 +51,10 @@ import java.util.stream.StreamSupport;
 
 public class RecordingExporter implements Exporter {
 
+  public static long maxWait = Duration.ofSeconds(5).toMillis();
   private static final List<Record<?>> RECORDS = new CopyOnWriteArrayList<>();
-
   private static final Lock LOCK = new ReentrantLock();
   private static final Condition IS_EMPTY = LOCK.newCondition();
-
-  public static long maxWait = Duration.ofSeconds(5).toMillis();
 
   @Override
   public void export(final Record record) {

--- a/test/src/main/java/io/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/zeebe/test/EmbeddedBrokerRule.java
@@ -59,11 +59,10 @@ public class EmbeddedBrokerRule extends ExternalResource {
   protected final ControlledActorClock controlledActorClock = new ControlledActorClock();
   protected final Supplier<InputStream> configSupplier;
   protected final Consumer<BrokerCfg>[] configurators;
-  private final int timeout;
-  private final File newTemporaryFolder;
-
   protected Broker broker;
   protected long startTime;
+  private final int timeout;
+  private final File newTemporaryFolder;
   private List<String> dataDirectories;
 
   @SafeVarargs

--- a/transport/src/main/java/io/zeebe/transport/ClientTransportBuilder.java
+++ b/transport/src/main/java/io/zeebe/transport/ClientTransportBuilder.java
@@ -34,13 +34,13 @@ public class ClientTransportBuilder {
   protected static final Duration DEFAULT_CHANNEL_KEEP_ALIVE_PERIOD = Duration.ofSeconds(5);
 
   protected static final long DEFAULT_CHANNEL_CONNECT_TIMEOUT = 500;
-  private final String name;
   protected Duration keepAlivePeriod = DEFAULT_CHANNEL_KEEP_ALIVE_PERIOD;
   protected Dispatcher receiveBuffer;
   protected List<ClientInputListener> listeners;
   protected TransportChannelFactory channelFactory;
   protected Duration defaultRequestRetryTimeout = Duration.ofSeconds(15);
   protected Duration defaultMessageRetryTimeout = Duration.ofSeconds(1);
+  private final String name;
   private int messageMaxLength = 1024 * 512;
   private ActorScheduler scheduler;
   private TransportMemoryPool requestMemoryPool =

--- a/transport/src/main/java/io/zeebe/transport/ServerResponse.java
+++ b/transport/src/main/java/io/zeebe/transport/ServerResponse.java
@@ -21,10 +21,10 @@ public class ServerResponse implements BufferWriter {
       new TransportHeaderDescriptor();
   protected final ClaimedFragment claimedFragment = new ClaimedFragment();
   protected final DirectBufferWriter writerAdapter = new DirectBufferWriter();
-  private final RequestResponseHeaderDescriptor requestResponseHeaderDescriptor =
-      new RequestResponseHeaderDescriptor();
   protected BufferWriter writer;
   protected int remoteStreamId;
+  private final RequestResponseHeaderDescriptor requestResponseHeaderDescriptor =
+      new RequestResponseHeaderDescriptor();
   private long requestId;
 
   public ServerResponse writer(BufferWriter writer) {

--- a/transport/src/main/java/io/zeebe/transport/impl/actor/Conductor.java
+++ b/transport/src/main/java/io/zeebe/transport/impl/actor/Conductor.java
@@ -31,9 +31,9 @@ public abstract class Conductor extends Actor implements ChannelLifecycleListene
   protected final TransportContext transportContext;
   protected final AtomicBoolean closing = new AtomicBoolean(false);
   protected final TransportChannelFactory channelFactory;
+  protected Int2ObjectHashMap<TransportChannel> channels = new Int2ObjectHashMap<>();
   private final List<TransportListener> transportListeners = new ArrayList<>();
   private final ActorContext actorContext;
-  protected Int2ObjectHashMap<TransportChannel> channels = new Int2ObjectHashMap<>();
 
   public Conductor(ActorContext actorContext, TransportContext context) {
     this.actorContext = actorContext;

--- a/transport/src/main/java/io/zeebe/transport/impl/selector/ReadTransportPoller.java
+++ b/transport/src/main/java/io/zeebe/transport/impl/selector/ReadTransportPoller.java
@@ -24,8 +24,8 @@ public class ReadTransportPoller extends TransportPoller {
   protected final List<TransportChannel> channels = new ArrayList<>();
   protected final List<TransportChannel> channelsToAdd = new ArrayList<>();
   protected final ToIntFunction<SelectionKey> processKeyFn = this::processKey;
-  private final ActorControl actor;
   protected final Runnable pollNow = this::pollNow;
+  private final ActorControl actor;
 
   public ReadTransportPoller(ActorControl actor) {
     this.actor = actor;

--- a/transport/src/test/java/io/zeebe/transport/MixedProtocolsTest.java
+++ b/transport/src/test/java/io/zeebe/transport/MixedProtocolsTest.java
@@ -23,11 +23,11 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 
 public class MixedProtocolsTest {
-  protected final UnsafeBuffer requestBuffer = new UnsafeBuffer(new byte[1024]);
-  protected final DirectBufferWriter bufferWriter = new DirectBufferWriter();
   public ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule(3);
   public AutoCloseableRule closeables = new AutoCloseableRule();
   @Rule public RuleChain ruleChain = RuleChain.outerRule(actorSchedulerRule).around(closeables);
+  protected final UnsafeBuffer requestBuffer = new UnsafeBuffer(new byte[1024]);
+  protected final DirectBufferWriter bufferWriter = new DirectBufferWriter();
 
   @Test
   public void shouldEchoMessages() throws InterruptedException, ExecutionException {

--- a/util/src/main/java/io/zeebe/util/sched/ActorTask.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorTask.java
@@ -39,21 +39,15 @@ public class ActorTask {
 
   public final CompletableActorFuture<Void> closeFuture = new CompletableActorFuture<>();
   final Actor actor;
+  ActorJob currentJob;
+  boolean shouldYield;
+  volatile TaskSchedulingState schedulingState = null;
+  volatile long stateCount = 0;
   private final CompletableActorFuture<Void> jobClosingTaskFuture = new CompletableActorFuture<>();
   private final CompletableActorFuture<Void> startingFuture = new CompletableActorFuture<>();
   private final CompletableActorFuture<Void> jobStartingTaskFuture = new CompletableActorFuture<>();
-  volatile TaskSchedulingState schedulingState = null;
-  volatile long stateCount = 0;
-  ActorJob currentJob;
-  boolean shouldYield;
   private ActorExecutor actorExecutor;
   private ActorThreadGroup actorThreadGroup;
-  /**
-   * jobs that are submitted to this task externally. A job is submitted "internally" if it is
-   * submitted from a job within the same actor while the task is in RUNNING state.
-   */
-  private volatile Queue<ActorJob> submittedJobs = new ClosedQueue();
-
   private Deque<ActorJob> fastLaneJobs = new ClosedQueue();
   private ActorLifecyclePhase lifecyclePhase = ActorLifecyclePhase.CLOSED;
   private ActorSubscription[] subscriptions = new ActorSubscription[0];
@@ -61,6 +55,11 @@ public class ActorTask {
    * the priority class of the task. Only set if the task is scheduled as non-blocking, CPU-bound
    */
   private int priority = ActorPriority.REGULAR.getPriorityClass();
+  /**
+   * jobs that are submitted to this task externally. A job is submitted "internally" if it is
+   * submitted from a job within the same actor while the task is in RUNNING state.
+   */
+  private volatile Queue<ActorJob> submittedJobs = new ClosedQueue();
 
   public ActorTask(Actor actor) {
     this.actor = actor;

--- a/util/src/main/java/io/zeebe/util/sched/ActorTaskQueue.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorTaskQueue.java
@@ -14,9 +14,9 @@ import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 /** Adapted from Agrona's {@link ManyToOneConcurrentLinkedQueue}. */
 @SuppressWarnings("restriction")
 public class ActorTaskQueue extends ActorTaskQueueHead {
-  private final ActorTaskQueueNode empty = new ActorTaskQueueNode();
   @SuppressWarnings("unused")
   protected long p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45;
+  private final ActorTaskQueueNode empty = new ActorTaskQueueNode();
 
   public ActorTaskQueue() {
     headOrdered(empty);

--- a/util/src/main/java/io/zeebe/util/sched/ActorThread.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorThread.java
@@ -51,15 +51,14 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
   public final ManyToManyConcurrentArrayQueue<Runnable> submittedCallbacks =
       new ManyToManyConcurrentArrayQueue<>(1024 * 24);
   protected final ActorTimerQueue timerJobQueue;
+  protected ActorTaskRunnerIdleStrategy idleStrategy = new ActorTaskRunnerIdleStrategy();
+  ActorTask currentTask;
   private final CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
   private final ActorClock clock;
   private final int threadId;
-
   private final TaskScheduler taskScheduler;
   private final BoundedArrayQueue<ActorJob> jobs = new BoundedArrayQueue<>(2048);
   private final ActorThreadGroup actorThreadGroup;
-  protected ActorTaskRunnerIdleStrategy idleStrategy = new ActorTaskRunnerIdleStrategy();
-  ActorTask currentTask;
   private volatile ActorThreadState state;
 
   public ActorThread(

--- a/util/src/main/java/io/zeebe/util/sched/future/CompletableActorFuture.java
+++ b/util/src/main/java/io/zeebe/util/sched/future/CompletableActorFuture.java
@@ -40,12 +40,12 @@ public class CompletableActorFuture<V> implements ActorFuture<V> {
     }
   }
 
-  private final ManyToOneConcurrentLinkedQueue<ActorTask> blockedTasks =
-      new ManyToOneConcurrentLinkedQueue<>();
-  private final ReentrantLock completionLock = new ReentrantLock();
   protected V value;
   protected String failure;
   protected Throwable failureCause;
+  private final ManyToOneConcurrentLinkedQueue<ActorTask> blockedTasks =
+      new ManyToOneConcurrentLinkedQueue<>();
+  private final ReentrantLock completionLock = new ReentrantLock();
   private volatile int state = CLOSED;
   private Condition isDoneCondition;
 

--- a/zb-db/src/test/java/io/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/ColumnFamilyTest.java
@@ -22,9 +22,9 @@ import org.junit.rules.TemporaryFolder;
 
 public class ColumnFamilyTest {
 
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
       DefaultZeebeDbFactory.getDefaultFactory(DefaultColumnFamily.class);
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private ZeebeDb<DefaultColumnFamily> zeebeDb;
   private ColumnFamily<DbLong, DbLong> columnFamily;
   private DbLong key;

--- a/zb-db/src/test/java/io/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
@@ -22,9 +22,9 @@ import org.junit.rules.TemporaryFolder;
 
 public class DbCompositeKeyColumnFamilyTest {
 
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
       DefaultZeebeDbFactory.getDefaultFactory(DefaultColumnFamily.class);
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private ZeebeDb<DefaultColumnFamily> zeebeDb;
   private ColumnFamily<DbCompositeKey<DbString, DbLong>, DbString> columnFamily;
   private DbString firstKey;

--- a/zb-db/src/test/java/io/zeebe/db/impl/DbStringColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/DbStringColumnFamilyTest.java
@@ -23,9 +23,9 @@ import org.junit.rules.TemporaryFolder;
 
 public class DbStringColumnFamilyTest {
 
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
       DefaultZeebeDbFactory.getDefaultFactory(DefaultColumnFamily.class);
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private ZeebeDb<DefaultColumnFamily> zeebeDb;
   private ColumnFamily<DbString, DbString> columnFamily;
   private DbString key;

--- a/zb-db/src/test/java/io/zeebe/db/impl/DbTransactionTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/DbTransactionTest.java
@@ -25,9 +25,9 @@ import org.junit.rules.TemporaryFolder;
 
 public class DbTransactionTest {
 
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private final ZeebeDbFactory<ColumnFamilies> dbFactory =
       DefaultZeebeDbFactory.getDefaultFactory(ColumnFamilies.class);
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private DbContext dbContext;
 
   private ColumnFamily<DbLong, DbLong> oneColumnFamily;

--- a/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbIterationTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbIterationTest.java
@@ -27,9 +27,9 @@ import org.rocksdb.RocksIterator;
 
 public class ZeebeRocksDbIterationTest {
 
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
       DefaultZeebeDbFactory.getDefaultFactory(DefaultColumnFamily.class);
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private ZeebeTransactionDb<DefaultColumnFamily> zeebeDb;
   private ColumnFamily<DbCompositeKey<DbLong, DbLong>, DbNil> columnFamily;
   private DbLong firstKey;

--- a/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbTransactionTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbTransactionTest.java
@@ -31,9 +31,9 @@ import org.rocksdb.Status.SubCode;
 
 public class ZeebeRocksDbTransactionTest {
 
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
       DefaultZeebeDbFactory.getDefaultFactory(DefaultColumnFamily.class);
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private DbContext dbContext;
 
   @Before


### PR DESCRIPTION
## Description

Adds a new Checkstyle check to enforce declaration order. The main difference is that fields are now only grouped by static/instance, and the final modifier is ignored. So before, we had:

```java
public class MyClass {
  private static final int A = 1;
  public static int b;

  private final String topic;
  protected boolean isRunning;
  // ...
}
```

Which now becomes:

```java
public class MyClass {
  public static int b;
  private static final int A = 1;

  protected boolean isRunning;
  private final String topic;

 // ...
}
```

I think the trade off here that it's now enforced is worth it.

## Related issues


## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
