### PR TITLE
fix(broker): cancel workflow instance

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/AbstractHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/AbstractHandler.java
@@ -24,7 +24,7 @@ public abstract class AbstractHandler<T extends ExecutableFlowElement>
    *     this state if successfully handled, otherwise will not. Asynchronous handlers should thus
    *     pass null here.
    */
-  public AbstractHandler(final WorkflowInstanceIntent nextState) {
+  public AbstractHandler(WorkflowInstanceIntent nextState) {
     this.nextState = nextState;
   }
 
@@ -35,7 +35,7 @@ public abstract class AbstractHandler<T extends ExecutableFlowElement>
    * @param context current step context
    */
   @Override
-  public void handle(final BpmnStepContext<T> context) {
+  public void handle(BpmnStepContext<T> context) {
     if (shouldHandleState(context)) {
       final boolean handled = handleState(context);
 
@@ -44,7 +44,9 @@ public abstract class AbstractHandler<T extends ExecutableFlowElement>
       }
     } else {
       Loggers.WORKFLOW_PROCESSOR_LOGGER.debug(
-          "Skipping record {} due to step guard; in-memory element is {}",
+          "Skipping record [key: {}, intent: {}, value: {}] due to step guard; in-memory element is {}",
+          context.getKey(),
+          context.getState(),
           context.getValue(),
           context.getElementInstance());
     }
@@ -58,11 +60,11 @@ public abstract class AbstractHandler<T extends ExecutableFlowElement>
    */
   protected abstract boolean handleState(BpmnStepContext<T> context);
 
-  protected boolean shouldHandleState(final BpmnStepContext<T> context) {
+  protected boolean shouldHandleState(BpmnStepContext<T> context) {
     return true;
   }
 
-  protected boolean isRootScope(final BpmnStepContext<T> context) {
+  protected boolean isRootScope(BpmnStepContext<T> context) {
     return context.getValue().getFlowScopeKey() == -1;
   }
 
@@ -72,16 +74,16 @@ public abstract class AbstractHandler<T extends ExecutableFlowElement>
    * ELEMENT_ACTIVATING and ELEMENT_ACTIVATED in the same step will transition the element to
    * ACTIVATED, and we shouldn't process the ELEMENT_ACTIVATING in that case).
    */
-  protected boolean isStateSameAsElementState(final BpmnStepContext<T> context) {
+  protected boolean isStateSameAsElementState(BpmnStepContext<T> context) {
     return context.getElementInstance() != null
         && context.getState() == context.getElementInstance().getState();
   }
 
-  protected boolean isElementActive(final ElementInstance instance) {
+  protected boolean isElementActive(ElementInstance instance) {
     return instance != null && instance.isActive();
   }
 
-  protected boolean isElementTerminating(final ElementInstance instance) {
+  protected boolean isElementTerminating(ElementInstance instance) {
     return instance != null && instance.isTerminating();
   }
 
@@ -89,8 +91,8 @@ public abstract class AbstractHandler<T extends ExecutableFlowElement>
     return nextState != null;
   }
 
-  protected void transitionToNext(final BpmnStepContext<T> context) {
-    transitionTo(context, nextState);
+  protected void transitionToNext(BpmnStepContext<T> context) {
+    this.transitionTo(context, nextState);
   }
 
   protected void transitionTo(

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/CancelWorkflowInstanceConcurrentlyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/CancelWorkflowInstanceConcurrentlyTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.instance;
+
+import static io.zeebe.protocol.record.intent.WorkflowInstanceIntent.CANCEL;
+import static io.zeebe.protocol.record.intent.WorkflowInstanceIntent.ELEMENT_ACTIVATED;
+import static io.zeebe.protocol.record.intent.WorkflowInstanceIntent.ELEMENT_TERMINATED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.engine.util.RecordToWrite;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.protocol.record.value.JobRecordValue;
+import io.zeebe.protocol.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class CancelWorkflowInstanceConcurrentlyTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String ELEMENT_ID = "task";
+  private static final String JOB_TYPE = "test";
+  private static final String INPUT_COLLECTION_VARIABLE = "items";
+
+  private static final BpmnModelInstance SEQUENTIAL_FLOW =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .parallelGateway("fork")
+          .serviceTask(ELEMENT_ID, t -> t.zeebeTaskType(JOB_TYPE))
+          .serviceTask("task-after", t -> t.zeebeTaskType("nope"))
+          .done();
+
+  private static final BpmnModelInstance PARALLEL_FLOW =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .parallelGateway("fork")
+          .serviceTask(ELEMENT_ID, t -> t.zeebeTaskType(JOB_TYPE))
+          .endEvent()
+          .moveToLastGateway()
+          .serviceTask("parallel-task", t -> t.zeebeTaskType("nope"))
+          .endEvent()
+          .done();
+
+  private static final BpmnModelInstance SUB_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .subProcess(
+              "sub-process",
+              s ->
+                  s.embeddedSubProcess()
+                      .startEvent()
+                      .parallelGateway("fork")
+                      .serviceTask(ELEMENT_ID, t -> t.zeebeTaskType(JOB_TYPE))
+                      .endEvent()
+                      .moveToLastGateway()
+                      .serviceTask("parallel-task", t -> t.zeebeTaskType("nope"))
+                      .endEvent())
+          .done();
+
+  private static final BpmnModelInstance MULTI_INSTANCE =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .serviceTask(
+              ELEMENT_ID,
+              t ->
+                  t.zeebeTaskType(JOB_TYPE)
+                      .multiInstance(
+                          m -> m.parallel().zeebeInputCollection(INPUT_COLLECTION_VARIABLE)))
+          .serviceTask("task-after", t -> t.zeebeTaskType("nope"))
+          .done();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Parameter(0)
+  public String description;
+
+  @Parameter(1)
+  public BpmnModelInstance workflow;
+
+  @Parameter(2)
+  public List<String> expectedTerminatedElementIds;
+
+  private long workflowInstanceKey;
+  private Record<JobRecordValue> createdJob;
+  private Record<WorkflowInstanceRecordValue> activityActivated;
+
+  @Parameters(name = "{0}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {"sequential flow", SEQUENTIAL_FLOW, Arrays.asList(PROCESS_ID)},
+      {"parallel flow", PARALLEL_FLOW, Arrays.asList("parallel-task", PROCESS_ID)},
+      {"sub-process", SUB_PROCESS, Arrays.asList("parallel-task", "sub-process", PROCESS_ID)},
+      {"multi-instance", MULTI_INSTANCE, Arrays.asList(ELEMENT_ID, ELEMENT_ID, PROCESS_ID)},
+    };
+  }
+
+  @Before
+  public void init() {
+    ENGINE.deployment().withXmlResource(workflow).deploy();
+
+    workflowInstanceKey =
+        ENGINE
+            .workflowInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable(INPUT_COLLECTION_VARIABLE, Arrays.asList("one", "two"))
+            .create();
+
+    activityActivated =
+        RecordingExporter.workflowInstanceRecords()
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .withElementId(ELEMENT_ID)
+            .withIntent(ELEMENT_ACTIVATED)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst();
+
+    createdJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .withType(JOB_TYPE)
+            .getFirst();
+
+    ENGINE.stop();
+  }
+
+  @Test
+  public void shouldCancelAfterJobComplete() {
+    // given
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .job(JobIntent.COMPLETE, createdJob.getValue())
+            .key(createdJob.getKey()),
+        RecordToWrite.command()
+            .workflowInstance(CANCEL, new WorkflowInstanceRecord())
+            .key(workflowInstanceKey));
+
+    // when
+    ENGINE.start();
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .limitToWorkflowInstanceTerminated()
+                .filter(r -> r.getIntent() == ELEMENT_TERMINATED))
+        .extracting(r -> r.getValue().getElementId())
+        .containsSubsequence(expectedTerminatedElementIds)
+        .contains(ELEMENT_ID);
+  }
+
+  @Test
+  public void shouldCancelAfterJobCompleted() {
+    // given
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .job(JobIntent.COMPLETE, createdJob.getValue())
+            .key(createdJob.getKey()),
+        RecordToWrite.event()
+            .job(JobIntent.COMPLETED, createdJob.getValue())
+            .key(createdJob.getKey())
+            .causedBy(0),
+        RecordToWrite.command()
+            .workflowInstance(CANCEL, new WorkflowInstanceRecord())
+            .key(workflowInstanceKey));
+
+    // when
+    ENGINE.start();
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .limitToWorkflowInstanceTerminated()
+                .filter(r -> r.getIntent() == ELEMENT_TERMINATED))
+        .extracting(r -> r.getValue().getElementId())
+        .containsSubsequence(expectedTerminatedElementIds);
+  }
+
+  @Test
+  public void shouldCancelAfterElementCompleting() {
+    // given
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .job(JobIntent.COMPLETE, createdJob.getValue())
+            .key(createdJob.getKey()),
+        RecordToWrite.event()
+            .job(JobIntent.COMPLETED, createdJob.getValue())
+            .key(createdJob.getKey())
+            .causedBy(0),
+        RecordToWrite.event()
+            .workflowInstance(
+                WorkflowInstanceIntent.ELEMENT_COMPLETING, activityActivated.getValue())
+            .key(activityActivated.getKey())
+            .causedBy(1),
+        RecordToWrite.command()
+            .workflowInstance(CANCEL, new WorkflowInstanceRecord())
+            .key(workflowInstanceKey));
+
+    // when
+    ENGINE.start();
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .limitToWorkflowInstanceTerminated()
+                .filter(r -> r.getIntent() == ELEMENT_TERMINATED))
+        .extracting(r -> r.getValue().getElementId())
+        .containsSubsequence(expectedTerminatedElementIds);
+  }
+
+  @Test
+  public void shouldCancelAfterElementCompleted() {
+    // given
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .job(JobIntent.COMPLETE, createdJob.getValue())
+            .key(createdJob.getKey()),
+        RecordToWrite.event()
+            .job(JobIntent.COMPLETED, createdJob.getValue())
+            .key(createdJob.getKey())
+            .causedBy(0),
+        RecordToWrite.event()
+            .workflowInstance(
+                WorkflowInstanceIntent.ELEMENT_COMPLETING, activityActivated.getValue())
+            .key(activityActivated.getKey())
+            .causedBy(1),
+        RecordToWrite.event()
+            .workflowInstance(
+                WorkflowInstanceIntent.ELEMENT_COMPLETED, activityActivated.getValue())
+            .key(activityActivated.getKey())
+            .causedBy(2),
+        RecordToWrite.command()
+            .workflowInstance(CANCEL, new WorkflowInstanceRecord())
+            .key(workflowInstanceKey));
+
+    // when
+    ENGINE.start();
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .limitToWorkflowInstanceTerminated()
+                .filter(r -> r.getIntent() == ELEMENT_TERMINATED))
+        .extracting(r -> r.getValue().getElementId())
+        .containsSubsequence(expectedTerminatedElementIds);
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/RecordToWrite.java
+++ b/engine/src/test/java/io/zeebe/engine/util/RecordToWrite.java
@@ -11,19 +11,26 @@ import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.JobBatchIntent;
 import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.JobRecordValue;
+import io.zeebe.protocol.record.value.WorkflowInstanceRecordValue;
 
 public final class RecordToWrite {
 
-  private static final int DEFAULT_KEY = 1;
+  private static final long DEFAULT_KEY = 1;
+
   private final RecordMetadata recordMetadata;
   private UnifiedRecordValue unifiedRecordValue;
+
+  private long key = DEFAULT_KEY;
   private int sourceIndex = -1;
 
-  private RecordToWrite(RecordMetadata recordMetadata) {
+  private RecordToWrite(final RecordMetadata recordMetadata) {
     this.recordMetadata = recordMetadata;
   }
 
@@ -37,17 +44,11 @@ public final class RecordToWrite {
     return new RecordToWrite(recordMetadata.recordType(RecordType.EVENT));
   }
 
-  public RecordToWrite job(JobIntent intent) {
-    recordMetadata.valueType(ValueType.JOB).intent(intent);
-
-    final JobRecord jobRecord = new JobRecord();
-    jobRecord.setType("type").setRetries(3).setWorker("worker");
-
-    unifiedRecordValue = jobRecord;
-    return this;
+  public RecordToWrite job(final JobIntent intent) {
+    return job(intent, new JobRecord().setType("type").setRetries(3).setWorker("worker"));
   }
 
-  public RecordToWrite jobBatch(JobBatchIntent intent) {
+  public RecordToWrite jobBatch(final JobBatchIntent intent) {
     recordMetadata.valueType(ValueType.JOB_BATCH).intent(intent);
 
     final JobBatchRecord jobBatchRecord =
@@ -61,13 +62,31 @@ public final class RecordToWrite {
     return this;
   }
 
-  public RecordToWrite causedBy(int index) {
+  public RecordToWrite job(final JobIntent intent, final JobRecordValue value) {
+    recordMetadata.valueType(ValueType.JOB).intent(intent);
+    unifiedRecordValue = (JobRecord) value;
+    return this;
+  }
+
+  public RecordToWrite workflowInstance(
+      final WorkflowInstanceIntent intent, final WorkflowInstanceRecordValue value) {
+    recordMetadata.valueType(ValueType.WORKFLOW_INSTANCE).intent(intent);
+    unifiedRecordValue = (WorkflowInstanceRecord) value;
+    return this;
+  }
+
+  public RecordToWrite causedBy(final int index) {
     sourceIndex = index;
     return this;
   }
 
+  public RecordToWrite key(final long key) {
+    this.key = key;
+    return this;
+  }
+
   public long getKey() {
-    return DEFAULT_KEY;
+    return key;
   }
 
   public RecordMetadata getRecordMetadata() {

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -62,11 +62,12 @@ public class StreamProcessorRule implements TestRule {
     this(PARTITION_ID);
   }
 
-  public StreamProcessorRule(int partitionId) {
+  public StreamProcessorRule(final int partitionId) {
     this(partitionId, 1, DefaultZeebeDbFactory.DEFAULT_DB_FACTORY);
   }
 
-  public StreamProcessorRule(int startPartitionId, int partitionCount, ZeebeDbFactory dbFactory) {
+  public StreamProcessorRule(
+      final int startPartitionId, final int partitionCount, final ZeebeDbFactory dbFactory) {
     this.startPartitionId = startPartitionId;
     this.partitionCount = partitionCount;
 
@@ -83,15 +84,15 @@ public class StreamProcessorRule implements TestRule {
   }
 
   @Override
-  public Statement apply(Statement base, Description description) {
+  public Statement apply(final Statement base, final Description description) {
     return chain.apply(base, description);
   }
 
-  public LogStream getLogStream(int partitionId) {
+  public LogStream getLogStream(final int partitionId) {
     return streams.getLogStream(getLogName(partitionId));
   }
 
-  public StreamProcessor startTypedStreamProcessor(StreamProcessorTestFactory factory) {
+  public StreamProcessor startTypedStreamProcessor(final StreamProcessorTestFactory factory) {
     return startTypedStreamProcessor(
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
@@ -99,12 +100,12 @@ public class StreamProcessorRule implements TestRule {
         });
   }
 
-  public StreamProcessor startTypedStreamProcessor(TypedRecordProcessorFactory factory) {
+  public StreamProcessor startTypedStreamProcessor(final TypedRecordProcessorFactory factory) {
     return startTypedStreamProcessor(startPartitionId, factory);
   }
 
   public StreamProcessor startTypedStreamProcessor(
-      int partitionId, TypedRecordProcessorFactory factory) {
+      final int partitionId, final TypedRecordProcessorFactory factory) {
     return streams.startStreamProcessor(
         getLogName(partitionId),
         zeebeDbFactory,
@@ -114,11 +115,15 @@ public class StreamProcessorRule implements TestRule {
         }));
   }
 
-  public void closeStreamProcessor(int partitionId) throws Exception {
-    streams.closeProcessor(getLogName(partitionId));
+  public void closeStreamProcessor(final int partitionId) {
+    try {
+      streams.closeProcessor(getLogName(partitionId));
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
-  public void closeStreamProcessor() throws Exception {
+  public void closeStreamProcessor() {
     closeStreamProcessor(startPartitionId);
   }
 
@@ -126,7 +131,7 @@ public class StreamProcessorRule implements TestRule {
     return streams.getLogStream(getLogName(startPartitionId)).getCommitPosition();
   }
 
-  public StateSnapshotController getStateSnapshotController(int partitionId) {
+  public StateSnapshotController getStateSnapshotController(final int partitionId) {
     return streams.getStateSnapshotController(getLogName(partitionId));
   }
 
@@ -158,12 +163,12 @@ public class StreamProcessorRule implements TestRule {
     }
   }
 
-  public long writeWorkflowInstanceEvent(WorkflowInstanceIntent intent) {
+  public long writeWorkflowInstanceEvent(final WorkflowInstanceIntent intent) {
     return writeWorkflowInstanceEvent(intent, 1);
   }
 
   public long writeWorkflowInstanceEventWithSource(
-      WorkflowInstanceIntent intent, int instanceKey, long sourceEventPosition) {
+      final WorkflowInstanceIntent intent, final int instanceKey, final long sourceEventPosition) {
     return streams
         .newRecord(getLogName(startPartitionId))
         .event(workflowInstance(instanceKey))
@@ -173,7 +178,8 @@ public class StreamProcessorRule implements TestRule {
         .write();
   }
 
-  public long writeWorkflowInstanceEvent(WorkflowInstanceIntent intent, int instanceKey) {
+  public long writeWorkflowInstanceEvent(
+      final WorkflowInstanceIntent intent, final int instanceKey) {
     return streams
         .newRecord(getLogName(startPartitionId))
         .event(workflowInstance(instanceKey))
@@ -182,7 +188,7 @@ public class StreamProcessorRule implements TestRule {
         .write();
   }
 
-  public long writeEvent(long key, Intent intent, UnpackedObject value) {
+  public long writeEvent(final long key, final Intent intent, final UnpackedObject value) {
     return streams
         .newRecord(getLogName(startPartitionId))
         .recordType(RecordType.EVENT)
@@ -192,7 +198,7 @@ public class StreamProcessorRule implements TestRule {
         .write();
   }
 
-  public long writeEvent(Intent intent, UnpackedObject value) {
+  public long writeEvent(final Intent intent, final UnpackedObject value) {
     return streams
         .newRecord(getLogName(startPartitionId))
         .recordType(RecordType.EVENT)
@@ -201,11 +207,12 @@ public class StreamProcessorRule implements TestRule {
         .write();
   }
 
-  public long writeBatch(RecordToWrite... recordToWrites) {
+  public long writeBatch(final RecordToWrite... recordToWrites) {
     return streams.writeBatch(getLogName(startPartitionId), recordToWrites);
   }
 
-  public long writeCommandOnPartition(int partition, Intent intent, UnpackedObject value) {
+  public long writeCommandOnPartition(
+      final int partition, final Intent intent, final UnpackedObject value) {
     return streams
         .newRecord(getLogName(partition))
         .recordType(RecordType.COMMAND)
@@ -215,7 +222,7 @@ public class StreamProcessorRule implements TestRule {
   }
 
   public long writeCommandOnPartition(
-      int partition, long key, Intent intent, UnpackedObject value) {
+      final int partition, final long key, final Intent intent, final UnpackedObject value) {
     return streams
         .newRecord(getLogName(partition))
         .key(key)
@@ -225,7 +232,7 @@ public class StreamProcessorRule implements TestRule {
         .write();
   }
 
-  public long writeCommand(long key, Intent intent, UnpackedObject value) {
+  public long writeCommand(final long key, final Intent intent, final UnpackedObject value) {
     return streams
         .newRecord(getLogName(startPartitionId))
         .recordType(RecordType.COMMAND)
@@ -235,7 +242,7 @@ public class StreamProcessorRule implements TestRule {
         .write();
   }
 
-  public long writeCommand(Intent intent, UnpackedObject value) {
+  public long writeCommand(final Intent intent, final UnpackedObject value) {
     return streams
         .newRecord(getLogName(startPartitionId))
         .recordType(RecordType.COMMAND)
@@ -244,7 +251,7 @@ public class StreamProcessorRule implements TestRule {
         .write();
   }
 
-  private static String getLogName(int partitionId) {
+  private static String getLogName(final int partitionId) {
     return STREAM_NAME + partitionId;
   }
 
@@ -258,7 +265,7 @@ public class StreamProcessorRule implements TestRule {
     private final int startPartitionId;
     private final int partitionCount;
 
-    SetupRule(int startPartitionId, int partitionCount) {
+    SetupRule(final int startPartitionId, final int partitionCount) {
       this.startPartitionId = startPartitionId;
       this.partitionCount = partitionCount;
     }
@@ -279,7 +286,7 @@ public class StreamProcessorRule implements TestRule {
   private class FailedTestRecordPrinter extends TestWatcher {
 
     @Override
-    protected void failed(Throwable e, Description description) {
+    protected void failed(final Throwable e, final Description description) {
       LOG.info("Test failed, following records where exported:");
       printAllRecords();
     }


### PR DESCRIPTION
## Description

* consume child tokens when terminating the flow scope if the child instances can't be terminated

## Related issues

closes #2935 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
