### PR TITLE
chore(broker): notify gateways for every job created

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
@@ -291,13 +291,12 @@ public class JobState {
     EnsureUtil.ensureNotNullOrEmpty("type", type);
 
     jobTypeKey.wrapBuffer(type);
-    final boolean firstActivatableJob = !activatableColumnFamily.existsPrefix(jobTypeKey);
 
     jobKey.wrapLong(key);
     activatableColumnFamily.put(typeJobKey, DbNil.INSTANCE);
-    if (firstActivatableJob) {
-      notifyJobAvailable(type);
-    }
+
+    // always notify
+    notifyJobAvailable(type);
   }
 
   private void makeJobNotActivatable(DirectBuffer type) {

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/job/ActivatableJobsNotificationTests.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/job/ActivatableJobsNotificationTests.java
@@ -61,28 +61,19 @@ public class ActivatableJobsNotificationTests {
   }
 
   @Test
-  public void shouldNotifyWhenFirstJobCreated() {
+  public void shouldNotifyWhenJobCreated() {
     // when
-    createWorkflowInstanceAndJobs(1);
+    createWorkflowInstanceAndJobs(3);
 
     // then
-    Mockito.verify(jobAvailableCallback, times(1)).accept(taskType);
-  }
-
-  @Test
-  public void shouldNotNotifyWhenSecondJobCreated() {
-    // when
-    createWorkflowInstanceAndJobs(2);
-
-    // then
-    Mockito.verify(jobAvailableCallback, times(1)).accept(taskType);
+    Mockito.verify(jobAvailableCallback, times(3)).accept(taskType);
   }
 
   @Test
   public void shouldNotifyWhenJobsAvailableAgain() {
     // given
-    createWorkflowInstanceAndJobs(2);
-    final Record<JobBatchRecordValue> jobs = activateJobs(2);
+    createWorkflowInstanceAndJobs(1);
+    final Record<JobBatchRecordValue> jobs = activateJobs(1);
 
     // when
     createWorkflowInstanceAndJobs(1);
@@ -105,20 +96,6 @@ public class ActivatableJobsNotificationTests {
   }
 
   @Test
-  public void shouldNotNotifyWhenActivatedJobCanceled() {
-    // given
-    final List<Long> instanceKeys = createWorkflowInstanceAndJobs(2);
-    activateJobs(1);
-    ENGINE.workflowInstance().withInstanceKey(instanceKeys.get(0)).cancel();
-
-    // when
-    createWorkflowInstanceAndJobs(1);
-
-    // then
-    Mockito.verify(jobAvailableCallback, times(1)).accept(taskType);
-  }
-
-  @Test
   public void shouldNotifyWhenJobsAvailableAfterTimeOut() {
     // given
     createWorkflowInstanceAndJobs(1);
@@ -133,7 +110,7 @@ public class ActivatableJobsNotificationTests {
   }
 
   @Test
-  public void shouldNotifyWhenJobAvailableAfterNotActivatedJobCompleted() {
+  public void shouldNotifyWhenJobCreatedAfterNotActivatedJobCompleted() {
     // given
     createWorkflowInstanceAndJobs(1);
     final long jobKey = activateJobs(1, Duration.ofMillis(10)).getValue().getJobKeys().get(0);

--- a/zb-db/src/main/java/io/zeebe/db/ColumnFamily.java
+++ b/zb-db/src/main/java/io/zeebe/db/ColumnFamily.java
@@ -159,14 +159,6 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue> 
   boolean exists(KeyType key);
 
   /**
-   * Checks if a key with prefix keyPrefix exists in the column family.
-   *
-   * @param keyPrefix the prefix to look for
-   * @return true if atleast one key exists in this column family with the prefix, false otherwise
-   */
-  boolean existsPrefix(DbKey keyPrefix);
-
-  /**
    * Checks if the column family has any entry.
    *
    * @return <code>true</code> if the column family has no entry

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -119,11 +119,6 @@ class TransactionalColumnFamily<
   }
 
   @Override
-  public boolean existsPrefix(DbKey keyPrefix) {
-    return transactionDb.existsPrefix(handle, context, keyPrefix, keyInstance, valueInstance);
-  }
-
-  @Override
   public boolean isEmpty() {
     return isEmpty(context);
   }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -212,18 +212,6 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
             transaction.delete(columnFamilyHandle, context.getKeyBufferArray(), key.getLength()));
   }
 
-  boolean existsPrefix(
-      long columnFamilyHandle,
-      DbContext context,
-      DbKey keyPrefix,
-      DbKey keyInstance,
-      DbValue valueInstance) {
-    context.wrapValueView(new byte[0]);
-    whileEqualPrefix(
-        columnFamilyHandle, context, keyPrefix, keyInstance, valueInstance, (key, value) -> false);
-    return !context.isValueViewEmpty();
-  }
-
   ////////////////////////////////////////////////////////////////////
   //////////////////////////// ITERATION /////////////////////////////
   ////////////////////////////////////////////////////////////////////

--- a/zb-db/src/test/java/io/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
@@ -373,30 +373,6 @@ public class DbCompositeKeyColumnFamilyTest {
     assertThat(secondKeyParts).containsExactly(34L, 37426L, 923113L, 255L);
   }
 
-  @Test
-  public void shouldExistsPrefixTrue() {
-    // given
-    firstKey.wrapString("foo");
-    assertThat(columnFamily.existsPrefix(firstKey)).isFalse();
-
-    // then
-    putKeyValuePair("foo", 12, "baring");
-
-    // then
-    assertThat(columnFamily.existsPrefix(firstKey)).isTrue();
-  }
-
-  @Test
-  public void shouldExistsPrefixFalseWhenDelete() {
-    // given
-    firstKey.wrapString("foo");
-    putKeyValuePair("foo", 12, "baring");
-    columnFamily.delete(compositeKey);
-
-    // then
-    assertThat(columnFamily.existsPrefix(firstKey)).isFalse();
-  }
-
   private void putKeyValuePair(String firstKey, long secondKey, String value) {
     this.firstKey.wrapString(firstKey);
     this.secondKey.wrapLong(secondKey);


### PR DESCRIPTION
## Description

Broker broadcasts a notification for every job created. Previously, the notification were sent only if it is the first activatable job. This was causing performance regressions because of the `existPrefix` check on rocks db. 

## Related issues

closes #2934 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
