### PR TITLE
Fix Javadoc generation

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe BOM</name>
@@ -14,7 +16,7 @@
     <artifactId>camunda-release-parent</artifactId>
     <version>3.7</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <properties>
@@ -26,6 +28,9 @@
     </nexus.release.repository>
 
     <version.netty>4.1.38.Final</version.netty>
+
+    <version.java>11</version.java>
+    <plugin.version.javadoc>3.1.1</plugin.version.javadoc>
   </properties>
 
   <dependencyManagement>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Build Tools</name>
@@ -25,5 +27,4 @@
       <version>1.7.27</version>
     </dependency>
   </dependencies>
-
 </project>

--- a/gateway-protocol-impl/pom.xml
+++ b/gateway-protocol-impl/pom.xml
@@ -25,6 +25,7 @@
     <version.java>8</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
     <proto.dir>${project.build.directory}/proto</proto.dir>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <dependencies>

--- a/json-el/pom.xml
+++ b/json-el/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Msgpack Json Expression Language</name>
   <artifactId>zeebe-msgpack-json-el</artifactId>
@@ -10,6 +12,11 @@
     <version>0.21.0-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
+
+
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -26,8 +26,6 @@
 
   <properties>
 
-    <version.java>11</version.java>
-
     <!-- Zeebe Community License v1.0 header -->
     <license.header>${maven.multiModuleProjectDirectory}/parent/COPYING-HEADER.txt</license.header>
 
@@ -562,6 +560,25 @@
           <configuration>
             <release>${version.java}</release>
           </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${plugin.version.javadoc}</version>
+          <configuration>
+            <source>${version.java}</source>
+            <quiet>true</quiet>
+            <additionalOptions>-Xdoclint:none</additionalOptions>
+          </configuration>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
 
         <!-- LICENSE PLUGIN -->

--- a/protocol-asserts/pom.xml
+++ b/protocol-asserts/pom.xml
@@ -14,6 +14,10 @@
     <relativePath>../parent</relativePath>
   </parent>
 
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>


### PR DESCRIPTION
## Description


  After migration to Java 11 the generation of JavaDoc failed on develop.The following error was printed:

```java
[2019-08-09T16:16:31.038Z] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:jar (default-cli) on project zeebe-build-tools: MavenReportException: Error while creating archive: 
[2019-08-09T16:16:31.038Z] [ERROR] Exit code: 1 - Picked up JAVA_TOOL_OPTIONS: -XX:+UseContainerSupport
[2019-08-09T16:16:31.038Z] [ERROR] 
[2019-08-09T16:16:31.038Z] [ERROR] javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/7/docs/api/ are in the unnamed module.
[2019-08-09T16:16:31.038Z] [ERROR] 
[2019-08-09T16:16:31.038Z] [ERROR] Command line was: /docker-java-home/bin/javadoc @options @packages
[2019-08-09T16:16:31.038Z] [ERROR] 
[2019-08-09T16:16:31.038Z] [ERROR] Refer to the generated Javadoc files in '/home/jenkins/workspace/zeebe-io_zeebe_develop/build-tools/target/apidocs' dir.
[2019-08-09T16:16:31.038Z] [ERROR] -> [Help 1]
```

Multiple things where problematic. As first we used an old java doc plugin, inherited by the camunda release parent and the java version was not set correctly.

After fixing this, some other modules had still a problem with generating java doc.
 * `json-el`:
   * Scala currently do not support 100% Java 11.
      See:
        * https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
        * https://github.com/scala/scala-dev/issues/559
  * `gateway-protocol-impl` 
    * is compiled with 8, but if we execute java doc with 11 we get the error that javax was not found.
  * `protocol-assert`:
    * generated code seems to have some problems with the javadoc.

To verify the changes you can run:

```bash
 mvn -B -T1C generate-sources source:jar javadoc:jar clean verify -DskipTests
```

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
