### PR TITLE
chore(project): run client test with jdk 8

### DIFF
--- a/.ci/podSpecs/distribution.yml
+++ b/.ci/podSpecs/distribution.yml
@@ -28,6 +28,25 @@ spec:
         requests:
           cpu: 8
           memory: 32Gi
+    - name: maven-jdk8
+      image: maven:3.6.0-jdk-8
+      command: ["cat"]
+      tty: true
+      env:
+        - name: LIMITS_CPU
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: JAVA_TOOL_OPTIONS
+          value: |
+            -XX:+UseContainerSupport
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
     - name: golang
       image: golang:1.12.2
       command: ["cat"]

--- a/.ci/scripts/distribution/test-java8.sh
+++ b/.ci/scripts/distribution/test-java8.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -eux
+
+
+export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
+
+su jenkins -c "mvn -v"
+
+su jenkins -c "mvn -o -B -T$LIMITS_CPU -s .ci/settings.xml verify -pl clients/java -DtestMavenId=3"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,9 +28,14 @@ pipeline {
         stage('Prepare') {
             steps {
                 checkout scm
+
                 container('maven') {
                     sh '.ci/scripts/distribution/prepare.sh'
                 }
+                container('maven-jdk8') {
+                    sh '.ci/scripts/distribution/prepare.sh'
+                }
+
             }
         }
 
@@ -62,6 +67,13 @@ pipeline {
                     steps {
                         container('maven') {
                             sh '.ci/scripts/distribution/test-java.sh'
+                        }
+                    }
+                }
+                stage('Unit 8 (Java 8)') {
+                    steps {
+                        container('maven-jdk8') {
+                            sh '.ci/scripts/distribution/test-java8.sh'
                         }
                     }
                 }

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -14,6 +14,10 @@
     <relativePath>../bom</relativePath>
   </parent>
 
+  <properties>
+    <version.java>8</version.java>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
## Description

 * add extra stage to test client API with Java 8
 * For this we need to build build-tools with 8 as well,
   since the TestListener are executed by surefire.
 * We print the maven version (incl. Java version) before we start the
 test

## Related issues

closes #2945

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
