### PR TITLE
chore(ci): integrate SonarCloud into build process

### DIFF
--- a/.ci/scripts/distribution/analyse-java.sh
+++ b/.ci/scripts/distribution/analyse-java.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -ef -o pipefail
+
+PROPERTIES=("-DskipTests -Dcheckstyle.skip")
+GIT_URL=${GIT_URL:-$(git remote get-url origin)}
+GIT_BRANCH=${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
+
+# Assume if CHANGE_ID defined that we're building a PR
+if [ ! -z "${CHANGE_ID}" ]; then
+  PROPERTIES+=("-Dsonar.pullrequest.key=${CHANGE_ID}")
+
+  if [ ! -z "${CHANGE_BRANCH}" ]; then
+    PROPERTIES+=("-Dsonar.pullrequest.branch=${CHANGE_BRANCH}")
+  fi
+
+  if [ ! -z "${CHANGE_TARGET}" ]; then
+    PROPERTIES+=("-Dsonar.pullrequest.base=${CHANGE_TARGET}")
+    git fetch --no-tags "${GIT_URL}" "+refs/heads/${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}"
+  fi
+else
+  if [ ! -z "${GIT_BRANCH}" ]; then
+    PROPERTIES+=("-Dsonar.branch.name=${GIT_BRANCH}")
+  fi
+
+  if [ "${GIT_BRANCH}" == "master" ] || [ "${GIT_BRANCH}" == "develop" ]; then
+    TARGET_BRANCH="master"
+  else
+    TARGET_BRANCH="develop"
+  fi
+
+  PROPERTIES+=("-Dsonar.branch.target=${TARGET_BRANCH}")
+  git fetch --no-tags "${GIT_URL}" "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+fi
+
+echo "Properties: ${PROPERTIES[@]}"
+mvn -s .ci/settings.xml -P sonar sonar:sonar ${PROPERTIES[@]}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,11 +15,11 @@ pipeline {
 
     environment {
       NEXUS = credentials("camunda-nexus")
+      SONARCLOUD_TOKEN = credentials('zeebe-sonarcloud-token')
     }
 
     options {
         buildDiscarder(logRotator(daysToKeepStr: '-1', numToKeepStr: '10'))
-        skipDefaultCheckout()
         timestamps()
         timeout(time: 45, unit: 'MINUTES')
     }
@@ -27,8 +27,6 @@ pipeline {
     stages {
         stage('Prepare') {
             steps {
-                checkout scm
-
                 container('maven') {
                     sh '.ci/scripts/distribution/prepare.sh'
                 }
@@ -63,6 +61,14 @@ pipeline {
 
         stage('Test (Java)') {
             parallel {
+                stage('Analyse (Java)') {
+                      steps {
+                          container('maven') {
+                              sh '.ci/scripts/distribution/analyse-java.sh'
+                          }
+                      }
+                }
+
                 stage('Unit (Java)') {
                     steps {
                         container('maven') {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -101,6 +101,7 @@
     <plugin.version.enforcer>3.0.0-M2</plugin.version.enforcer>
     <plugin.version.dependency>3.1.1</plugin.version.dependency>
     <plugin.version.spotbugs>3.1.12.2</plugin.version.spotbugs>
+    <plugin.version.sonar>3.6.0.1398</plugin.version.sonar>
 
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.6.2</extension.version.os-maven-plugin>
@@ -1102,6 +1103,36 @@
                     <dep>org.apache.maven.surefire:surefire-junit47</dep>
                   </ignoredUnusedDeclaredDependencies>
                 </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- profile to perform only static code analysis using sonar scanner -->
+    <profile>
+      <id>sonar</id>
+      <properties>
+        <!-- sonarscanner integration -->
+        <!-- sonar.login token must be passed at runtime to avoid sharing token -->
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.organization>zeebe-io</sonar.organization>
+        <sonar.login>${env.SONARCLOUD_TOKEN}</sonar.login>
+        <sonar.links.issue>${scm.url}/issues</sonar.links.issue>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonarsource.scanner.maven</groupId>
+            <artifactId>sonar-maven-plugin</artifactId>
+            <version>${plugin.version.sonar}</version>
+            <executions>
+              <execution>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sonar</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
## Description

Integrates SonarCloud into our build process, locally and on CI. Modifies the pipeline to add an `Analyse (Java)` phase, which runs a new shell script. Shell script is just a way to properly define the correct SonarQube analysis parameters based on whether this is a PR or just a normal build.

## Related issues

closes #2964

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
