### PR TITLE
feat(broker): collect the output of a multi-instance activity

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractMultiInstanceLoopCharacteristicsBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractMultiInstanceLoopCharacteristicsBuilder.java
@@ -29,9 +29,9 @@ public class AbstractMultiInstanceLoopCharacteristicsBuilder<
     extends AbstractBaseElementBuilder<B, MultiInstanceLoopCharacteristics> {
 
   protected AbstractMultiInstanceLoopCharacteristicsBuilder(
-      BpmnModelInstance modelInstance,
-      MultiInstanceLoopCharacteristics element,
-      Class<?> selfType) {
+      final BpmnModelInstance modelInstance,
+      final MultiInstanceLoopCharacteristics element,
+      final Class<?> selfType) {
     super(modelInstance, element, selfType);
   }
 
@@ -61,7 +61,7 @@ public class AbstractMultiInstanceLoopCharacteristicsBuilder<
    * @param expression the cardinality expression
    * @return the builder object
    */
-  public B cardinality(String expression) {
+  public B cardinality(final String expression) {
     final LoopCardinality cardinality = getCreateSingleChild(LoopCardinality.class);
     cardinality.setTextContent(expression);
 
@@ -74,7 +74,7 @@ public class AbstractMultiInstanceLoopCharacteristicsBuilder<
    * @param expression the completion condition expression
    * @return the builder object
    */
-  public B completionCondition(String expression) {
+  public B completionCondition(final String expression) {
     final CompletionCondition condition = getCreateSingleChild(CompletionCondition.class);
     condition.setTextContent(expression);
 
@@ -86,22 +86,35 @@ public class AbstractMultiInstanceLoopCharacteristicsBuilder<
    *
    * @return the parent activity builder
    */
-  @SuppressWarnings({"rawtypes", "unchecked"})
   public <T extends AbstractActivityBuilder> T multiInstanceDone() {
     return (T) ((Activity) element.getParentElement()).builder();
   }
 
-  public B zeebeInputCollection(String inputCollection) {
+  public B zeebeInputCollection(final String inputCollection) {
     final ZeebeLoopCharacteristics characteristics =
         getCreateSingleExtensionElement(ZeebeLoopCharacteristics.class);
     characteristics.setInputCollection(inputCollection);
     return myself;
   }
 
-  public B zeebeInputElement(String inputElement) {
+  public B zeebeInputElement(final String inputElement) {
     final ZeebeLoopCharacteristics characteristics =
         getCreateSingleExtensionElement(ZeebeLoopCharacteristics.class);
     characteristics.setInputElement(inputElement);
+    return myself;
+  }
+
+  public B zeebeOutputCollection(final String outputCollection) {
+    final ZeebeLoopCharacteristics characteristics =
+        getCreateSingleExtensionElement(ZeebeLoopCharacteristics.class);
+    characteristics.setOutputCollection(outputCollection);
+    return myself;
+  }
+
+  public B zeebeOutputElement(final String outputElement) {
+    final ZeebeLoopCharacteristics characteristics =
+        getCreateSingleExtensionElement(ZeebeLoopCharacteristics.class);
+    characteristics.setOutputElement(outputElement);
     return myself;
   }
 }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -30,6 +30,8 @@ public class ZeebeConstants {
 
   public static final String ATTRIBUTE_INPUT_COLLECTION = "inputCollection";
   public static final String ATTRIBUTE_INPUT_ELEMENT = "inputElement";
+  public static final String ATTRIBUTE_OUTPUT_COLLECTION = "outputCollection";
+  public static final String ATTRIBUTE_OUTPUT_ELEMENT = "outputElement";
 
   public static final String ELEMENT_HEADER = "header";
   public static final String ELEMENT_INPUT = "input";

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/zeebe/ZeebeLoopCharacteristicsImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/zeebe/ZeebeLoopCharacteristicsImpl.java
@@ -30,11 +30,14 @@ public class ZeebeLoopCharacteristicsImpl extends BpmnModelElementInstanceImpl
   private static Attribute<String> inputCollectionAttribute;
   private static Attribute<String> inputElementAttribute;
 
-  public ZeebeLoopCharacteristicsImpl(ModelTypeInstanceContext instanceContext) {
+  private static Attribute<String> outputCollectionAttribute;
+  private static Attribute<String> outputElementAttribute;
+
+  public ZeebeLoopCharacteristicsImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
   }
 
-  public static void registerType(ModelBuilder modelBuilder) {
+  public static void registerType(final ModelBuilder modelBuilder) {
     final ModelElementTypeBuilder typeBuilder =
         modelBuilder
             .defineType(ZeebeLoopCharacteristics.class, ZeebeConstants.ELEMENT_LOOP_CHARACTERISTICS)
@@ -54,6 +57,18 @@ public class ZeebeLoopCharacteristicsImpl extends BpmnModelElementInstanceImpl
             .namespace(BpmnModelConstants.ZEEBE_NS)
             .build();
 
+    outputCollectionAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_OUTPUT_COLLECTION)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    outputElementAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_OUTPUT_ELEMENT)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
     typeBuilder.build();
   }
 
@@ -63,7 +78,7 @@ public class ZeebeLoopCharacteristicsImpl extends BpmnModelElementInstanceImpl
   }
 
   @Override
-  public void setInputCollection(String inputCollection) {
+  public void setInputCollection(final String inputCollection) {
     inputCollectionAttribute.setValue(this, inputCollection);
   }
 
@@ -73,7 +88,27 @@ public class ZeebeLoopCharacteristicsImpl extends BpmnModelElementInstanceImpl
   }
 
   @Override
-  public void setInputElement(String inputElement) {
+  public void setInputElement(final String inputElement) {
     inputElementAttribute.setValue(this, inputElement);
+  }
+
+  @Override
+  public String getOutputCollection() {
+    return outputCollectionAttribute.getValue(this);
+  }
+
+  @Override
+  public void setOutputCollection(final String outputCollection) {
+    outputCollectionAttribute.setValue(this, outputCollection);
+  }
+
+  @Override
+  public String getOutputElement() {
+    return outputElementAttribute.getValue(this);
+  }
+
+  @Override
+  public void setOutputElement(final String outputElement) {
+    outputElementAttribute.setValue(this, outputElement);
   }
 }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeLoopCharacteristics.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeLoopCharacteristics.java
@@ -26,4 +26,12 @@ public interface ZeebeLoopCharacteristics extends BpmnModelElementInstance {
   String getInputElement();
 
   void setInputElement(String inputElement);
+
+  String getOutputCollection();
+
+  void setOutputCollection(String outputCollection);
+
+  String getOutputElement();
+
+  void setOutputElement(String outputElement);
 }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeLoopCharacteristicsValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeLoopCharacteristicsValidator.java
@@ -17,6 +17,7 @@ package io.zeebe.model.bpmn.validation.zeebe;
 
 import io.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
+import java.util.Optional;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
@@ -30,7 +31,8 @@ public class ZeebeLoopCharacteristicsValidator
 
   @Override
   public void validate(
-      ZeebeLoopCharacteristics element, ValidationResultCollector validationResultCollector) {
+      final ZeebeLoopCharacteristics element,
+      final ValidationResultCollector validationResultCollector) {
 
     final String inputCollection = element.getInputCollection();
 
@@ -40,6 +42,26 @@ public class ZeebeLoopCharacteristicsValidator
           String.format(
               "Attribute '%s' must be present and not empty",
               ZeebeConstants.ATTRIBUTE_INPUT_COLLECTION));
+    }
+
+    final Optional<String> outputCollection =
+        Optional.ofNullable(element.getOutputCollection()).filter(o -> !o.isEmpty());
+    final Optional<String> outputElement =
+        Optional.ofNullable(element.getOutputElement()).filter(o -> !o.isEmpty());
+
+    if (outputCollection.isPresent() && !outputElement.isPresent()) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "Attribute '%s' must be present if the attribute '%s' is set",
+              ZeebeConstants.ATTRIBUTE_OUTPUT_ELEMENT, ZeebeConstants.ATTRIBUTE_OUTPUT_COLLECTION));
+
+    } else if (outputElement.isPresent() && !outputCollection.isPresent()) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "Attribute '%s' must be present if the attribute '%s' is set",
+              ZeebeConstants.ATTRIBUTE_OUTPUT_COLLECTION, ZeebeConstants.ATTRIBUTE_OUTPUT_ELEMENT));
     }
   }
 }

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeLoopCharacteristicsTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeLoopCharacteristicsTest.java
@@ -37,6 +37,8 @@ public class ZeebeLoopCharacteristicsTest extends BpmnModelElementInstanceTest {
   public Collection<AttributeAssumption> getAttributesAssumptions() {
     return Arrays.asList(
         new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "inputCollection", false, true),
-        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "inputElement", false, false));
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "inputElement", false, false),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "outputCollection", false, false),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "outputElement", false, false));
   }
 }

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeMultiInstanceLoopCharacteristicsValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeMultiInstanceLoopCharacteristicsValidationTest.java
@@ -50,6 +50,35 @@ public class ZeebeMultiInstanceLoopCharacteristicsValidationTest
                 ZeebeLoopCharacteristics.class,
                 "Attribute 'inputCollection' must be present and not empty"))
       },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeTaskType("test")
+                        .multiInstance(
+                            b -> b.zeebeInputCollection("xs").zeebeOutputCollection("ys")))
+            .done(),
+        singletonList(
+            expect(
+                ZeebeLoopCharacteristics.class,
+                "Attribute 'outputElement' must be present if the attribute 'outputCollection' is set"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeTaskType("test")
+                        .multiInstance(b -> b.zeebeInputCollection("xs").zeebeOutputElement("y")))
+            .done(),
+        singletonList(
+            expect(
+                ZeebeLoopCharacteristics.class,
+                "Attribute 'outputCollection' must be present if the attribute 'outputElement' is set"))
+      },
     };
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableLoopCharacteristics.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableLoopCharacteristics.java
@@ -7,8 +7,6 @@
  */
 package io.zeebe.engine.processor.workflow.deployment.model.element;
 
-import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
-
 import io.zeebe.msgpack.jsonpath.JsonPathQuery;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -20,21 +18,24 @@ public class ExecutableLoopCharacteristics {
   private final JsonPathQuery inputCollection;
   private final Optional<DirectBuffer> inputElement;
 
+  private final Optional<DirectBuffer> outputCollection;
+  private final Optional<JsonPathQuery> outputElement;
+
   public ExecutableLoopCharacteristics(
       final boolean isSequential,
       final JsonPathQuery inputCollection,
-      final Optional<DirectBuffer> inputElement) {
+      final Optional<DirectBuffer> inputElement,
+      final Optional<DirectBuffer> outputCollection,
+      final Optional<JsonPathQuery> outputElement) {
     this.isSequential = isSequential;
     this.inputCollection = inputCollection;
     this.inputElement = inputElement;
+    this.outputCollection = outputCollection;
+    this.outputElement = outputElement;
   }
 
   public boolean isSequential() {
     return isSequential;
-  }
-
-  public boolean isParallel() {
-    return !isSequential;
   }
 
   public JsonPathQuery getInputCollection() {
@@ -45,15 +46,27 @@ public class ExecutableLoopCharacteristics {
     return inputElement;
   }
 
+  public Optional<DirectBuffer> getOutputCollection() {
+    return outputCollection;
+  }
+
+  public Optional<JsonPathQuery> getOutputElement() {
+    return outputElement;
+  }
+
   @Override
   public String toString() {
     return "ExecutableLoopCharacteristics{"
         + "isSequential="
         + isSequential
         + ", inputCollection="
-        + bufferAsString(inputCollection.getExpression())
+        + inputCollection
         + ", inputElement="
         + inputElement
+        + ", outputCollection="
+        + outputCollection
+        + ", outputElement="
+        + outputElement
         + '}';
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/MultiInstanceActivityTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/MultiInstanceActivityTransformer.java
@@ -105,6 +105,17 @@ public class MultiInstanceActivityTransformer implements ModelElementTransformer
             .filter(e -> !e.isEmpty())
             .map(BufferUtil::wrapString);
 
-    return new ExecutableLoopCharacteristics(isSequential, inputCollection, inputElement);
+    final Optional<DirectBuffer> outputCollection =
+        Optional.ofNullable(zeebeLoopCharacteristics.getOutputCollection())
+            .filter(e -> !e.isEmpty())
+            .map(BufferUtil::wrapString);
+
+    final Optional<JsonPathQuery> outputElement =
+        Optional.ofNullable(zeebeLoopCharacteristics.getOutputElement())
+            .filter(e -> !e.isEmpty())
+            .map(e -> context.getJsonPathQueryCompiler().compile(e));
+
+    return new ExecutableLoopCharacteristics(
+        isSequential, inputCollection, inputElement, outputCollection, outputElement);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ZeebeLoopCharacteristicsValidator.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ZeebeLoopCharacteristicsValidator.java
@@ -8,6 +8,7 @@
 package io.zeebe.engine.processor.workflow.deployment.model.validation;
 
 import io.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
+import java.util.Optional;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
@@ -16,7 +17,7 @@ public class ZeebeLoopCharacteristicsValidator
 
   private final ZeebeExpressionValidator expressionValidator;
 
-  public ZeebeLoopCharacteristicsValidator(ZeebeExpressionValidator expressionValidator) {
+  public ZeebeLoopCharacteristicsValidator(final ZeebeExpressionValidator expressionValidator) {
     this.expressionValidator = expressionValidator;
   }
 
@@ -27,7 +28,12 @@ public class ZeebeLoopCharacteristicsValidator
 
   @Override
   public void validate(
-      ZeebeLoopCharacteristics element, ValidationResultCollector validationResultCollector) {
+      final ZeebeLoopCharacteristics element,
+      final ValidationResultCollector validationResultCollector) {
     expressionValidator.validateJsonPath(element.getInputCollection(), validationResultCollector);
+
+    Optional.ofNullable(element.getOutputElement())
+        .filter(e -> !e.isEmpty())
+        .ifPresent(e -> expressionValidator.validateJsonPath(e, validationResultCollector));
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/multiinstance/AbstractMultiInstanceBodyHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/multiinstance/AbstractMultiInstanceBodyHandler.java
@@ -16,14 +16,17 @@ import io.zeebe.engine.processor.workflow.handlers.AbstractHandler;
 import io.zeebe.engine.state.instance.VariablesState;
 import io.zeebe.msgpack.jsonpath.JsonPathQuery;
 import io.zeebe.msgpack.query.MsgPackQueryProcessor;
-import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.msgpack.spec.MsgPackHelper;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import java.util.Collections;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public abstract class AbstractMultiInstanceBodyHandler
     extends AbstractHandler<ExecutableMultiInstanceBody> {
+
+  private static final DirectBuffer NIL_VALUE = new UnsafeBuffer(MsgPackHelper.NIL);
 
   private final Function<BpmnStep, BpmnStepHandler> innerHandlerLookup;
   private final MsgPackQueryProcessor queryProcessor = new MsgPackQueryProcessor();
@@ -94,10 +97,11 @@ public abstract class AbstractMultiInstanceBodyHandler
       final long bodyInstanceKey,
       final DirectBuffer item) {
 
-    final ExecutableMultiInstanceBody multiInstanceBody = context.getElement();
+    final var elementInstanceState = context.getElementInstanceState();
+    final var variablesState = elementInstanceState.getVariablesState();
 
-    final WorkflowInstanceRecord innerActivityRecord = context.getValue();
-    innerActivityRecord.setFlowScopeKey(bodyInstanceKey);
+    final var multiInstanceBody = context.getElement();
+    final var innerActivityRecord = context.getValue().setFlowScopeKey(bodyInstanceKey);
 
     final long elementInstanceKey =
         context
@@ -107,18 +111,33 @@ public abstract class AbstractMultiInstanceBodyHandler
                 innerActivityRecord,
                 multiInstanceBody.getInnerActivity());
 
-    // need to spawn token for child instance
-    context.getElementInstanceState().spawnToken(bodyInstanceKey);
+    // update loop counters
+    final var bodyInstance = elementInstanceState.getInstance(bodyInstanceKey);
+    bodyInstance.spawnToken();
+    bodyInstance.incrementMultiInstanceLoopCounter();
+    elementInstanceState.updateInstance(bodyInstance);
 
-    // set instance variable
-    final VariablesState variablesState = context.getElementInstanceState().getVariablesState();
+    final var innerInstance = elementInstanceState.getInstance(elementInstanceKey);
+    innerInstance.setMultiInstanceLoopCounter(bodyInstance.getMultiInstanceLoopCounter());
+    elementInstanceState.updateInstance(innerInstance);
 
-    multiInstanceBody
-        .getLoopCharacteristics()
+    // set instance variables
+    final var workflowKey = innerActivityRecord.getWorkflowKey();
+    final var loopCharacteristics = multiInstanceBody.getLoopCharacteristics();
+
+    loopCharacteristics
         .getInputElement()
         .ifPresent(
-            inputElement ->
+            variableName ->
                 variablesState.setVariableLocal(
-                    elementInstanceKey, innerActivityRecord.getWorkflowKey(), inputElement, item));
+                    elementInstanceKey, workflowKey, variableName, item));
+
+    loopCharacteristics
+        .getOutputElement()
+        .map(JsonPathQuery::getVariableName)
+        .ifPresent(
+            variableName ->
+                variablesState.setVariableLocal(
+                    elementInstanceKey, workflowKey, variableName, NIL_VALUE));
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/multiinstance/MultiInstanceBodyCompletedHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/multiinstance/MultiInstanceBodyCompletedHandler.java
@@ -11,14 +11,25 @@ import io.zeebe.engine.processor.workflow.BpmnStepContext;
 import io.zeebe.engine.processor.workflow.BpmnStepHandler;
 import io.zeebe.engine.processor.workflow.deployment.model.BpmnStep;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableMultiInstanceBody;
-import io.zeebe.engine.state.instance.ElementInstance;
-import io.zeebe.msgpack.query.MsgPackQueryProcessor.ArrayResult;
+import io.zeebe.msgpack.query.MsgPackQueryProcessor;
+import io.zeebe.msgpack.spec.MsgPackReader;
+import io.zeebe.msgpack.spec.MsgPackWriter;
+import java.util.List;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public class MultiInstanceBodyCompletedHandler extends AbstractMultiInstanceBodyHandler {
 
   private final BpmnStepHandler multiInstanceBodyHandler;
+
+  private final MsgPackReader variableReader = new MsgPackReader();
+  private final MsgPackWriter variableWriter = new MsgPackWriter();
+  private final MsgPackQueryProcessor queryProcessor = new MsgPackQueryProcessor();
+
+  private final ExpandableArrayBuffer variableBuffer = new ExpandableArrayBuffer();
+  private final DirectBuffer resultBuffer = new UnsafeBuffer(0, 0);
 
   public MultiInstanceBodyCompletedHandler(
       final Function<BpmnStep, BpmnStepHandler> innerHandlerLookup) {
@@ -29,23 +40,23 @@ public class MultiInstanceBodyCompletedHandler extends AbstractMultiInstanceBody
 
   @Override
   protected void handleInnerActivity(final BpmnStepContext<ExecutableMultiInstanceBody> context) {
+    final var loopCharacteristics = context.getElement().getLoopCharacteristics();
 
-    if (context.getElement().getLoopCharacteristics().isSequential()) {
+    if (loopCharacteristics.isSequential()) {
 
-      final ArrayResult array = readInputCollectionVariable(context).getSingleResult().getArray();
-
-      final int loopCounter = context.getFlowScopeInstance().getMultiInstanceLoopCounter();
+      final var array = readInputCollectionVariable(context).getSingleResult().getArray();
+      final var loopCounter = context.getFlowScopeInstance().getMultiInstanceLoopCounter();
 
       if (loopCounter < array.size()) {
 
-        final DirectBuffer item = array.getElement(loopCounter);
+        final var item = array.getElement(loopCounter);
         createInnerInstance(context, context.getFlowScopeInstance().getKey(), item);
-
-        final ElementInstance flowScopeInstance = context.getFlowScopeInstance();
-        flowScopeInstance.incrementMultiInstanceLoopCounter();
-        context.getElementInstanceState().updateInstance(flowScopeInstance);
       }
     }
+
+    loopCharacteristics
+        .getOutputCollection()
+        .ifPresent(variableName -> updateOutputCollection(context, variableName));
 
     // completing the multi-instance body if there are no more tokens
     super.handleInnerActivity(context);
@@ -56,5 +67,58 @@ public class MultiInstanceBodyCompletedHandler extends AbstractMultiInstanceBody
       final BpmnStepContext<ExecutableMultiInstanceBody> context) {
     multiInstanceBodyHandler.handle(context);
     return true;
+  }
+
+  private void updateOutputCollection(
+      final BpmnStepContext<ExecutableMultiInstanceBody> context, final DirectBuffer variableName) {
+
+    final var variablesState = context.getElementInstanceState().getVariablesState();
+    final var bodyInstanceKey = context.getFlowScopeInstance().getKey();
+    final var workflowKey = context.getValue().getWorkflowKey();
+    final var loopCounter = context.getElementInstance().getMultiInstanceLoopCounter();
+
+    final var elementVariable = readOutputElementVariable(context);
+    final var currentCollection = variablesState.getVariableLocal(bodyInstanceKey, variableName);
+
+    final var updatedCollection = insertAt(currentCollection, loopCounter, elementVariable);
+
+    variablesState.setVariableLocal(bodyInstanceKey, workflowKey, variableName, updatedCollection);
+  }
+
+  private DirectBuffer readOutputElementVariable(
+      final BpmnStepContext<ExecutableMultiInstanceBody> context) {
+
+    final var query =
+        context.getElement().getLoopCharacteristics().getOutputElement().orElseThrow();
+
+    final var document =
+        context
+            .getElementInstanceState()
+            .getVariablesState()
+            .getVariablesAsDocument(context.getKey(), List.of(query.getVariableName()));
+
+    return queryProcessor.process(query, document).getSingleResult().getValue();
+  }
+
+  private DirectBuffer insertAt(
+      final DirectBuffer array, final int index, final DirectBuffer element) {
+
+    variableReader.wrap(array, 0, array.capacity());
+    variableReader.readArrayHeader();
+    variableReader.skipValues(index - 1);
+
+    final var offsetBefore = variableReader.getOffset();
+    variableReader.skipValue();
+    final var offsetAfter = variableReader.getOffset();
+
+    variableWriter.wrap(variableBuffer, 0);
+    variableWriter.writeRaw(array, 0, offsetBefore);
+    variableWriter.writeRaw(element);
+    variableWriter.writeRaw(array, offsetAfter, array.capacity() - offsetAfter);
+
+    final var length = variableWriter.getOffset();
+
+    resultBuffer.wrap(variableBuffer, 0, length);
+    return resultBuffer;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstance.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstance.java
@@ -126,6 +126,10 @@ public class ElementInstance implements DbValue {
     return multiInstanceLoopCounter;
   }
 
+  public void setMultiInstanceLoopCounter(final int loopCounter) {
+    multiInstanceLoopCounter = loopCounter;
+  }
+
   public void incrementMultiInstanceLoopCounter() {
     multiInstanceLoopCounter += 1;
   }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/VariablesState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/VariablesState.java
@@ -73,7 +73,9 @@ public class VariablesState {
   private int variableCount = 0;
 
   public VariablesState(
-      ZeebeDb<ZbColumnFamilies> zeebeDb, DbContext dbContext, KeyGenerator keyGenerator) {
+      final ZeebeDb<ZbColumnFamilies> zeebeDb,
+      final DbContext dbContext,
+      final KeyGenerator keyGenerator) {
     this.keyGenerator = keyGenerator;
 
     parentKey = new DbLong();
@@ -95,7 +97,7 @@ public class VariablesState {
   }
 
   public void setVariablesLocalFromDocument(
-      long scopeKey, long workflowKey, DirectBuffer document) {
+      final long scopeKey, final long workflowKey, final DirectBuffer document) {
     reader.wrap(document, 0, document.capacity());
 
     final int variables = reader.readMapHeader();
@@ -122,19 +124,33 @@ public class VariablesState {
   }
 
   public void setVariableLocal(
-      long scopeKey, long workflowKey, DirectBuffer name, DirectBuffer value) {
+      final long scopeKey,
+      final long workflowKey,
+      final DirectBuffer name,
+      final DirectBuffer value) {
     setVariableLocal(scopeKey, workflowKey, name, 0, name.capacity(), value, 0, value.capacity());
   }
 
   public void setVariableLocal(
-      long scopeKey,
-      long workflowKey,
-      DirectBuffer name,
-      int nameOffset,
-      int nameLength,
-      DirectBuffer value,
-      int valueOffset,
-      int valueLength) {
+      final long scopeKey,
+      final long workflowKey,
+      final DirectBuffer name,
+      final DirectBuffer value,
+      final int valueOffset,
+      final int valueLength) {
+    setVariableLocal(
+        scopeKey, workflowKey, name, 0, name.capacity(), value, valueOffset, valueLength);
+  }
+
+  public void setVariableLocal(
+      final long scopeKey,
+      final long workflowKey,
+      final DirectBuffer name,
+      final int nameOffset,
+      final int nameLength,
+      final DirectBuffer value,
+      final int valueOffset,
+      final int valueLength) {
 
     newVariable.reset();
     newVariable.setValue(value, valueOffset, valueLength);
@@ -178,15 +194,15 @@ public class VariablesState {
   }
 
   private boolean hasVariableLocal(
-      long scopeKey, DirectBuffer name, int nameOffset, int nameLength) {
+      final long scopeKey, final DirectBuffer name, final int nameOffset, final int nameLength) {
     this.scopeKey.wrapLong(scopeKey);
     variableNameView.wrap(name, nameOffset, nameLength);
-    this.variableName.wrapBuffer(variableNameView);
+    variableName.wrapBuffer(variableNameView);
 
     return variablesColumnFamily.exists(scopeKeyVariableNameKey);
   }
 
-  public DirectBuffer getVariableLocal(long scopeKey, DirectBuffer name) {
+  public DirectBuffer getVariableLocal(final long scopeKey, final DirectBuffer name) {
     final VariableInstance variable = getVariableLocal(scopeKey, name, 0, name.capacity());
 
     if (variable != null) {
@@ -197,15 +213,16 @@ public class VariablesState {
   }
 
   private VariableInstance getVariableLocal(
-      long scopeKey, DirectBuffer name, int nameOffset, int nameLength) {
+      final long scopeKey, final DirectBuffer name, final int nameOffset, final int nameLength) {
     this.scopeKey.wrapLong(scopeKey);
     variableNameView.wrap(name, nameOffset, nameLength);
-    this.variableName.wrapBuffer(variableNameView);
+    variableName.wrapBuffer(variableNameView);
 
     return variablesColumnFamily.get(scopeKeyVariableNameKey);
   }
 
-  public void setVariablesFromDocument(long scopeKey, long workflowKey, DirectBuffer document) {
+  public void setVariablesFromDocument(
+      final long scopeKey, final long workflowKey, final DirectBuffer document) {
     // 1. index entries in the document
     indexedDocument.index(document);
     if (!indexedDocument.hasEntries()) {
@@ -264,14 +281,14 @@ public class VariablesState {
     }
   }
 
-  private long getParent(long childKey) {
+  private long getParent(final long childKey) {
     this.childKey.wrapLong(childKey);
 
     final DbLong parentKey = childParentColumnFamily.get(this.childKey);
     return parentKey != null ? parentKey.getValue() : NO_PARENT;
   }
 
-  public DirectBuffer getVariablesAsDocument(long scopeKey) {
+  public DirectBuffer getVariablesAsDocument(final long scopeKey) {
 
     collectedVariables.clear();
     writer.wrap(documentResultBuffer, 0);
@@ -299,7 +316,8 @@ public class VariablesState {
     return resultView;
   }
 
-  public DirectBuffer getVariablesAsDocument(long scopeKey, Collection<DirectBuffer> names) {
+  public DirectBuffer getVariablesAsDocument(
+      final long scopeKey, final Collection<DirectBuffer> names) {
 
     variablesToCollect.clear();
     variablesToCollect.addAll(names);
@@ -325,7 +343,7 @@ public class VariablesState {
     return resultView;
   }
 
-  public DirectBuffer getVariablesLocalAsDocument(long scopeKey) {
+  public DirectBuffer getVariablesLocalAsDocument(final long scopeKey) {
 
     writer.wrap(documentResultBuffer, 0);
 
@@ -355,10 +373,10 @@ public class VariablesState {
    * the scope hierarchy.
    */
   private void visitVariables(
-      long scopeKey,
-      Predicate<DbString> filter,
-      BiConsumer<DbString, VariableInstance> variableConsumer,
-      BooleanSupplier completionCondition) {
+      final long scopeKey,
+      final Predicate<DbString> filter,
+      final BiConsumer<DbString, VariableInstance> variableConsumer,
+      final BooleanSupplier completionCondition) {
     long currentScope = scopeKey;
 
     boolean completed;
@@ -381,10 +399,10 @@ public class VariablesState {
    * @return true if the completion condition was met
    */
   private boolean visitVariablesLocal(
-      long scopeKey,
-      Predicate<DbString> variableFilter,
-      BiConsumer<DbString, VariableInstance> variableConsumer,
-      BooleanSupplier completionCondition) {
+      final long scopeKey,
+      final Predicate<DbString> variableFilter,
+      final BiConsumer<DbString, VariableInstance> variableConsumer,
+      final BooleanSupplier completionCondition) {
     this.scopeKey.wrapLong(scopeKey);
 
     variablesColumnFamily.whileEqualPrefix(
@@ -401,14 +419,14 @@ public class VariablesState {
     return false;
   }
 
-  public void createScope(long childKey, long parentKey) {
+  public void createScope(final long childKey, final long parentKey) {
     this.childKey.wrapLong(childKey);
     this.parentKey.wrapLong(parentKey);
 
     childParentColumnFamily.put(this.childKey, this.parentKey);
   }
 
-  public void removeScope(long scopeKey) {
+  public void removeScope(final long scopeKey) {
     this.scopeKey.wrapLong(scopeKey);
 
     removeAllVariables(scopeKey);
@@ -416,7 +434,7 @@ public class VariablesState {
     childParentColumnFamily.delete(this.scopeKey);
   }
 
-  public void removeAllVariables(long scopeKey) {
+  public void removeAllVariables(final long scopeKey) {
     visitVariablesLocal(
         scopeKey,
         dbString -> true,
@@ -424,20 +442,20 @@ public class VariablesState {
         () -> false);
   }
 
-  public void setTemporaryVariables(long scopeKey, DirectBuffer variables) {
+  public void setTemporaryVariables(final long scopeKey, final DirectBuffer variables) {
     this.scopeKey.wrapLong(scopeKey);
     temporaryVariables.wrapBuffer(variables);
     temporaryVariableStoreColumnFamily.put(this.scopeKey, temporaryVariables);
   }
 
-  public DirectBuffer getTemporaryVariables(long scopeKey) {
+  public DirectBuffer getTemporaryVariables(final long scopeKey) {
     this.scopeKey.wrapLong(scopeKey);
     final DbBuffer variables = temporaryVariableStoreColumnFamily.get(this.scopeKey);
 
     return variables == null ? null : variables.getValue();
   }
 
-  public void removeTemporaryVariables(long scopeKey) {
+  public void removeTemporaryVariables(final long scopeKey) {
     this.scopeKey.wrapLong(scopeKey);
     temporaryVariableStoreColumnFamily.delete(this.scopeKey);
   }
@@ -448,7 +466,7 @@ public class VariablesState {
         && temporaryVariableStoreColumnFamily.isEmpty();
   }
 
-  public void setListener(VariableListener listener) {
+  public void setListener(final VariableListener listener) {
     if (this.listener != null) {
       throw new IllegalStateException("variable listener is already set");
     }
@@ -456,7 +474,7 @@ public class VariablesState {
     this.listener = listener;
   }
 
-  private long getRootScopeKey(long scopeKey) {
+  private long getRootScopeKey(final long scopeKey) {
     long rootScopeKey = scopeKey;
     long currentScopeKey = scopeKey;
 
@@ -494,7 +512,7 @@ public class VariablesState {
     private final DocumentEntryIterator iterator = new DocumentEntryIterator();
     private DirectBuffer document;
 
-    public void index(DirectBuffer document) {
+    public void index(final DirectBuffer document) {
       this.document = document;
       entries.clear();
       final int documentLength = document.capacity();
@@ -564,10 +582,10 @@ public class VariablesState {
       iterator.remove();
     }
 
-    public void wrap(DirectBuffer document, EntryIterator iterator) {
+    public void wrap(final DirectBuffer document, final EntryIterator iterator) {
       this.iterator = iterator;
       this.document = document;
-      this.documentLength = document.capacity();
+      documentLength = document.capacity();
     }
 
     /** excluding string header */

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -159,10 +159,28 @@ public class ZeebeRuntimeValidationTest {
                 ZeebeLoopCharacteristics.class,
                 "JSON path query is invalid: Unexpected json-path token ROOT_OBJECT"))
       },
+      {
+        // output element expression is not supported
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.multiInstance(
+                        m ->
+                            m.zeebeInputCollection("foo")
+                                .zeebeOutputCollection("bar")
+                                .zeebeOutputElement("$.b")))
+            .done(),
+        Arrays.asList(
+            expect(
+                ZeebeLoopCharacteristics.class,
+                "JSON path query is invalid: Unexpected json-path token ROOT_OBJECT"))
+      },
     };
   }
 
-  private static ValidationResults validate(BpmnModelInstance model) {
+  private static ValidationResults validate(final BpmnModelInstance model) {
     final ModelWalker walker = new ModelWalker(model);
     final ValidationVisitor visitor = new ValidationVisitor(ZeebeRuntimeValidators.VALIDATORS);
     walker.walk(visitor);
@@ -236,7 +254,8 @@ public class ZeebeRuntimeValidationTest {
     fail(sb.toString());
   }
 
-  private static void describeUnmatchedResults(StringBuilder sb, List<ValidationResult> results) {
+  private static void describeUnmatchedResults(
+      final StringBuilder sb, final List<ValidationResult> results) {
     sb.append("Unmatched results:\n");
     results.forEach(
         e -> {
@@ -246,7 +265,7 @@ public class ZeebeRuntimeValidationTest {
   }
 
   private static void describeUnmatchedExpectations(
-      StringBuilder sb, List<ExpectedValidationResult> expectations) {
+      final StringBuilder sb, final List<ExpectedValidationResult> expectations) {
     sb.append("Unmatched expectations:\n");
     expectations.forEach(
         e -> {

--- a/engine/src/test/java/io/zeebe/engine/util/client/JobClient.java
+++ b/engine/src/test/java/io/zeebe/engine/util/client/JobClient.java
@@ -13,7 +13,9 @@ import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.value.JobRecordValue;
+import io.zeebe.test.util.MsgPackUtil;
 import io.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -38,42 +40,52 @@ public class JobClient {
 
   private Function<Long, Record<JobRecordValue>> expectation = SUCCESS_SUPPLIER;
 
-  public JobClient(StreamProcessorRule environmentRule) {
+  public JobClient(final StreamProcessorRule environmentRule) {
     this.environmentRule = environmentRule;
-    this.jobRecord = new JobRecord();
+    jobRecord = new JobRecord();
   }
 
-  public JobClient ofInstance(long workflowInstanceKey) {
+  public JobClient ofInstance(final long workflowInstanceKey) {
     this.workflowInstanceKey = workflowInstanceKey;
     return this;
   }
 
-  public JobClient withType(String jobType) {
+  public JobClient withType(final String jobType) {
     jobRecord.setType(jobType);
     return this;
   }
 
-  public JobClient withKey(long jobKey) {
+  public JobClient withKey(final long jobKey) {
     this.jobKey = jobKey;
     return this;
   }
 
-  public JobClient withVariables(String variables) {
+  public JobClient withVariables(final String variables) {
     jobRecord.setVariables(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(variables)));
     return this;
   }
 
-  public JobClient withVariables(DirectBuffer variables) {
+  public JobClient withVariables(final DirectBuffer variables) {
     jobRecord.setVariables(variables);
     return this;
   }
 
-  public JobClient withRetries(int retries) {
+  public JobClient withVariable(final String key, final Object value) {
+    jobRecord.setVariables(MsgPackUtil.asMsgPack(key, value));
+    return this;
+  }
+
+  public JobClient withVariables(final Map<String, Object> variables) {
+    jobRecord.setVariables(MsgPackUtil.asMsgPack(variables));
+    return this;
+  }
+
+  public JobClient withRetries(final int retries) {
     jobRecord.setRetries(retries);
     return this;
   }
 
-  public JobClient withErrorMessage(String errorMessage) {
+  public JobClient withErrorMessage(final String errorMessage) {
     jobRecord.setErrorMessage(errorMessage);
     return this;
   }

--- a/json-path/src/main/java/io/zeebe/msgpack/jsonpath/JsonPathQuery.java
+++ b/json-path/src/main/java/io/zeebe/msgpack/jsonpath/JsonPathQuery.java
@@ -9,6 +9,7 @@ package io.zeebe.msgpack.jsonpath;
 
 import io.zeebe.msgpack.filter.MsgPackFilter;
 import io.zeebe.msgpack.query.MsgPackFilterContext;
+import io.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -27,11 +28,11 @@ public class JsonPathQuery {
   protected int invalidPosition;
   protected String errorMessage;
 
-  public JsonPathQuery(MsgPackFilter[] filters) {
+  public JsonPathQuery(final MsgPackFilter[] filters) {
     this.filters = filters;
   }
 
-  public void wrap(DirectBuffer buffer, int offset, int length) {
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     filterInstances.clear();
     invalidPosition = NO_INVALID_POSITION;
 
@@ -46,9 +47,9 @@ public class JsonPathQuery {
     return filters;
   }
 
-  public void invalidate(int position, String message) {
-    this.invalidPosition = position;
-    this.errorMessage = message;
+  public void invalidate(final int position, final String message) {
+    invalidPosition = position;
+    errorMessage = message;
   }
 
   public boolean isValid() {
@@ -63,6 +64,11 @@ public class JsonPathQuery {
     return errorMessage;
   }
 
+  @Override
+  public String toString() {
+    return "JsonPathQuery{" + "expression=" + BufferUtil.bufferAsString(expressionBuffer) + '}';
+  }
+
   public DirectBuffer getExpression() {
     return expressionBuffer;
   }
@@ -71,7 +77,7 @@ public class JsonPathQuery {
     return variableName;
   }
 
-  public void setVariableName(byte[] topLevelVariable) {
-    this.variableName.wrap(topLevelVariable);
+  public void setVariableName(final byte[] topLevelVariable) {
+    variableName.wrap(topLevelVariable);
   }
 }

--- a/json-path/src/main/java/io/zeebe/msgpack/query/MsgPackQueryProcessor.java
+++ b/json-path/src/main/java/io/zeebe/msgpack/query/MsgPackQueryProcessor.java
@@ -120,6 +120,11 @@ public class MsgPackQueryProcessor {
       return arrayResult;
     }
 
+    public DirectBuffer getValue() {
+      resultBuffer.wrap(reader.getBuffer());
+      return resultBuffer;
+    }
+
     public String getType() {
       return token.getType().name();
     }


### PR DESCRIPTION
## Description

* add output collection and output element to model API
* create output collection variable when multi-instance body is activated
* create output element variable when inner activity is activated
* update output collection variable when inner activity is completed
* propagate output collection variable when body is completed

## Related issues

closes #2854 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
