### PR TITLE
Fix javadoc plugin configuration on build-tools

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -8,6 +8,7 @@
   <packaging>jar</packaging>
 
   <parent>
+    <!-- We can't reference zeebe parent as parent otherwise we will have a circle dependency -->
     <groupId>io.zeebe</groupId>
     <artifactId>zeebe-bom</artifactId>
     <version>0.21.0-SNAPSHOT</version>
@@ -31,4 +32,30 @@
       <version>1.7.28</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <!-- Since we can't use zeebe parent as parent we have to declare/configure the java doc plugin again -->
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${plugin.version.javadoc}</version>
+          <configuration>
+            <source>${version.java}</source>
+            <quiet>true</quiet>
+            <additionalOptions>-Xdoclint:none</additionalOptions>
+          </configuration>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>


### PR DESCRIPTION
## Description

We haven't build an SNAPSHOT since 8 days, because the CI fails building the develop branch.
The reason seems to be the javadoc plugin which is is not correctly configured on the build-tools module.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2962 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
