### PR TITLE
Remove streamex dependency

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -75,7 +75,6 @@
     <version.scala>2.13.0</version.scala>
     <version.slf4j>1.7.28</version.slf4j>
     <version.snakeyaml>1.25</version.snakeyaml>
-    <version.streamex>0.7.0</version.streamex>
     <version.toml>0.7.2</version.toml>
     <version.javax>1.3.2</version.javax>
 
@@ -349,12 +348,6 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
         <version>${version.netty}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>one.util</groupId>
-        <artifactId>streamex</artifactId>
-        <version>${version.streamex}</version>
       </dependency>
 
       <dependency>

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Test Util</name>
@@ -26,11 +28,6 @@
     <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-exporter-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>one.util</groupId>
-      <artifactId>streamex</artifactId>
     </dependency>
 
     <dependency>

--- a/test-util/src/main/java/io/zeebe/test/util/stream/StreamWrapper.java
+++ b/test-util/src/main/java/io/zeebe/test/util/stream/StreamWrapper.java
@@ -29,7 +29,6 @@ import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
-import one.util.streamex.StreamEx;
 
 public abstract class StreamWrapper<T, S extends StreamWrapper<T, S>> implements Stream<T> {
   private final Stream<T> wrappedStream;
@@ -45,15 +44,14 @@ public abstract class StreamWrapper<T, S extends StreamWrapper<T, S>> implements
    * predicate.
    */
   public S skipUntil(Predicate<T> predicate) {
-    return supply(StreamEx.of(this).dropWhile(predicate.negate()));
+    return supply(this.dropWhile(predicate.negate()));
   }
 
   /**
    * short-circuiting operation; limits the stream to the first element that fulfills the predicate
    */
   public S limit(Predicate<T> predicate) {
-    // #takeWhile comes with Java >= 9
-    return supply(StreamEx.of(this).takeWhileInclusive(predicate.negate()));
+    return supply(this.takeWhile(predicate.negate()));
   }
 
   // Helper to extract values


### PR DESCRIPTION
## Description

Replaced the streamex dependency and the `takeWhileInclusive(Predicate)` and `skip(Predicate)` usage, with java language based implementation. The takeWhileInclusive was replaced with takeWhile and a smaller implementation detail.

<!-- Please explain the changes you made here. -->


## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
