### PR TITLE
Add retrying logic for credential providers

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -122,6 +122,18 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/clients/java/src/main/java/io/zeebe/client/CredentialsProvider.java
+++ b/clients/java/src/main/java/io/zeebe/client/CredentialsProvider.java
@@ -29,6 +29,8 @@ public interface CredentialsProvider {
    */
   void applyCredentials(Metadata headers);
 
+  boolean shouldRetryRequest(Throwable throwable);
+
   /** @return a builder to configure and create a new {@link OAuthCredentialsProvider}. */
   static OAuthCredentialsProviderBuilder newCredentialsProviderBuilder() {
     return new OAuthCredentialsProviderBuilder();

--- a/clients/java/src/main/java/io/zeebe/client/impl/NoopCredentialsProvider.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/NoopCredentialsProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl;
+
+import io.grpc.Metadata;
+import io.zeebe.client.CredentialsProvider;
+
+public class NoopCredentialsProvider implements CredentialsProvider {
+
+  @Override
+  public void applyCredentials(Metadata headers) {
+    // Noop
+  }
+
+  @Override
+  public boolean shouldRetryRequest(Throwable throwable) {
+    return false;
+  }
+}

--- a/clients/java/src/main/java/io/zeebe/client/impl/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/OAuthCredentialsProviderBuilder.java
@@ -50,10 +50,7 @@ public class OAuthCredentialsProviderBuilder {
     return clientSecret;
   }
 
-  /**
-   * The recipient of the access token. Should be equal to the broker contact point {@link
-   * ZeebeClientBuilderImpl#brokerContactPoint(String)}.
-   */
+  /** The resource for which the the access token should be valid. */
   public OAuthCredentialsProviderBuilder audience(String audience) {
     this.audience = audience;
     return this;
@@ -71,7 +68,7 @@ public class OAuthCredentialsProviderBuilder {
   }
 
   /** @see OAuthCredentialsProviderBuilder#authorizationServerUrl(String) */
-  public URL getAuthorizationServer() {
+  URL getAuthorizationServer() {
     return authorizationServer;
   }
 

--- a/clients/java/src/main/java/io/zeebe/client/impl/RetriableClientFutureImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/RetriableClientFutureImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl;
+
+import io.grpc.stub.StreamObserver;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class RetriableClientFutureImpl<R, T> extends ZeebeClientFutureImpl<R, T> {
+
+  private final Predicate<Throwable> retryPredicate;
+  private final Consumer<StreamObserver<T>> retryAction;
+
+  public RetriableClientFutureImpl(
+      Predicate<Throwable> retryPredicate, Consumer<StreamObserver<T>> retryAction) {
+    this(brokerResponse -> null, retryPredicate, retryAction);
+  }
+
+  public RetriableClientFutureImpl(
+      Function<T, R> responseMapper,
+      Predicate<Throwable> retryPredicate,
+      Consumer<StreamObserver<T>> retryAction) {
+    super(responseMapper);
+
+    Objects.requireNonNull(retryPredicate, "Expected to have non-null retry predicate.");
+    Objects.requireNonNull(retryAction, "Expected to have non-null retry action.");
+    this.retryPredicate = retryPredicate;
+    this.retryAction = retryAction;
+  }
+
+  @Override
+  public void onError(Throwable throwable) {
+    if (retryPredicate.test(throwable)) {
+      retryAction.accept(this);
+    } else {
+      super.onError(throwable);
+    }
+  }
+}

--- a/clients/java/src/main/java/io/zeebe/client/impl/RetriableStreamingFutureImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/RetriableStreamingFutureImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl;
+
+import io.grpc.stub.StreamObserver;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+public class RetriableStreamingFutureImpl<C, B> extends ZeebeStreamingClientFutureImpl<C, B> {
+
+  private final Predicate<Throwable> retryPredicate;
+  private final Consumer<StreamObserver<B>> retryAction;
+
+  public RetriableStreamingFutureImpl(
+      C clientResponse,
+      Consumer<B> collector,
+      Predicate<Throwable> retryPredicate,
+      Consumer<StreamObserver<B>> retryAction) {
+    super(clientResponse, collector);
+
+    Objects.requireNonNull(retryPredicate, "Expected to have non-null retry predicate.");
+    Objects.requireNonNull(retryAction, "Expected to have non-null retry action.");
+    this.retryPredicate = retryPredicate;
+    this.retryAction = retryAction;
+  }
+
+  @Override
+  public void onError(Throwable throwable) {
+    if (retryPredicate.test(throwable)) {
+      retryAction.accept(this);
+    } else {
+      super.onError(throwable);
+    }
+  }
+}

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeCallCredentials.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeCallCredentials.java
@@ -46,5 +46,8 @@ public class ZeebeCallCredentials extends io.grpc.CallCredentials {
   }
 
   @Override
-  public void thisUsesUnstableApi() {}
+  public void thisUsesUnstableApi() {
+    // This method's purpose is to make it clearer to implementors that the API is unstable.
+    // Therefore, it's never called.
+  }
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientCredentials.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientCredentials.java
@@ -16,14 +16,15 @@
 package io.zeebe.client.impl;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
-public class ZeebeClientCredentials {
+class ZeebeClientCredentials {
 
   @JsonProperty("access_token")
   private String accessToken;
 
   @JsonProperty("expires_in")
-  private String expiresIn;
+  private long expiresIn;
 
   @JsonProperty("token_type")
   private String tokenType;
@@ -31,13 +32,30 @@ public class ZeebeClientCredentials {
   @JsonProperty("scope")
   private String scope;
 
-  public ZeebeClientCredentials() {}
-
-  public String getAccessToken() {
+  String getAccessToken() {
     return accessToken;
   }
 
-  public String getTokenType() {
+  String getTokenType() {
     return tokenType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(accessToken, expiresIn, tokenType, scope);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || !o.getClass().equals(this.getClass())) {
+      return false;
+    }
+
+    final ZeebeClientCredentials other = (ZeebeClientCredentials) o;
+
+    return accessToken.equals(other.accessToken)
+        && expiresIn == other.expiresIn
+        && tokenType.equals(other.tokenType)
+        && scope.equals(other.scope);
   }
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
@@ -70,6 +70,7 @@ public class ZeebeClientImpl implements ZeebeClient {
   private final ScheduledExecutorService executorService;
   private final List<Closeable> closeables = new CopyOnWriteArrayList<>();
   private final JobClient jobClient;
+  private final CredentialsProvider credentialsProvider;
 
   public ZeebeClientImpl(final ZeebeClientConfiguration configuration) {
     this(configuration, buildChannel(configuration));
@@ -96,6 +97,12 @@ public class ZeebeClientImpl implements ZeebeClient {
     this.channel = channel;
     this.asyncStub = gatewayStub;
     this.executorService = executorService;
+
+    if (config.getCredentialsProvider() != null) {
+      this.credentialsProvider = config.getCredentialsProvider();
+    } else {
+      this.credentialsProvider = new NoopCredentialsProvider();
+    }
     this.jobClient = newJobClient();
   }
 
@@ -153,7 +160,8 @@ public class ZeebeClientImpl implements ZeebeClient {
 
   public static GatewayStub buildGatewayStub(
       ManagedChannel channel, ZeebeClientConfiguration config) {
-    return GatewayGrpc.newStub(channel).withCallCredentials(buildCallCredentials(config));
+    final CallCredentials credentials = buildCallCredentials(config);
+    return GatewayGrpc.newStub(channel).withCallCredentials(credentials);
   }
 
   private static ScheduledExecutorService buildExecutorService(
@@ -164,7 +172,8 @@ public class ZeebeClientImpl implements ZeebeClient {
 
   @Override
   public TopologyRequestStep1 newTopologyRequest() {
-    return new TopologyRequestImpl(asyncStub, config.getDefaultRequestTimeout());
+    return new TopologyRequestImpl(
+        asyncStub, config.getDefaultRequestTimeout(), credentialsProvider::shouldRetryRequest);
   }
 
   @Override
@@ -210,57 +219,84 @@ public class ZeebeClientImpl implements ZeebeClient {
 
   @Override
   public DeployWorkflowCommandStep1 newDeployCommand() {
-    return new DeployWorkflowCommandImpl(asyncStub, config.getDefaultRequestTimeout());
+    return new DeployWorkflowCommandImpl(
+        asyncStub, config.getDefaultRequestTimeout(), credentialsProvider::shouldRetryRequest);
   }
 
   @Override
   public CreateWorkflowInstanceCommandStep1 newCreateInstanceCommand() {
     return new CreateWorkflowInstanceCommandImpl(
-        asyncStub, objectMapper, config.getDefaultRequestTimeout());
+        asyncStub,
+        objectMapper,
+        config.getDefaultRequestTimeout(),
+        credentialsProvider::shouldRetryRequest);
   }
 
   @Override
   public CancelWorkflowInstanceCommandStep1 newCancelInstanceCommand(
       final long workflowInstanceKey) {
     return new CancelWorkflowInstanceCommandImpl(
-        asyncStub, workflowInstanceKey, config.getDefaultRequestTimeout());
+        asyncStub,
+        workflowInstanceKey,
+        config.getDefaultRequestTimeout(),
+        credentialsProvider::shouldRetryRequest);
   }
 
   @Override
   public SetVariablesCommandStep1 newSetVariablesCommand(final long elementInstanceKey) {
     return new SetVariablesCommandImpl(
-        asyncStub, objectMapper, elementInstanceKey, config.getDefaultRequestTimeout());
+        asyncStub,
+        objectMapper,
+        elementInstanceKey,
+        config.getDefaultRequestTimeout(),
+        credentialsProvider::shouldRetryRequest);
   }
 
   @Override
   public PublishMessageCommandStep1 newPublishMessageCommand() {
-    return new PublishMessageCommandImpl(asyncStub, config, objectMapper);
+    return new PublishMessageCommandImpl(
+        asyncStub, config, objectMapper, credentialsProvider::shouldRetryRequest);
   }
 
   @Override
   public ResolveIncidentCommandStep1 newResolveIncidentCommand(long incidentKey) {
     return new ResolveIncidentCommandImpl(
-        asyncStub, incidentKey, config.getDefaultRequestTimeout());
+        asyncStub,
+        incidentKey,
+        config.getDefaultRequestTimeout(),
+        credentialsProvider::shouldRetryRequest);
   }
 
   @Override
   public UpdateRetriesJobCommandStep1 newUpdateRetriesCommand(long jobKey) {
-    return new JobUpdateRetriesCommandImpl(asyncStub, jobKey, config.getDefaultRequestTimeout());
+    return new JobUpdateRetriesCommandImpl(
+        asyncStub,
+        jobKey,
+        config.getDefaultRequestTimeout(),
+        credentialsProvider::shouldRetryRequest);
   }
 
   @Override
   public JobWorkerBuilderStep1 newWorker() {
     return new JobWorkerBuilderImpl(
-        config, asyncStub, jobClient, objectMapper, executorService, closeables);
+        config,
+        asyncStub,
+        jobClient,
+        objectMapper,
+        executorService,
+        closeables,
+        credentialsProvider::shouldRetryRequest);
   }
 
   @Override
   public ActivateJobsCommandStep1 newActivateJobsCommand() {
-    return new ActivateJobsCommandImpl(asyncStub, config, objectMapper);
+    return new ActivateJobsCommandImpl(
+        asyncStub, config, objectMapper, credentialsProvider::shouldRetryRequest);
   }
 
   private JobClient newJobClient() {
-    return new JobClientImpl(asyncStub, config, objectMapper);
+    return new JobClientImpl(
+        asyncStub, config, objectMapper, credentialsProvider::shouldRetryRequest);
   }
 
   @Override

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/CancelWorkflowInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/CancelWorkflowInstanceCommandImpl.java
@@ -15,27 +15,34 @@
  */
 package io.zeebe.client.impl.command;
 
+import io.grpc.stub.StreamObserver;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.CancelWorkflowInstanceCommandStep1;
 import io.zeebe.client.api.command.FinalCommandStep;
-import io.zeebe.client.impl.ZeebeClientFutureImpl;
+import io.zeebe.client.impl.RetriableClientFutureImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CancelWorkflowInstanceRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CancelWorkflowInstanceRequest.Builder;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CancelWorkflowInstanceResponse;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 public class CancelWorkflowInstanceCommandImpl implements CancelWorkflowInstanceCommandStep1 {
 
   private final GatewayStub asyncStub;
   private final Builder builder;
+  private final Predicate<Throwable> retryPredicate;
   private Duration requestTimeout;
 
   public CancelWorkflowInstanceCommandImpl(
-      GatewayStub asyncStub, long workflowInstanceKey, Duration requestTimeout) {
+      GatewayStub asyncStub,
+      long workflowInstanceKey,
+      Duration requestTimeout,
+      Predicate<Throwable> retryPredicate) {
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;
+    this.retryPredicate = retryPredicate;
     this.builder = CancelWorkflowInstanceRequest.newBuilder();
     builder.setWorkflowInstanceKey(workflowInstanceKey);
   }
@@ -50,12 +57,19 @@ public class CancelWorkflowInstanceCommandImpl implements CancelWorkflowInstance
   public ZeebeFuture<Void> send() {
     final CancelWorkflowInstanceRequest request = builder.build();
 
-    final ZeebeClientFutureImpl<Void, CancelWorkflowInstanceResponse> future =
-        new ZeebeClientFutureImpl<>();
+    final RetriableClientFutureImpl<Void, CancelWorkflowInstanceResponse> future =
+        new RetriableClientFutureImpl<>(
+            retryPredicate, streamObserver -> send(request, streamObserver));
 
+    send(request, future);
+    return future;
+  }
+
+  private void send(
+      CancelWorkflowInstanceRequest request,
+      StreamObserver<CancelWorkflowInstanceResponse> future) {
     asyncStub
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .cancelWorkflowInstance(request, future);
-    return future;
   }
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/JobUpdateRetriesCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/JobUpdateRetriesCommandImpl.java
@@ -15,28 +15,36 @@
  */
 package io.zeebe.client.impl.command;
 
+import io.grpc.stub.StreamObserver;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.FinalCommandStep;
 import io.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
 import io.zeebe.client.api.command.UpdateRetriesJobCommandStep1.UpdateRetriesJobCommandStep2;
-import io.zeebe.client.impl.ZeebeClientFutureImpl;
+import io.zeebe.client.impl.RetriableClientFutureImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest.Builder;
 import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesResponse;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 public class JobUpdateRetriesCommandImpl
     implements UpdateRetriesJobCommandStep1, UpdateRetriesJobCommandStep2 {
 
   private final GatewayStub asyncStub;
   private final Builder builder;
+  private final Predicate<Throwable> retryPredicate;
   private Duration requestTimeout;
 
-  public JobUpdateRetriesCommandImpl(GatewayStub asyncStub, long jobKey, Duration requestTimeout) {
+  public JobUpdateRetriesCommandImpl(
+      GatewayStub asyncStub,
+      long jobKey,
+      Duration requestTimeout,
+      Predicate<Throwable> retryPredicate) {
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;
+    this.retryPredicate = retryPredicate;
     builder = UpdateJobRetriesRequest.newBuilder();
     builder.setJobKey(jobKey);
   }
@@ -57,12 +65,18 @@ public class JobUpdateRetriesCommandImpl
   public ZeebeFuture<Void> send() {
     final UpdateJobRetriesRequest request = builder.build();
 
-    final ZeebeClientFutureImpl<Void, UpdateJobRetriesResponse> future =
-        new ZeebeClientFutureImpl<>();
+    final RetriableClientFutureImpl<Void, UpdateJobRetriesResponse> future =
+        new RetriableClientFutureImpl<>(
+            retryPredicate, streamObserver -> send(request, streamObserver));
 
+    send(request, future);
+    return future;
+  }
+
+  private void send(
+      UpdateJobRetriesRequest request, StreamObserver<UpdateJobRetriesResponse> streamObserver) {
     asyncStub
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
-        .updateJobRetries(request, future);
-    return future;
+        .updateJobRetries(request, streamObserver);
   }
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/TopologyRequestImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/TopologyRequestImpl.java
@@ -15,26 +15,31 @@
  */
 package io.zeebe.client.impl.command;
 
+import io.grpc.stub.StreamObserver;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.FinalCommandStep;
 import io.zeebe.client.api.command.TopologyRequestStep1;
 import io.zeebe.client.api.response.Topology;
-import io.zeebe.client.impl.ZeebeClientFutureImpl;
+import io.zeebe.client.impl.RetriableClientFutureImpl;
 import io.zeebe.client.impl.response.TopologyImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.zeebe.gateway.protocol.GatewayOuterClass.TopologyRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.TopologyResponse;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 public class TopologyRequestImpl implements TopologyRequestStep1 {
 
   private final GatewayStub asyncStub;
+  private final Predicate<Throwable> retryPredicate;
   private Duration requestTimeout;
 
-  public TopologyRequestImpl(final GatewayStub asyncStub, Duration requestTimeout) {
+  public TopologyRequestImpl(
+      final GatewayStub asyncStub, Duration requestTimeout, Predicate<Throwable> retryPredicate) {
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;
+    this.retryPredicate = retryPredicate;
   }
 
   @Override
@@ -47,13 +52,18 @@ public class TopologyRequestImpl implements TopologyRequestStep1 {
   public ZeebeFuture<Topology> send() {
     final TopologyRequest request = TopologyRequest.getDefaultInstance();
 
-    final ZeebeClientFutureImpl<Topology, TopologyResponse> future =
-        new ZeebeClientFutureImpl<>(TopologyImpl::new);
+    final RetriableClientFutureImpl<Topology, TopologyResponse> future =
+        new RetriableClientFutureImpl<>(
+            TopologyImpl::new, retryPredicate, streamObserver -> send(request, streamObserver));
 
-    asyncStub
-        .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
-        .topology(request, future);
+    send(request, future);
 
     return future;
+  }
+
+  private void send(TopologyRequest request, StreamObserver<TopologyResponse> streamObserver) {
+    asyncStub
+        .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
+        .topology(request, streamObserver);
   }
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/worker/JobClientImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/worker/JobClientImpl.java
@@ -23,28 +23,35 @@ import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.client.impl.command.CompleteJobCommandImpl;
 import io.zeebe.client.impl.command.FailJobCommandImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import java.util.function.Predicate;
 
 public class JobClientImpl implements JobClient {
 
   private final GatewayStub asyncStub;
   private final ZeebeClientConfiguration config;
   private final ZeebeObjectMapper objectMapper;
+  private final Predicate<Throwable> retryPredicate;
 
   public JobClientImpl(
-      GatewayStub asyncStub, ZeebeClientConfiguration config, ZeebeObjectMapper objectMapper) {
+      GatewayStub asyncStub,
+      ZeebeClientConfiguration config,
+      ZeebeObjectMapper objectMapper,
+      Predicate<Throwable> retryPredicate) {
     this.asyncStub = asyncStub;
     this.config = config;
     this.objectMapper = objectMapper;
+    this.retryPredicate = retryPredicate;
   }
 
   @Override
   public CompleteJobCommandStep1 newCompleteCommand(long jobKey) {
     return new CompleteJobCommandImpl(
-        asyncStub, objectMapper, jobKey, config.getDefaultRequestTimeout());
+        asyncStub, objectMapper, jobKey, config.getDefaultRequestTimeout(), retryPredicate);
   }
 
   @Override
   public FailJobCommandStep1 newFailCommand(long jobKey) {
-    return new FailJobCommandImpl(asyncStub, jobKey, config.getDefaultRequestTimeout());
+    return new FailJobCommandImpl(
+        asyncStub, jobKey, config.getDefaultRequestTimeout(), retryPredicate);
   }
 }

--- a/clients/java/src/test/java/io/zeebe/client/job/JobPollerTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/job/JobPollerTest.java
@@ -33,7 +33,8 @@ public class JobPollerTest extends ClientTest {
             rule.getGatewayStub(),
             ActivateJobsRequest.newBuilder(),
             new ZeebeObjectMapper(),
-            requestTimeout);
+            requestTimeout,
+            (t) -> false);
 
     // when
     jobPoller.poll(123, job -> {}, integer -> {});

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -77,6 +77,8 @@
     <version.snakeyaml>1.25</version.snakeyaml>
     <version.toml>0.7.2</version.toml>
     <version.javax>1.3.2</version.javax>
+    <version.wiremock>2.24.1</version.wiremock>
+    <version.asm>7.0</version.asm>
 
     <!-- maven plugins -->
     <plugin.version.antrun>1.8</plugin.version.antrun>
@@ -512,6 +514,19 @@
         <version>${version.javax}</version>
       </dependency>
 
+      <dependency>
+        <groupId>com.github.tomakehurst</groupId>
+        <artifactId>wiremock-jre8</artifactId>
+        <version>${version.wiremock}</version>
+      </dependency>
+
+      <dependency>
+        <!-- NOTE: required because of https://github.com/tomakehurst/wiremock/issues/1083-->
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>${version.asm}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 
@@ -910,6 +925,7 @@
                   <dep>org.apache.logging.log4j:log4j-core</dep>
                   <dep>io.zeebe:zeebe-build-tools</dep>
                   <dep>io.zeebe:zeebe-gateway-protocol</dep>
+                  <dep>org.ow2.asm:asm</dep>
                 </ignoredUnusedDeclaredDependencies>
               </configuration>
             </execution>


### PR DESCRIPTION
## Description

Adds support for retrying requests: 
* CredentialProviders can specify when requests should be retried
* The built-in OAuth provider retries requests if they failed with UNAUTHENTICATED and if it has updated credentials

## Related issues

closes #2898

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
