### PR TITLE
feat(clients/go): add refresh token and retry logic

### DIFF
--- a/clients/go/Gopkg.lock
+++ b/clients/go/Gopkg.lock
@@ -217,6 +217,7 @@
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "github.com/stretchr/testify/suite",
+    "golang.org/x/net/context",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/credentials",

--- a/clients/go/Makefile
+++ b/clients/go/Makefile
@@ -9,3 +9,4 @@ test:
 	go test -v ./entities/
 	go test -v ./worker/
 	go test -v ./tests/
+	go test -v ./zbc/

--- a/clients/go/commands/activateJobs_command_test.go
+++ b/clients/go/commands/activateJobs_command_test.go
@@ -112,7 +112,7 @@ func TestActivateJobsCommand(t *testing.T) {
 
 	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
 
-	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout).JobType("foo").MaxJobsToActivate(5).Send()
+	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(error) bool { return false }).JobType("foo").MaxJobsToActivate(5).Send()
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -147,7 +147,7 @@ func TestActivateJobsCommandWithTimeout(t *testing.T) {
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
 
-	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout).JobType("foo").MaxJobsToActivate(5).Timeout(1 * time.Minute).Send()
+	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(error) bool { return false }).JobType("foo").MaxJobsToActivate(5).Timeout(1 * time.Minute).Send()
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -176,7 +176,7 @@ func TestActivateJobsCommandWithWorkerName(t *testing.T) {
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
 
-	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout).JobType("foo").MaxJobsToActivate(5).WorkerName("bar").Send()
+	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(error) bool { return false }).JobType("foo").MaxJobsToActivate(5).WorkerName("bar").Send()
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -201,14 +201,14 @@ func TestActivateJobsCommandWithFetchVariables(t *testing.T) {
 		MaxJobsToActivate: 5,
 		Worker:            DefaultJobWorkerName,
 		Timeout:           DefaultJobTimeoutInMs,
-		FetchVariable:     fetchVariables,		
+		FetchVariable:     fetchVariables,
 		RequestTimeout:    int64(utils.DefaultTestTimeout / time.Millisecond),
 	}
 
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
 
-	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout).JobType("foo").MaxJobsToActivate(5).FetchVariables(fetchVariables...).Send()
+	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(error) bool { return false }).JobType("foo").MaxJobsToActivate(5).FetchVariables(fetchVariables...).Send()
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/commands/cancelInstance_command_test.go
+++ b/clients/go/commands/cancelInstance_command_test.go
@@ -35,7 +35,7 @@ func TestCancelWorkflowInstanceCommand(t *testing.T) {
 
 	client.EXPECT().CancelWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCancelInstanceCommand(client, utils.DefaultTestTimeout)
+	command := NewCancelInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.WorkflowInstanceKey(123).Send()
 

--- a/clients/go/commands/completeJob_command_test.go
+++ b/clients/go/commands/completeJob_command_test.go
@@ -35,7 +35,7 @@ func TestCompleteJobCommand(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	response, err := NewCompleteJobCommand(client, utils.DefaultTestTimeout).JobKey(123).Send()
+	response, err := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false }).JobKey(123).Send()
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -62,7 +62,7 @@ func TestCompleteJobCommandWithVariablesFromString(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout)
+	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromString(variables)
 	if err != nil {
@@ -96,7 +96,7 @@ func TestCompleteJobCommandWithVariablesFromStringer(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout)
+	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromStringer(DataType{Foo: "bar"})
 	if err != nil {
@@ -130,7 +130,7 @@ func TestCompleteJobCommandWithVariablesFromObject(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout)
+	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
@@ -164,7 +164,7 @@ func TestCompleteJobCommandWithVariablesFromObjectOmitempty(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout)
+	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
@@ -198,7 +198,7 @@ func TestCompleteJobCommandWithVariablesFromObjectIgnoreOmitempty(t *testing.T) 
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout)
+	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
@@ -234,7 +234,7 @@ func TestCompleteJobCommandWithVariablesFromMap(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout)
+	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromMap(variableMaps)
 	if err != nil {

--- a/clients/go/commands/createInstance_command_test.go
+++ b/clients/go/commands/createInstance_command_test.go
@@ -49,7 +49,7 @@ func TestCreateWorkflowInstanceCommand(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout)
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.WorkflowKey(123).Send()
 
@@ -81,7 +81,7 @@ func TestCreateWorkflowInstanceCommandByBpmnProcessId(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout)
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.BPMNProcessId("foo").LatestVersion().Send()
 
@@ -113,7 +113,7 @@ func TestCreateWorkflowInstanceCommandByBpmnProcessIdAndVersion(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout)
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.BPMNProcessId("foo").Version(56).Send()
 
@@ -147,7 +147,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromString(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout)
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromString(variables)
 	if err != nil {
@@ -186,7 +186,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromStringer(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout)
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromStringer(DataType{Foo: "bar"})
 	if err != nil {
@@ -225,7 +225,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromObject(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout)
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
@@ -264,7 +264,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromObjectOmitempty(t *testin
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout)
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
@@ -303,7 +303,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromObjectIgnoreOmitempty(t *
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout)
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
@@ -344,7 +344,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromMap(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout)
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromMap(variablesMap)
 	if err != nil {

--- a/clients/go/commands/deploy_command_test.go
+++ b/clients/go/commands/deploy_command_test.go
@@ -59,7 +59,7 @@ func TestDeployCommand_AddResourceFile(t *testing.T) {
 
 	client.EXPECT().DeployWorkflow(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewDeployCommand(client, utils.DefaultTestTimeout)
+	command := NewDeployCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.
 		AddResourceFile(demoName).
@@ -98,7 +98,7 @@ func TestDeployCommand_AddResource(t *testing.T) {
 
 	client.EXPECT().DeployWorkflow(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewDeployCommand(client, utils.DefaultTestTimeout)
+	command := NewDeployCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.
 		AddResource(demoBytes, demoName, pb.WorkflowRequestObject_BPMN).

--- a/clients/go/commands/failJob_command.go
+++ b/clients/go/commands/failJob_command.go
@@ -42,6 +42,7 @@ type FailJobCommand struct {
 	request        *pb.FailJobRequest
 	gateway        pb.GatewayClient
 	requestTimeout time.Duration
+	retryPredicate func(error) bool
 }
 
 func (cmd *FailJobCommand) JobKey(jobKey int64) FailJobCommandStep2 {
@@ -66,10 +67,11 @@ func (cmd *FailJobCommand) Send() (*pb.FailJobResponse, error) {
 	return cmd.gateway.FailJob(ctx, cmd.request)
 }
 
-func NewFailJobCommand(gateway pb.GatewayClient, requestTimeout time.Duration) FailJobCommandStep1 {
+func NewFailJobCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(error) bool) FailJobCommandStep1 {
 	return &FailJobCommand{
 		request:        &pb.FailJobRequest{},
 		gateway:        gateway,
 		requestTimeout: requestTimeout,
+		retryPredicate: retryPredicate,
 	}
 }

--- a/clients/go/commands/failJob_command_test.go
+++ b/clients/go/commands/failJob_command_test.go
@@ -37,7 +37,7 @@ func TestFailJobCommand(t *testing.T) {
 
 	client.EXPECT().FailJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewFailJobCommand(client, utils.DefaultTestTimeout)
+	command := NewFailJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.JobKey(123).Retries(12).Send()
 
@@ -67,7 +67,7 @@ func TestFailJobCommand_ErrorMessage(t *testing.T) {
 
 	client.EXPECT().FailJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewFailJobCommand(client, utils.DefaultTestTimeout)
+	command := NewFailJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.JobKey(123).Retries(12).ErrorMessage(errorMessage).Send()
 

--- a/clients/go/commands/publishMessage_command_test.go
+++ b/clients/go/commands/publishMessage_command_test.go
@@ -38,7 +38,7 @@ func TestPublishMessageCommand(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout)
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.MessageName("foo").CorrelationKey("bar").Send()
 
@@ -66,7 +66,7 @@ func TestPublishMessageCommandWithMessageId(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout)
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.MessageName("foo").CorrelationKey("bar").MessageId("hello").Send()
 
@@ -94,7 +94,7 @@ func TestPublishMessageCommandWithTimeToLive(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout)
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.MessageName("foo").CorrelationKey("bar").TimeToLive(time.Duration(6 * time.Minute)).Send()
 
@@ -124,7 +124,7 @@ func TestPublishMessageCommandWithVariablesFromString(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout)
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromString(variables)
 	if err != nil {
@@ -159,7 +159,7 @@ func TestPublishMessageCommandWithVariablesFromStringer(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout)
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromStringer(DataType{Foo: "bar"})
 	if err != nil {
@@ -194,7 +194,7 @@ func TestPublishMessageCommandWithVariablesFromObject(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout)
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
@@ -229,7 +229,7 @@ func TestPublishMessageCommandWithVariablesFromObjectOmitempty(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout)
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
@@ -264,7 +264,7 @@ func TestPublishMessageCommandWithVariablesFromObjectIgnoreOmitEmpty(t *testing.
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout)
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
@@ -301,7 +301,7 @@ func TestPublishMessageCommandWithVariablesFromMap(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout)
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromMap(variablesMap)
 	if err != nil {

--- a/clients/go/commands/resolveIncident_command_test.go
+++ b/clients/go/commands/resolveIncident_command_test.go
@@ -37,7 +37,7 @@ func TestResolveIncidentCommand(t *testing.T) {
 
 	client.EXPECT().ResolveIncident(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewResolveIncidentCommand(client, utils.DefaultTestTimeout)
+	command := NewResolveIncidentCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.IncidentKey(123).Send()
 

--- a/clients/go/commands/setVariables_command_test.go
+++ b/clients/go/commands/setVariables_command_test.go
@@ -38,7 +38,7 @@ func TestSetVariablesCommandWithVariablesFromString(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout)
+	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromString(variables)
 	if err != nil {
@@ -72,7 +72,7 @@ func TestSetVariablesCommandWithVariablesFromStringer(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout)
+	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromStringer(DataType{Foo: "bar"})
 	if err != nil {
@@ -106,7 +106,7 @@ func TestSetVariablesCommandWithVariablesFromObject(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout)
+	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
@@ -140,7 +140,7 @@ func TestSetVariablesCommandWithVariablesFromObjectOmitempty(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout)
+	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
@@ -174,7 +174,7 @@ func TestSetVariablesCommandWithVariablesFromObjectIgnoreOmitempty(t *testing.T)
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout)
+	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
@@ -210,7 +210,7 @@ func TestSetVariablesCommandWithVariablesFromMap(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout)
+	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromMap(variablesMap)
 	if err != nil {

--- a/clients/go/commands/topology_command_test.go
+++ b/clients/go/commands/topology_command_test.go
@@ -69,7 +69,7 @@ func TestTopologyCommand(t *testing.T) {
 
 	client.EXPECT().Topology(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewTopologyCommand(client, utils.DefaultTestTimeout)
+	command := NewTopologyCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.Send()
 

--- a/clients/go/commands/updateJobRetries_command_test.go
+++ b/clients/go/commands/updateJobRetries_command_test.go
@@ -37,7 +37,7 @@ func TestUpdateJobRetriesCommand(t *testing.T) {
 
 	client.EXPECT().UpdateJobRetries(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewUpdateJobRetriesCommand(client, utils.DefaultTestTimeout)
+	command := NewUpdateJobRetriesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.JobKey(123).Send()
 
@@ -64,7 +64,7 @@ func TestUpdateJobRetriesCommandWithRetries(t *testing.T) {
 
 	client.EXPECT().UpdateJobRetries(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewUpdateJobRetriesCommand(client, utils.DefaultTestTimeout)
+	command := NewUpdateJobRetriesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
 
 	response, err := command.JobKey(123).Retries(23).Send()
 

--- a/clients/go/zbc/credentialsProvider.go
+++ b/clients/go/zbc/credentialsProvider.go
@@ -14,135 +14,24 @@
 
 package zbc
 
-import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"github.com/go-ozzo/ozzo-validation"
-	"github.com/go-ozzo/ozzo-validation/is"
-	"github.com/pkg/errors"
-	"io/ioutil"
-	"net/http"
-	"os"
-)
-
 // CredentialsProvider is responsible for adding credentials to each gRPC call's headers.
 type CredentialsProvider interface {
-	// Takes a map of gRPC headers as defined in credentials.PerRPCCredentials and adds credentials to them
+	// Takes a map of gRPC headers as defined in credentials.PerRPCCredentials and adds credentials to them.
 	ApplyCredentials(headers map[string]string)
+	// Returns true if the request should be retried, false otherwise.
+	ShouldRetryRequest(err error) bool
 }
 
-// A built-in CredentialsProvider that contains contains credentials obtained from an OAuth authorization server,
-// including a token prefix and an access token. Using these values it sets the 'Authorization' header of each gRPC call.
-type OAuthCredentialsProvider struct {
-	Credentials *OauthCredentials
+// NoopCredentialsProvider implements the CredentialsProvider interface but doesn't modify the authorization headers and
+// doesn't retry requests in case of failure.
+type NoopCredentialsProvider struct{}
+
+// ApplyCredentials does nothing.
+func (NoopCredentialsProvider) ApplyCredentials(headers map[string]string) {
+	// Noop
 }
 
-// Configuration data for the OAuthCredentialsProvider, containing the required data to request an access token from
-// an OAuth authorization server which will be appended to each gRPC call's headers.
-type OAuthProviderConfig struct {
-	// The client identifier used to request an access token. Can be overridden with the environment variable 'ZEEBE_CLIENT_ID'.
-	ClientId string
-	// The client secret used to request an access token. Can be overridden with the environment variable 'ZEEBE_CLIENT_SECRET'.
-	ClientSecret string
-	// The audience to which the access token will be sent. Can be overridden with the environment variable 'ZEEBE_TOKEN_AUDIENCE'.
-	Audience string
-	// The URL for the authorization server from which the access token will be requested. Can be overridden with
-	// the environment variable 'ZEEBE_AUTHORIZATION_SERVER_URL'.
-	AuthorizationServerUrl string
-}
-
-type OauthCredentials struct {
-	AccessToken string `json:"access_token"`
-	ExpiresIn   uint64 `json:"expires_in"`
-	TokenType   string `json:"token_type"`
-	Scope       string `json:"scope"`
-}
-
-type oauthRequestPayload struct {
-	ClientId     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-	Audience     string `json:"audience"`
-	GrantType    string `json:"grant_type"`
-}
-
-// Takes a map of headers as input and adds an access token prefixed by a token type to the 'Authorization'
-// header of a gRPC call.
-func (provider *OAuthCredentialsProvider) ApplyCredentials(headers map[string]string) {
-	headers["Authorization"] = fmt.Sprintf("%s %s", provider.Credentials.TokenType, provider.Credentials.AccessToken)
-}
-
-// Requests credentials from an authorization server which are then used to create an OAuthCredentialsProvider.
-func NewOAuthCredentialsProvider(config *OAuthProviderConfig) (*OAuthCredentialsProvider, error) {
-	applyEnvironmentOverrides(config)
-
-	if err := validation.Validate(config.AuthorizationServerUrl, validation.Required, is.URL); err != nil {
-		return nil, invalidArgumentError("authorization server URL", err.Error())
-	} else if err := validation.Validate(config.ClientId, validation.Required); err != nil {
-		return nil, invalidArgumentError("client ID", err.Error())
-	} else if err := validation.Validate(config.ClientSecret, validation.Required); err != nil {
-		return nil, invalidArgumentError("client secret", err.Error())
-	} else if err := validation.Validate(config.Audience, validation.Required); err != nil {
-		return nil, invalidArgumentError("audience", err.Error())
-	}
-
-	payload := &oauthRequestPayload{
-		ClientId:     config.ClientId,
-		ClientSecret: config.ClientSecret,
-		Audience:     config.Audience,
-		GrantType:    "client_credentials",
-	}
-
-	credentials, err := fetchAccessToken(config.AuthorizationServerUrl, payload)
-	if err != nil {
-		return nil, err
-	}
-
-	return &OAuthCredentialsProvider{Credentials: credentials}, nil
-}
-
-func applyEnvironmentOverrides(config *OAuthProviderConfig) {
-	if envClientId := os.Getenv("ZEEBE_CLIENT_ID"); envClientId != "" {
-		config.ClientId = envClientId
-	}
-	if envClientSecret := os.Getenv("ZEEBE_CLIENT_SECRET"); envClientSecret != "" {
-		config.ClientSecret = envClientSecret
-	}
-	if envAudience := os.Getenv("ZEEBE_TOKEN_AUDIENCE"); envAudience != "" {
-		config.Audience = envAudience
-	}
-	if envAuthzServerUrl := os.Getenv("ZEEBE_AUTHORIZATION_SERVER_URL"); envAuthzServerUrl != "" {
-		config.AuthorizationServerUrl = envAuthzServerUrl
-	}
-}
-
-func fetchAccessToken(authorizationServerUrl string, payload *oauthRequestPayload) (*OauthCredentials, error) {
-	jsonPayload, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
-
-	reader := bytes.NewReader(jsonPayload)
-	response, err := http.Post(authorizationServerUrl, "application/json", reader)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed while requesting access token from URL '%s'", authorizationServerUrl))
-	}
-
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		return nil, errors.New(fmt.Sprintf("access token request failed with status code %d and message %s", response.StatusCode, response.Status))
-	}
-
-	jsonResponse, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed while reading response to access token request")
-	}
-
-	responsePayload := &OauthCredentials{}
-	if err := json.Unmarshal(jsonResponse, responsePayload); err != nil {
-		return nil, errors.Wrap(err, "failed while unmarshalling access token response from JSON")
-	}
-
-	return responsePayload, nil
+// ShouldRetryRequest always returns false.
+func (NoopCredentialsProvider) ShouldRetryRequest(err error) bool {
+	return false
 }

--- a/clients/go/zbc/oauthCredentialsProvider.go
+++ b/clients/go/zbc/oauthCredentialsProvider.go
@@ -1,0 +1,169 @@
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zbc
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	validation "github.com/go-ozzo/ozzo-validation"
+	"github.com/go-ozzo/ozzo-validation/is"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+)
+
+// OAuthCredentialsProvider is a built-in CredentialsProvider that contains credentials obtained from an OAuth
+// authorization server, including a token prefix and an access token. Using these values it sets the 'Authorization'
+// header of each gRPC call.
+type OAuthCredentialsProvider struct {
+	Credentials    *OAuthCredentials
+	RequestPayload *oauthRequestPayload
+	AuthzServerURL string
+}
+
+// OAuthProviderConfig configures an OAuthCredentialsProvider, containing the required data to request an access token
+// from an OAuth authorization server which will be appended to each gRPC call's headers.
+type OAuthProviderConfig struct {
+	// The client identifier used to request an access token. Can be overridden with the environment variable 'ZEEBE_CLIENT_ID'.
+	ClientID string
+	// The client secret used to request an access token. Can be overridden with the environment variable 'ZEEBE_CLIENT_SECRET'.
+	ClientSecret string
+	// The audience to which the access token will be sent. Can be overridden with the environment variable 'ZEEBE_TOKEN_AUDIENCE'.
+	Audience string
+	// The URL for the authorization server from which the access token will be requested. Can be overridden with
+	// the environment variable 'ZEEBE_AUTHORIZATION_SERVER_URL'.
+	AuthorizationServerURL string
+}
+
+// OAuthCredentials contains the data returned by the OAuth authorization server. These credentials are used to modify
+// the gRPC call headers.
+type OAuthCredentials struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   uint64 `json:"expires_in"`
+	TokenType   string `json:"token_type"`
+	Scope       string `json:"scope"`
+}
+
+type oauthRequestPayload struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	Audience     string `json:"audience"`
+	GrantType    string `json:"grant_type"`
+}
+
+// ApplyCredentials takes a map of headers as input and adds an access token prefixed by a token type to the 'Authorization'
+// header of a gRPC call.
+func (provider *OAuthCredentialsProvider) ApplyCredentials(headers map[string]string) {
+	headers["Authorization"] = fmt.Sprintf("%s %s", provider.Credentials.TokenType, provider.Credentials.AccessToken)
+}
+
+// ShouldRetryRequest checks if the error is UNAUTHENTICATED and, if so, attempts to refresh the access token. If the
+// new credentials are different from the stored ones, returns true. If the credentials are the same, returns false.
+func (provider *OAuthCredentialsProvider) ShouldRetryRequest(err error) bool {
+	if status.Code(err) == codes.Unauthenticated {
+		credentials, err := fetchAccessToken(provider.AuthzServerURL, provider.RequestPayload)
+
+		if err != nil {
+			log.Printf("failed while attempting to refresh credentials: %s", err.Error())
+			return false
+		}
+
+		shouldRetry := *(provider.Credentials) != *credentials
+		provider.Credentials = credentials
+		return shouldRetry
+	}
+
+	return false
+}
+
+// NewOAuthCredentialsProvider requests credentials from an authorization server and uses them to create an OAuthCredentialsProvider.
+func NewOAuthCredentialsProvider(config *OAuthProviderConfig) (*OAuthCredentialsProvider, error) {
+	applyEnvironmentOverrides(config)
+
+	if err := validation.Validate(config.AuthorizationServerURL, validation.Required, is.URL); err != nil {
+		return nil, invalidArgumentError("authorization server URL", err.Error())
+	} else if err := validation.Validate(config.ClientID, validation.Required); err != nil {
+		return nil, invalidArgumentError("client ID", err.Error())
+	} else if err := validation.Validate(config.ClientSecret, validation.Required); err != nil {
+		return nil, invalidArgumentError("client secret", err.Error())
+	} else if err := validation.Validate(config.Audience, validation.Required); err != nil {
+		return nil, invalidArgumentError("audience", err.Error())
+	}
+
+	payload := &oauthRequestPayload{
+		ClientID:     config.ClientID,
+		ClientSecret: config.ClientSecret,
+		Audience:     config.Audience,
+		GrantType:    "client_credentials",
+	}
+
+	credentials, err := fetchAccessToken(config.AuthorizationServerURL, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OAuthCredentialsProvider{Credentials: credentials, RequestPayload: payload, AuthzServerURL: config.AuthorizationServerURL}, nil
+}
+
+func applyEnvironmentOverrides(config *OAuthProviderConfig) {
+	if envClientID := os.Getenv("ZEEBE_CLIENT_ID"); envClientID != "" {
+		config.ClientID = envClientID
+	}
+	if envClientSecret := os.Getenv("ZEEBE_CLIENT_SECRET"); envClientSecret != "" {
+		config.ClientSecret = envClientSecret
+	}
+	if envAudience := os.Getenv("ZEEBE_TOKEN_AUDIENCE"); envAudience != "" {
+		config.Audience = envAudience
+	}
+	if envAuthzServerURL := os.Getenv("ZEEBE_AUTHORIZATION_SERVER_URL"); envAuthzServerURL != "" {
+		config.AuthorizationServerURL = envAuthzServerURL
+	}
+}
+
+func fetchAccessToken(authorizationServerURL string, payload *oauthRequestPayload) (*OAuthCredentials, error) {
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := bytes.NewReader(jsonPayload)
+	response, err := http.Post(authorizationServerURL, "application/json", reader)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed while requesting access token from URL '%s'", authorizationServerURL))
+	}
+
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, errors.New(fmt.Sprintf("access token request failed with status code %d and message %s", response.StatusCode, response.Status))
+	}
+
+	jsonResponse, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed while reading response to access token request")
+	}
+
+	responsePayload := &OAuthCredentials{}
+	if err := json.Unmarshal(jsonResponse, responsePayload); err != nil {
+		return nil, errors.Wrap(err, "failed while unmarshalling access token response from JSON")
+	}
+
+	return responsePayload, nil
+}

--- a/clients/go/zbc/oauthCredentialsProvider_test.go
+++ b/clients/go/zbc/oauthCredentialsProvider_test.go
@@ -1,0 +1,342 @@
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zbc
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+type mutableToken struct {
+	value string
+}
+
+func TestOAuthCredentialsProvider(t *testing.T) {
+	// given
+	interceptor := newRecordingInterceptor(nil)
+	gatewayLis, grpcServer := createServerWithInterceptor(interceptor.unaryClientInterceptor)
+
+	go grpcServer.Serve(gatewayLis)
+	defer func() {
+		grpcServer.Stop()
+		_ = gatewayLis.Close()
+	}()
+
+	authzServer := mockAuthorizationServer(t, &mutableToken{value: accessToken})
+	defer authzServer.Close()
+
+	credsProvider, err := NewOAuthCredentialsProvider(&OAuthProviderConfig{
+		ClientID:               clientID,
+		ClientSecret:           clientSecret,
+		Audience:               audience,
+		AuthorizationServerURL: authzServer.URL,
+	})
+
+	require.NoError(t, err)
+	parts := strings.Split(gatewayLis.Addr().String(), ":")
+	client, err := NewZBClient(&ZBClientConfig{
+		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
+		UsePlaintextConnection: true,
+		CredentialsProvider:    credsProvider,
+	})
+	require.NoError(t, err)
+
+	// when
+	_, err = client.NewTopologyCommand().Send()
+
+	// then
+	require.Error(t, err)
+	if errorStatus, ok := status.FromError(err); ok {
+		require.Equal(t, codes.Unimplemented, errorStatus.Code())
+	}
+	require.Equal(t, tokenType+" "+accessToken, interceptor.authHeader)
+}
+
+func TestOAuthProviderRetry(t *testing.T) {
+	// given
+	token := &mutableToken{value: "firstToken"}
+	first := true
+	interceptor := newRecordingInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if first {
+			first = false
+			token.value = accessToken
+			return nil, status.Error(codes.Unauthenticated, "UNAUTHENTICATED")
+		}
+
+		return handler(ctx, req)
+	})
+
+	gatewayLis, grpcServer := createServerWithInterceptor(interceptor.unaryClientInterceptor)
+
+	go grpcServer.Serve(gatewayLis)
+	defer func() {
+		grpcServer.Stop()
+		_ = gatewayLis.Close()
+	}()
+
+	authzServer := mockAuthorizationServer(t, token)
+	defer authzServer.Close()
+
+	credsProvider, err := NewOAuthCredentialsProvider(&OAuthProviderConfig{
+		ClientID:               clientID,
+		ClientSecret:           clientSecret,
+		Audience:               audience,
+		AuthorizationServerURL: authzServer.URL,
+	})
+
+	require.NoError(t, err)
+	parts := strings.Split(gatewayLis.Addr().String(), ":")
+	client, err := NewZBClient(&ZBClientConfig{
+		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
+		UsePlaintextConnection: true,
+		CredentialsProvider:    credsProvider,
+	})
+	require.NoError(t, err)
+
+	// when
+	_, err = client.NewTopologyCommand().Send()
+
+	// then
+	require.Error(t, err)
+	if errorStatus, ok := status.FromError(err); ok {
+		require.Equal(t, codes.Unimplemented, errorStatus.Code())
+	}
+	require.EqualValues(t, 2, interceptor.interceptCounter)
+}
+
+func TestNotRetryWithSameCredentials(t *testing.T) {
+	// given
+	token := &mutableToken{value: accessToken}
+
+	interceptor := newRecordingInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		return nil, status.Error(codes.Unauthenticated, "UNAUTHENTICATED")
+	})
+
+	gatewayLis, grpcServer := createServerWithInterceptor(interceptor.unaryClientInterceptor)
+
+	go grpcServer.Serve(gatewayLis)
+	defer func() {
+		grpcServer.Stop()
+		_ = gatewayLis.Close()
+	}()
+
+	authzServer := mockAuthorizationServer(t, token)
+	defer authzServer.Close()
+
+	credsProvider, err := NewOAuthCredentialsProvider(&OAuthProviderConfig{
+		ClientID:               clientID,
+		ClientSecret:           clientSecret,
+		Audience:               audience,
+		AuthorizationServerURL: authzServer.URL,
+	})
+
+	require.NoError(t, err)
+	parts := strings.Split(gatewayLis.Addr().String(), ":")
+	client, err := NewZBClient(&ZBClientConfig{
+		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
+		UsePlaintextConnection: true,
+		CredentialsProvider:    credsProvider,
+	})
+	require.NoError(t, err)
+
+	// when
+	_, err = client.NewTopologyCommand().Send()
+
+	// then
+	require.Error(t, err)
+	if errorStatus, ok := status.FromError(err); ok {
+		require.Equal(t, codes.Unauthenticated, errorStatus.Code())
+	}
+	require.EqualValues(t, 1, interceptor.interceptCounter)
+}
+
+var configErrorTests = []struct {
+	name       string
+	config     *OAuthProviderConfig
+	err        ZBError
+	errMessage string
+}{
+	{"missing authorization server URL",
+		&OAuthProviderConfig{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			Audience:     audience,
+		},
+		InvalidArgumentError,
+		invalidArgumentError("authorization server URL", "cannot be blank").Error(),
+	},
+	{
+		"malformed authorization server URL",
+		&OAuthProviderConfig{
+			ClientID:               clientID,
+			ClientSecret:           clientSecret,
+			Audience:               audience,
+			AuthorizationServerURL: "foo",
+		},
+		InvalidArgumentError,
+		invalidArgumentError("authorization server URL", "must be a valid URL").Error(),
+	},
+	{
+		"missing client id",
+		&OAuthProviderConfig{
+
+			ClientSecret:           clientSecret,
+			Audience:               audience,
+			AuthorizationServerURL: "http://foo",
+		},
+		InvalidArgumentError,
+		invalidArgumentError("client ID", "cannot be blank").Error(),
+	},
+	{
+		"missing client secret",
+		&OAuthProviderConfig{
+			ClientID:               clientID,
+			Audience:               audience,
+			AuthorizationServerURL: "http://foo",
+		},
+		InvalidArgumentError,
+		invalidArgumentError("client secret", "cannot be blank").Error(),
+	},
+	{
+		"missing audience",
+		&OAuthProviderConfig{
+			ClientID:               clientID,
+			ClientSecret:           clientSecret,
+			AuthorizationServerURL: "http://foo",
+		},
+		InvalidArgumentError,
+		invalidArgumentError("audience", "cannot be blank").Error(),
+	},
+}
+
+func TestInvalidOAuthProviderConfigurations(t *testing.T) {
+	for _, test := range configErrorTests {
+		t.Run(test.name, func(t *testing.T) {
+			// when
+			_, err := NewOAuthCredentialsProvider(test.config)
+
+			//then
+			require.EqualValues(t, test.err, errors.Cause(err))
+			require.EqualValues(t, test.errMessage, err.Error())
+		})
+	}
+}
+
+type fieldExtractor func(config *OAuthProviderConfig) string
+
+var envVarTests = []struct {
+	name           string
+	envVar         string
+	value          string
+	fieldExtractor fieldExtractor
+}{
+	{
+		"environment variable client id",
+		"ZEEBE_CLIENT_ID",
+		"envClient",
+		func(c *OAuthProviderConfig) string { return c.ClientID },
+	},
+	{
+		"environment variable client secret",
+		"ZEEBE_CLIENT_SECRET",
+		"envSecret",
+		func(c *OAuthProviderConfig) string { return c.ClientSecret },
+	},
+	{
+		"environment variable audience",
+		"ZEEBE_TOKEN_AUDIENCE",
+		"envAudience",
+		func(c *OAuthProviderConfig) string { return c.Audience },
+	},
+	{
+		"environment variable authorization server URL",
+		"ZEEBE_AUTHORIZATION_SERVER_URL",
+		"https://envAuthzUrl",
+		func(c *OAuthProviderConfig) string { return c.AuthorizationServerURL },
+	},
+}
+
+func TestOAuthProviderWithEnvVars(t *testing.T) {
+	for _, test := range envVarTests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := os.Setenv(test.envVar, test.value); err != nil {
+				panic(err)
+			}
+
+			config := &OAuthProviderConfig{
+				ClientID:               clientID,
+				ClientSecret:           clientSecret,
+				Audience:               audience,
+				AuthorizationServerURL: "http://foo",
+			}
+
+			// when
+			_, _ = NewOAuthCredentialsProvider(config)
+
+			// then
+			require.EqualValues(t, test.value, test.fieldExtractor(config))
+		})
+		if err := os.Unsetenv(test.envVar); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func mockAuthorizationServer(t *testing.T, token *mutableToken) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		bytes, err := ioutil.ReadAll(request.Body)
+		if err != nil {
+			panic(err)
+		}
+
+		requestPayload := &oauthRequestPayload{}
+		err = json.Unmarshal(bytes, requestPayload)
+		if err != nil {
+			panic(err)
+		}
+
+		require.EqualValues(t, &oauthRequestPayload{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			Audience:     audience,
+			GrantType:    "client_credentials",
+		}, requestPayload)
+
+		writer.WriteHeader(200)
+		responsePayload := []byte("{\"access_token\": \"" + token.value + "\"," +
+			"\"expires_in\": 3600," +
+			"\"token_type\": \"" + tokenType + "\"," +
+			"\"scope\": \"grpc\"}")
+
+		_, err = writer.Write(responsePayload)
+		if err != nil {
+			panic(err)
+		}
+	}))
+
+	return server
+}

--- a/clients/zbctl/cmd/root.go
+++ b/clients/zbctl/cmd/root.go
@@ -113,10 +113,10 @@ func parseAddress() string {
 func parseCredentials() (credsProvider zbc.CredentialsProvider, err error) {
 	if useOAuthFlag || clientIdFlag != "" || clientSecretFlag != "" || audienceFlag != "" || authzUrlFlag != "" {
 		return zbc.NewOAuthCredentialsProvider(&zbc.OAuthProviderConfig{
-			ClientId:               clientIdFlag,
+			ClientID:               clientIdFlag,
 			ClientSecret:           clientSecretFlag,
 			Audience:               audienceFlag,
-			AuthorizationServerUrl: authzUrlFlag,
+			AuthorizationServerURL: authzUrlFlag,
 		})
 	}
 


### PR DESCRIPTION
## Description

Adds retry support to credentials providers:
* The CredentialProvider interface was augmented with a new predicate method
* The OAuthCredentialProvider attempts to refresh the credentials if a request is failed with an UNAUTHENTICATED code
* Added a NoopCredentialsProvider for simplification purposes
* Improved the recordingInterceptor to do more than just record the grpc headers. It now supports a intercept action (to reject calls, etc) and it contains a mock object which allows us to assert things on the interception


I also split the credentials code to make a bit simpler, the tests were getting difficult to navigate as well.

## Related issues

closes #2985 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
