### PR TITLE
feat(engine): trigger boundary events on multi-instance activities

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/BpmnStepHandlers.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/BpmnStepHandlers.java
@@ -150,7 +150,7 @@ public class BpmnStepHandlers {
 
     stepHandlers.put(
         BpmnStep.MULTI_INSTANCE_ACTIVATING,
-        new MultiInstanceBodyActivatingHandler(stepHandlers::get));
+        new MultiInstanceBodyActivatingHandler(stepHandlers::get, catchEventSubscriber));
     stepHandlers.put(
         BpmnStep.MULTI_INSTANCE_ACTIVATED,
         new MultiInstanceBodyActivatedHandler(stepHandlers::get));
@@ -165,7 +165,7 @@ public class BpmnStepHandlers {
         new MultiInstanceBodyTerminatingHandler(stepHandlers::get, catchEventSubscriber));
     stepHandlers.put(
         BpmnStep.MULTI_INSTANCE_EVENT_OCCURRED,
-        new MultiInstanceBodyEventOccurredHandler(stepHandlers::get, catchEventSubscriber));
+        new MultiInstanceBodyEventOccurredHandler(stepHandlers::get));
   }
 
   public void handle(final BpmnStepContext context) {

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/MultiInstanceActivityTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/MultiInstanceActivityTransformer.java
@@ -70,7 +70,8 @@ public class MultiInstanceActivityTransformer implements ModelElementTransformer
       multiInstanceBody.bindLifecycleState(
           WorkflowInstanceIntent.EVENT_OCCURRED, BpmnStep.MULTI_INSTANCE_EVENT_OCCURRED);
 
-      // TODO (saig0) - #2855: attach boundary events to the multi-instance body
+      // attach boundary events to the multi-instance body
+      innerActivity.getBoundaryEvents().forEach(multiInstanceBody::attach);
       innerActivity.getEvents().removeAll(innerActivity.getBoundaryEvents());
       innerActivity.getInterruptingElementIds().clear();
 

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/multiinstance/MultiInstanceBodyEventOccurredHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/multiinstance/MultiInstanceBodyEventOccurredHandler.java
@@ -11,19 +11,17 @@ import io.zeebe.engine.processor.workflow.BpmnStepContext;
 import io.zeebe.engine.processor.workflow.BpmnStepHandler;
 import io.zeebe.engine.processor.workflow.deployment.model.BpmnStep;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableMultiInstanceBody;
-import io.zeebe.engine.processor.workflow.handlers.CatchEventSubscriber;
-import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import java.util.function.Function;
 
 public class MultiInstanceBodyEventOccurredHandler extends AbstractMultiInstanceBodyHandler {
 
-  private final CatchEventSubscriber catchEventSubscriber;
+  private final BpmnStepHandler eventHandler;
 
   public MultiInstanceBodyEventOccurredHandler(
-      final Function<BpmnStep, BpmnStepHandler> innerHandlerLookup,
-      final CatchEventSubscriber catchEventSubscriber) {
-    super(WorkflowInstanceIntent.ELEMENT_COMPLETED, innerHandlerLookup);
-    this.catchEventSubscriber = catchEventSubscriber;
+      final Function<BpmnStep, BpmnStepHandler> innerHandlerLookup) {
+    super(null, innerHandlerLookup);
+
+    eventHandler = innerHandlerLookup.apply(BpmnStep.ACTIVITY_EVENT_OCCURRED);
   }
 
   @Override
@@ -34,7 +32,7 @@ public class MultiInstanceBodyEventOccurredHandler extends AbstractMultiInstance
   @Override
   protected boolean handleMultiInstanceBody(
       final BpmnStepContext<ExecutableMultiInstanceBody> context) {
-    // TODO (saig0) - #2855: handle occurred boundary events
+    eventHandler.handle(context);
     return true;
   }
 }


### PR DESCRIPTION
## Description

* boundary events can be attached to multi-instance activities
* interrupting boundary events cancel all inner instances and the body instance
* non-interrupting boundary events don't affect the inner instances

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2855 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
