### PR TITLE
fix(broker): avoid NPE on model validation of messages

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/ModelUtil.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/ModelUtil.java
@@ -15,17 +15,37 @@
  */
 package io.zeebe.model.bpmn.util;
 
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
+
 import io.zeebe.model.bpmn.instance.Activity;
+import io.zeebe.model.bpmn.instance.Message;
 import io.zeebe.model.bpmn.instance.MessageEventDefinition;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ModelUtil {
-  public static List<MessageEventDefinition> getActivityMessageBoundaryEvents(Activity activity) {
+  public static Stream<MessageEventDefinition> getActivityMessageBoundaryEvents(Activity activity) {
+
     return activity.getBoundaryEvents().stream()
         .flatMap(event -> event.getEventDefinitions().stream())
         .filter(definition -> definition instanceof MessageEventDefinition)
-        .map(MessageEventDefinition.class::cast)
+        .map(MessageEventDefinition.class::cast);
+  }
+
+  public static List<String> getDuplicateMessageNames(
+      Stream<MessageEventDefinition> eventDefinitions) {
+
+    final Stream<Message> messages =
+        eventDefinitions
+            .map(MessageEventDefinition::getMessage)
+            .filter(m -> m.getName() != null && !m.getName().isEmpty());
+
+    return messages.collect(groupingBy(Message::getName, counting())).entrySet().stream()
+        .filter(e -> e.getValue() > 1)
+        .map(Entry::getKey)
         .collect(Collectors.toList());
   }
 }

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeEventBasedGatewayValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeEventBasedGatewayValidationTest.java
@@ -21,6 +21,9 @@ import static java.util.Collections.singletonList;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.instance.EventBasedGateway;
 import io.zeebe.model.bpmn.instance.IntermediateCatchEvent;
+import io.zeebe.model.bpmn.instance.Message;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription;
+import java.util.Arrays;
 import org.junit.runners.Parameterized.Parameters;
 
 public class ZeebeEventBasedGatewayValidationTest extends AbstractZeebeValidationTest {
@@ -68,7 +71,21 @@ public class ZeebeEventBasedGatewayValidationTest extends AbstractZeebeValidatio
         singletonList(
             expect(
                 EventBasedGateway.class,
-                "Multiple message catch events with the same name are not allowed."))
+                "Multiple message catch events with the same name 'msg' are not allowed."))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .eventBasedGateway()
+            .intermediateCatchEvent(
+                "catch-1", c -> c.message(m -> m.name(null).zeebeCorrelationKey("$.foo")))
+            .moveToLastGateway()
+            .intermediateCatchEvent(
+                "catch-2", c -> c.message(m -> m.name("msg").zeebeCorrelationKey(null)))
+            .done(),
+        Arrays.asList(
+            expect(Message.class, "Name must be present and not empty"),
+            expect(ZeebeSubscription.class, "zeebe:correlationKey must be present and not empty"))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
@@ -143,6 +143,35 @@ public class ZeebeMessageValidationTest extends AbstractZeebeValidationTest {
         singletonList(
             expect("start-message", "A message cannot be referred by more than one start event"))
       },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeTaskType("test"))
+            .boundaryEvent(
+                "boundary-1",
+                b -> b.message(m -> m.name(null).zeebeCorrelationKey("correlationKey")))
+            .endEvent()
+            .moveToActivity("task")
+            .boundaryEvent(
+                "boundary-2",
+                b -> b.message(m -> m.name(null).zeebeCorrelationKey("correlationKey")))
+            .endEvent()
+            .done(),
+        Arrays.asList(
+            expect(Message.class, "Name must be present and not empty"),
+            expect(Message.class, "Name must be present and not empty"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .receiveTask("task")
+            .message(m -> m.name("message").zeebeCorrelationKey("correlationKey"))
+            .boundaryEvent("boundary")
+            .message(m -> m.name(null).zeebeCorrelationKey("correlationKey"))
+            .endEvent()
+            .done(),
+        singletonList(expect(Message.class, "Name must be present and not empty"))
+      },
     };
   }
 

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
@@ -96,7 +96,7 @@ public class ZeebeValidationTest extends AbstractZeebeValidationTest {
         singletonList(
             expect(
                 "task",
-                "Cannot have two message catch boundary events with the same name: message"))
+                "Multiple message boundary events with the same name 'message' are not allowed."))
       },
     };
   }


### PR DESCRIPTION
## Description

* on validation, verify that a message name is set before doing additional checks

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2972 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
