### PR TITLE
Replace seek to last event on primitive start

### DIFF
--- a/broker/src/test/java/io/zeebe/broker/transport/commandapi/CommandApiMessageHandlerTest.java
+++ b/broker/src/test/java/io/zeebe/broker/transport/commandapi/CommandApiMessageHandlerTest.java
@@ -114,11 +114,6 @@ public class CommandApiMessageHandlerTest {
 
       FieldSetter.setField(
           distributedLogImpl,
-          DefaultDistributedLogstreamService.class.getDeclaredField("logStorage"),
-          logStream.getLogStorage());
-
-      FieldSetter.setField(
-          distributedLogImpl,
           DefaultDistributedLogstreamService.class.getDeclaredField("currentLeader"),
           nodeId);
 

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
@@ -183,7 +183,7 @@ public class ZeebeClientImpl implements ZeebeClient {
           }
         });
 
-    executorService.shutdown();
+    executorService.shutdownNow();
 
     try {
       if (!executorService.awaitTermination(15, TimeUnit.SECONDS)) {
@@ -195,7 +195,7 @@ public class ZeebeClientImpl implements ZeebeClient {
           "Unexpected interrupted awaiting termination of job worker executor", e);
     }
 
-    channel.shutdown();
+    channel.shutdownNow();
 
     try {
       if (!channel.awaitTermination(15, TimeUnit.SECONDS)) {

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Workflow Engine</name>
@@ -145,14 +147,6 @@
     <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-test-util</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-logstreams</artifactId>
-      <type>test-jar</type>
-      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
 

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -76,7 +76,7 @@ public class StreamProcessor extends Actor implements Service<StreamProcessor> {
 
   @Override
   public String getName() {
-    return "stream-processor";
+    return "partition-" + partitionId + "-processor";
   }
 
   @Override

--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorReprocessingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorReprocessingTest.java
@@ -67,7 +67,7 @@ public class StreamProcessorReprocessingTest {
 
     verify(typedRecordProcessor, TIMEOUT.times(1))
         .processRecord(eq(secondPosition), any(), any(), any(), any());
-    streamProcessor.closeAsync().join();
+    streamProcessorRule.closeStreamProcessor();
 
     // then
     final InOrder inOrder = inOrder(typedRecordProcessor);
@@ -106,16 +106,15 @@ public class StreamProcessorReprocessingTest {
 
     // when
     final TypedRecordProcessor typedRecordProcessor = mock(TypedRecordProcessor.class);
-    final StreamProcessor streamProcessor =
-        streamProcessorRule.startTypedStreamProcessor(
-            (processors, state) ->
-                processors
-                    .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor)
-                    .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATED, typedRecordProcessor));
+    streamProcessorRule.startTypedStreamProcessor(
+        (processors, state) ->
+            processors
+                .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor)
+                .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATED, typedRecordProcessor));
 
     verify(typedRecordProcessor, TIMEOUT.times(1))
         .processRecord(eq(normalProcessingPosition), any(), any(), any(), any());
-    streamProcessor.closeAsync().join();
+    streamProcessorRule.closeStreamProcessor();
 
     // then
     final InOrder inOrder = inOrder(typedRecordProcessor);
@@ -165,7 +164,7 @@ public class StreamProcessorReprocessingTest {
 
     verify(typedRecordProcessor, TIMEOUT.times(1))
         .processRecord(eq(secondPosition), any(), any(), any(), any());
-    streamProcessor.closeAsync().join();
+    streamProcessorRule.closeStreamProcessor();
 
     // then
     final InOrder inOrder = inOrder(typedRecordProcessor);

--- a/engine/src/test/java/io/zeebe/engine/util/ZeebeStateRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/ZeebeStateRule.java
@@ -46,6 +46,7 @@ public class ZeebeStateRule extends ExternalResource {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+    tempFolder.delete();
   }
 
   public ZeebeState getZeebeState() {

--- a/engine/src/test/resources/log4j2-test.xml
+++ b/engine/src/test/resources/log4j2-test.xml
@@ -3,7 +3,7 @@
 
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] %-5level %logger{36} - %msg%n"/>
     </Console>
   </Appenders>
 

--- a/logstreams/src/main/java/io/zeebe/distributedlog/impl/DefaultDistributedLogstreamService.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/impl/DefaultDistributedLogstreamService.java
@@ -30,16 +30,13 @@ import io.zeebe.distributedlog.restore.snapshot.RestoreSnapshotReplicator;
 import io.zeebe.distributedlog.restore.snapshot.SnapshotRestoreContext;
 import io.zeebe.logstreams.LogStreams;
 import io.zeebe.logstreams.impl.service.LogStreamServiceNames;
-import io.zeebe.logstreams.log.BufferedLogStreamReader;
 import io.zeebe.logstreams.log.LogStream;
-import io.zeebe.logstreams.spi.LogStorage;
 import io.zeebe.logstreams.state.FileSnapshotConsumer;
 import io.zeebe.logstreams.state.SnapshotConsumer;
 import io.zeebe.logstreams.state.StateStorage;
 import io.zeebe.servicecontainer.ServiceContainer;
 import io.zeebe.util.ZbLogger;
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CountDownLatch;
@@ -54,7 +51,6 @@ public class DefaultDistributedLogstreamService
       LoggerFactory.getLogger(DefaultDistributedLogstreamService.class);
 
   private LogStream logStream;
-  private LogStorage logStorage;
   private String logName;
   private int partitionId;
   private String currentLeader;
@@ -84,7 +80,6 @@ public class DefaultDistributedLogstreamService
           getLocalMemberId().id(),
           logName);
       logStream = getOrCreateLogStream(logName);
-      logStorage = logStream.getLogStorage();
       initLastPosition();
       logger.debug(
           "Configured with LogStream {} and last appended event at position {}",
@@ -165,13 +160,7 @@ public class DefaultDistributedLogstreamService
   }
 
   private void initLastPosition() {
-    final BufferedLogStreamReader reader = new BufferedLogStreamReader(logStream);
-    reader.seekToLastEvent();
-    lastPosition = reader.getPosition();
-    if (lastPosition > 0) {
-      logStream.setCommitPosition(lastPosition);
-    }
-    reader.close();
+    lastPosition = logStream.getCommitPosition();
   }
 
   @Override
@@ -213,29 +202,12 @@ public class DefaultDistributedLogstreamService
       return 1; // Assume the append was successful because event was previously appended.
     }
 
-    final ByteBuffer buffer = ByteBuffer.wrap(blockBuffer);
-    final long appendResult = appendBlock(buffer);
-    updateCommitPosition(commitPosition);
-    return appendResult;
-  }
-
-  private long appendBlock(ByteBuffer buffer) {
-    long appendResult = -1;
-    boolean notAppended = true;
     try {
+      final ByteBuffer buffer = ByteBuffer.wrap(blockBuffer);
+      final long appendResult = logStream.append(commitPosition, buffer);
+      lastPosition = commitPosition;
 
-      do {
-        try {
-          appendResult = logStorage.append(buffer);
-          notAppended = false;
-        } catch (IOException ioe) {
-          // we want to retry the append
-          // we avoid recursion, otherwise we can get stack overflow exceptions
-          LOG.error(
-              "Expected to append new buffer, but caught IOException. Will retry this operation.",
-              ioe);
-        }
-      } while (notAppended);
+      return appendResult;
     } catch (Exception e) {
       // block the primitive
       LOG.error(
@@ -249,8 +221,6 @@ public class DefaultDistributedLogstreamService
         }
       }
     }
-
-    return appendResult;
   }
 
   @Override
@@ -329,10 +299,5 @@ public class DefaultDistributedLogstreamService
         snapshotReplicator,
         restoreThreadContext,
         logger);
-  }
-
-  private void updateCommitPosition(long commitPosition) {
-    logStream.setCommitPosition(commitPosition);
-    lastPosition = commitPosition;
   }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/CompleteEventsInBlockProcessor.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/CompleteEventsInBlockProcessor.java
@@ -20,7 +20,7 @@ public class CompleteEventsInBlockProcessor implements ReadResultProcessor {
   private final MutableDirectBuffer directBuffer = new UnsafeBuffer(0, 0);
   private long lastReadEventPosition = -1;
 
-  long getLastReadEventPosition() {
+  public long getLastReadEventPosition() {
     return lastReadEventPosition;
   }
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/fs/FsLogSegments.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/fs/FsLogSegments.java
@@ -66,8 +66,10 @@ public class FsLogSegments {
 
   public void closeAll() {
     final FsLogSegment[] segments = this.segments;
-    for (FsLogSegment readableLogSegment : segments) {
-      readableLogSegment.closeSegment();
+
+    for (int i = 0; i < segments.length; i++) {
+      segments[i].closeSegment();
+      segments[i] = null;
     }
 
     this.segments = new FsLogSegment[0];

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogWriteBufferService.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogWriteBufferService.java
@@ -11,7 +11,6 @@ import io.zeebe.dispatcher.Dispatcher;
 import io.zeebe.dispatcher.DispatcherBuilder;
 import io.zeebe.dispatcher.impl.PositionUtil;
 import io.zeebe.logstreams.log.BufferedLogStreamReader;
-import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.logstreams.spi.LogStorage;
 import io.zeebe.servicecontainer.Injector;
 import io.zeebe.servicecontainer.Service;
@@ -58,14 +57,8 @@ public class LogWriteBufferService implements Service<Dispatcher> {
     try (BufferedLogStreamReader logReader = new BufferedLogStreamReader()) {
       logReader.wrap(logStorage);
 
-      long lastPosition = 0;
-
       // Get position of last entry
-      logReader.seekToLastEvent();
-      if (logReader.hasNext()) {
-        final LoggedEvent lastEntry = logReader.next();
-        lastPosition = lastEntry.getPosition();
-      }
+      final long lastPosition = logReader.seekToEnd();
 
       // dispatcher needs to generate positions greater than the last position
       int partitionId = 0;

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStream.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStream.java
@@ -12,6 +12,7 @@ import io.zeebe.logstreams.impl.LogStorageAppender;
 import io.zeebe.logstreams.spi.LogStorage;
 import io.zeebe.util.sched.ActorCondition;
 import io.zeebe.util.sched.future.ActorFuture;
+import java.nio.ByteBuffer;
 
 /**
  * Represents a stream of events from a log storage.
@@ -46,8 +47,13 @@ public interface LogStream extends AutoCloseable {
   /** @return the current commit position, or a negative value if no entry is committed. */
   long getCommitPosition();
 
-  /** Sets the log streams commit position to the given position. */
-  void setCommitPosition(long commitPosition);
+  /**
+   * Appends the given block of events to the logstream and updates the commit position.
+   *
+   * @param commitPosition the new commit position (position of the last event in the given buffer)
+   * @param buffer the events to append
+   */
+  long append(long commitPosition, ByteBuffer buffer);
 
   /**
    * Returns the log storage, which is accessed by the LogStream.

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamReader.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamReader.java
@@ -63,8 +63,12 @@ public interface LogStreamReader extends Iterator<LoggedEvent>, CloseableSilentl
   /** Seek to the log position of the first event. */
   void seekToFirstEvent();
 
-  /** Seek to the log position of the last event. */
-  void seekToLastEvent();
+  /**
+   * Seek to the end of the log, which means after the last event.
+   *
+   * @return the position of the last entry
+   */
+  long seekToEnd();
 
   /**
    * Returns the current log position of the reader.

--- a/logstreams/src/main/java/io/zeebe/logstreams/spi/LogStorage.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/spi/LogStorage.java
@@ -119,6 +119,16 @@ public interface LogStorage {
   long read(ByteBuffer readBuffer, long addr, ReadResultProcessor processor);
 
   /**
+   * Reads bytes into the given read buffer, starts with the last written blocks and iterates with
+   * help of the given processor.
+   *
+   * @param readBuffer the buffer which will contain the last block after this method returns
+   * @param processor the processor process the read bytes
+   * @return the address of the last block
+   */
+  long readLastBlock(ByteBuffer readBuffer, ReadResultProcessor processor);
+
+  /**
    * @return true if the storage is byte addressable (each byte managed in the underlying storage
    *     can be uniquely addressed using a long addr. False in case the storage is block
    *     addressable.

--- a/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/RestoreControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/RestoreControllerTest.java
@@ -48,12 +48,14 @@ public class RestoreControllerTest {
   private static final DirectBuffer EVENT = wrapString("FOO");
 
   private final TemporaryFolder temporaryFolderClient = new TemporaryFolder();
-  private final LogStreamRule logStreamRuleClient = new LogStreamRule(temporaryFolderClient);
+  private final LogStreamRule logStreamRuleClient =
+      LogStreamRule.startByDefault(temporaryFolderClient);
   private final LogStreamWriterRule writerClient = new LogStreamWriterRule(logStreamRuleClient);
   private final LogStreamReaderRule readerClient = new LogStreamReaderRule(logStreamRuleClient);
 
   private final TemporaryFolder temporaryFolderServer = new TemporaryFolder();
-  private final LogStreamRule logStreamRuleServer = new LogStreamRule(temporaryFolderServer);
+  private final LogStreamRule logStreamRuleServer =
+      LogStreamRule.startByDefault(temporaryFolderServer);
   private final LogStreamWriterRule writerServer = new LogStreamWriterRule(logStreamRuleServer);
   private final LogStreamReaderRule readerServer = new LogStreamReaderRule(logStreamRuleServer);
 
@@ -112,17 +114,10 @@ public class RestoreControllerTest {
 
     final LogReplicator logReplicator =
         new LogReplicator(
-            (commitPosition, blockBuffer) -> {
-              logStreamRuleClient.getLogStream().setCommitPosition(commitPosition);
-              try {
-                return logStreamRuleClient
+            (commitPosition, blockBuffer) ->
+                logStreamRuleClient
                     .getLogStream()
-                    .getLogStorage()
-                    .append(ByteBuffer.wrap(blockBuffer));
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            },
+                    .append(commitPosition, ByteBuffer.wrap(blockBuffer)),
             restoreClient,
             restoreThreadContext,
             log);

--- a/logstreams/src/test/java/io/zeebe/distributedlog/restore/log/impl/DefaultLogReplicationRequestHandlerTest.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/restore/log/impl/DefaultLogReplicationRequestHandlerTest.java
@@ -31,7 +31,7 @@ import org.slf4j.helpers.NOPLogger;
 
 public class DefaultLogReplicationRequestHandlerTest {
   private static final TemporaryFolder LOG_FOLDER = new TemporaryFolder();
-  private static final LogStreamRule LOG_STREAM_RULE = new LogStreamRule(LOG_FOLDER);
+  private static final LogStreamRule LOG_STREAM_RULE = LogStreamRule.startByDefault(LOG_FOLDER);
   private static final LogStreamWriterRule LOG_STREAM_WRITER_RULE =
       new LogStreamWriterRule(LOG_STREAM_RULE);
   private static final LogStreamReaderRule LOG_STREAM_READER_RULE =

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStorageAppenderTest.java
@@ -35,7 +35,7 @@ public class LogStorageAppenderTest {
   private final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   private final LogStreamRule logStreamRule =
-      new LogStreamRule(
+      LogStreamRule.startByDefault(
           temporaryFolder,
           b -> {
             b.logStorageStubber(logStorage -> spy(logStorage));

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamBatchWriterTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamBatchWriterTest.java
@@ -44,7 +44,7 @@ public class LogStreamBatchWriterTest {
   @Rule public ExpectedException expectedException = ExpectedException.none();
 
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
-  public LogStreamRule logStreamRule = new LogStreamRule(temporaryFolder);
+  public LogStreamRule logStreamRule = LogStreamRule.startByDefault(temporaryFolder);
   public LogStreamReaderRule readerRule = new LogStreamReaderRule(logStreamRule);
   public LogStreamWriterRule writerRule = new LogStreamWriterRule(logStreamRule);
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamDeleteTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamDeleteTest.java
@@ -9,141 +9,54 @@ package io.zeebe.logstreams.log;
 
 import static io.zeebe.dispatcher.impl.log.DataFrameDescriptor.alignedLength;
 import static io.zeebe.logstreams.impl.LogEntryDescriptor.HEADER_BLOCK_LENGTH;
-import static io.zeebe.logstreams.impl.service.LogStreamServiceNames.distributedLogPartitionServiceName;
 import static io.zeebe.logstreams.log.LogStreamTest.writeEvent;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 
-import io.zeebe.distributedlog.DistributedLogstreamService;
-import io.zeebe.distributedlog.impl.DefaultDistributedLogstreamService;
-import io.zeebe.distributedlog.impl.DistributedLogstreamPartition;
-import io.zeebe.logstreams.impl.LogStreamBuilder;
 import io.zeebe.logstreams.impl.log.fs.FsLogSegmentDescriptor;
-import io.zeebe.servicecontainer.testing.ServiceContainerRule;
-import io.zeebe.test.util.AutoCloseableRule;
+import io.zeebe.logstreams.util.LogStreamRule;
 import io.zeebe.util.buffer.BufferUtil;
-import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.File;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.internal.util.reflection.FieldSetter;
-import org.mockito.stubbing.Answer;
 
 public class LogStreamDeleteTest {
-  public static final int PARTITION_ID = 0;
-
-  @Rule public ExpectedException thrown = ExpectedException.none();
-
-  public TemporaryFolder tempFolder = new TemporaryFolder();
-
-  public AutoCloseableRule closeables = new AutoCloseableRule();
-  public ActorSchedulerRule actorScheduler = new ActorSchedulerRule();
-  public ServiceContainerRule serviceContainer = new ServiceContainerRule(actorScheduler);
-
-  @Rule
-  public RuleChain chain =
-      RuleChain.outerRule(tempFolder)
-          .around(actorScheduler)
-          .around(serviceContainer)
-          .around(closeables);
 
   private long firstPosition;
   private long secondPosition;
   private long thirdPosition;
   private long fourthPosition;
 
-  protected LogStream buildLogStream(final Consumer<LogStreamBuilder> streamConfig) {
-    final LogStreamBuilder builder = new LogStreamBuilder(PARTITION_ID);
-    builder
-        .logName("test-log-name")
-        .serviceContainer(serviceContainer.get())
-        .logRootPath(tempFolder.getRoot().getAbsolutePath());
+  private final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    streamConfig.accept(builder);
+  private final LogStreamRule logStreamRule =
+      LogStreamRule.createRuleWithoutStarting(temporaryFolder);
 
-    final LogStream logStream = builder.build().join();
-
-    final DistributedLogstreamPartition mockDistLog = mock(DistributedLogstreamPartition.class);
-
-    final DistributedLogstreamService distributedLogImpl = new DefaultDistributedLogstreamService();
-
-    final String nodeId = "0";
-    try {
-      FieldSetter.setField(
-          distributedLogImpl,
-          DefaultDistributedLogstreamService.class.getDeclaredField("logStream"),
-          logStream);
-
-      FieldSetter.setField(
-          distributedLogImpl,
-          DefaultDistributedLogstreamService.class.getDeclaredField("logStorage"),
-          logStream.getLogStorage());
-
-      FieldSetter.setField(
-          distributedLogImpl,
-          DefaultDistributedLogstreamService.class.getDeclaredField("currentLeader"),
-          nodeId);
-
-    } catch (NoSuchFieldException e) {
-      e.printStackTrace();
-    }
-
-    doAnswer(
-            (Answer<CompletableFuture<Long>>)
-                invocation -> {
-                  final Object[] arguments = invocation.getArguments();
-                  if (arguments != null
-                      && arguments.length > 1
-                      && arguments[0] != null
-                      && arguments[1] != null) {
-                    final byte[] bytes = (byte[]) arguments[0];
-                    final long pos = (long) arguments[1];
-                    return CompletableFuture.completedFuture(
-                        distributedLogImpl.append(nodeId, pos, bytes));
-                  }
-                  return null;
-                })
-        .when(mockDistLog)
-        .asyncAppend(any(), anyLong());
-
-    serviceContainer
-        .get()
-        .createService(distributedLogPartitionServiceName("test-log-name"), () -> mockDistLog)
-        .install()
-        .join();
-
-    return logStream;
-  }
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(temporaryFolder).around(logStreamRule);
 
   @Test
   public void shouldDeleteOnClose() {
-    final File logDir = tempFolder.getRoot();
+    final File logDir = temporaryFolder.getRoot();
     final LogStream logStream =
-        buildLogStream(b -> b.logRootPath(logDir.getAbsolutePath()).deleteOnClose(true));
+        logStreamRule.startLogStreamWithConfiguration(
+            b -> b.logRootPath(logDir.getAbsolutePath()).deleteOnClose(true));
 
     // when
     logStream.close();
 
     // then
     final File[] files = logDir.listFiles();
-    assertThat(files).isNotNull();
-    assertThat(files.length).isEqualTo(0);
+    assertThat(files).isNull();
   }
 
   @Test
   public void shouldNotDeleteOnCloseByDefault() {
-    final File logDir = tempFolder.getRoot();
-    final LogStream logStream = buildLogStream(b -> b.logRootPath(logDir.getAbsolutePath()));
+    final File logDir = temporaryFolder.getRoot();
+    final LogStream logStream =
+        logStreamRule.startLogStreamWithConfiguration(b -> b.logRootPath(logDir.getAbsolutePath()));
 
     // when
     logStream.close();
@@ -163,14 +76,13 @@ public class LogStreamDeleteTest {
     logStream.delete(fourthPosition);
 
     // then
-    assertThat(events(logStream).count()).isEqualTo(2);
+    assertThat(events().count()).isEqualTo(2);
 
-    assertThat(events(logStream).anyMatch(e -> e.getPosition() == firstPosition)).isFalse();
-    assertThat(events(logStream).anyMatch(e -> e.getPosition() == secondPosition)).isFalse();
+    assertThat(events().anyMatch(e -> e.getPosition() == firstPosition)).isFalse();
+    assertThat(events().anyMatch(e -> e.getPosition() == secondPosition)).isFalse();
 
-    assertThat(events(logStream).findFirst().get().getPosition()).isEqualTo(thirdPosition);
-    assertThat(events(logStream).filter(e -> e.getPosition() == fourthPosition).findAny())
-        .isNotEmpty();
+    assertThat(events().findFirst().get().getPosition()).isEqualTo(thirdPosition);
+    assertThat(events().filter(e -> e.getPosition() == fourthPosition).findAny()).isNotEmpty();
   }
 
   @Test
@@ -182,16 +94,12 @@ public class LogStreamDeleteTest {
     logStream.delete(-1);
 
     // then - segment 0 and 1 are removed
-    assertThat(events(logStream).count()).isEqualTo(4);
+    assertThat(events().count()).isEqualTo(4);
 
-    assertThat(events(logStream).filter(e -> e.getPosition() == firstPosition).findAny())
-        .isNotEmpty();
-    assertThat(events(logStream).filter(e -> e.getPosition() == secondPosition).findAny())
-        .isNotEmpty();
-    assertThat(events(logStream).filter(e -> e.getPosition() == thirdPosition).findAny())
-        .isNotEmpty();
-    assertThat(events(logStream).filter(e -> e.getPosition() == fourthPosition).findAny())
-        .isNotEmpty();
+    assertThat(events().filter(e -> e.getPosition() == firstPosition).findAny()).isNotEmpty();
+    assertThat(events().filter(e -> e.getPosition() == secondPosition).findAny()).isNotEmpty();
+    assertThat(events().filter(e -> e.getPosition() == thirdPosition).findAny()).isNotEmpty();
+    assertThat(events().filter(e -> e.getPosition() == fourthPosition).findAny()).isNotEmpty();
   }
 
   private LogStream prepareLogstream() {
@@ -201,9 +109,8 @@ public class LogStreamDeleteTest {
             - FsLogSegmentDescriptor.METADATA_LENGTH
             - alignedLength(HEADER_BLOCK_LENGTH + 2 + 8)
             - 1);
-    final LogStream logStream = buildLogStream(c -> c.logSegmentSize(segmentSize));
-    logStream.openAppender().join();
-    closeables.manage(logStream);
+    final LogStream logStream =
+        logStreamRule.startLogStreamWithConfiguration(c -> c.logSegmentSize(segmentSize));
     final byte[] largeEvent = new byte[remainingCapacity];
 
     // log storage always returns on append as address (segment id, segment OFFSET)
@@ -222,15 +129,13 @@ public class LogStreamDeleteTest {
     // written from segment 3 4096 -> 8192, but idx block address segment 2 - 8192
     fourthPosition = writeEvent(logStream, BufferUtil.wrapArray(largeEvent));
 
-    logStream.setCommitPosition(fourthPosition);
+    //    logStream.setCommitPosition(fourthPosition);
 
     return logStream;
   }
 
-  private Stream<LoggedEvent> events(final LogStream stream) {
-    final BufferedLogStreamReader reader = new BufferedLogStreamReader(stream);
-    closeables.manage(reader);
-
+  private Stream<LoggedEvent> events() {
+    final LogStreamReader reader = logStreamRule.getLogStreamReader();
     reader.seekToFirstEvent();
     final Iterable<LoggedEvent> iterable = () -> reader;
     return StreamSupport.stream(iterable.spliterator(), false);

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamReaderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamReaderTest.java
@@ -34,7 +34,7 @@ public class LogStreamReaderTest {
       new UnsafeBuffer(new byte[BufferedLogStreamReader.DEFAULT_INITIAL_BUFFER_CAPACITY * 2]);
   @Rule public ExpectedException expectedException = ExpectedException.none();
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
-  public LogStreamRule logStreamRule = new LogStreamRule(temporaryFolder);
+  public LogStreamRule logStreamRule = LogStreamRule.startByDefault(temporaryFolder);
   public LogStreamWriterRule writer = new LogStreamWriterRule(logStreamRule);
   public LogStreamReaderRule readerRule = new LogStreamReaderRule(logStreamRule);
 
@@ -179,15 +179,30 @@ public class LogStreamReaderTest {
     final long lastPosition = writer.writeEvents(eventCount, EVENT_VALUE);
 
     // when
-    reader.seekToLastEvent();
+    final long seekedPosition = reader.seekToEnd();
 
     // then
+    assertThat(reader.hasNext()).isFalse();
+    assertThat(lastPosition).isEqualTo(seekedPosition);
+  }
+
+  @Test
+  public void shouldReturnNextAfterSeekToEnd() {
+    // given
+    final int eventCount = 10;
+    final long lastEventPosition = writer.writeEvents(eventCount, EVENT_VALUE);
+    final long seekedPosition = reader.seekToEnd();
+
+    // when
+    final long newLastPosition = writer.writeEvent(EVENT_VALUE);
+
+    // then
+    assertThat(lastEventPosition).isEqualTo(seekedPosition);
+    assertThat(newLastPosition).isGreaterThan(seekedPosition);
+
     assertThat(reader.hasNext()).isTrue();
     final LoggedEvent loggedEvent = reader.next();
-    assertThat(loggedEvent.getKey()).isEqualTo(eventCount);
-    assertThat(loggedEvent.getPosition()).isEqualTo(lastPosition);
-
-    assertThat(reader.hasNext()).isFalse();
+    assertThat(loggedEvent.getPosition()).isEqualTo(newLastPosition);
   }
 
   @Test
@@ -251,13 +266,10 @@ public class LogStreamReaderTest {
     final long lastPosition = writer.writeEvents(eventCount, BIG_EVENT_VALUE);
 
     // when
-    reader.seekToLastEvent();
+    final long seekedPosition = reader.seekToEnd();
 
     // then
-    final LoggedEvent loggedEvent = reader.next();
-    assertThat(loggedEvent.getKey()).isEqualTo(eventCount);
-    assertThat(loggedEvent.getPosition()).isEqualTo(lastPosition);
-
+    assertThat(lastPosition).isEqualTo(seekedPosition);
     assertThat(reader.hasNext()).isFalse();
   }
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamTest.java
@@ -7,150 +7,65 @@
  */
 package io.zeebe.logstreams.log;
 
-import static io.zeebe.logstreams.impl.service.LogStreamServiceNames.distributedLogPartitionServiceName;
 import static io.zeebe.test.util.TestUtil.waitUntil;
 import static io.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 
 import io.zeebe.dispatcher.Dispatcher;
-import io.zeebe.distributedlog.DistributedLogstreamService;
-import io.zeebe.distributedlog.impl.DefaultDistributedLogstreamService;
-import io.zeebe.distributedlog.impl.DistributedLogstreamPartition;
-import io.zeebe.logstreams.impl.LogStreamBuilder;
-import io.zeebe.servicecontainer.testing.ServiceContainerRule;
-import io.zeebe.test.util.AutoCloseableRule;
-import io.zeebe.util.sched.testing.ActorSchedulerRule;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
+import io.zeebe.logstreams.spi.LogStorage;
+import io.zeebe.logstreams.util.LogStreamRule;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import org.agrona.DirectBuffer;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.internal.util.reflection.FieldSetter;
-import org.mockito.stubbing.Answer;
 
 public class LogStreamTest {
   public static final int PARTITION_ID = 0;
 
-  @Rule public ExpectedException thrown = ExpectedException.none();
+  private final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  public TemporaryFolder tempFolder = new TemporaryFolder();
+  private final LogStreamRule logStreamRule =
+      LogStreamRule.startByDefault(
+          temporaryFolder,
+          b -> {
+            b.logStorageStubber(logStorage -> spy(logStorage));
+          });
 
-  public AutoCloseableRule closeables = new AutoCloseableRule();
-  public ActorSchedulerRule actorScheduler = new ActorSchedulerRule();
-  public ServiceContainerRule serviceContainer = new ServiceContainerRule(actorScheduler);
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(temporaryFolder).around(logStreamRule);
 
-  @Rule
-  public RuleChain chain =
-      RuleChain.outerRule(tempFolder)
-          .around(actorScheduler)
-          .around(serviceContainer)
-          .around(closeables);
+  private LogStream logStream;
+  private LogStorage logStorageSpy;
 
-  protected LogStream buildLogStream(final Consumer<LogStreamBuilder> streamConfig) {
-    final LogStreamBuilder builder = new LogStreamBuilder(PARTITION_ID);
-    builder
-        .logName("test-log-name")
-        .serviceContainer(serviceContainer.get())
-        .logRootPath(tempFolder.getRoot().getAbsolutePath());
-
-    streamConfig.accept(builder);
-
-    final LogStream logStream = builder.build().join();
-
-    final DistributedLogstreamPartition mockDistLog = mock(DistributedLogstreamPartition.class);
-
-    final DistributedLogstreamService distributedLogImpl = new DefaultDistributedLogstreamService();
-
-    final String nodeId = "0";
-    try {
-      FieldSetter.setField(
-          distributedLogImpl,
-          DefaultDistributedLogstreamService.class.getDeclaredField("logStream"),
-          logStream);
-
-      FieldSetter.setField(
-          distributedLogImpl,
-          DefaultDistributedLogstreamService.class.getDeclaredField("logStorage"),
-          logStream.getLogStorage());
-
-      FieldSetter.setField(
-          distributedLogImpl,
-          DefaultDistributedLogstreamService.class.getDeclaredField("currentLeader"),
-          nodeId);
-
-    } catch (NoSuchFieldException e) {
-      e.printStackTrace();
-    }
-
-    doAnswer(
-            (Answer<CompletableFuture<Long>>)
-                invocation -> {
-                  final Object[] arguments = invocation.getArguments();
-                  if (arguments != null
-                      && arguments.length > 1
-                      && arguments[0] != null
-                      && arguments[1] != null) {
-                    final byte[] bytes = (byte[]) arguments[0];
-                    final long pos = (long) arguments[1];
-                    return CompletableFuture.completedFuture(
-                        distributedLogImpl.append(nodeId, pos, bytes));
-                  }
-                  return null;
-                })
-        .when(mockDistLog)
-        .asyncAppend(any(), anyLong());
-
-    serviceContainer
-        .get()
-        .createService(distributedLogPartitionServiceName("test-log-name"), () -> mockDistLog)
-        .install()
-        .join();
-
-    return logStream;
-  }
-
-  protected LogStream buildLogStream() {
-    return buildLogStream(c -> {});
+  @Before
+  public void setup() {
+    logStream = logStreamRule.getLogStream();
+    logStorageSpy = logStream.getLogStorage();
   }
 
   @Test
   public void shouldBuildLogStream() {
     // given
-    final LogStream logStream = buildLogStream();
 
     // when
-    closeables.manage(logStream);
 
     // then
     assertThat(logStream.getPartitionId()).isEqualTo(PARTITION_ID);
-    assertThat(logStream.getLogName()).isEqualTo("test-log-name");
+    assertThat(logStream.getLogName()).isEqualTo("0");
 
     assertThat(logStream.getLogStorage()).isNotNull();
     assertThat(logStream.getLogStorage().isOpen()).isTrue();
 
     assertThat(logStream.getCommitPosition()).isEqualTo(-1L);
 
-    assertThat(logStream.getLogStorageAppender()).isNull();
-    assertThat(logStream.getWriteBuffer()).isNull();
-  }
-
-  @Test
-  public void shouldOpenLogStorageAppender() {
-    // given
-    final LogStream logStream = buildLogStream();
-
-    // when
-    logStream.openAppender().join();
-    closeables.manage(logStream);
-
-    // then
     assertThat(logStream.getLogStorageAppender()).isNotNull();
     assertThat(logStream.getWriteBuffer()).isNotNull();
   }
@@ -158,9 +73,6 @@ public class LogStreamTest {
   @Test
   public void shouldCloseLogStorageAppender() {
     // given
-    final LogStream logStream = buildLogStream();
-
-    logStream.openAppender().join();
 
     final Dispatcher writeBuffer = logStream.getWriteBuffer();
 
@@ -177,10 +89,6 @@ public class LogStreamTest {
   @Test
   public void shouldCloseLogStream() {
     // given
-    final LogStream logStream = buildLogStream();
-
-    logStream.openAppender().join();
-
     final Dispatcher writeBuffer = logStream.getWriteBuffer();
 
     // when
@@ -194,13 +102,25 @@ public class LogStreamTest {
   @Test
   public void shouldSetCommitPosition() {
     // given
-    final LogStream logStream = buildLogStream();
 
     // when
-    logStream.setCommitPosition(123L);
+    logStream.append(123L, ByteBuffer.wrap("foo".getBytes()));
 
     // then
     assertThat(logStream.getCommitPosition()).isEqualTo(123L);
+  }
+
+  @Test
+  public void shouldRetryOnAppend() throws Exception {
+    // given
+    doThrow(IOException.class).doCallRealMethod().when(logStorageSpy).append(any());
+
+    // when
+    logStream.append(123L, ByteBuffer.wrap("foo".getBytes()));
+
+    // then
+    assertThat(logStream.getCommitPosition()).isEqualTo(123L);
+    verify(logStorageSpy, timeout(5_000).times(2)).append(any());
   }
 
   static long writeEvent(final LogStream logStream) {

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamWriterTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamWriterTest.java
@@ -39,7 +39,7 @@ public class LogStreamWriterTest {
   @Rule public ExpectedException expectedException = ExpectedException.none();
 
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
-  public LogStreamRule logStreamRule = new LogStreamRule(temporaryFolder);
+  public LogStreamRule logStreamRule = LogStreamRule.startByDefault(temporaryFolder);
   public LogStreamReaderRule readerRule = new LogStreamReaderRule(logStreamRule);
   public LogStreamWriterRule writerRule = new LogStreamWriterRule(logStreamRule);
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
@@ -9,6 +9,7 @@ package io.zeebe.broker.it;
 
 import static io.zeebe.test.util.TestUtil.waitUntil;
 
+import io.zeebe.broker.TestLoggers;
 import io.zeebe.broker.it.clustering.ClusteringRule;
 import io.zeebe.broker.test.EmbeddedBrokerRule;
 import io.zeebe.client.ZeebeClient;
@@ -27,11 +28,15 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
 
 public class GrpcClientRule extends ExternalResource {
 
+  private static final Logger LOG = TestLoggers.TEST_LOGGER;
+
   protected ZeebeClient client;
   private final Consumer<ZeebeClientBuilder> configurator;
+  private long startTime;
 
   public GrpcClientRule(final EmbeddedBrokerRule brokerRule) {
     this(brokerRule, config -> {});
@@ -60,15 +65,22 @@ public class GrpcClientRule extends ExternalResource {
 
   @Override
   public void before() {
+    startTime = System.currentTimeMillis();
     final ZeebeClientBuilder builder =
         ZeebeClient.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(10));
     configurator.accept(builder);
     client = builder.build();
+    LOG.info("\n====\nClient startup time: {}\n====\n", (System.currentTimeMillis() - startTime));
+    startTime = System.currentTimeMillis();
   }
 
   @Override
   public void after() {
+    LOG.info(
+        "Client Rule assumption: Test execution time: " + (System.currentTimeMillis() - startTime));
+    startTime = System.currentTimeMillis();
     client.close();
+    LOG.info("Client closing time: " + (System.currentTimeMillis() - startTime));
     client = null;
   }
 


### PR DESCRIPTION
## Description

### chore(logstreams): replace seek to last event
 * seek to last event on primitive configuration and dispatcher creation
 was replaced by a new seekToEnd method, which simply goes to the last
 log segment and iterates over the existing blocks to find the last event
 position

 We can still improve here. It could be possible to write the last
 position every time we write an block to the segment, but this would
 increase the writes so I'm currently not sure. This new approach reduces
 the finding of the last position execution by an factor of 75 - 100.
 Before it took's several minutes for large logs it could be 10+ minutes.
 Now it took between 1 - 10 seconds, if we reduce the log segment size
 we could reduce the execution time again.


### chore(clients/java): force shutdown on close
 I had some problems because of weird test timeouts and had a deeper look and
it seems that the client close took 10 seconds

 * we now use shutdownNow instead of shutdown, this reduces the time of client.close by
 10 seconds
 * before we had to wait until the client has successfully closed - this
 is done in the qa test as well - it took around 10 sec to close the
 GRPCRule for example
 * after changing this the rule can close in 22 ms -> reduces the test
 execution as well


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3006 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
