### PR TITLE
Add credentials cache

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -132,6 +132,10 @@
       <artifactId>asm</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/clients/java/src/main/java/io/zeebe/client/CredentialsProvider.java
+++ b/clients/java/src/main/java/io/zeebe/client/CredentialsProvider.java
@@ -16,8 +16,8 @@
 package io.zeebe.client;
 
 import io.grpc.Metadata;
-import io.zeebe.client.impl.OAuthCredentialsProvider;
-import io.zeebe.client.impl.OAuthCredentialsProviderBuilder;
+import io.zeebe.client.impl.oauth.OAuthCredentialsProvider;
+import io.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
 
 public interface CredentialsProvider {
 

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientCredentials.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientCredentials.java
@@ -18,7 +18,7 @@ package io.zeebe.client.impl;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
-class ZeebeClientCredentials {
+public class ZeebeClientCredentials {
 
   @JsonProperty("access_token")
   private String accessToken;
@@ -32,11 +32,21 @@ class ZeebeClientCredentials {
   @JsonProperty("scope")
   private String scope;
 
-  String getAccessToken() {
+  public ZeebeClientCredentials() {}
+
+  public ZeebeClientCredentials(
+      final String accessToken, final long expiresIn, final String tokenType, final String scope) {
+    this.accessToken = accessToken;
+    this.expiresIn = expiresIn;
+    this.tokenType = tokenType;
+    this.scope = scope;
+  }
+
+  public String getAccessToken() {
     return accessToken;
   }
 
-  String getTokenType() {
+  public String getTokenType() {
     return tokenType;
   }
 
@@ -46,7 +56,7 @@ class ZeebeClientCredentials {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (o == null || !o.getClass().equals(this.getClass())) {
       return false;
     }

--- a/clients/java/src/main/java/io/zeebe/client/impl/oauth/OAuthCredentialsCache.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/oauth/OAuthCredentialsCache.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl.oauth;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.zeebe.client.impl.ZeebeClientCredentials;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+public class OAuthCredentialsCache {
+  private static final String KEY_AUTH = "auth";
+  private static final String KEY_CREDENTIALS = "credentials";
+  private static final TypeReference<Map<String, OAuthCachedCredentials>> TYPE_REFERENCE =
+      new TypeReference<Map<String, OAuthCachedCredentials>>() {};
+  private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
+
+  private final Map<String, OAuthCachedCredentials> audiences;
+  private final File cacheFile;
+
+  public OAuthCredentialsCache(final File cacheFile) {
+    this.cacheFile = cacheFile;
+    this.audiences = new HashMap<>();
+  }
+
+  public OAuthCredentialsCache readCache() throws IOException {
+    if (!cacheFile.exists() || cacheFile.length() == 0) {
+      return this;
+    }
+
+    final Map<String, OAuthCachedCredentials> cache = MAPPER.readValue(cacheFile, TYPE_REFERENCE);
+    audiences.clear();
+    audiences.putAll(cache);
+
+    return this;
+  }
+
+  public void writeCache() throws IOException {
+    final Map<String, Map<String, OAuthCachedCredentials>> cache = new HashMap<>(audiences.size());
+    for (final Entry<String, OAuthCachedCredentials> audience : audiences.entrySet()) {
+      cache.put(audience.getKey(), Collections.singletonMap(KEY_AUTH, audience.getValue()));
+    }
+
+    ensureCacheFileExists();
+    MAPPER.writer().writeValue(cacheFile, cache);
+  }
+
+  public Optional<ZeebeClientCredentials> get(final String endpoint) {
+    return Optional.ofNullable(audiences.get(endpoint)).map(OAuthCachedCredentials::getCredentials);
+  }
+
+  public OAuthCredentialsCache put(
+      final String endpoint, final ZeebeClientCredentials credentials) {
+    audiences.put(endpoint, new OAuthCachedCredentials(credentials));
+    return this;
+  }
+
+  public int size() {
+    return audiences.size();
+  }
+
+  private void ensureCacheFileExists() {
+    if (cacheFile.exists()) {
+      return;
+    }
+
+    try {
+      Files.createDirectories(cacheFile.getParentFile().toPath());
+      Files.createFile(cacheFile.toPath());
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static final class OAuthCachedCredentials {
+    private final ZeebeClientCredentials credentials;
+
+    @JsonCreator
+    private OAuthCachedCredentials(
+        @JsonProperty(KEY_AUTH) final Map<String, ZeebeClientCredentials> auth) {
+      this(auth.get(KEY_CREDENTIALS));
+    }
+
+    private OAuthCachedCredentials(final ZeebeClientCredentials credentials) {
+      this.credentials = credentials;
+    }
+
+    @JsonGetter(KEY_CREDENTIALS)
+    private ZeebeClientCredentials getCredentials() {
+      return credentials;
+    }
+  }
+}

--- a/clients/java/src/test/java/io/zeebe/client/OAuthCredentialsProviderTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/OAuthCredentialsProviderTest.java
@@ -17,12 +17,16 @@ package io.zeebe.client;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.grpc.Metadata;
@@ -32,10 +36,14 @@ import io.grpc.ServerInterceptors;
 import io.grpc.Status;
 import io.grpc.testing.GrpcServerRule;
 import io.zeebe.client.api.command.ClientException;
-import io.zeebe.client.impl.OAuthCredentialsProviderBuilder;
 import io.zeebe.client.impl.ZeebeClientBuilderImpl;
+import io.zeebe.client.impl.ZeebeClientCredentials;
 import io.zeebe.client.impl.ZeebeClientImpl;
+import io.zeebe.client.impl.oauth.OAuthCredentialsCache;
+import io.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.zeebe.client.util.RecordingGatewayService;
+import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.time.Duration;
 import java.util.function.BiConsumer;
@@ -43,11 +51,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+@SuppressWarnings("ResultOfMethodCallIgnored")
 public class OAuthCredentialsProviderTest {
 
+  private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
   private static final Key<String> AUTH_KEY =
       Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
   private static final String SCOPE = "grpc";
@@ -57,8 +68,8 @@ public class OAuthCredentialsProviderTest {
   private static final String ACCESS_TOKEN = "someToken";
   private static final String TOKEN_TYPE = "Bearer";
   private static final String CLIENT_ID = "client";
-
   @Rule public final GrpcServerRule serverRule = new GrpcServerRule();
+  @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
 
   @Rule
   public final WireMockRule wireMockRule =
@@ -86,7 +97,7 @@ public class OAuthCredentialsProviderTest {
   }
 
   @Test
-  public void shouldRequestTokenAndAddToCall() {
+  public void shouldRequestTokenAndAddToCall() throws IOException {
     // given
     mockCredentials(ACCESS_TOKEN);
 
@@ -99,6 +110,7 @@ public class OAuthCredentialsProviderTest {
                 .clientSecret(SECRET)
                 .audience(AUDIENCE)
                 .authorizationServerUrl("http://localhost:" + wireMockRule.port() + "/oauth/token")
+                .credentialsCachePath(tempFolder.newFile().getPath())
                 .build());
     client = new ZeebeClientImpl(builder, serverRule.getChannel());
 
@@ -111,7 +123,7 @@ public class OAuthCredentialsProviderTest {
   }
 
   @Test
-  public void shouldRetryRequestWithNewCredentials() {
+  public void shouldRetryRequestWithNewCredentials() throws IOException {
     // given
     final String firstToken = "firstToken";
     mockCredentials(firstToken);
@@ -119,7 +131,7 @@ public class OAuthCredentialsProviderTest {
         Mockito.spy(
             new BiConsumer<ServerCall, Metadata>() {
               @Override
-              public void accept(ServerCall call, Metadata headers) {
+              public void accept(final ServerCall call, final Metadata headers) {
                 mockCredentials(ACCESS_TOKEN);
                 recordingInterceptor.reset();
                 call.close(Status.UNAUTHENTICATED, headers);
@@ -137,6 +149,7 @@ public class OAuthCredentialsProviderTest {
                 .clientSecret(SECRET)
                 .audience(AUDIENCE)
                 .authorizationServerUrl("http://localhost:" + wireMockRule.port() + "/oauth/token")
+                .credentialsCachePath(tempFolder.newFile().getPath())
                 .build());
 
     client = new ZeebeClientImpl(builder, serverRule.getChannel());
@@ -154,14 +167,14 @@ public class OAuthCredentialsProviderTest {
   }
 
   @Test
-  public void shouldNotRetryWithSameCredentials() {
+  public void shouldNotRetryWithSameCredentials() throws IOException {
     // given
     mockCredentials(ACCESS_TOKEN);
     final BiConsumer<ServerCall, Metadata> interceptAction =
         Mockito.spy(
             new BiConsumer<ServerCall, Metadata>() {
               @Override
-              public void accept(ServerCall call, Metadata headers) {
+              public void accept(final ServerCall call, final Metadata headers) {
                 call.close(Status.UNAUTHENTICATED, headers);
               }
             });
@@ -177,6 +190,7 @@ public class OAuthCredentialsProviderTest {
                 .clientSecret(SECRET)
                 .audience(AUDIENCE)
                 .authorizationServerUrl("http://localhost:" + wireMockRule.port() + "/oauth/token")
+                .credentialsCachePath(tempFolder.newFile().getPath())
                 .build());
 
     client = new ZeebeClientImpl(builder, serverRule.getChannel());
@@ -185,6 +199,113 @@ public class OAuthCredentialsProviderTest {
     assertThatThrownBy(() -> client.newTopologyRequest().send().join())
         .isInstanceOf(ClientException.class);
     Mockito.verify(interceptAction, times(1)).accept(any(ServerCall.class), any(Metadata.class));
+  }
+
+  @Test
+  public void shouldUseCachedCredentials() throws IOException {
+    // given
+    mockCredentials(ACCESS_TOKEN);
+    final String cachePath = tempFolder.getRoot().getPath() + File.separator + ".credsCache";
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache(new File(cachePath));
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+
+    cache
+        .put(AUDIENCE, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRES_IN, TOKEN_TYPE, SCOPE))
+        .writeCache();
+    builder
+        .usePlaintext()
+        .credentialsProvider(
+            new OAuthCredentialsProviderBuilder()
+                .clientId(CLIENT_ID)
+                .clientSecret(SECRET)
+                .audience(AUDIENCE)
+                .authorizationServerUrl("http://localhost:" + wireMockRule.port() + "/oauth/token")
+                .credentialsCachePath(cachePath)
+                .build());
+    client = new ZeebeClientImpl(builder, serverRule.getChannel());
+
+    // when
+    client.newTopologyRequest().send().join();
+
+    // then
+    assertThat(recordingInterceptor.getCapturedHeaders().get(AUTH_KEY))
+        .isEqualTo(TOKEN_TYPE + " " + ACCESS_TOKEN);
+    verify(0, postRequestedFor(WireMock.urlPathEqualTo("/oauth/token")));
+  }
+
+  @Test
+  public void shouldCacheAndReuseCredentials() throws IOException {
+    // given
+    mockCredentials(ACCESS_TOKEN);
+    final String cachePath = tempFolder.getRoot().getPath() + File.separator + ".credsCache";
+
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    final OAuthCredentialsProviderBuilder credsBuilder =
+        new OAuthCredentialsProviderBuilder()
+            .clientId(CLIENT_ID)
+            .clientSecret(SECRET)
+            .audience(AUDIENCE)
+            .authorizationServerUrl("http://localhost:" + wireMockRule.port() + "/oauth/token")
+            .credentialsCachePath(cachePath);
+    builder.usePlaintext().credentialsProvider(credsBuilder.build());
+    client = new ZeebeClientImpl(builder, serverRule.getChannel());
+
+    // when
+    client.newTopologyRequest().send().join();
+    verify(1, postRequestedFor(WireMock.urlPathEqualTo("/oauth/token")));
+
+    builder.usePlaintext().credentialsProvider(credsBuilder.build());
+    client = new ZeebeClientImpl(builder, serverRule.getChannel());
+    client.newTopologyRequest().send().join();
+
+    // then
+    assertThat(recordingInterceptor.getCapturedHeaders().get(AUTH_KEY))
+        .isEqualTo(TOKEN_TYPE + " " + ACCESS_TOKEN);
+    verify(1, postRequestedFor(WireMock.urlPathEqualTo("/oauth/token")));
+    assertCacheContents(cachePath);
+  }
+
+  @Test
+  public void shouldUpdateCacheIfStale() throws IOException {
+    // given
+    mockCredentials(ACCESS_TOKEN);
+    recordingInterceptor.setInterceptAction(
+        new BiConsumer<ServerCall, Metadata>() {
+          @Override
+          public void accept(final ServerCall call, final Metadata metadata) {
+            final String authHeader = metadata.get(AUTH_KEY);
+            if (authHeader != null && authHeader.endsWith("staleToken")) {
+              call.close(Status.UNAUTHENTICATED, metadata);
+            }
+          }
+        });
+    final String cachePath = tempFolder.getRoot().getPath() + File.separator + ".credsCache";
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache(new File(cachePath));
+    cache
+        .put(AUDIENCE, new ZeebeClientCredentials("staleToken", EXPIRES_IN, TOKEN_TYPE, SCOPE))
+        .writeCache();
+
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder
+        .usePlaintext()
+        .credentialsProvider(
+            new OAuthCredentialsProviderBuilder()
+                .clientId(CLIENT_ID)
+                .clientSecret(SECRET)
+                .audience(AUDIENCE)
+                .authorizationServerUrl("http://localhost:" + wireMockRule.port() + "/oauth/token")
+                .credentialsCachePath(cachePath)
+                .build());
+    client = new ZeebeClientImpl(builder, serverRule.getChannel());
+
+    // when
+    client.newTopologyRequest().send().join();
+
+    // then
+    assertThat(recordingInterceptor.getCapturedHeaders().get(AUTH_KEY))
+        .isEqualTo(TOKEN_TYPE + " " + ACCESS_TOKEN);
+    verify(1, postRequestedFor(WireMock.urlPathEqualTo("/oauth/token")));
+    assertCacheContents(cachePath);
   }
 
   @Test
@@ -263,6 +384,31 @@ public class OAuthCredentialsProviderTest {
         .hasCauseInstanceOf(MalformedURLException.class);
   }
 
+  @Test
+  public void shouldFailIfSpecifiedCacheIsDir() {
+    // given
+    final String cachePath = tempFolder.getRoot().getAbsolutePath() + File.separator + "404_folder";
+    new File(cachePath).mkdir();
+
+    // when/then
+    assertThatThrownBy(
+            () ->
+                new OAuthCredentialsProviderBuilder()
+                    .audience(AUDIENCE)
+                    .clientId(CLIENT_ID)
+                    .clientSecret(SECRET)
+                    .authorizationServerUrl("http://localhost")
+                    .credentialsCachePath(cachePath)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected specified credentials cache to be a file but found directory instead.");
+  }
+
+  /**
+   * Mocks an authorization server that returns credentials with the provided access token. Returns
+   * the credentials to be return by the server.
+   */
   private void mockCredentials(final String accessToken) {
     wireMockRule.stubFor(
         WireMock.post(WireMock.urlPathEqualTo("/oauth/token"))
@@ -287,5 +433,12 @@ public class OAuthCredentialsProviderTest {
                         + ",\"scope\":\""
                         + SCOPE
                         + "\"}")));
+  }
+
+  private void assertCacheContents(final String cachePath) throws IOException {
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache(new File(cachePath)).readCache();
+    final ZeebeClientCredentials credentials =
+        new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRES_IN, TOKEN_TYPE, SCOPE);
+    assertThat(cache.get(AUDIENCE)).contains(credentials);
   }
 }

--- a/clients/java/src/test/java/io/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.client.impl.ZeebeClientCredentials;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class OAuthCredentialsCacheTest {
+  private static final String WOMBAT_ENDPOINT = "wombat.cloud.camunda.io";
+  private static final String AARDVARK_ENDPOINT = "aardvark.cloud.camunda.io";
+  private static final String GOLDEN_FILE = "/oauth/credentialsCache.yml";
+  private static final ZeebeClientCredentials WOMBAT =
+      new ZeebeClientCredentials("wombat", 3600, "Bearer", "grpc");
+  private static final ZeebeClientCredentials AARDVARK =
+      new ZeebeClientCredentials("aardvark", 1800, "Bearer", "grpc");
+
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private File cacheFile;
+
+  @Before
+  public void setUp() throws IOException {
+    cacheFile = new File(temporaryFolder.getRoot(), ".credsCache.yml");
+    try (InputStream input = getClass().getResourceAsStream(GOLDEN_FILE)) {
+      Files.copy(input, cacheFile.toPath());
+    }
+  }
+
+  @Test
+  public void shouldReadGoldenFile() throws IOException {
+    // given
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFile);
+
+    // when
+    cache.readCache();
+
+    // then
+    assertThat(cache.get(WOMBAT_ENDPOINT)).contains(WOMBAT);
+    assertThat(cache.get(AARDVARK_ENDPOINT)).contains(AARDVARK);
+    assertThat(cache.size()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldWriteGoldenFile() throws IOException {
+    // given
+    final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFile);
+
+    // when
+    cache.put(WOMBAT_ENDPOINT, WOMBAT).put(AARDVARK_ENDPOINT, AARDVARK).writeCache();
+
+    // then
+    final OAuthCredentialsCache copy = new OAuthCredentialsCache(cacheFile).readCache();
+    assertThat(copy.get(WOMBAT_ENDPOINT)).contains(WOMBAT);
+    assertThat(copy.get(AARDVARK_ENDPOINT)).contains(AARDVARK);
+    assertThat(copy.size()).isEqualTo(2);
+  }
+}

--- a/clients/java/src/test/resources/oauth/credentialsCache.yml
+++ b/clients/java/src/test/resources/oauth/credentialsCache.yml
@@ -1,0 +1,18 @@
+# OAuth Credentials Cache Golden File
+# Use this as a template which should match whatever the Cloud products generate
+---
+wombat.cloud.camunda.io:
+  auth:
+    credentials:
+      access_token: "wombat"
+      token_type: "Bearer"
+      expires_in: 3600
+      scope: "grpc"
+
+aardvark.cloud.camunda.io:
+  auth:
+    credentials:
+      access_token: "aardvark"
+      token_type: "Bearer"
+      expires_in: 1800
+      scope: "grpc"


### PR DESCRIPTION
## Description

Caches client credentials. Doesn't introduce locking so concurrent writes might cause credentials to be lost.

## Related issues


closes #3009 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
