### PR TITLE
chore(clients/java): added default audience and authz url

### DIFF
--- a/clients/go/zbc/client.go
+++ b/clients/go/zbc/client.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/zeebe-io/zeebe/clients/go/commands"
@@ -134,6 +135,34 @@ func NewZBClient(config *ZBClientConfig) (ZBClient, error) {
 		connection:          conn,
 		credentialsProvider: provider,
 	}, nil
+}
+
+// NewOAuthZBClient is a convenience function that builds a client with an OAuth credentials provider using the provided
+// credentials. The gateway address is used as the OAuth token's audience and a default value is used in place of the
+// authorization server URL. This function is meant to simplify client configuration for Camunda Cloud.
+func NewOAuthZBClient(gatewayAddress, clientID, clientSecret string) (ZBClient, error) {
+	return newOAuthZBClientWithAuthzURL(&ZBClientConfig{GatewayAddress: gatewayAddress}, clientID, clientSecret, "")
+}
+
+func newOAuthZBClientWithAuthzURL(config *ZBClientConfig, clientID, clientSecret, authzServer string) (ZBClient, error) {
+	var err error
+	var audience string
+	index := strings.LastIndex(config.GatewayAddress, ":")
+	if index > 0 {
+		audience = config.GatewayAddress[0:index]
+	}
+
+	config.CredentialsProvider, err = NewOAuthCredentialsProvider(&OAuthProviderConfig{
+		ClientID:               clientID,
+		ClientSecret:           clientSecret,
+		Audience:               audience,
+		AuthorizationServerURL: authzServer,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return NewZBClient(config)
 }
 
 func configureCredentialsProvider(config *ZBClientConfig, opts *[]grpc.DialOption) CredentialsProvider {

--- a/clients/go/zbc/client_test.go
+++ b/clients/go/zbc/client_test.go
@@ -39,15 +39,15 @@ func TestNewZBClientWithTls(t *testing.T) {
 	}()
 
 	parts := strings.Split(lis.Addr().String(), ":")
-	client, e := NewZBClient(&ZBClientConfig{
+	client, err := NewZBClient(&ZBClientConfig{
 		GatewayAddress:    fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 		CaCertificatePath: "../resources/ca.cert.pem",
 	})
 
-	require.NoError(t, e)
+	require.NoError(t, err)
 
 	// when
-	_, err := client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send()
 
 	// then
 	require.Error(t, err)
@@ -70,23 +70,22 @@ func TestNewZBClientWithoutTls(t *testing.T) {
 	}()
 
 	parts := strings.Split(lis.Addr().String(), ":")
-	client, e := NewZBClient(&ZBClientConfig{
+	client, err := NewZBClient(&ZBClientConfig{
 		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 		UsePlaintextConnection: true,
 		CaCertificatePath:      "../resources/ca.cert.pem",
 	})
 
-	require.NoError(t, e)
+	require.NoError(t, err)
 
 	// when
-	_, err := client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send()
 
 	// then
 	require.Error(t, err)
 	if status, ok := status.FromError(err); ok {
 		require.Equal(t, codes.Unimplemented, status.Code())
 	}
-
 }
 
 func TestNewZBClientWithDefaultRootCa(t *testing.T) {
@@ -100,14 +99,14 @@ func TestNewZBClientWithDefaultRootCa(t *testing.T) {
 	}()
 
 	parts := strings.Split(lis.Addr().String(), ":")
-	client, e := NewZBClient(&ZBClientConfig{
+	client, err := NewZBClient(&ZBClientConfig{
 		GatewayAddress: fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 	})
 
-	require.NoError(t, e)
+	require.NoError(t, err)
 
 	// then
-	_, err := client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send()
 
 	// when
 	require.Error(t, err)
@@ -148,4 +147,39 @@ func createSecureServer() (net.Listener, *grpc.Server) {
 	pb.RegisterGatewayServer(grpcServer, &pb.UnimplementedGatewayServer{})
 
 	return listener, grpcServer
+}
+
+func TestNewOAuthZbClient(t *testing.T) {
+	// given
+	lis, _ := net.Listen("tcp", "0.0.0.0:0")
+
+	grpcServer := grpc.NewServer()
+	pb.RegisterGatewayServer(grpcServer, &pb.UnimplementedGatewayServer{})
+
+	go grpcServer.Serve(lis)
+	defer func() {
+		grpcServer.Stop()
+		_ = lis.Close()
+	}()
+
+	authzServer := mockAuthorizationServerWithAudience(t, &mutableToken{value: accessToken}, "0.0.0.0")
+	defer authzServer.Close()
+
+	parts := strings.Split(lis.Addr().String(), ":")
+	config := &ZBClientConfig{
+		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
+		UsePlaintextConnection: true,
+	}
+	client, err := newOAuthZBClientWithAuthzURL(config, clientID, clientSecret, authzServer.URL)
+
+	require.NoError(t, err)
+
+	// when
+	_, err = client.NewTopologyCommand().Send()
+
+	// then
+	require.Error(t, err)
+	if status, ok := status.FromError(err); ok {
+		require.Equal(t, codes.Unimplemented, status.Code())
+	}
 }

--- a/clients/go/zbc/oauthCredentialsProvider.go
+++ b/clients/go/zbc/oauthCredentialsProvider.go
@@ -29,6 +29,9 @@ import (
 	"os"
 )
 
+// OAuthDefaultAuthzURL points to the expected default URL for this credentials provider, the Camunda Cloud endpoint.
+const OAuthDefaultAuthzURL = "https://login.cloud.camunda.io/oauth/token/"
+
 // OAuthCredentialsProvider is a built-in CredentialsProvider that contains credentials obtained from an OAuth
 // authorization server, including a token prefix and an access token. Using these values it sets the 'Authorization'
 // header of each gRPC call.
@@ -96,8 +99,9 @@ func (provider *OAuthCredentialsProvider) ShouldRetryRequest(err error) bool {
 // NewOAuthCredentialsProvider requests credentials from an authorization server and uses them to create an OAuthCredentialsProvider.
 func NewOAuthCredentialsProvider(config *OAuthProviderConfig) (*OAuthCredentialsProvider, error) {
 	applyEnvironmentOverrides(config)
+	applyDefaults(config)
 
-	if err := validation.Validate(config.AuthorizationServerURL, validation.Required, is.URL); err != nil {
+	if err := validation.Validate(config.AuthorizationServerURL, is.URL); err != nil {
 		return nil, invalidArgumentError("authorization server URL", err.Error())
 	} else if err := validation.Validate(config.ClientID, validation.Required); err != nil {
 		return nil, invalidArgumentError("client ID", err.Error())
@@ -134,6 +138,12 @@ func applyEnvironmentOverrides(config *OAuthProviderConfig) {
 	}
 	if envAuthzServerURL := os.Getenv("ZEEBE_AUTHORIZATION_SERVER_URL"); envAuthzServerURL != "" {
 		config.AuthorizationServerURL = envAuthzServerURL
+	}
+}
+
+func applyDefaults(config *OAuthProviderConfig) {
+	if config.AuthorizationServerURL == "" {
+		config.AuthorizationServerURL = OAuthDefaultAuthzURL
 	}
 }
 

--- a/clients/go/zbc/oauthCredentialsProvider_test.go
+++ b/clients/go/zbc/oauthCredentialsProvider_test.go
@@ -180,15 +180,6 @@ var configErrorTests = []struct {
 	err        ZBError
 	errMessage string
 }{
-	{"missing authorization server URL",
-		&OAuthProviderConfig{
-			ClientID:     clientID,
-			ClientSecret: clientSecret,
-			Audience:     audience,
-		},
-		InvalidArgumentError,
-		invalidArgumentError("authorization server URL", "cannot be blank").Error(),
-	},
 	{
 		"malformed authorization server URL",
 		&OAuthProviderConfig{
@@ -307,6 +298,10 @@ func TestOAuthProviderWithEnvVars(t *testing.T) {
 }
 
 func mockAuthorizationServer(t *testing.T, token *mutableToken) *httptest.Server {
+	return mockAuthorizationServerWithAudience(t, token, audience)
+}
+
+func mockAuthorizationServerWithAudience(t *testing.T, token *mutableToken, audience string) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		bytes, err := ioutil.ReadAll(request.Body)
 		if err != nil {

--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
@@ -16,6 +16,7 @@
 package io.zeebe.client;
 
 import io.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
+import io.zeebe.client.impl.oauth.OAuthCredentialsProvider;
 import java.time.Duration;
 import java.util.Properties;
 
@@ -82,6 +83,16 @@ public interface ZeebeClientBuilder {
    * requests.
    */
   ZeebeClientBuilder credentialsProvider(CredentialsProvider credentialsProvider);
+
+  /** Creates an {@link OAuthCredentialsProvider} with the specified client credentials. */
+  ZeebeClientBuilder oAuthCredentialsProvider(String clientId, String clientSecret);
+
+  /**
+   * Creates an {@link OAuthCredentialsProvider} with the specified client credentials and
+   * authorization server URL.
+   */
+  ZeebeClientBuilder oAuthCredentialsProvider(
+      String clientId, String clientSecret, String authzServerUrl);
 
   /** @return a new {@link ZeebeClient} with the provided configuration options. */
   ZeebeClient build();

--- a/clients/java/src/main/java/io/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 
 public class OAuthCredentialsProviderBuilder {
   public static final String INVALID_ARGUMENT_MSG = "Expected valid %s but none was provided.";
+  private static final String DEFAULT_AUTHZ_SERVER = "https://login.cloud.camunda.io/oauth/token/";
 
   private String clientId;
   private String clientSecret;
@@ -32,7 +33,7 @@ public class OAuthCredentialsProviderBuilder {
   private File credentialsCache;
 
   /** Client id to be used when requesting access token from OAuth authorization server. */
-  public OAuthCredentialsProviderBuilder clientId(String clientId) {
+  public OAuthCredentialsProviderBuilder clientId(final String clientId) {
     this.clientId = clientId;
     return this;
   }
@@ -43,7 +44,7 @@ public class OAuthCredentialsProviderBuilder {
   }
 
   /** Client secret to be used when requesting access token from OAuth authorization server. */
-  public OAuthCredentialsProviderBuilder clientSecret(String clientSecret) {
+  public OAuthCredentialsProviderBuilder clientSecret(final String clientSecret) {
     this.clientSecret = clientSecret;
     return this;
   }
@@ -54,7 +55,7 @@ public class OAuthCredentialsProviderBuilder {
   }
 
   /** The resource for which the the access token should be valid. */
-  public OAuthCredentialsProviderBuilder audience(String audience) {
+  public OAuthCredentialsProviderBuilder audience(final String audience) {
     this.audience = audience;
     return this;
   }
@@ -65,7 +66,8 @@ public class OAuthCredentialsProviderBuilder {
   }
 
   /** The authorization server's URL, from which the access token will be requested. */
-  public OAuthCredentialsProviderBuilder authorizationServerUrl(String authorizationServerUrl) {
+  public OAuthCredentialsProviderBuilder authorizationServerUrl(
+      final String authorizationServerUrl) {
     this.authorizationServerUrl = authorizationServerUrl;
     return this;
   }
@@ -79,7 +81,7 @@ public class OAuthCredentialsProviderBuilder {
    * The location for the credentials cache file. If none (or null) is specified the default will be
    * $HOME/.camunda/credentials
    */
-  public OAuthCredentialsProviderBuilder credentialsCachePath(String cachePath) {
+  public OAuthCredentialsProviderBuilder credentialsCachePath(final String cachePath) {
     this.credentialsCachePath = cachePath;
     return this;
   }
@@ -121,6 +123,10 @@ public class OAuthCredentialsProviderBuilder {
       this.credentialsCachePath =
           System.getProperty("user.home") + File.separator + ".camunda/credentials";
     }
+
+    if (authorizationServerUrl == null) {
+      authorizationServerUrl = DEFAULT_AUTHZ_SERVER;
+    }
   }
 
   private void validate() {
@@ -138,7 +144,7 @@ public class OAuthCredentialsProviderBuilder {
         throw new IllegalArgumentException(
             "Expected specified credentials cache to be a file but found directory instead.");
       }
-    } catch (NullPointerException | IOException e) {
+    } catch (final NullPointerException | IOException e) {
       throw new IllegalArgumentException(e);
     }
   }


### PR DESCRIPTION
## Description

Added default values for the authorization server URL and the audience. The default audience is the broker contact point and the authz server is the camunda cloud login oauth address.
## Related issues


closes #3025, closes #3030 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
