### PR TITLE
chore(clients/go): auto detect default credentials provider

### DIFF
--- a/clients/go/zbc/credentialsProvider_test.go
+++ b/clients/go/zbc/credentialsProvider_test.go
@@ -70,7 +70,7 @@ func TestCustomCredentialsProvider(t *testing.T) {
 
 	parts := strings.Split(lis.Addr().String(), ":")
 
-	client, err := NewZBClient(&ZBClientConfig{
+	client, err := NewZBClientWithConfig(&ZBClientConfig{
 		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 		UsePlaintextConnection: true,
 		CredentialsProvider:    credsProvider,
@@ -112,7 +112,7 @@ func TestRetryMoreThanOnce(t *testing.T) {
 	}
 
 	parts := strings.Split(lis.Addr().String(), ":")
-	client, err := NewZBClient(&ZBClientConfig{
+	client, err := NewZBClientWithConfig(&ZBClientConfig{
 		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 		UsePlaintextConnection: true,
 		CredentialsProvider:    provider,
@@ -145,7 +145,7 @@ func TestNoRetryWithoutProvider(t *testing.T) {
 	}()
 
 	parts := strings.Split(lis.Addr().String(), ":")
-	client, err := NewZBClient(&ZBClientConfig{
+	client, err := NewZBClientWithConfig(&ZBClientConfig{
 		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 		UsePlaintextConnection: true,
 		CredentialsProvider:    nil,

--- a/clients/go/zbc/oauthCredentialsProvider.go
+++ b/clients/go/zbc/oauthCredentialsProvider.go
@@ -29,6 +29,11 @@ import (
 	"os"
 )
 
+const OAuthClientIdEnvVar = "ZEEBE_CLIENT_ID"
+const OAuthClientSecretEnvVar = "ZEEBE_CLIENT_SECRET"
+const OAuthTokenAudienceEnvVar = "ZEEBE_TOKEN_AUDIENCE"
+const OAuthAuthorizationUrlEnvVar = "ZEEBE_AUTHORIZATION_SERVER_URL"
+
 // OAuthDefaultAuthzURL points to the expected default URL for this credentials provider, the Camunda Cloud endpoint.
 const OAuthDefaultAuthzURL = "https://login.cloud.camunda.io/oauth/token/"
 
@@ -127,16 +132,16 @@ func NewOAuthCredentialsProvider(config *OAuthProviderConfig) (*OAuthCredentials
 }
 
 func applyEnvironmentOverrides(config *OAuthProviderConfig) {
-	if envClientID := os.Getenv("ZEEBE_CLIENT_ID"); envClientID != "" {
+	if envClientID := os.Getenv(OAuthClientIdEnvVar); envClientID != "" {
 		config.ClientID = envClientID
 	}
-	if envClientSecret := os.Getenv("ZEEBE_CLIENT_SECRET"); envClientSecret != "" {
+	if envClientSecret := os.Getenv(OAuthClientSecretEnvVar); envClientSecret != "" {
 		config.ClientSecret = envClientSecret
 	}
-	if envAudience := os.Getenv("ZEEBE_TOKEN_AUDIENCE"); envAudience != "" {
+	if envAudience := os.Getenv(OAuthTokenAudienceEnvVar); envAudience != "" {
 		config.Audience = envAudience
 	}
-	if envAuthzServerURL := os.Getenv("ZEEBE_AUTHORIZATION_SERVER_URL"); envAuthzServerURL != "" {
+	if envAuthzServerURL := os.Getenv(OAuthAuthorizationUrlEnvVar); envAuthzServerURL != "" {
 		config.AuthorizationServerURL = envAuthzServerURL
 	}
 }

--- a/clients/go/zbc/oauthCredentialsProvider_test.go
+++ b/clients/go/zbc/oauthCredentialsProvider_test.go
@@ -58,7 +58,7 @@ func TestOAuthCredentialsProvider(t *testing.T) {
 
 	require.NoError(t, err)
 	parts := strings.Split(gatewayLis.Addr().String(), ":")
-	client, err := NewZBClient(&ZBClientConfig{
+	client, err := NewZBClientWithConfig(&ZBClientConfig{
 		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 		UsePlaintextConnection: true,
 		CredentialsProvider:    credsProvider,
@@ -110,7 +110,7 @@ func TestOAuthProviderRetry(t *testing.T) {
 
 	require.NoError(t, err)
 	parts := strings.Split(gatewayLis.Addr().String(), ":")
-	client, err := NewZBClient(&ZBClientConfig{
+	client, err := NewZBClientWithConfig(&ZBClientConfig{
 		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 		UsePlaintextConnection: true,
 		CredentialsProvider:    credsProvider,
@@ -156,7 +156,7 @@ func TestNotRetryWithSameCredentials(t *testing.T) {
 
 	require.NoError(t, err)
 	parts := strings.Split(gatewayLis.Addr().String(), ":")
-	client, err := NewZBClient(&ZBClientConfig{
+	client, err := NewZBClientWithConfig(&ZBClientConfig{
 		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 		UsePlaintextConnection: true,
 		CredentialsProvider:    credsProvider,

--- a/clients/zbctl/cmd/activateJobs.go
+++ b/clients/zbctl/cmd/activateJobs.go
@@ -15,56 +15,56 @@
 package cmd
 
 import (
-    "github.com/spf13/cobra"
-    "github.com/zeebe-io/zeebe/clients/go/commands"
-    "log"
-    "time"
+	"github.com/spf13/cobra"
+	"github.com/zeebe-io/zeebe/clients/go/commands"
+	"log"
+	"time"
 )
 
 const (
-    DefaultJobWorkerName = "zbctl"
+	DefaultJobWorkerName = "zbctl"
 )
 
 var (
-    maxJobsToActivateFlag          int32
-    activateJobsWorkerFlag         string
-    activateJobsTimeoutFlag        time.Duration
-    activateJobsFetchVariablesFlag []string
-    activateJobsRequestTimeoutFlag time.Duration
+	maxJobsToActivateFlag          int32
+	activateJobsWorkerFlag         string
+	activateJobsTimeoutFlag        time.Duration
+	activateJobsFetchVariablesFlag []string
+	activateJobsRequestTimeoutFlag time.Duration
 )
 
 var activateJobsCmd = &cobra.Command{
-    Use:     "jobs <type>",
-    Short:   "Activate jobs for type",
-    Args:    cobra.ExactArgs(1),
-    PreRunE: initClient,
-    RunE: func(cmd *cobra.Command, args []string) error {
-        jobType := args[0]
-        jobs, err := client.NewActivateJobsCommand().JobType(jobType).MaxJobsToActivate(maxJobsToActivateFlag).WorkerName(activateJobsWorkerFlag).Timeout(activateJobsTimeoutFlag).FetchVariables(activateJobsFetchVariablesFlag...).RequestTimeout(activateJobsRequestTimeoutFlag).Send()
-        if err != nil {
-            return err
-        }
+	Use:     "jobs <type>",
+	Short:   "Activate jobs for type",
+	Args:    cobra.ExactArgs(1),
+	PreRunE: initClient,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		jobType := args[0]
+		jobs, err := client.NewActivateJobsCommand().JobType(jobType).MaxJobsToActivate(maxJobsToActivateFlag).WorkerName(activateJobsWorkerFlag).Timeout(activateJobsTimeoutFlag).FetchVariables(activateJobsFetchVariablesFlag...).RequestTimeout(activateJobsRequestTimeoutFlag).Send()
+		if err != nil {
+			return err
+		}
 
-        jobsCount := len(jobs)
-        if jobsCount > 0 {
-            log.Println("Activated", jobsCount, "for type", jobType)
-            for index, job := range jobs {
-                log.Println("Job", index+1, "/", jobsCount)
-                printJson(job)
-            }
-        } else {
-            log.Println("No jobs found to activate for type", jobType)
-        }
+		jobsCount := len(jobs)
+		if jobsCount > 0 {
+			log.Println("Activated", jobsCount, "for type", jobType)
+			for index, job := range jobs {
+				log.Println("Job", index+1, "/", jobsCount)
+				printJson(job)
+			}
+		} else {
+			log.Println("No jobs found to activate for type", jobType)
+		}
 
-        return nil
-    },
+		return nil
+	},
 }
 
 func init() {
-    activateCmd.AddCommand(activateJobsCmd)
-    activateJobsCmd.Flags().Int32Var(&maxJobsToActivateFlag, "maxJobsToActivate", 1, "Specify the maximum amount of jobs to activate")
-    activateJobsCmd.Flags().StringVar(&activateJobsWorkerFlag, "worker", DefaultJobWorkerName, "Specify the name of the worker")
-    activateJobsCmd.Flags().DurationVar(&activateJobsTimeoutFlag, "timeout", commands.DefaultJobTimeout, "Specify the timeout of the activated job")
-    activateJobsCmd.Flags().StringSliceVar(&activateJobsFetchVariablesFlag, "variables", []string{}, "Specify the list of variable names which should be fetch on job activation (comma-separated)")
-    activateJobsCmd.Flags().DurationVar(&activateJobsRequestTimeoutFlag, "requestTimeout", 0, "Specify the request timeout")
+	activateCmd.AddCommand(activateJobsCmd)
+	activateJobsCmd.Flags().Int32Var(&maxJobsToActivateFlag, "maxJobsToActivate", 1, "Specify the maximum amount of jobs to activate")
+	activateJobsCmd.Flags().StringVar(&activateJobsWorkerFlag, "worker", DefaultJobWorkerName, "Specify the name of the worker")
+	activateJobsCmd.Flags().DurationVar(&activateJobsTimeoutFlag, "timeout", commands.DefaultJobTimeout, "Specify the timeout of the activated job")
+	activateJobsCmd.Flags().StringSliceVar(&activateJobsFetchVariablesFlag, "variables", []string{}, "Specify the list of variable names which should be fetch on job activation (comma-separated)")
+	activateJobsCmd.Flags().DurationVar(&activateJobsRequestTimeoutFlag, "requestTimeout", 0, "Specify the request timeout")
 }

--- a/clients/zbctl/cmd/createWorker.go
+++ b/clients/zbctl/cmd/createWorker.go
@@ -15,135 +15,135 @@
 package cmd
 
 import (
-    "bytes"
-    "fmt"
-    "github.com/spf13/cobra"
-    "github.com/zeebe-io/zeebe/clients/go/commands"
-    "github.com/zeebe-io/zeebe/clients/go/entities"
-    "github.com/zeebe-io/zeebe/clients/go/worker"
-    "github.com/zeebe-io/zeebe/clients/go/zbc"
-    "io"
-    "log"
-    "os/exec"
-    "strings"
-    "time"
+	"bytes"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/zeebe-io/zeebe/clients/go/commands"
+	"github.com/zeebe-io/zeebe/clients/go/entities"
+	"github.com/zeebe-io/zeebe/clients/go/worker"
+	"github.com/zeebe-io/zeebe/clients/go/zbc"
+	"io"
+	"log"
+	"os/exec"
+	"strings"
+	"time"
 )
 
 var (
-    createWorkerHandlerFlag        string
-    createWorkerNameFlag           string
-    createWorkerTimeoutFlag        time.Duration
-    createWorkerRequestTimeoutFlag time.Duration
-    createWorkerMaxJobsActiveFlag  int
-    createWorkerConcurrencyFlag    int
-    createWorkerPollIntervalFlag   time.Duration
-    createWorkerPollThresholdFlag  float64
+	createWorkerHandlerFlag        string
+	createWorkerNameFlag           string
+	createWorkerTimeoutFlag        time.Duration
+	createWorkerRequestTimeoutFlag time.Duration
+	createWorkerMaxJobsActiveFlag  int
+	createWorkerConcurrencyFlag    int
+	createWorkerPollIntervalFlag   time.Duration
+	createWorkerPollThresholdFlag  float64
 
-    createWorkerHandlerArgs []string
+	createWorkerHandlerArgs []string
 )
 
 // createWorkerCmd represents the createWorker command
 var createWorkerCmd = &cobra.Command{
-    Use:   "worker <type>",
-    Short: "Create a polling job worker",
-    Long: `Create a polling job worker which will call the given handler for every job.
+	Use:   "worker <type>",
+	Short: "Create a polling job worker",
+	Long: `Create a polling job worker which will call the given handler for every job.
 The handler will receive the variables of the activated job as JSON object on stdin.
 If the handler finishes successful the job will be completed with the variables provided on stdout, again as JSON object.
 If the handler exits with an none zero exit code the job will be failed, the handler can provide a failure message on stderr.
 `,
-    Args:    cobra.ExactArgs(1),
-    PreRunE: initClient,
-    Run: func(cmd *cobra.Command, args []string) {
-        createWorkerHandlerArgs = strings.Split(createWorkerHandlerFlag, " ")
+	Args:    cobra.ExactArgs(1),
+	PreRunE: initClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		createWorkerHandlerArgs = strings.Split(createWorkerHandlerFlag, " ")
 
-        jobWorker := client.NewJobWorker().
-            JobType(args[0]).
-            Handler(handle).
-            Name(createWorkerNameFlag).
-            Timeout(createWorkerTimeoutFlag).
-            RequestTimeout(createWorkerRequestTimeoutFlag).
-            MaxJobsActive(createWorkerMaxJobsActiveFlag).
-            Concurrency(createWorkerConcurrencyFlag).
-            PollInterval(createWorkerPollIntervalFlag).
-            PollThreshold(createWorkerPollThresholdFlag).
-            Open()
+		jobWorker := client.NewJobWorker().
+			JobType(args[0]).
+			Handler(handle).
+			Name(createWorkerNameFlag).
+			Timeout(createWorkerTimeoutFlag).
+			RequestTimeout(createWorkerRequestTimeoutFlag).
+			MaxJobsActive(createWorkerMaxJobsActiveFlag).
+			Concurrency(createWorkerConcurrencyFlag).
+			PollInterval(createWorkerPollIntervalFlag).
+			PollThreshold(createWorkerPollThresholdFlag).
+			Open()
 
-        jobWorker.AwaitClose()
-    },
+		jobWorker.AwaitClose()
+	},
 }
 
 func handle(jobClient worker.JobClient, job entities.Job) {
-    key := job.Key
-    variables := job.Variables
-    log.Println("Activated job", key, "with variables", variables)
+	key := job.Key
+	variables := job.Variables
+	log.Println("Activated job", key, "with variables", variables)
 
-    command := exec.Command(createWorkerHandlerArgs[0], createWorkerHandlerArgs[1:]...)
+	command := exec.Command(createWorkerHandlerArgs[0], createWorkerHandlerArgs[1:]...)
 
-    // capture stdout and stderr for completing/failing job
-    var stdout, stderr bytes.Buffer
-    command.Stdout = &stdout
-    command.Stderr = &stderr
+	// capture stdout and stderr for completing/failing job
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
 
-    // get stdin of handler command and send variables
-    stdin, err := command.StdinPipe()
-    if err != nil {
-        log.Fatal("Failed to get stdin for command", createWorkerHandlerFlag, err)
-    }
-    io.WriteString(stdin, variables)
-    stdin.Close()
+	// get stdin of handler command and send variables
+	stdin, err := command.StdinPipe()
+	if err != nil {
+		log.Fatal("Failed to get stdin for command", createWorkerHandlerFlag, err)
+	}
+	io.WriteString(stdin, variables)
+	stdin.Close()
 
-    // start and wait for handler command to finish
-    err = command.Start()
-    if err != nil {
-        log.Fatal("Failed to start command", createWorkerHandlerFlag, err)
-    }
+	// start and wait for handler command to finish
+	err = command.Start()
+	if err != nil {
+		log.Fatal("Failed to start command", createWorkerHandlerFlag, err)
+	}
 
-    if command.Wait() == nil {
-        variables := string(stdout.Bytes())
-        if len(variables) < 2 {
-            // use empty variables if non was returned
-            variables = "{}"
-        }
-        completeJob(jobClient, job, variables)
-    } else {
-        failJob(jobClient, job, string(stderr.Bytes()))
-    }
+	if command.Wait() == nil {
+		variables := string(stdout.Bytes())
+		if len(variables) < 2 {
+			// use empty variables if non was returned
+			variables = "{}"
+		}
+		completeJob(jobClient, job, variables)
+	} else {
+		failJob(jobClient, job, string(stderr.Bytes()))
+	}
 }
 
 func completeJob(jobClient worker.JobClient, job entities.Job, variables string) {
-    key := job.Key
-    request, err := jobClient.NewCompleteJobCommand().JobKey(key).VariablesFromString(variables)
-    if err != nil {
-        failJob(jobClient, job, fmt.Sprint("Unable to set variables", variables, "to complete job", key, err))
-    } else {
-        log.Println("Handler completed job", job.Key, "with variables", variables)
+	key := job.Key
+	request, err := jobClient.NewCompleteJobCommand().JobKey(key).VariablesFromString(variables)
+	if err != nil {
+		failJob(jobClient, job, fmt.Sprint("Unable to set variables", variables, "to complete job", key, err))
+	} else {
+		log.Println("Handler completed job", job.Key, "with variables", variables)
 
-        _, err = request.Send()
-        if err != nil {
-            log.Println("Unable to complete job", key, err)
-        }
-    }
+		_, err = request.Send()
+		if err != nil {
+			log.Println("Unable to complete job", key, err)
+		}
+	}
 }
 
 func failJob(jobClient worker.JobClient, job entities.Job, error string) {
-    log.Println("Command failed to handle job", job.Key, error)
-    _, err := jobClient.NewFailJobCommand().JobKey(job.Key).Retries(job.Retries - 1).ErrorMessage(error).Send()
-    if err != nil {
-        log.Println("Unable to fail job", err)
-    }
+	log.Println("Command failed to handle job", job.Key, error)
+	_, err := jobClient.NewFailJobCommand().JobKey(job.Key).Retries(job.Retries - 1).ErrorMessage(error).Send()
+	if err != nil {
+		log.Println("Unable to fail job", err)
+	}
 }
 
 func init() {
-    createCmd.AddCommand(createWorkerCmd)
+	createCmd.AddCommand(createWorkerCmd)
 
-    createWorkerCmd.Flags().StringVar(&createWorkerHandlerFlag, "handler", "", "Specify handler to invoke for each job")
-    createWorkerCmd.MarkFlagRequired("handler")
+	createWorkerCmd.Flags().StringVar(&createWorkerHandlerFlag, "handler", "", "Specify handler to invoke for each job")
+	createWorkerCmd.MarkFlagRequired("handler")
 
-    createWorkerCmd.Flags().StringVar(&createWorkerNameFlag, "name", DefaultJobWorkerName, "Specify the worker name")
-    createWorkerCmd.Flags().DurationVar(&createWorkerTimeoutFlag, "timeout", commands.DefaultJobTimeout, "Specify the duration no other worker should work on job activated by this worker")
-    createWorkerCmd.Flags().DurationVar(&createWorkerRequestTimeoutFlag, "requestTimeout", zbc.DefaultRequestTimeout, "Specify the timeout for a request")
-    createWorkerCmd.Flags().IntVar(&createWorkerMaxJobsActiveFlag, "maxJobsActive", worker.DefaultJobWorkerMaxJobActive, "Specify the maximum number of jobs which will be activated for this worker at the same time")
-    createWorkerCmd.Flags().IntVar(&createWorkerConcurrencyFlag, "concurrency", worker.DefaultJobWorkerConcurrency, "Specify the maximum number of concurrent spawned goroutines to complete jobs")
-    createWorkerCmd.Flags().DurationVar(&createWorkerPollIntervalFlag, "pollInterval", worker.DefaultJobWorkerPollInterval, "Specify the maximal interval between polling for new jobs")
-    createWorkerCmd.Flags().Float64Var(&createWorkerPollThresholdFlag, "pollThreshold", worker.DefaultJobWorkerPollThreshold, "Specify the threshold of buffered activated jobs before polling for new jobs, i.e. pollThreshold * maxJobsActive")
+	createWorkerCmd.Flags().StringVar(&createWorkerNameFlag, "name", DefaultJobWorkerName, "Specify the worker name")
+	createWorkerCmd.Flags().DurationVar(&createWorkerTimeoutFlag, "timeout", commands.DefaultJobTimeout, "Specify the duration no other worker should work on job activated by this worker")
+	createWorkerCmd.Flags().DurationVar(&createWorkerRequestTimeoutFlag, "requestTimeout", zbc.DefaultRequestTimeout, "Specify the timeout for a request")
+	createWorkerCmd.Flags().IntVar(&createWorkerMaxJobsActiveFlag, "maxJobsActive", worker.DefaultJobWorkerMaxJobActive, "Specify the maximum number of jobs which will be activated for this worker at the same time")
+	createWorkerCmd.Flags().IntVar(&createWorkerConcurrencyFlag, "concurrency", worker.DefaultJobWorkerConcurrency, "Specify the maximum number of concurrent spawned goroutines to complete jobs")
+	createWorkerCmd.Flags().DurationVar(&createWorkerPollIntervalFlag, "pollInterval", worker.DefaultJobWorkerPollInterval, "Specify the maximal interval between polling for new jobs")
+	createWorkerCmd.Flags().Float64Var(&createWorkerPollThresholdFlag, "pollThreshold", worker.DefaultJobWorkerPollThreshold, "Specify the threshold of buffered activated jobs before polling for new jobs, i.e. pollThreshold * maxJobsActive")
 }


### PR DESCRIPTION
## Description

 if ZEEBE_CLIENT_ID or ZEEBE_CLIENT_SECRET is defined, create a default OAuthCredentialsProvider
- default provider uses environment variable and potentially gateway host as audience
- removes `useOAuth` flag
- pass gateway host as default audience unless specified
- formatting

## Related issues

closes #3064 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
