### PR TITLE
chore(clients/java): auto detect default credentials provider

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
@@ -16,7 +16,6 @@
 package io.zeebe.client;
 
 import io.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
-import io.zeebe.client.impl.oauth.OAuthCredentialsProvider;
 import java.time.Duration;
 import java.util.Properties;
 
@@ -83,16 +82,6 @@ public interface ZeebeClientBuilder {
    * requests.
    */
   ZeebeClientBuilder credentialsProvider(CredentialsProvider credentialsProvider);
-
-  /** Creates an {@link OAuthCredentialsProvider} with the specified client credentials. */
-  ZeebeClientBuilder oAuthCredentialsProvider(String clientId, String clientSecret);
-
-  /**
-   * Creates an {@link OAuthCredentialsProvider} with the specified client credentials and
-   * authorization server URL.
-   */
-  ZeebeClientBuilder oAuthCredentialsProvider(
-      String clientId, String clientSecret, String authzServerUrl);
 
   /** @return a new {@link ZeebeClient} with the provided configuration options. */
   ZeebeClient build();

--- a/clients/java/src/main/java/io/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -15,13 +15,20 @@
  */
 package io.zeebe.client.impl.oauth;
 
+import io.zeebe.client.util.Environment;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.Objects;
 
 public class OAuthCredentialsProviderBuilder {
   public static final String INVALID_ARGUMENT_MSG = "Expected valid %s but none was provided.";
+  public static final String OAUTH_ENV_CLIENT_ID = "ZEEBE_CLIENT_ID";
+  public static final String OAUTH_ENV_CLIENT_SECRET = "ZEEBE_CLIENT_SECRET";
+  public static final String OAUTH_ENV_TOKEN_AUDIENCE = "ZEEBE_TOKEN_AUDIENCE";
+  public static final String OAUTH_ENV_AUTHORIZATION_SERVER = "ZEEBE_AUTHORIZATION_SERVER_URL";
+  public static final String OAUTH_ENV_CACHE_PATH = "ZEEBE_CLIENT_CONFIG_PATH";
   private static final String DEFAULT_AUTHZ_SERVER = "https://login.cloud.camunda.io/oauth/token/";
 
   private String clientId;
@@ -101,27 +108,39 @@ public class OAuthCredentialsProviderBuilder {
   }
 
   private void checkEnvironmentOverrides() {
-    if (System.getenv("ZEEBE_CLIENT_ID") != null) {
-      this.clientId = System.getenv("ZEEBE_CLIENT_ID");
+    final String envClientId = Environment.system().get(OAUTH_ENV_CLIENT_ID);
+    final String envClientSecret = Environment.system().get(OAUTH_ENV_CLIENT_SECRET);
+    final String envAudience = Environment.system().get(OAUTH_ENV_TOKEN_AUDIENCE);
+    final String envAuthorizationUrl = Environment.system().get(OAUTH_ENV_AUTHORIZATION_SERVER);
+    final String envCachePath = Environment.system().get(OAUTH_ENV_CACHE_PATH);
+
+    if (envClientId != null) {
+      clientId = envClientId;
     }
-    if (System.getenv("ZEEBE_CLIENT_SECRET") != null) {
-      this.clientSecret = System.getenv("ZEEBE_CLIENT_SECRET");
+
+    if (envClientSecret != null) {
+      clientSecret = envClientSecret;
     }
-    if (System.getenv("ZEEBE_TOKEN_AUDIENCE") != null) {
-      this.audience = System.getenv("ZEEBE_TOKEN_AUDIENCE");
+
+    if (envAudience != null) {
+      audience = envAudience;
     }
-    if (System.getenv("ZEEBE_AUTHORIZATION_SERVER_URL") != null) {
-      this.authorizationServerUrl = System.getenv("ZEEBE_AUTHORIZATION_SERVER_URL");
+
+    if (envAuthorizationUrl != null) {
+      authorizationServerUrl = envAuthorizationUrl;
     }
-    if (System.getenv("ZEEBE_CLIENT_CONFIG_PATH") != null) {
-      this.credentialsCachePath = System.getenv("ZEEBE_CLIENT_CONFIG_PATH");
+
+    if (envCachePath != null) {
+      credentialsCachePath = envCachePath;
     }
   }
 
   private void applyDefaults() {
     if (credentialsCachePath == null) {
-      this.credentialsCachePath =
-          System.getProperty("user.home") + File.separator + ".camunda/credentials";
+      credentialsCachePath =
+          Paths.get(System.getProperty("user.home"), ".camunda", "credentials")
+              .toAbsolutePath()
+              .toString();
     }
 
     if (authorizationServerUrl == null) {

--- a/clients/java/src/main/java/io/zeebe/client/util/Environment.java
+++ b/clients/java/src/main/java/io/zeebe/client/util/Environment.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of client environment variables
+ *
+ * <p>Useful primarily to allow us to test with custom environment variables
+ */
+public final class Environment {
+  private final Map<String, String> variables;
+
+  private Environment(final Map<String, String> variables) {
+    this.variables = new HashMap<>(variables);
+  }
+
+  public static Environment system() {
+    return EnvironmentSingleton.SYSTEM;
+  }
+
+  public String get(final String key) {
+    return variables.getOrDefault(key, System.getenv(key));
+  }
+
+  public void put(final String key, final String value) {
+    variables.put(key, value);
+  }
+
+  public String remove(final String key) {
+    return variables.remove(key);
+  }
+
+  public boolean isDefined(final String key) {
+    return get(key) != null;
+  }
+
+  // primarily for testing
+  Map<String, String> copy() {
+    return new HashMap<>(variables);
+  }
+
+  // primarily for testing
+  void overwrite(final Map<String, String> environment) {
+    variables.clear();
+    variables.putAll(environment);
+  }
+
+  // Returns an environment created from the system's environment variables using System#getenv()
+  private static class EnvironmentSingleton {
+    private static final Environment SYSTEM = new Environment(System.getenv());
+  }
+}

--- a/clients/java/src/test/java/io/zeebe/client/util/EnvironmentRule.java
+++ b/clients/java/src/test/java/io/zeebe/client/util/EnvironmentRule.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.util;
+
+import java.util.Map;
+import org.junit.rules.ExternalResource;
+
+public class EnvironmentRule extends ExternalResource {
+
+  private Map<String, String> previousEnvironment;
+
+  @Override
+  protected void before() throws Throwable {
+    previousEnvironment = Environment.system().copy();
+  }
+
+  @Override
+  protected void after() {
+    Environment.system().overwrite(previousEnvironment);
+  }
+}


### PR DESCRIPTION
## Description

- use system environment wrapper to allow testing
- remove convenience oauth* methods from builder
- if ZEEBE_CLIENT_ID or ZEEBE_CLIENT_SECRET is present use default OAuthCredentialsProvider
- use contact point host if using default credentials provider

## Related issues

closes #3067 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
