### PR TITLE
chore(clients/zbctl): fix audience parsing

### DIFF
--- a/clients/zbctl/cmd/root.go
+++ b/clients/zbctl/cmd/root.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	DefaultAddressHost = "127.0.0.1"
-	DefaultAddressPort = 26500
+	DefaultAddressPort = "26500"
 )
 
 var client zbc.ZBClient
@@ -70,7 +70,7 @@ func init() {
 		" If unspecified, the address will be used as default and the authzUrl parameter will be ignored")
 	rootCmd.PersistentFlags().StringVar(&authzURLFlag, "authzUrl", zbc.OAuthDefaultAuthzURL, "Specify an authorization server URL from which to request an access token. Can be overridden by the environment variable '"+zbc.OAuthAuthorizationUrlEnvVar+"'")
 	rootCmd.PersistentFlags().BoolVar(&insecureFlag, "insecure", false, "Specify if zbctl should use an unsecured connection")
-	rootCmd.PersistentFlags().StringVar(&clientCacheFlag, "clientCache", zbc.DefaultOauthYamlCachePath, "Specify the path to use for the OAuth credentials cache. Can be overriden by the environment variable '" + zbc.OAuthCachePathEnvVar + "'")
+	rootCmd.PersistentFlags().StringVar(&clientCacheFlag, "clientCache", zbc.DefaultOauthYamlCachePath, "Specify the path to use for the OAuth credentials cache. Can be overriden by the environment variable '"+zbc.OAuthCachePathEnvVar+"'")
 }
 
 // initClient will create a client with in the following precedence: address flag, environment variable, default address
@@ -78,27 +78,27 @@ var initClient = func(cmd *cobra.Command, args []string) error {
 	var err error
 	var credsProvider zbc.CredentialsProvider
 
-	address := parseAddress()
+	host, port := parseAddress()
 
 	if clientIDFlag != "" || clientSecretFlag != "" {
-	    audience := audienceFlag
+		audience := audienceFlag
 		if audience == "" {
-            audience = address
+			audience = host
 		}
 
-        providerConfig := zbc.OAuthProviderConfig{
-            ClientID:               clientIDFlag,
-            ClientSecret:           clientSecretFlag,
-            Audience:               audience,
-            AuthorizationServerURL: authzURLFlag,
-        }
+		providerConfig := zbc.OAuthProviderConfig{
+			ClientID:               clientIDFlag,
+			ClientSecret:           clientSecretFlag,
+			Audience:               audience,
+			AuthorizationServerURL: authzURLFlag,
+		}
 
-        if clientCacheFlag != "" {
-            providerConfig.Cache, err = zbc.NewOAuthYamlCredentialsCache(clientCacheFlag)
-            if err != nil {
-                return err
-            }
-        }
+		if clientCacheFlag != "" {
+			providerConfig.Cache, err = zbc.NewOAuthYamlCredentialsCache(clientCacheFlag)
+			if err != nil {
+				return err
+			}
+		}
 
 		// create a credentials provider with the specified parameters
 		credsProvider, err = zbc.NewOAuthCredentialsProvider(&providerConfig)
@@ -109,7 +109,7 @@ var initClient = func(cmd *cobra.Command, args []string) error {
 	}
 
 	client, err = zbc.NewZBClientWithConfig(&zbc.ZBClientConfig{
-		GatewayAddress:         appendPort(address),
+		GatewayAddress:         fmt.Sprintf("%s:%s", host, port),
 		UsePlaintextConnection: insecureFlag,
 		CaCertificatePath:      caCertPathFlag,
 		CredentialsProvider:    credsProvider,
@@ -117,8 +117,9 @@ var initClient = func(cmd *cobra.Command, args []string) error {
 	return err
 }
 
-func parseAddress() string {
-	address := DefaultAddressHost
+func parseAddress() (address string, port string) {
+	address = DefaultAddressHost
+	port = DefaultAddressPort
 
 	addressEnv := os.Getenv("ZEEBE_ADDRESS")
 	if len(addressEnv) > 0 {
@@ -126,10 +127,16 @@ func parseAddress() string {
 	}
 
 	if len(addressFlag) > 0 {
-		address = addressFlag
+		if strings.Contains(addressFlag, ":") {
+			parts := strings.Split(addressFlag, ":")
+			address = parts[0]
+			port = parts[1]
+		} else {
+			address = addressFlag
+		}
 	}
 
-	return address
+	return
 }
 
 func keyArg(key *int64) cobra.PositionalArgs {
@@ -155,12 +162,4 @@ func printJson(value interface{}) error {
 		fmt.Println(string(valueJson))
 	}
 	return err
-}
-
-func appendPort(address string) string {
-	if strings.Contains(address, ":") {
-		return address
-	} else {
-		return fmt.Sprintf("%s:%d", address, DefaultAddressPort)
-	}
 }

--- a/clients/zbctl/cmd/root.go
+++ b/clients/zbctl/cmd/root.go
@@ -70,7 +70,7 @@ func init() {
 		" If unspecified, the address will be used as default and the authzUrl parameter will be ignored")
 	rootCmd.PersistentFlags().StringVar(&authzURLFlag, "authzUrl", zbc.OAuthDefaultAuthzURL, "Specify an authorization server URL from which to request an access token. Can be overridden by the environment variable '"+zbc.OAuthAuthorizationUrlEnvVar+"'")
 	rootCmd.PersistentFlags().BoolVar(&insecureFlag, "insecure", false, "Specify if zbctl should use an unsecured connection")
-	rootCmd.PersistentFlags().StringVar(&clientCacheFlag, "clientCache", zbc.DefaultOauthYamlCachePath, "Specify the path to use for the OAuth credentials cache. Can be overriden by the environment variable '"+zbc.OAuthCachePathEnvVar+"'")
+	rootCmd.PersistentFlags().StringVar(&clientCacheFlag, "clientCache", zbc.DefaultOauthYamlCachePath, "Specify the path to use for the OAuth credentials cache. Can be overriden by the environment variable '" + zbc.OAuthCachePathEnvVar + "'")
 }
 
 // initClient will create a client with in the following precedence: address flag, environment variable, default address
@@ -81,24 +81,24 @@ var initClient = func(cmd *cobra.Command, args []string) error {
 	host, port := parseAddress()
 
 	if clientIDFlag != "" || clientSecretFlag != "" {
-		audience := audienceFlag
+	    audience := audienceFlag
 		if audience == "" {
-			audience = host
+            audience = host
 		}
 
-		providerConfig := zbc.OAuthProviderConfig{
-			ClientID:               clientIDFlag,
-			ClientSecret:           clientSecretFlag,
-			Audience:               audience,
-			AuthorizationServerURL: authzURLFlag,
-		}
+        providerConfig := zbc.OAuthProviderConfig{
+            ClientID:               clientIDFlag,
+            ClientSecret:           clientSecretFlag,
+            Audience:               audience,
+            AuthorizationServerURL: authzURLFlag,
+        }
 
-		if clientCacheFlag != "" {
-			providerConfig.Cache, err = zbc.NewOAuthYamlCredentialsCache(clientCacheFlag)
-			if err != nil {
-				return err
-			}
-		}
+        if clientCacheFlag != "" {
+            providerConfig.Cache, err = zbc.NewOAuthYamlCredentialsCache(clientCacheFlag)
+            if err != nil {
+                return err
+            }
+        }
 
 		// create a credentials provider with the specified parameters
 		credsProvider, err = zbc.NewOAuthCredentialsProvider(&providerConfig)
@@ -124,17 +124,15 @@ func parseAddress() (address string, port string) {
 	addressEnv := os.Getenv("ZEEBE_ADDRESS")
 	if len(addressEnv) > 0 {
 		address = addressEnv
-	}
+	} else if len(addressFlag) > 0 {
+	    address = addressFlag
+    }
 
-	if len(addressFlag) > 0 {
-		if strings.Contains(addressFlag, ":") {
-			parts := strings.Split(addressFlag, ":")
-			address = parts[0]
-			port = parts[1]
-		} else {
-			address = addressFlag
-		}
-	}
+    if strings.Contains(address, ":") {
+        parts := strings.Split(address, ":")
+        address = parts[0]
+        port = parts[1]
+    }
 
 	return
 }


### PR DESCRIPTION
## Description

While the default audience works fine, it seems we broke during one refactoring parsing the audience properly. This fixes that.

NOTE: another reason why we reaaaally need tests in zbctl :speak_no_evil: 

## Related issues


## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
