### PR TITLE
fix(exporters/elasticsearch): log error on flush exception instead of failing

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
@@ -90,10 +90,14 @@ public class ElasticsearchExporter implements Exporter {
   }
 
   private void flush() {
-    if (client.flush()) {
-      controller.updateLastExportedRecordPosition(lastPosition);
-    } else {
-      log.warn("Failed to flush bulk completely");
+    try {
+      if (client.flush()) {
+        controller.updateLastExportedRecordPosition(lastPosition);
+      } else {
+        log.warn("Failed to flush bulk completely");
+      }
+    } catch (Exception e) {
+      log.error("Failed to flush bulk", e);
     }
   }
 

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
@@ -296,6 +296,22 @@ public class ElasticsearchExporterTest {
     assertThat(testHarness.getController().getPosition()).isEqualTo(exported.get(3).getPosition());
   }
 
+  @Test
+  public void shouldHandleExceptionOnFlush() {
+    // given
+    when(esClient.shouldFlush()).thenReturn(true);
+    when(esClient.flush()).thenThrow(new ElasticsearchExporterException("expected"));
+
+    createAndOpenExporter();
+
+    // when
+    testHarness.export();
+    testHarness.export();
+
+    // then
+    verify(esClient, times(2)).flush();
+  }
+
   private ElasticsearchExporter createExporter() {
     return createExporter(esClient);
   }


### PR DESCRIPTION
## Description

If the flush of the elasticsearch client fails the exporter catches the exception and logs and error message.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3003

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
