### PR TITLE
chore(engine): message started instance is correlated

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/catchevent/StartEventEventOccurredHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/catchevent/StartEventEventOccurredHandler.java
@@ -16,6 +16,7 @@ import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.deployment.DeployedWorkflow;
 import io.zeebe.engine.state.deployment.WorkflowState;
 import io.zeebe.engine.state.instance.EventTrigger;
+import io.zeebe.engine.state.message.MessageState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
@@ -28,20 +29,23 @@ public class StartEventEventOccurredHandler<T extends ExecutableCatchEventElemen
 
   private final WorkflowInstanceRecord record = new WorkflowInstanceRecord();
   private final WorkflowState state;
+  private final MessageState messageState;
   private final KeyGenerator keyGenerator;
 
-  public StartEventEventOccurredHandler(ZeebeState zeebeState) {
+  public StartEventEventOccurredHandler(final ZeebeState zeebeState) {
     this(null, zeebeState);
   }
 
-  public StartEventEventOccurredHandler(WorkflowInstanceIntent nextState, ZeebeState zeebeState) {
+  public StartEventEventOccurredHandler(
+      final WorkflowInstanceIntent nextState, final ZeebeState zeebeState) {
     super(nextState);
     this.state = zeebeState.getWorkflowState();
+    this.messageState = zeebeState.getMessageState();
     keyGenerator = zeebeState.getKeyGenerator();
   }
 
   @Override
-  protected boolean handleState(BpmnStepContext<T> context) {
+  protected boolean handleState(final BpmnStepContext<T> context) {
     final WorkflowInstanceRecord event = context.getValue();
     final long workflowKey = event.getWorkflowKey();
     final DeployedWorkflow workflow = state.getWorkflowByKey(workflowKey);
@@ -70,11 +74,20 @@ public class StartEventEventOccurredHandler<T extends ExecutableCatchEventElemen
             .setFlowScopeKey(workflowInstanceKey);
 
     deferEvent(context, workflowKey, workflowInstanceKey, record, triggeredEvent);
+
+    // should mark particular message as already correlated for this instance
+    if (context.getElement().isMessage()) {
+      final long messageKey = triggeredEvent.getEventKey();
+      messageState.putMessageCorrelation(messageKey, workflowInstanceKey);
+    }
+
     return true;
   }
 
   private void createWorkflowInstance(
-      BpmnStepContext<T> context, DeployedWorkflow workflow, long workflowInstanceKey) {
+      final BpmnStepContext<T> context,
+      final DeployedWorkflow workflow,
+      final long workflowInstanceKey) {
     record
         .setBpmnProcessId(workflow.getBpmnProcessId())
         .setWorkflowKey(workflow.getKey())
@@ -88,15 +101,5 @@ public class StartEventEventOccurredHandler<T extends ExecutableCatchEventElemen
             WorkflowInstanceIntent.ELEMENT_ACTIVATING,
             record,
             workflow.getWorkflow());
-  }
-
-  private void deferStartEventRecord(
-      BpmnStepContext<T> context, long workflowInstanceKey, WorkflowInstanceRecord event) {
-    event.setWorkflowInstanceKey(workflowInstanceKey);
-    event.setFlowScopeKey(workflowInstanceKey);
-
-    context
-        .getOutput()
-        .deferRecord(workflowInstanceKey, event, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/PublishMessageProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/PublishMessageProcessor.java
@@ -199,13 +199,12 @@ public class PublishMessageProcessor implements TypedRecordProcessor<MessageReco
             .setElementId(startEventId)
             .setBpmnElementType(BpmnElementType.START_EVENT);
 
-    final long eventKey = keyGenerator.nextKey();
     final boolean wasTriggered =
         scopeEventInstanceState.triggerEvent(
-            workflowKey, eventKey, startEventId, command.getValue().getVariablesBuffer());
+            workflowKey, messageKey, startEventId, command.getValue().getVariablesBuffer());
 
     if (wasTriggered) {
-      streamWriter.appendNewEvent(eventKey, WorkflowInstanceIntent.EVENT_OCCURRED, record);
+      streamWriter.appendNewEvent(messageKey, WorkflowInstanceIntent.EVENT_OCCURRED, record);
     } else {
       Loggers.WORKFLOW_PROCESSOR_LOGGER.error(
           String.format(ERROR_START_EVENT_NOT_TRIGGERED_MESSAGE, workflowKey));

--- a/engine/src/test/java/io/zeebe/engine/util/client/PublishMessageClient.java
+++ b/engine/src/test/java/io/zeebe/engine/util/client/PublishMessageClient.java
@@ -14,8 +14,10 @@ import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.intent.MessageIntent;
 import io.zeebe.protocol.record.value.MessageRecordValue;
+import io.zeebe.test.util.MsgPackUtil;
 import io.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
+import java.util.Map;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -77,6 +79,10 @@ public class PublishMessageClient {
   public PublishMessageClient withTimeToLive(long timeToLive) {
     messageRecord.setTimeToLive(timeToLive);
     return this;
+  }
+
+  public PublishMessageClient withVariables(Map<String, Object> variables) {
+    return withVariables(MsgPackUtil.asMsgPack(variables));
   }
 
   public PublishMessageClient withVariables(DirectBuffer variables) {


### PR DESCRIPTION
## Description

- ensures a message which starts a workflow instance is marked as correlated for that workflow instance
- uses the message key as the event trigger key in order to later correlate the message once the start event is triggered

## Related issues

closes #3050 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
