### PR TITLE
fix(clients/java): ignore unknown JSON properties with object mapper

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeObjectMapper.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeObjectMapper.java
@@ -17,6 +17,7 @@ package io.zeebe.client.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.zeebe.client.api.command.InternalClientException;
 import java.io.IOException;
@@ -30,6 +31,10 @@ public class ZeebeObjectMapper extends ObjectMapper {
 
   private static final TypeReference<Map<String, String>> STRING_MAP_TYPE_REFERENCE =
       new TypeReference<Map<String, String>>() {};
+
+  public ZeebeObjectMapper() {
+    this.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  }
 
   public <T> T fromJson(String json, Class<T> typeClass) {
     try {

--- a/clients/java/src/test/java/io/zeebe/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/job/ActivateJobsTest.java
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.zeebe.client.api.command.ClientException;
 import io.zeebe.client.api.response.ActivateJobsResponse;
+import io.zeebe.client.impl.ZeebeObjectMapper;
+import io.zeebe.client.impl.response.ActivatedJobImpl;
 import io.zeebe.client.util.ClientTest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
@@ -224,5 +226,37 @@ public class ActivateJobsTest extends ClientTest {
 
     // then
     assertThat(request.getRequestTimeout()).isEqualTo(requestTimeout.toMillis());
+  }
+
+  @Test
+  public void shouldDeserializePartiallyToPojo() {
+    // given
+    final ActivatedJobImpl activatedJob =
+        new ActivatedJobImpl(
+            new ZeebeObjectMapper(),
+            ActivatedJob.newBuilder()
+                .setCustomHeaders("{}")
+                .setVariables("{\"a\": 1, \"b\": 2}")
+                .build());
+
+    // when
+    final VariablesPojo variablesPojo = activatedJob.getVariablesAsType(VariablesPojo.class);
+
+    // then
+    assertThat(variablesPojo.getA()).isEqualTo(1);
+  }
+
+  static class VariablesPojo {
+
+    int a;
+
+    public int getA() {
+      return a;
+    }
+
+    public VariablesPojo setA(int a) {
+      this.a = a;
+      return this;
+    }
   }
 }


### PR DESCRIPTION
## Description

The Zeebe object mapper is configured to not fail on unknown properties to allow partial deserialization.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3043

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
