### PR TITLE
chore(bpmn-model): validate service task retries is integer

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
@@ -47,6 +47,7 @@ import io.zeebe.model.bpmn.instance.dc.Bounds;
 import io.zeebe.model.bpmn.instance.di.Waypoint;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.function.Consumer;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 
 /** @author Sebastian Menski */
@@ -290,6 +291,13 @@ public abstract class AbstractBaseElementBuilder<
     final ExtensionElements extensionElements = getCreateSingleChild(ExtensionElements.class);
     extensionElements.addChildElement(extensionElement);
     return myself;
+  }
+
+  public <T extends BpmnModelElementInstance> B addExtensionElement(
+      Class<T> extensionClass, Consumer<T> builder) {
+    final T element = createInstance(extensionClass);
+    builder.accept(element);
+    return addExtensionElement(element);
   }
 
   public BpmnShape createBpmnShape(FlowNode node) {

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/zeebe/ZeebeTaskDefinitionImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/zeebe/ZeebeTaskDefinitionImpl.java
@@ -30,7 +30,7 @@ public class ZeebeTaskDefinitionImpl extends BpmnModelElementInstanceImpl
   protected static Attribute<String> typeAttribute;
   protected static Attribute<Integer> retriesAttribute;
 
-  public ZeebeTaskDefinitionImpl(ModelTypeInstanceContext instanceContext) {
+  public ZeebeTaskDefinitionImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
   }
 
@@ -40,21 +40,21 @@ public class ZeebeTaskDefinitionImpl extends BpmnModelElementInstanceImpl
   }
 
   @Override
-  public void setType(String type) {
+  public void setType(final String type) {
     typeAttribute.setValue(this, type);
   }
 
   @Override
-  public int getRetries() {
+  public Integer getRetries() {
     return retriesAttribute.getValue(this);
   }
 
   @Override
-  public void setRetries(int retries) {
+  public void setRetries(final int retries) {
     retriesAttribute.setValue(this, retries);
   }
 
-  public static void registerType(ModelBuilder modelBuilder) {
+  public static void registerType(final ModelBuilder modelBuilder) {
     final ModelElementTypeBuilder typeBuilder =
         modelBuilder
             .defineType(ZeebeTaskDefinition.class, ZeebeConstants.ELEMENT_TASK_DEFINITION)

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeTaskDefinition.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeTaskDefinition.java
@@ -25,7 +25,7 @@ public interface ZeebeTaskDefinition extends BpmnModelElementInstance {
 
   void setType(String type);
 
-  int getRetries();
+  Integer getRetries();
 
   void setRetries(int retries);
 }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeTaskDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeTaskDefinitionValidator.java
@@ -28,12 +28,16 @@ public class ZeebeTaskDefinitionValidator implements ModelElementValidator<Zeebe
 
   @Override
   public void validate(
-      ZeebeTaskDefinition element, ValidationResultCollector validationResultCollector) {
-
+      final ZeebeTaskDefinition element,
+      final ValidationResultCollector validationResultCollector) {
     final String taskType = element.getType();
 
     if (taskType == null || element.getType().isEmpty()) {
       validationResultCollector.addError(0, "Task type must be present and not empty");
+    }
+
+    if (element.getRetries() == null) {
+      validationResultCollector.addError(0, "Task retries must be an integer");
     }
   }
 }

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeServiceTaskValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeServiceTaskValidationTest.java
@@ -19,6 +19,8 @@ import static io.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
 import static java.util.Collections.singletonList;
 
 import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import org.junit.runners.Parameterized.Parameters;
 
@@ -41,6 +43,22 @@ public class ZeebeServiceTaskValidationTest extends AbstractZeebeValidationTest 
             .done(),
         singletonList(expect(ZeebeTaskDefinition.class, "Task type must be present and not empty"))
       },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task")
+            .addExtensionElement(
+                ZeebeTaskDefinition.class,
+                b ->
+                    b.setAttributeValueNs(
+                        BpmnModelConstants.ZEEBE_NS,
+                        ZeebeConstants.ATTRIBUTE_RETRIES,
+                        "notANumber"))
+            .zeebeTaskType("type")
+            .endEvent()
+            .done(),
+        singletonList(expect(ZeebeTaskDefinition.class, "Task retries must be an integer"))
+      }
     };
   }
 }


### PR DESCRIPTION
## Description

Fails validation if a task retries is not a number.

## Related issues

closes #3085

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
