### PR TITLE
chore(broker): never reject job fail command due to backpresure

### DIFF
--- a/broker/src/test/java/io/zeebe/broker/transport/backpressure/CommandRateLimiterTest.java
+++ b/broker/src/test/java/io/zeebe/broker/transport/backpressure/CommandRateLimiterTest.java
@@ -79,6 +79,16 @@ public class CommandRateLimiterTest {
   }
 
   @Test
+  public void shouldAcquireWhenJobFailCommandAfterLimit() {
+    // given
+    IntStream.range(0, limit.getLimit())
+        .forEach(i -> assertThat(rateLimiter.tryAcquire(0, 1, context)).isTrue());
+
+    // then
+    assertThat(rateLimiter.tryAcquire(0, 1, JobIntent.FAIL)).isTrue();
+  }
+
+  @Test
   public void shouldReleaseRequestOnIgnore() {
     // given
     rateLimiter.tryAcquire(0, 1, context);


### PR DESCRIPTION
## Description

Whitelist job fail command from backpressure.

## Related issues

closes #3109 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
