### PR TITLE
chore(docs): document backpressure

### DIFF
--- a/docs/src/basics/protocols.md
+++ b/docs/src/basics/protocols.md
@@ -5,11 +5,9 @@ between client and gateway [gRPC](https://grpc.io/) is used. The communication p
 Protocol Buffers v3 ([proto3](https://developers.google.com/protocol-buffers/docs/proto3)), and you can find it in the
 [Zeebe repository](https://github.com/zeebe-io/zeebe/tree/develop/gateway-protocol).
 
-
 ## What is gRPC?
 gRPC was first developed by Google and is now an open-source project and part of the Cloud Native Computing Foundation.
 If you’re new to gRPC, the [“What is gRPC”](https://grpc.io/docs/guides/index.html) page on the project website provides a good introduction to it.
-
 
 ## Why gRPC?
 gRPC has many nice features that make it a good fit for Zeebe. It:
@@ -27,3 +25,22 @@ to create a very basic one.
 
 You can find a list of existing clients in the [Awesome Zeebe repository](https://github.com/zeebe-io/awesome-zeebe#clients).
 Additionally, a [blog post](https://zeebe.io/blog/2018/11/grpc-generating-a-zeebe-python-client/) was published with a short tutorial on how to write a new client from scratch in Python.
+
+
+## Handling back-pressure
+
+When a broker receives a user request, it is written to the *event stream* first (see section [Internal Processing](/basics/internal-processing.html) for details), and processed later by the stream processor.
+If the processing is slow or if there are many user requests in the stream, it might take too long for the processor to start processing the command.
+If the broker keeps accepting new requests from the user, the back log increases and the processing latency can grow beyond an acceptable time.
+To avoid such problems, Zeebe employs a back-pressure mechanism.
+When the broker receives more requests than it can process with an acceptable latency, it rejects some requests. 
+
+The maximum rate of requests that can be processed by a broker depends on the processing capacity of the machine, the network latency, current load of the system and so on.
+Hence, there is no fixed limit configured in Zeebe for the maximum rate of requests it accepts. 
+Instead, Zeebe uses an adaptive algorithm to dynamically determine the limit of the number of inflight requests (the requests that are accepted by the broker, but not yet processed).
+The inflight request count is incremented when a request is accepted and decremented when a response is sent back to the client.
+The broker rejects requests when the inflight request count reaches the limit. 
+
+When the broker rejects requests due to back-pressure, the clients can retry them with an appropriate retry strategy.
+If the rejection rate is high, it indicates that the broker is constantly under high load.
+In that case, it is recommended to reduce the request rate.

--- a/docs/src/operations/metrics.md
+++ b/docs/src/operations/metrics.md
@@ -54,7 +54,7 @@ Most metrics have the following common label:
 
 * `partition`: cluster-unique id of the partition
 
-The following metrics are collected:
+**Metrics related to workflow processing:**
 
 * `zeebe_stream_processor_events_total`: The number of events processed by the stream processor.
 The `action` label separates processed, skipped and written events. 
@@ -71,5 +71,14 @@ created, activated, timed out, completed, failed and canceled jobs.
 * `zeebe_incident_events_total`: The number of incident events. The `action` label separates the number
 of created and resolved incident events.
 * `zeebe_pending_incidents_total`: The number of currently pending incident, i.e. not resolved.
+
+**Metrics related to performance:**
+
+Zeebe has a back-pressure mechanism by which it rejects requests, when it receives more requests than it can handle with out incurring high processing latency.
+The following metrics can be used to monitor back-pressure and processing latency of the commands.
+ 
+* `zeebe_dropped_request_count_total`: The number of user requests rejected by the broker due to backpressure.
+* `zeebe_backpressure_requests_limit`: The limit for the number of inflight requests used for backpressure.
+* `zeebe_stream_processor_latency_bucket`: The processing latency for commands and event.
 
 [prom-format]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details

--- a/docs/src/reference/grpc.md
+++ b/docs/src/reference/grpc.md
@@ -24,13 +24,20 @@ communicate with the broker.
 
 As a result of this proxying, any errors which occur between the gateway and the broker
 *for which the client is not at fault* (e.g. the gateway cannot deserialize the broker response,
-the broker is unavailable, etc.) are reported to the client as internal errors
-using the `GRPC_STATUS_INTERNAL` code. One exception to this is if the gateway itself is in
-an invalid state (e.g. out of memory), at which point it will return `GRPC_STATUS_UNAVAILABLE`.
+the broker is unavailable, etc.) are reported to the client using the following error codes.
+ * `GRPC_STATUS_RESOURCE_EXHAUSTED`: if the broker is receiving too many requests more than what it can handle, it kicks off back-pressure and rejects requests with this error code.
+    In this case, it is possible to retry the requests with an appropriate retry strategy.
+    If you receive many such errors with in a small time period, it indicates that the broker is constantly under high load. 
+    It is recommended to reduce the rate of requests.
+    When the back-pressure kicks off, the broker may reject any request except *CompleteJob* RPC and *FailJob* RPC.
+    These requests are white-listed for back-pressure and are always accepted by the broker even if it is receiving requests above its limits. 
+ * `GRPC_STATUS_UNAVAILABLE`:  if the gateway itself is in an invalid state (e.g. out of memory)
+ * `GRPC_STATUS_INTERNAL`:  for any other internal errors that occurred between the gateway and the broker.
 
 This behavior applies to every single possible RPC; in these cases, it is possible that retrying
 would succeed, but it is recommended to do so with an appropriate retry policy
-(e.g. a combination of exponential backoff or jitter wrapped in a circuit breaker).
+(e.g. a combination of exponential backoff or jitter wrapped in a circuit breaker). 
+
 
 In the documentation below, the documented errors are business logic errors, meaning
 errors which are a result of request processing logic, and not serialization, network, or


### PR DESCRIPTION
## Description

Added documentation for the "Resource_exhausted" error code returned due to backpressure.

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
