### PR TITLE
chore(broker): set raft segment size equal to log segment size

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -10,6 +10,7 @@ package io.zeebe.broker.system.configuration;
 import io.zeebe.util.Environment;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class DataCfg implements ConfigurationEntry {
   public static final String DEFAULT_DIRECTORY = "data";
@@ -27,6 +28,8 @@ public class DataCfg implements ConfigurationEntry {
 
   @Override
   public void init(BrokerCfg globalConfig, String brokerBase, Environment environment) {
+    raftSegmentSize = Optional.ofNullable(raftSegmentSize).orElse(logSegmentSize);
+
     applyEnvironment(environment);
     directories.replaceAll(d -> ConfigurationUtil.toAbsolutePath(d, brokerBase));
   }


### PR DESCRIPTION
## Description
Currently per default the raft segment size is `32 MB` and our log segment size is 512 MB.
As we saw in https://github.com/zeebe-io/zeebe/issues/3090 per `JournalSegment` a writer and some readers are created. Depending on our current `maxEntrySize`, which is currently 4 MB it will allocate byte buffers twice as big as the `maxEntrySize`. This means we had per Journal of 32 MB 24 MB byte buffers allocated in memory. To reduce this overhead I would like to increase the `raftSegmentSize` configuration. I think it makes sense that both values `raftSegmentSize` and `logSegmentSize` using the same size.