### PR TITLE
chore(logstreams): optimize seek by skipping through the segments

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/spi/LogStorage.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/spi/LogStorage.java
@@ -9,6 +9,7 @@ package io.zeebe.logstreams.spi;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.function.LongUnaryOperator;
 
 /** Log structured storage abstraction */
 public interface LogStorage {
@@ -127,6 +128,16 @@ public interface LogStorage {
    * @return the address of the last block
    */
   long readLastBlock(ByteBuffer readBuffer, ReadResultProcessor processor);
+
+  /**
+   * Returns an address of the block that may contain the position. The exact address returned can
+   * be implementation-dependent. For example, a segmented storage can return the address of the
+   * first byte in the segment.
+   *
+   * @param positionReader takes an address as input and returns a position
+   * @return address in the underlying storage for which positionReader returns a value <= position
+   */
+  long lookUpApproximateAddress(long position, LongUnaryOperator positionReader);
 
   /**
    * @return true if the storage is byte addressable (each byte managed in the underlying storage

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamDeleteTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamDeleteTest.java
@@ -76,13 +76,13 @@ public class LogStreamDeleteTest {
     logStream.delete(fourthPosition);
 
     // then
-    assertThat(events().count()).isEqualTo(2);
+    assertThat(events().count()).isEqualTo(1);
 
     assertThat(events().anyMatch(e -> e.getPosition() == firstPosition)).isFalse();
     assertThat(events().anyMatch(e -> e.getPosition() == secondPosition)).isFalse();
+    assertThat(events().anyMatch(e -> e.getPosition() == thirdPosition)).isFalse();
 
-    assertThat(events().findFirst().get().getPosition()).isEqualTo(thirdPosition);
-    assertThat(events().filter(e -> e.getPosition() == fourthPosition).findAny()).isNotEmpty();
+    assertThat(events().findFirst().get().getPosition()).isEqualTo(fourthPosition);
   }
 
   @Test
@@ -114,20 +114,13 @@ public class LogStreamDeleteTest {
             c -> c.logSegmentSize(segmentSize).maxFragmentSize(segmentSize));
     final byte[] largeEvent = new byte[remainingCapacity];
 
-    // log storage always returns on append as address (segment id, segment OFFSET)
-    // where offset should be the start of the event to be written
-    // this is in most cases true, besides the case where the end of an segment is reached
-    // If the segment is full on append - a new segment is created, but as offset
-    // the old position is used (which is the end of the segment) and the old segment id
-    // that is the reason why the tests will only delete 2 segments instead of expected three
-
-    // written from segment 0 4096 -> 8192, idx block address 4096
+    // written from segment 0 4096 -> 8192
     firstPosition = writeEvent(logStream, BufferUtil.wrapArray(largeEvent));
-    // written from segment 1 4096 -> 8192, but idx block address segment 0 - 8192
+    // written from segment 1 4096 -> 8192
     secondPosition = writeEvent(logStream, BufferUtil.wrapArray(largeEvent));
-    // written from segment 2 4096 -> 8192, but idx block address segment 1 - 8192
+    // written from segment 2 4096 -> 8192
     thirdPosition = writeEvent(logStream, BufferUtil.wrapArray(largeEvent));
-    // written from segment 3 4096 -> 8192, but idx block address segment 2 - 8192
+    // written from segment 3 4096 -> 8192
     fourthPosition = writeEvent(logStream, BufferUtil.wrapArray(largeEvent));
 
     //    logStream.setCommitPosition(fourthPosition);


### PR DESCRIPTION
## Description

Implements a faster seek that
  * reads the position of the first event in a segment
  * skip to the next segment until the first event position > look up position
  * seek the event in the prev segment by iterating through all events in the segments

## Related issues

Related to #3123 
closes #3131 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
