### PR TITLE
chore(clients/go): wrap env vars to make tests controllable

### DIFF
--- a/clients/go/zbc/client.go
+++ b/clients/go/zbc/client.go
@@ -147,11 +147,11 @@ func NewZBClientWithConfig(config *ZBClientConfig) (ZBClient, error) {
 }
 
 func applyZBClientEnvOverrides(config *ZBClientConfig) {
-	if insecureConn, found := os.LookupEnv(ZbInsecureEnvVar); found {
+	if insecureConn := env.get(ZbInsecureEnvVar); insecureConn != "" {
 		config.UsePlaintextConnection = (insecureConn == "true")
 	}
 
-	if caCertificatePath := os.Getenv(ZbCaCertificatePath); caCertificatePath != "" {
+	if caCertificatePath := env.get(ZbCaCertificatePath); caCertificatePath != "" {
 		config.CaCertificatePath = caCertificatePath
 	}
 }
@@ -178,7 +178,7 @@ func configureCredentialsProvider(config *ZBClientConfig, opts *[]grpc.DialOptio
 }
 
 func shouldUseDefaultCredentialsProvider() bool {
-	return os.Getenv(OAuthClientSecretEnvVar) != "" || os.Getenv(OAuthClientIdEnvVar) != ""
+	return env.get(OAuthClientSecretEnvVar) != "" || env.get(OAuthClientIdEnvVar) != ""
 }
 
 func setDefaultCredentialsProvider(config *ZBClientConfig) error {

--- a/clients/go/zbc/envWrapper.go
+++ b/clients/go/zbc/envWrapper.go
@@ -1,0 +1,94 @@
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zbc
+
+import (
+	"github.com/stretchr/testify/suite"
+	"os"
+	"strings"
+)
+
+var env = newEnvironmentWrapper()
+
+type environment interface {
+	get(variable string) string
+	set(variable, value string)
+	unset(variable string)
+	lookup(variable string) (string, bool)
+	copy() map[string]string
+	overwrite(environ map[string]string)
+}
+
+type envWrapper struct {
+	vars map[string]string
+}
+
+func (w *envWrapper) set(variable, value string) {
+	w.vars[variable] = value
+}
+
+func (w *envWrapper) get(variable string) string {
+	return w.vars[variable]
+}
+
+func (w *envWrapper) unset(variable string) {
+	if _, present := w.vars[variable]; present {
+		delete(w.vars, variable)
+	}
+}
+
+func (w *envWrapper) lookup(variable string) (string, bool) {
+	value, ok := w.vars[variable]
+	return value, ok
+}
+
+func (w *envWrapper) copy() map[string]string {
+	envDup := make(map[string]string, len(w.vars))
+
+	for envVar, val := range w.vars {
+		envDup[envVar] = val
+	}
+
+	return envDup
+}
+
+func (w *envWrapper) overwrite(environ map[string]string) {
+	w.vars = environ
+}
+
+func newEnvironmentWrapper() environment {
+	environ := os.Environ()
+
+	wrapper := envWrapper{vars: make(map[string]string, len(environ))}
+	for _, envVar := range environ {
+		parts := strings.SplitN(envVar, "=", 2)
+		wrapper.vars[parts[0]] = parts[1]
+	}
+
+	return &wrapper
+}
+
+type envSuite struct {
+	suite.Suite
+	envCopy map[string]string
+}
+
+func (s *envSuite) SetupTest() {
+	s.envCopy = env.copy()
+}
+
+func (s *envSuite) TearDownTest() {
+	env.overwrite(s.envCopy)
+}

--- a/clients/go/zbc/envWrapper_test.go
+++ b/clients/go/zbc/envWrapper_test.go
@@ -1,0 +1,68 @@
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zbc
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestReadEnvWrapper(t *testing.T) {
+	// given
+	env.set(ZbCaCertificatePath, "path")
+	defer env.unset(ZbCaCertificatePath)
+
+	// when
+	config := &ZBClientConfig{}
+	_, _ = NewZBClientWithConfig(config)
+
+	// then
+	require.EqualValues(t, config.CaCertificatePath, "path")
+}
+
+func TestUnsetEnv(t *testing.T) {
+	// given
+	env.set(ZbCaCertificatePath, "path")
+	env.unset(ZbCaCertificatePath)
+
+	// when
+	config := &ZBClientConfig{}
+	_, _ = NewZBClientWithConfig(config)
+
+	// then
+	require.Empty(t, config.CaCertificatePath)
+
+}
+
+func TestRestoreEnv(t *testing.T) {
+	// given
+	presentVar := "present_env_var"
+	absentVar := "absent_env_var"
+
+	env.set(presentVar, "someValue")
+	defer env.unset(presentVar)
+	environ := env.copy()
+	env.set(absentVar, "someValue")
+
+	// when
+	env.overwrite(environ)
+
+	// then
+	_, present := env.lookup(presentVar)
+	require.True(t, present)
+
+	_, present = env.lookup(absentVar)
+	require.False(t, present)
+}

--- a/clients/go/zbc/oauthCredentialsCache.go
+++ b/clients/go/zbc/oauthCredentialsCache.go
@@ -57,7 +57,7 @@ type oauthCachedCredentials struct {
 func NewOAuthYamlCredentialsCache(path string) (*oauthYamlCredentialsCache, error) {
 	var err error
 
-	envCachePath := os.Getenv(OAuthCachePathEnvVar)
+	envCachePath := env.get(OAuthCachePathEnvVar)
 	if envCachePath != "" {
 		path = envCachePath
 	} else if path == "" {

--- a/clients/go/zbc/oauthCredentialsProvider.go
+++ b/clients/go/zbc/oauthCredentialsProvider.go
@@ -26,7 +26,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 )
 
 const OAuthClientIdEnvVar = "ZEEBE_CLIENT_ID"
@@ -174,16 +173,16 @@ func (provider *OAuthCredentialsProvider) getCachedCredentials() *OAuthCredentia
 }
 
 func applyCredentialEnvOverrides(config *OAuthProviderConfig) {
-	if envClientID := os.Getenv(OAuthClientIdEnvVar); envClientID != "" {
+	if envClientID := env.get(OAuthClientIdEnvVar); envClientID != "" {
 		config.ClientID = envClientID
 	}
-	if envClientSecret := os.Getenv(OAuthClientSecretEnvVar); envClientSecret != "" {
+	if envClientSecret := env.get(OAuthClientSecretEnvVar); envClientSecret != "" {
 		config.ClientSecret = envClientSecret
 	}
-	if envAudience := os.Getenv(OAuthTokenAudienceEnvVar); envAudience != "" {
+	if envAudience := env.get(OAuthTokenAudienceEnvVar); envAudience != "" {
 		config.Audience = envAudience
 	}
-	if envAuthzServerURL := os.Getenv(OAuthAuthorizationUrlEnvVar); envAuthzServerURL != "" {
+	if envAuthzServerURL := env.get(OAuthAuthorizationUrlEnvVar); envAuthzServerURL != "" {
 		config.AuthorizationServerURL = envAuthzServerURL
 	}
 }

--- a/clients/go/zbc/oauthCredentialsProvider_test.go
+++ b/clients/go/zbc/oauthCredentialsProvider_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -28,7 +29,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 )
@@ -37,7 +37,15 @@ type mutableToken struct {
 	value string
 }
 
-func TestOAuthCredentialsProvider(t *testing.T) {
+type oauthCredsProviderTestSuite struct {
+	*envSuite
+}
+
+func TestOAuthCredsProviderSuite(t *testing.T) {
+	suite.Run(t, oauthCredsProviderTestSuite{envSuite: new(envSuite)})
+}
+
+func (s *oauthCredsProviderTestSuite) TestOAuthCredentialsProvider() {
 	// given
 	truncateDefaultOAuthYamlCacheFile()
 	interceptor := newRecordingInterceptor(nil)
@@ -49,7 +57,7 @@ func TestOAuthCredentialsProvider(t *testing.T) {
 		_ = gatewayLis.Close()
 	}()
 
-	authzServer := mockAuthorizationServer(t, &mutableToken{value: accessToken})
+	authzServer := mockAuthorizationServer(s.T(), &mutableToken{value: accessToken})
 	defer authzServer.Close()
 
 	credsProvider, err := NewOAuthCredentialsProvider(&OAuthProviderConfig{
@@ -59,27 +67,27 @@ func TestOAuthCredentialsProvider(t *testing.T) {
 		AuthorizationServerURL: authzServer.URL,
 	})
 
-	require.NoError(t, err)
+	s.NoError(err)
 	parts := strings.Split(gatewayLis.Addr().String(), ":")
 	client, err := NewZBClientWithConfig(&ZBClientConfig{
 		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 		UsePlaintextConnection: true,
 		CredentialsProvider:    credsProvider,
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// when
 	_, err = client.NewTopologyCommand().Send()
 
 	// then
-	require.Error(t, err)
+	s.Error(err)
 	if errorStatus, ok := status.FromError(err); ok {
-		require.Equal(t, codes.Unimplemented, errorStatus.Code())
+		s.Equal(codes.Unimplemented, errorStatus.Code())
 	}
-	require.Equal(t, tokenType+" "+accessToken, interceptor.authHeader)
+	s.Equal(tokenType+" "+accessToken, interceptor.authHeader)
 }
 
-func TestOAuthProviderRetry(t *testing.T) {
+func (s *oauthCredsProviderTestSuite) TestOAuthProviderRetry() {
 	// given
 	truncateDefaultOAuthYamlCacheFile()
 	token := &mutableToken{value: "firstToken"}
@@ -102,7 +110,7 @@ func TestOAuthProviderRetry(t *testing.T) {
 		_ = gatewayLis.Close()
 	}()
 
-	authzServer := mockAuthorizationServer(t, token)
+	authzServer := mockAuthorizationServer(s.T(), token)
 	defer authzServer.Close()
 
 	credsProvider, err := NewOAuthCredentialsProvider(&OAuthProviderConfig{
@@ -112,27 +120,27 @@ func TestOAuthProviderRetry(t *testing.T) {
 		AuthorizationServerURL: authzServer.URL,
 	})
 
-	require.NoError(t, err)
+	s.NoError(err)
 	parts := strings.Split(gatewayLis.Addr().String(), ":")
 	client, err := NewZBClientWithConfig(&ZBClientConfig{
 		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 		UsePlaintextConnection: true,
 		CredentialsProvider:    credsProvider,
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// when
 	_, err = client.NewTopologyCommand().Send()
 
 	// then
-	require.Error(t, err)
+	s.Error(err)
 	if errorStatus, ok := status.FromError(err); ok {
-		require.Equal(t, codes.Unimplemented, errorStatus.Code())
+		s.Equal(codes.Unimplemented, errorStatus.Code())
 	}
-	require.EqualValues(t, 2, interceptor.interceptCounter)
+	s.EqualValues(2, interceptor.interceptCounter)
 }
 
-func TestNotRetryWithSameCredentials(t *testing.T) {
+func (s *oauthCredsProviderTestSuite) TestNotRetryWithSameCredentials() {
 	// given
 	truncateDefaultOAuthYamlCacheFile()
 	token := &mutableToken{value: accessToken}
@@ -149,7 +157,7 @@ func TestNotRetryWithSameCredentials(t *testing.T) {
 		_ = gatewayLis.Close()
 	}()
 
-	authzServer := mockAuthorizationServer(t, token)
+	authzServer := mockAuthorizationServer(s.T(), token)
 	defer authzServer.Close()
 
 	credsProvider, err := NewOAuthCredentialsProvider(&OAuthProviderConfig{
@@ -159,24 +167,24 @@ func TestNotRetryWithSameCredentials(t *testing.T) {
 		AuthorizationServerURL: authzServer.URL,
 	})
 
-	require.NoError(t, err)
+	s.NoError(err)
 	parts := strings.Split(gatewayLis.Addr().String(), ":")
 	client, err := NewZBClientWithConfig(&ZBClientConfig{
 		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 		UsePlaintextConnection: true,
 		CredentialsProvider:    credsProvider,
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// when
 	_, err = client.NewTopologyCommand().Send()
 
 	// then
-	require.Error(t, err)
+	s.Error(err)
 	if errorStatus, ok := status.FromError(err); ok {
-		require.Equal(t, codes.Unauthenticated, errorStatus.Code())
+		s.Equal(codes.Unauthenticated, errorStatus.Code())
 	}
-	require.EqualValues(t, 1, interceptor.interceptCounter)
+	s.EqualValues(1, interceptor.interceptCounter)
 }
 
 var configErrorTests = []struct {
@@ -245,70 +253,83 @@ func TestInvalidOAuthProviderConfigurations(t *testing.T) {
 	}
 }
 
-type fieldExtractor func(config *OAuthProviderConfig) string
+func (s *oauthCredsProviderTestSuite) TestClientIdEnvOverride() {
+	// given
+	truncateDefaultOAuthYamlCacheFile()
+	env.set(OAuthClientIdEnvVar, "envClient")
 
-var envVarTests = []struct {
-	name           string
-	envVar         string
-	value          string
-	fieldExtractor fieldExtractor
-}{
-	{
-		"environment variable client id",
-		OAuthClientIdEnvVar,
-		"envClient",
-		func(c *OAuthProviderConfig) string { return c.ClientID },
-	},
-	{
-		"environment variable client secret",
-		OAuthClientSecretEnvVar,
-		"envSecret",
-		func(c *OAuthProviderConfig) string { return c.ClientSecret },
-	},
-	{
-		"environment variable audience",
-		OAuthTokenAudienceEnvVar,
-		"envAudience",
-		func(c *OAuthProviderConfig) string { return c.Audience },
-	},
-	{
-		"environment variable authorization server URL",
-		OAuthAuthorizationUrlEnvVar,
-		"https://envAuthzUrl",
-		func(c *OAuthProviderConfig) string { return c.AuthorizationServerURL },
-	},
-}
-
-func TestOAuthProviderWithEnvVars(t *testing.T) {
-	for _, test := range envVarTests {
-		t.Run(test.name, func(t *testing.T) {
-			// given
-			truncateDefaultOAuthYamlCacheFile()
-
-			if err := os.Setenv(test.envVar, test.value); err != nil {
-				panic(err)
-			}
-
-			config := &OAuthProviderConfig{
-				ClientID:               clientID,
-				ClientSecret:           clientSecret,
-				Audience:               audience,
-				AuthorizationServerURL: "http://foo",
-			}
-
-			// when
-			_, _ = NewOAuthCredentialsProvider(config)
-
-			// then
-			require.EqualValues(t, test.value, test.fieldExtractor(config))
-		})
-		if err := os.Unsetenv(test.envVar); err != nil {
-			panic(err)
-		}
+	config := &OAuthProviderConfig{
+		ClientID:               clientID,
+		ClientSecret:           clientSecret,
+		Audience:               audience,
+		AuthorizationServerURL: "http://foo",
 	}
+
+	// when
+	_, _ = NewOAuthCredentialsProvider(config)
+
+	// then
+	s.EqualValues("envClient", config.ClientID)
 }
 
-func TestOAuthCredentialsProviderCachesCredentials(t *testing.T) {
+func (s *oauthCredsProviderTestSuite) TestClientSecretEnvOverride() {
+	// given
+	truncateDefaultOAuthYamlCacheFile()
+	env.set(OAuthClientSecretEnvVar, "envSecret")
+
+	config := &OAuthProviderConfig{
+		ClientID:               clientID,
+		ClientSecret:           clientSecret,
+		Audience:               audience,
+		AuthorizationServerURL: "http://foo",
+	}
+
+	// when
+	_, _ = NewOAuthCredentialsProvider(config)
+
+	// then
+	s.EqualValues("envSecret", config.ClientSecret)
+}
+
+func (s *oauthCredsProviderTestSuite) TestAudienceEnvOverride() {
+	// given
+	truncateDefaultOAuthYamlCacheFile()
+	env.set(OAuthTokenAudienceEnvVar, "envAudience")
+
+	config := &OAuthProviderConfig{
+		ClientID:               clientID,
+		ClientSecret:           clientSecret,
+		Audience:               audience,
+		AuthorizationServerURL: "http://foo",
+	}
+
+	// when
+	_, _ = NewOAuthCredentialsProvider(config)
+
+	// then
+	s.EqualValues("envAudience", config.Audience)
+}
+
+func (s *oauthCredsProviderTestSuite) TestAuthzUrlEnvOverride() {
+	// given
+	truncateDefaultOAuthYamlCacheFile()
+	env.set(OAuthAuthorizationUrlEnvVar, "https://envAuthzUrl")
+
+	config := &OAuthProviderConfig{
+		ClientID:               clientID,
+		ClientSecret:           clientSecret,
+		Audience:               audience,
+		AuthorizationServerURL: "http://foo",
+	}
+
+	// when
+	_, _ = NewOAuthCredentialsProvider(config)
+
+	// then
+	s.EqualValues("https://envAuthzUrl", config.AuthorizationServerURL)
+}
+
+func (s *oauthCredsProviderTestSuite) TestOAuthCredentialsProviderCachesCredentials() {
 	// create fake gRPC server which returns UNAUTHENTICATED always except if we use the token `accessToken`
 	truncateDefaultOAuthYamlCacheFile()
 	gatewayLis, grpcServer := createAuthenticatedGrpcServer(accessToken)
@@ -320,7 +341,7 @@ func TestOAuthCredentialsProviderCachesCredentials(t *testing.T) {
 
 	// setup authorization server to return valid token
 	token := mutableToken{accessToken}
-	authzServer := mockAuthorizationServer(t, &token)
+	authzServer := mockAuthorizationServer(s.T(), &token)
 	defer authzServer.Close()
 
 	// use a fake authorization server which would fail if we actually used it
@@ -331,30 +352,30 @@ func TestOAuthCredentialsProviderCachesCredentials(t *testing.T) {
 		AuthorizationServerURL: authzServer.URL,
 	})
 
-	require.NoError(t, err)
+	s.NoError(err)
 	parts := strings.Split(gatewayLis.Addr().String(), ":")
 	client, err := NewZBClientWithConfig(&ZBClientConfig{
 		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 		UsePlaintextConnection: true,
 		CredentialsProvider:    credsProvider,
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// when
 	_, err = client.NewTopologyCommand().Send()
 
 	// then
-	require.NoError(t, err)
+	s.NoError(err)
 	if errorStatus, ok := status.FromError(err); ok {
-		require.Equal(t, codes.OK, errorStatus.Code())
+		s.Equal(codes.OK, errorStatus.Code())
 	}
 	cache, err := NewOAuthYamlCredentialsCache("")
-	require.NoError(t, err)
-	require.NoError(t, cache.Refresh())
-	require.Equal(t, accessToken, cache.Get(audience).AccessToken)
+	s.NoError(err)
+	s.NoError(cache.Refresh())
+	s.Equal(accessToken, cache.Get(audience).AccessToken)
 }
 
-func TestOAuthCredentialsProviderUsesCachedCredentials(t *testing.T) {
+func (s *oauthCredsProviderTestSuite) TestOAuthCredentialsProviderUsesCachedCredentials() {
 	// create fake gRPC server which returns UNAUTHENTICATED always except if we use the token `accessToken`
 	gatewayLis, grpcServer := createAuthenticatedGrpcServer(accessToken)
 	go grpcServer.Serve(gatewayLis)
@@ -366,14 +387,14 @@ func TestOAuthCredentialsProviderUsesCachedCredentials(t *testing.T) {
 	// setup cache with correct token
 	truncateDefaultOAuthYamlCacheFile()
 	cache, err := NewOAuthYamlCredentialsCache(DefaultOauthYamlCachePath)
-	require.NoError(t, err)
+	s.NoError(err)
 	err = cache.Update(audience, &OAuthCredentials{
 		AccessToken: accessToken,
 		ExpiresIn:   3600,
 		TokenType:   "Bearer",
 		Scope:       "grpc",
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// use a fake authorization server which would fail if we actually used it
 	credsProvider, err := NewOAuthCredentialsProvider(&OAuthProviderConfig{
@@ -383,22 +404,22 @@ func TestOAuthCredentialsProviderUsesCachedCredentials(t *testing.T) {
 		AuthorizationServerURL: "http://foo.bar",
 	})
 
-	require.NoError(t, err)
+	s.NoError(err)
 	parts := strings.Split(gatewayLis.Addr().String(), ":")
 	client, err := NewZBClientWithConfig(&ZBClientConfig{
 		GatewayAddress:         fmt.Sprintf("0.0.0.0:%s", parts[len(parts)-1]),
 		UsePlaintextConnection: true,
 		CredentialsProvider:    credsProvider,
 	})
-	require.NoError(t, err)
+	s.NoError(err)
 
 	// when
 	_, err = client.NewTopologyCommand().Send()
 
 	// then
-	require.NoError(t, err)
+	s.NoError(err)
 	if errorStatus, ok := status.FromError(err); ok {
-		require.Equal(t, codes.OK, errorStatus.Code())
+		s.Equal(codes.OK, errorStatus.Code())
 	}
 }
 

--- a/docs/src/operations/authentication.md
+++ b/docs/src/operations/authentication.md
@@ -58,7 +58,7 @@ public class InsecureClient {
 }
 ```
 
-Alternatively, you can use the `ZEEBE_INSECURE_CONNECTION` environment variable to override the code configuration. To enable an insecure connection, just set it to "true", setting it to any other value is equivalent to setting it to false.
+Alternatively, you can use the `ZEEBE_INSECURE_CONNECTION` environment variable to override the code configuration. To enable an insecure connection, you can it to "true". To use a secure connection, you can set it any non-empty value other than "true". Setting the environment variable to an empty string is equivalent to unsetting it.
 
 ### Go
 


### PR DESCRIPTION
## Description

This adds a wrapper around env vars which allows us to control them better in tests. 
One note is that I changed most zbc tests to use testify.suite in order to have an easy way of copying/restoring the environment before/after each test. To do this I had to move one of the table tests to normal test methods. Since these tests were about env var configuration it made sense to use the suite.

## Related issues

closes #3112 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
