### PR TITLE
chore(broker): introduce advertised address

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/ClusterComponent.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/ClusterComponent.java
@@ -53,7 +53,8 @@ public class ClusterComponent implements Component {
 
     final NodeInfo localMember =
         new NodeInfo(
-            brokerConfig.getCluster().getNodeId(), networkCfg.getCommandApi().toSocketAddress());
+            brokerConfig.getCluster().getNodeId(),
+            networkCfg.getCommandApi().getAdvertisedAddress());
 
     /* A hack so that DistributedLogstream primitive can create logstream services using this serviceContainer */
     LogstreamConfig.putServiceContainer(

--- a/broker/src/main/java/io/zeebe/broker/clustering/base/gossip/AtomixService.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/base/gossip/AtomixService.java
@@ -58,8 +58,8 @@ public class AtomixService implements Service<Atomix> {
     final String localMemberId = Integer.toString(nodeId);
 
     final NetworkCfg networkCfg = configuration.getNetwork();
-    final String host = networkCfg.getInternalApi().getHost();
-    final int port = networkCfg.getInternalApi().getPort();
+    final String host = networkCfg.getInternalApi().getAdvertisedHost();
+    final int port = networkCfg.getInternalApi().getAdvertisedPort();
 
     final NodeDiscoveryProvider discoveryProvider =
         createDiscoveryProvider(clusterCfg, localMemberId);
@@ -71,6 +71,8 @@ public class AtomixService implements Service<Atomix> {
             .withClusterId(clusterCfg.getClusterName())
             .withMemberId(localMemberId)
             .withAddress(Address.from(host, port))
+            .withMessagingPort(networkCfg.getInternalApi().getPort())
+            .withMessagingInterface(networkCfg.getInternalApi().getHost())
             .withMembershipProvider(discoveryProvider);
 
     final DataCfg dataConfiguration = configuration.getData();

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/EmbeddedGatewayCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/EmbeddedGatewayCfg.java
@@ -32,7 +32,7 @@ public class EmbeddedGatewayCfg extends GatewayCfg implements ConfigurationEntry
     init(environment, networkCfg.getHost());
 
     // ensure embedded gateway can access local broker
-    getCluster().setContactPoint(networkCfg.getInternalApi().toSocketAddress().toString());
+    getCluster().setContactPoint(networkCfg.getInternalApi().getAddress().toString());
 
     // configure embedded gateway based on broker config
     getNetwork().setPort(getNetwork().getPort() + (networkCfg.getPortOffset() * 10));

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
@@ -11,6 +11,7 @@ public class EnvironmentConstants {
 
   public static final String ENV_NODE_ID = "ZEEBE_NODE_ID";
   public static final String ENV_HOST = "ZEEBE_HOST";
+  public static final String ENV_ADVERTISED_HOST = "ZEEBE_ADVERTISED_HOST";
   public static final String ENV_PORT_OFFSET = "ZEEBE_PORT_OFFSET";
   public static final String ENV_INITIAL_CONTACT_POINTS = "ZEEBE_CONTACT_POINTS";
   public static final String ENV_DIRECTORIES = "ZEEBE_DIRECTORIES";

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/NetworkCfg.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.broker.system.configuration;
 
+import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_ADVERTISED_HOST;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_HOST;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_PORT_OFFSET;
 
@@ -15,6 +16,7 @@ import io.zeebe.broker.system.configuration.SocketBindingCfg.InternalApiCfg;
 import io.zeebe.broker.system.configuration.SocketBindingCfg.MonitoringApiCfg;
 import io.zeebe.util.ByteValue;
 import io.zeebe.util.Environment;
+import java.util.Optional;
 
 public class NetworkCfg implements ConfigurationEntry {
 
@@ -27,6 +29,7 @@ public class NetworkCfg implements ConfigurationEntry {
   private String host = DEFAULT_HOST;
   private int portOffset = 0;
   private String maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
+  private String advertisedHost;
 
   private CommandApiCfg commandApi = new CommandApiCfg();
   private InternalApiCfg internalApi = new InternalApiCfg();
@@ -44,6 +47,7 @@ public class NetworkCfg implements ConfigurationEntry {
   private void applyEnvironment(final Environment environment) {
     environment.get(ENV_HOST).ifPresent(this::setHost);
     environment.getInt(ENV_PORT_OFFSET).ifPresent(this::setPortOffset);
+    environment.get(ENV_ADVERTISED_HOST).ifPresent(this::setAdvertisedHost);
   }
 
   public String getHost() {
@@ -52,6 +56,14 @@ public class NetworkCfg implements ConfigurationEntry {
 
   public void setHost(final String host) {
     this.host = host;
+  }
+
+  public void setAdvertisedHost(final String advertisedHost) {
+    this.advertisedHost = advertisedHost;
+  }
+
+  public String getAdvertisedHost() {
+    return Optional.ofNullable(advertisedHost).orElse(getHost());
   }
 
   public int getPortOffset() {
@@ -70,12 +82,8 @@ public class NetworkCfg implements ConfigurationEntry {
     this.maxMessageSize = maxMessageSize;
   }
 
-  public SocketBindingCfg getCommandApi() {
+  public CommandApiCfg getCommandApi() {
     return commandApi;
-  }
-
-  public void setCommandApi(final CommandApiCfg commandApi) {
-    this.commandApi = commandApi;
   }
 
   public SocketBindingCfg getMonitoringApi() {

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/SocketBindingCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/SocketBindingCfg.java
@@ -12,22 +12,34 @@ import java.util.Optional;
 
 public class SocketBindingCfg {
 
-  protected String host;
-  protected int port;
+  private final int defaultPort;
+  private String host;
+  private Integer port;
+  private String advertisedHost;
+  private Integer advertisedPort;
 
   private SocketBindingCfg(final int defaultPort) {
-    port = defaultPort;
+    this.defaultPort = defaultPort;
   }
 
-  public SocketAddress toSocketAddress() {
+  public SocketAddress getAddress() {
     return new SocketAddress(host, port);
   }
 
+  public SocketAddress getAdvertisedAddress() {
+    return new SocketAddress(advertisedHost, advertisedPort);
+  }
+
   public void applyDefaults(final NetworkCfg networkCfg) {
-
+    advertisedHost =
+        Optional.ofNullable(advertisedHost)
+            .orElseGet(() -> Optional.ofNullable(host).orElseGet(networkCfg::getAdvertisedHost));
     host = Optional.ofNullable(host).orElse(networkCfg.getHost());
-
-    port += networkCfg.getPortOffset() * 10;
+    port = Optional.ofNullable(port).orElse(defaultPort) + networkCfg.getPortOffset() * 10;
+    advertisedPort =
+        Optional.ofNullable(advertisedPort)
+            .map(p -> p + networkCfg.getPortOffset() * 10)
+            .orElse(port);
   }
 
   public String getHost() {
@@ -38,6 +50,14 @@ public class SocketBindingCfg {
     this.host = host;
   }
 
+  public String getAdvertisedHost() {
+    return advertisedHost;
+  }
+
+  public void setAdvertisedHost(final String advertisedHost) {
+    this.advertisedHost = advertisedHost;
+  }
+
   public int getPort() {
     return port;
   }
@@ -46,9 +66,27 @@ public class SocketBindingCfg {
     this.port = port;
   }
 
+  public int getAdvertisedPort() {
+    return advertisedPort;
+  }
+
+  public void setAdvertisedPort(final int advertisedPort) {
+    this.advertisedPort = advertisedPort;
+  }
+
   @Override
   public String toString() {
-    return "SocketBindingCfg{" + "host='" + host + '\'' + ", port=" + port + '}';
+    return "SocketBindingCfg{"
+        + "host='"
+        + host
+        + '\''
+        + ", port="
+        + port
+        + ", advertisedHost="
+        + advertisedHost
+        + ", advertisedPort="
+        + advertisedPort
+        + "}";
   }
 
   public static class CommandApiCfg extends SocketBindingCfg {

--- a/broker/src/main/java/io/zeebe/broker/transport/TransportComponent.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/TransportComponent.java
@@ -75,7 +75,7 @@ public class TransportComponent implements Component {
       final NetworkCfg networkCfg,
       final CommandApiMessageHandler commandApiMessageHandler) {
 
-    final SocketAddress bindAddr = networkCfg.getCommandApi().toSocketAddress();
+    final SocketAddress bindAddr = networkCfg.getCommandApi().getAddress();
 
     return createServerTransport(
         systemContext,

--- a/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -171,7 +171,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
   }
 
   public SocketAddress getCommandAdress() {
-    return brokerCfg.getNetwork().getCommandApi().toSocketAddress();
+    return brokerCfg.getNetwork().getCommandApi().getAddress();
   }
 
   public SocketAddress getGatewayAddress() {

--- a/broker/src/test/resources/system/advertised-address-cfg.toml
+++ b/broker/src/test/resources/system/advertised-address-cfg.toml
@@ -1,0 +1,3 @@
+[network.commandApi]
+advertisedHost = "zeebe.io"
+advertisedPort = 8080

--- a/broker/src/test/resources/system/advertised-host-cfg.toml
+++ b/broker/src/test/resources/system/advertised-host-cfg.toml
@@ -1,0 +1,2 @@
+[network.commandApi]
+advertisedHost = "zeebe.io"

--- a/broker/src/test/resources/system/default-advertised-host-cfg.toml
+++ b/broker/src/test/resources/system/default-advertised-host-cfg.toml
@@ -1,0 +1,2 @@
+[network]
+advertisedHost = "zeebe.io"

--- a/dist/src/main/config/zeebe.cfg.toml
+++ b/dist/src/main/config/zeebe.cfg.toml
@@ -98,6 +98,10 @@
 # This setting can also be overridden using the environment variable ZEEBE_HOST.
 # host = "0.0.0.0"
 
+# Controls the advertised host; if omitted defaults to the host. This is particularly useful if your
+# broker stands behind a proxy.
+# advertisedHost = "0.0.0.0"
+
 # If a port offset is set it will be added to all ports specified in the config
 # or the default values. This is a shortcut to not always specifying every port.
 #

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -252,8 +252,7 @@ public class ClusteringRule extends ExternalResource {
       // all nodes have to join the same broker
       // https://github.com/zeebe-io/zeebe/issues/2012
 
-      setInitialContactPoints(
-              getBrokerCfg(0).getNetwork().getInternalApi().toSocketAddress().toString())
+      setInitialContactPoints(getBrokerCfg(0).getNetwork().getInternalApi().getAddress().toString())
           .accept(brokerCfg);
     }
 
@@ -278,7 +277,7 @@ public class ClusteringRule extends ExternalResource {
 
   private Gateway createGateway() {
     final String contactPoint =
-        getBrokerCfg(0).getNetwork().getInternalApi().toSocketAddress().toString();
+        getBrokerCfg(0).getNetwork().getInternalApi().getAddress().toString();
 
     final GatewayCfg gatewayCfg = new GatewayCfg();
     gatewayCfg.getCluster().setContactPoint(contactPoint).setClusterName(clusterName);
@@ -333,7 +332,7 @@ public class ClusteringRule extends ExternalResource {
     final Set<SocketAddress> addresses =
         brokers.values().stream()
             .map(Broker::getConfig)
-            .map(b -> b.getNetwork().getCommandApi().toSocketAddress())
+            .map(b -> b.getNetwork().getCommandApi().getAddress())
             .collect(Collectors.toSet());
 
     waitForTopology(
@@ -419,8 +418,7 @@ public class ClusteringRule extends ExternalResource {
   public void restartBroker(final int nodeId) {
     stopBroker(nodeId);
     final Broker broker = getBroker(nodeId);
-    final SocketAddress commandApi =
-        broker.getConfig().getNetwork().getCommandApi().toSocketAddress();
+    final SocketAddress commandApi = broker.getConfig().getNetwork().getCommandApi().getAddress();
     waitUntilBrokerIsAddedToTopology(commandApi);
     waitForPartitionReplicationFactor();
   }
@@ -472,14 +470,13 @@ public class ClusteringRule extends ExternalResource {
 
   public SocketAddress[] getOtherBrokers(final SocketAddress address) {
     return getBrokers().stream()
-        .map(b -> b.getConfig().getNetwork().getCommandApi().toSocketAddress())
+        .map(b -> b.getConfig().getNetwork().getCommandApi().getAddress())
         .filter(a -> !address.equals(a))
         .toArray(SocketAddress[]::new);
   }
 
   public SocketAddress[] getOtherBrokers(final int nodeId) {
-    final SocketAddress filter =
-        getBrokerCfg(nodeId).getNetwork().getCommandApi().toSocketAddress();
+    final SocketAddress filter = getBrokerCfg(nodeId).getNetwork().getCommandApi().getAddress();
     return getOtherBrokers(filter);
   }
 
@@ -499,7 +496,7 @@ public class ClusteringRule extends ExternalResource {
     final Broker broker = brokers.remove(nodeId);
     if (broker != null) {
       final SocketAddress socketAddress =
-          broker.getConfig().getNetwork().getCommandApi().toSocketAddress();
+          broker.getConfig().getNetwork().getCommandApi().getAddress();
       final List<Integer> brokersLeadingPartitions = getBrokersLeadingPartitions(socketAddress);
       broker.close();
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/shutdown/BrokerShutdownTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/shutdown/BrokerShutdownTest.java
@@ -58,7 +58,7 @@ public class BrokerShutdownTest {
     // then
     final NetworkCfg networkCfg = broker.getBrokerContext().getBrokerConfiguration().getNetwork();
 
-    tryToBindSocketAddress(networkCfg.getCommandApi().toSocketAddress());
+    tryToBindSocketAddress(networkCfg.getCommandApi().getAddress());
   }
 
   private void tryToBindSocketAddress(SocketAddress socketAddress) {


### PR DESCRIPTION
## Description

- adds `advertisedHost` and `advertisedPort` to `SocketBindingCfg`
- adds `advertisedHost` as default advertised host in `NetworkCfg`, overwritable with `ZEEBE_ADVERTISED_HOST`

## Related issues

closes #3143 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
