### PR TITLE
chore(logstreams): use lastSegmentId when reading last block

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/fs/FsLogStorage.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/fs/FsLogStorage.java
@@ -153,8 +153,7 @@ public class FsLogStorage implements LogStorage {
   public long readLastBlock(final ByteBuffer readBuffer, final ReadResultProcessor processor) {
     ensureOpenedStorage();
 
-    final int segmentCount = logSegments.segmentCount;
-    final FsLogSegment lastSegment = logSegments.getSegment(segmentCount - 1);
+    final FsLogSegment lastSegment = logSegments.getSegment(logSegments.getLastSegmentId());
 
     if (lastSegment != null && lastSegment.getSizeVolatile() > METADATA_LENGTH) {
       boolean findLast = true;


### PR DESCRIPTION
## Description

`readLastBlock` in FsLogStorage returns `OP_RESULT_NO_DATA` if there is only one segment left after compaction. This causes a restarted broker to incorrectly assume it is missing some events because it is reading the wrong event as the last one.

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
