### PR TITLE
test(service-container): fix flaky tests

### DIFF
--- a/service-container/src/test/java/io/zeebe/servicecontainer/impl/CompositeInstallOperationTest.java
+++ b/service-container/src/test/java/io/zeebe/servicecontainer/impl/CompositeInstallOperationTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.mockito.InOrder;
 
-@SuppressWarnings("unchecked")
 public class CompositeInstallOperationTest {
   public ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
   public ServiceContainerRule serviceContainerRule = new ServiceContainerRule(actorSchedulerRule);
@@ -72,7 +71,7 @@ public class CompositeInstallOperationTest {
     final ActorFuture<Object> service1Future =
         composite.createService(service1Name, mockService1).install();
     final ActorFuture<Object> service2Future =
-        composite.createService(service1Name, mockService2).install();
+        composite.createService(service2Name, mockService2).install();
 
     final ActorFuture<Void> compositeFuture = composite.install();
 
@@ -95,7 +94,7 @@ public class CompositeInstallOperationTest {
     final ActorFuture<Object> service1Future =
         composite.createService(service1Name, mockService1).install();
     final ActorFuture<Object> service2Future =
-        composite.createService(service1Name, asyncService2).install();
+        composite.createService(service2Name, asyncService2).install();
 
     final ActorFuture<Void> compositeFuture = composite.install();
 
@@ -121,7 +120,7 @@ public class CompositeInstallOperationTest {
     final ActorFuture<Object> service1Future =
         composite.createService(service1Name, mockService1).install();
     final ActorFuture<Object> service2Future =
-        composite.createService(service1Name, asyncService2).install();
+        composite.createService(service2Name, asyncService2).install();
 
     final ActorFuture<Void> compositeFuture = composite.install();
 

--- a/service-container/src/test/java/io/zeebe/servicecontainer/impl/InjectedDependencyTest.java
+++ b/service-container/src/test/java/io/zeebe/servicecontainer/impl/InjectedDependencyTest.java
@@ -26,7 +26,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InOrder;
 
-@SuppressWarnings("unchecked")
 public class InjectedDependencyTest {
   @Rule public ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
 
@@ -138,10 +137,11 @@ public class InjectedDependencyTest {
     serviceContainer
         .createService(service1Name, mockService1)
         .dependency(service2Name, injector)
-        .install();
+        .install()
+        .join();
 
     // when
-    serviceContainer.removeService(service1Name);
+    serviceContainer.removeService(service1Name).join();
 
     // then
     assertThat(injector.getValue()).isNull();
@@ -151,11 +151,13 @@ public class InjectedDependencyTest {
   public void shouldUninjectAfterStop() {
     // given
     final Injector<Object> injector = mock(Injector.class);
-    serviceContainer
-        .createService(service1Name, mockService1)
-        .dependency(service2Name, injector)
-        .install();
+    final ActorFuture<Object> install =
+        serviceContainer
+            .createService(service1Name, mockService1)
+            .dependency(service2Name, injector)
+            .install();
     serviceContainer.createService(service2Name, mockService2).install().join();
+    install.join();
 
     // when
     serviceContainer.removeService(service1Name).join();
@@ -171,15 +173,17 @@ public class InjectedDependencyTest {
     // given
     final Injector<Object> injector = new Injector<>();
     final Injector<Object> anotherInjector = new Injector<>();
-    serviceContainer
-        .createService(service1Name, mockService1)
-        .dependency(service2Name, injector)
-        .dependency(service2Name, anotherInjector)
-        .install();
+    final ActorFuture<Object> install =
+        serviceContainer
+            .createService(service1Name, mockService1)
+            .dependency(service2Name, injector)
+            .dependency(service2Name, anotherInjector)
+            .install();
     serviceContainer.createService(service2Name, mockService2).install();
+    install.join();
 
     // when
-    serviceContainer.removeService(service1Name);
+    serviceContainer.removeService(service1Name).join();
 
     // then
     assertThat(injector.getValue()).isNull();
@@ -191,12 +195,14 @@ public class InjectedDependencyTest {
     // given
     final Injector<Object> injector = new Injector<>();
     final Injector<Object> anotherInjector = new Injector<>();
-    serviceContainer
-        .createService(service1Name, mockService1)
-        .dependency(service2Name, injector)
-        .dependency(service2Name, anotherInjector)
-        .install();
+    final ActorFuture<Object> install =
+        serviceContainer
+            .createService(service1Name, mockService1)
+            .dependency(service2Name, injector)
+            .dependency(service2Name, anotherInjector)
+            .install();
     serviceContainer.createService(service2Name, mockService2).install().join();
+    install.join();
 
     // when + then
     assertThat(serviceContainer.hasService(service1Name).join()).isTrue();


### PR DESCRIPTION
## Description

* make test in service-container less flaky
* InjectedDependencyTest: same tests fail because one service was removed before it was started
* CompositeInstallOperationTest: tests try to install two services with the same name in a composite - changed to different names 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
