### PR TITLE
chore(broker): notify backpressure when a command is processed

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/engine/EngineService.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/EngineService.java
@@ -92,8 +92,8 @@ public class EngineService implements Service<EngineService> {
         .additionalDependencies(serviceContext.getServiceName())
         .zeebeDb(partition.getZeebeDb())
         .serviceContainer(serviceContainer)
-        .commandResponseWriter(
-            commandApiService.newCommandResponseWriter(partition.getPartitionId()))
+        .commandResponseWriter(commandApiService.newCommandResponseWriter())
+        .onProcessedListener(commandApiService.getOnProcessedListener(partition.getPartitionId()))
         .streamProcessorFactory(
             (processingContext) -> {
               final ActorControl actor = processingContext.getActor();

--- a/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandResponseWriterImpl.java
@@ -11,7 +11,6 @@ import static io.zeebe.protocol.record.ExecuteCommandResponseEncoder.keyNullValu
 import static io.zeebe.protocol.record.ExecuteCommandResponseEncoder.partitionIdNullValue;
 import static io.zeebe.protocol.record.ExecuteCommandResponseEncoder.valueHeaderLength;
 
-import io.zeebe.broker.transport.backpressure.RequestLimiter;
 import io.zeebe.engine.processor.CommandResponseWriter;
 import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.record.ExecuteCommandResponseEncoder;
@@ -35,7 +34,6 @@ public class CommandResponseWriterImpl implements CommandResponseWriter, BufferW
   private final ServerResponse response = new ServerResponse();
   private final ServerOutput output;
   private final UnsafeBuffer rejectionReason = new UnsafeBuffer(0, 0);
-  private final RequestLimiter limiter;
   private int partitionId = partitionIdNullValue();
   private long key = keyNullValue();
   private BufferWriter valueWriter;
@@ -44,9 +42,8 @@ public class CommandResponseWriterImpl implements CommandResponseWriter, BufferW
   private short intent = Intent.NULL_VAL;
   private RejectionType rejectionType = RejectionType.NULL_VAL;
 
-  public CommandResponseWriterImpl(final ServerOutput output, RequestLimiter limiter) {
+  public CommandResponseWriterImpl(final ServerOutput output) {
     this.output = output;
-    this.limiter = limiter;
   }
 
   @Override
@@ -102,7 +99,6 @@ public class CommandResponseWriterImpl implements CommandResponseWriter, BufferW
     Objects.requireNonNull(valueWriter);
 
     try {
-      limiter.onResponse(remoteStreamId, requestId);
       response.reset().remoteStreamId(remoteStreamId).requestId(requestId).writer(this);
 
       return output.sendResponse(response);

--- a/engine/src/main/java/io/zeebe/engine/processor/ProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ProcessingContext.java
@@ -13,6 +13,7 @@ import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
 import io.zeebe.util.sched.ActorControl;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 
 public class ProcessingContext implements ReadonlyProcessingContext {
 
@@ -29,6 +30,7 @@ public class ProcessingContext implements ReadonlyProcessingContext {
   private DbContext dbContext;
 
   private BooleanSupplier abortCondition;
+  private Consumer<TypedRecord> onProcessedListener = record -> {};
 
   public ProcessingContext actor(ActorControl actor) {
     this.actor = actor;
@@ -85,6 +87,11 @@ public class ProcessingContext implements ReadonlyProcessingContext {
     return this;
   }
 
+  public ProcessingContext onProcessedListener(Consumer<TypedRecord> onProcessedListener) {
+    this.onProcessedListener = onProcessedListener;
+    return this;
+  }
+
   public ActorControl getActor() {
     return actor;
   }
@@ -127,5 +134,9 @@ public class ProcessingContext implements ReadonlyProcessingContext {
 
   public BooleanSupplier getAbortCondition() {
     return abortCondition;
+  }
+
+  public Consumer<TypedRecord> getOnProcessedListener() {
+    return onProcessedListener;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorBuilder.java
@@ -24,6 +24,7 @@ import io.zeebe.util.sched.future.ActorFuture;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 public class StreamProcessorBuilder {
 
@@ -67,6 +68,11 @@ public class StreamProcessorBuilder {
 
   public StreamProcessorBuilder commandResponseWriter(CommandResponseWriter commandResponseWriter) {
     processingContext.commandResponseWriter(commandResponseWriter);
+    return this;
+  }
+
+  public StreamProcessorBuilder onProcessedListener(Consumer<TypedRecord> onProcessed) {
+    processingContext.onProcessedListener(onProcessed);
     return this;
   }
 

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -12,6 +12,7 @@ import static io.zeebe.engine.util.Records.workflowInstance;
 import io.zeebe.db.ZeebeDbFactory;
 import io.zeebe.engine.processor.CommandResponseWriter;
 import io.zeebe.engine.processor.StreamProcessor;
+import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.engine.processor.TypedRecordProcessorFactory;
 import io.zeebe.engine.processor.TypedRecordProcessors;
 import io.zeebe.engine.state.DefaultZeebeDbFactory;
@@ -30,6 +31,7 @@ import io.zeebe.util.sched.clock.ControlledActorClock;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.File;
 import java.io.IOException;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
@@ -146,6 +148,10 @@ public class StreamProcessorRule implements TestRule {
 
   public CommandResponseWriter getCommandResponseWriter() {
     return streams.getMockedResponseWriter();
+  }
+
+  public Consumer<TypedRecord> getProcessedListener() {
+    return streams.getMockedOnProcessedListener();
   }
 
   public ControlledActorClock getClock() {

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -29,6 +29,7 @@ import io.zeebe.engine.processor.ReadonlyProcessingContext;
 import io.zeebe.engine.processor.StreamProcessor;
 import io.zeebe.engine.processor.StreamProcessorLifecycleAware;
 import io.zeebe.engine.processor.TypedEventRegistry;
+import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.engine.processor.TypedRecordProcessorFactory;
 import io.zeebe.engine.processor.TypedRecordProcessors;
 import io.zeebe.engine.state.StateStorageFactory;
@@ -63,6 +64,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.junit.rules.TemporaryFolder;
@@ -86,6 +88,7 @@ public class TestStreams {
   private final ActorScheduler actorScheduler;
 
   private final CommandResponseWriter mockCommandResponseWriter;
+  private final Consumer<TypedRecord> mockOnProcessedListener;
   private final Map<String, LogContext> logContextMap = new HashMap<>();
   private final Map<String, ProcessorContext> streamContextMap = new HashMap<>();
 
@@ -110,10 +113,15 @@ public class TestStreams {
     when(mockCommandResponseWriter.valueWriter(any())).thenReturn(mockCommandResponseWriter);
 
     when(mockCommandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
+    mockOnProcessedListener = mock(Consumer.class);
   }
 
   public CommandResponseWriter getMockedResponseWriter() {
     return mockCommandResponseWriter;
+  }
+
+  public Consumer<TypedRecord> getMockedOnProcessedListener() {
+    return mockOnProcessedListener;
   }
 
   public LogStream createLogStream(final String name) {
@@ -275,6 +283,7 @@ public class TestStreams {
             .actorScheduler(actorScheduler)
             .serviceContainer(serviceContainer)
             .commandResponseWriter(mockCommandResponseWriter)
+            .onProcessedListener(mockOnProcessedListener)
             .streamProcessorFactory(
                 (context) -> {
                   final TypedRecordProcessors processors = factory.createProcessors(context);


### PR DESCRIPTION
## Description

* processor notifies backpressure when a command is processed instead of when a response is send

## Related issues
closes #3184 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
