### PR TITLE
fix(clients/go): create env wrapper with client instead of pkg

### DIFF
--- a/clients/go/zbc/envWrapper_test.go
+++ b/clients/go/zbc/envWrapper_test.go
@@ -29,7 +29,7 @@ func TestReadEnvWrapper(t *testing.T) {
 	_, _ = NewZBClientWithConfig(config)
 
 	// then
-	require.EqualValues(t, config.CaCertificatePath, "path")
+	require.EqualValues(t, "path", config.CaCertificatePath)
 }
 
 func TestUnsetEnv(t *testing.T) {


### PR DESCRIPTION
## Description

The env wrapper was being populated during package initialization which meant that changes to the environment between pkg initialization and client creation were being ignored. This PR fixes the issue by keeping the env wrapper creation at package init but allowing it to fall back to the process env


## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
