### PR TITLE
chore(engine): processor sends workflow completed response

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/CommandProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/CommandProcessor.java
@@ -17,11 +17,13 @@ import io.zeebe.protocol.record.intent.Intent;
  */
 public interface CommandProcessor<T extends UnifiedRecordValue> {
 
-  default void onCommand(TypedRecord<T> command, CommandControl<T> commandControl) {}
+  default boolean onCommand(TypedRecord<T> command, CommandControl<T> commandControl) {
+    return true;
+  }
 
-  default void onCommand(
+  default boolean onCommand(
       TypedRecord<T> command, CommandControl<T> commandControl, TypedStreamWriter streamWriter) {
-    onCommand(command, commandControl);
+    return onCommand(command, commandControl);
   }
 
   interface CommandControl<T> {

--- a/engine/src/main/java/io/zeebe/engine/processor/CommandProcessorImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/CommandProcessorImpl.java
@@ -44,9 +44,9 @@ public class CommandProcessorImpl<T extends UnifiedRecordValue>
       final TypedStreamWriter streamWriter) {
 
     entityKey = command.getKey();
-    wrappedProcessor.onCommand(command, this, streamWriter);
+    final boolean shouldRespond = wrappedProcessor.onCommand(command, this, streamWriter);
 
-    final boolean respond = command.hasRequestMetadata();
+    final boolean respond = shouldRespond && command.hasRequestMetadata();
 
     if (isAccepted) {
       streamWriter.appendFollowUpEvent(entityKey, newState, updatedValue);

--- a/engine/src/main/java/io/zeebe/engine/processor/NoopResponseWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/NoopResponseWriter.java
@@ -12,27 +12,29 @@ import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.Intent;
 
-public interface TypedResponseWriter {
+public final class NoopResponseWriter implements TypedResponseWriter {
 
-  void writeRejectionOnCommand(TypedRecord<?> command, RejectionType type, String reason);
+  @Override
+  public void writeRejectionOnCommand(TypedRecord<?> command, RejectionType type, String reason) {}
 
-  void writeEvent(TypedRecord<?> event);
+  @Override
+  public void writeEvent(TypedRecord<?> event) {}
 
-  void writeEventOnCommand(
-      long eventKey, Intent eventState, UnpackedObject eventValue, TypedRecord<?> command);
+  @Override
+  public void writeEventOnCommand(
+      long eventKey, Intent eventState, UnpackedObject eventValue, TypedRecord<?> command) {}
 
-  void writeResponse(
+  @Override
+  public void writeResponse(
       long eventKey,
       Intent eventState,
       UnpackedObject eventValue,
       ValueType valueType,
       long requestId,
-      int requestStreamId);
+      int requestStreamId) {}
 
-  /**
-   * Submits the response to transport.
-   *
-   * @return false in case of backpressure, else true
-   */
-  boolean flush();
+  @Override
+  public boolean flush() {
+    return false;
+  }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
@@ -363,23 +363,4 @@ public final class ReProcessingStateMachine {
       return 0;
     }
   }
-
-  private static final class NoopResponseWriter implements TypedResponseWriter {
-
-    @Override
-    public void writeRejectionOnCommand(
-        TypedRecord<?> command, RejectionType type, String reason) {}
-
-    @Override
-    public void writeEvent(TypedRecord<?> event) {}
-
-    @Override
-    public void writeEventOnCommand(
-        long eventKey, Intent eventState, UnpackedObject eventValue, TypedRecord<?> command) {}
-
-    @Override
-    public boolean flush() {
-      return false;
-    }
-  }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedEventRegistry.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedEventRegistry.java
@@ -22,6 +22,7 @@ import io.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.zeebe.protocol.impl.record.value.variable.VariableRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceResultRecord;
 import io.zeebe.protocol.record.ValueType;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -50,6 +51,7 @@ public class TypedEventRegistry {
     registry.put(ValueType.VARIABLE_DOCUMENT, VariableDocumentRecord.class);
     registry.put(ValueType.WORKFLOW_INSTANCE_CREATION, WorkflowInstanceCreationRecord.class);
     registry.put(ValueType.ERROR, ErrorRecord.class);
+    registry.put(ValueType.WORKFLOW_INSTANCE_RESULT, WorkflowInstanceResultRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedResponseWriterImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedResponseWriterImpl.java
@@ -80,6 +80,28 @@ public class TypedResponseWriterImpl implements TypedResponseWriter, SideEffectP
         eventValue);
   }
 
+  @Override
+  public void writeResponse(
+      long eventKey,
+      Intent eventState,
+      UnpackedObject eventValue,
+      ValueType valueType,
+      long requestId,
+      int requestStreamId) {
+    stringWrapper.wrap(0, 0);
+
+    stage(
+        RecordType.EVENT,
+        eventState,
+        eventKey,
+        RejectionType.NULL_VAL,
+        stringWrapper,
+        valueType,
+        requestId,
+        requestStreamId,
+        eventValue);
+  }
+
   public boolean flush() {
     if (isResponseStaged) {
       return writer.tryWriteResponse(requestStreamId, requestId);

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/BpmnStepContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/BpmnStepContext.java
@@ -8,6 +8,7 @@
 package io.zeebe.engine.processor.workflow;
 
 import io.zeebe.engine.processor.TypedCommandWriter;
+import io.zeebe.engine.processor.TypedResponseWriter;
 import io.zeebe.engine.processor.TypedStreamWriter;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableFlowElement;
 import io.zeebe.engine.state.deployment.WorkflowState;
@@ -73,6 +74,10 @@ public class BpmnStepContext<T extends ExecutableFlowElement> {
   public void setStreamWriter(final TypedStreamWriter streamWriter) {
     this.eventOutput.setStreamWriter(streamWriter);
     this.commandWriter = streamWriter;
+  }
+
+  public void setResponseWriter(final TypedResponseWriter responseWriter) {
+    this.eventOutput.setResponseWriter(responseWriter);
   }
 
   public TypedCommandWriter getCommandWriter() {

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/BpmnStepProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/BpmnStepProcessor.java
@@ -57,6 +57,7 @@ public class BpmnStepProcessor implements TypedRecordProcessor<WorkflowInstanceR
         record.getValue(),
         (WorkflowInstanceIntent) record.getIntent(),
         streamWriter,
+        responseWriter,
         sideEffect);
   }
 
@@ -65,8 +66,9 @@ public class BpmnStepProcessor implements TypedRecordProcessor<WorkflowInstanceR
       WorkflowInstanceRecord recordValue,
       WorkflowInstanceIntent intent,
       TypedStreamWriter streamWriter,
+      TypedResponseWriter responseWriter,
       Consumer<SideEffectProducer> sideEffect) {
-    populateEventContext(key, recordValue, intent, streamWriter, sideEffect);
+    populateEventContext(key, recordValue, intent, streamWriter, responseWriter, sideEffect);
     stepHandlers.handle(context);
   }
 
@@ -75,10 +77,12 @@ public class BpmnStepProcessor implements TypedRecordProcessor<WorkflowInstanceR
       WorkflowInstanceRecord recordValue,
       WorkflowInstanceIntent intent,
       TypedStreamWriter streamWriter,
+      TypedResponseWriter responseWriter,
       Consumer<SideEffectProducer> sideEffect) {
 
     context.init(key, recordValue, intent);
     context.setStreamWriter(streamWriter);
+    context.setResponseWriter(responseWriter);
 
     context.getSideEffect().clear();
     sideEffect.accept(context.getSideEffect());

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/EventOutput.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/EventOutput.java
@@ -8,6 +8,7 @@
 package io.zeebe.engine.processor.workflow;
 
 import io.zeebe.engine.processor.KeyGenerator;
+import io.zeebe.engine.processor.TypedResponseWriter;
 import io.zeebe.engine.processor.TypedStreamWriter;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableFlowElement;
 import io.zeebe.engine.state.instance.StoredRecord.Purpose;
@@ -22,6 +23,7 @@ public class EventOutput {
   private final KeyGenerator keyGenerator;
 
   private TypedStreamWriter streamWriter;
+  private TypedResponseWriter responseWriter;
 
   public EventOutput(final WorkflowEngineState materializedState, final KeyGenerator keyGenerator) {
     this.materializedState = materializedState;
@@ -103,5 +105,13 @@ public class EventOutput {
   public void storeFailedRecord(
       long key, WorkflowInstanceRecord recordValue, WorkflowInstanceIntent intent) {
     materializedState.storeFailedRecord(key, recordValue, intent);
+  }
+
+  public TypedResponseWriter getResponseWriter() {
+    return responseWriter;
+  }
+
+  public void setResponseWriter(TypedResponseWriter responseWriter) {
+    this.responseWriter = responseWriter;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/WorkflowEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/WorkflowEventProcessors.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.processor.workflow;
 import io.zeebe.engine.processor.KeyGenerator;
 import io.zeebe.engine.processor.TypedRecordProcessors;
 import io.zeebe.engine.processor.workflow.instance.CreateWorkflowInstanceProcessor;
+import io.zeebe.engine.processor.workflow.instance.CreateWorkflowInstanceWithResultProcessor;
 import io.zeebe.engine.processor.workflow.message.CloseWorkflowInstanceSubscription;
 import io.zeebe.engine.processor.workflow.message.CorrelateWorkflowInstanceSubscription;
 import io.zeebe.engine.processor.workflow.message.OpenWorkflowInstanceSubscriptionProcessor;
@@ -153,10 +154,17 @@ public class WorkflowEventProcessors {
     final VariablesState variablesState = elementInstanceState.getVariablesState();
     final KeyGenerator keyGenerator = zeebeState.getKeyGenerator();
 
+    final CreateWorkflowInstanceProcessor createProcessor =
+        new CreateWorkflowInstanceProcessor(
+            workflowState, elementInstanceState, variablesState, keyGenerator);
     typedRecordProcessors.onCommand(
         ValueType.WORKFLOW_INSTANCE_CREATION,
         WorkflowInstanceCreationIntent.CREATE,
-        new CreateWorkflowInstanceProcessor(
-            workflowState, elementInstanceState, variablesState, keyGenerator));
+        createProcessor);
+
+    typedRecordProcessors.onCommand(
+        ValueType.WORKFLOW_INSTANCE_CREATION,
+        WorkflowInstanceCreationIntent.CREATE_WITH_AWAITING_RESULT,
+        new CreateWorkflowInstanceWithResultProcessor(createProcessor, elementInstanceState));
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/incident/CreateIncidentProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/incident/CreateIncidentProcessor.java
@@ -34,7 +34,7 @@ public final class CreateIncidentProcessor implements CommandProcessor<IncidentR
   }
 
   @Override
-  public void onCommand(
+  public boolean onCommand(
       TypedRecord<IncidentRecord> command, CommandControl<IncidentRecord> commandControl) {
     final IncidentRecord incidentEvent = command.getValue();
 
@@ -44,6 +44,8 @@ public final class CreateIncidentProcessor implements CommandProcessor<IncidentR
       final long incidentKey = commandControl.accept(IncidentIntent.CREATED, incidentEvent);
       zeebeState.getIncidentState().createIncident(incidentKey, incidentEvent);
     }
+
+    return true;
   }
 
   public boolean rejectIncidentCreation(

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/incident/ResolveIncidentProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.engine.processor.workflow.incident;
 
+import io.zeebe.engine.processor.NoopResponseWriter;
 import io.zeebe.engine.processor.SideEffectProducer;
 import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.engine.processor.TypedRecordProcessor;
@@ -32,6 +33,7 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
   private final BpmnStepProcessor stepProcessor;
   private final ZeebeState zeebeState;
   private final SideEffectQueue queue = new SideEffectQueue();
+  private final TypedResponseWriter noopResponseWriter = new NoopResponseWriter();
 
   public ResolveIncidentProcessor(BpmnStepProcessor stepProcessor, ZeebeState zeebeState) {
     this.stepProcessor = stepProcessor;
@@ -106,6 +108,7 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
           failedRecord.getValue(),
           failedRecord.getState(),
           streamWriter,
+          noopResponseWriter,
           queue::add);
 
       sideEffect.accept(queue);

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/instance/CreateWorkflowInstanceWithResultProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/instance/CreateWorkflowInstanceWithResultProcessor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.instance;
+
+import io.zeebe.engine.processor.CommandProcessor;
+import io.zeebe.engine.processor.TypedRecord;
+import io.zeebe.engine.processor.TypedStreamWriter;
+import io.zeebe.engine.state.instance.AwaitWorkflowInstanceResultMetadata;
+import io.zeebe.engine.state.instance.ElementInstanceState;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
+import io.zeebe.protocol.record.RejectionType;
+import io.zeebe.protocol.record.intent.Intent;
+
+public class CreateWorkflowInstanceWithResultProcessor
+    implements CommandProcessor<WorkflowInstanceCreationRecord> {
+
+  private final CreateWorkflowInstanceProcessor createProcessor;
+  private final ElementInstanceState elementInstanceState;
+  private final AwaitWorkflowInstanceResultMetadata awaitResultMetadata =
+      new AwaitWorkflowInstanceResultMetadata();
+
+  private final CommandControlWithAwaitResult wrappedController =
+      new CommandControlWithAwaitResult();
+
+  private boolean shouldRespond;
+
+  public CreateWorkflowInstanceWithResultProcessor(
+      CreateWorkflowInstanceProcessor createProcessor, ElementInstanceState elementInstanceState) {
+    this.createProcessor = createProcessor;
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public boolean onCommand(
+      TypedRecord<WorkflowInstanceCreationRecord> command,
+      CommandControl<WorkflowInstanceCreationRecord> controller,
+      TypedStreamWriter streamWriter) {
+    wrappedController.setCommand(command).setController(controller);
+    createProcessor.onCommand(command, wrappedController, streamWriter);
+    return shouldRespond;
+  }
+
+  private class CommandControlWithAwaitResult
+      implements CommandControl<WorkflowInstanceCreationRecord> {
+    TypedRecord<WorkflowInstanceCreationRecord> command;
+    CommandControl<WorkflowInstanceCreationRecord> controller;
+
+    public CommandControlWithAwaitResult setCommand(
+        TypedRecord<WorkflowInstanceCreationRecord> command) {
+      this.command = command;
+      return this;
+    }
+
+    public CommandControlWithAwaitResult setController(
+        CommandControl<WorkflowInstanceCreationRecord> controller) {
+      this.controller = controller;
+      return this;
+    }
+
+    @Override
+    public long accept(Intent newState, WorkflowInstanceCreationRecord updatedValue) {
+      shouldRespond = false;
+      awaitResultMetadata
+          .setRequestId(command.getRequestId())
+          .setRequestStreamId(command.getRequestStreamId());
+
+      elementInstanceState.setAwaitResultRequestMetadata(
+          updatedValue.getWorkflowInstanceKey(), awaitResultMetadata);
+      return controller.accept(newState, updatedValue);
+    }
+
+    @Override
+    public void reject(RejectionType type, String reason) {
+      shouldRespond = true;
+      controller.reject(type, reason);
+    }
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/CancelProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/CancelProcessor.java
@@ -25,7 +25,8 @@ public class CancelProcessor implements CommandProcessor<JobRecord> {
   }
 
   @Override
-  public void onCommand(TypedRecord<JobRecord> command, CommandControl<JobRecord> commandControl) {
+  public boolean onCommand(
+      TypedRecord<JobRecord> command, CommandControl<JobRecord> commandControl) {
     final long jobKey = command.getKey();
     final JobRecord job = state.getJob(jobKey);
     if (job != null) {
@@ -34,5 +35,7 @@ public class CancelProcessor implements CommandProcessor<JobRecord> {
     } else {
       commandControl.reject(RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, jobKey));
     }
+
+    return true;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/CompleteProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/CompleteProcessor.java
@@ -28,7 +28,8 @@ public class CompleteProcessor implements CommandProcessor<JobRecord> {
   }
 
   @Override
-  public void onCommand(TypedRecord<JobRecord> command, CommandControl<JobRecord> commandControl) {
+  public boolean onCommand(
+      TypedRecord<JobRecord> command, CommandControl<JobRecord> commandControl) {
     final long jobKey = command.getKey();
     final JobState.State jobState = state.getState(jobKey);
 
@@ -43,5 +44,6 @@ public class CompleteProcessor implements CommandProcessor<JobRecord> {
       state.complete(jobKey, job);
       commandControl.accept(JobIntent.COMPLETED, job);
     }
+    return true;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/CreateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/CreateProcessor.java
@@ -22,8 +22,10 @@ public class CreateProcessor implements CommandProcessor<JobRecord> {
   }
 
   @Override
-  public void onCommand(TypedRecord<JobRecord> command, CommandControl<JobRecord> commandControl) {
+  public boolean onCommand(
+      TypedRecord<JobRecord> command, CommandControl<JobRecord> commandControl) {
     final long key = commandControl.accept(JobIntent.CREATED, command.getValue());
     state.create(key, command.getValue());
+    return true;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/FailProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/FailProcessor.java
@@ -25,7 +25,8 @@ public class FailProcessor implements CommandProcessor<JobRecord> {
   }
 
   @Override
-  public void onCommand(TypedRecord<JobRecord> command, CommandControl<JobRecord> commandControl) {
+  public boolean onCommand(
+      TypedRecord<JobRecord> command, CommandControl<JobRecord> commandControl) {
     final long key = command.getKey();
     final JobState.State jobState = state.getState(key);
 
@@ -48,5 +49,6 @@ public class FailProcessor implements CommandProcessor<JobRecord> {
       commandControl.reject(
           RejectionType.NOT_FOUND, String.format(NOT_ACTIVATED_JOB_MESSAGE, key, "does not exist"));
     }
+    return true;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/TimeOutProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/TimeOutProcessor.java
@@ -25,7 +25,8 @@ public class TimeOutProcessor implements CommandProcessor<JobRecord> {
   }
 
   @Override
-  public void onCommand(TypedRecord<JobRecord> command, CommandControl<JobRecord> commandControl) {
+  public boolean onCommand(
+      TypedRecord<JobRecord> command, CommandControl<JobRecord> commandControl) {
     final long jobKey = command.getKey();
     final JobState.State jobState = state.getState(jobKey);
 
@@ -50,5 +51,6 @@ public class TimeOutProcessor implements CommandProcessor<JobRecord> {
       commandControl.reject(
           RejectionType.NOT_FOUND, String.format(NOT_ACTIVATED_JOB_MESSAGE, jobKey, textState));
     }
+    return true;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/UpdateRetriesProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/UpdateRetriesProcessor.java
@@ -29,7 +29,8 @@ public class UpdateRetriesProcessor implements CommandProcessor<JobRecord> {
   }
 
   @Override
-  public void onCommand(TypedRecord<JobRecord> command, CommandControl<JobRecord> commandControl) {
+  public boolean onCommand(
+      TypedRecord<JobRecord> command, CommandControl<JobRecord> commandControl) {
     final long key = command.getKey();
     final int retries = command.getValue().getRetries();
 
@@ -44,5 +45,6 @@ public class UpdateRetriesProcessor implements CommandProcessor<JobRecord> {
       commandControl.reject(
           RejectionType.INVALID_ARGUMENT, String.format(NEGATIVE_RETRIES_MESSAGE, key, retries));
     }
+    return true;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/variable/UpdateVariableDocumentProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/variable/UpdateVariableDocumentProcessor.java
@@ -31,7 +31,7 @@ public class UpdateVariableDocumentProcessor implements CommandProcessor<Variabl
   }
 
   @Override
-  public void onCommand(
+  public boolean onCommand(
       TypedRecord<VariableDocumentRecord> command,
       CommandControl<VariableDocumentRecord> controller) {
     final VariableDocumentRecord record = command.getValue();
@@ -43,8 +43,7 @@ public class UpdateVariableDocumentProcessor implements CommandProcessor<Variabl
           String.format(
               "Expected to update variables for element with key '%d', but no such element was found",
               record.getScopeKey()));
-
-      return;
+      return true;
     }
 
     final long workflowKey = scope.getValue().getWorkflowKey();
@@ -52,6 +51,7 @@ public class UpdateVariableDocumentProcessor implements CommandProcessor<Variabl
     if (mergeDocument(record, workflowKey, controller)) {
       controller.accept(VariableDocumentIntent.UPDATED, record);
     }
+    return true;
   }
 
   private boolean mergeDocument(

--- a/engine/src/main/java/io/zeebe/engine/state/ZbColumnFamilies.java
+++ b/engine/src/main/java/io/zeebe/engine/state/ZbColumnFamilies.java
@@ -77,5 +77,7 @@ public enum ZbColumnFamilies {
 
   BLACKLIST,
 
-  EXPORTER
+  EXPORTER,
+
+  AWAIT_WORKLOW_RESULT
 }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/AwaitWorkflowInstanceResultMetadata.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/AwaitWorkflowInstanceResultMetadata.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.instance;
+
+import static io.zeebe.db.impl.ZeebeDbConstants.ZB_DB_BYTE_ORDER;
+
+import io.zeebe.db.DbValue;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class AwaitWorkflowInstanceResultMetadata implements DbValue {
+
+  private long requestId;
+  private int requestStreamId;
+
+  public AwaitWorkflowInstanceResultMetadata() {}
+
+  public AwaitWorkflowInstanceResultMetadata(long requestId, int requestStreamId) {
+    this.requestId = requestId;
+    this.requestStreamId = requestStreamId;
+  }
+
+  public long getRequestId() {
+    return requestId;
+  }
+
+  public AwaitWorkflowInstanceResultMetadata setRequestId(long requestId) {
+    this.requestId = requestId;
+    return this;
+  }
+
+  public int getRequestStreamId() {
+    return requestStreamId;
+  }
+
+  public AwaitWorkflowInstanceResultMetadata setRequestStreamId(int requestStreamId) {
+    this.requestStreamId = requestStreamId;
+    return this;
+  }
+
+  @Override
+  public void wrap(DirectBuffer buffer, int offset, int length) {
+    final int startOffset = offset;
+    requestId = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
+    offset += Long.BYTES;
+
+    requestStreamId = buffer.getInt(offset, ZB_DB_BYTE_ORDER);
+    offset += Integer.BYTES;
+
+    assert (offset - startOffset) == length : "End offset differs from length";
+  }
+
+  @Override
+  public int getLength() {
+    return Long.BYTES + Integer.BYTES;
+  }
+
+  @Override
+  public void write(MutableDirectBuffer buffer, int offset) {
+    final int startOffset = offset;
+
+    buffer.putLong(offset, requestId, ZB_DB_BYTE_ORDER);
+    offset += Long.BYTES;
+
+    buffer.putInt(offset, requestStreamId, ZB_DB_BYTE_ORDER);
+    offset += Integer.BYTES;
+
+    assert (offset - startOffset) == getLength() : "End offset differs from getLength()";
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/CreateWorkflowInstanceWithResultTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/CreateWorkflowInstanceWithResultTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.instance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import io.zeebe.engine.processor.CommandResponseWriter;
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceResultRecord;
+import io.zeebe.protocol.record.RejectionType;
+import io.zeebe.protocol.record.intent.WorkflowInstanceResultIntent;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+public class CreateWorkflowInstanceWithResultTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final BpmnModelInstance WORKFLOW =
+      Bpmn.createExecutableProcess("WORKFLOW").startEvent().endEvent().done();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private WorkflowInstanceResultRecord response;
+
+  @BeforeClass
+  public static void init() {
+    ENGINE.deployment().withXmlResource(WORKFLOW).deploy();
+  }
+
+  @Test
+  public void shouldSendResultAfterCompletion() {
+    // given
+    final CommandResponseWriter mockCommandResponseWriter = ENGINE.getCommandResponseWriter();
+    Mockito.clearInvocations(mockCommandResponseWriter);
+    interceptResponseWriter(mockCommandResponseWriter);
+
+    final long workflowInstanceKey =
+        ENGINE
+            .workflowInstance()
+            .ofBpmnProcessId("WORKFLOW")
+            .withVariables(Map.of("x", "foo"))
+            .withResult()
+            .withRequestId(1L)
+            .withRequestStreamId(1)
+            .create();
+
+    // then
+    verify(mockCommandResponseWriter, timeout(1000).times(1))
+        .intent(WorkflowInstanceResultIntent.COMPLETED);
+    verify(mockCommandResponseWriter, timeout(1000).times(1)).tryWriteResponse(1, 1L);
+    assertThat(response.getVariables()).containsExactly(Map.entry("x", "foo"));
+    assertThat(response.getWorkflowInstanceKey()).isEqualTo(workflowInstanceKey);
+    assertThat(response.getBpmnProcessId()).isEqualTo("WORKFLOW");
+  }
+
+  @Test
+  public void shouldSendRejectionImmediately() {
+    Mockito.clearInvocations(ENGINE.getCommandResponseWriter());
+    // when
+    ENGINE
+        .workflowInstance()
+        .ofBpmnProcessId("INVALID-WORKFLOW")
+        .withResult()
+        .withRequestId(3L)
+        .withRequestStreamId(3)
+        .asyncCreate();
+
+    // then
+
+    verify(ENGINE.getCommandResponseWriter(), timeout(1000).times(1))
+        .rejectionType(RejectionType.NOT_FOUND);
+    verify(ENGINE.getCommandResponseWriter(), timeout(1000).times(1)).tryWriteResponse(3, 3);
+  }
+
+  private void interceptResponseWriter(CommandResponseWriter mockCommandResponseWriter) {
+    doAnswer(
+            (Answer<CommandResponseWriter>)
+                (invocation -> {
+                  final Object[] arguments = invocation.getArguments();
+                  if (arguments != null
+                      && arguments.length == 1
+                      && arguments[0] != null
+                      && arguments[0] instanceof WorkflowInstanceResultRecord) {
+                    response = (WorkflowInstanceResultRecord) arguments[0];
+                  }
+                  return mockCommandResponseWriter;
+                }))
+        .when(mockCommandResponseWriter)
+        .valueWriter(any());
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -425,6 +425,26 @@ public class ElementInstanceStateTest {
     Assertions.assertThat(elementInstanceState.isEmpty()).isTrue();
   }
 
+  @Test
+  public void shouldUpdateAwaitResultMetadata() {
+    final long key = 10L;
+    final int streamId = 2;
+    final long requestId = 10000L;
+
+    // when
+    elementInstanceState.setAwaitResultRequestMetadata(
+        key,
+        new AwaitWorkflowInstanceResultMetadata()
+            .setRequestStreamId(streamId)
+            .setRequestId(requestId));
+    final AwaitWorkflowInstanceResultMetadata metadata =
+        elementInstanceState.getAwaitResultRequestMetadata(key);
+
+    // then
+    assertThat(metadata.getRequestId()).isEqualTo(requestId);
+    assertThat(metadata.getRequestStreamId()).isEqualTo(streamId);
+  }
+
   private void assertElementInstance(ElementInstance elementInstance, int childCount) {
     Assertions.assertThat(elementInstance.getKey()).isEqualTo(100);
     Assertions.assertThat(elementInstance.getState())

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -11,6 +11,7 @@ import static io.zeebe.test.util.record.RecordingExporter.jobRecords;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.zeebe.engine.processor.CommandResponseWriter;
 import io.zeebe.engine.processor.ReadonlyProcessingContext;
 import io.zeebe.engine.processor.RecordValues;
 import io.zeebe.engine.processor.StreamProcessorLifecycleAware;
@@ -247,6 +248,10 @@ public final class EngineRule extends ExternalResource {
 
   public void writeRecords(final RecordToWrite... records) {
     environmentRule.writeBatch(records);
+  }
+
+  public CommandResponseWriter getCommandResponseWriter() {
+    return environmentRule.getCommandResponseWriter();
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -262,6 +262,18 @@ public class StreamProcessorRule implements TestRule {
         .write();
   }
 
+  public long writeCommand(
+      int requestStreamId, long requestId, final Intent intent, final UnpackedObject value) {
+    return streams
+        .newRecord(getLogName(startPartitionId))
+        .recordType(RecordType.COMMAND)
+        .requestId(requestId)
+        .requestStreamId(requestStreamId)
+        .intent(intent)
+        .event(value)
+        .write();
+  }
+
   private static String getLogName(final int partitionId) {
     return STREAM_NAME + partitionId;
   }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/workflowinstance/WorkflowInstanceResultRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/workflowinstance/WorkflowInstanceResultRecord.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.protocol.impl.record.value.workflowinstance;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.zeebe.msgpack.property.DocumentProperty;
+import io.zeebe.msgpack.property.IntegerProperty;
+import io.zeebe.msgpack.property.LongProperty;
+import io.zeebe.msgpack.property.StringProperty;
+import io.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.zeebe.protocol.record.value.WorkflowInstanceResultRecordValue;
+import io.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+
+public class WorkflowInstanceResultRecord extends UnifiedRecordValue
+    implements WorkflowInstanceResultRecordValue {
+
+  private final StringProperty bpmnProcessIdProperty = new StringProperty("bpmnProcessId", "");
+  private final LongProperty workflowKeyProperty = new LongProperty("workflowKey", -1);
+  private final IntegerProperty versionProperty = new IntegerProperty("version", -1);
+  private final DocumentProperty variablesProperty = new DocumentProperty("variables");
+  private final LongProperty workflowInstanceKeyProperty =
+      new LongProperty("workflowInstanceKey", -1);
+
+  public WorkflowInstanceResultRecord() {
+    this.declareProperty(bpmnProcessIdProperty)
+        .declareProperty(workflowKeyProperty)
+        .declareProperty(workflowInstanceKeyProperty)
+        .declareProperty(versionProperty)
+        .declareProperty(variablesProperty);
+  }
+
+  public String getBpmnProcessId() {
+    return BufferUtil.bufferAsString(bpmnProcessIdProperty.getValue());
+  }
+
+  public WorkflowInstanceResultRecord setBpmnProcessId(String bpmnProcessId) {
+    this.bpmnProcessIdProperty.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public WorkflowInstanceResultRecord setBpmnProcessId(DirectBuffer bpmnProcessId) {
+    this.bpmnProcessIdProperty.setValue(bpmnProcessId);
+    return this;
+  }
+
+  public int getVersion() {
+    return versionProperty.getValue();
+  }
+
+  public WorkflowInstanceResultRecord setVersion(int version) {
+    this.versionProperty.setValue(version);
+    return this;
+  }
+
+  public long getWorkflowKey() {
+    return workflowKeyProperty.getValue();
+  }
+
+  public WorkflowInstanceResultRecord setWorkflowKey(long key) {
+    this.workflowKeyProperty.setValue(key);
+    return this;
+  }
+
+  @Override
+  public long getWorkflowInstanceKey() {
+    return workflowInstanceKeyProperty.getValue();
+  }
+
+  public WorkflowInstanceResultRecord setWorkflowInstanceKey(long instanceKey) {
+    this.workflowInstanceKeyProperty.setValue(instanceKey);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBpmnProcessIdBuffer() {
+    return bpmnProcessIdProperty.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variablesProperty.getValue();
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return MsgPackConverter.convertToMap(variablesProperty.getValue());
+  }
+
+  public WorkflowInstanceResultRecord setVariables(DirectBuffer variables) {
+    variablesProperty.setValue(variables);
+    return this;
+  }
+}

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/Intent.java
@@ -86,6 +86,8 @@ public interface Intent {
         return WorkflowInstanceCreationIntent.from(intent);
       case ERROR:
         return ErrorIntent.from(intent);
+      case WORKFLOW_INSTANCE_RESULT:
+        return WorkflowInstanceResultIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -129,6 +131,8 @@ public interface Intent {
         return WorkflowInstanceCreationIntent.valueOf(intent);
       case ERROR:
         return ErrorIntent.valueOf(intent);
+      case WORKFLOW_INSTANCE_RESULT:
+        return WorkflowInstanceResultIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/WorkflowInstanceResultIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/WorkflowInstanceResultIntent.java
@@ -15,19 +15,17 @@
  */
 package io.zeebe.protocol.record.intent;
 
-public enum WorkflowInstanceCreationIntent implements Intent, WorkflowInstanceRelatedIntent {
-  CREATE(0, false),
-  CREATED(1, true),
-  CREATE_WITH_AWAITING_RESULT(2, false);
+public enum WorkflowInstanceResultIntent implements Intent, WorkflowInstanceRelatedIntent {
+  COMPLETED(0, false);
 
   private final short value;
   private final boolean shouldBlacklist;
 
-  WorkflowInstanceCreationIntent(int value, boolean shouldBlacklist) {
+  WorkflowInstanceResultIntent(int value, boolean shouldBlacklist) {
     this((short) value, shouldBlacklist);
   }
 
-  WorkflowInstanceCreationIntent(short value, boolean shouldBlacklist) {
+  WorkflowInstanceResultIntent(short value, boolean shouldBlacklist) {
     this.value = value;
     this.shouldBlacklist = shouldBlacklist;
   }
@@ -40,11 +38,7 @@ public enum WorkflowInstanceCreationIntent implements Intent, WorkflowInstanceRe
   public static Intent from(short value) {
     switch (value) {
       case 0:
-        return CREATE;
-      case 1:
-        return CREATED;
-      case 2:
-        return CREATE_WITH_AWAITING_RESULT;
+        return COMPLETED;
       default:
         return UNKNOWN;
     }

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/WorkflowInstanceResultRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/WorkflowInstanceResultRecordValue.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.protocol.record.value;
+
+import io.zeebe.protocol.record.RecordValueWithVariables;
+import io.zeebe.protocol.record.intent.WorkflowInstanceResultIntent;
+
+/**
+ * Represents a workflow instance related command or event.
+ *
+ * <p>See {@link WorkflowInstanceResultIntent} for intents.
+ */
+public interface WorkflowInstanceResultRecordValue
+    extends RecordValueWithVariables, WorkflowInstanceRelated {
+  /** @return the BPMN process id this workflow instance belongs to. */
+  String getBpmnProcessId();
+
+  /** @return the version of the deployed workflow this instance belongs to. */
+  int getVersion();
+
+  /** @return the key of the deployed workflow this instance belongs to. */
+  long getWorkflowKey();
+
+  /** @return the key of the workflow instance */
+  long getWorkflowInstanceKey();
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -35,6 +35,7 @@
       <validValue name="VARIABLE_DOCUMENT">18</validValue>
       <validValue name="WORKFLOW_INSTANCE_CREATION">19</validValue>
       <validValue name="ERROR">20</validValue>
+      <validValue name="WORKFLOW_INSTANCE_RESULT">21</validValue>
     </enum>
 
     <enum name="RecordType" encodingType="uint8">

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
@@ -35,6 +35,7 @@ import io.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.zeebe.protocol.record.value.VariableRecordValue;
 import io.zeebe.protocol.record.value.WorkflowInstanceCreationRecordValue;
 import io.zeebe.protocol.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.protocol.record.value.WorkflowInstanceResultRecordValue;
 import io.zeebe.protocol.record.value.WorkflowInstanceSubscriptionRecordValue;
 import java.time.Duration;
 import java.util.Iterator;
@@ -210,6 +211,11 @@ public class RecordingExporter implements Exporter {
   public static WorkflowInstanceCreationRecordStream workflowInstanceCreationRecords() {
     return new WorkflowInstanceCreationRecordStream(
         records(ValueType.WORKFLOW_INSTANCE_CREATION, WorkflowInstanceCreationRecordValue.class));
+  }
+
+  public static WorkflowInstanceResultRecordStream workflowInstanceResultRecords() {
+    return new WorkflowInstanceResultRecordStream(
+        records(ValueType.WORKFLOW_INSTANCE_RESULT, WorkflowInstanceResultRecordValue.class));
   }
 
   public static class RecordIterator implements Iterator<Record<?>> {

--- a/test-util/src/main/java/io/zeebe/test/util/record/WorkflowInstanceResultRecordStream.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/WorkflowInstanceResultRecordStream.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.test.util.record;
+
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.value.WorkflowInstanceResultRecordValue;
+import java.util.stream.Stream;
+
+public class WorkflowInstanceResultRecordStream
+    extends ExporterRecordStream<
+        WorkflowInstanceResultRecordValue, WorkflowInstanceResultRecordStream> {
+
+  public WorkflowInstanceResultRecordStream(
+      Stream<Record<WorkflowInstanceResultRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected WorkflowInstanceResultRecordStream supply(
+      Stream<Record<WorkflowInstanceResultRecordValue>> wrappedStream) {
+    return new WorkflowInstanceResultRecordStream(wrappedStream);
+  }
+
+  public WorkflowInstanceResultRecordStream withBpmnProcessId(final String bpmnProcessId) {
+    return valueFilter(v -> bpmnProcessId.equals(v.getBpmnProcessId()));
+  }
+
+  public WorkflowInstanceResultRecordStream withWorkflowInstanceKey(
+      final long workflowInstanceKey) {
+    return valueFilter(v -> workflowInstanceKey == v.getWorkflowInstanceKey());
+  }
+}


### PR DESCRIPTION
## Description

* Added new command `CREATE_WITH_AWAIT_RESULT`
* Element completed handler writes a new follow up event `WorkflowInstanceResult.COMPLETED` and writes the response with all variables. 

## Related issues

closes #3194 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
