### PR TITLE
chore(dockerfile): remove max ram setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV ZB_HOME=/usr/local/zeebe \
     ZEEBE_GATEWAY_HOST=0.0.0.0 \
     ZEEBE_STANDALONE_GATEWAY=false
 ENV PATH "${ZB_HOME}/bin:${PATH}"
-ENV JAVA_OPTS -XX:MaxRAMPercentage=80.0
 
 ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini /bin/tini
 RUN chmod +x /bin/tini


### PR DESCRIPTION
We set the `-XX:MaxRAMPercentage=80.0` which seems to cause some issues on our current cluster tests. The default value is 25, which should fine for now.