### PR TITLE
chore(exporters): do not catch flush exception on export

### DIFF
--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
@@ -297,7 +297,7 @@ public class ElasticsearchExporterTest {
   }
 
   @Test
-  public void shouldHandleExceptionOnFlush() {
+  public void shouldNotHandleFlushException() {
     // given
     when(esClient.shouldFlush()).thenReturn(true);
     when(esClient.flush()).thenThrow(new ElasticsearchExporterException("expected"));
@@ -305,11 +305,12 @@ public class ElasticsearchExporterTest {
     createAndOpenExporter();
 
     // when
-    testHarness.export();
-    testHarness.export();
+    assertThatThrownBy(() -> testHarness.export())
+        .isInstanceOf(ElasticsearchExporterException.class)
+        .withFailMessage("expected");
 
     // then
-    verify(esClient, times(2)).flush();
+    verify(esClient, times(1)).flush();
   }
 
   private ElasticsearchExporter createExporter() {


### PR DESCRIPTION
 * on export bulk flush could fail but the exception was just logged the
 exporter director then continues with next records, which means records are pilled up in the bulk request

We don't catch the flush exception in the export anymore such that the director can handle this case.