### PR TITLE
chore(gateway): fix long polling flaky tests

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/zeebe/gateway/Gateway.java
@@ -89,8 +89,7 @@ public class Gateway {
 
     brokerClient = buildBrokerClient();
 
-    final LongPollingActivateJobsHandler longPollingHandler =
-        LongPollingActivateJobsHandler.newBuilder().setBrokerClient(brokerClient).build();
+    final LongPollingActivateJobsHandler longPollingHandler = buildLongPollingHandler(brokerClient);
     actorScheduler.submitActor(longPollingHandler);
 
     final EndpointManager endpointManager = new EndpointManager(brokerClient, longPollingHandler);
@@ -152,6 +151,10 @@ public class Gateway {
 
   protected BrokerClient buildBrokerClient() {
     return brokerClientFactory.apply(gatewayCfg);
+  }
+
+  protected LongPollingActivateJobsHandler buildLongPollingHandler(BrokerClient brokerClient) {
+    return LongPollingActivateJobsHandler.newBuilder().setBrokerClient(brokerClient).build();
   }
 
   public void listenAndServe() throws InterruptedException, IOException {

--- a/gateway/src/test/java/io/zeebe/gateway/api/deployment/DeployWorkflowStub.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/deployment/DeployWorkflowStub.java
@@ -7,8 +7,8 @@
  */
 package io.zeebe.gateway.api.deployment;
 
-import io.zeebe.gateway.api.util.StubbedGateway;
-import io.zeebe.gateway.api.util.StubbedGateway.RequestStub;
+import io.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.zeebe.gateway.impl.broker.request.BrokerDeployWorkflowRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
@@ -21,7 +21,7 @@ public class DeployWorkflowStub
   private static final int WORKFLOW_VERSION = 789;
 
   @Override
-  public void registerWith(StubbedGateway gateway) {
+  public void registerWith(StubbedBrokerClient gateway) {
     gateway.registerHandler(BrokerDeployWorkflowRequest.class, this);
   }
 

--- a/gateway/src/test/java/io/zeebe/gateway/api/deployment/DeployWorkflowTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/deployment/DeployWorkflowTest.java
@@ -29,7 +29,7 @@ public class DeployWorkflowTest extends GatewayTest {
   public void shouldMapRequestAndResponse() {
     // given
     final DeployWorkflowStub stub = new DeployWorkflowStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final String bpmnName = "testProcess.bpmn";
     final String yamlName = "testProcess.yaml";
@@ -67,7 +67,7 @@ public class DeployWorkflowTest extends GatewayTest {
     assertThat(workflow.getWorkflowKey()).isEqualTo(stub.getWorkflowKey());
     assertThat(workflow.getVersion()).isEqualTo(stub.getWorkflowVersion());
 
-    final BrokerDeployWorkflowRequest brokerRequest = gateway.getSingleBrokerRequest();
+    final BrokerDeployWorkflowRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getIntent()).isEqualTo(DeploymentIntent.CREATE);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.DEPLOYMENT);
   }
@@ -76,7 +76,7 @@ public class DeployWorkflowTest extends GatewayTest {
   public void shouldDetermineResourceTypeBasedOnFileExtension() {
     // given
     final DeployWorkflowStub stub = new DeployWorkflowStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final Builder builder = DeployWorkflowRequest.newBuilder();
     builder
@@ -94,7 +94,7 @@ public class DeployWorkflowTest extends GatewayTest {
     client.deployWorkflow(request);
 
     // then
-    final BrokerDeployWorkflowRequest brokerRequest = gateway.getSingleBrokerRequest();
+    final BrokerDeployWorkflowRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     final DeploymentRecord record = brokerRequest.getRequestWriter();
 
     assertThat(record.resources())
@@ -108,7 +108,7 @@ public class DeployWorkflowTest extends GatewayTest {
   public void shouldAcceptProvidedResourceTypes() {
     // given
     final DeployWorkflowStub stub = new DeployWorkflowStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final Builder builder = DeployWorkflowRequest.newBuilder();
     builder
@@ -128,7 +128,7 @@ public class DeployWorkflowTest extends GatewayTest {
     client.deployWorkflow(request);
 
     // then
-    final BrokerDeployWorkflowRequest brokerRequest = gateway.getSingleBrokerRequest();
+    final BrokerDeployWorkflowRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     final DeploymentRecord record = brokerRequest.getRequestWriter();
 
     assertThat(record.resources())

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/ActivateJobsStub.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/ActivateJobsStub.java
@@ -9,8 +9,8 @@ package io.zeebe.gateway.api.job;
 
 import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
 
-import io.zeebe.gateway.api.util.StubbedGateway;
-import io.zeebe.gateway.api.util.StubbedGateway.RequestStub;
+import io.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.zeebe.protocol.Protocol;
@@ -148,7 +148,7 @@ public class ActivateJobsStub
   }
 
   @Override
-  public void registerWith(StubbedGateway gateway) {
+  public void registerWith(StubbedBrokerClient gateway) {
     gateway.registerHandler(BrokerActivateJobsRequest.class, this);
   }
 }

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/ActivateJobsTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/ActivateJobsTest.java
@@ -31,7 +31,7 @@ public class ActivateJobsTest extends GatewayTest {
   public void shouldMapRequestAndResponse() {
     // given
     final ActivateJobsStub stub = new ActivateJobsStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final String jobType = "testJob";
     final String worker = "testWorker";
@@ -78,7 +78,7 @@ public class ActivateJobsTest extends GatewayTest {
       JsonUtil.assertEquality(job.getVariables(), stub.getVariables());
     }
 
-    final BrokerActivateJobsRequest brokerRequest = gateway.getSingleBrokerRequest();
+    final BrokerActivateJobsRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     final JobBatchRecord brokerRequestValue = brokerRequest.getRequestWriter();
     assertThat(brokerRequestValue.getMaxJobsToActivate()).isEqualTo(maxJobsToActivate);
     assertThat(brokerRequestValue.getTypeBuffer()).isEqualTo(wrapString(jobType));
@@ -93,7 +93,7 @@ public class ActivateJobsTest extends GatewayTest {
   public void shouldActivateJobsRoundRobin() {
     // given
     final ActivateJobsStub stub = new ActivateJobsStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final String type = "test";
     final int maxJobsToActivate = 2;

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/CompleteJobStub.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/CompleteJobStub.java
@@ -7,8 +7,8 @@
  */
 package io.zeebe.gateway.api.job;
 
-import io.zeebe.gateway.api.util.StubbedGateway;
-import io.zeebe.gateway.api.util.StubbedGateway.RequestStub;
+import io.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.zeebe.gateway.impl.broker.request.BrokerCompleteJobRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -23,7 +23,7 @@ public class CompleteJobStub extends JobRequestStub
   }
 
   @Override
-  public void registerWith(StubbedGateway gateway) {
+  public void registerWith(StubbedBrokerClient gateway) {
     gateway.registerHandler(BrokerCompleteJobRequest.class, this);
   }
 }

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/CompleteJobTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/CompleteJobTest.java
@@ -27,7 +27,7 @@ public class CompleteJobTest extends GatewayTest {
   public void shouldMapRequestAndResponse() {
     // given
     final CompleteJobStub stub = new CompleteJobStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final String variables = JsonUtil.toJson(Collections.singletonMap("key", "value"));
 
@@ -40,7 +40,7 @@ public class CompleteJobTest extends GatewayTest {
     // then
     assertThat(response).isNotNull();
 
-    final BrokerCompleteJobRequest brokerRequest = gateway.getSingleBrokerRequest();
+    final BrokerCompleteJobRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getKey()).isEqualTo(stub.getKey());
     assertThat(brokerRequest.getIntent()).isEqualTo(JobIntent.COMPLETE);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.JOB);
@@ -53,7 +53,7 @@ public class CompleteJobTest extends GatewayTest {
   public void shouldConvertEmptyVariables() {
     // given
     final CompleteJobStub stub = new CompleteJobStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final CompleteJobRequest request =
         CompleteJobRequest.newBuilder().setJobKey(stub.getKey()).setVariables("").build();
@@ -64,7 +64,7 @@ public class CompleteJobTest extends GatewayTest {
     // then
     assertThat(response).isNotNull();
 
-    final BrokerCompleteJobRequest brokerRequest = gateway.getSingleBrokerRequest();
+    final BrokerCompleteJobRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getKey()).isEqualTo(stub.getKey());
 
     final JobRecord brokerRequestValue = brokerRequest.getRequestWriter();

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/FailJobStub.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/FailJobStub.java
@@ -7,8 +7,8 @@
  */
 package io.zeebe.gateway.api.job;
 
-import io.zeebe.gateway.api.util.StubbedGateway;
-import io.zeebe.gateway.api.util.StubbedGateway.RequestStub;
+import io.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.zeebe.gateway.impl.broker.request.BrokerFailJobRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -25,7 +25,7 @@ public class FailJobStub extends JobRequestStub
   }
 
   @Override
-  public void registerWith(StubbedGateway gateway) {
+  public void registerWith(StubbedBrokerClient gateway) {
     gateway.registerHandler(BrokerFailJobRequest.class, this);
   }
 }

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/FailJobTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/FailJobTest.java
@@ -25,7 +25,7 @@ public class FailJobTest extends GatewayTest {
   public void shouldMapRequestAndResponse() {
     // given
     final FailJobStub stub = new FailJobStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final int retries = 123;
 
@@ -42,7 +42,7 @@ public class FailJobTest extends GatewayTest {
     // then
     assertThat(response).isNotNull();
 
-    final BrokerFailJobRequest brokerRequest = gateway.getSingleBrokerRequest();
+    final BrokerFailJobRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getKey()).isEqualTo(stub.getKey());
     assertThat(brokerRequest.getIntent()).isEqualTo(JobIntent.FAIL);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.JOB);

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/UpdateJobRetriesStub.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/UpdateJobRetriesStub.java
@@ -7,8 +7,8 @@
  */
 package io.zeebe.gateway.api.job;
 
-import io.zeebe.gateway.api.util.StubbedGateway;
-import io.zeebe.gateway.api.util.StubbedGateway.RequestStub;
+import io.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.zeebe.gateway.impl.broker.request.BrokerUpdateJobRetriesRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -17,7 +17,7 @@ public class UpdateJobRetriesStub extends JobRequestStub
     implements RequestStub<BrokerUpdateJobRetriesRequest, BrokerResponse<JobRecord>> {
 
   @Override
-  public void registerWith(StubbedGateway gateway) {
+  public void registerWith(StubbedBrokerClient gateway) {
     gateway.registerHandler(BrokerUpdateJobRetriesRequest.class, this);
   }
 

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/UpdateJobRetriesTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/UpdateJobRetriesTest.java
@@ -24,7 +24,7 @@ public class UpdateJobRetriesTest extends GatewayTest {
   public void shouldMapRequestAndResponse() {
     // given
     final UpdateJobRetriesStub stub = new UpdateJobRetriesStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final int retries = 123;
 
@@ -37,7 +37,7 @@ public class UpdateJobRetriesTest extends GatewayTest {
     // then
     assertThat(response).isNotNull();
 
-    final BrokerUpdateJobRetriesRequest brokerRequest = gateway.getSingleBrokerRequest();
+    final BrokerUpdateJobRetriesRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getKey()).isEqualTo(stub.getKey());
     assertThat(brokerRequest.getIntent()).isEqualTo(JobIntent.UPDATE_RETRIES);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.JOB);

--- a/gateway/src/test/java/io/zeebe/gateway/api/util/GatewayTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/util/GatewayTest.java
@@ -7,7 +7,6 @@
  */
 package io.zeebe.gateway.api.util;
 
-import io.zeebe.gateway.impl.broker.BrokerClient;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
 import io.zeebe.util.sched.clock.ControlledActorClock;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
@@ -21,14 +20,15 @@ public class GatewayTest {
   public ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule(actorClock);
   public StubbedGatewayRule gatewayRule = new StubbedGatewayRule(actorSchedulerRule);
   @Rule public RuleChain ruleChain = RuleChain.outerRule(actorSchedulerRule).around(gatewayRule);
+
   protected StubbedGateway gateway;
   protected GatewayBlockingStub client;
-  protected BrokerClient brokerClient;
+  protected StubbedBrokerClient brokerClient;
 
   @Before
   public void setUp() {
     gateway = gatewayRule.getGateway();
     client = gatewayRule.getClient();
-    brokerClient = gateway.getBrokerClient();
+    brokerClient = gatewayRule.getBrokerClient();
   }
 }

--- a/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.api.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.gateway.cmd.BrokerErrorException;
+import io.zeebe.gateway.cmd.BrokerRejectionException;
+import io.zeebe.gateway.cmd.BrokerResponseException;
+import io.zeebe.gateway.cmd.IllegalBrokerResponseException;
+import io.zeebe.gateway.impl.broker.BrokerClient;
+import io.zeebe.gateway.impl.broker.BrokerResponseConsumer;
+import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
+import io.zeebe.gateway.impl.broker.request.BrokerRequest;
+import io.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.zeebe.util.sched.future.ActorFuture;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class StubbedBrokerClient implements BrokerClient {
+
+  BrokerTopologyManager topologyManager = new StubbedTopologyManager();
+  private Consumer<String> jobsAvailableHandler;
+
+  private Map<Class<?>, RequestHandler> requestHandlers = new HashMap<>();
+
+  private List<BrokerRequest> brokerRequests = new ArrayList<>();
+
+  public StubbedBrokerClient() {}
+
+  @Override
+  public void close() {}
+
+  @Override
+  public <T> ActorFuture<BrokerResponse<T>> sendRequest(BrokerRequest<T> request) {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public <T> void sendRequest(
+      BrokerRequest<T> request,
+      BrokerResponseConsumer<T> responseConsumer,
+      Consumer<Throwable> throwableConsumer) {
+    brokerRequests.add(request);
+    try {
+      final RequestHandler requestHandler = requestHandlers.get(request.getClass());
+      final BrokerResponse<T> response = requestHandler.handle(request);
+      if (response.isResponse()) {
+        responseConsumer.accept(response.getKey(), response.getResponse());
+      } else if (response.isRejection()) {
+        throwableConsumer.accept(new BrokerRejectionException(response.getRejection()));
+      } else if (response.isError()) {
+        throwableConsumer.accept(new BrokerErrorException(response.getError()));
+      } else {
+        throwableConsumer.accept(
+            new IllegalBrokerResponseException("Unknown response received: " + response));
+      }
+    } catch (Exception e) {
+      throwableConsumer.accept(new BrokerResponseException(e));
+    }
+  }
+
+  @Override
+  public <T> ActorFuture<BrokerResponse<T>> sendRequest(
+      BrokerRequest<T> request, Duration requestTimeout) {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public <T> void sendRequest(
+      BrokerRequest<T> request,
+      BrokerResponseConsumer<T> responseConsumer,
+      Consumer<Throwable> throwableConsumer,
+      Duration requestTimeout) {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
+  public BrokerTopologyManager getTopologyManager() {
+    return topologyManager;
+  }
+
+  @Override
+  public void subscribeJobAvailableNotification(String topic, Consumer<String> handler) {
+    this.jobsAvailableHandler = handler;
+  }
+
+  public <RequestT extends BrokerRequest<?>, ResponseT extends BrokerResponse<?>>
+      void registerHandler(
+          Class<?> requestType, RequestHandler<RequestT, ResponseT> requestHandler) {
+    requestHandlers.put(requestType, requestHandler);
+  }
+
+  public void notifyJobsAvailable(String type) {
+    jobsAvailableHandler.accept(type);
+  }
+
+  public <T extends BrokerRequest<?>> T getSingleBrokerRequest() {
+    assertThat(brokerRequests).hasSize(1);
+    return (T) brokerRequests.get(0);
+  }
+
+  public interface RequestStub<
+          RequestT extends BrokerRequest<?>, ResponseT extends BrokerResponse<?>>
+      extends RequestHandler<RequestT, ResponseT> {
+    void registerWith(StubbedBrokerClient gateway);
+  }
+
+  @FunctionalInterface
+  interface RequestHandler<RequestT extends BrokerRequest<?>, ResponseT extends BrokerResponse<?>> {
+    ResponseT handle(RequestT request) throws Exception;
+  }
+}

--- a/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.api.util;
+
+import static io.zeebe.protocol.Protocol.START_PARTITION_ID;
+
+import io.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
+import io.zeebe.gateway.impl.broker.cluster.BrokerClusterStateImpl;
+import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
+
+public class StubbedTopologyManager implements BrokerTopologyManager {
+
+  private final BrokerClusterStateImpl clusterState;
+
+  StubbedTopologyManager() {
+    this(8);
+  }
+
+  StubbedTopologyManager(int partitionsCount) {
+    clusterState = new BrokerClusterStateImpl();
+    clusterState.addBrokerIfAbsent(0);
+    clusterState.setBrokerAddressIfPresent(0, "localhost:26501");
+    for (int partitionOffset = 0; partitionOffset < partitionsCount; partitionOffset++) {
+      clusterState.setPartitionLeader(START_PARTITION_ID + partitionOffset, 0);
+      clusterState.addPartitionIfAbsent(START_PARTITION_ID + partitionOffset);
+    }
+    clusterState.setPartitionsCount(partitionsCount);
+  }
+
+  @Override
+  public BrokerClusterState getTopology() {
+    return clusterState;
+  }
+}

--- a/gateway/src/test/java/io/zeebe/gateway/api/workflow/CancelWorkflowInstanceStub.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/workflow/CancelWorkflowInstanceStub.java
@@ -7,8 +7,8 @@
  */
 package io.zeebe.gateway.api.workflow;
 
-import io.zeebe.gateway.api.util.StubbedGateway;
-import io.zeebe.gateway.api.util.StubbedGateway.RequestStub;
+import io.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.zeebe.gateway.impl.broker.request.BrokerCancelWorkflowInstanceRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
@@ -18,7 +18,7 @@ public class CancelWorkflowInstanceStub
         BrokerCancelWorkflowInstanceRequest, BrokerResponse<WorkflowInstanceRecord>> {
 
   @Override
-  public void registerWith(StubbedGateway gateway) {
+  public void registerWith(StubbedBrokerClient gateway) {
     gateway.registerHandler(BrokerCancelWorkflowInstanceRequest.class, this);
   }
 

--- a/gateway/src/test/java/io/zeebe/gateway/api/workflow/CancelWorkflowInstanceTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/workflow/CancelWorkflowInstanceTest.java
@@ -23,7 +23,7 @@ public class CancelWorkflowInstanceTest extends GatewayTest {
   public void shouldMapRequestAndResponse() {
     // given
     final CancelWorkflowInstanceStub stub = new CancelWorkflowInstanceStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final CancelWorkflowInstanceRequest request =
         CancelWorkflowInstanceRequest.newBuilder().setWorkflowInstanceKey(123).build();
@@ -34,7 +34,7 @@ public class CancelWorkflowInstanceTest extends GatewayTest {
     // then
     assertThat(response).isNotNull();
 
-    final BrokerCancelWorkflowInstanceRequest brokerRequest = gateway.getSingleBrokerRequest();
+    final BrokerCancelWorkflowInstanceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getKey()).isEqualTo(123);
     assertThat(brokerRequest.getIntent()).isEqualTo(WorkflowInstanceIntent.CANCEL);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.WORKFLOW_INSTANCE);

--- a/gateway/src/test/java/io/zeebe/gateway/api/workflow/CreateWorkflowInstanceStub.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/workflow/CreateWorkflowInstanceStub.java
@@ -7,8 +7,8 @@
  */
 package io.zeebe.gateway.api.workflow;
 
-import io.zeebe.gateway.api.util.StubbedGateway;
-import io.zeebe.gateway.api.util.StubbedGateway.RequestStub;
+import io.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.zeebe.gateway.impl.broker.request.BrokerCreateWorkflowInstanceRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
@@ -23,7 +23,7 @@ public class CreateWorkflowInstanceStub
   public static final long WORKFLOW_KEY = 456;
 
   @Override
-  public void registerWith(StubbedGateway gateway) {
+  public void registerWith(StubbedBrokerClient gateway) {
     gateway.registerHandler(BrokerCreateWorkflowInstanceRequest.class, this);
   }
 

--- a/gateway/src/test/java/io/zeebe/gateway/api/workflow/CreateWorkflowInstanceTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/workflow/CreateWorkflowInstanceTest.java
@@ -24,7 +24,7 @@ public class CreateWorkflowInstanceTest extends GatewayTest {
   public void shouldMapRequestAndResponse() {
     // given
     final CreateWorkflowInstanceStub stub = new CreateWorkflowInstanceStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final CreateWorkflowInstanceRequest request =
         CreateWorkflowInstanceRequest.newBuilder().setWorkflowKey(stub.getWorkflowKey()).build();
@@ -38,7 +38,7 @@ public class CreateWorkflowInstanceTest extends GatewayTest {
     assertThat(response.getWorkflowKey()).isEqualTo(stub.getWorkflowKey());
     assertThat(response.getWorkflowInstanceKey()).isEqualTo(stub.getWorkflowInstanceKey());
 
-    final BrokerCreateWorkflowInstanceRequest brokerRequest = gateway.getSingleBrokerRequest();
+    final BrokerCreateWorkflowInstanceRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getIntent()).isEqualTo(WorkflowInstanceCreationIntent.CREATE);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.WORKFLOW_INSTANCE_CREATION);
 

--- a/gateway/src/test/java/io/zeebe/gateway/api/workflow/CreateWorkflowInstanceWithResultStub.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/workflow/CreateWorkflowInstanceWithResultStub.java
@@ -7,8 +7,8 @@
  */
 package io.zeebe.gateway.api.workflow;
 
-import io.zeebe.gateway.api.util.StubbedGateway;
-import io.zeebe.gateway.api.util.StubbedGateway.RequestStub;
+import io.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.zeebe.gateway.impl.broker.request.BrokerCreateWorkflowInstanceWithResultRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceResultRecord;
@@ -24,8 +24,8 @@ public class CreateWorkflowInstanceWithResultStub
   public static final long WORKFLOW_KEY = 456;
 
   @Override
-  public void registerWith(StubbedGateway gateway) {
-    gateway.registerHandler(BrokerCreateWorkflowInstanceWithResultRequest.class, this);
+  public void registerWith(StubbedBrokerClient brokerClient) {
+    brokerClient.registerHandler(BrokerCreateWorkflowInstanceWithResultRequest.class, this);
   }
 
   public long getWorkflowInstanceKey() {

--- a/gateway/src/test/java/io/zeebe/gateway/api/workflow/CreateWorkflowInstanceWithResultTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/workflow/CreateWorkflowInstanceWithResultTest.java
@@ -25,7 +25,7 @@ public class CreateWorkflowInstanceWithResultTest extends GatewayTest {
   public void shouldMapRequestAndResponse() {
     // given
     final CreateWorkflowInstanceWithResultStub stub = new CreateWorkflowInstanceWithResultStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final CreateWorkflowInstanceWithResultRequest request =
         CreateWorkflowInstanceWithResultRequest.newBuilder()
@@ -44,7 +44,7 @@ public class CreateWorkflowInstanceWithResultTest extends GatewayTest {
     assertThat(response.getWorkflowInstanceKey()).isEqualTo(stub.getWorkflowInstanceKey());
 
     final BrokerCreateWorkflowInstanceWithResultRequest brokerRequest =
-        gateway.getSingleBrokerRequest();
+        brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getIntent())
         .isEqualTo(WorkflowInstanceCreationIntent.CREATE_WITH_AWAITING_RESULT);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.WORKFLOW_INSTANCE_CREATION);

--- a/gateway/src/test/java/io/zeebe/gateway/api/workflow/PublishMessageStub.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/workflow/PublishMessageStub.java
@@ -7,8 +7,8 @@
  */
 package io.zeebe.gateway.api.workflow;
 
-import io.zeebe.gateway.api.util.StubbedGateway;
-import io.zeebe.gateway.api.util.StubbedGateway.RequestStub;
+import io.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.zeebe.gateway.impl.broker.request.BrokerPublishMessageRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 
@@ -16,7 +16,7 @@ public class PublishMessageStub
     implements RequestStub<BrokerPublishMessageRequest, BrokerResponse<Void>> {
 
   @Override
-  public void registerWith(StubbedGateway gateway) {
+  public void registerWith(StubbedBrokerClient gateway) {
     gateway.registerHandler(BrokerPublishMessageRequest.class, this);
   }
 

--- a/gateway/src/test/java/io/zeebe/gateway/api/workflow/PublishMessageTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/workflow/PublishMessageTest.java
@@ -28,7 +28,7 @@ public class PublishMessageTest extends GatewayTest {
   public void shouldMapRequestAndResponse() {
     // given
     final PublishMessageStub stub = new PublishMessageStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final String variables = JsonUtil.toJson(Collections.singletonMap("key", "value"));
 
@@ -47,7 +47,7 @@ public class PublishMessageTest extends GatewayTest {
     // then
     assertThat(response).isNotNull();
 
-    final BrokerPublishMessageRequest brokerRequest = gateway.getSingleBrokerRequest();
+    final BrokerPublishMessageRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getIntent()).isEqualTo(MessageIntent.PUBLISH);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.MESSAGE);
 

--- a/gateway/src/test/java/io/zeebe/gateway/api/workflow/ResolveIncidentStub.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/workflow/ResolveIncidentStub.java
@@ -9,8 +9,8 @@ package io.zeebe.gateway.api.workflow;
 
 import static io.zeebe.util.buffer.BufferUtil.wrapString;
 
-import io.zeebe.gateway.api.util.StubbedGateway;
-import io.zeebe.gateway.api.util.StubbedGateway.RequestStub;
+import io.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.zeebe.gateway.impl.broker.request.BrokerResolveIncidentRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
@@ -25,7 +25,7 @@ public class ResolveIncidentStub
   public static final DirectBuffer PROCESS_ID = wrapString("process");
 
   @Override
-  public void registerWith(StubbedGateway gateway) {
+  public void registerWith(StubbedBrokerClient gateway) {
     gateway.registerHandler(BrokerResolveIncidentRequest.class, this);
   }
 

--- a/gateway/src/test/java/io/zeebe/gateway/api/workflow/ResolveIncidentTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/workflow/ResolveIncidentTest.java
@@ -23,7 +23,7 @@ public class ResolveIncidentTest extends GatewayTest {
   public void shouldMapRequestAndResponse() {
     // given
     final ResolveIncidentStub stub = new ResolveIncidentStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final ResolveIncidentRequest request =
         ResolveIncidentRequest.newBuilder().setIncidentKey(stub.getIncidentKey()).build();
@@ -34,7 +34,7 @@ public class ResolveIncidentTest extends GatewayTest {
     // then
     assertThat(response).isNotNull();
 
-    final BrokerResolveIncidentRequest brokerRequest = gateway.getSingleBrokerRequest();
+    final BrokerResolveIncidentRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getIntent()).isEqualTo(IncidentIntent.RESOLVE);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.INCIDENT);
     assertThat(brokerRequest.getKey()).isEqualTo(stub.getIncidentKey());

--- a/gateway/src/test/java/io/zeebe/gateway/api/workflow/SetVariablesStub.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/workflow/SetVariablesStub.java
@@ -7,8 +7,8 @@
  */
 package io.zeebe.gateway.api.workflow;
 
-import io.zeebe.gateway.api.util.StubbedGateway;
-import io.zeebe.gateway.api.util.StubbedGateway.RequestStub;
+import io.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.zeebe.gateway.api.util.StubbedBrokerClient.RequestStub;
 import io.zeebe.gateway.impl.broker.request.BrokerSetVariablesRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
@@ -17,7 +17,7 @@ public class SetVariablesStub
     implements RequestStub<BrokerSetVariablesRequest, BrokerResponse<VariableDocumentRecord>> {
 
   @Override
-  public void registerWith(StubbedGateway gateway) {
+  public void registerWith(StubbedBrokerClient gateway) {
     gateway.registerHandler(BrokerSetVariablesRequest.class, this);
   }
 

--- a/gateway/src/test/java/io/zeebe/gateway/api/workflow/SetVariablesTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/workflow/SetVariablesTest.java
@@ -28,7 +28,7 @@ public class SetVariablesTest extends GatewayTest {
   public void shouldMapRequestAndResponse() {
     // given
     final SetVariablesStub stub = new SetVariablesStub();
-    stub.registerWith(gateway);
+    stub.registerWith(brokerClient);
 
     final String variables = JsonUtil.toJson(Collections.singletonMap("key", "value"));
 
@@ -46,7 +46,7 @@ public class SetVariablesTest extends GatewayTest {
     // then
     assertThat(response).isNotNull();
 
-    final BrokerSetVariablesRequest brokerRequest = gateway.getSingleBrokerRequest();
+    final BrokerSetVariablesRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getKey()).isEqualTo(-1);
     assertThat(brokerRequest.getIntent()).isEqualTo(VariableDocumentIntent.UPDATE);
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.VARIABLE_DOCUMENT);


### PR DESCRIPTION
## Description

* Use long polling handler created by the stubbed gateway in tests.

## Related issues
closes #3217 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
