### PR TITLE
fix(logstreams): use concurrent data structure in log storage

### DIFF
--- a/logstreams/src/test/java/io/zeebe/logstreams/fs/log/FsLogSegmentsTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/fs/log/FsLogSegmentsTest.java
@@ -8,10 +8,14 @@
 package io.zeebe.logstreams.fs.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.zeebe.logstreams.impl.log.fs.FsLogSegment;
 import io.zeebe.logstreams.impl.log.fs.FsLogSegments;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -29,9 +33,8 @@ public class FsLogSegmentsTest {
 
   @Test
   public void shouldGetFirstSegment() {
-    final FsLogSegments fsLogSegments = new FsLogSegments();
-
-    fsLogSegments.init(0, new FsLogSegment[] {firstSegment, secondSegment});
+    final FsLogSegments fsLogSegments =
+        FsLogSegments.fromFsLogSegmentsArray(List.of(firstSegment, secondSegment));
 
     final FsLogSegment segment = fsLogSegments.getFirst();
 
@@ -40,9 +43,8 @@ public class FsLogSegmentsTest {
 
   @Test
   public void shouldGetFirstSegmentWithInitialSegmentId() {
-    final FsLogSegments fsLogSegments = new FsLogSegments();
-
-    fsLogSegments.init(1, new FsLogSegment[] {firstSegment, secondSegment});
+    final FsLogSegments fsLogSegments =
+        FsLogSegments.fromFsLogSegmentsArray(List.of(firstSegment, secondSegment));
 
     final FsLogSegment segment = fsLogSegments.getFirst();
 
@@ -50,21 +52,56 @@ public class FsLogSegmentsTest {
   }
 
   @Test
-  public void shouldNotGetFirstSegmentIfEmpty() {
-    final FsLogSegments fsLogSegments = new FsLogSegments();
+  public void shouldNotInitWithEmptyList() {
 
-    fsLogSegments.init(0, new FsLogSegment[0]);
+    assertThatThrownBy(() -> FsLogSegments.fromFsLogSegmentsArray(List.of()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 
-    final FsLogSegment segment = fsLogSegments.getFirst();
+  @Test
+  public void shouldThrowOnGetFirstWhenAlreadyClosed() {
+    // given
+    final FsLogSegments segments = FsLogSegments.fromFsLogSegmentsArray(List.of(firstSegment));
+    segments.closeAll();
 
-    assertThat(segment).isNull();
+    // expect - when
+    assertThatThrownBy(segments::getFirst).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void shouldThrowOnGetFirstSegmentIdWhenAlreadyClosed() {
+    // given
+    final FsLogSegments segments = FsLogSegments.fromFsLogSegmentsArray(List.of(firstSegment));
+    segments.closeAll();
+
+    // expect - when
+    assertThatThrownBy(segments::getFirstSegmentId).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void shouldThrowOnGetWhenAlreadyClosed() {
+    // given
+    final FsLogSegments segments = FsLogSegments.fromFsLogSegmentsArray(List.of(firstSegment));
+    segments.closeAll();
+
+    // expect - when
+    assertThatThrownBy(() -> segments.getSegment(0)).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void shouldThrowOnGetLastSegmentIdWhenAlreadyClosed() {
+    // given
+    final FsLogSegments segments = FsLogSegments.fromFsLogSegmentsArray(List.of(firstSegment));
+    segments.closeAll();
+
+    // expect - when
+    assertThatThrownBy(segments::getLastSegmentId).isInstanceOf(IllegalStateException.class);
   }
 
   @Test
   public void shouldGetSegment() {
-    final FsLogSegments fsLogSegments = new FsLogSegments();
-
-    fsLogSegments.init(0, new FsLogSegment[] {firstSegment, secondSegment});
+    final FsLogSegments fsLogSegments =
+        FsLogSegments.fromFsLogSegmentsArray(List.of(firstSegment, secondSegment));
 
     assertThat(fsLogSegments.getSegment(0)).isEqualTo(firstSegment);
     assertThat(fsLogSegments.getSegment(1)).isEqualTo(secondSegment);
@@ -72,9 +109,9 @@ public class FsLogSegmentsTest {
 
   @Test
   public void shouldGetSegmentWithInitialSegmentId() {
-    final FsLogSegments fsLogSegments = new FsLogSegments();
-
-    fsLogSegments.init(1, new FsLogSegment[] {firstSegment, secondSegment});
+    final FsLogSegments fsLogSegments =
+        FsLogSegments.fromFsLogSegmentsArray(List.of(firstSegment, secondSegment));
+    when(firstSegment.getSegmentId()).thenReturn(1);
 
     assertThat(fsLogSegments.getSegment(1)).isEqualTo(firstSegment);
     assertThat(fsLogSegments.getSegment(2)).isEqualTo(secondSegment);
@@ -82,9 +119,9 @@ public class FsLogSegmentsTest {
 
   @Test
   public void shouldNotGetSegmentIfNotExists() {
-    final FsLogSegments fsLogSegments = new FsLogSegments();
-
-    fsLogSegments.init(1, new FsLogSegment[] {firstSegment, secondSegment});
+    final FsLogSegments fsLogSegments =
+        FsLogSegments.fromFsLogSegmentsArray(List.of(firstSegment, secondSegment));
+    when(firstSegment.getSegmentId()).thenReturn(1);
 
     assertThat(fsLogSegments.getSegment(0)).isNull();
     assertThat(fsLogSegments.getSegment(3)).isNull();
@@ -92,9 +129,7 @@ public class FsLogSegmentsTest {
 
   @Test
   public void shouldAddSegment() {
-    final FsLogSegments fsLogSegments = new FsLogSegments();
-
-    fsLogSegments.init(0, new FsLogSegment[] {firstSegment});
+    final FsLogSegments fsLogSegments = FsLogSegments.fromFsLogSegmentsArray(List.of(firstSegment));
 
     fsLogSegments.addSegment(secondSegment);
 
@@ -103,15 +138,57 @@ public class FsLogSegmentsTest {
 
   @Test
   public void shouldCloseAllSegments() {
-    final FsLogSegments fsLogSegments = new FsLogSegments();
-
-    fsLogSegments.init(0, new FsLogSegment[] {firstSegment, secondSegment});
+    final FsLogSegments fsLogSegments =
+        FsLogSegments.fromFsLogSegmentsArray(List.of(firstSegment, secondSegment));
 
     fsLogSegments.closeAll();
 
     verify(firstSegment).closeSegment();
     verify(secondSegment).closeSegment();
 
-    assertThat(fsLogSegments.getFirst()).isNull();
+    assertThatThrownBy(fsLogSegments::getFirst).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void shouldDeleteUntilSegmentId() {
+    // given
+    final FsLogSegment thirdSegment = mock(FsLogSegment.class);
+    final FsLogSegment fourthSegment = mock(FsLogSegment.class);
+    final FsLogSegment fifthSegment = mock(FsLogSegment.class);
+
+    when(firstSegment.getSegmentId()).thenReturn(1);
+    when(secondSegment.getSegmentId()).thenReturn(2);
+    when(thirdSegment.getSegmentId()).thenReturn(3);
+    when(fourthSegment.getSegmentId()).thenReturn(4);
+    when(fifthSegment.getSegmentId()).thenReturn(5);
+
+    final FsLogSegments fsLogSegments =
+        FsLogSegments.fromFsLogSegmentsArray(
+            List.of(firstSegment, secondSegment, thirdSegment, fourthSegment, fifthSegment));
+
+    // when
+    fsLogSegments.deleteSegmentsUntil(3);
+
+    // then
+    assertThat(fsLogSegments.getFirstSegmentId()).isEqualTo(3);
+    assertThat(fsLogSegments.getFirst()).isEqualTo(thirdSegment);
+  }
+
+  @Test
+  public void shouldNotDeleteUntilWithNegativeSegmentId() {
+    // given
+    when(firstSegment.getSegmentId()).thenReturn(1);
+    when(secondSegment.getSegmentId()).thenReturn(2);
+
+    final FsLogSegments fsLogSegments =
+        FsLogSegments.fromFsLogSegmentsArray(List.of(firstSegment, secondSegment));
+
+    // when
+    fsLogSegments.deleteSegmentsUntil(-1);
+
+    // then
+    assertThat(fsLogSegments.getFirstSegmentId()).isEqualTo(1);
+    assertThat(fsLogSegments.getFirst()).isEqualTo(firstSegment);
+    assertThat(fsLogSegments.getLastSegmentId()).isEqualTo(2);
   }
 }


### PR DESCRIPTION
 * log storage was accessed by multiple parties like BufferedLogStreamReader (processor, exporter), AsyncSnapshotDirector (delete), LogPrimitive (append) etc.
 * to sync the access and protect the resource by multiple accessor's
   we now use a concurrent data structure until we completely replace the log storage implementation
 * _alternative_ was to sync the access from the different parties (via actor logic) but this would be a more major refactoring

**Note:**

In a perfect world we do not need a thread safe data structure here. I hope we get rid of it soon as possible again with replacing the log stream. Or we can replace it with a lock free data structure. 

## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #3215 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
