### PR TITLE
feat(broker): specify variables to include in workflow result

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/api/command/CreateWorkflowInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/command/CreateWorkflowInstanceCommandStep1.java
@@ -18,6 +18,7 @@ package io.zeebe.client.api.command;
 import io.zeebe.client.api.response.WorkflowInstanceEvent;
 import io.zeebe.client.api.response.WorkflowInstanceResult;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 
 public interface CreateWorkflowInstanceCommandStep1 {
@@ -111,5 +112,24 @@ public interface CreateWorkflowInstanceCommandStep1 {
   }
 
   interface CreateWorkflowInstanceWithResultCommandStep1
-      extends FinalCommandStep<WorkflowInstanceResult> {}
+      extends FinalCommandStep<WorkflowInstanceResult> {
+
+    /**
+     * Set a list of variables names which should be fetched in the response.
+     *
+     * @param fetchVariables set of names of variables to be included in the response
+     * @return the builder for this command. Call {@link #send()} to complete the command and send *
+     *     it to the broker
+     */
+    CreateWorkflowInstanceWithResultCommandStep1 fetchVariables(List<String> fetchVariables);
+
+    /**
+     * Set a list of variables names which should be fetched in the response.
+     *
+     * @param fetchVariables set of names of variables to be included in the response
+     * @return the builder for this command. Call {@link #send()} to complete the command and send *
+     *     it to the broker
+     */
+    CreateWorkflowInstanceWithResultCommandStep1 fetchVariables(String... fetchVariables);
+  }
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/CreateWorkflowInstanceWithResultCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/CreateWorkflowInstanceWithResultCommandImpl.java
@@ -29,6 +29,8 @@ import io.zeebe.gateway.protocol.GatewayOuterClass.CreateWorkflowInstanceWithRes
 import io.zeebe.gateway.protocol.GatewayOuterClass.CreateWorkflowInstanceWithResultRequest.Builder;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CreateWorkflowInstanceWithResultResponse;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
@@ -91,5 +93,17 @@ public class CreateWorkflowInstanceWithResultCommandImpl
     asyncStub
         .withDeadlineAfter(requestTimeout.plus(DEADLINE_OFFSET).toMillis(), TimeUnit.MILLISECONDS)
         .createWorkflowInstanceWithResult(request, future);
+  }
+
+  @Override
+  public CreateWorkflowInstanceWithResultCommandStep1 fetchVariables(List<String> fetchVariables) {
+    builder.addAllFetchVariables(fetchVariables);
+    return this;
+  }
+
+  @Override
+  public CreateWorkflowInstanceWithResultCommandStep1 fetchVariables(String... fetchVariables) {
+    builder.addAllFetchVariables(Arrays.asList(fetchVariables));
+    return this;
   }
 }

--- a/clients/java/src/test/java/io/zeebe/client/workflow/CreateWorkflowInstanceWithResultTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/workflow/CreateWorkflowInstanceWithResultTest.java
@@ -56,6 +56,31 @@ public class CreateWorkflowInstanceWithResultTest extends ClientTest {
     final CreateWorkflowInstanceWithResultRequest request = gatewayService.getLastRequest();
     assertThat(request.getRequest().getWorkflowKey()).isEqualTo(123);
     assertThat(request.getRequestTimeout()).isEqualTo(Duration.ofSeconds(123).toMillis());
+    assertThat(request.getFetchVariablesList()).isEmpty();
+  }
+
+  @Test
+  public void shouldBeAbleToSpecifyFetchVariables() {
+    // given
+    final String variables = "{\"key\": \"val\"}";
+    gatewayService.onCreateWorkflowInstanceWithResultRequest(123, "testProcess", 12, 32, variables);
+
+    // when
+    final WorkflowInstanceResult response =
+        client
+            .newCreateInstanceCommand()
+            .workflowKey(123)
+            .withResult()
+            .fetchVariables("x")
+            .requestTimeout(Duration.ofSeconds(123))
+            .send()
+            .join();
+
+    // then
+    final CreateWorkflowInstanceWithResultRequest request = gatewayService.getLastRequest();
+    assertThat(request.getRequest().getWorkflowKey()).isEqualTo(123);
+    assertThat(request.getRequestTimeout()).isEqualTo(Duration.ofSeconds(123).toMillis());
+    assertThat(request.getFetchVariablesList()).containsExactly("x");
   }
 
   @Test

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/instance/CreateWorkflowInstanceWithResultProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/instance/CreateWorkflowInstanceWithResultProcessor.java
@@ -12,6 +12,8 @@ import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.engine.processor.TypedStreamWriter;
 import io.zeebe.engine.state.instance.AwaitWorkflowInstanceResultMetadata;
 import io.zeebe.engine.state.instance.ElementInstanceState;
+import io.zeebe.msgpack.property.ArrayProperty;
+import io.zeebe.msgpack.value.StringValue;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.Intent;
@@ -65,9 +67,11 @@ public class CreateWorkflowInstanceWithResultProcessor
     @Override
     public long accept(Intent newState, WorkflowInstanceCreationRecord updatedValue) {
       shouldRespond = false;
+      final ArrayProperty<StringValue> fetchVariables = command.getValue().fetchVariables();
       awaitResultMetadata
           .setRequestId(command.getRequestId())
-          .setRequestStreamId(command.getRequestStreamId());
+          .setRequestStreamId(command.getRequestStreamId())
+          .setFetchVariables(fetchVariables);
 
       elementInstanceState.setAwaitResultRequestMetadata(
           updatedValue.getWorkflowInstanceKey(), awaitResultMetadata);

--- a/engine/src/main/java/io/zeebe/engine/state/instance/AwaitWorkflowInstanceResultMetadata.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/AwaitWorkflowInstanceResultMetadata.java
@@ -7,69 +7,77 @@
  */
 package io.zeebe.engine.state.instance;
 
-import static io.zeebe.db.impl.ZeebeDbConstants.ZB_DB_BYTE_ORDER;
-
 import io.zeebe.db.DbValue;
-import org.agrona.DirectBuffer;
-import org.agrona.MutableDirectBuffer;
+import io.zeebe.msgpack.property.ArrayProperty;
+import io.zeebe.msgpack.property.IntegerProperty;
+import io.zeebe.msgpack.property.LongProperty;
+import io.zeebe.msgpack.value.StringValue;
+import io.zeebe.protocol.impl.record.UnifiedRecordValue;
+import java.util.Objects;
 
-public class AwaitWorkflowInstanceResultMetadata implements DbValue {
+public class AwaitWorkflowInstanceResultMetadata extends UnifiedRecordValue implements DbValue {
 
-  private long requestId;
-  private int requestStreamId;
+  private final LongProperty requestIdProperty = new LongProperty("requestId", -1);
+  private final IntegerProperty requestStreamIdProperty =
+      new IntegerProperty("requestStreamId", -1);
+  private final ArrayProperty<StringValue> fetchVariablesProperty =
+      new ArrayProperty<>("fetchVariables", new StringValue());
 
-  public AwaitWorkflowInstanceResultMetadata() {}
-
-  public AwaitWorkflowInstanceResultMetadata(long requestId, int requestStreamId) {
-    this.requestId = requestId;
-    this.requestStreamId = requestStreamId;
+  public AwaitWorkflowInstanceResultMetadata() {
+    this.declareProperty(requestIdProperty)
+        .declareProperty(requestStreamIdProperty)
+        .declareProperty(fetchVariablesProperty);
   }
 
   public long getRequestId() {
-    return requestId;
+    return requestIdProperty.getValue();
   }
 
   public AwaitWorkflowInstanceResultMetadata setRequestId(long requestId) {
-    this.requestId = requestId;
+    requestIdProperty.setValue(requestId);
     return this;
   }
 
   public int getRequestStreamId() {
-    return requestStreamId;
+    return requestStreamIdProperty.getValue();
   }
 
   public AwaitWorkflowInstanceResultMetadata setRequestStreamId(int requestStreamId) {
-    this.requestStreamId = requestStreamId;
+    requestStreamIdProperty.setValue(requestStreamId);
+    return this;
+  }
+
+  public ArrayProperty<StringValue> fetchVariables() {
+    return fetchVariablesProperty;
+  }
+
+  public AwaitWorkflowInstanceResultMetadata setFetchVariables(
+      ArrayProperty<StringValue> variables) {
+    fetchVariablesProperty.reset();
+    variables.forEach(variable -> fetchVariablesProperty.add().wrap(variable));
     return this;
   }
 
   @Override
-  public void wrap(DirectBuffer buffer, int offset, int length) {
-    final int startOffset = offset;
-    requestId = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
-    offset += Long.BYTES;
-
-    requestStreamId = buffer.getInt(offset, ZB_DB_BYTE_ORDER);
-    offset += Integer.BYTES;
-
-    assert (offset - startOffset) == length : "End offset differs from length";
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(), requestIdProperty, requestStreamIdProperty, fetchVariablesProperty);
   }
 
   @Override
-  public int getLength() {
-    return Long.BYTES + Integer.BYTES;
-  }
-
-  @Override
-  public void write(MutableDirectBuffer buffer, int offset) {
-    final int startOffset = offset;
-
-    buffer.putLong(offset, requestId, ZB_DB_BYTE_ORDER);
-    offset += Long.BYTES;
-
-    buffer.putInt(offset, requestStreamId, ZB_DB_BYTE_ORDER);
-    offset += Integer.BYTES;
-
-    assert (offset - startOffset) == getLength() : "End offset differs from getLength()";
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    final AwaitWorkflowInstanceResultMetadata that = (AwaitWorkflowInstanceResultMetadata) o;
+    return requestIdProperty.equals(that.requestIdProperty)
+        && requestStreamIdProperty.equals(that.requestStreamIdProperty)
+        && fetchVariablesProperty.equals(that.fetchVariablesProperty);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstanceState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstanceState.java
@@ -44,7 +44,7 @@ public class ElementInstanceState {
   private final ColumnFamily<DbCompositeKey<DbCompositeKey<DbLong, DbByte>, DbLong>, DbNil>
       recordParentChildColumnFamily;
 
-  private final AwaitWorkflowInstanceResultMetadata awaitResultMetada;
+  private final AwaitWorkflowInstanceResultMetadata awaitResultMetadata;
   private final ColumnFamily<DbLong, AwaitWorkflowInstanceResultMetadata>
       awaitWorkflowInstanceResultMetadataColumnFamily;
 
@@ -88,13 +88,13 @@ public class ElementInstanceState {
             DbNil.INSTANCE);
 
     variablesState = new VariablesState(zeebeDb, dbContext, keyGenerator);
-    awaitResultMetada = new AwaitWorkflowInstanceResultMetadata();
+    awaitResultMetadata = new AwaitWorkflowInstanceResultMetadata();
     awaitWorkflowInstanceResultMetadataColumnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.AWAIT_WORKLOW_RESULT,
             dbContext,
             elementInstanceKey,
-            awaitResultMetada);
+            awaitResultMetadata);
   }
 
   public ElementInstance newInstance(

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -119,6 +119,9 @@ message CreateWorkflowInstanceWithResultRequest {
   // before the requestTimeout.
   // if requestTimeout = 0, uses the generic requestTimeout configured in the gateway.
   int64 requestTimeout = 2;
+  // list of names of variables to be included in `CreateWorkflowInstanceWithResultResponse.variables`
+  // if empty, all visible variables in the root scope will be returned.
+  repeated string fetchVariables = 3;
 }
 
 message CreateWorkflowInstanceWithResultResponse {
@@ -132,7 +135,8 @@ message CreateWorkflowInstanceWithResultResponse {
   // the unique identifier of the created workflow instance; to be used wherever a request
   // needs a workflow instance key (e.g. CancelWorkflowInstanceRequest)
   int64 workflowInstanceKey = 4;
-  // consisting of all visible variables to the root scope
+  // JSON document
+  // consists of visible variables in the root scope
   string variables = 5;
 
 }

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -244,6 +244,12 @@
                 "id": 2,
                 "name": "requestTimeout",
                 "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "fetchVariables",
+                "type": "string",
+                "is_repeated": true
               }
             ]
           },

--- a/gateway/src/main/java/io/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/zeebe/gateway/RequestMapper.java
@@ -102,7 +102,8 @@ public class RequestMapper {
         .setBpmnProcessId(request.getBpmnProcessId())
         .setKey(request.getWorkflowKey())
         .setVersion(request.getVersion())
-        .setVariables(ensureJsonSet(request.getVariables()));
+        .setVariables(ensureJsonSet(request.getVariables()))
+        .setFetchVariables(grpcRequest.getFetchVariablesList());
 
     return brokerRequest;
   }

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/request/BrokerCreateWorkflowInstanceWithResultRequest.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/request/BrokerCreateWorkflowInstanceWithResultRequest.java
@@ -11,6 +11,7 @@ import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCrea
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceResultRecord;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.WorkflowInstanceCreationIntent;
+import java.util.List;
 import org.agrona.DirectBuffer;
 
 public class BrokerCreateWorkflowInstanceWithResultRequest
@@ -40,6 +41,12 @@ public class BrokerCreateWorkflowInstanceWithResultRequest
 
   public BrokerCreateWorkflowInstanceWithResultRequest setVariables(DirectBuffer variables) {
     requestDto.setVariables(variables);
+    return this;
+  }
+
+  public BrokerCreateWorkflowInstanceWithResultRequest setFetchVariables(
+      List<String> fetchVariables) {
+    requestDto.setFetchVariables(fetchVariables);
     return this;
   }
 

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/workflowinstance/WorkflowInstanceCreationRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/workflowinstance/WorkflowInstanceCreationRecord.java
@@ -7,15 +7,20 @@
  */
 package io.zeebe.protocol.impl.record.value.workflowinstance;
 
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.zeebe.msgpack.property.ArrayProperty;
 import io.zeebe.msgpack.property.DocumentProperty;
 import io.zeebe.msgpack.property.IntegerProperty;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
+import io.zeebe.msgpack.value.StringValue;
 import io.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.value.WorkflowInstanceCreationRecordValue;
 import io.zeebe.util.buffer.BufferUtil;
+import java.util.List;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 
@@ -28,13 +33,16 @@ public class WorkflowInstanceCreationRecord extends UnifiedRecordValue
   private final DocumentProperty variablesProperty = new DocumentProperty("variables");
   private final LongProperty workflowInstanceKeyProperty =
       new LongProperty("workflowInstanceKey", -1);
+  private final ArrayProperty<StringValue> fetchVariablesProperty =
+      new ArrayProperty<>("fetchVariables", new StringValue());
 
   public WorkflowInstanceCreationRecord() {
     this.declareProperty(bpmnProcessIdProperty)
         .declareProperty(workflowKeyProperty)
         .declareProperty(workflowInstanceKeyProperty)
         .declareProperty(versionProperty)
-        .declareProperty(variablesProperty);
+        .declareProperty(variablesProperty)
+        .declareProperty(fetchVariablesProperty);
   }
 
   @Override
@@ -88,6 +96,15 @@ public class WorkflowInstanceCreationRecord extends UnifiedRecordValue
 
   public WorkflowInstanceCreationRecord setVariables(DirectBuffer variables) {
     variablesProperty.setValue(variables);
+    return this;
+  }
+
+  public ArrayProperty<StringValue> fetchVariables() {
+    return fetchVariablesProperty;
+  }
+
+  public WorkflowInstanceCreationRecord setFetchVariables(List<String> fetchVariables) {
+    fetchVariables.forEach(variable -> fetchVariablesProperty.add().wrap(wrapString(variable)));
     return this;
   }
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/CreateWorkflowInstanceWithResultTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/CreateWorkflowInstanceWithResultTest.java
@@ -141,6 +141,27 @@ public class CreateWorkflowInstanceWithResultTest {
             "Expected to find workflow definition with key '123', but none found");
   }
 
+  @Test
+  public void shouldCreateWorkflowInstanceAwaitResultsWithFetchVariables() {
+    // when
+    final Map<String, Object> variables = Map.of("x", "foo", "y", "bar");
+    final WorkflowInstanceResult result =
+        CLIENT_RULE
+            .getClient()
+            .newCreateInstanceCommand()
+            .workflowKey(workflowKey)
+            .variables(variables)
+            .withResult()
+            .fetchVariables("y")
+            .send()
+            .join();
+
+    // then
+    assertThat(result.getBpmnProcessId()).isEqualTo(processId);
+    assertThat(result.getWorkflowKey()).isEqualTo(workflowKey);
+    assertThat(result.getVariablesAsMap()).containsExactly(entry("y", "bar"));
+  }
+
   private ZeebeFuture<WorkflowInstanceResult> createWorkflowInstanceWithVariables(
       Map<String, Object> variables) {
     return CLIENT_RULE


### PR DESCRIPTION
## Description

* Added another field in grpc message 'CreateWorkflowInstanceWithResultRequest'
* Response will now include only the requested variables

## Related issues

closes #3226 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
