### PR TITLE
chore(gateway): start partition service in gateway

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -40,6 +40,11 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
+      <artifactId>atomix</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-cluster</artifactId>
     </dependency>
 

--- a/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
@@ -9,6 +9,7 @@ package io.zeebe.gateway;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
+import io.atomix.core.Atomix;
 import io.atomix.utils.net.Address;
 import io.prometheus.client.exporter.HTTPServer;
 import io.zeebe.gateway.impl.broker.BrokerClient;
@@ -37,9 +38,9 @@ public class StandaloneGateway {
     this.gatewayCfg = gatewayCfg;
   }
 
-  private AtomixCluster createAtomixCluster(ClusterCfg clusterCfg) {
-    final AtomixCluster atomixCluster =
-        AtomixCluster.builder()
+  private AtomixCluster createAtomixCluster(final ClusterCfg clusterCfg) {
+    final var atomix =
+        Atomix.builder()
             .withMemberId(clusterCfg.getMemberId())
             .withAddress(Address.from(clusterCfg.getHost(), clusterCfg.getPort()))
             .withClusterId(clusterCfg.getClusterName())
@@ -49,9 +50,8 @@ public class StandaloneGateway {
                     .build())
             .build();
 
-    atomixCluster.start();
-
-    return atomixCluster;
+    atomix.start();
+    return atomix;
   }
 
   private ActorScheduler createActorScheduler(GatewayCfg configuration) {

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -21,6 +21,7 @@ import static io.zeebe.test.util.TestUtil.waitUntil;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
+import io.atomix.core.Atomix;
 import io.atomix.utils.net.Address;
 import io.zeebe.broker.Broker;
 import io.zeebe.broker.system.configuration.BrokerCfg;
@@ -291,7 +292,7 @@ public class ClusteringRule extends ExternalResource {
 
     // copied from StandaloneGateway
     atomixCluster =
-        AtomixCluster.builder()
+        Atomix.builder()
             .withMemberId(clusterCfg.getMemberId())
             .withAddress(Address.from(clusterCfg.getHost(), clusterCfg.getPort()))
             .withClusterId(clusterCfg.getClusterName())


### PR DESCRIPTION
## Description

Use Atomix as builder to start the default partition service even in the standalone gateway, to ensure all nodes can be bootstrapped properly. As described in #3263, when a node is bootstrapping its partition service, it polls every node in the cluster on a particular topic, and will retry forever if the node is not subscribed to that topic (I imagine for fault-tolerance issue). Simplest fix is to have the node start its own partition service without being part of any partitions regardless.

This seems to be a safe solution, but we could go for a more "ideal" solution where nodes will bootstrap their partitions only from other partition-aware nodes - I'm not sure if that's necessary here however.

## Related issues

closes #3250 
closes #3263 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
