### PR TITLE
chore(broker): move exporter clear state to service to ensure dependency

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/exporter/ExporterClearStateService.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/ExporterClearStateService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.exporter;
+
+import io.zeebe.broker.Loggers;
+import io.zeebe.broker.exporter.stream.ExportersState;
+import io.zeebe.db.ZeebeDb;
+import io.zeebe.servicecontainer.Service;
+import io.zeebe.servicecontainer.ServiceStartContext;
+import org.slf4j.Logger;
+
+public class ExporterClearStateService implements Service<Void> {
+
+  private static final Logger LOG = Loggers.EXPORTER_LOGGER;
+
+  private final ZeebeDb zeebeDb;
+
+  public ExporterClearStateService(ZeebeDb zeebeDb) {
+    this.zeebeDb = zeebeDb;
+  }
+
+  @Override
+  public void start(ServiceStartContext startContext) {
+    // We need to remove the exporter positions from the state in case that one of the exporters is
+    // configured later again. The processor would try to continue from the previous position which
+    // may not
+    // exist anymore in the logstream.
+
+    try {
+      final ExportersState state = new ExportersState(zeebeDb, zeebeDb.createContext());
+
+      state.visitPositions(
+          (exporterId, position) -> {
+            state.removePosition(exporterId);
+
+            LOG.info(
+                "The exporter '{}' is not configured anymore. Its position is removed from the state.",
+                exporterId);
+          });
+    } catch (Exception e) {
+      LOG.error("Failed to remove exporters from state", e);
+    }
+  }
+
+  @Override
+  public Void get() {
+    return null;
+  }
+}

--- a/broker/src/main/java/io/zeebe/broker/exporter/ExporterServiceNames.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/ExporterServiceNames.java
@@ -18,4 +18,9 @@ public class ExporterServiceNames {
     final String name = String.format("io.zeebe.broker.exporter.%d", partitionId);
     return ServiceName.newServiceName(name, ExporterDirector.class);
   }
+
+  public static ServiceName<Void> exporterClearStateServiceName(int partitionId) {
+    final String name = String.format("io.zeebe.broker.exporter.clear-state.%d", partitionId);
+    return ServiceName.newServiceName(name, Void.class);
+  }
 }


### PR DESCRIPTION
## Description

Move `clearExporterState` method to own service to make partition dependency explicit.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3256

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
