### PR TITLE
feat(broker): support interrupting timer event subprocess

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableActivity.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableActivity.java
@@ -25,7 +25,7 @@ public class ExecutableActivity extends ExecutableFlowNode implements Executable
     boundaryEvents.add(boundaryEvent);
     catchEvents.add(boundaryEvent);
 
-    if (boundaryEvent.cancelActivity()) {
+    if (boundaryEvent.interrupting()) {
       interruptingIds.add(boundaryEvent.getId());
     }
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableBoundaryEvent.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableBoundaryEvent.java
@@ -8,22 +8,13 @@
 package io.zeebe.engine.processor.workflow.deployment.model.element;
 
 public class ExecutableBoundaryEvent extends ExecutableCatchEventElement {
-  private boolean cancelActivity;
 
   public ExecutableBoundaryEvent(String id) {
     super(id);
   }
 
-  public boolean cancelActivity() {
-    return cancelActivity;
-  }
-
   @Override
   public boolean shouldCloseMessageSubscriptionOnCorrelate() {
-    return cancelActivity;
-  }
-
-  public void setCancelActivity(boolean cancelActivity) {
-    this.cancelActivity = cancelActivity;
+    return interrupting();
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableCatchEventElement.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableCatchEventElement.java
@@ -19,6 +19,7 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
 
   private ExecutableMessage message;
   private Timer timer;
+  private boolean interrupting;
 
   public ExecutableCatchEventElement(String id) {
     super(id);
@@ -60,5 +61,13 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
   @Override
   public Collection<DirectBuffer> getInterruptingElementIds() {
     return Collections.singleton(getId());
+  }
+
+  public boolean interrupting() {
+    return interrupting;
+  }
+
+  public void setInterrupting(boolean interrupting) {
+    this.interrupting = interrupting;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/BoundaryEventTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/BoundaryEventTransformer.java
@@ -27,7 +27,7 @@ public class BoundaryEventTransformer implements ModelElementTransformer<Boundar
     final ExecutableBoundaryEvent element =
         workflow.getElementById(event.getId(), ExecutableBoundaryEvent.class);
 
-    element.setCancelActivity(event.cancelActivity());
+    element.setInterrupting(event.cancelActivity());
     attachToActivity(event, workflow, element);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/FlowNodeTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/FlowNodeTransformer.java
@@ -36,7 +36,7 @@ public class FlowNodeTransformer implements ModelElementTransformer<FlowNode> {
     final ExecutableFlowNode element =
         workflow.getElementById(flowNode.getId(), ExecutableFlowNode.class);
 
-    transformIoMappings(flowNode, element, context);
+    transformIoMappings(flowNode, element);
     bindLifecycle(element);
   }
 
@@ -56,8 +56,7 @@ public class FlowNodeTransformer implements ModelElementTransformer<FlowNode> {
         WorkflowInstanceIntent.ELEMENT_TERMINATED, BpmnStep.ELEMENT_TERMINATED);
   }
 
-  private void transformIoMappings(
-      FlowNode element, final ExecutableFlowNode flowNode, TransformContext context) {
+  private void transformIoMappings(FlowNode element, final ExecutableFlowNode flowNode) {
     final ZeebeIoMapping ioMapping = element.getSingleExtensionElement(ZeebeIoMapping.class);
 
     if (ioMapping != null) {

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/StartEventTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/StartEventTransformer.java
@@ -31,6 +31,8 @@ public class StartEventTransformer implements ModelElementTransformer<StartEvent
     final ExecutableStartEvent startEvent =
         workflow.getElementById(element.getId(), ExecutableStartEvent.class);
 
+    startEvent.setInterrupting(element.isInterrupting());
+
     if (element.getScope() instanceof FlowNode) {
       final FlowNode scope = (FlowNode) element.getScope();
 

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/SubProcessTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/SubProcessTransformer.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.processor.workflow.deployment.model.transformer;
 import io.zeebe.engine.processor.workflow.deployment.model.BpmnStep;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableCatchEvent;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableFlowElementContainer;
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableStartEvent;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableWorkflow;
 import io.zeebe.engine.processor.workflow.deployment.model.transformation.ModelElementTransformer;
 import io.zeebe.engine.processor.workflow.deployment.model.transformation.TransformContext;
@@ -60,14 +61,11 @@ public class SubProcessTransformer implements ModelElementTransformer<SubProcess
       parentEvents = currentWorkflow.getEvents();
     }
 
-    subprocess
-        .getStartEvents()
-        .forEach(
-            startEvent -> {
-              parentEvents.add(startEvent);
-              startEvent.setEventSubProcess(subprocess.getId());
-              startEvent.bindLifecycleState(
-                  WorkflowInstanceIntent.EVENT_OCCURRED, BpmnStep.EVENT_SUBPROC_EVENT_OCCURRED);
-            });
+    final ExecutableStartEvent startEvent = subprocess.getStartEvents().iterator().next();
+
+    parentEvents.add(startEvent);
+    startEvent.setEventSubProcess(subprocess.getId());
+    startEvent.bindLifecycleState(
+        WorkflowInstanceIntent.EVENT_OCCURRED, BpmnStep.EVENT_SUBPROC_EVENT_OCCURRED);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/AbstractHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/AbstractHandler.java
@@ -114,4 +114,17 @@ public abstract class AbstractHandler<T extends ExecutableFlowElement>
       context.getStateDb().getEventScopeInstanceState().shutdownInstance(context.getKey());
     }
   }
+
+  /**
+   * @return true if an interrupting event (e.g., interrupting event subprocess) occurred and it
+   *     wasn't produced by the current element.
+   */
+  protected boolean isElementInterrupted(BpmnStepContext<T> context) {
+    if (context.getFlowScopeInstance() != null) {
+      final long interruptingKey = context.getFlowScopeInstance().getInterruptingEventKey();
+      return interruptingKey != -1 && interruptingKey != context.getKey();
+    }
+
+    return false;
+  }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/activity/ActivityEventOccurredHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/activity/ActivityEventOccurredHandler.java
@@ -42,7 +42,7 @@ public class ActivityEventOccurredHandler<T extends ExecutableActivity>
 
     final WorkflowInstanceRecord eventRecord =
         getEventRecord(context, event, boundaryEvent.getElementType());
-    if (boundaryEvent.cancelActivity()) {
+    if (boundaryEvent.interrupting()) {
       transitionTo(context, WorkflowInstanceIntent.ELEMENT_TERMINATING);
       deferEvent(context, context.getKey(), context.getKey(), eventRecord, event);
     } else {

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/container/ContainerElementActivatedHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/container/ContainerElementActivatedHandler.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.processor.workflow.handlers.container;
 import io.zeebe.engine.processor.workflow.BpmnStepContext;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableCatchEventElement;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableFlowElementContainer;
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableStartEvent;
 import io.zeebe.engine.processor.workflow.handlers.element.ElementActivatedHandler;
 import io.zeebe.engine.state.deployment.WorkflowState;
 import io.zeebe.engine.state.instance.IndexedRecord;
@@ -39,12 +40,12 @@ public class ContainerElementActivatedHandler<T extends ExecutableFlowElementCon
     }
 
     final ExecutableFlowElementContainer element = context.getElement();
-    final ExecutableCatchEventElement firstStartEvent = element.getStartEvents().get(0);
+    final ExecutableStartEvent firstStartEvent = element.getStartEvents().get(0);
 
     // workflows with none start event only have a single none start event and no other types of
-    // start events; note that embedded sub-processes only have a single none start event, so
+    // start events; note that sub-processes only have a single none start event, so
     // publishing a deferred record only applies to processes
-    if (firstStartEvent.isNone()) {
+    if (firstStartEvent.isNone() || firstStartEvent.getEventSubProcess() != null) {
       activateNoneStartEvent(context, firstStartEvent);
     } else {
       publishDeferredRecord(context);

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/element/ElementActivatingHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/element/ElementActivatingHandler.java
@@ -53,6 +53,7 @@ public class ElementActivatingHandler<T extends ExecutableFlowNode> extends Abst
   protected boolean shouldHandleState(BpmnStepContext<T> context) {
     return super.shouldHandleState(context)
         && isStateSameAsElementState(context)
-        && (isRootScope(context) || isElementActive(context.getFlowScopeInstance()));
+        && (isRootScope(context) || isElementActive(context.getFlowScopeInstance()))
+        && !isElementInterrupted(context);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/seqflow/SequenceFlowTakenHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/seqflow/SequenceFlowTakenHandler.java
@@ -19,10 +19,6 @@ public class SequenceFlowTakenHandler<T extends ExecutableSequenceFlow> extends 
     super(null);
   }
 
-  public SequenceFlowTakenHandler(WorkflowInstanceIntent nextState) {
-    super(nextState);
-  }
-
   @Override
   protected boolean handleState(BpmnStepContext<T> context) {
     final ExecutableSequenceFlow sequenceFlow = context.getElement();
@@ -38,6 +34,8 @@ public class SequenceFlowTakenHandler<T extends ExecutableSequenceFlow> extends 
 
   @Override
   protected boolean shouldHandleState(BpmnStepContext<T> context) {
-    return super.shouldHandleState(context) && isElementActive(context.getFlowScopeInstance());
+    return super.shouldHandleState(context)
+        && isElementActive(context.getFlowScopeInstance())
+        && !isElementInterrupted(context);
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/handlers/element/ElementCompletedHandlerTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/handlers/element/ElementCompletedHandlerTest.java
@@ -79,6 +79,7 @@ public class ElementCompletedHandlerTest extends ElementHandlerTestCase<Executab
     // given
     final ElementInstance flowScope = newElementInstance(WorkflowInstanceIntent.ELEMENT_ACTIVATED);
     createAndSetContextElementInstance(WorkflowInstanceIntent.ELEMENT_COMPLETED, flowScope);
+    context.setElement(new ExecutableFlowNode("id"));
 
     // when
     handler.handleState(context);


### PR DESCRIPTION
## Description

Adds support for interrupting timer event subprocesses. 

## Related issues

closes #3208 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
