### PR TITLE
chore(transport): add info to help debug flaky test

### DIFF
--- a/transport/src/main/java/io/zeebe/transport/ClientOutput.java
+++ b/transport/src/main/java/io/zeebe/transport/ClientOutput.java
@@ -17,15 +17,6 @@ import org.agrona.DirectBuffer;
 public interface ClientOutput {
 
   /**
-   * Sends a message according to the single message protocol.
-   *
-   * <p>Returns false if the message cannot be currently written due to an unknown endpoint or
-   * exhausted capacity. Throws an exception if the request is not sendable at all (e.g. buffer
-   * writer throws exception).
-   */
-  boolean sendMessage(Integer nodeId, BufferWriter writer);
-
-  /**
    * Like {@link #sendRequest(Integer, BufferWriter, Duration)} where the timeout is set to the
    * configured default timeout.
    *

--- a/transport/src/test/java/io/zeebe/transport/BufferingServerTransportTest.java
+++ b/transport/src/test/java/io/zeebe/transport/BufferingServerTransportTest.java
@@ -7,31 +7,20 @@
  */
 package io.zeebe.transport;
 
-import static io.zeebe.test.util.TestUtil.doRepeatedly;
-import static io.zeebe.util.buffer.DirectBufferWriter.writerFor;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.zeebe.dispatcher.Dispatcher;
 import io.zeebe.dispatcher.Dispatchers;
 import io.zeebe.test.util.AutoCloseableRule;
 import io.zeebe.test.util.socket.SocketUtil;
-import io.zeebe.transport.impl.TransportHeaderDescriptor;
 import io.zeebe.transport.util.RecordingMessageHandler;
-import io.zeebe.transport.util.TransportTestUtil;
 import io.zeebe.util.ByteValue;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.RuleChain;
 
 public class BufferingServerTransportTest {
   public static final ByteValue BUFFER_SIZE = ByteValue.ofKilobytes(16);
   public static final SocketAddress SERVER_ADDRESS = new SocketAddress(SocketUtil.getNextAddress());
-  public static final int NODE_ID = 1;
 
   public ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule(3);
   public AutoCloseableRule closeables = new AutoCloseableRule();
@@ -63,45 +52,5 @@ public class BufferingServerTransportTest {
             .bindAddress(SERVER_ADDRESS.toInetSocketAddress())
             .buildBuffering(serverReceiveBuffer);
     closeables.manage(serverTransport);
-  }
-
-  @Test
-  public void shouldPostponeMessagesOnReceiveBufferBackpressure() throws InterruptedException {
-    // given
-    final int maximumMessageLength =
-        serverReceiveBuffer.getMaxFragmentLength()
-            - TransportHeaderDescriptor.HEADER_LENGTH
-            - 1; // https://github.com/zeebe-io/zb-dispatcher/issues/21
-
-    final DirectBuffer largeBuf = new UnsafeBuffer(new byte[maximumMessageLength]);
-
-    final int messagesToExhaustReceiveBuffer =
-        ((int) BUFFER_SIZE.toBytes() / largeBuf.capacity()) + 1;
-
-    clientTransport.registerEndpoint(NODE_ID, SERVER_ADDRESS);
-
-    final ServerInputSubscription serverSubscription =
-        serverTransport.openSubscription("foo", serverHandler, null).join();
-
-    // exhaust server's receive buffer
-    for (int i = 0; i < messagesToExhaustReceiveBuffer; i++) {
-      doRepeatedly(() -> clientTransport.getOutput().sendMessage(NODE_ID, writerFor(largeBuf)))
-          .until(s -> s);
-    }
-
-    TransportTestUtil.waitUntilExhausted(serverReceiveBuffer);
-    Thread.sleep(200L); // give transport some time to try to push things on top
-
-    // when
-    final AtomicInteger receivedMessages = new AtomicInteger(0);
-    doRepeatedly(
-            () -> {
-              final int polledMessages = serverSubscription.poll();
-              return receivedMessages.addAndGet(polledMessages);
-            })
-        .until(m -> m == messagesToExhaustReceiveBuffer);
-
-    // then
-    assertThat(receivedMessages.get()).isEqualTo(messagesToExhaustReceiveBuffer);
   }
 }

--- a/transport/src/test/java/io/zeebe/transport/MixedProtocolsTest.java
+++ b/transport/src/test/java/io/zeebe/transport/MixedProtocolsTest.java
@@ -7,19 +7,13 @@
  */
 package io.zeebe.transport;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.zeebe.test.util.AutoCloseableRule;
-import io.zeebe.test.util.socket.SocketUtil;
 import io.zeebe.transport.impl.TransportHeaderDescriptor;
 import io.zeebe.util.buffer.DirectBufferWriter;
-import io.zeebe.util.sched.future.ActorFuture;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
-import java.util.concurrent.ExecutionException;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.RuleChain;
 
 public class MixedProtocolsTest {
@@ -28,44 +22,6 @@ public class MixedProtocolsTest {
   @Rule public RuleChain ruleChain = RuleChain.outerRule(actorSchedulerRule).around(closeables);
   protected final UnsafeBuffer requestBuffer = new UnsafeBuffer(new byte[1024]);
   protected final DirectBufferWriter bufferWriter = new DirectBufferWriter();
-
-  @Test
-  public void shouldEchoMessages() throws InterruptedException, ExecutionException {
-    final int nodeId = 1;
-    final SocketAddress addr = new SocketAddress(SocketUtil.getNextAddress());
-    final int numRequests = 1000;
-
-    final ClientTransport clientTransport =
-        Transports.newClientTransport("test").scheduler(actorSchedulerRule.get()).build();
-    closeables.manage(clientTransport);
-
-    final ReverseOrderChannelHandler handler = new ReverseOrderChannelHandler();
-
-    final ServerTransport serverTransport =
-        Transports.newServerTransport()
-            .bindAddress(addr.toInetSocketAddress())
-            .scheduler(actorSchedulerRule.get())
-            .build(handler, handler);
-    closeables.manage(serverTransport);
-
-    clientTransport.registerEndpointAndAwaitChannel(nodeId, addr);
-
-    for (int i = 0; i < numRequests; i++) {
-      requestBuffer.putInt(0, i);
-      bufferWriter.wrap(requestBuffer, 0, requestBuffer.capacity());
-      final ActorFuture<ClientResponse> responseFuture =
-          clientTransport.getOutput().sendRequest(nodeId, bufferWriter);
-
-      requestBuffer.putInt(0, numRequests - i);
-      final boolean success = clientTransport.getOutput().sendMessage(nodeId, bufferWriter);
-      if (!success) {
-        throw new RuntimeException("Could not send message");
-      }
-
-      final ClientResponse response = responseFuture.join();
-      assertThat(response.getResponseBuffer().getInt(0)).isEqualTo(i);
-    }
-  }
 
   /**
    * Echos messages by copying to the send buffer, but inverts the order of request-response

--- a/transport/src/test/java/io/zeebe/transport/ServerTransportTest.java
+++ b/transport/src/test/java/io/zeebe/transport/ServerTransportTest.java
@@ -7,17 +7,10 @@
  */
 package io.zeebe.transport;
 
-import static io.zeebe.test.util.BufferAssert.assertThatBuffer;
-import static io.zeebe.test.util.TestUtil.waitUntil;
-import static io.zeebe.util.buffer.DirectBufferWriter.writerFor;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.zeebe.dispatcher.Dispatcher;
 import io.zeebe.dispatcher.Dispatchers;
 import io.zeebe.test.util.AutoCloseableRule;
-import io.zeebe.test.util.TestUtil;
 import io.zeebe.test.util.socket.SocketUtil;
-import io.zeebe.transport.util.RecordingChannelListener;
 import io.zeebe.transport.util.RecordingMessageHandler;
 import io.zeebe.util.ByteValue;
 import io.zeebe.util.buffer.BufferUtil;
@@ -25,7 +18,6 @@ import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import org.agrona.DirectBuffer;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.RuleChain;
 
 public class ServerTransportTest {
@@ -74,57 +66,5 @@ public class ServerTransportTest {
     closeables.manage(serverTransport);
 
     clientSubscription = clientTransport.openSubscription("receiver", clientHandler).join();
-  }
-
-  /**
-   * When a single remote reconnects, the stream ID for messages/responses sent by the server should
-   * be changed, so that the client does not accidentally receive any messages that were scheduled
-   * before reconnect and were in the send buffer during reconnection (for example this is important
-   * for subscriptions).
-   */
-  @Test
-  public void shouldNotSendMessagesForPreviousStreamIdAfterReconnect() {
-    // given
-    final ServerOutput serverOutput = serverTransport.getOutput();
-    final ClientOutput clientOutput = clientTransport.getOutput();
-
-    final RecordingChannelListener channelListener = new RecordingChannelListener();
-
-    clientTransport.registerChannelListener(channelListener);
-
-    clientTransport.registerEndpoint(NODE_ID, SERVER_ADDRESS);
-    waitUntil(() -> channelListener.getOpenedConnections().size() == 1);
-
-    // make first request
-    clientOutput.sendMessage(NODE_ID, writerFor(BUF1));
-    TestUtil.waitUntil(() -> serverHandler.numReceivedMessages() == 1);
-
-    final RemoteAddress firstRemote = serverHandler.getMessage(0).getRemote();
-
-    // close client channel
-    clientTransport.closeAllChannels().join();
-
-    // wait for reconnect
-    waitUntil(() -> channelListener.getOpenedConnections().size() == 2);
-
-    // make a second request
-    clientOutput.sendMessage(NODE_ID, writerFor(BUF1));
-    TestUtil.waitUntil(() -> serverHandler.numReceivedMessages() == 2);
-    final RemoteAddress secondRemote = serverHandler.getMessage(1).getRemote();
-
-    // when
-    // sending server message with previous stream id
-    serverOutput.sendMessage(firstRemote.getStreamId(), writerFor(BUF1));
-
-    // and sending server message with new stream id
-    serverOutput.sendMessage(secondRemote.getStreamId(), writerFor(BUF2));
-
-    // then
-    // first message has not been received by client
-    assertThat(firstRemote.getStreamId()).isNotEqualTo(secondRemote.getStreamId());
-
-    TestUtil.doRepeatedly(() -> clientSubscription.poll())
-        .until(i -> clientHandler.numReceivedMessages() == 1);
-    assertThatBuffer(clientHandler.getMessage(0).getBuffer()).hasBytes(BUF2);
   }
 }


### PR DESCRIPTION
## Description

- removes message (i.e. unicast) capabilities from ClientTransport, as it was not stable

In general, as our goal is to get rid of the transport, I don't foresee us adding new features using these capabilities, and as our tests are flaky, we might as well just remove the whole thing.

## Related issues

Closes #3273 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
