### PR TITLE
chore(servicecontainer): always stop dependents when stoping a service

### DIFF
--- a/service-container/src/main/java/io/zeebe/servicecontainer/impl/ServiceController.java
+++ b/service-container/src/main/java/io/zeebe/servicecontainer/impl/ServiceController.java
@@ -228,8 +228,7 @@ public class ServiceController extends Actor {
     }
 
     private void onDependenciesUnAvailable(ServiceEvent evt) {
-      state = removedState;
-      fireEvent(ServiceEventType.SERVICE_REMOVED);
+      fireEvent(ServiceEventType.SERVICE_STOPPING);
     }
 
     private void onStopping() {
@@ -285,6 +284,8 @@ public class ServiceController extends Actor {
           onStartFailed((Throwable) t.getPayload());
           break;
         case DEPENDENCIES_UNAVAILABLE:
+          fireEvent(ServiceEventType.SERVICE_STOPPING);
+          break;
         case DEPENDENTS_STOPPED:
         case SERVICE_STOPPING:
           if (startContext.isInterruptible()) {
@@ -319,8 +320,8 @@ public class ServiceController extends Actor {
     public void onStartFailed(Throwable t) {
       LOG.error("Service {} failed to start while in AwaitStartState", name, t);
       startFuture.completeExceptionally(t);
-      state = awaitStopState;
-      fireEvent(ServiceEventType.SERVICE_STOPPED);
+      state = awaitDependentsStopped;
+      fireEvent(ServiceEventType.SERVICE_STOPPING);
     }
   }
 

--- a/service-container/src/test/java/io/zeebe/servicecontainer/impl/AsyncStartTest.java
+++ b/service-container/src/test/java/io/zeebe/servicecontainer/impl/AsyncStartTest.java
@@ -354,7 +354,7 @@ public class AsyncStartTest {
     // then
     assertFailed(service1StartFuture);
     assertCompleted(removeFuture);
-    assertThat(service.wasStopped).isFalse();
+    assertThat(service.wasStopped).isTrue();
   }
 
   static class AsyncStartService implements Service<Object> {


### PR DESCRIPTION
## Description

- Send event `SERVICE_STOPPING` even if service is not started yet, so that dependents are also removed.
- `Service.stop()` will be called even if start failed exceptionally. This allows to cleanup the services.

## Related issues

closes #3289

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
