### PR TITLE
fix(broker): don't activate call activity if incident is created

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/callactivity/CallActivityActivatingHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/callactivity/CallActivityActivatingHandler.java
@@ -40,7 +40,9 @@ public class CallActivityActivatingHandler
 
   @Override
   protected boolean handleState(BpmnStepContext<ExecutableCallActivity> context) {
-    super.handleState(context);
+    if (!super.handleState(context)) {
+      return false;
+    }
 
     getProcessId(context)
         .map(processId -> getCalledWorkflow(processId, context))


### PR DESCRIPTION
## Description

* before activating the call activity check if the preconditions are passed (i.e. input mappings, event subscriptions)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3287 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
