### PR TITLE
chore(protocol): downgrade protocol module to java 8

### DIFF
--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -21,6 +21,7 @@
   </licenses>
 
   <properties>
+    <version.java>8</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
     <protocol.version>1</protocol.version>
   </properties>

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/Intent.java
@@ -16,12 +16,12 @@
 package io.zeebe.protocol.record.intent;
 
 import io.zeebe.protocol.record.ValueType;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 public interface Intent {
   Collection<Class<? extends Intent>> INTENT_CLASSES =
-      List.of(
+      Arrays.asList(
           DeploymentIntent.class,
           IncidentIntent.class,
           JobIntent.class,


### PR DESCRIPTION
## Description

Allow to use the protocol module with older java versions 8+

## Related issues

closes #3298

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
