### PR TITLE
fix(broker): terminate call activity on completing

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/callactivity/CallActivityTerminatingHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/callactivity/CallActivityTerminatingHandler.java
@@ -29,7 +29,7 @@ public class CallActivityTerminatingHandler
     final var calledChildInstanceKey = context.getElementInstance().getCalledChildInstanceKey();
     final var childInstance = context.getElementInstanceState().getInstance(calledChildInstanceKey);
 
-    if (childInstance != null && childInstance.isActive()) {
+    if (childInstance != null && childInstance.canTerminate()) {
       context
           .getOutput()
           .appendFollowUpEvent(
@@ -37,9 +37,11 @@ public class CallActivityTerminatingHandler
               WorkflowInstanceIntent.ELEMENT_TERMINATING,
               childInstance.getValue());
 
-      return true;
+    } else {
+      // child instance is already completed or terminated
+      transitionTo(context, WorkflowInstanceIntent.ELEMENT_TERMINATED);
     }
 
-    return false;
+    return true;
   }
 }


### PR DESCRIPTION
## Description

* if the called child workflow instance can not be terminated (e.g. because it is already completed) then the call activity is terminated immediately

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3288 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
