### PR TITLE
chore(qa): fix race condition when getting a service

### DIFF
--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -605,8 +605,11 @@ public class ClusteringRule extends ExternalResource {
       throw new RuntimeException(e);
     }
 
+    // need to extract value before removing the service, as once stopped we will
+    // uninject the value
+    final var injected = injector.getValue();
     serviceContainer.removeService(accessorServiceName);
 
-    return injector.getValue();
+    return injected;
   }
 }


### PR DESCRIPTION
## Description

When removing a service, once the service is fully stopped, the value of its injectors is set to null explicitly; in our tests we sometimes get injected services, but we remove the service before returning the injected value. This results in a potential race condition where the service is fully stopped and the injected value nulled before the method returns.

## Related issues

closes #3296 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
