### PR TITLE
chore(ci): New pipeline to run chaos tests

### DIFF
--- a/.ci/jobs/chaos_test_zeebe.dsl
+++ b/.ci/jobs/chaos_test_zeebe.dsl
@@ -1,0 +1,11 @@
+// vim: set filetype=groovy:
+
+pipelineJob('chaos-test') {
+    displayName 'Zeebe Chaos Test'
+    definition {
+        cps {
+            script(readFileFromWorkspace('.ci/pipelines/chaos_test_zeebe.groovy'))
+            sandbox()
+        }
+    }
+}

--- a/.ci/pipelines/chaos_test_zeebe.groovy
+++ b/.ci/pipelines/chaos_test_zeebe.groovy
@@ -1,0 +1,140 @@
+final PROJECT = "zeebe"
+final CHAOS_TEST_NAMESPACE = "zeebe-chaos-test"
+final NOTIFY_EMAIL = "christopher.zell@camunda.com"
+
+pipeline {
+    triggers {
+        cron('H 1 * * *')
+    }
+
+    options {
+        buildDiscarder(
+                logRotator(
+                        numToKeepStr: '10',
+                        daysToKeepStr: '-1',
+                        artifactDaysToKeepStr: '-1',
+                        artifactNumToKeepStr: '10'))
+        timeout(time: 1, unit: 'HOURS')
+        skipDefaultCheckout()
+        timestamps()
+    }
+
+    agent {
+        kubernetes {
+            cloud "${PROJECT}-ci"
+            label "${PROJECT}-ci-build-${env.JOB_BASE_NAME}-${env.BUILD_ID}"
+            defaultContainer 'jnlp'
+            yaml pythonAgent()
+        }
+    }
+
+    stages {
+        stage('Clone') {
+            steps {
+                dir('zeebe-benchmark') {
+                    git url: 'git@github.com:zeebe-io/zeebe-benchmark',
+                            branch: "master",
+                            credentialsId: 'camunda-jenkins-github-ssh',
+                            poll: false
+                }
+                dir('zeebe') {
+                    git url: 'git@github.com:zeebe-io/zeebe',
+                            branch: "develop",
+                            credentialsId: 'camunda-jenkins-github-ssh',
+                            poll: false
+                }
+            }
+        }
+
+        stage('Install dependencies') {
+            steps {
+                container('python') {
+                    sh "zeebe/.ci/scripts/chaos-tests/install_deps.sh"
+                }
+            }
+        }
+
+        stage('Create cluster') {
+            steps {
+                container('python') {
+                    // copy dummy kubeconfig so we can change default namespace later, without the config
+                    // file `kubectl` cannot change the context since it's not defined
+                    sh 'mkdir -p ~/.kube && cp zeebe/.ci/scripts/chaos-tests/kubeconfig ~/.kube/config'
+                    sh "cp -a zeebe-benchmark/k8s/. zeebe/.ci/scripts/chaos-tests/kustomize/"
+
+                    dir('zeebe/.ci/scripts/chaos-tests/') {
+                        sh "./setup.sh --action=create --namespace=${CHAOS_TEST_NAMESPACE}"
+                        sh "kubectl config set-context --current --namespace=${CHAOS_TEST_NAMESPACE}"
+                        sh 'kubectl apply --kustomize kustomize'
+                    }
+                }
+            }
+        }
+
+        stage('Run chaos tests') {
+            steps {
+                container('python') {
+                    dir('zeebe-benchmark/chaos') {
+                        script {
+                            findFiles(glob: '**/*.json').each {
+                                sh 'PATH="$PATH:$(pwd)/scripts/" chaos run ' + it
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            container('python') {
+                sh "zeebe/.ci/scripts/chaos-tests/setup.sh --action=delete --namespace=${CHAOS_TEST_NAMESPACE}"
+            }
+        }
+
+        failure {
+            buildNotification(currentBuild.result, NOTIFY_EMAIL)
+        }
+    }
+}
+
+void buildNotification(String buildStatus, String to) {
+    buildStatus = buildStatus ?: 'SUCCESS'
+
+    String subject = "[${buildStatus}] - ${env.JOB_NAME} - Build #${env.BUILD_NUMBER}"
+    String body = "See: ${env.BUILD_URL}consoleFull"
+
+    emailext subject: subject, body: body, to: to
+}
+
+static String pythonAgent() {
+    def nodePool = 'slaves'
+    def project = 'zeebe'
+    """
+metadata:
+  labels:
+    agent: ${project}-ci-build
+spec:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: ${nodePool}
+  tolerations:
+    - key: "${nodePool}"
+      operator: "Exists"
+      effect: "NoSchedule"
+  serviceAccountName: ci-${project}-camunda-cloud
+  containers:
+  - name: python
+    image: python:3.8-alpine
+    imagePullPolicy: Always
+    command: ["cat"]
+    tty: true
+    resources:
+      limits:
+        cpu: 1
+        memory: 512Mi
+      requests:
+        cpu: 200m
+        memory: 128Mi
+"""
+}

--- a/.ci/scripts/chaos-tests/install_deps.sh
+++ b/.ci/scripts/chaos-tests/install_deps.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -ex
+
+apk --no-cache add bash make curl
+
+pip install chaostoolkit
+chaos --version
+
+kubectl_version=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+curl -LO https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/linux/amd64/kubectl
+install kubectl /usr/local/bin/
+kubectl version --client

--- a/.ci/scripts/chaos-tests/kubeconfig
+++ b/.ci/scripts/chaos-tests/kubeconfig
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Config
+preferences: {}
+
+contexts:
+- context:
+  name: zeebe
+
+current-context: zeebe

--- a/.ci/scripts/chaos-tests/kustomize/kustomization.yml
+++ b/.ci/scripts/chaos-tests/kustomize/kustomization.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: zeebe-chaos-test
+
+resources:
+  - zeebe.yaml
+  - starter.yaml
+  - worker.yaml
+
+patchesStrategicMerge:
+  - zeebe_statefulset_tolerations.yml

--- a/.ci/scripts/chaos-tests/kustomize/zeebe_statefulset_tolerations.yml
+++ b/.ci/scripts/chaos-tests/kustomize/zeebe_statefulset_tolerations.yml
@@ -1,0 +1,16 @@
+# Zeebe cluster has large CPU and RAM requirements, we need to make sure they can be run
+# on powerful enough nodes in the CI cluster
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: zeebe
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: slaves
+      tolerations:
+        - key: "slaves"
+          operator: "Exists"
+          effect: "NoSchedule"

--- a/.ci/scripts/chaos-tests/setup.sh
+++ b/.ci/scripts/chaos-tests/setup.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: ${0} --action=[create|delete] --namespace=<namespace>"
+}
+
+fail() {
+  usage
+  echo "[${0}] Error: ${1}"
+  exit 1
+}
+
+namespace_create() {
+  set +e
+  kubectl get namespace "${1}" > /dev/null 2>&1
+  if [[ $? -eq 0 ]]; then
+    fail "Namespace ${1} already exists. Is the previous test still running?"
+  fi
+  set -e
+
+  kubectl create namespace "${1}"
+}
+
+namespace_delete() {
+  set +e
+  kubectl delete namespace "${1}"
+  set -e
+}
+
+ACTION=""
+NAMESPACE=""
+
+for i in "$@"
+do
+case $i in
+  -a=*|--action=*)
+    ACTION="${i#*=}"
+    shift
+    ;;
+  -ns=*|--namespace=*)
+    NAMESPACE="${i#*=}"
+    shift
+    ;;
+  *)
+    fail "Unknown option provided"
+    ;;
+esac
+done
+
+if ! [[ "${ACTION}" =~ ^(create|delete)$ ]]; then
+  fail "Action must be either 'create' or 'delete', got '${ACTION}'"
+fi
+
+if ! [[ "${NAMESPACE}" =~ ^zeebe-chaos.* ]]; then
+  fail "Namespace must start with 'zeebe-chaos', got '${NAMESPACE}'"
+fi
+
+namespace_${ACTION} "${NAMESPACE}"

--- a/.ci/seed.dsl
+++ b/.ci/seed.dsl
@@ -57,7 +57,12 @@ def seedJob = job('seed-job-zeebe') {
     }
   }
 
-  logRotator(-1, 5, -1, 1)
+  logRotator {
+    daysToKeep(-1)
+    numToKeep(5)
+    artifactDaysToKeep(-1)
+    artifactNumToKeep(1)
+  }
 }
 
 queue(seedJob)


### PR DESCRIPTION
Related: SRE-668

## Description

Added pipeline for running chaos tests

## Related issues

SRE-668

closes https://github.com/zeebe-io/zeebe/issues/2997

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
