### PR TITLE
feat(logstreams): add back pressure on log appender

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -233,10 +233,10 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>com.netflix.concurrency-limits</groupId>
       <artifactId>concurrency-limits-core</artifactId>
-      <version>0.3.6</version>
     </dependency>
 
   </dependencies>

--- a/logstreams/pom.xml
+++ b/logstreams/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Logstreams</name>
@@ -114,6 +116,16 @@
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-transport</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.netflix.concurrency-limits</groupId>
+      <artifactId>concurrency-limits-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
     </dependency>
   </dependencies>
 

--- a/logstreams/src/main/java/io/zeebe/distributedlog/impl/DistributedLogstreamPartition.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/impl/DistributedLogstreamPartition.java
@@ -118,4 +118,8 @@ public class DistributedLogstreamPartition implements Service<DistributedLogstre
         .withProtocol(PROTOCOL)
         .buildAsync();
   }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/AlgorithmCfg.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/AlgorithmCfg.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.impl.backpressure;
+
+import com.netflix.concurrency.limits.limit.AbstractLimit;
+import io.zeebe.util.Environment;
+import java.util.function.Supplier;
+
+public interface AlgorithmCfg extends Supplier<AbstractLimit> {
+
+  void applyEnvironment(Environment environment);
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/AppendBackpressureMetrics.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/AppendBackpressureMetrics.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.impl.backpressure;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+
+public class AppendBackpressureMetrics {
+
+  private static final Counter TOTAL_DEFERRED_APPEND_COUNT =
+      Counter.build()
+          .namespace("zeebe")
+          .name("deferred_append_count_total")
+          .help("Number of deferred appends due to backpressure")
+          .labelNames("partition")
+          .register();
+
+  private static final Counter TOTAL_APPEND_TRY_COUNT =
+      Counter.build()
+          .namespace("zeebe")
+          .name("try_to_append_total")
+          .help("Number of tries to append")
+          .labelNames("partition")
+          .register();
+
+  private static final Gauge CURRENT_INFLIGHT =
+      Gauge.build()
+          .namespace("zeebe")
+          .name("backpressure_inflight_append_count")
+          .help("Current number of append inflight")
+          .labelNames("partition")
+          .register();
+
+  private static final Gauge CURRENT_LIMIT =
+      Gauge.build()
+          .namespace("zeebe")
+          .name("backpressure_append_limit")
+          .help("Current limit for number of inflight appends")
+          .labelNames("partition")
+          .register();
+
+  private final int partitionId;
+
+  public AppendBackpressureMetrics(int partitionId) {
+    this.partitionId = partitionId;
+  }
+
+  public void deferred() {
+    TOTAL_DEFERRED_APPEND_COUNT.labels(String.valueOf(partitionId)).inc();
+  }
+
+  public void newEntryToAppend() {
+    TOTAL_APPEND_TRY_COUNT.labels(String.valueOf(partitionId)).inc();
+  }
+
+  public void incInflight() {
+    CURRENT_INFLIGHT.labels(String.valueOf(partitionId)).inc();
+  }
+
+  public void decInflight() {
+    CURRENT_INFLIGHT.labels(String.valueOf(partitionId)).dec();
+  }
+
+  public void setNewLimit(int newLimit) {
+    CURRENT_LIMIT.labels(String.valueOf(partitionId)).set(newLimit);
+  }
+
+  public void setInflight(int count) {
+    CURRENT_INFLIGHT.labels(String.valueOf(partitionId)).set(0);
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/AppendEntryLimiter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/AppendEntryLimiter.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.impl.backpressure;
+
+import com.netflix.concurrency.limits.limiter.AbstractLimiter;
+import io.zeebe.logstreams.impl.Loggers;
+import java.util.Optional;
+import org.agrona.collections.Long2ObjectHashMap;
+
+public final class AppendEntryLimiter extends AbstractLimiter<Long> implements AppendLimiter {
+
+  private final Long2ObjectHashMap<Listener> appendedListeners = new Long2ObjectHashMap<>();
+  private final AppendBackpressureMetrics metrics;
+
+  private AppendEntryLimiter(AppendEntryLimiterBuilder builder, int partitionId) {
+    super(builder);
+    metrics = new AppendBackpressureMetrics(partitionId);
+    metrics.setInflight(0);
+    metrics.setNewLimit(getLimit());
+  }
+
+  public Optional<Listener> acquire(Long position) {
+    if (getInflight() >= getLimit()) {
+      return createRejectedListener();
+    }
+    final Listener listener = createListener();
+    return Optional.of(listener);
+  }
+
+  private void registerListener(long position, Listener listener) {
+    appendedListeners.put(position, listener);
+  }
+
+  public boolean tryAcquire(Long position) {
+    final Optional<Listener> acquired = acquire(position);
+    return acquired
+        .map(
+            listener -> {
+              registerListener(position, listener);
+              metrics.incInflight();
+              return true;
+            })
+        .orElse(false);
+  }
+
+  public void onCommit(long position) {
+    final Listener listener = appendedListeners.remove(position);
+    if (listener != null) {
+      listener.onSuccess();
+      metrics.decInflight();
+    } else {
+      Loggers.LOGSTREAMS_LOGGER.warn(
+          "We encountered an problem on releasing the acquired in flight append."
+              + " There was no listener registered for the given position {}, this should not happen.",
+          position);
+    }
+  }
+
+  @Override
+  protected void onNewLimit(int newLimit) {
+    super.onNewLimit(newLimit);
+    metrics.setNewLimit(newLimit);
+  }
+
+  public static AppendEntryLimiterBuilder builder() {
+    return new AppendEntryLimiterBuilder();
+  }
+
+  public static class AppendEntryLimiterBuilder
+      extends AbstractLimiter.Builder<AppendEntryLimiterBuilder> {
+
+    private int partitionId;
+
+    @Override
+    protected AppendEntryLimiterBuilder self() {
+      return this;
+    }
+
+    public AppendEntryLimiterBuilder partitionId(int partition) {
+      partitionId = partition;
+      return this;
+    }
+
+    public AppendEntryLimiter build() {
+      return new AppendEntryLimiter(this, partitionId);
+    }
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/AppendLimiter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/AppendLimiter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.impl.backpressure;
+
+public interface AppendLimiter {
+
+  /**
+   * Try to add to the in flight appends. If success, {@link #onCommit(long)} ()} must be called
+   * when the appending was successful
+   *
+   * @param position the corresponding position
+   * @return true if request is added to the in flight requests, false otherwise
+   */
+  boolean tryAcquire(Long position);
+
+  /**
+   * Notify when then entry with the given position have been committed. This will release the
+   * acquired position and decrement the in flight count.
+   *
+   * @param position the committed position
+   */
+  void onCommit(long position);
+
+  /**
+   * The current in flight append request count.
+   *
+   * @return the current in flight
+   */
+  int getInflight();
+
+  /**
+   * The current limit of concurrent appends.
+   *
+   * @return the limit
+   */
+  int getLimit();
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/AppenderGradient2Cfg.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/AppenderGradient2Cfg.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.impl.backpressure;
+
+import static io.zeebe.logstreams.impl.backpressure.BackpressureConstants.ENV_BP_APPENDER_GRADIENT2_INIT_LIMIT;
+import static io.zeebe.logstreams.impl.backpressure.BackpressureConstants.ENV_BP_APPENDER_GRADIENT2_LONG_WINDOW;
+import static io.zeebe.logstreams.impl.backpressure.BackpressureConstants.ENV_BP_APPENDER_GRADIENT2_MAX_CONCURRENCY;
+import static io.zeebe.logstreams.impl.backpressure.BackpressureConstants.ENV_BP_APPENDER_GRADIENT2_MIN_LIMIT;
+import static io.zeebe.logstreams.impl.backpressure.BackpressureConstants.ENV_BP_APPENDER_GRADIENT2_QUEUE_SIZE;
+import static io.zeebe.logstreams.impl.backpressure.BackpressureConstants.ENV_BP_APPENDER_GRADIENT2_RTT_TOLERANCE;
+
+import com.netflix.concurrency.limits.limit.AbstractLimit;
+import com.netflix.concurrency.limits.limit.Gradient2Limit;
+import io.zeebe.util.Environment;
+
+/**
+ * This class should be later be located in the broker configs - due to the primitive usage
+ * currently we are not able to access the BrokerCfg, this is the reason why the configuration is
+ * only based on environment variables.
+ */
+public class AppenderGradient2Cfg implements AlgorithmCfg {
+
+  private int initialLimit = 1024;
+  private int maxConcurrency = 1024 * 32;
+  private int queueSize = 32;
+  private int minLimit = 256;
+  private int longWindow = 1200;
+  private double rttTolerance = 1.5;
+
+  @Override
+  public void applyEnvironment(final Environment environment) {
+    environment.getInt(ENV_BP_APPENDER_GRADIENT2_INIT_LIMIT).ifPresent(this::setInitialLimit);
+    environment
+        .getInt(ENV_BP_APPENDER_GRADIENT2_MAX_CONCURRENCY)
+        .ifPresent(this::setMaxConcurrency);
+    environment.getInt(ENV_BP_APPENDER_GRADIENT2_QUEUE_SIZE).ifPresent(this::setQueueSize);
+    environment.getInt(ENV_BP_APPENDER_GRADIENT2_MIN_LIMIT).ifPresent(this::setMinLimit);
+    environment.getInt(ENV_BP_APPENDER_GRADIENT2_LONG_WINDOW).ifPresent(this::setLongWindow);
+    environment.getDouble(ENV_BP_APPENDER_GRADIENT2_RTT_TOLERANCE).ifPresent(this::setRttTolerance);
+  }
+
+  public int getInitialLimit() {
+    return initialLimit;
+  }
+
+  public AppenderGradient2Cfg setInitialLimit(int initialLimit) {
+    this.initialLimit = initialLimit;
+    return this;
+  }
+
+  public int getMaxConcurrency() {
+    return maxConcurrency;
+  }
+
+  public AppenderGradient2Cfg setMaxConcurrency(int maxConcurrency) {
+    this.maxConcurrency = maxConcurrency;
+    return this;
+  }
+
+  public int getQueueSize() {
+    return queueSize;
+  }
+
+  public AppenderGradient2Cfg setQueueSize(int queueSize) {
+    this.queueSize = queueSize;
+    return this;
+  }
+
+  public int getMinLimit() {
+    return minLimit;
+  }
+
+  public AppenderGradient2Cfg setMinLimit(int minLimit) {
+    this.minLimit = minLimit;
+    return this;
+  }
+
+  public int getLongWindow() {
+    return longWindow;
+  }
+
+  public AppenderGradient2Cfg setLongWindow(int longWindow) {
+    this.longWindow = longWindow;
+    return this;
+  }
+
+  public double getRttTolerance() {
+    return rttTolerance;
+  }
+
+  public AppenderGradient2Cfg setRttTolerance(double rttTolerance) {
+    this.rttTolerance = rttTolerance;
+    return this;
+  }
+
+  @Override
+  public AbstractLimit get() {
+    return Gradient2Limit.newBuilder()
+        .initialLimit(initialLimit)
+        .maxConcurrency(maxConcurrency)
+        .queueSize(queueSize)
+        .minLimit(minLimit)
+        .longWindow(longWindow)
+        .rttTolerance(rttTolerance)
+        .build();
+  }
+
+  @Override
+  public String toString() {
+    return "AppenderGradient2Cfg{"
+        + "initialLimit="
+        + initialLimit
+        + ", maxConcurrency="
+        + maxConcurrency
+        + ", queueSize="
+        + queueSize
+        + ", minLimit="
+        + minLimit
+        + ", longWindow="
+        + longWindow
+        + ", rttTolerance="
+        + rttTolerance
+        + '}';
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/AppenderVegasCfg.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/AppenderVegasCfg.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.impl.backpressure;
+
+import static io.zeebe.logstreams.impl.backpressure.BackpressureConstants.ENV_BP_APPENDER_VEGAS_ALPHA_LIMIT;
+import static io.zeebe.logstreams.impl.backpressure.BackpressureConstants.ENV_BP_APPENDER_VEGAS_BETA_LIMIT;
+import static io.zeebe.logstreams.impl.backpressure.BackpressureConstants.ENV_BP_APPENDER_VEGAS_INIT_LIMIT;
+import static io.zeebe.logstreams.impl.backpressure.BackpressureConstants.ENV_BP_APPENDER_VEGAS_MAX_CONCURRENCY;
+
+import com.netflix.concurrency.limits.limit.AbstractLimit;
+import com.netflix.concurrency.limits.limit.VegasLimit;
+import io.zeebe.util.Environment;
+
+/**
+ * This class should be later be located in the broker configs - due to the primitive usage
+ * currently we are not able to access the BrokerCfg, this is the reason why the configuration is
+ * only based on environment variables.
+ */
+public class AppenderVegasCfg implements AlgorithmCfg {
+
+  private int initialLimit = 1024;
+  private int maxConcurrency = 1024 * 32;
+
+  /*
+   * - Copied from the Vegas JavaDoc -
+   * Queue size is calculated using the formula,
+   *  queue_use = limit − BWE×RTTnoLoad = limit × (1 − RTTnoLoad/RTTactual)
+   *
+   * For traditional TCP Vegas alpha is typically 2-3 and beta is typically 4-6.  To allow for better growth and
+   * stability at higher limits we set alpha=Max(3, 10% of the current limit) and beta=Max(6, 20% of the current limit)
+   *
+   * ------
+   *
+   * We tested with 10% and 20%, but do not get good results with the default values of
+   * * alpha = Max(3, limit * 0.7)
+   * * beta= Max(3, limit * 0.95)
+   * We get much better results
+   */
+  private double alphaLimit = 0.7;
+  private double betaLimit = 0.95;
+
+  @Override
+  public void applyEnvironment(final Environment environment) {
+    environment.getInt(ENV_BP_APPENDER_VEGAS_INIT_LIMIT).ifPresent(this::setInitialLimit);
+    environment.getInt(ENV_BP_APPENDER_VEGAS_MAX_CONCURRENCY).ifPresent(this::setMaxConcurrency);
+    environment.getDouble(ENV_BP_APPENDER_VEGAS_ALPHA_LIMIT).ifPresent(this::setAlphaLimit);
+    environment.getDouble(ENV_BP_APPENDER_VEGAS_BETA_LIMIT).ifPresent(this::setBetaLimit);
+  }
+
+  public int getInitialLimit() {
+    return initialLimit;
+  }
+
+  public AppenderVegasCfg setInitialLimit(int initialLimit) {
+    this.initialLimit = initialLimit;
+    return this;
+  }
+
+  public int getMaxConcurrency() {
+    return maxConcurrency;
+  }
+
+  public AppenderVegasCfg setMaxConcurrency(int maxConcurrency) {
+    this.maxConcurrency = maxConcurrency;
+    return this;
+  }
+
+  public double getAlphaLimit() {
+    return alphaLimit;
+  }
+
+  public AppenderVegasCfg setAlphaLimit(double alphaLimit) {
+    this.alphaLimit = alphaLimit;
+    return this;
+  }
+
+  public double getBetaLimit() {
+    return betaLimit;
+  }
+
+  public AppenderVegasCfg setBetaLimit(double betaLimit) {
+    this.betaLimit = betaLimit;
+    return this;
+  }
+
+  @Override
+  public AbstractLimit get() {
+    return VegasLimit.newBuilder()
+        .alpha(limit -> Math.max(3, (int) (limit * alphaLimit)))
+        .beta(limit -> Math.max(6, (int) (limit * betaLimit)))
+        .initialLimit(initialLimit)
+        .maxConcurrency(maxConcurrency)
+        // per default Vegas uses log10
+        .increase(limit -> limit + Math.log(limit))
+        .decrease(limit -> limit - Math.log(limit))
+        .build();
+  }
+
+  @Override
+  public String toString() {
+    return "AppenderVegasCfg{"
+        + "initialLimit="
+        + initialLimit
+        + ", maxConcurrency="
+        + maxConcurrency
+        + ", alphaLimit="
+        + alphaLimit
+        + ", betaLimit="
+        + betaLimit
+        + '}';
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/BackpressureConstants.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/BackpressureConstants.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.impl.backpressure;
+
+/**
+ * This class should be later be located in the broker configs - due to the primitive usage
+ * currently we are not able to access the BrokerCfg, this is the reason why the configuration is
+ * only based on environment variables.
+ *
+ * <p>The constants should then be copied to EnvironmentConstants class.
+ */
+public class BackpressureConstants {
+
+  // BACK PRESSURE ON LOG APPENDER
+  public static final String ENV_BP_APPENDER = "ZEEBE_BP_APPENDER";
+  public static final String ENV_BP_APPENDER_WINDOWED = "ZEEBE_BP_APPENDER_WINDOWED";
+  public static final String ENV_BP_APPENDER_ALGORITHM = "ZEEBE_BP_APPENDER_ALGORITHM";
+
+  // APPEND LIMITER - VEGAS ALGORITHM
+  public static final String ENV_BP_APPENDER_VEGAS_INIT_LIMIT =
+      "ZEEBE_BP_APPENDER_VEGAS_INIT_LIMIT";
+  public static final String ENV_BP_APPENDER_VEGAS_MAX_CONCURRENCY =
+      "ZEEBE_BP_APPENDER_VEGAS_MAX_CONCURRENCY";
+  public static final String ENV_BP_APPENDER_VEGAS_ALPHA_LIMIT =
+      "ZEEBE_BP_APPENDER_VEGAS_ALPHA_LIMIT";
+  public static final String ENV_BP_APPENDER_VEGAS_BETA_LIMIT =
+      "ZEEBE_BP_APPENDER_VEGAS_BETA_LIMIT";
+
+  // APPEND LIMITER - GRADIENT2 ALGORITHM
+  public static final String ENV_BP_APPENDER_GRADIENT2_INIT_LIMIT =
+      "ZEEBE_BP_APPENDER_GRADIENT2_INIT_LIMIT";
+  public static final String ENV_BP_APPENDER_GRADIENT2_MAX_CONCURRENCY =
+      "ZEEBE_BP_APPENDER_GRADIENT2_MAX_CONCURRENCY";
+  public static final String ENV_BP_APPENDER_GRADIENT2_QUEUE_SIZE =
+      "ZEEBE_BP_APPENDER_GRADIENT2_QUEUE_SIZE";
+  public static final String ENV_BP_APPENDER_GRADIENT2_MIN_LIMIT =
+      "ZEEBE_BP_APPENDER_VEGAS_BETA_LIMIT";
+  public static final String ENV_BP_APPENDER_GRADIENT2_LONG_WINDOW =
+      "ZEEBE_BP_APPENDER_GRADIENT2_LONG_WINDOW";
+  public static final String ENV_BP_APPENDER_GRADIENT2_RTT_TOLERANCE =
+      "ZEEBE_BP_APPENDER_GRADIENT2_RTT_TOLERANCE";
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/NoopAppendLimiter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/backpressure/NoopAppendLimiter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.impl.backpressure;
+
+public class NoopAppendLimiter implements AppendLimiter {
+
+  @Override
+  public boolean tryAcquire(Long position) {
+    return true;
+  }
+
+  @Override
+  public void onCommit(long position) {}
+
+  @Override
+  public int getInflight() {
+    return 0;
+  }
+
+  @Override
+  public int getLimit() {
+    return 0;
+  }
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/backpressure/AppendEntryLimiterTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/backpressure/AppendEntryLimiterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.impl.backpressure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.concurrency.limits.Limit;
+import com.netflix.concurrency.limits.limit.SettableLimit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class AppendEntryLimiterTest {
+
+  @Parameter public Limit limit;
+  private AppendLimiter limiter;
+
+  @Parameters(name = "{index}: {0}")
+  public static Object[][] limits() {
+    return new Object[][] {
+      {new SettableLimit(1)},
+      {new AppenderVegasCfg().setInitialLimit(1).setMaxConcurrency(1).get()},
+      {new AppenderGradient2Cfg().setInitialLimit(1).setMinLimit(1).setMaxConcurrency(1).get()}
+    };
+  }
+
+  @Before
+  public void init() {
+    limiter = AppendEntryLimiter.builder().limit(limit).build();
+  }
+
+  @Test
+  public void shouldAcquire() {
+    // given
+
+    // when
+    final boolean acquired = limiter.tryAcquire(1024L);
+
+    // then
+    assertThat(acquired).isTrue();
+    assertThat(limiter.getInflight()).isEqualTo(1);
+    assertThat(limiter.getLimit()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldNotAcquireMore() {
+    // given
+    limiter.tryAcquire(1024L);
+
+    // when
+    final boolean acquired = limiter.tryAcquire(1024L);
+
+    // then
+    assertThat(acquired).isFalse();
+    assertThat(limiter.getInflight()).isEqualTo(1);
+    assertThat(limiter.getLimit()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldReclaim() {
+    // given
+    limiter.tryAcquire(1024L);
+
+    // when
+    limiter.onCommit(1024L);
+
+    // then
+    assertThat(limiter.getInflight()).isEqualTo(0);
+    assertThat(limiter.getLimit()).isEqualTo(1);
+  }
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/backpressure/AppendGradient2LimiterTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/backpressure/AppendGradient2LimiterTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.impl.backpressure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.concurrency.limits.limit.AbstractLimit;
+import io.zeebe.util.Environment;
+import java.util.Map;
+import org.junit.Test;
+
+public class AppendGradient2LimiterTest {
+
+  @Test
+  public void shouldUseDefaultValues() {
+    // given - when
+    final AppenderGradient2Cfg gradient2Cfg = new AppenderGradient2Cfg();
+
+    // then
+    assertThat(gradient2Cfg.getInitialLimit()).isEqualTo(1024);
+    assertThat(gradient2Cfg.getMaxConcurrency()).isEqualTo(1024 * 32);
+    assertThat(gradient2Cfg.getLongWindow()).isEqualTo(1200);
+    assertThat(gradient2Cfg.getMinLimit()).isEqualTo(256);
+    assertThat(gradient2Cfg.getQueueSize()).isEqualTo(32);
+    assertThat(gradient2Cfg.getRttTolerance()).isEqualTo(1.5);
+  }
+
+  @Test
+  public void shouldUseDefaultValuesForNoExistingValues() {
+    // given
+    final Environment environment = new Environment();
+    final AppenderGradient2Cfg gradient2Cfg = new AppenderGradient2Cfg();
+
+    // when
+    gradient2Cfg.applyEnvironment(environment);
+
+    // then
+    assertThat(gradient2Cfg.getInitialLimit()).isEqualTo(1024);
+    assertThat(gradient2Cfg.getMaxConcurrency()).isEqualTo(1024 * 32);
+    assertThat(gradient2Cfg.getLongWindow()).isEqualTo(1200);
+    assertThat(gradient2Cfg.getMinLimit()).isEqualTo(256);
+    assertThat(gradient2Cfg.getQueueSize()).isEqualTo(32);
+    assertThat(gradient2Cfg.getRttTolerance()).isEqualTo(1.5);
+  }
+
+  @Test
+  public void shouldConfigure() {
+    // given
+    final Map<String, String> cfgMap =
+        Map.of(
+            BackpressureConstants.ENV_BP_APPENDER_GRADIENT2_INIT_LIMIT,
+            "12",
+            BackpressureConstants.ENV_BP_APPENDER_GRADIENT2_MAX_CONCURRENCY,
+            "24",
+            BackpressureConstants.ENV_BP_APPENDER_GRADIENT2_LONG_WINDOW,
+            "300",
+            BackpressureConstants.ENV_BP_APPENDER_GRADIENT2_QUEUE_SIZE,
+            "3",
+            BackpressureConstants.ENV_BP_APPENDER_GRADIENT2_RTT_TOLERANCE,
+            "0.3",
+            BackpressureConstants.ENV_BP_APPENDER_GRADIENT2_MIN_LIMIT,
+            "1");
+    final Environment environment = new Environment(cfgMap);
+    final AppenderGradient2Cfg gradient2Cfg = new AppenderGradient2Cfg();
+
+    // when
+    gradient2Cfg.applyEnvironment(environment);
+
+    // then
+    assertThat(gradient2Cfg.getInitialLimit()).isEqualTo(12);
+    assertThat(gradient2Cfg.getMaxConcurrency()).isEqualTo(24);
+    assertThat(gradient2Cfg.getLongWindow()).isEqualTo(300);
+    assertThat(gradient2Cfg.getMinLimit()).isEqualTo(1);
+    assertThat(gradient2Cfg.getQueueSize()).isEqualTo(3);
+    assertThat(gradient2Cfg.getRttTolerance()).isEqualTo(0.3);
+  }
+
+  @Test
+  public void shouldBuild() {
+    // given
+    final AppenderGradient2Cfg gradient2Cfg = new AppenderGradient2Cfg();
+
+    // when
+    final AbstractLimit abstractLimit = gradient2Cfg.get();
+
+    // then
+    assertThat(abstractLimit.getLimit()).isEqualTo(1024);
+  }
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/backpressure/AppendVegasLimiterTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/backpressure/AppendVegasLimiterTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.impl.backpressure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.concurrency.limits.limit.AbstractLimit;
+import io.zeebe.util.Environment;
+import java.util.Map;
+import org.junit.Test;
+
+public class AppendVegasLimiterTest {
+
+  @Test
+  public void shouldUseDefaultValues() {
+    // given - when
+    final AppenderVegasCfg vegasCfg = new AppenderVegasCfg();
+
+    // then
+    assertThat(vegasCfg.getAlphaLimit()).isEqualTo(0.7);
+    assertThat(vegasCfg.getBetaLimit()).isEqualTo(0.95);
+    assertThat(vegasCfg.getInitialLimit()).isEqualTo(1024);
+    assertThat(vegasCfg.getMaxConcurrency()).isEqualTo(1024 * 32);
+  }
+
+  @Test
+  public void shouldUseDefaultValuesForNoExistingValues() {
+    // given
+    final Environment environment = new Environment();
+    final AppenderVegasCfg vegasCfg = new AppenderVegasCfg();
+
+    // when
+    vegasCfg.applyEnvironment(environment);
+
+    // then
+    assertThat(vegasCfg.getAlphaLimit()).isEqualTo(0.7);
+    assertThat(vegasCfg.getBetaLimit()).isEqualTo(0.95);
+    assertThat(vegasCfg.getInitialLimit()).isEqualTo(1024);
+    assertThat(vegasCfg.getMaxConcurrency()).isEqualTo(1024 * 32);
+  }
+
+  @Test
+  public void shouldConfigure() {
+    // given
+    final Map<String, String> cfgMap =
+        Map.of(
+            BackpressureConstants.ENV_BP_APPENDER_VEGAS_INIT_LIMIT,
+            "12",
+            BackpressureConstants.ENV_BP_APPENDER_VEGAS_MAX_CONCURRENCY,
+            "24",
+            BackpressureConstants.ENV_BP_APPENDER_VEGAS_ALPHA_LIMIT,
+            "0.1",
+            BackpressureConstants.ENV_BP_APPENDER_VEGAS_BETA_LIMIT,
+            "0.5");
+    final Environment environment = new Environment(cfgMap);
+
+    final AppenderVegasCfg vegasCfg = new AppenderVegasCfg();
+
+    // when
+    vegasCfg.applyEnvironment(environment);
+
+    // then
+    assertThat(vegasCfg.getAlphaLimit()).isEqualTo(0.1);
+    assertThat(vegasCfg.getBetaLimit()).isEqualTo(0.5);
+    assertThat(vegasCfg.getInitialLimit()).isEqualTo(12);
+    assertThat(vegasCfg.getMaxConcurrency()).isEqualTo(24);
+  }
+
+  @Test
+  public void shouldBuild() {
+    // given
+    final AppenderVegasCfg vegasCfg = new AppenderVegasCfg();
+
+    // when
+    final AbstractLimit abstractLimit = vegasCfg.get();
+
+    // then
+    assertThat(abstractLimit.getLimit()).isEqualTo(1024);
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -77,6 +77,7 @@
     <version.wiremock>2.25.1</version.wiremock>
     <version.asm>7.2</version.asm>
     <version.testcontainers>1.12.3</version.testcontainers>
+    <version.netflix.concurrency>0.3.6</version.netflix.concurrency>
 
     <!-- maven plugins -->
     <plugin.version.antrun>1.8</plugin.version.antrun>
@@ -517,6 +518,15 @@
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers</artifactId>
         <version>${version.testcontainers}</version>
+      </dependency>
+
+
+
+
+      <dependency>
+        <groupId>com.netflix.concurrency-limits</groupId>
+        <artifactId>concurrency-limits-core</artifactId>
+        <version>${version.netflix.concurrency}</version>
       </dependency>
 
     </dependencies>

--- a/util/src/main/java/io/zeebe/util/Environment.java
+++ b/util/src/main/java/io/zeebe/util/Environment.java
@@ -41,6 +41,24 @@ public class Environment {
     }
   }
 
+  public Optional<Double> getDouble(String name) {
+    try {
+      return get(name).map(Double::valueOf);
+    } catch (Exception e) {
+      LOG.warn("Failed to parse environment variable {}", name, e);
+      return Optional.empty();
+    }
+  }
+
+  public Optional<Long> getLong(String name) {
+    try {
+      return get(name).map(Long::valueOf);
+    } catch (Exception e) {
+      LOG.warn("Failed to parse environment variable {}", name, e);
+      return Optional.empty();
+    }
+  }
+
   public Optional<Boolean> getBool(String name) {
     try {
       return get(name).map(Boolean::valueOf);


### PR DESCRIPTION
 We observed due to high load in atomix disruptive clusters https://github.com/zeebe-io/zeebe/issues/3257, which are
 mostly caused by high append latencies.
 With introducing a dynamic back pressure into the log storage
 appender, we try to avoid the overloading of atomix.
 It is possible to use either gradient2 or vegas as back pressure
 algorithm.
 In  our benchmarks it shows that vegas, with configured alpha=MAX(3,
 limit * 0.7)
 and beta=MAX(6, limit * 0.95) functions fits our current needs.

 To see all results take a look at zeebe-io/zeebe#3306
