### PR TITLE
feat(broker): support message start event subprocess

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
@@ -77,5 +77,18 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
                 0, "Start events in event subprocesses must of type message or timer");
           }
         });
+
+    if (start.isInterrupting() && hasTimeCycle(start)) {
+      validationResultCollector.addError(
+          0, "Interrupting timer start events in event subprocesses can't have time cycles");
+    }
+  }
+
+  private boolean hasTimeCycle(StartEvent start) {
+    return start.getEventDefinitions().stream()
+        .anyMatch(
+            def ->
+                TimerEventDefinition.class.isAssignableFrom(def.getClass())
+                    && ((TimerEventDefinition) def).getTimeCycle() != null);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableStartEvent.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableStartEvent.java
@@ -23,4 +23,9 @@ public class ExecutableStartEvent extends ExecutableCatchEventElement {
   public void setEventSubProcess(DirectBuffer eventSubProcess) {
     this.eventSubProcess = eventSubProcess;
   }
+
+  @Override
+  public boolean shouldCloseMessageSubscriptionOnCorrelate() {
+    return interrupting();
+  }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/eventsubproc/EventSubProcessEventOccurredHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/eventsubproc/EventSubProcessEventOccurredHandler.java
@@ -66,9 +66,8 @@ public class EventSubProcessEventOccurredHandler<T extends ExecutableStartEvent>
 
   private long handleInterrupting(
       BpmnStepContext<T> context, EventTrigger triggeredEvent, long scopeKey) {
-    final boolean waitForTermination = terminatableChildrenExist(context);
+    final boolean waitForTermination = interruptParentScope(context);
 
-    interruptParentProcess(context);
     if (waitForTermination) {
       return deferEvent(context, context.getKey(), scopeKey, containerRecord, triggeredEvent);
     } else {
@@ -78,12 +77,14 @@ public class EventSubProcessEventOccurredHandler<T extends ExecutableStartEvent>
     }
   }
 
-  private void interruptParentProcess(BpmnStepContext<T> context) {
+  private boolean interruptParentScope(BpmnStepContext<T> context) {
     final long scopeKey = context.getValue().getFlowScopeKey();
     final List<ElementInstance> children = context.getElementInstanceState().getChildren(scopeKey);
+    boolean waitForTermination = false;
 
     for (final ElementInstance child : children) {
       if (child.canTerminate()) {
+        waitForTermination = true;
         context
             .getOutput()
             .appendFollowUpEvent(
@@ -92,12 +93,8 @@ public class EventSubProcessEventOccurredHandler<T extends ExecutableStartEvent>
         context.getElementInstanceState().consumeToken(scopeKey);
       }
     }
-  }
 
-  private boolean terminatableChildrenExist(BpmnStepContext<T> context) {
-    return context.getElementInstanceState().getChildren(context.getValue().getFlowScopeKey())
-        .stream()
-        .anyMatch(ElementInstance::canTerminate);
+    return waitForTermination;
   }
 
   private void prepareActivateContainer(

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/CorrelateWorkflowInstanceSubscription.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/CorrelateWorkflowInstanceSubscription.java
@@ -14,16 +14,21 @@ import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.engine.processor.TypedRecordProcessor;
 import io.zeebe.engine.processor.TypedResponseWriter;
 import io.zeebe.engine.processor.TypedStreamWriter;
+import io.zeebe.engine.processor.workflow.deployment.model.element.AbstractFlowElement;
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableStartEvent;
 import io.zeebe.engine.processor.workflow.message.command.SubscriptionCommandSender;
 import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.deployment.DeployedWorkflow;
 import io.zeebe.engine.state.deployment.WorkflowState;
 import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.engine.state.message.WorkflowInstanceSubscription;
 import io.zeebe.engine.state.message.WorkflowInstanceSubscriptionState;
 import io.zeebe.protocol.impl.record.value.message.WorkflowInstanceSubscriptionRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceSubscriptionIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.util.buffer.BufferUtil;
 import io.zeebe.util.sched.ActorControl;
 import java.time.Duration;
@@ -50,6 +55,7 @@ public final class CorrelateWorkflowInstanceSubscription
   private final WorkflowState workflowState;
   private final KeyGenerator keyGenerator;
 
+  private WorkflowInstanceRecord eventSubprocessRecord = new WorkflowInstanceRecord();
   private WorkflowInstanceSubscriptionRecord subscriptionRecord;
   private DirectBuffer correlationKey;
 
@@ -134,10 +140,7 @@ public final class CorrelateWorkflowInstanceSubscription
 
       streamWriter.appendFollowUpEvent(
           record.getKey(), WorkflowInstanceSubscriptionIntent.CORRELATED, subscriptionRecord);
-      streamWriter.appendFollowUpEvent(
-          subscriptionRecord.getElementInstanceKey(),
-          WorkflowInstanceIntent.EVENT_OCCURRED,
-          elementInstance.getValue());
+      writeEventOccurred(record, streamWriter, subscription, elementInstance);
     } else {
       correlationKey = subscription.getCorrelationKey();
       sideEffect.accept(this::sendRejectionCommand);
@@ -150,6 +153,42 @@ public final class CorrelateWorkflowInstanceSubscription
               subscriptionRecord.getElementInstanceKey(),
               BufferUtil.bufferAsString(subscriptionRecord.getMessageNameBuffer())));
     }
+  }
+
+  private void writeEventOccurred(
+      TypedRecord<WorkflowInstanceSubscriptionRecord> record,
+      TypedStreamWriter streamWriter,
+      WorkflowInstanceSubscription subscription,
+      ElementInstance elementInstance) {
+    final long workflowKey = elementInstance.getValue().getWorkflowKey();
+    final DeployedWorkflow workflow = workflowState.getWorkflowByKey(workflowKey);
+
+    if (isEventSubprocessStart(workflow, subscription.getTargetElementId())) {
+      eventSubprocessRecord.reset();
+      eventSubprocessRecord
+          .setWorkflowKey(workflowKey)
+          .setElementId(subscription.getTargetElementId())
+          .setWorkflowInstanceKey(record.getValue().getWorkflowInstanceKey())
+          .setBpmnElementType(BpmnElementType.START_EVENT)
+          .setBpmnProcessId(workflow.getBpmnProcessId())
+          .setVersion(workflow.getVersion())
+          .setFlowScopeKey(elementInstance.getKey());
+
+      streamWriter.appendFollowUpEvent(
+          keyGenerator.nextKey(), WorkflowInstanceIntent.EVENT_OCCURRED, eventSubprocessRecord);
+    } else {
+      streamWriter.appendFollowUpEvent(
+          subscriptionRecord.getElementInstanceKey(),
+          WorkflowInstanceIntent.EVENT_OCCURRED,
+          elementInstance.getValue());
+    }
+  }
+
+  private boolean isEventSubprocessStart(DeployedWorkflow workflow, DirectBuffer catchEventId) {
+    final AbstractFlowElement catchEvent = workflow.getWorkflow().getElementById(catchEventId);
+
+    return ExecutableStartEvent.class.isAssignableFrom(catchEvent.getClass())
+        && ((ExecutableStartEvent) catchEvent).getEventSubProcess() != null;
   }
 
   private boolean sendAcknowledgeCommand() {

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/PublishMessageProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/PublishMessageProcessor.java
@@ -148,9 +148,8 @@ public class PublishMessageProcessor implements TypedRecordProcessor<MessageReco
       messageState.put(message);
 
       correlatedWorkflowInstances.forEachOrderedLong(
-          workflowInstanceKey -> {
-            messageState.putMessageCorrelation(message.getKey(), workflowInstanceKey);
-          });
+          workflowInstanceKey ->
+              messageState.putMessageCorrelation(message.getKey(), workflowInstanceKey));
 
     } else {
       // don't add the message to the store to avoid that it can be correlated afterwards

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/subprocess/MultipleEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/subprocess/MultipleEventSubprocessTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.subprocess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.builder.EmbeddedSubProcessBuilder;
+import io.zeebe.model.bpmn.builder.ProcessBuilder;
+import io.zeebe.model.bpmn.builder.StartEventBuilder;
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.test.util.BrokerClassRuleHelper;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MultipleEventSubprocessTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldTriggerMultipleEventSubprocesses() {
+    final BpmnModelInstance model = twoEventSubprocModel(false, false, helper.getMessageName());
+    ENGINE.deployment().withXmlResource(model).deploy();
+
+    // when
+    final long wfInstanceKey =
+        ENGINE.workflowInstance().ofBpmnProcessId("proc").withVariable("key", "123").create();
+    triggerTimerStart(wfInstanceKey);
+    triggerMessageStart(wfInstanceKey, helper.getMessageName());
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(wfInstanceKey)
+                .withElementType(BpmnElementType.SUB_PROCESS)
+                .limit(8))
+        .extracting(r -> tuple(r.getValue().getElementId(), r.getIntent()))
+        .containsSubsequence(
+            tuple("event_sub_proc_timer", WorkflowInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("event_sub_proc_timer", WorkflowInstanceIntent.ELEMENT_COMPLETED))
+        .containsSubsequence(
+            tuple("event_sub_proc_msg", WorkflowInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("event_sub_proc_msg", WorkflowInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldInterruptOtherActiveEventSubprocess() {
+    // given
+    final BpmnModelInstance model =
+        twoEventSubprocWithTasksModel(false, true, helper.getMessageName());
+    ENGINE.deployment().withXmlResource(model).deploy();
+
+    // when
+    final long wfInstanceKey =
+        ENGINE.workflowInstance().ofBpmnProcessId("proc").withVariable("key", "123").create();
+
+    triggerTimerStart(wfInstanceKey);
+    assertThat(
+            RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+                .withWorkflowInstanceKey(wfInstanceKey)
+                .withElementId("event_sub_task_timer")
+                .exists())
+        .describedAs("Expected service task after timer start event to exist")
+        .isTrue();
+    triggerMessageStart(wfInstanceKey, helper.getMessageName());
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(wfInstanceKey)
+                .limitToWorkflowInstanceCompleted())
+        .extracting(r -> tuple(r.getValue().getElementId(), r.getIntent()))
+        .containsSubsequence(
+            tuple("event_sub_proc_timer", WorkflowInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("event_sub_task_timer", WorkflowInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("event_sub_start_msg", WorkflowInstanceIntent.EVENT_OCCURRED),
+            tuple("event_sub_proc_timer", WorkflowInstanceIntent.ELEMENT_TERMINATING),
+            tuple("event_sub_task_timer", WorkflowInstanceIntent.ELEMENT_TERMINATED),
+            tuple("event_sub_proc_timer", WorkflowInstanceIntent.ELEMENT_TERMINATED),
+            tuple("event_sub_proc_msg", WorkflowInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("event_sub_proc_msg", WorkflowInstanceIntent.ELEMENT_COMPLETED),
+            tuple("proc", WorkflowInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldCloseEventSubscriptionWhenScopeCloses() {
+    final BpmnModelInstance model = nestedMsgModel(helper.getMessageName());
+    ENGINE.deployment().withXmlResource(model).deploy();
+
+    // when
+    final long wfInstanceKey =
+        ENGINE.workflowInstance().ofBpmnProcessId("proc").withVariable("key", "123").create();
+
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+                .withWorkflowInstanceKey(wfInstanceKey)
+                .exists())
+        .describedAs("Expected event subprocess message start subscription to be opened.")
+        .isTrue();
+    completeJob(wfInstanceKey, "sub_proc_type");
+
+    // then
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CLOSED)
+                .withWorkflowInstanceKey(wfInstanceKey)
+                .withMessageName(helper.getMessageName())
+                .exists())
+        .describedAs("Expected event subprocess start message subscription to be closed.")
+        .isTrue();
+  }
+
+  @Test
+  public void shouldCorrelateTwoMessagesIfNonInterrupting() {
+    // given
+    final BpmnModelInstance model =
+        twoEventSubprocWithTasksModel(false, false, helper.getMessageName());
+    ENGINE.deployment().withXmlResource(model).deploy();
+
+    // when
+    final long wfInstanceKey =
+        ENGINE.workflowInstance().ofBpmnProcessId("proc").withVariable("key", "123").create();
+    triggerMessageStart(wfInstanceKey, helper.getMessageName());
+    triggerMessageStart(wfInstanceKey, helper.getMessageName());
+
+    // then
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)
+                .withWorkflowInstanceKey(wfInstanceKey)
+                .limit(2)
+                .count())
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void shouldKeepWorkflowInstanceActive() {
+    // given
+    final BpmnModelInstance model =
+        twoEventSubprocWithTasksModel(false, false, helper.getMessageName());
+    ENGINE.deployment().withXmlResource(model).deploy();
+
+    final long wfInstanceKey =
+        ENGINE.workflowInstance().ofBpmnProcessId("proc").withVariable("key", "123").create();
+    triggerTimerStart(wfInstanceKey);
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withWorkflowInstanceKey(wfInstanceKey)
+        .withType("timerTask")
+        .await();
+
+    // when
+    completeJob(wfInstanceKey, "type");
+
+    // then
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(wfInstanceKey)
+        .withElementType(BpmnElementType.END_EVENT)
+        .withElementId("end_proc")
+        .await();
+
+    completeJob(wfInstanceKey, "timerTask");
+    assertThat(RecordingExporter.workflowInstanceRecords().limitToWorkflowInstanceCompleted())
+        .extracting(r -> tuple(r.getValue().getElementId(), r.getIntent()))
+        .containsSubsequence(
+            tuple("event_sub_task_timer", WorkflowInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("end_proc", WorkflowInstanceIntent.ELEMENT_COMPLETED),
+            tuple("event_sub_task_timer", WorkflowInstanceIntent.ELEMENT_COMPLETED),
+            tuple("proc", WorkflowInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldTerminateEventSubprocessIfScopeTerminates() {
+    // given
+    final BpmnModelInstance model =
+        twoEventSubprocWithTasksModel(false, false, helper.getMessageName());
+    ENGINE.deployment().withXmlResource(model).deploy();
+
+    final long wfInstanceKey =
+        ENGINE.workflowInstance().ofBpmnProcessId("proc").withVariable("key", "123").create();
+    triggerTimerStart(wfInstanceKey);
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withWorkflowInstanceKey(wfInstanceKey)
+        .withType("timerTask")
+        .await();
+
+    // when
+    ENGINE.workflowInstance().withInstanceKey(wfInstanceKey).cancel();
+
+    // then
+    assertThat(RecordingExporter.workflowInstanceRecords().limitToWorkflowInstanceTerminated())
+        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
+        .containsSubsequence(
+            tuple(BpmnElementType.SERVICE_TASK, WorkflowInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.PROCESS, WorkflowInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SUB_PROCESS, WorkflowInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SERVICE_TASK, WorkflowInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SERVICE_TASK, WorkflowInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.SUB_PROCESS, WorkflowInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, WorkflowInstanceIntent.ELEMENT_TERMINATED));
+  }
+
+  private void triggerMessageStart(long wfInstanceKey, String msgName) {
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+        .withWorkflowInstanceKey(wfInstanceKey)
+        .await();
+
+    ENGINE.message().withName(msgName).withCorrelationKey("123").publish();
+  }
+
+  private void triggerTimerStart(long wfInstanceKey) {
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+        .withWorkflowInstanceKey(wfInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .await();
+
+    ENGINE.increaseTime(Duration.ofSeconds(60));
+  }
+
+  private static void completeJob(long wfInstanceKey, String taskType) {
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withWorkflowInstanceKey(wfInstanceKey)
+        .withType(taskType)
+        .await();
+
+    ENGINE.job().ofInstance(wfInstanceKey).withType(taskType).complete();
+  }
+
+  private BpmnModelInstance twoEventSubprocModel(
+      boolean timerInterrupt, boolean msgInterrupt, String msgName) {
+    final ProcessBuilder builder = Bpmn.createExecutableProcess("proc");
+
+    builder
+        .eventSubProcess("event_sub_proc_timer")
+        .startEvent("event_sub_start_timer")
+        .interrupting(timerInterrupt)
+        .timerWithDuration("PT60S")
+        .endEvent("event_sub_end_timer");
+    builder
+        .eventSubProcess("event_sub_proc_msg")
+        .startEvent("event_sub_start_msg")
+        .interrupting(msgInterrupt)
+        .message(b -> b.name(msgName).zeebeCorrelationKey("key"))
+        .endEvent("event_sub_end_msg");
+
+    return builder
+        .startEvent("start_proc")
+        .serviceTask("task", t -> t.zeebeTaskType("type"))
+        .endEvent("end_proc")
+        .done();
+  }
+
+  private BpmnModelInstance twoEventSubprocWithTasksModel(
+      boolean timerInterrupt, boolean msgInterrupt, String msgName) {
+    final ProcessBuilder builder = Bpmn.createExecutableProcess("proc");
+
+    builder
+        .eventSubProcess("event_sub_proc_timer")
+        .startEvent("event_sub_start_timer")
+        .interrupting(timerInterrupt)
+        .timerWithDuration("PT60S")
+        .serviceTask("event_sub_task_timer", b -> b.zeebeTaskType("timerTask"))
+        .endEvent("event_sub_end_timer");
+    builder
+        .eventSubProcess("event_sub_proc_msg")
+        .startEvent("event_sub_start_msg")
+        .interrupting(msgInterrupt)
+        .message(b -> b.name(msgName).zeebeCorrelationKey("key"))
+        .endEvent("event_sub_end_msg");
+
+    return builder
+        .startEvent("start_proc")
+        .serviceTask("task", t -> t.zeebeTaskType("type"))
+        .endEvent("end_proc")
+        .done();
+  }
+
+  private static BpmnModelInstance nestedMsgModel(String msgName) {
+    final StartEventBuilder procBuilder =
+        Bpmn.createExecutableProcess("proc").startEvent("proc_start");
+    procBuilder.serviceTask("proc_task", b -> b.zeebeTaskType("proc_type")).endEvent();
+    final EmbeddedSubProcessBuilder subProcBuilder =
+        procBuilder.subProcess("sub_proc").embeddedSubProcess();
+
+    subProcBuilder
+        .eventSubProcess("event_sub_proc")
+        .startEvent("event_sub_start")
+        .interrupting(true)
+        .message(b -> b.name(msgName).zeebeCorrelationKey("key"))
+        .endEvent("event_sub_end");
+    return subProcBuilder
+        .startEvent("sub_start")
+        .serviceTask("sub_proc_task", t -> t.zeebeTaskType("sub_proc_type"))
+        .endEvent("sub_end")
+        .done();
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -83,7 +83,7 @@ public class StreamProcessorRule implements TestRule {
     chain =
         RuleChain.outerRule(tempFolder)
             .around(actorSchedulerRule)
-            .around(new CleanUpRule(() -> tempFolder.getRoot()))
+            .around(new CleanUpRule(tempFolder::getRoot))
             .around(serviceContainerRule)
             .around(closeables)
             .around(new FailedTestRecordPrinter())


### PR DESCRIPTION
## Description

Adds support for message start events subprocesses (1st commit) and improves the test coverage (2nd commit). I'm not closing issue #3247 because variables tests are not included in this PR.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3209 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
