### PR TITLE
fix(clients/java): omit polling exception if closing

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/impl/worker/JobWorkerImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/worker/JobWorkerImpl.java
@@ -102,7 +102,8 @@ public class JobWorkerImpl implements JobWorker, Closeable {
               activatedJobs -> {
                 remainingJobs.addAndGet(activatedJobs);
                 this.jobPoller.set(jobPoller);
-              });
+              },
+              this::isOpen);
         } catch (Exception e) {
           LOG.warn("Failed to activate jobs", e);
           this.jobPoller.set(jobPoller);

--- a/clients/java/src/test/java/io/zeebe/client/job/JobPollerTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/job/JobPollerTest.java
@@ -37,7 +37,7 @@ public class JobPollerTest extends ClientTest {
             (t) -> false);
 
     // when
-    jobPoller.poll(123, job -> {}, integer -> {});
+    jobPoller.poll(123, job -> {}, integer -> {}, () -> true);
 
     // then
     rule.verifyRequestTimeout(requestTimeout);


### PR DESCRIPTION
## Description

Checks if the job worker is closing before logging an exception to prevent misleading the user by showing an expected failure.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3318 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
