### PR TITLE
fix(exporter): allow multiple shards for Elasticsearch indices

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
@@ -69,7 +69,8 @@ public class ElasticsearchClient {
 
     final IndexRequest request =
         new IndexRequest(indexFor(record), typeFor(record), idFor(record))
-            .source(record.toJson(), XContentType.JSON);
+            .source(record.toJson(), XContentType.JSON)
+            .routing(String.valueOf(record.getPartitionId()));
     bulk(request);
   }
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
@@ -211,8 +211,7 @@ public class ElasticsearchClient {
 
   protected String indexFor(final Record<?> record) {
     final Instant timestamp = Instant.ofEpochMilli(record.getTimestamp());
-    return indexPrefixForValueType(record.getValueType())
-        + INDEX_DELIMITER
+    return indexPrefixForValueTypeWithDelimiter(record.getValueType())
         + formatter.format(timestamp);
   }
 
@@ -222,6 +221,10 @@ public class ElasticsearchClient {
 
   protected String typeFor(final Record<?> record) {
     return "_doc";
+  }
+
+  protected String indexPrefixForValueTypeWithDelimiter(final ValueType valueType) {
+    return indexPrefixForValueType(valueType) + INDEX_DELIMITER;
   }
 
   private String indexPrefixForValueType(final ValueType valueType) {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -3,6 +3,9 @@
     "zeebe-record-job_*"
   ],
   "order": 20,
+  "settings": {
+    "number_of_shards": 3
+  },
   "aliases": {
     "zeebe-record-job": {}
   },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -5,7 +5,8 @@
   "order": 10,
   "settings": {
     "number_of_shards": 1,
-    "number_of_replicas": 0
+    "number_of_replicas": 0,
+    "index.queries.cache.enabled": false
   },
   "aliases": {
     "zeebe-record": {}

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-template.json
@@ -3,6 +3,9 @@
     "zeebe-record-workflow-instance_*"
   ],
   "order": 20,
+  "settings": {
+    "number_of_shards": 3
+  },
   "aliases": {
     "zeebe-record-workflow-instance": {}
   },

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.exporter;
 
+import static io.zeebe.exporter.ElasticsearchClient.INDEX_DELIMITER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
@@ -15,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.zeebe.exporter.util.ElasticsearchContainer;
 import io.zeebe.exporter.util.ElasticsearchNode;
 import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.ValueType;
 import io.zeebe.test.exporter.ExporterIntegrationRule;
 import io.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.zeebe.util.ZbLogger;
@@ -71,16 +73,26 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
       final Integer numberOfShards = settings.getAsInt("index.number_of_shards", -1);
       final Integer numberOfReplicas = settings.getAsInt("index.number_of_replicas", -1);
 
+      int expectedNumberOfShards = 1;
+      if (key.value.toLowerCase().contains(indexDef(ValueType.WORKFLOW_INSTANCE))
+          || key.value.toLowerCase().contains(indexDef(ValueType.JOB))) {
+        expectedNumberOfShards = 3;
+      }
       assertThat(numberOfShards)
           .withFailMessage(
-              "Expected number of shards of index %s to be 1 but was %d", key.value, numberOfShards)
-          .isEqualTo(1);
+              "Expected number of shards of index %s to be %d but was %d",
+              key.value, expectedNumberOfShards, numberOfShards)
+          .isEqualTo(expectedNumberOfShards);
       assertThat(numberOfReplicas)
           .withFailMessage(
               "Expected number of replicas of index %s to be 0 but was %d",
               key.value, numberOfReplicas)
           .isEqualTo(0);
     }
+  }
+
+  private String indexDef(final ValueType valueType) {
+    return valueType.name().toLowerCase().replaceAll("_", "-") + INDEX_DELIMITER;
   }
 
   protected void assertRecordExported(Record<?> record) {
@@ -158,7 +170,9 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
     }
 
     Map<String, Object> get(Record<?> record) {
-      final GetRequest request = new GetRequest(indexFor(record), typeFor(record), idFor(record));
+      final GetRequest request =
+          new GetRequest(indexFor(record), typeFor(record), idFor(record))
+              .routing(String.valueOf(record.getPartitionId()));
       try {
         final GetResponse response = client.get(request, RequestOptions.DEFAULT);
         if (response.isExists()) {


### PR DESCRIPTION
## Description

* use routing = partitionId when indexing records
* set default shard number to 3 for WORKFLOW_INSTANCE adn JOB indices
* disable query caching for all indices

## Related issues

closes #3329

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
