### PR TITLE
Fix failing QA tests and reduce qa execution time

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/ClusterCfg.java
@@ -22,6 +22,11 @@ public class ClusterCfg implements ConfigurationEntry {
   public static final int DEFAULT_CLUSTER_SIZE = 1;
   public static final String DEFAULT_CLUSTER_NAME = "zeebe-cluster";
 
+  // the following values are from atomix per default
+  private static final long DEFAULT_GOSSIP_FAILURE_TIMEOUT = 10_000;
+  private static final int DEFAULT_GOSSIP_INTERVAL = 250;
+  private static final int DEFAULT_GOSSIP_PROBE_INTERVAL = 1000;
+
   private List<String> initialContactPoints = DEFAULT_CONTACT_POINTS;
 
   private List<Integer> partitionIds;
@@ -30,6 +35,11 @@ public class ClusterCfg implements ConfigurationEntry {
   private int replicationFactor = DEFAULT_REPLICATION_FACTOR;
   private int clusterSize = DEFAULT_CLUSTER_SIZE;
   private String clusterName = DEFAULT_CLUSTER_NAME;
+
+  // We do not add this to the toString or env - to hide it from the config
+  private long gossipFailureTimeout = DEFAULT_GOSSIP_FAILURE_TIMEOUT;
+  private long gossipInterval = DEFAULT_GOSSIP_INTERVAL;
+  private long gossipProbeInterval = DEFAULT_GOSSIP_PROBE_INTERVAL;
 
   @Override
   public void init(
@@ -114,6 +124,30 @@ public class ClusterCfg implements ConfigurationEntry {
 
   public void setClusterName(String clusterName) {
     this.clusterName = clusterName;
+  }
+
+  public long getGossipFailureTimeout() {
+    return gossipFailureTimeout;
+  }
+
+  public void setGossipFailureTimeout(long gossipFailureTimeout) {
+    this.gossipFailureTimeout = gossipFailureTimeout;
+  }
+
+  public long getGossipInterval() {
+    return gossipInterval;
+  }
+
+  public void setGossipInterval(long gossipInterval) {
+    this.gossipInterval = gossipInterval;
+  }
+
+  public long getGossipProbeInterval() {
+    return gossipProbeInterval;
+  }
+
+  public void setGossipProbeInterval(long gossipProbeInterval) {
+    this.gossipProbeInterval = gossipProbeInterval;
   }
 
   @Override

--- a/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerConfigurator.java
+++ b/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerConfigurator.java
@@ -52,6 +52,9 @@ public class EmbeddedBrokerConfigurator {
       cluster.setReplicationFactor(replicationFactor);
       cluster.setClusterSize(clusterSize);
       cluster.setClusterName(clusterName);
+      cluster.setGossipFailureTimeout(2000);
+      cluster.setGossipInterval(150);
+      cluster.setGossipProbeInterval(250);
     };
   }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Parent</name>
@@ -38,7 +40,7 @@
     <version.agrona>1.0.10</version.agrona>
     <version.animal-sniffer>1.18</version.animal-sniffer>
     <version.assertj>3.14.0</version.assertj>
-    <version.atomix>3.2.0-alpha8</version.atomix>
+    <version.atomix>3.2.0-SNAPSHOT</version.atomix>
     <version.camunda>7.10.0</version.camunda>
     <version.commons-lang>3.9</version.commons-lang>
     <version.commons-logging>1.2</version.commons-logging>
@@ -521,8 +523,6 @@
       </dependency>
 
 
-
-
       <dependency>
         <groupId>com.netflix.concurrency-limits</groupId>
         <artifactId>concurrency-limits-core</artifactId>
@@ -810,7 +810,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -903,7 +903,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <dependencyConvergence />
+                  <dependencyConvergence/>
                 </rules>
               </configuration>
             </execution>


### PR DESCRIPTION
## Description

We use now the atomix snapshot to use the fix of https://github.com/zeebe-io/atomix/pull/55, which solves our current start up problems. I assume we will fix in the next time more often stuff in atomix why I think it makes sense to use the snapshot version for now. If we create a new release we should change the version to a released version. (BTW maven release will fail anyway when snapshot versions are defined)
With the Snapshot version we also see earlier when an atomix changes breaks something in zeebe.

I configured the gossip timeouts because in some of our QA tests we wait until brokers are removed from the topology, this takes 10 seconds because the default failure timeout is 10 seconds.
This change for example reduces the `RestoreTest` execution time from 1:36 minutes to 1:06 minutes.
