### PR TITLE
fix(broker): fix sigseg on replication thread

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotReplication.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotReplication.java
@@ -26,5 +26,5 @@ public interface SnapshotReplication {
   void consume(Consumer<SnapshotChunk> consumer);
 
   /** Closes the snapshot replication. */
-  void close();
+  void close() throws Exception;
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.zeebe.broker.Broker;
 import io.zeebe.broker.it.util.GrpcClientRule;
 import io.zeebe.client.ZeebeClient;
-import io.zeebe.engine.Loggers;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.File;
@@ -70,7 +69,7 @@ public class SnapshotReplicationTest {
     waitForValidSnapshotAtBroker(leader);
 
     final List<Broker> otherBrokers = clusteringRule.getOtherBrokerObjects(leaderNodeId);
-    for (Broker broker : otherBrokers) {
+    for (final Broker broker : otherBrokers) {
       waitForValidSnapshotAtBroker(broker);
     }
 
@@ -106,11 +105,8 @@ public class SnapshotReplicationTest {
               validSnapshotDir -> {
                 final File[] snapshotFiles = validSnapshotDir.listFiles();
                 if (snapshotFiles != null) {
-                  for (File snapshotFile : snapshotFiles) {
+                  for (final File snapshotFile : snapshotFiles) {
                     final long checksum = createCheckSumForFile(snapshotFile);
-
-                    Loggers.STREAM_PROCESSING.debug(
-                        "Created checksum {} for file {}", checksum, snapshotFile);
                     checksums.put(snapshotFile.getName(), checksum);
                   }
                 }
@@ -126,7 +122,7 @@ public class SnapshotReplicationTest {
       while (checkedInputStream.skip(512) > 0) {}
 
       return checkedInputStream.getChecksum().getValue();
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
@@ -136,7 +132,7 @@ public class SnapshotReplicationTest {
     return new File(dataDir, "partition-1/state/snapshots");
   }
 
-  protected void waitForValidSnapshotAtBroker(Broker broker) {
+  protected void waitForValidSnapshotAtBroker(final Broker broker) {
     final File snapshotsDir = getSnapshotsDirectory(broker);
 
     waitUntil(


### PR DESCRIPTION


## Description
 * the replication executor was closed/shutdown but the termination was not awaited, which means it will still run some tasks - if we then concurrently close the database this could cause segmentation faults
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3338

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
