### PR TITLE
chore(ci): increase jenkins master reconnect timeout

### DIFF
--- a/.ci/pipelines/chaos_test_zeebe.groovy
+++ b/.ci/pipelines/chaos_test_zeebe.groovy
@@ -24,6 +24,7 @@ pipeline {
             cloud "${PROJECT}-ci"
             label "${PROJECT}-ci-build-${env.JOB_BASE_NAME}-${env.BUILD_ID}"
             defaultContainer 'jnlp'
+            slaveConnectTimeout 600
             yaml pythonAgent()
         }
     }

--- a/.ci/pipelines/docker_zeebe.groovy
+++ b/.ci/pipelines/docker_zeebe.groovy
@@ -5,6 +5,7 @@ pipeline {
       cloud 'zeebe-ci'
       label "zeebe-ci-build_${env.JOB_BASE_NAME}-${env.BUILD_ID}"
       defaultContainer 'jnlp'
+      slaveConnectTimeout 600
       yaml '''\
 metadata:
   labels:

--- a/.ci/pipelines/docs_zeebe_io.groovy
+++ b/.ci/pipelines/docs_zeebe_io.groovy
@@ -4,6 +4,7 @@ pipeline {
             cloud 'zeebe-ci'
                 label "zeebe-ci-build_${env.JOB_BASE_NAME}-${env.BUILD_ID}"
                 defaultContainer 'jnlp'
+                slaveConnectTimeout 600
                 yaml '''\
 metadata:
   labels:

--- a/.ci/pipelines/release_zeebe.groovy
+++ b/.ci/pipelines/release_zeebe.groovy
@@ -9,6 +9,7 @@ pipeline {
             cloud 'zeebe-ci'
             label "zeebe-ci-release_${buildName}"
             defaultContainer 'jnlp'
+            slaveConnectTimeout 600
             yaml '''\
 metadata:
   labels:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
         cloud 'zeebe-ci'
         label "zeebe-ci-build_${buildName}"
         defaultContainer 'jnlp'
+        slaveConnectTimeout 600
         yamlFile '.ci/podSpecs/distribution.yml'
       }
     }


### PR DESCRIPTION
## Description

Increases the timeout for jenkins pipelines as the default is 100 seconds and doesn't allow us to restart the master jenkins without loosing running jobs.
Pipelines go into a hibernate mode and can survive master restarts as long as the timeout is high enough.

## Related issues

closes [SRE-775](https://app.camunda.com/jira/browse/SRE-775)

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
