### PR TITLE
feat(broker): correlate only once per workflow

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/CatchEventBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/CatchEventBehavior.java
@@ -140,6 +140,7 @@ public class CatchEventBehavior {
     final ExecutableMessage message = handler.getMessage();
 
     final long workflowInstanceKey = context.getValue().getWorkflowInstanceKey();
+    final DirectBuffer bpmnProcessId = cloneBuffer(context.getValue().getBpmnProcessIdBuffer());
     final long elementInstanceKey = context.getKey();
     final DirectBuffer messageName = cloneBuffer(message.getMessageName());
     final DirectBuffer correlationKey = extractedKey;
@@ -152,6 +153,7 @@ public class CatchEventBehavior {
     subscription.setElementInstanceKey(elementInstanceKey);
     subscription.setCommandSentTime(ActorClock.currentTimeMillis());
     subscription.setWorkflowInstanceKey(workflowInstanceKey);
+    subscription.setBpmnProcessId(bpmnProcessId);
     subscription.setCorrelationKey(correlationKey);
     subscription.setTargetElementId(handler.getId());
     subscription.setCloseOnCorrelate(closeOnCorrelate);
@@ -165,6 +167,7 @@ public class CatchEventBehavior {
                     subscriptionPartitionId,
                     workflowInstanceKey,
                     elementInstanceKey,
+                    bpmnProcessId,
                     messageName,
                     correlationKey,
                     closeOnCorrelate));
@@ -242,6 +245,7 @@ public class CatchEventBehavior {
       int subscriptionPartitionId,
       long workflowInstanceKey,
       long elementInstanceKey,
+      DirectBuffer bpmnProcessId,
       DirectBuffer messageName,
       DirectBuffer correlationKey,
       boolean closeOnCorrelate) {
@@ -249,6 +253,7 @@ public class CatchEventBehavior {
         subscriptionPartitionId,
         workflowInstanceKey,
         elementInstanceKey,
+        bpmnProcessId,
         messageName,
         correlationKey,
         closeOnCorrelate);

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/DeploymentCreatedProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/DeploymentCreatedProcessor.java
@@ -102,6 +102,7 @@ public class DeploymentCreatedProcessor implements TypedRecordProcessor<Deployme
         subscriptionRecord
             .setMessageName(startEvent.getMessage().getMessageName())
             .setWorkflowKey(workflowKey)
+            .setBpmnProcessId(workflow.getId())
             .setStartEventId(startEvent.getId());
         streamWriter.appendNewCommand(MessageStartEventSubscriptionIntent.OPEN, subscriptionRecord);
       }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/catchevent/StartEventEventOccurredHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/catchevent/StartEventEventOccurredHandler.java
@@ -16,7 +16,6 @@ import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.deployment.DeployedWorkflow;
 import io.zeebe.engine.state.deployment.WorkflowState;
 import io.zeebe.engine.state.instance.EventTrigger;
-import io.zeebe.engine.state.message.MessageState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
@@ -29,7 +28,6 @@ public class StartEventEventOccurredHandler<T extends ExecutableCatchEventElemen
 
   private final WorkflowInstanceRecord record = new WorkflowInstanceRecord();
   private final WorkflowState state;
-  private final MessageState messageState;
   private final KeyGenerator keyGenerator;
 
   public StartEventEventOccurredHandler(final ZeebeState zeebeState) {
@@ -39,8 +37,7 @@ public class StartEventEventOccurredHandler<T extends ExecutableCatchEventElemen
   public StartEventEventOccurredHandler(
       final WorkflowInstanceIntent nextState, final ZeebeState zeebeState) {
     super(nextState);
-    this.state = zeebeState.getWorkflowState();
-    this.messageState = zeebeState.getMessageState();
+    state = zeebeState.getWorkflowState();
     keyGenerator = zeebeState.getKeyGenerator();
   }
 
@@ -74,12 +71,6 @@ public class StartEventEventOccurredHandler<T extends ExecutableCatchEventElemen
             .setFlowScopeKey(workflowInstanceKey);
 
     deferEvent(context, workflowKey, workflowInstanceKey, record, triggeredEvent);
-
-    // should mark particular message as already correlated for this instance
-    if (context.getElement().isMessage()) {
-      final long messageKey = triggeredEvent.getEventKey();
-      messageState.putMessageCorrelation(messageKey, workflowInstanceKey);
-    }
 
     return true;
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/CorrelateWorkflowInstanceSubscription.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/CorrelateWorkflowInstanceSubscription.java
@@ -55,7 +55,7 @@ public final class CorrelateWorkflowInstanceSubscription
   private final WorkflowState workflowState;
   private final KeyGenerator keyGenerator;
 
-  private WorkflowInstanceRecord eventSubprocessRecord = new WorkflowInstanceRecord();
+  private final WorkflowInstanceRecord eventSubprocessRecord = new WorkflowInstanceRecord();
   private WorkflowInstanceSubscriptionRecord subscriptionRecord;
   private DirectBuffer correlationKey;
 
@@ -65,8 +65,8 @@ public final class CorrelateWorkflowInstanceSubscription
       final ZeebeState zeebeState) {
     this.subscriptionState = subscriptionState;
     this.subscriptionCommandSender = subscriptionCommandSender;
-    this.workflowState = zeebeState.getWorkflowState();
-    this.keyGenerator = zeebeState.getKeyGenerator();
+    workflowState = zeebeState.getWorkflowState();
+    keyGenerator = zeebeState.getKeyGenerator();
   }
 
   @Override
@@ -196,13 +196,14 @@ public final class CorrelateWorkflowInstanceSubscription
         subscriptionRecord.getSubscriptionPartitionId(),
         subscriptionRecord.getWorkflowInstanceKey(),
         subscriptionRecord.getElementInstanceKey(),
+        subscriptionRecord.getBpmnProcessIdBuffer(),
         subscriptionRecord.getMessageNameBuffer());
   }
 
   private boolean sendRejectionCommand() {
     return subscriptionCommandSender.rejectCorrelateMessageSubscription(
         subscriptionRecord.getWorkflowInstanceKey(),
-        subscriptionRecord.getElementInstanceKey(),
+        subscriptionRecord.getBpmnProcessIdBuffer(),
         subscriptionRecord.getMessageKey(),
         subscriptionRecord.getMessageNameBuffer(),
         correlationKey);

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageCorrelator.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageCorrelator.java
@@ -31,18 +31,18 @@ public class MessageCorrelator {
   private long messageKey;
 
   public MessageCorrelator(
-      MessageState messageState,
-      MessageSubscriptionState subscriptionState,
-      SubscriptionCommandSender commandSender) {
+      final MessageState messageState,
+      final MessageSubscriptionState subscriptionState,
+      final SubscriptionCommandSender commandSender) {
     this.messageState = messageState;
     this.subscriptionState = subscriptionState;
     this.commandSender = commandSender;
   }
 
   public void correlateNextMessage(
-      MessageSubscription subscription,
-      MessageSubscriptionRecord subscriptionRecord,
-      Consumer<SideEffectProducer> sideEffect) {
+      final MessageSubscription subscription,
+      final MessageSubscriptionRecord subscriptionRecord,
+      final Consumer<SideEffectProducer> sideEffect) {
     this.subscription = subscription;
     this.subscriptionRecord = subscriptionRecord;
     this.sideEffect = sideEffect;
@@ -56,7 +56,7 @@ public class MessageCorrelator {
     messageKey = message.getKey();
     final boolean isCorrelatedBefore =
         messageState.existMessageCorrelation(
-            messageKey, subscriptionRecord.getWorkflowInstanceKey());
+            messageKey, subscriptionRecord.getBpmnProcessIdBuffer());
 
     if (!isCorrelatedBefore) {
       subscriptionState.updateToCorrelatingState(
@@ -66,7 +66,7 @@ public class MessageCorrelator {
       messageVariables.wrap(message.getVariables());
       sideEffect.accept(this::sendCorrelateCommand);
 
-      messageState.putMessageCorrelation(messageKey, subscriptionRecord.getWorkflowInstanceKey());
+      messageState.putMessageCorrelation(messageKey, subscriptionRecord.getBpmnProcessIdBuffer());
     }
 
     return isCorrelatedBefore;
@@ -76,6 +76,7 @@ public class MessageCorrelator {
     return commandSender.correlateWorkflowInstanceSubscription(
         subscriptionRecord.getWorkflowInstanceKey(),
         subscriptionRecord.getElementInstanceKey(),
+        subscriptionRecord.getBpmnProcessIdBuffer(),
         subscriptionRecord.getMessageNameBuffer(),
         messageKey,
         messageVariables);

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/OpenMessageSubscriptionProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/OpenMessageSubscriptionProcessor.java
@@ -40,7 +40,7 @@ public class OpenMessageSubscriptionProcessor
       final SubscriptionCommandSender commandSender) {
     this.subscriptionState = subscriptionState;
     this.commandSender = commandSender;
-    this.messageCorrelator = new MessageCorrelator(messageState, subscriptionState, commandSender);
+    messageCorrelator = new MessageCorrelator(messageState, subscriptionState, commandSender);
   }
 
   @Override
@@ -76,6 +76,7 @@ public class OpenMessageSubscriptionProcessor
         new MessageSubscription(
             subscriptionRecord.getWorkflowInstanceKey(),
             subscriptionRecord.getElementInstanceKey(),
+            subscriptionRecord.getBpmnProcessIdBuffer(),
             subscriptionRecord.getMessageNameBuffer(),
             subscriptionRecord.getCorrelationKeyBuffer(),
             subscriptionRecord.shouldCloseOnCorrelate());

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/PendingMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/PendingMessageSubscriptionChecker.java
@@ -19,9 +19,9 @@ public class PendingMessageSubscriptionChecker implements Runnable {
   private final long subscriptionTimeout;
 
   public PendingMessageSubscriptionChecker(
-      SubscriptionCommandSender commandSender,
-      MessageSubscriptionState subscriptionState,
-      long subscriptionTimeout) {
+      final SubscriptionCommandSender commandSender,
+      final MessageSubscriptionState subscriptionState,
+      final long subscriptionTimeout) {
     this.commandSender = commandSender;
     this.subscriptionState = subscriptionState;
     this.subscriptionTimeout = subscriptionTimeout;
@@ -33,11 +33,12 @@ public class PendingMessageSubscriptionChecker implements Runnable {
         ActorClock.currentTimeMillis() - subscriptionTimeout, this::sendCommand);
   }
 
-  private boolean sendCommand(MessageSubscription subscription) {
+  private boolean sendCommand(final MessageSubscription subscription) {
     final boolean success =
         commandSender.correlateWorkflowInstanceSubscription(
             subscription.getWorkflowInstanceKey(),
             subscription.getElementInstanceKey(),
+            subscription.getBpmnProcessId(),
             subscription.getMessageName(),
             subscription.getMessageKey(),
             subscription.getMessageVariables());

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/PendingWorkflowInstanceSubscriptionChecker.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/PendingWorkflowInstanceSubscriptionChecker.java
@@ -57,6 +57,7 @@ public class PendingWorkflowInstanceSubscriptionChecker implements Runnable {
         subscription.getSubscriptionPartitionId(),
         subscription.getWorkflowInstanceKey(),
         subscription.getElementInstanceKey(),
+        subscription.getBpmnProcessId(),
         subscription.getMessageName(),
         subscription.getCorrelationKey(),
         subscription.shouldCloseOnCorrelate());

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/RejectMessageCorrelationProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/RejectMessageCorrelationProcessor.java
@@ -22,6 +22,7 @@ import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.zeebe.util.sched.clock.ActorClock;
 import java.util.function.Consumer;
+import org.agrona.DirectBuffer;
 
 public class RejectMessageCorrelationProcessor
     implements TypedRecordProcessor<MessageSubscriptionRecord> {
@@ -50,19 +51,20 @@ public class RejectMessageCorrelationProcessor
     final MessageSubscriptionRecord subscriptionRecord = record.getValue();
     final long messageKey = subscriptionRecord.getMessageKey();
     final long workflowInstanceKey = subscriptionRecord.getWorkflowInstanceKey();
+    final DirectBuffer bpmnProcessId = subscriptionRecord.getBpmnProcessIdBuffer();
 
-    if (!messageState.existMessageCorrelation(messageKey, workflowInstanceKey)) {
+    if (!messageState.existMessageCorrelation(messageKey, bpmnProcessId)) {
       streamWriter.appendRejection(
           record,
           RejectionType.INVALID_STATE,
           String.format(
-              "Expected message %d to be correlated in workflow instance %d but no correlation was found",
-              messageKey, workflowInstanceKey));
+              "Expected message '%d' to be correlated for workflow with BPMN process id '%s' but no correlation was found",
+              messageKey, subscriptionRecord.getBpmnProcessId()));
       return;
     }
-    messageState.removeMessageCorrelation(messageKey, workflowInstanceKey);
+    messageState.removeMessageCorrelation(messageKey, bpmnProcessId);
 
-    findSubscriptionToCorrelate(sideEffect, subscriptionRecord, messageKey, workflowInstanceKey);
+    findSubscriptionToCorrelate(sideEffect, subscriptionRecord, messageKey);
 
     streamWriter.appendFollowUpEvent(
         record.getKey(), MessageSubscriptionIntent.REJECTED, record.getValue());
@@ -71,8 +73,7 @@ public class RejectMessageCorrelationProcessor
   private void findSubscriptionToCorrelate(
       final Consumer<SideEffectProducer> sideEffect,
       final MessageSubscriptionRecord subscriptionRecord,
-      final long messageKey,
-      final long workflowInstanceKey) {
+      final long messageKey) {
 
     // the message TTL may expire after the previous correlation attempt
     final Message message = messageState.getMessage(messageKey);
@@ -84,7 +85,7 @@ public class RejectMessageCorrelationProcessor
         subscriptionRecord.getMessageNameBuffer(),
         subscriptionRecord.getCorrelationKeyBuffer(),
         subscription -> {
-          if (subscription.getWorkflowInstanceKey() == workflowInstanceKey
+          if (subscription.getBpmnProcessId().equals(subscriptionRecord.getBpmnProcessIdBuffer())
               && !subscription.isCorrelating()) {
             subscription.setMessageKey(messageKey);
             subscription.setMessageVariables(message.getVariables());
@@ -98,15 +99,17 @@ public class RejectMessageCorrelationProcessor
 
   private void correlateMessage(
       final MessageSubscription subscription, final Consumer<SideEffectProducer> sideEffect) {
+
     subscriptionState.updateToCorrelatingState(
         subscription,
         subscription.getMessageVariables(),
         ActorClock.currentTimeMillis(),
         subscription.getMessageKey());
-    messageState.putMessageCorrelation(
-        subscription.getMessageKey(), subscription.getWorkflowInstanceKey());
-    this.subscription = subscription;
 
+    messageState.putMessageCorrelation(
+        subscription.getMessageKey(), subscription.getBpmnProcessId());
+
+    this.subscription = subscription;
     sideEffect.accept(this::sendCorrelateCommand);
   }
 
@@ -114,6 +117,7 @@ public class RejectMessageCorrelationProcessor
     return commandSender.correlateWorkflowInstanceSubscription(
         subscription.getWorkflowInstanceKey(),
         subscription.getElementInstanceKey(),
+        subscription.getBpmnProcessId(),
         subscription.getMessageName(),
         subscription.getMessageKey(),
         subscription.getMessageVariables());

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/Subscriptions.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/Subscriptions.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.message;
+
+import io.zeebe.engine.state.message.MessageSubscription;
+import io.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
+import io.zeebe.util.collection.Reusable;
+import io.zeebe.util.collection.ReusableObjectList;
+import java.util.function.Consumer;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public class Subscriptions {
+
+  private final ReusableObjectList<Subscription> subscriptions =
+      new ReusableObjectList<>(Subscription::new);
+
+  public void clear() {
+    subscriptions.clear();
+  }
+
+  public boolean contains(final DirectBuffer bpmnProcessId) {
+    for (final Subscription subscription : subscriptions) {
+      if (subscription.getBpmnProcessId().equals(bpmnProcessId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public void add(final MessageSubscription subscription) {
+    final var newSubscription = subscriptions.add();
+    newSubscription.setBpmnProcessId(subscription.getBpmnProcessId());
+    newSubscription.workflowInstanceKey = subscription.getWorkflowInstanceKey();
+    newSubscription.elementInstanceKey = subscription.getElementInstanceKey();
+  }
+
+  public void add(final MessageStartEventSubscriptionRecord subscription) {
+    final var newSubscription = subscriptions.add();
+    newSubscription.setBpmnProcessId(subscription.getBpmnProcessIdBuffer());
+    newSubscription.isStartEventSubscription = true;
+  }
+
+  public void visitBpmnProcessIds(final Consumer<DirectBuffer> bpmnProcessIdConsumer) {
+    for (final Subscription subscription : subscriptions) {
+      bpmnProcessIdConsumer.accept(subscription.getBpmnProcessId());
+    }
+  }
+
+  public boolean visitSubscriptions(final SubscriptionVisitor subscriptionConsumer) {
+    for (final Subscription subscription : subscriptions) {
+      if (!subscription.isStartEventSubscription) {
+
+        final var applied = subscriptionConsumer.apply(subscription);
+        if (!applied) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  @FunctionalInterface
+  public interface SubscriptionVisitor {
+    boolean apply(Subscription subscription);
+  }
+
+  public class Subscription implements Reusable {
+
+    private final MutableDirectBuffer bpmnProcessId = new ExpandableArrayBuffer();
+    private final DirectBuffer bufferView = new UnsafeBuffer(bpmnProcessId);
+    private int bufferLength = 0;
+
+    private long workflowInstanceKey;
+    private long elementInstanceKey;
+    private boolean isStartEventSubscription;
+
+    @Override
+    public void reset() {
+      bufferLength = 0;
+      bufferView.wrap(0, 0);
+
+      workflowInstanceKey = -1L;
+      elementInstanceKey = -1L;
+      isStartEventSubscription = false;
+    }
+
+    public DirectBuffer getBpmnProcessId() {
+      return bufferView;
+    }
+
+    private void setBpmnProcessId(final DirectBuffer bpmnProcessId) {
+      bufferLength = bpmnProcessId.capacity();
+      bpmnProcessId.getBytes(0, this.bpmnProcessId, 0, bufferLength);
+      bufferView.wrap(this.bpmnProcessId, 0, bufferLength);
+    }
+
+    public long getWorkflowInstanceKey() {
+      return workflowInstanceKey;
+    }
+
+    public long getElementInstanceKey() {
+      return elementInstanceKey;
+    }
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/CorrelateMessageSubscriptionCommand.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/CorrelateMessageSubscriptionCommand.java
@@ -21,6 +21,7 @@ public class CorrelateMessageSubscriptionCommand
   private final CorrelateMessageSubscriptionDecoder decoder =
       new CorrelateMessageSubscriptionDecoder();
   private final UnsafeBuffer messageName = new UnsafeBuffer(0, 0);
+  private final UnsafeBuffer bpmnProcessId = new UnsafeBuffer(0, 0);
   private int subscriptionPartitionId;
   private long workflowInstanceKey;
   private long elementInstanceKey;
@@ -42,28 +43,32 @@ public class CorrelateMessageSubscriptionCommand
     workflowInstanceKey = CorrelateMessageSubscriptionDecoder.workflowInstanceKeyNullValue();
     elementInstanceKey = CorrelateMessageSubscriptionDecoder.elementInstanceKeyNullValue();
     messageName.wrap(0, 0);
+    bpmnProcessId.wrap(0, 0);
   }
 
   @Override
   public int getLength() {
     return super.getLength()
         + CorrelateMessageSubscriptionDecoder.messageNameHeaderLength()
-        + messageName.capacity();
+        + messageName.capacity()
+        + CorrelateMessageSubscriptionDecoder.bpmnProcessIdHeaderLength()
+        + bpmnProcessId.capacity();
   }
 
   @Override
-  public void write(MutableDirectBuffer buffer, int offset) {
+  public void write(final MutableDirectBuffer buffer, final int offset) {
     super.write(buffer, offset);
 
     encoder
         .subscriptionPartitionId(subscriptionPartitionId)
         .workflowInstanceKey(workflowInstanceKey)
         .elementInstanceKey(elementInstanceKey)
-        .putMessageName(messageName, 0, messageName.capacity());
+        .putMessageName(messageName, 0, messageName.capacity())
+        .putBpmnProcessId(bpmnProcessId, 0, bpmnProcessId.capacity());
   }
 
   @Override
-  public void wrap(DirectBuffer buffer, int offset, int length) {
+  public void wrap(final DirectBuffer buffer, int offset, final int length) {
     super.wrap(buffer, offset, length);
 
     subscriptionPartitionId = decoder.subscriptionPartitionId();
@@ -75,13 +80,21 @@ public class CorrelateMessageSubscriptionCommand
     offset += CorrelateMessageSubscriptionDecoder.messageNameHeaderLength();
     final int messageNameLength = decoder.messageNameLength();
     messageName.wrap(buffer, offset, messageNameLength);
+    offset += messageNameLength;
+    decoder.limit(offset);
+
+    offset += CorrelateMessageSubscriptionDecoder.bpmnProcessIdHeaderLength();
+    final int bpmnProcessIdLength = decoder.bpmnProcessIdLength();
+    bpmnProcessId.wrap(buffer, offset, bpmnProcessIdLength);
+    offset += bpmnProcessIdLength;
+    decoder.limit(offset);
   }
 
   public int getSubscriptionPartitionId() {
     return subscriptionPartitionId;
   }
 
-  public void setSubscriptionPartitionId(int subscriptionPartitionId) {
+  public void setSubscriptionPartitionId(final int subscriptionPartitionId) {
     this.subscriptionPartitionId = subscriptionPartitionId;
   }
 
@@ -89,7 +102,7 @@ public class CorrelateMessageSubscriptionCommand
     return workflowInstanceKey;
   }
 
-  public void setWorkflowInstanceKey(long workflowInstanceKey) {
+  public void setWorkflowInstanceKey(final long workflowInstanceKey) {
     this.workflowInstanceKey = workflowInstanceKey;
   }
 
@@ -97,11 +110,15 @@ public class CorrelateMessageSubscriptionCommand
     return elementInstanceKey;
   }
 
-  public void setElementInstanceKey(long elementInstanceKey) {
+  public void setElementInstanceKey(final long elementInstanceKey) {
     this.elementInstanceKey = elementInstanceKey;
   }
 
   public DirectBuffer getMessageName() {
     return messageName;
+  }
+
+  public DirectBuffer getBpmnProcessId() {
+    return bpmnProcessId;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/CorrelateWorkflowInstanceSubscriptionCommand.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/CorrelateWorkflowInstanceSubscriptionCommand.java
@@ -23,6 +23,7 @@ public class CorrelateWorkflowInstanceSubscriptionCommand
       new CorrelateWorkflowInstanceSubscriptionDecoder();
   private final UnsafeBuffer messageName = new UnsafeBuffer(0, 0);
   private final UnsafeBuffer variables = new UnsafeBuffer(0, 0);
+  private final UnsafeBuffer bpmnProcessId = new UnsafeBuffer(0, 0);
   private int subscriptionPartitionId;
   private long workflowInstanceKey;
   private long elementInstanceKey;
@@ -49,6 +50,7 @@ public class CorrelateWorkflowInstanceSubscriptionCommand
 
     messageName.wrap(0, 0);
     variables.wrap(0, 0);
+    bpmnProcessId.wrap(0, 0);
   }
 
   @Override
@@ -57,11 +59,13 @@ public class CorrelateWorkflowInstanceSubscriptionCommand
         + CorrelateWorkflowInstanceSubscriptionDecoder.messageNameHeaderLength()
         + messageName.capacity()
         + CorrelateWorkflowInstanceSubscriptionDecoder.variablesHeaderLength()
-        + variables.capacity();
+        + variables.capacity()
+        + CorrelateWorkflowInstanceSubscriptionDecoder.bpmnProcessIdHeaderLength()
+        + bpmnProcessId.capacity();
   }
 
   @Override
-  public void write(MutableDirectBuffer buffer, int offset) {
+  public void write(final MutableDirectBuffer buffer, final int offset) {
     super.write(buffer, offset);
 
     encoder
@@ -70,11 +74,12 @@ public class CorrelateWorkflowInstanceSubscriptionCommand
         .elementInstanceKey(elementInstanceKey)
         .messageKey(messageKey)
         .putMessageName(messageName, 0, messageName.capacity())
-        .putVariables(variables, 0, variables.capacity());
+        .putVariables(variables, 0, variables.capacity())
+        .putBpmnProcessId(bpmnProcessId, 0, bpmnProcessId.capacity());
   }
 
   @Override
-  public void wrap(DirectBuffer buffer, int offset, int length) {
+  public void wrap(final DirectBuffer buffer, int offset, final int length) {
     super.wrap(buffer, offset, length);
 
     subscriptionPartitionId = decoder.subscriptionPartitionId();
@@ -95,13 +100,19 @@ public class CorrelateWorkflowInstanceSubscriptionCommand
     variables.wrap(buffer, offset, variablesLength);
     offset += variablesLength;
     decoder.limit(offset);
+
+    offset += CorrelateWorkflowInstanceSubscriptionDecoder.bpmnProcessIdHeaderLength();
+    final int bpmnProcessIdLength = decoder.bpmnProcessIdLength();
+    bpmnProcessId.wrap(buffer, offset, bpmnProcessIdLength);
+    offset += bpmnProcessIdLength;
+    decoder.limit(offset);
   }
 
   public int getSubscriptionPartitionId() {
     return subscriptionPartitionId;
   }
 
-  public void setSubscriptionPartitionId(int subscriptionPartitionId) {
+  public void setSubscriptionPartitionId(final int subscriptionPartitionId) {
     this.subscriptionPartitionId = subscriptionPartitionId;
   }
 
@@ -109,7 +120,7 @@ public class CorrelateWorkflowInstanceSubscriptionCommand
     return workflowInstanceKey;
   }
 
-  public void setWorkflowInstanceKey(long workflowInstanceKey) {
+  public void setWorkflowInstanceKey(final long workflowInstanceKey) {
     this.workflowInstanceKey = workflowInstanceKey;
   }
 
@@ -117,7 +128,7 @@ public class CorrelateWorkflowInstanceSubscriptionCommand
     return elementInstanceKey;
   }
 
-  public void setElementInstanceKey(long elementInstanceKey) {
+  public void setElementInstanceKey(final long elementInstanceKey) {
     this.elementInstanceKey = elementInstanceKey;
   }
 
@@ -135,5 +146,9 @@ public class CorrelateWorkflowInstanceSubscriptionCommand
 
   public DirectBuffer getVariables() {
     return variables;
+  }
+
+  public DirectBuffer getBpmnProcessId() {
+    return bpmnProcessId;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/OpenMessageSubscriptionCommand.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/OpenMessageSubscriptionCommand.java
@@ -19,6 +19,7 @@ public class OpenMessageSubscriptionCommand
   private final OpenMessageSubscriptionDecoder decoder = new OpenMessageSubscriptionDecoder();
   private final UnsafeBuffer messageName = new UnsafeBuffer(0, 0);
   private final UnsafeBuffer correlationKey = new UnsafeBuffer(0, 0);
+  private final UnsafeBuffer bpmnProcessId = new UnsafeBuffer(0, 0);
   private int subscriptionPartitionId;
   private long workflowInstanceKey;
   private long elementInstanceKey;
@@ -41,6 +42,7 @@ public class OpenMessageSubscriptionCommand
     elementInstanceKey = OpenMessageSubscriptionDecoder.elementInstanceKeyNullValue();
     messageName.wrap(0, 0);
     correlationKey.wrap(0, 0);
+    bpmnProcessId.wrap(0, 0);
   }
 
   @Override
@@ -49,7 +51,9 @@ public class OpenMessageSubscriptionCommand
         + OpenMessageSubscriptionDecoder.messageNameHeaderLength()
         + messageName.capacity()
         + OpenMessageSubscriptionDecoder.correlationKeyHeaderLength()
-        + correlationKey.capacity();
+        + correlationKey.capacity()
+        + OpenMessageSubscriptionDecoder.bpmnProcessIdHeaderLength()
+        + bpmnProcessId.capacity();
   }
 
   @Override
@@ -62,7 +66,8 @@ public class OpenMessageSubscriptionCommand
         .elementInstanceKey(elementInstanceKey)
         .closeOnCorrelate(closeOnCorrelate ? BooleanType.TRUE : BooleanType.FALSE)
         .putMessageName(messageName, 0, messageName.capacity())
-        .putCorrelationKey(correlationKey, 0, correlationKey.capacity());
+        .putCorrelationKey(correlationKey, 0, correlationKey.capacity())
+        .putBpmnProcessId(bpmnProcessId, 0, bpmnProcessId.capacity());
   }
 
   @Override
@@ -86,6 +91,12 @@ public class OpenMessageSubscriptionCommand
     final int correlationKeyLength = decoder.correlationKeyLength();
     correlationKey.wrap(buffer, offset, correlationKeyLength);
     offset += correlationKeyLength;
+    decoder.limit(offset);
+
+    offset += OpenMessageSubscriptionDecoder.bpmnProcessIdHeaderLength();
+    final int bpmnProcessIdLength = decoder.bpmnProcessIdLength();
+    bpmnProcessId.wrap(buffer, offset, bpmnProcessIdLength);
+    offset += bpmnProcessIdLength;
     decoder.limit(offset);
   }
 
@@ -127,5 +138,9 @@ public class OpenMessageSubscriptionCommand
 
   public void setCloseOnCorrelate(boolean closeOnCorrelate) {
     this.closeOnCorrelate = closeOnCorrelate;
+  }
+
+  public DirectBuffer getBpmnProcessId() {
+    return bpmnProcessId;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/RejectCorrelateMessageSubscriptionCommand.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/RejectCorrelateMessageSubscriptionCommand.java
@@ -22,6 +22,7 @@ public class RejectCorrelateMessageSubscriptionCommand
       new RejectCorrelateMessageSubscriptionDecoder();
   private final UnsafeBuffer messageName = new UnsafeBuffer(0, 0);
   private final UnsafeBuffer correlationKey = new UnsafeBuffer(0, 0);
+  private final UnsafeBuffer bpmnProcessId = new UnsafeBuffer(0, 0);
   private int subscriptionPartitionId;
   private long workflowInstanceKey;
   private long messageKey;
@@ -44,6 +45,7 @@ public class RejectCorrelateMessageSubscriptionCommand
     messageKey = RejectCorrelateMessageSubscriptionDecoder.messageKeyNullValue();
     messageName.wrap(0, 0);
     correlationKey.wrap(0, 0);
+    bpmnProcessId.wrap(0, 0);
   }
 
   @Override
@@ -52,7 +54,9 @@ public class RejectCorrelateMessageSubscriptionCommand
         + RejectCorrelateMessageSubscriptionDecoder.messageNameHeaderLength()
         + messageName.capacity()
         + RejectCorrelateMessageSubscriptionDecoder.correlationKeyHeaderLength()
-        + correlationKey.capacity();
+        + correlationKey.capacity()
+        + RejectCorrelateMessageSubscriptionDecoder.bpmnProcessIdHeaderLength()
+        + bpmnProcessId.capacity();
   }
 
   @Override
@@ -64,7 +68,8 @@ public class RejectCorrelateMessageSubscriptionCommand
         .workflowInstanceKey(workflowInstanceKey)
         .messageKey(messageKey)
         .putMessageName(messageName, 0, messageName.capacity())
-        .putCorrelationKey(correlationKey, 0, correlationKey.capacity());
+        .putCorrelationKey(correlationKey, 0, correlationKey.capacity())
+        .putBpmnProcessId(bpmnProcessId, 0, bpmnProcessId.capacity());
   }
 
   @Override
@@ -77,6 +82,7 @@ public class RejectCorrelateMessageSubscriptionCommand
 
     decoder.wrapMessageName(messageName);
     decoder.wrapCorrelationKey(correlationKey);
+    decoder.wrapBpmnProcessId(bpmnProcessId);
   }
 
   public int getSubscriptionPartitionId() {
@@ -109,5 +115,9 @@ public class RejectCorrelateMessageSubscriptionCommand
 
   public DirectBuffer getCorrelationKey() {
     return correlationKey;
+  }
+
+  public DirectBuffer getBpmnProcessId() {
+    return bpmnProcessId;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/SubscriptionCommandMessageHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/SubscriptionCommandMessageHandler.java
@@ -66,13 +66,14 @@ public class SubscriptionCommandMessageHandler
   private final Function<Integer, LogStream> logstreamSupplier;
 
   public SubscriptionCommandMessageHandler(
-      Consumer<Runnable> enviromentToRun, Function<Integer, LogStream> logstreamSupplier) {
+      final Consumer<Runnable> enviromentToRun,
+      final Function<Integer, LogStream> logstreamSupplier) {
     this.enviromentToRun = enviromentToRun;
     this.logstreamSupplier = logstreamSupplier;
   }
 
   @Override
-  public CompletableFuture<Void> apply(byte[] bytes) {
+  public CompletableFuture<Void> apply(final byte[] bytes) {
     final CompletableFuture<Void> future = new CompletableFuture<>();
     enviromentToRun.accept(
         () -> {
@@ -114,12 +115,14 @@ public class SubscriptionCommandMessageHandler
     return future;
   }
 
-  private boolean onOpenMessageSubscription(DirectBuffer buffer, int offset, int length) {
+  private boolean onOpenMessageSubscription(
+      final DirectBuffer buffer, final int offset, final int length) {
     openMessageSubscriptionCommand.wrap(buffer, offset, length);
 
     messageSubscriptionRecord
         .setWorkflowInstanceKey(openMessageSubscriptionCommand.getWorkflowInstanceKey())
         .setElementInstanceKey(openMessageSubscriptionCommand.getElementInstanceKey())
+        .setBpmnProcessId(openMessageSubscriptionCommand.getBpmnProcessId())
         .setMessageKey(-1)
         .setMessageName(openMessageSubscriptionCommand.getMessageName())
         .setCorrelationKey(openMessageSubscriptionCommand.getCorrelationKey())
@@ -132,7 +135,8 @@ public class SubscriptionCommandMessageHandler
         messageSubscriptionRecord);
   }
 
-  private boolean onOpenWorkflowInstanceSubscription(DirectBuffer buffer, int offset, int length) {
+  private boolean onOpenWorkflowInstanceSubscription(
+      final DirectBuffer buffer, final int offset, final int length) {
     openWorkflowInstanceSubscriptionCommand.wrap(buffer, offset, length);
 
     final long workflowInstanceKey =
@@ -157,7 +161,7 @@ public class SubscriptionCommandMessageHandler
   }
 
   private boolean onCorrelateWorkflowInstanceSubscription(
-      DirectBuffer buffer, int offset, int length) {
+      final DirectBuffer buffer, final int offset, final int length) {
     correlateWorkflowInstanceSubscriptionCommand.wrap(buffer, offset, length);
 
     final long workflowInstanceKey =
@@ -169,6 +173,7 @@ public class SubscriptionCommandMessageHandler
             correlateWorkflowInstanceSubscriptionCommand.getSubscriptionPartitionId())
         .setWorkflowInstanceKey(workflowInstanceKey)
         .setElementInstanceKey(correlateWorkflowInstanceSubscriptionCommand.getElementInstanceKey())
+        .setBpmnProcessId(correlateWorkflowInstanceSubscriptionCommand.getBpmnProcessId())
         .setMessageKey(correlateWorkflowInstanceSubscriptionCommand.getMessageKey())
         .setMessageName(correlateWorkflowInstanceSubscriptionCommand.getMessageName())
         .setVariables(correlateWorkflowInstanceSubscriptionCommand.getVariables());
@@ -180,13 +185,15 @@ public class SubscriptionCommandMessageHandler
         workflowInstanceSubscriptionRecord);
   }
 
-  private boolean onCorrelateMessageSubscription(DirectBuffer buffer, int offset, int length) {
+  private boolean onCorrelateMessageSubscription(
+      final DirectBuffer buffer, final int offset, final int length) {
     correlateMessageSubscriptionCommand.wrap(buffer, offset, length);
 
     messageSubscriptionRecord.reset();
     messageSubscriptionRecord
         .setWorkflowInstanceKey(correlateMessageSubscriptionCommand.getWorkflowInstanceKey())
         .setElementInstanceKey(correlateMessageSubscriptionCommand.getElementInstanceKey())
+        .setBpmnProcessId(correlateMessageSubscriptionCommand.getBpmnProcessId())
         .setMessageKey(-1)
         .setMessageName(correlateMessageSubscriptionCommand.getMessageName());
 
@@ -197,7 +204,8 @@ public class SubscriptionCommandMessageHandler
         messageSubscriptionRecord);
   }
 
-  private boolean onCloseMessageSubscription(DirectBuffer buffer, int offset, int length) {
+  private boolean onCloseMessageSubscription(
+      final DirectBuffer buffer, final int offset, final int length) {
     closeMessageSubscriptionCommand.wrap(buffer, offset, length);
 
     messageSubscriptionRecord.reset();
@@ -214,7 +222,8 @@ public class SubscriptionCommandMessageHandler
         messageSubscriptionRecord);
   }
 
-  private boolean onCloseWorkflowInstanceSubscription(DirectBuffer buffer, int offset, int length) {
+  private boolean onCloseWorkflowInstanceSubscription(
+      final DirectBuffer buffer, final int offset, final int length) {
     closeWorkflowInstanceSubscriptionCommand.wrap(buffer, offset, length);
 
     final long workflowInstanceKey =
@@ -238,7 +247,7 @@ public class SubscriptionCommandMessageHandler
   }
 
   private boolean onRejectCorrelateMessageSubscription(
-      DirectBuffer buffer, int offset, int length) {
+      final DirectBuffer buffer, final int offset, final int length) {
     resetMessageCorrelationCommand.wrap(buffer, offset, length);
 
     final long workflowInstanceKey = resetMessageCorrelationCommand.getWorkflowInstanceKey();
@@ -247,6 +256,7 @@ public class SubscriptionCommandMessageHandler
     messageSubscriptionRecord
         .setWorkflowInstanceKey(workflowInstanceKey)
         .setElementInstanceKey(-1L)
+        .setBpmnProcessId(resetMessageCorrelationCommand.getBpmnProcessId())
         .setMessageName(resetMessageCorrelationCommand.getMessageName())
         .setCorrelationKey(resetMessageCorrelationCommand.getCorrelationKey())
         .setMessageKey(resetMessageCorrelationCommand.getMessageKey())
@@ -260,7 +270,10 @@ public class SubscriptionCommandMessageHandler
   }
 
   private boolean writeCommand(
-      int partitionId, ValueType valueType, Intent intent, UnpackedObject command) {
+      final int partitionId,
+      final ValueType valueType,
+      final Intent intent,
+      final UnpackedObject command) {
 
     final LogStream logStream = logstreamSupplier.apply(partitionId);
     if (logStream == null) {

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/SubscriptionCommandSender.java
@@ -58,7 +58,7 @@ public class SubscriptionCommandSender {
   private final int senderPartition;
 
   public SubscriptionCommandSender(
-      int senderPartition, PartitionCommandSender partitionCommandSender) {
+      final int senderPartition, final PartitionCommandSender partitionCommandSender) {
     this.senderPartition = senderPartition;
     this.partitionCommandSender = partitionCommandSender;
   }
@@ -67,12 +67,14 @@ public class SubscriptionCommandSender {
       final int subscriptionPartitionId,
       final long workflowInstanceKey,
       final long elementInstanceKey,
+      final DirectBuffer bpmnProcessId,
       final DirectBuffer messageName,
       final DirectBuffer correlationKey,
       final boolean closeOnCorrelate) {
     openMessageSubscriptionCommand.setSubscriptionPartitionId(subscriptionPartitionId);
     openMessageSubscriptionCommand.setWorkflowInstanceKey(workflowInstanceKey);
     openMessageSubscriptionCommand.setElementInstanceKey(elementInstanceKey);
+    openMessageSubscriptionCommand.getBpmnProcessId().wrap(bpmnProcessId);
     openMessageSubscriptionCommand.getMessageName().wrap(messageName);
     openMessageSubscriptionCommand.getCorrelationKey().wrap(correlationKey);
     openMessageSubscriptionCommand.setCloseOnCorrelate(closeOnCorrelate);
@@ -102,6 +104,7 @@ public class SubscriptionCommandSender {
   public boolean correlateWorkflowInstanceSubscription(
       final long workflowInstanceKey,
       final long elementInstanceKey,
+      final DirectBuffer bpmnProcessId,
       final DirectBuffer messageName,
       final long messageKey,
       final DirectBuffer variables) {
@@ -111,6 +114,7 @@ public class SubscriptionCommandSender {
     correlateWorkflowInstanceSubscriptionCommand.setSubscriptionPartitionId(senderPartition);
     correlateWorkflowInstanceSubscriptionCommand.setWorkflowInstanceKey(workflowInstanceKey);
     correlateWorkflowInstanceSubscriptionCommand.setElementInstanceKey(elementInstanceKey);
+    correlateWorkflowInstanceSubscriptionCommand.getBpmnProcessId().wrap(bpmnProcessId);
     correlateWorkflowInstanceSubscriptionCommand.setMessageKey(messageKey);
     correlateWorkflowInstanceSubscriptionCommand.getMessageName().wrap(messageName);
     correlateWorkflowInstanceSubscriptionCommand.getVariables().wrap(variables);
@@ -123,11 +127,13 @@ public class SubscriptionCommandSender {
       final int subscriptionPartitionId,
       final long workflowInstanceKey,
       final long elementInstanceKey,
+      final DirectBuffer bpmnProcessId,
       final DirectBuffer messageName) {
 
     correlateMessageSubscriptionCommand.setSubscriptionPartitionId(subscriptionPartitionId);
     correlateMessageSubscriptionCommand.setWorkflowInstanceKey(workflowInstanceKey);
     correlateMessageSubscriptionCommand.setElementInstanceKey(elementInstanceKey);
+    correlateMessageSubscriptionCommand.getBpmnProcessId().wrap(bpmnProcessId);
     correlateMessageSubscriptionCommand.getMessageName().wrap(messageName);
 
     return partitionCommandSender.sendCommand(
@@ -167,7 +173,7 @@ public class SubscriptionCommandSender {
 
   public boolean rejectCorrelateMessageSubscription(
       final long workflowInstanceKey,
-      final long elementInstanceKey,
+      final DirectBuffer bpmnProcessId,
       final long messageKey,
       final DirectBuffer messageName,
       final DirectBuffer correlationKey) {
@@ -176,6 +182,7 @@ public class SubscriptionCommandSender {
 
     rejectCorrelateMessageSubscriptionCommand.setSubscriptionPartitionId(senderPartition);
     rejectCorrelateMessageSubscriptionCommand.setWorkflowInstanceKey(workflowInstanceKey);
+    rejectCorrelateMessageSubscriptionCommand.getBpmnProcessId().wrap(bpmnProcessId);
     rejectCorrelateMessageSubscriptionCommand.setMessageKey(messageKey);
     rejectCorrelateMessageSubscriptionCommand.getMessageName().wrap(messageName);
     rejectCorrelateMessageSubscriptionCommand.getCorrelationKey().wrap(correlationKey);

--- a/engine/src/main/java/io/zeebe/engine/state/message/MessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/MessageStartEventSubscriptionState.java
@@ -64,6 +64,7 @@ public class MessageStartEventSubscriptionState {
     subscriptionRecord.setStartEventId(subscription.getStartEventIdBuffer());
     subscriptionRecord.setMessageName(subscription.getMessageNameBuffer());
     subscriptionRecord.setWorkflowKey(subscription.getWorkflowKey());
+    subscriptionRecord.setBpmnProcessId(subscription.getBpmnProcessIdBuffer());
 
     messageName.wrapBuffer(subscription.getMessageNameBuffer());
     workflowKey.wrapLong(subscription.getWorkflowKey());

--- a/engine/src/main/java/io/zeebe/engine/state/message/WorkflowInstanceSubscription.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/WorkflowInstanceSubscription.java
@@ -26,6 +26,7 @@ public class WorkflowInstanceSubscription implements DbValue {
   private final DirectBuffer messageName = new UnsafeBuffer();
   private final DirectBuffer correlationKey = new UnsafeBuffer();
   private final DirectBuffer targetElementId = new UnsafeBuffer();
+  private final DirectBuffer bpmnProcessId = new UnsafeBuffer();
 
   private long workflowInstanceKey;
   private long elementInstanceKey;
@@ -37,20 +38,23 @@ public class WorkflowInstanceSubscription implements DbValue {
 
   public WorkflowInstanceSubscription() {}
 
-  public WorkflowInstanceSubscription(long workflowInstanceKey, long elementInstanceKey) {
+  public WorkflowInstanceSubscription(
+      long workflowInstanceKey, long elementInstanceKey, DirectBuffer bpmnProcessId) {
     this.workflowInstanceKey = workflowInstanceKey;
     this.elementInstanceKey = elementInstanceKey;
+    this.bpmnProcessId.wrap(bpmnProcessId);
   }
 
   public WorkflowInstanceSubscription(
       long workflowInstanceKey,
       long elementInstanceKey,
       DirectBuffer targetElementId,
+      DirectBuffer bpmnProcessId,
       DirectBuffer messageName,
       DirectBuffer correlationKey,
       long commandSentTime,
       boolean closeOnCorrelate) {
-    this(workflowInstanceKey, elementInstanceKey);
+    this(workflowInstanceKey, elementInstanceKey, bpmnProcessId);
 
     this.targetElementId.wrap(targetElementId);
     this.commandSentTime = commandSentTime;
@@ -99,6 +103,14 @@ public class WorkflowInstanceSubscription implements DbValue {
     this.elementInstanceKey = elementInstanceKey;
   }
 
+  public DirectBuffer getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public void setBpmnProcessId(DirectBuffer bpmnProcessId) {
+    this.bpmnProcessId.wrap(bpmnProcessId);
+  }
+
   public long getCommandSentTime() {
     return commandSentTime;
   }
@@ -142,27 +154,28 @@ public class WorkflowInstanceSubscription implements DbValue {
   @Override
   public void wrap(final DirectBuffer buffer, int offset, final int length) {
     final int startOffset = offset;
-    this.workflowInstanceKey = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
+    workflowInstanceKey = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
     offset += Long.BYTES;
 
-    this.elementInstanceKey = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
+    elementInstanceKey = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
     offset += Long.BYTES;
 
-    this.subscriptionPartitionId = buffer.getInt(offset, ZB_DB_BYTE_ORDER);
+    subscriptionPartitionId = buffer.getInt(offset, ZB_DB_BYTE_ORDER);
     offset += Integer.BYTES;
 
-    this.commandSentTime = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
+    commandSentTime = buffer.getLong(offset, ZB_DB_BYTE_ORDER);
     offset += Long.BYTES;
 
-    this.state = buffer.getInt(offset, ZB_DB_BYTE_ORDER);
+    state = buffer.getInt(offset, ZB_DB_BYTE_ORDER);
     offset += Integer.BYTES;
 
-    this.closeOnCorrelate = buffer.getByte(offset) == 1;
+    closeOnCorrelate = buffer.getByte(offset) == 1;
     offset += 1;
 
     offset = readIntoBuffer(buffer, offset, messageName);
     offset = readIntoBuffer(buffer, offset, correlationKey);
     offset = readIntoBuffer(buffer, offset, targetElementId);
+    offset = readIntoBuffer(buffer, offset, bpmnProcessId);
 
     assert (offset - startOffset) == length : "End offset differs from length";
   }
@@ -171,10 +184,11 @@ public class WorkflowInstanceSubscription implements DbValue {
   public int getLength() {
     return 1
         + Long.BYTES * 3
-        + Integer.BYTES * 5
+        + Integer.BYTES * 6
         + messageName.capacity()
         + correlationKey.capacity()
-        + targetElementId.capacity();
+        + targetElementId.capacity()
+        + bpmnProcessId.capacity();
   }
 
   @Override
@@ -200,6 +214,8 @@ public class WorkflowInstanceSubscription implements DbValue {
     offset = writeIntoBuffer(buffer, offset, messageName);
     offset = writeIntoBuffer(buffer, offset, correlationKey);
     offset = writeIntoBuffer(buffer, offset, targetElementId);
+    offset = writeIntoBuffer(buffer, offset, bpmnProcessId);
+
     assert offset == getLength() : "End offset differs with getLength()";
   }
 

--- a/engine/src/main/resources/subscription-schema.xml
+++ b/engine/src/main/resources/subscription-schema.xml
@@ -14,6 +14,7 @@
     <field name="closeOnCorrelate" id="3" type="BooleanType"/>
     <data name="messageName" id="4" type="varDataEncoding"/>
     <data name="correlationKey" id="5" type="varDataEncoding"/>
+    <data name="bpmnProcessId" id="6" type="varDataEncoding"/>
   </sbe:message>
 
   <sbe:message name="OpenWorkflowInstanceSubscription" id="1">
@@ -31,6 +32,7 @@
     <field name="messageKey" id="3" type="uint64"/>
     <data name="messageName" id="4" type="varDataEncoding"/>
     <data name="variables" id="5" type="varDataEncoding"/>
+    <data name="bpmnProcessId" id="6" type="varDataEncoding"/>
   </sbe:message>
 
   <sbe:message name="CorrelateMessageSubscription" id="3">
@@ -38,6 +40,7 @@
     <field name="workflowInstanceKey" id="1" type="uint64"/>
     <field name="elementInstanceKey" id="2" type="uint64"/>
     <data name="messageName" id="3" type="varDataEncoding"/>
+    <data name="bpmnProcessId" id="4" type="varDataEncoding"/>
   </sbe:message>
 
   <sbe:message name="CloseMessageSubscription" id="4">
@@ -60,5 +63,6 @@
     <field name="messageKey" id="2" type="uint64"/>
     <data name="messageName" id="3" type="varDataEncoding"/>
     <data name="correlationKey" id="4" type="varDataEncoding"/>
+    <data name="bpmnProcessId" id="5" type="varDataEncoding"/>
   </sbe:message>
 </sbe:messageSchema>

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorRule.java
@@ -85,16 +85,16 @@ public class WorkflowInstanceStreamProcessorRule extends ExternalResource
     mockSubscriptionCommandSender = mock(SubscriptionCommandSender.class);
 
     when(mockSubscriptionCommandSender.openMessageSubscription(
-            anyInt(), anyLong(), anyLong(), any(), any(), anyBoolean()))
+            anyInt(), anyLong(), anyLong(), any(), any(), any(), anyBoolean()))
         .thenReturn(true);
     when(mockSubscriptionCommandSender.correlateMessageSubscription(
-            anyInt(), anyLong(), anyLong(), any()))
+            anyInt(), anyLong(), anyLong(), any(), any()))
         .thenReturn(true);
     when(mockSubscriptionCommandSender.closeMessageSubscription(
             anyInt(), anyLong(), anyLong(), any(DirectBuffer.class)))
         .thenReturn(true);
     when(mockSubscriptionCommandSender.rejectCorrelateMessageSubscription(
-            anyLong(), anyLong(), anyLong(), any(), any()))
+            anyLong(), any(), anyLong(), any(), any()))
         .thenReturn(true);
 
     environmentRule.startTypedStreamProcessor(

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorTest.java
@@ -222,6 +222,7 @@ public class WorkflowInstanceStreamProcessorTest {
             START_PARTITION_ID,
             catchEvent.getValue().getWorkflowInstanceKey(),
             catchEvent.getKey(),
+            catchEvent.getValue().getBpmnProcessIdBuffer(),
             wrapString("order canceled"),
             wrapString("order-123"),
             true);
@@ -292,13 +293,14 @@ public class WorkflowInstanceStreamProcessorTest {
             eq(subscription.getSubscriptionPartitionId()),
             eq(subscription.getWorkflowInstanceKey()),
             eq(subscription.getElementInstanceKey()),
+            eq(subscription.getBpmnProcessIdBuffer()),
             captor.capture());
     BufferUtil.equals(captor.getValue(), subscription.getMessageNameBuffer());
 
     verify(streamProcessorRule.getMockSubscriptionCommandSender(), timeout(5_000))
         .rejectCorrelateMessageSubscription(
             eq(subscription.getWorkflowInstanceKey()),
-            eq(subscription.getElementInstanceKey()),
+            eq(subscription.getBpmnProcessIdBuffer()),
             eq(subscription.getMessageKey()),
             captor.capture(),
             any());

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/TransformingDeploymentCreateProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/TransformingDeploymentCreateProcessorTest.java
@@ -50,10 +50,10 @@ public class TransformingDeploymentCreateProcessorTest {
     mockSubscriptionCommandSender = mock(SubscriptionCommandSender.class);
 
     when(mockSubscriptionCommandSender.openMessageSubscription(
-            anyInt(), anyLong(), anyLong(), any(), any(), anyBoolean()))
+            anyInt(), anyLong(), anyLong(), any(), any(), any(), anyBoolean()))
         .thenReturn(true);
     when(mockSubscriptionCommandSender.correlateMessageSubscription(
-            anyInt(), anyLong(), anyLong(), any()))
+            anyInt(), anyLong(), anyLong(), any(), any()))
         .thenReturn(true);
     when(mockSubscriptionCommandSender.closeMessageSubscription(
             anyInt(), anyLong(), anyLong(), any(DirectBuffer.class)))

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/IncidentStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/IncidentStreamProcessorRule.java
@@ -64,10 +64,10 @@ public class IncidentStreamProcessorRule extends ExternalResource {
     mockTimerEventScheduler = mock(DueDateTimerChecker.class);
 
     when(mockSubscriptionCommandSender.openMessageSubscription(
-            anyInt(), anyLong(), anyLong(), any(), any(), anyBoolean()))
+            anyInt(), anyLong(), anyLong(), any(), any(), any(), anyBoolean()))
         .thenReturn(true);
     when(mockSubscriptionCommandSender.correlateMessageSubscription(
-            anyInt(), anyLong(), anyLong(), any()))
+            anyInt(), anyLong(), anyLong(), any(), any()))
         .thenReturn(true);
     when(mockSubscriptionCommandSender.closeMessageSubscription(
             anyInt(), anyLong(), anyLong(), any(DirectBuffer.class)))

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStreamProcessorTest.java
@@ -52,7 +52,7 @@ public class MessageStreamProcessorTest {
         .thenReturn(true);
 
     when(mockSubscriptionCommandSender.correlateWorkflowInstanceSubscription(
-            anyLong(), anyLong(), any(), anyLong(), any()))
+            anyLong(), anyLong(), any(), any(), anyLong(), any()))
         .thenReturn(true);
 
     when(mockSubscriptionCommandSender.closeWorkflowInstanceSubscription(
@@ -114,6 +114,7 @@ public class MessageStreamProcessorTest {
         .correlateWorkflowInstanceSubscription(
             subscription.getWorkflowInstanceKey(),
             subscription.getElementInstanceKey(),
+            subscription.getBpmnProcessIdBuffer(),
             subscription.getMessageNameBuffer(),
             messageKey,
             message.getVariablesBuffer());
@@ -148,6 +149,7 @@ public class MessageStreamProcessorTest {
         .correlateWorkflowInstanceSubscription(
             subscription.getWorkflowInstanceKey(),
             subscription.getElementInstanceKey(),
+            subscription.getBpmnProcessIdBuffer(),
             subscription.getMessageNameBuffer(),
             messageKey,
             message.getVariablesBuffer());
@@ -230,11 +232,12 @@ public class MessageStreamProcessorTest {
 
     verify(mockSubscriptionCommandSender, timeout(5_000).times(1))
         .correlateWorkflowInstanceSubscription(
-            subscription.getWorkflowInstanceKey(),
-            subscription.getElementInstanceKey(),
-            subscription.getMessageNameBuffer(),
-            messageKey,
-            message.getVariablesBuffer());
+            eq(subscription.getWorkflowInstanceKey()),
+            eq(subscription.getElementInstanceKey()),
+            any(),
+            any(),
+            eq(messageKey),
+            any());
   }
 
   @Test
@@ -269,6 +272,7 @@ public class MessageStreamProcessorTest {
         .correlateWorkflowInstanceSubscription(
             eq(subscription.getWorkflowInstanceKey()),
             eq(subscription.getElementInstanceKey()),
+            eq(subscription.getBpmnProcessIdBuffer()),
             any(),
             eq(firstMessageKey),
             any());
@@ -277,6 +281,7 @@ public class MessageStreamProcessorTest {
         .correlateWorkflowInstanceSubscription(
             eq(subscription.getWorkflowInstanceKey()),
             eq(subscription.getElementInstanceKey()),
+            eq(subscription.getBpmnProcessIdBuffer()),
             any(),
             eq(lastMessageKey),
             any());
@@ -365,6 +370,7 @@ public class MessageStreamProcessorTest {
         .correlateWorkflowInstanceSubscription(
             eq(firstSubscription.getWorkflowInstanceKey()),
             eq(firstSubscription.getElementInstanceKey()),
+            eq(firstSubscription.getBpmnProcessIdBuffer()),
             any(DirectBuffer.class),
             eq(messageKey),
             any(DirectBuffer.class));
@@ -373,13 +379,16 @@ public class MessageStreamProcessorTest {
         .correlateWorkflowInstanceSubscription(
             eq(secondSubscription.getWorkflowInstanceKey()),
             eq(secondSubscription.getElementInstanceKey()),
+            eq(secondSubscription.getBpmnProcessIdBuffer()),
             any(DirectBuffer.class),
             eq(messageKey),
             any(DirectBuffer.class));
   }
 
   private void assertAllMessagesReceived(
-      MessageSubscriptionRecord subscription, MessageRecord first, MessageRecord second) {
+      final MessageSubscriptionRecord subscription,
+      final MessageRecord first,
+      final MessageRecord second) {
     final ArgumentCaptor<DirectBuffer> nameCaptor = ArgumentCaptor.forClass(DirectBuffer.class);
     final ArgumentCaptor<DirectBuffer> variablesCaptor =
         ArgumentCaptor.forClass(DirectBuffer.class);
@@ -402,6 +411,7 @@ public class MessageStreamProcessorTest {
         .correlateWorkflowInstanceSubscription(
             eq(subscription.getWorkflowInstanceKey()),
             eq(subscription.getElementInstanceKey()),
+            eq(subscription.getBpmnProcessIdBuffer()),
             nameCaptor.capture(),
             eq(firstMessageKey),
             variablesCaptor.capture());
@@ -410,6 +420,7 @@ public class MessageStreamProcessorTest {
         .correlateWorkflowInstanceSubscription(
             eq(subscription.getWorkflowInstanceKey()),
             eq(subscription.getElementInstanceKey()),
+            eq(subscription.getBpmnProcessIdBuffer()),
             nameCaptor.capture(),
             eq(lastMessageKey),
             variablesCaptor.capture());
@@ -428,6 +439,7 @@ public class MessageStreamProcessorTest {
     subscription
         .setWorkflowInstanceKey(1L)
         .setElementInstanceKey(2L)
+        .setBpmnProcessId(wrapString("workflow"))
         .setMessageKey(-1L)
         .setMessageName(wrapString("order canceled"))
         .setCorrelationKey(wrapString("order-123"))

--- a/engine/src/test/java/io/zeebe/engine/state/message/MessageStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/message/MessageStateTest.java
@@ -97,7 +97,7 @@ public class MessageStateTest {
     messageState.put(message);
 
     // when
-    final List<Message> messages = new ArrayList<Message>();
+    final List<Message> messages = new ArrayList<>();
     messageState.visitMessages(wrapString("name"), wrapString("correlationKey"), messages::add);
 
     // then
@@ -239,8 +239,8 @@ public class MessageStateTest {
     final Message message = createMessage(1L, "name", "correlationKey", "{}", "id", 1234);
     messageState.put(message);
 
-    messageState.putMessageCorrelation(1L, 2L);
-    messageState.putMessageCorrelation(1L, 3L);
+    messageState.putMessageCorrelation(1L, wrapString("a"));
+    messageState.putMessageCorrelation(1L, wrapString("b"));
 
     // when
     messageState.remove(message.getKey());
@@ -265,8 +265,8 @@ public class MessageStateTest {
     assertThat(exist).isFalse();
 
     // and
-    assertThat(messageState.existMessageCorrelation(1L, 2L)).isFalse();
-    assertThat(messageState.existMessageCorrelation(1L, 3L)).isFalse();
+    assertThat(messageState.existMessageCorrelation(1L, wrapString("a"))).isFalse();
+    assertThat(messageState.existMessageCorrelation(1L, wrapString("b"))).isFalse();
   }
 
   @Test
@@ -332,8 +332,8 @@ public class MessageStateTest {
 
     messageState.put(message);
 
-    messageState.putMessageCorrelation(1L, 3L);
-    messageState.putMessageCorrelation(2L, 4L);
+    messageState.putMessageCorrelation(1L, wrapString("a"));
+    messageState.putMessageCorrelation(2L, wrapString("b"));
 
     // when
     messageState.remove(message2.getKey());
@@ -358,19 +358,19 @@ public class MessageStateTest {
     assertThat(exist).isTrue();
 
     // and
-    assertThat(messageState.existMessageCorrelation(1L, 3L)).isTrue();
+    assertThat(messageState.existMessageCorrelation(1L, wrapString("a"))).isTrue();
   }
 
   @Test
   public void shouldExistCorrelatedMessage() {
     // when
-    messageState.putMessageCorrelation(1L, 2L);
+    messageState.putMessageCorrelation(1L, wrapString("a"));
 
     // then
-    assertThat(messageState.existMessageCorrelation(1L, 2L)).isTrue();
+    assertThat(messageState.existMessageCorrelation(1L, wrapString("a"))).isTrue();
 
-    assertThat(messageState.existMessageCorrelation(3L, 2L)).isFalse();
-    assertThat(messageState.existMessageCorrelation(1L, 3L)).isFalse();
+    assertThat(messageState.existMessageCorrelation(3L, wrapString("a"))).isFalse();
+    assertThat(messageState.existMessageCorrelation(1L, wrapString("b"))).isFalse();
   }
 
   @Test
@@ -378,13 +378,13 @@ public class MessageStateTest {
     // given
     final long messageKey = 6L;
     final long workflowInstanceKey = 9L;
-    messageState.putMessageCorrelation(messageKey, workflowInstanceKey);
+    messageState.putMessageCorrelation(messageKey, wrapString("a"));
 
     // when
-    messageState.removeMessageCorrelation(messageKey, workflowInstanceKey);
+    messageState.removeMessageCorrelation(messageKey, wrapString("a"));
 
     // then
-    assertThat(messageState.existMessageCorrelation(messageKey, workflowInstanceKey)).isFalse();
+    assertThat(messageState.existMessageCorrelation(messageKey, wrapString("a"))).isFalse();
   }
 
   private Message createMessage(long key, String name, String correlationKey) {

--- a/engine/src/test/java/io/zeebe/engine/state/message/MessageSubscriptionStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/message/MessageSubscriptionStateTest.java
@@ -336,6 +336,11 @@ public class MessageSubscriptionStateTest {
   private MessageSubscription subscription(
       String name, String correlationKey, long elementInstanceKey) {
     return new MessageSubscription(
-        1L, elementInstanceKey, wrapString(name), wrapString(correlationKey), true);
+        1L,
+        elementInstanceKey,
+        wrapString("workflow"),
+        wrapString(name),
+        wrapString(correlationKey),
+        true);
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/state/message/WorkflowInstanceSubscriptionStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/message/WorkflowInstanceSubscriptionStateTest.java
@@ -285,6 +285,7 @@ public class WorkflowInstanceSubscriptionStateTest {
     return new WorkflowInstanceSubscription(
         1L,
         elementInstanceKey,
+        wrapString("workflow"),
         wrapString(handlerId),
         wrapString(name),
         wrapString(correlationKey),

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -26,6 +26,12 @@
             },
             "correlationKey": {
               "type": "text"
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "messageKey": {
+              "type": "long"
             }
           }
         }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-subscription-template.json
@@ -23,6 +23,12 @@
             },
             "variables": {
               "enabled": false
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "messageKey": {
+              "type": "long"
             }
           }
         }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
@@ -7,25 +7,28 @@
  */
 package io.zeebe.protocol.impl.record.value.message;
 
+import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
-import io.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
 public class MessageStartEventSubscriptionRecord extends UnifiedRecordValue
     implements MessageStartEventSubscriptionRecordValue {
 
   private final LongProperty workflowKeyProp = new LongProperty("workflowKey");
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final StringProperty messageNameProp = new StringProperty("messageName", "");
   private final StringProperty startEventIdProp = new StringProperty("startEventId", "");
 
   public MessageStartEventSubscriptionRecord() {
-    this.declareProperty(workflowKeyProp)
+    declareProperty(workflowKeyProp)
         .declareProperty(messageNameProp)
-        .declareProperty(startEventIdProp);
+        .declareProperty(startEventIdProp)
+        .declareProperty(bpmnProcessIdProp);
   }
 
   @JsonIgnore
@@ -38,18 +41,29 @@ public class MessageStartEventSubscriptionRecord extends UnifiedRecordValue
     return startEventIdProp.getValue();
   }
 
+  @Override
   public long getWorkflowKey() {
     return workflowKeyProp.getValue();
   }
 
+  public MessageStartEventSubscriptionRecord setWorkflowKey(long key) {
+    workflowKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
   @Override
   public String getStartEventId() {
-    return BufferUtil.bufferAsString(startEventIdProp.getValue());
+    return bufferAsString(startEventIdProp.getValue());
   }
 
   @Override
   public String getMessageName() {
-    return BufferUtil.bufferAsString(messageNameProp.getValue());
+    return bufferAsString(messageNameProp.getValue());
   }
 
   public MessageStartEventSubscriptionRecord setMessageName(DirectBuffer messageName) {
@@ -58,12 +72,17 @@ public class MessageStartEventSubscriptionRecord extends UnifiedRecordValue
   }
 
   public MessageStartEventSubscriptionRecord setStartEventId(DirectBuffer startEventId) {
-    this.startEventIdProp.setValue(startEventId);
+    startEventIdProp.setValue(startEventId);
     return this;
   }
 
-  public MessageStartEventSubscriptionRecord setWorkflowKey(long key) {
-    workflowKeyProp.setValue(key);
+  public MessageStartEventSubscriptionRecord setBpmnProcessId(DirectBuffer bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBpmnProcessIdBuffer() {
+    return bpmnProcessIdProp.getValue();
   }
 }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -7,6 +7,8 @@
  */
 package io.zeebe.protocol.impl.record.value.message;
 
+import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.zeebe.msgpack.property.BooleanProperty;
 import io.zeebe.msgpack.property.LongProperty;
@@ -14,7 +16,6 @@ import io.zeebe.msgpack.property.StringProperty;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.zeebe.protocol.record.value.WorkflowInstanceRelated;
-import io.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
 public class MessageSubscriptionRecord extends UnifiedRecordValue
@@ -22,19 +23,21 @@ public class MessageSubscriptionRecord extends UnifiedRecordValue
 
   private final LongProperty workflowInstanceKeyProp = new LongProperty("workflowInstanceKey");
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey");
-  private final LongProperty messageKeyProp = new LongProperty("messageKey");
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
+  private final LongProperty messageKeyProp = new LongProperty("messageKey", -1L);
   private final StringProperty messageNameProp = new StringProperty("messageName", "");
   private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
   private final BooleanProperty closeOnCorrelateProp =
       new BooleanProperty("closeOnCorrelate", true);
 
   public MessageSubscriptionRecord() {
-    this.declareProperty(workflowInstanceKeyProp)
+    declareProperty(workflowInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(messageKeyProp)
         .declareProperty(messageNameProp)
         .declareProperty(correlationKeyProp)
-        .declareProperty(closeOnCorrelateProp);
+        .declareProperty(closeOnCorrelateProp)
+        .declareProperty(bpmnProcessIdProp);
   }
 
   public boolean shouldCloseOnCorrelate() {
@@ -46,42 +49,53 @@ public class MessageSubscriptionRecord extends UnifiedRecordValue
     return correlationKeyProp.getValue();
   }
 
+  @Override
   public long getElementInstanceKey() {
     return elementInstanceKeyProp.getValue();
   }
 
-  @Override
-  public String getMessageName() {
-    return BufferUtil.bufferAsString(messageNameProp.getValue());
-  }
-
-  @Override
-  public String getCorrelationKey() {
-    return BufferUtil.bufferAsString(correlationKeyProp.getValue());
-  }
-
-  public MessageSubscriptionRecord setCorrelationKey(DirectBuffer correlationKey) {
-    correlationKeyProp.setValue(correlationKey);
-    return this;
-  }
-
-  public MessageSubscriptionRecord setMessageName(DirectBuffer messageName) {
-    messageNameProp.setValue(messageName);
-    return this;
-  }
-
-  public MessageSubscriptionRecord setElementInstanceKey(long key) {
+  public MessageSubscriptionRecord setElementInstanceKey(final long key) {
     elementInstanceKeyProp.setValue(key);
     return this;
   }
 
-  @JsonIgnore
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  @Override
+  public String getMessageName() {
+    return bufferAsString(messageNameProp.getValue());
+  }
+
+  @Override
+  public String getCorrelationKey() {
+    return bufferAsString(correlationKeyProp.getValue());
+  }
+
+  public MessageSubscriptionRecord setCorrelationKey(final DirectBuffer correlationKey) {
+    correlationKeyProp.setValue(correlationKey);
+    return this;
+  }
+
+  @Override
   public long getMessageKey() {
     return messageKeyProp.getValue();
   }
 
-  public MessageSubscriptionRecord setMessageKey(long messageKey) {
-    this.messageKeyProp.setValue(messageKey);
+  public MessageSubscriptionRecord setMessageKey(final long messageKey) {
+    messageKeyProp.setValue(messageKey);
+    return this;
+  }
+
+  public MessageSubscriptionRecord setMessageName(final DirectBuffer messageName) {
+    messageNameProp.setValue(messageName);
+    return this;
+  }
+
+  public MessageSubscriptionRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
     return this;
   }
 
@@ -90,17 +104,23 @@ public class MessageSubscriptionRecord extends UnifiedRecordValue
     return messageNameProp.getValue();
   }
 
+  @Override
   public long getWorkflowInstanceKey() {
     return workflowInstanceKeyProp.getValue();
   }
 
-  public MessageSubscriptionRecord setWorkflowInstanceKey(long key) {
+  public MessageSubscriptionRecord setWorkflowInstanceKey(final long key) {
     workflowInstanceKeyProp.setValue(key);
     return this;
   }
 
-  public MessageSubscriptionRecord setCloseOnCorrelate(boolean closeOnCorrelate) {
-    this.closeOnCorrelateProp.setValue(closeOnCorrelate);
+  public MessageSubscriptionRecord setCloseOnCorrelate(final boolean closeOnCorrelate) {
+    closeOnCorrelateProp.setValue(closeOnCorrelate);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBpmnProcessIdBuffer() {
+    return bpmnProcessIdProp.getValue();
   }
 }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/WorkflowInstanceSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/WorkflowInstanceSubscriptionRecord.java
@@ -7,6 +7,8 @@
  */
 package io.zeebe.protocol.impl.record.value.message;
 
+import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.zeebe.msgpack.property.BooleanProperty;
 import io.zeebe.msgpack.property.DocumentProperty;
@@ -17,7 +19,6 @@ import io.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.value.WorkflowInstanceRelated;
 import io.zeebe.protocol.record.value.WorkflowInstanceSubscriptionRecordValue;
-import io.zeebe.util.buffer.BufferUtil;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 
@@ -28,53 +29,71 @@ public class WorkflowInstanceSubscriptionRecord extends UnifiedRecordValue
       new IntegerProperty("subscriptionPartitionId");
   private final LongProperty workflowInstanceKeyProp = new LongProperty("workflowInstanceKey");
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey");
-  private final LongProperty messageKeyProp = new LongProperty("messageKey");
+  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
+  private final LongProperty messageKeyProp = new LongProperty("messageKey", -1L);
   private final StringProperty messageNameProp = new StringProperty("messageName", "");
   private final DocumentProperty variablesProp = new DocumentProperty("variables");
   private final BooleanProperty closeOnCorrelateProp =
       new BooleanProperty("closeOnCorrelate", true);
 
   public WorkflowInstanceSubscriptionRecord() {
-    this.declareProperty(subscriptionPartitionIdProp)
+    declareProperty(subscriptionPartitionIdProp)
         .declareProperty(workflowInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(messageKeyProp)
         .declareProperty(messageNameProp)
         .declareProperty(variablesProp)
-        .declareProperty(closeOnCorrelateProp);
+        .declareProperty(closeOnCorrelateProp)
+        .declareProperty(bpmnProcessIdProp);
   }
 
   public boolean shouldCloseOnCorrelate() {
     return closeOnCorrelateProp.getValue();
   }
 
+  @Override
   public long getElementInstanceKey() {
     return elementInstanceKeyProp.getValue();
   }
 
-  @Override
-  public String getMessageName() {
-    return BufferUtil.bufferAsString(messageNameProp.getValue());
-  }
-
-  public WorkflowInstanceSubscriptionRecord setMessageName(DirectBuffer messageName) {
-    messageNameProp.setValue(messageName);
-    return this;
-  }
-
-  public WorkflowInstanceSubscriptionRecord setElementInstanceKey(long key) {
+  public WorkflowInstanceSubscriptionRecord setElementInstanceKey(final long key) {
     elementInstanceKeyProp.setValue(key);
     return this;
   }
 
-  @JsonIgnore
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProp.getValue());
+  }
+
+  public WorkflowInstanceSubscriptionRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  @Override
   public long getMessageKey() {
     return messageKeyProp.getValue();
   }
 
-  public WorkflowInstanceSubscriptionRecord setMessageKey(long messageKey) {
+  @Override
+  public String getMessageName() {
+    return bufferAsString(messageNameProp.getValue());
+  }
+
+  public WorkflowInstanceSubscriptionRecord setMessageName(final DirectBuffer messageName) {
+    messageNameProp.setValue(messageName);
+    return this;
+  }
+
+  public WorkflowInstanceSubscriptionRecord setMessageKey(final long messageKey) {
     messageKeyProp.setValue(messageKey);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBpmnProcessIdBuffer() {
+    return bpmnProcessIdProp.getValue();
   }
 
   @JsonIgnore
@@ -87,7 +106,7 @@ public class WorkflowInstanceSubscriptionRecord extends UnifiedRecordValue
     return subscriptionPartitionIdProp.getValue();
   }
 
-  public WorkflowInstanceSubscriptionRecord setSubscriptionPartitionId(int partitionId) {
+  public WorkflowInstanceSubscriptionRecord setSubscriptionPartitionId(final int partitionId) {
     subscriptionPartitionIdProp.setValue(partitionId);
     return this;
   }
@@ -97,7 +116,7 @@ public class WorkflowInstanceSubscriptionRecord extends UnifiedRecordValue
     return MsgPackConverter.convertToMap(variablesProp.getValue());
   }
 
-  public WorkflowInstanceSubscriptionRecord setVariables(DirectBuffer variables) {
+  public WorkflowInstanceSubscriptionRecord setVariables(final DirectBuffer variables) {
     variablesProp.setValue(variables);
     return this;
   }
@@ -107,17 +126,18 @@ public class WorkflowInstanceSubscriptionRecord extends UnifiedRecordValue
     return variablesProp.getValue();
   }
 
+  @Override
   public long getWorkflowInstanceKey() {
     return workflowInstanceKeyProp.getValue();
   }
 
-  public WorkflowInstanceSubscriptionRecord setWorkflowInstanceKey(long key) {
+  public WorkflowInstanceSubscriptionRecord setWorkflowInstanceKey(final long key) {
     workflowInstanceKeyProp.setValue(key);
     return this;
   }
 
-  public WorkflowInstanceSubscriptionRecord setCloseOnCorrelate(boolean closeOnCorrelate) {
-    this.closeOnCorrelateProp.setValue(closeOnCorrelate);
+  public WorkflowInstanceSubscriptionRecord setCloseOnCorrelate(final boolean closeOnCorrelate) {
+    closeOnCorrelateProp.setValue(closeOnCorrelate);
     return this;
   }
 }

--- a/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -409,13 +409,15 @@ public class JsonSerializableToJsonTest {
               final String messageName = "name";
               final String startEventId = "startEvent";
               final int workflowKey = 22334;
+              final String bpmnProcessId = "workflow";
 
               return new MessageStartEventSubscriptionRecord()
                   .setMessageName(wrapString(messageName))
                   .setStartEventId(wrapString(startEventId))
-                  .setWorkflowKey(workflowKey);
+                  .setWorkflowKey(workflowKey)
+                  .setBpmnProcessId(wrapString(bpmnProcessId));
             },
-        "{'workflowKey':22334,'messageName':'name','startEventId':'startEvent'}"
+        "{'workflowKey':22334,'messageName':'name','startEventId':'startEvent','bpmnProcessId':'workflow'}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -429,7 +431,7 @@ public class JsonSerializableToJsonTest {
 
               return new MessageStartEventSubscriptionRecord().setWorkflowKey(workflowKey);
             },
-        "{'workflowKey':22334,'messageName':'','startEventId':''}"
+        "{'workflowKey':22334,'messageName':'','startEventId':'','bpmnProcessId':''}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -439,20 +441,22 @@ public class JsonSerializableToJsonTest {
         "MessageSubscriptionRecord",
         (Supplier<UnifiedRecordValue>)
             () -> {
-              final long activityInstanceKey = 1L;
+              final long elementInstanceKey = 1L;
+              final String bpmnProcessId = "workflow";
               final String messageName = "name";
-              final long workflowInstanceKey = 1L;
+              final long workflowInstanceKey = 2L;
               final String correlationKey = "key";
-              final long messageKey = 1L;
+              final long messageKey = 3L;
 
               return new MessageSubscriptionRecord()
-                  .setElementInstanceKey(activityInstanceKey)
+                  .setElementInstanceKey(elementInstanceKey)
+                  .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setMessageKey(messageKey)
                   .setMessageName(wrapString(messageName))
                   .setWorkflowInstanceKey(workflowInstanceKey)
                   .setCorrelationKey(wrapString(correlationKey));
             },
-        "{'workflowInstanceKey':1,'elementInstanceKey':1,'messageName':'name','correlationKey':'key'}"
+        "{'workflowInstanceKey':2,'elementInstanceKey':1,'messageName':'name','correlationKey':'key','bpmnProcessId':'workflow','messageKey':3}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////// Empty MessageSubscriptionRecord
@@ -469,7 +473,7 @@ public class JsonSerializableToJsonTest {
                   .setWorkflowInstanceKey(workflowInstanceKey)
                   .setElementInstanceKey(elementInstanceKey);
             },
-        "{'workflowInstanceKey':1,'elementInstanceKey':13,'messageName':'','correlationKey':''}"
+        "{'workflowInstanceKey':1,'elementInstanceKey':13,'messageName':'','correlationKey':'','bpmnProcessId':'','messageKey':-1}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -479,21 +483,23 @@ public class JsonSerializableToJsonTest {
         "WorkflowInstanceSubscriptionRecord",
         (Supplier<UnifiedRecordValue>)
             () -> {
-              final long activityInstanceKey = 123;
+              final long elementInstanceKey = 123;
+              final String bpmnProcessId = "workflow";
               final String messageName = "test-message";
               final int subscriptionPartitionId = 2;
               final int messageKey = 3;
               final long workflowInstanceKey = 1345;
 
               return new WorkflowInstanceSubscriptionRecord()
-                  .setElementInstanceKey(activityInstanceKey)
+                  .setElementInstanceKey(elementInstanceKey)
+                  .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setMessageName(wrapString(messageName))
                   .setMessageKey(messageKey)
                   .setSubscriptionPartitionId(subscriptionPartitionId)
                   .setWorkflowInstanceKey(workflowInstanceKey)
                   .setVariables(VARIABLES_MSGPACK);
             },
-        "{'elementInstanceKey':123,'messageName':'test-message','workflowInstanceKey':1345,'variables':{'foo':'bar'}}"
+        "{'elementInstanceKey':123,'messageName':'test-message','workflowInstanceKey':1345,'variables':{'foo':'bar'},'bpmnProcessId':'workflow','messageKey':3}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -510,7 +516,7 @@ public class JsonSerializableToJsonTest {
                   .setWorkflowInstanceKey(workflowInstanceKey)
                   .setElementInstanceKey(elementInstanceKey);
             },
-        "{'elementInstanceKey':123,'messageName':'','workflowInstanceKey':1345,'variables':{}}"
+        "{'elementInstanceKey':123,'messageName':'','workflowInstanceKey':1345,'variables':{},'bpmnProcessId':'','messageKey':-1}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -677,7 +683,7 @@ public class JsonSerializableToJsonTest {
     JsonUtil.assertEquality(json, expectedJson);
   }
 
-  private static String errorRecordAsJson(long workflowInstanceKey, String stacktrace) {
+  private static String errorRecordAsJson(final long workflowInstanceKey, final String stacktrace) {
     final Map<String, Object> params = new HashMap<>();
     params.put("exceptionMessage", "test");
     params.put("workflowInstanceKey", workflowInstanceKey);
@@ -686,7 +692,7 @@ public class JsonSerializableToJsonTest {
 
     try {
       return new ObjectMapper().writeValueAsString(params);
-    } catch (JsonProcessingException e) {
+    } catch (final JsonProcessingException e) {
       throw new RuntimeException(e);
     }
   }

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/MessageStartEventSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/MessageStartEventSubscriptionRecordValue.java
@@ -28,6 +28,9 @@ public interface MessageStartEventSubscriptionRecordValue extends RecordValue {
   /** @return the workflow key tied to the subscription */
   long getWorkflowKey();
 
+  /** @return the BPMN process id tied to the subscription */
+  String getBpmnProcessId();
+
   /** @return the id of the start event tied to the subscription */
   String getStartEventId();
 

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
@@ -31,9 +31,15 @@ public interface MessageSubscriptionRecordValue extends RecordValue {
   /** @return the element instance key tied to the subscription */
   long getElementInstanceKey();
 
+  /** @return the BPMN process id tied to the subscription */
+  String getBpmnProcessId();
+
   /** @return the name of the message */
   String getMessageName();
 
   /** @return the correlation key */
   String getCorrelationKey();
+
+  /** @return the key of the correlated message */
+  long getMessageKey();
 }

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/WorkflowInstanceSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/WorkflowInstanceSubscriptionRecordValue.java
@@ -30,6 +30,12 @@ public interface WorkflowInstanceSubscriptionRecordValue extends RecordValueWith
   /** @return the element instance key */
   long getElementInstanceKey();
 
+  /** @return the BPMN process id */
+  String getBpmnProcessId();
+
+  /** @return the key of the correlated message */
+  long getMessageKey();
+
   /** @return the message name */
   String getMessageName();
 }


### PR DESCRIPTION
## Description

* adjust message state to store correlated messages by BPMN process id
* check if a message is correlated to this BPMN process id before correlating
* add the BPMN process id on the subscription messages
* expose the BPMN process id and the message key on the subscription records
* adjust the ES templates

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3334 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
