### PR TITLE
Fix stream processor dependencies

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/engine/StreamProcessorService.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/StreamProcessorService.java
@@ -16,10 +16,10 @@ import io.zeebe.broker.engine.impl.LongPollingJobNotification;
 import io.zeebe.broker.engine.impl.PartitionCommandSenderImpl;
 import io.zeebe.broker.system.configuration.BrokerCfg;
 import io.zeebe.broker.system.configuration.ClusterCfg;
-import io.zeebe.broker.system.configuration.DataCfg;
 import io.zeebe.broker.system.management.LeaderManagementRequestHandler;
 import io.zeebe.broker.system.management.deployment.PushDeploymentRequestHandler;
 import io.zeebe.broker.transport.commandapi.CommandApiService;
+import io.zeebe.dispatcher.Dispatcher;
 import io.zeebe.engine.processor.ProcessingContext;
 import io.zeebe.engine.processor.StreamProcessor;
 import io.zeebe.engine.processor.TypedRecordProcessors;
@@ -27,18 +27,14 @@ import io.zeebe.engine.processor.workflow.EngineProcessors;
 import io.zeebe.engine.processor.workflow.message.command.SubscriptionCommandSender;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.logstreams.spi.LogStorage;
 import io.zeebe.servicecontainer.Injector;
 import io.zeebe.servicecontainer.Service;
 import io.zeebe.servicecontainer.ServiceStartContext;
 import io.zeebe.servicecontainer.ServiceStopContext;
-import io.zeebe.util.DurationUtil;
 import io.zeebe.util.sched.ActorControl;
-import io.zeebe.util.sched.future.ActorFuture;
-import java.time.Duration;
 
 public class StreamProcessorService implements Service<StreamProcessor> {
-
-  public static final String PROCESSOR_NAME = "zb-stream-processor";
 
   private final Injector<CommandApiService> commandApiServiceInjector = new Injector<>();
   private final Injector<TopologyManager> topologyManagerInjector = new Injector<>();
@@ -46,49 +42,33 @@ public class StreamProcessorService implements Service<StreamProcessor> {
   private final Injector<LeaderManagementRequestHandler> leaderManagementRequestHandlerInjector =
       new Injector<>();
   private final Injector<Partition> partitionInjector = new Injector<>();
+  private final Injector<Dispatcher> logStreamWriteBufferInjector = new Injector<>();
+  private Injector<LogStorage> logStorageInjector = new Injector<>();
 
   private final ClusterCfg clusterCfg;
-  private final Duration snapshotPeriod;
-  private ServiceStartContext serviceContext;
-  private CommandApiService commandApiService;
   private TopologyManager topologyManager;
   private Atomix atomix;
-  private Partition partition;
   private StreamProcessor streamProcessor;
 
   public StreamProcessorService(BrokerCfg brokerCfg) {
     clusterCfg = brokerCfg.getCluster();
-    final DataCfg dataCfg = brokerCfg.getData();
-    this.snapshotPeriod = DurationUtil.parse(dataCfg.getSnapshotPeriod());
   }
 
   @Override
   public void start(final ServiceStartContext serviceContext) {
-    this.serviceContext = serviceContext;
-    this.commandApiService = commandApiServiceInjector.getValue();
+    final CommandApiService commandApiService = commandApiServiceInjector.getValue();
     this.topologyManager = topologyManagerInjector.getValue();
     this.atomix = atomixInjector.getValue();
-    this.partition = partitionInjector.getValue();
-
-    serviceContext.async(startEngineForPartition(partition), true);
-  }
-
-  @Override
-  public void stop(ServiceStopContext stopContext) {
-    stopContext.async(streamProcessor.closeAsync());
-  }
-
-  @Override
-  public StreamProcessor get() {
-    return streamProcessor;
-  }
-
-  public ActorFuture<Void> startEngineForPartition(final Partition partition) {
+    final Partition partition = partitionInjector.getValue();
 
     final LogStream logStream = partition.getLogStream();
     streamProcessor =
         StreamProcessor.builder()
             .logStream(logStream)
+            // for the reader
+            .logStorage(logStorageInjector.getValue())
+            // for the writer
+            .writeBuffer(logStreamWriteBufferInjector.getValue())
             .actorScheduler(serviceContext.getScheduler())
             .zeebeDb(partition.getZeebeDb())
             .commandResponseWriter(commandApiService.newCommandResponseWriter())
@@ -102,7 +82,17 @@ public class StreamProcessorService implements Service<StreamProcessor> {
                 })
             .build();
 
-    return streamProcessor.openAsync();
+    serviceContext.async(streamProcessor.openAsync(), true);
+  }
+
+  @Override
+  public void stop(ServiceStopContext stopContext) {
+    stopContext.async(streamProcessor.closeAsync());
+  }
+
+  @Override
+  public StreamProcessor get() {
+    return streamProcessor;
   }
 
   public TypedRecordProcessors createTypedStreamProcessor(
@@ -155,5 +145,13 @@ public class StreamProcessorService implements Service<StreamProcessor> {
 
   public Injector<LeaderManagementRequestHandler> getLeaderManagementRequestInjector() {
     return leaderManagementRequestHandlerInjector;
+  }
+
+  public Injector<LogStorage> getLogStorageInjector() {
+    return logStorageInjector;
+  }
+
+  public Injector<Dispatcher> getLogStreamWriteBufferInjector() {
+    return logStreamWriteBufferInjector;
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -11,6 +11,7 @@ import io.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.zeebe.db.ZeebeDb;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
+import io.zeebe.logstreams.spi.LogStorage;
 import java.time.Duration;
 import java.util.Collection;
 
@@ -27,6 +28,11 @@ public class ExporterDirectorContext {
   private Duration snapshotPeriod;
   private ZeebeDb zeebeDb;
   private int maxSnapshots;
+  private LogStorage logStorage;
+
+  public LogStorage getLogStorage() {
+    return logStorage;
+  }
 
   public int getId() {
     return id;
@@ -72,6 +78,11 @@ public class ExporterDirectorContext {
 
   public ExporterDirectorContext logStream(LogStream logStream) {
     this.logStream = logStream;
+    return this;
+  }
+
+  public ExporterDirectorContext logStorage(LogStorage logStorage) {
+    this.logStorage = logStorage;
     return this;
   }
 

--- a/broker/src/main/java/io/zeebe/broker/logstreams/restore/BrokerRestoreServer.java
+++ b/broker/src/main/java/io/zeebe/broker/logstreams/restore/BrokerRestoreServer.java
@@ -12,7 +12,7 @@ import io.zeebe.distributedlog.restore.RestoreServer;
 import io.zeebe.distributedlog.restore.impl.DefaultRestoreInfoRequestHandler;
 import io.zeebe.distributedlog.restore.log.impl.DefaultLogReplicationRequestHandler;
 import io.zeebe.distributedlog.restore.snapshot.impl.DefaultSnapshotRequestHandler;
-import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.logstreams.spi.LogStorage;
 import io.zeebe.logstreams.spi.SnapshotController;
 import io.zeebe.util.ZbLogger;
 import java.util.concurrent.CompletableFuture;
@@ -58,11 +58,12 @@ public class BrokerRestoreServer implements RestoreServer {
     this.logger = logger;
   }
 
-  public CompletableFuture<Void> start(LogStream logStream, SnapshotController snapshotController) {
+  public CompletableFuture<Void> start(
+      int partitionId, LogStorage logStorage, SnapshotController snapshotController) {
     final LogReplicationRequestHandler logReplicationHandler =
-        new DefaultLogReplicationRequestHandler(logStream);
+        new DefaultLogReplicationRequestHandler(logStorage);
     final RestoreInfoRequestHandler restoreInfoHandler =
-        new DefaultRestoreInfoRequestHandler(logStream, snapshotController);
+        new DefaultRestoreInfoRequestHandler(partitionId, logStorage, snapshotController);
     final SnapshotRequestHandler snapshotRequestHandler =
         new DefaultSnapshotRequestHandler(snapshotController);
 

--- a/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterRule.java
@@ -95,6 +95,7 @@ public class ExporterRule implements TestRule {
             .id(EXPORTER_PROCESSOR_ID)
             .name(PROCESSOR_NAME)
             .logStream(stream)
+            .logStorage(stream.getLogStorage())
             .zeebeDb(capturedZeebeDb)
             .maxSnapshots(1)
             .descriptors(exporterDescriptors)

--- a/broker/src/test/java/io/zeebe/broker/transport/commandapi/CommandApiMessageHandlerTest.java
+++ b/broker/src/test/java/io/zeebe/broker/transport/commandapi/CommandApiMessageHandlerTest.java
@@ -179,7 +179,8 @@ public class CommandApiMessageHandlerTest {
     // then
     assertThat(isHandled).isTrue();
 
-    final BufferedLogStreamReader logStreamReader = new BufferedLogStreamReader(logStream);
+    final BufferedLogStreamReader logStreamReader =
+        new BufferedLogStreamReader(logStream.getLogStorage());
     waitForAvailableEvent(logStreamReader);
 
     final LoggedEvent loggedEvent = logStreamReader.next();

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
@@ -9,7 +9,7 @@ package io.zeebe.engine.processor;
 
 import static io.zeebe.engine.processor.TypedEventRegistry.EVENT_REGISTRY;
 
-import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.dispatcher.Dispatcher;
 import io.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.zeebe.logstreams.log.LogStreamBatchWriter.LogEntryBuilder;
 import io.zeebe.logstreams.log.LogStreamBatchWriterImpl;
@@ -27,16 +27,14 @@ import java.util.function.Consumer;
 public class TypedCommandWriterImpl implements TypedCommandWriter {
   protected final Consumer<RecordMetadata> noop = m -> {};
   protected final Map<Class<? extends UnpackedObject>, ValueType> typeRegistry;
-  protected final LogStream stream;
   protected RecordMetadata metadata = new RecordMetadata();
   protected LogStreamBatchWriter batchWriter;
 
   protected long sourceRecordPosition = -1;
 
-  public TypedCommandWriterImpl(final LogStream stream) {
-    this.stream = stream;
+  public TypedCommandWriterImpl(int partitionId, final Dispatcher dispatcher) {
     metadata.protocolVersion(Protocol.PROTOCOL_VERSION);
-    this.batchWriter = new LogStreamBatchWriterImpl(stream);
+    this.batchWriter = new LogStreamBatchWriterImpl(partitionId, dispatcher);
     this.typeRegistry = new HashMap<>();
     EVENT_REGISTRY.forEach((e, c) -> typeRegistry.put(c, e));
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedStreamWriterImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedStreamWriterImpl.java
@@ -7,7 +7,7 @@
  */
 package io.zeebe.engine.processor;
 
-import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.dispatcher.Dispatcher;
 import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.RecordType;
@@ -17,8 +17,8 @@ import java.util.function.Consumer;
 
 public class TypedStreamWriterImpl extends TypedCommandWriterImpl implements TypedStreamWriter {
 
-  public TypedStreamWriterImpl(final LogStream stream) {
-    super(stream);
+  public TypedStreamWriterImpl(int partitionId, Dispatcher dispatcher) {
+    super(partitionId, dispatcher);
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageObserver.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageObserver.java
@@ -13,6 +13,7 @@ import io.zeebe.engine.processor.TypedStreamWriterImpl;
 import io.zeebe.engine.processor.workflow.message.command.SubscriptionCommandSender;
 import io.zeebe.engine.state.message.MessageState;
 import io.zeebe.engine.state.message.MessageSubscriptionState;
+import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.util.sched.ActorControl;
 import java.time.Duration;
 
@@ -41,8 +42,9 @@ public class MessageObserver implements StreamProcessorLifecycleAware {
 
     final ActorControl actor = processingContext.getActor();
 
+    final LogStream logStream = processingContext.getLogStream();
     final TypedStreamWriterImpl typedStreamWriter =
-        new TypedStreamWriterImpl(processingContext.getLogStream());
+        new TypedStreamWriterImpl(logStream.getPartitionId(), logStream.getWriteBuffer());
     final MessageTimeToLiveChecker timeToLiveChecker =
         new MessageTimeToLiveChecker(typedStreamWriter, messageState);
     processingContext

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/timer/DueDateTimerChecker.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/timer/DueDateTimerChecker.java
@@ -12,6 +12,7 @@ import io.zeebe.engine.processor.StreamProcessorLifecycleAware;
 import io.zeebe.engine.processor.TypedStreamWriterImpl;
 import io.zeebe.engine.state.deployment.WorkflowState;
 import io.zeebe.engine.state.instance.TimerInstance;
+import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.zeebe.protocol.record.intent.TimerIntent;
 import io.zeebe.util.sched.ActorControl;
@@ -95,7 +96,9 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
   @Override
   public void onOpen(final ReadonlyProcessingContext processingContext) {
     this.actor = processingContext.getActor();
-    streamWriter = new TypedStreamWriterImpl(processingContext.getLogStream());
+    final LogStream logStream = processingContext.getLogStream();
+    streamWriter =
+        new TypedStreamWriterImpl(logStream.getPartitionId(), logStream.getWriteBuffer());
   }
 
   @Override

--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
@@ -769,7 +769,6 @@ public class StreamProcessorTest {
   public void shouldInvokeOnProcessedListener() throws InterruptedException {
     // given
     final CountDownLatch processLatch = new CountDownLatch(1);
-    final TypedRecordProcessor<?> typedRecordProcessor = mock(TypedRecordProcessor.class);
     streamProcessorRule.startTypedStreamProcessor(
         (processors, state) ->
             processors.onEvent(

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -277,7 +277,7 @@ public final class EngineRule extends ExternalResource {
       final LogStream logStream = context.getLogStream();
       logStream.registerOnCommitPositionUpdatedCondition(onCommitCondition);
 
-      logStreamReader = new BufferedLogStreamReader(logStream);
+      logStreamReader = new BufferedLogStreamReader(logStream.getLogStorage());
     }
 
     private void onNewEventCommitted() {

--- a/engine/src/test/java/io/zeebe/engine/util/LogStreamPrinter.java
+++ b/engine/src/test/java/io/zeebe/engine/util/LogStreamPrinter.java
@@ -45,7 +45,7 @@ public class LogStreamPrinter {
     final EnumMap<ValueType, UnpackedObject> eventCache = new EnumMap<>(ValueType.class);
     EVENT_REGISTRY.forEach((t, c) -> eventCache.put(t, ReflectUtil.newInstance(c)));
 
-    try (LogStreamReader streamReader = new BufferedLogStreamReader(logStream)) {
+    try (LogStreamReader streamReader = new BufferedLogStreamReader(logStream.getLogStorage())) {
       streamReader.seekToFirstEvent();
 
       while (streamReader.hasNext()) {

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -206,7 +206,7 @@ public class TestStreams {
   public Stream<LoggedEvent> events(final String logName) {
     final LogStream logStream = getLogStream(logName);
 
-    final LogStreamReader reader = new BufferedLogStreamReader(logStream);
+    final LogStreamReader reader = new BufferedLogStreamReader(logStream.getLogStorage());
     closeables.manage(reader);
 
     reader.seekToFirstEvent();
@@ -282,6 +282,8 @@ public class TestStreams {
             .actorScheduler(actorScheduler)
             .commandResponseWriter(mockCommandResponseWriter)
             .onProcessedListener(mockOnProcessedListener)
+            .writeBuffer(stream.getWriteBuffer())
+            .logStorage(stream.getLogStorage())
             .streamProcessorFactory(
                 (context) -> {
                   final TypedRecordProcessors processors = factory.createProcessors(context);
@@ -323,7 +325,8 @@ public class TestStreams {
 
   public long writeBatch(String logName, RecordToWrite[] recordToWrites) {
     final LogStream logStream = getLogStream(logName);
-    final LogStreamBatchWriterImpl logStreamBatchWriter = new LogStreamBatchWriterImpl(logStream);
+    final LogStreamBatchWriterImpl logStreamBatchWriter =
+        new LogStreamBatchWriterImpl(logStream.getPartitionId(), logStream.getWriteBuffer());
 
     for (RecordToWrite recordToWrite : recordToWrites) {
       logStreamBatchWriter

--- a/logstreams/src/main/java/io/zeebe/distributedlog/restore/impl/DefaultRestoreInfoRequestHandler.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/restore/impl/DefaultRestoreInfoRequestHandler.java
@@ -13,22 +13,20 @@ import io.zeebe.distributedlog.restore.RestoreInfoResponse.ReplicationTarget;
 import io.zeebe.distributedlog.restore.RestoreServer.RestoreInfoRequestHandler;
 import io.zeebe.distributedlog.restore.snapshot.SnapshotRestoreInfo;
 import io.zeebe.logstreams.log.BufferedLogStreamReader;
-import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
+import io.zeebe.logstreams.spi.LogStorage;
 import io.zeebe.logstreams.spi.SnapshotController;
 import org.slf4j.Logger;
 
 public class DefaultRestoreInfoRequestHandler implements RestoreInfoRequestHandler {
   private final SnapshotController snapshotController;
   private final LogStreamReader reader;
-  private final LogStream logStream;
   private final int partitionId;
 
   public DefaultRestoreInfoRequestHandler(
-      LogStream logStream, SnapshotController snapshotController) {
-    this.logStream = logStream;
-    partitionId = logStream.getPartitionId();
-    this.reader = new BufferedLogStreamReader(logStream);
+      int partitionId, LogStorage logStorage, SnapshotController snapshotController) {
+    this.partitionId = partitionId;
+    this.reader = new BufferedLogStreamReader(logStorage);
     this.snapshotController = snapshotController;
   }
 
@@ -51,10 +49,9 @@ public class DefaultRestoreInfoRequestHandler implements RestoreInfoRequestHandl
     }
 
     logger.trace(
-        "Responding restore info request with {} (snapshot position: {}, log position: {}) for partition {}",
+        "Responding restore info request with {} (snapshot position: {}) for partition {}",
         response,
         lastValidSnapshotPosition,
-        logStream.getCommitPosition(),
         partitionId);
     return response;
   }

--- a/logstreams/src/main/java/io/zeebe/distributedlog/restore/log/impl/DefaultLogReplicationRequestHandler.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/restore/log/impl/DefaultLogReplicationRequestHandler.java
@@ -11,9 +11,9 @@ import io.zeebe.distributedlog.restore.RestoreServer.LogReplicationRequestHandle
 import io.zeebe.distributedlog.restore.log.LogReplicationRequest;
 import io.zeebe.distributedlog.restore.log.LogReplicationResponse;
 import io.zeebe.logstreams.log.BufferedLogStreamReader;
-import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
 import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.logstreams.spi.LogStorage;
 import java.nio.ByteBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -25,12 +25,12 @@ public class DefaultLogReplicationRequestHandler implements LogReplicationReques
   private final LogStreamReader reader;
   private final MutableDirectBuffer readerBuffer;
 
-  public DefaultLogReplicationRequestHandler(LogStream logStream) {
-    this(logStream, DEFAULT_READ_BUFFER_SIZE);
+  public DefaultLogReplicationRequestHandler(LogStorage logStorage) {
+    this(logStorage, DEFAULT_READ_BUFFER_SIZE);
   }
 
-  public DefaultLogReplicationRequestHandler(LogStream logStream, int bufferSize) {
-    this.reader = new BufferedLogStreamReader(logStream);
+  public DefaultLogReplicationRequestHandler(LogStorage logStorage, int bufferSize) {
+    this.reader = new BufferedLogStreamReader(logStorage);
     this.readerBuffer = new UnsafeBuffer(ByteBuffer.allocate(bufferSize));
   }
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogStreamService.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/service/LogStreamService.java
@@ -77,7 +77,7 @@ public class LogStreamService implements LogStream, Service<LogStream> {
 
     serviceContext = startContext;
     logStorage = logStorageInjector.getValue();
-    this.reader = new BufferedLogStreamReader(this);
+    this.reader = new BufferedLogStreamReader(logStorage);
     setCommitPosition(reader.seekToEnd());
   }
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/BufferedLogStreamReader.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/BufferedLogStreamReader.java
@@ -46,23 +46,13 @@ public class BufferedLogStreamReader implements LogStreamReader {
   private ByteBuffer byteBuffer;
   private int bufferOffset;
 
-  public BufferedLogStreamReader(final LogStream logStream) {
+  public BufferedLogStreamReader(final LogStorage logStorage) {
     this();
-    wrap(logStream);
+    wrap(logStorage);
   }
 
   public BufferedLogStreamReader() {
     state = IteratorState.WRAP_NOT_CALLED;
-  }
-
-  @Override
-  public void wrap(final LogStream log) {
-    wrap(log, FIRST_POSITION);
-  }
-
-  @Override
-  public void wrap(final LogStream log, final long position) {
-    wrap(log.getLogStorage(), position);
   }
 
   @Override
@@ -161,10 +151,12 @@ public class BufferedLogStreamReader implements LogStreamReader {
     return allocatedBuffer == null;
   }
 
+  @Override
   public void wrap(final LogStorage logStorage) {
     wrap(logStorage, FIRST_POSITION);
   }
 
+  @Override
   public void wrap(final LogStorage logStorage, final long position) {
     this.logStorage = logStorage;
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamBatchWriter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamBatchWriter.java
@@ -17,9 +17,6 @@ import org.agrona.DirectBuffer;
  * <p>Note that the log entry data is buffered until {@link #tryWrite()} is called.
  */
 public interface LogStreamBatchWriter extends LogStreamWriter {
-  /** Initialize the write for the given log stream. */
-  void wrap(LogStream log);
-
   /** Set the source event for all log entries. */
   LogStreamBatchWriter sourceRecordPosition(long position);
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamBatchWriterImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamBatchWriterImpl.java
@@ -61,14 +61,9 @@ public class LogStreamBatchWriterImpl implements LogStreamBatchWriter, LogEntryB
   private BufferWriter metadataWriter;
   private BufferWriter valueWriter;
 
-  public LogStreamBatchWriterImpl(final LogStream logStream) {
-    wrap(logStream);
-  }
-
-  @Override
-  public void wrap(final LogStream logStream) {
-    this.logWriteBuffer = logStream.getWriteBuffer();
-    this.logId = logStream.getPartitionId();
+  public LogStreamBatchWriterImpl(int partitionId, Dispatcher dispatcher) {
+    this.logWriteBuffer = dispatcher;
+    this.logId = partitionId;
 
     reset();
   }

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamReader.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamReader.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.logstreams.log;
 
+import io.zeebe.logstreams.spi.LogStorage;
 import io.zeebe.util.CloseableSilently;
 import java.util.Iterator;
 
@@ -32,17 +33,17 @@ public interface LogStreamReader extends Iterator<LoggedEvent>, CloseableSilentl
   /**
    * Initialize the reader and seek to the first event.
    *
-   * @param log the stream which provides the log
+   * @param log the log storage to read from
    */
-  void wrap(LogStream log);
+  void wrap(LogStorage log);
 
   /**
    * Initialize the reader and seek to the given log position.
    *
-   * @param log the stream which provides the log
+   * @param log the log storage to read from
    * @param position the position in the log to seek to
    */
-  void wrap(LogStream log, long position);
+  void wrap(LogStorage log, long position);
 
   /**
    * Seeks to the event after the given position. On negative position it seeks to the first event.

--- a/logstreams/src/test/java/io/zeebe/distributedlog/DistributedLogPartitionRule.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/DistributedLogPartitionRule.java
@@ -76,7 +76,7 @@ public class DistributedLogPartitionRule {
 
     logStream = logStreamInjector.getValue();
     assertThat(logStream).isNotNull();
-    reader = new BufferedLogStreamReader(logStream);
+    reader = new BufferedLogStreamReader(logStream.getLogStorage());
   }
 
   private void createDistributedLog() {

--- a/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/ReplicatingRestoreClient.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/ReplicatingRestoreClient.java
@@ -56,7 +56,7 @@ public class ReplicatingRestoreClient implements RestoreClient {
   public CompletableFuture<LogReplicationResponse> requestLogReplication(
       MemberId server, LogReplicationRequest request) {
     return CompletableFuture.completedFuture(
-        new DefaultLogReplicationRequestHandler(serverLogstream)
+        new DefaultLogReplicationRequestHandler(serverLogstream.getLogStorage())
             .onReplicationRequest(request, NOPLogger.NOP_LOGGER));
   }
 
@@ -65,7 +65,10 @@ public class ReplicatingRestoreClient implements RestoreClient {
       MemberId server, RestoreInfoRequest request) {
     if (autoResponse) {
       return CompletableFuture.completedFuture(
-          new DefaultRestoreInfoRequestHandler(serverLogstream, replicatorSnapshotController)
+          new DefaultRestoreInfoRequestHandler(
+                  serverLogstream.getPartitionId(),
+                  serverLogstream.getLogStorage(),
+                  replicatorSnapshotController)
               .onRestoreInfoRequest(request, NOPLogger.NOP_LOGGER));
     }
     return restoreInfoResponse;

--- a/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/RestoreControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/restore/impl/RestoreControllerTest.java
@@ -8,8 +8,8 @@
 package io.zeebe.distributedlog.restore.impl;
 
 import static io.zeebe.util.buffer.BufferUtil.wrapString;
-import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.atomix.utils.concurrent.ThreadContext;

--- a/logstreams/src/test/java/io/zeebe/distributedlog/restore/log/impl/DefaultLogReplicationRequestHandlerTest.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/restore/log/impl/DefaultLogReplicationRequestHandlerTest.java
@@ -60,7 +60,7 @@ public class DefaultLogReplicationRequestHandlerTest {
     final LogReplicationRequest request =
         new DefaultLogReplicationRequest(EVENTS.get(0).getPosition(), events.lastPosition);
     final DefaultLogReplicationRequestHandler handler =
-        new DefaultLogReplicationRequestHandler(LOG_STREAM_RULE.getLogStream());
+        new DefaultLogReplicationRequestHandler(LOG_STREAM_RULE.getLogStorage());
 
     // when
     final LogReplicationResponse response =
@@ -81,7 +81,7 @@ public class DefaultLogReplicationRequestHandlerTest {
         new DefaultLogReplicationRequest(-1, EVENTS.get(5).getPosition());
     final DefaultLogReplicationRequestHandler handler =
         new DefaultLogReplicationRequestHandler(
-            LOG_STREAM_RULE.getLogStream(), events.serialized.length + 1);
+            LOG_STREAM_RULE.getLogStorage(), events.serialized.length + 1);
 
     // when
     final LogReplicationResponse response =
@@ -101,7 +101,7 @@ public class DefaultLogReplicationRequestHandlerTest {
     final EventRange events = new EventRange(EVENTS.subList(0, requestedCount));
     final LogReplicationRequest request = new DefaultLogReplicationRequest(-1, events.lastPosition);
     final DefaultLogReplicationRequestHandler handler =
-        new DefaultLogReplicationRequestHandler(LOG_STREAM_RULE.getLogStream());
+        new DefaultLogReplicationRequestHandler(LOG_STREAM_RULE.getLogStorage());
 
     // when
     final LogReplicationResponse response =
@@ -123,7 +123,7 @@ public class DefaultLogReplicationRequestHandlerTest {
         new DefaultLogReplicationRequest(
             EVENTS.get(requestedCount - 1).getPosition(), events.lastPosition);
     final DefaultLogReplicationRequestHandler handler =
-        new DefaultLogReplicationRequestHandler(LOG_STREAM_RULE.getLogStream());
+        new DefaultLogReplicationRequestHandler(LOG_STREAM_RULE.getLogStorage());
 
     // when
     final LogReplicationResponse response =
@@ -147,7 +147,7 @@ public class DefaultLogReplicationRequestHandlerTest {
         new DefaultLogReplicationRequest(
             EVENTS.get(requestedCount).getPosition(), events.lastPosition, true);
     final DefaultLogReplicationRequestHandler handler =
-        new DefaultLogReplicationRequestHandler(LOG_STREAM_RULE.getLogStream());
+        new DefaultLogReplicationRequestHandler(LOG_STREAM_RULE.getLogStorage());
 
     // when
     final LogReplicationResponse response =
@@ -169,7 +169,7 @@ public class DefaultLogReplicationRequestHandlerTest {
     final LogReplicationRequest request =
         new DefaultLogReplicationRequest(events.lastPosition + 1, events.lastPosition + 2);
     final DefaultLogReplicationRequestHandler handler =
-        new DefaultLogReplicationRequestHandler(LOG_STREAM_RULE.getLogStream());
+        new DefaultLogReplicationRequestHandler(LOG_STREAM_RULE.getLogStorage());
 
     // when
     final LogReplicationResponse response =
@@ -187,7 +187,7 @@ public class DefaultLogReplicationRequestHandlerTest {
     final EventRange events = new EventRange(EVENTS);
     final LogReplicationRequest request = new DefaultLogReplicationRequest(-1, events.lastPosition);
     final DefaultLogReplicationRequestHandler handler =
-        new DefaultLogReplicationRequestHandler(LOG_STREAM_RULE.getLogStream());
+        new DefaultLogReplicationRequestHandler(LOG_STREAM_RULE.getLogStorage());
 
     // when
     final LogReplicationResponse response =

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamBatchWriterTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamBatchWriterTest.java
@@ -61,7 +61,8 @@ public class LogStreamBatchWriterTest {
 
   @Before
   public void setUp() {
-    writer = new LogStreamBatchWriterImpl(logStreamRule.getLogStream());
+    final LogStream logStream = logStreamRule.getLogStream();
+    writer = new LogStreamBatchWriterImpl(logStream.getPartitionId(), logStream.getWriteBuffer());
   }
 
   private List<LoggedEvent> getWrittenEvents(final long position) {

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamReaderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamReaderTest.java
@@ -151,7 +151,7 @@ public class LogStreamReaderTest {
     // given
     reader.close();
     final long position = writer.writeEvent(w -> w.key(eventKey).value(EVENT_VALUE));
-    reader.wrap(logStreamRule.getLogStream());
+    reader.wrap(logStreamRule.getLogStorage());
 
     // then
     final LoggedEvent loggedEvent = readerRule.nextEvent();
@@ -166,7 +166,7 @@ public class LogStreamReaderTest {
     final long secondPos = writer.writeEvent(w -> w.key(eventKey).value(EVENT_VALUE));
 
     // when
-    reader.wrap(logStreamRule.getLogStream(), secondPos);
+    reader.wrap(logStreamRule.getLogStorage(), secondPos);
 
     // then
     final LoggedEvent loggedEvent = reader.next();

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamReaderRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamReaderRule.java
@@ -34,7 +34,7 @@ public class LogStreamReaderRule extends ExternalResource {
   @Override
   protected void before() {
     final LogStream logStream = logStreamRule.getLogStream();
-    logStreamReader.wrap(logStream);
+    logStreamReader.wrap(logStream.getLogStorage());
   }
 
   @Override

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamRule.java
@@ -21,6 +21,7 @@ import io.zeebe.logstreams.impl.LogStreamBuilder;
 import io.zeebe.logstreams.log.BufferedLogStreamReader;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
+import io.zeebe.logstreams.spi.LogStorage;
 import io.zeebe.servicecontainer.ServiceContainer;
 import io.zeebe.servicecontainer.impl.ServiceContainerImpl;
 import io.zeebe.util.sched.ActorScheduler;
@@ -186,7 +187,7 @@ public final class LogStreamRule extends ExternalResource {
     if (logStreamReader == null) {
       logStreamReader = new BufferedLogStreamReader();
     }
-    logStreamReader.wrap(logStream);
+    logStreamReader.wrap(getLogStorage());
     return logStreamReader;
   }
 
@@ -194,15 +195,11 @@ public final class LogStreamRule extends ExternalResource {
     return logStream;
   }
 
+  public LogStorage getLogStorage() {
+    return logStream.getLogStorage();
+  }
+
   public ControlledActorClock getClock() {
     return clock;
-  }
-
-  public ActorScheduler getActorScheduler() {
-    return actorScheduler;
-  }
-
-  public ServiceContainer getServiceContainer() {
-    return serviceContainer;
   }
 }

--- a/service-container/src/main/java/io/zeebe/servicecontainer/impl/ServiceContainerImpl.java
+++ b/service-container/src/main/java/io/zeebe/servicecontainer/impl/ServiceContainerImpl.java
@@ -20,6 +20,7 @@ import io.zeebe.util.sched.future.ActorFuture;
 import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -116,26 +117,38 @@ public class ServiceContainerImpl extends Actor implements ServiceContainer {
     try {
       containerCloseFuture.get(awaitTime, timeUnit);
     } catch (Exception ex) {
-      LOG.debug("Service container closing failed. Print dependencies.");
-
-      final StringBuilder builder = new StringBuilder();
-      dependencyResolver
-          .getControllers()
-          .forEach(
-              (c) -> {
-                builder.append("\n").append(c).append("\n\t\\");
-                c.getDependencies()
-                    .forEach(
-                        (d) -> {
-                          builder.append("\n \t-- ").append(dependencyResolver.getService(d));
-                        });
-              });
-
-      LOG.debug(builder.toString());
+      LOG.debug("Service container closing failed.");
+      printDependencies();
       throw ex;
     } finally {
       onClosed();
     }
+  }
+
+  private void printDependencies() {
+    final StringBuilder dotBuilder = new StringBuilder();
+    dotBuilder.append("digraph dependencyGraph").append("\n{");
+    dependencyResolver
+        .getControllers()
+        .forEach(
+            (c) -> {
+              final Set<ServiceName<?>> dependencies = c.getDependencies();
+              final String serviceName = c.getServiceName().getName().replace(".", "_").replace("-", "_");
+              if (!dependencies.isEmpty())
+              {
+                dependencies
+                  .forEach(
+                    (d) -> {
+                      final String name = d.getName().replace(".", "_").replace("-", "_");
+                      dotBuilder.append("\n").append(serviceName).append(" -> ").append(name).append(";");
+                    });
+              }
+              else {
+                dotBuilder.append("\n").append(serviceName).append(";");
+              }
+            });
+    dotBuilder.append("\n}");
+    LOG.debug("Dependency graph will be printed. To show the resulting graph copy it to a file and run 'dot -Tpng output.dot > output.png'\n{}", dotBuilder.toString());
   }
 
   @Override

--- a/service-container/src/main/java/io/zeebe/servicecontainer/impl/ServiceContainerImpl.java
+++ b/service-container/src/main/java/io/zeebe/servicecontainer/impl/ServiceContainerImpl.java
@@ -133,22 +133,27 @@ public class ServiceContainerImpl extends Actor implements ServiceContainer {
         .forEach(
             (c) -> {
               final Set<ServiceName<?>> dependencies = c.getDependencies();
-              final String serviceName = c.getServiceName().getName().replace(".", "_").replace("-", "_");
-              if (!dependencies.isEmpty())
-              {
-                dependencies
-                  .forEach(
+              final String serviceName =
+                  c.getServiceName().getName().replace(".", "_").replace("-", "_");
+              if (!dependencies.isEmpty()) {
+                dependencies.forEach(
                     (d) -> {
                       final String name = d.getName().replace(".", "_").replace("-", "_");
-                      dotBuilder.append("\n").append(serviceName).append(" -> ").append(name).append(";");
+                      dotBuilder
+                          .append("\n")
+                          .append(serviceName)
+                          .append(" -> ")
+                          .append(name)
+                          .append(";");
                     });
-              }
-              else {
+              } else {
                 dotBuilder.append("\n").append(serviceName).append(";");
               }
             });
     dotBuilder.append("\n}");
-    LOG.debug("Dependency graph will be printed. To show the resulting graph copy it to a file and run 'dot -Tpng output.dot > output.png'\n{}", dotBuilder.toString());
+    LOG.debug(
+        "Dependency graph will be printed. To show the resulting graph copy it to a file and run 'dot -Tpng output.dot > output.png'\n{}",
+        dotBuilder.toString());
   }
 
   @Override


### PR DESCRIPTION
## Description

* processor and exporter used the logstorage and writer from the logstream, but didn't depend on them
 * to avoid this usage of the log stream the reader and writer need to be created directly with the buffer and log storage to enforce the thinking about the current usage


This is the new dependency graph

![fixed](https://user-images.githubusercontent.com/2758593/68765459-1ab35500-061d-11ea-9041-7e2ba70bc9ff.png)

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3339 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
