### PR TITLE
Not refetch credentials if cache is present on second request

### DIFF
--- a/clients/go/zbc/oauthCredentialsProvider.go
+++ b/clients/go/zbc/oauthCredentialsProvider.go
@@ -133,10 +133,10 @@ func (provider *OAuthCredentialsProvider) getCredentials() *OAuthCredentials {
 		if credentials != nil {
 			provider.credentials = credentials
 			return credentials
+		} else {
+			provider.updateCredentials()
 		}
 	}
-
-	provider.updateCredentials()
 	return provider.credentials
 }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

If the credentials are cached and we send a second request we will not refresh the token.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3372 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
