### PR TITLE
docs(bpmn-workflows): allow multiple start events

### DIFF
--- a/docs/src/bpmn-workflows/message-events/message-events.md
+++ b/docs/src/bpmn-workflows/message-events/message-events.md
@@ -8,7 +8,7 @@ At the moment, messages can be published only externally by using one of the Zee
 
 ## Message Start Events
 
-A workflow can have one or more message start events. Each of the message events must have a unique message name. If the workflow has at least one message start event then it must not have a none start event. Other types of start events are allowed.
+A workflow can have one or more message start events (besides other types of start events). Each of the message events must have a unique message name.
 
 When a workflow is deployed then it creates a message subscription for each message start event. Message subscriptions of the previous version of the workflow (based on the BPMN process id) are closed.
 

--- a/docs/src/bpmn-workflows/none-events/none-events.md
+++ b/docs/src/bpmn-workflows/none-events/none-events.md
@@ -6,6 +6,8 @@ None events are unspecified events, also called ‘blank’ events.
 
 ## None Start Events
 
+A workflow can have at most one none start event (besides other types of start events).
+
 A none start event is where the workflow instance or a subprocess starts when the workflow or the subprocess is activated.
 
 ## None End Events

--- a/docs/src/bpmn-workflows/timer-events/timer-events.md
+++ b/docs/src/bpmn-workflows/timer-events/timer-events.md
@@ -6,7 +6,7 @@ Timer events are events which are triggered by a defined timer.
 
 ## Timer Start Events
 
-A workflow can have one or more timer start events. Each of the timer events must have either a **time date or time cycle** definition. If the workflow has at least one timer start event then it must not have a none start event. Other types of start events are allowed.
+A workflow can have one or more timer start events (besides other types of start events). Each of the timer events must have either a **time date or time cycle** definition. 
 
 When a workflow is deployed then it schedules a timer for each timer start event. Scheduled timers of the previous version of the workflow (based on the BPMN process id) are canceled.
 


### PR DESCRIPTION
## Description

* update documentation that multiple start events are allowed

## Related issues

implemented by #3317 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
