### PR TITLE
fix(logstreams): retry append on failure

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -175,15 +176,17 @@ public class TestStreams {
                       && arguments.length > 1
                       && arguments[0] != null
                       && arguments[1] != null) {
-                    final byte[] bytes = (byte[]) arguments[0];
-                    final long pos = (long) arguments[1];
+                    final long appendIndex = (long) arguments[0];
+                    final byte[] bytes = (byte[]) arguments[1];
+                    final long pos = (long) arguments[2];
                     return CompletableFuture.completedFuture(
-                        distributedLogImpl.append(nodeId, pos, bytes));
+                        distributedLogImpl.append(nodeId, appendIndex, pos, bytes));
                   }
                   return null;
                 })
         .when(mockDistLog)
-        .asyncAppend(any(byte[].class), anyLong());
+        .asyncAppend(anyLong(), any(byte[].class), anyLong());
+    doReturn(CompletableFuture.completedFuture(0L)).when(mockDistLog).getLastAppendIndex();
 
     serviceContainer
         .createService(distributedLogPartitionServiceName(name), () -> mockDistLog)

--- a/logstreams/src/main/java/io/zeebe/distributedlog/AsyncDistributedLogstream.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/AsyncDistributedLogstream.java
@@ -13,9 +13,11 @@ import java.util.concurrent.CompletableFuture;
 public interface AsyncDistributedLogstream extends AsyncPrimitive {
 
   CompletableFuture<Long> append(
-      String partition, String nodeId, long commitPosition, byte[] blockBuffer);
+      String partition, String nodeId, long appendIndex, long commitPosition, byte[] blockBuffer);
 
   CompletableFuture<Boolean> claimLeaderShip(String partition, String nodeId, long leaderTerm);
+
+  CompletableFuture<Long> lastAppendIndex(String partition);
 
   @Override
   DistributedLogstream sync();

--- a/logstreams/src/main/java/io/zeebe/distributedlog/DistributedLogstream.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/DistributedLogstream.java
@@ -13,7 +13,11 @@ import java.util.concurrent.TimeoutException;
 
 public interface DistributedLogstream extends SyncPrimitive {
 
-  long append(String partition, String nodeId, long commitPosition, byte[] blockBuffer)
+  long append(
+      String partition, String nodeId, long appendIndex, long commitPosition, byte[] blockBuffer)
+      throws InterruptedException, ExecutionException, TimeoutException;
+
+  long lastAppendIndex(String partition)
       throws InterruptedException, ExecutionException, TimeoutException;
 
   @Override

--- a/logstreams/src/main/java/io/zeebe/distributedlog/DistributedLogstreamService.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/DistributedLogstreamService.java
@@ -8,12 +8,17 @@
 package io.zeebe.distributedlog;
 
 import io.atomix.primitive.operation.Command;
+import io.atomix.primitive.operation.Query;
 
 public interface DistributedLogstreamService {
 
   /* Returns a positive value if the append was successful */
   @Command
-  long append(String nodeId, long commitPosition, byte[] blockBuffer);
+  long append(String nodeId, long appendIndex, long commitPosition, byte[] blockBuffer);
+
+  /* Returns the last successful appended index by the primitive. */
+  @Query
+  long lastAppendIndex();
 
   /* Return true if operation was successful */
   @Command

--- a/logstreams/src/main/java/io/zeebe/distributedlog/impl/BlockingDistributedLogstream.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/impl/BlockingDistributedLogstream.java
@@ -28,11 +28,18 @@ public class BlockingDistributedLogstream extends Synchronous<AsyncDistributedLo
   }
 
   @Override
-  public long append(String partition, String nodeId, long commitPosition, byte[] blockBuffer)
+  public long append(
+      String partition, String nodeId, long appendIndex, long commitPosition, byte[] blockBuffer)
       throws InterruptedException, ExecutionException, TimeoutException {
     return distributedLogstreamProxy
-        .append(partition, nodeId, commitPosition, blockBuffer)
+        .append(partition, nodeId, appendIndex, commitPosition, blockBuffer)
         .get(timeout, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public long lastAppendIndex(String partition)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return distributedLogstreamProxy.lastAppendIndex(partition).get(timeout, TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/logstreams/src/main/java/io/zeebe/distributedlog/impl/DistributedLogstreamPartition.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/impl/DistributedLogstreamPartition.java
@@ -19,8 +19,6 @@ import io.zeebe.servicecontainer.ServiceStopContext;
 import io.zeebe.util.ZbLogger;
 import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 
 public class DistributedLogstreamPartition implements Service<DistributedLogstreamPartition> {
@@ -46,13 +44,15 @@ public class DistributedLogstreamPartition implements Service<DistributedLogstre
     partitionName = DistributedLogstreamName.getPartitionKey(partitionId);
   }
 
-  public long append(byte[] blockBuffer, long commitPosition)
-      throws InterruptedException, ExecutionException, TimeoutException {
-    return distributedLog.append(partitionName, memberId, commitPosition, blockBuffer);
+  public CompletableFuture<Long> asyncAppend(
+      long appendIndex, byte[] blockBuffer, long commitPosition) {
+    return distributedLog
+        .async()
+        .append(partitionName, memberId, appendIndex, commitPosition, blockBuffer);
   }
 
-  public CompletableFuture<Long> asyncAppend(byte[] blockBuffer, long commitPosition) {
-    return distributedLog.async().append(partitionName, memberId, commitPosition, blockBuffer);
+  public CompletableFuture<Long> getLastAppendIndex() {
+    return distributedLog.async().lastAppendIndex(partitionName);
   }
 
   public CompletableFuture<Boolean> claimLeaderShip() {

--- a/logstreams/src/main/java/io/zeebe/distributedlog/impl/DistributedLogstreamProxy.java
+++ b/logstreams/src/main/java/io/zeebe/distributedlog/impl/DistributedLogstreamProxy.java
@@ -35,9 +35,14 @@ public class DistributedLogstreamProxy
 
   @Override
   public CompletableFuture<Long> append(
-      String partition, String nodeId, long commitPosition, byte[] buffer) {
+      String partition, String nodeId, long appendIndex, long commitPosition, byte[] buffer) {
     return getProxyClient()
-        .applyBy(partition, service -> service.append(nodeId, commitPosition, buffer));
+        .applyBy(partition, service -> service.append(nodeId, appendIndex, commitPosition, buffer));
+  }
+
+  @Override
+  public CompletableFuture<Long> lastAppendIndex(String partition) {
+    return getProxyClient().applyBy(partition, DistributedLogstreamService::lastAppendIndex);
   }
 
   @Override

--- a/logstreams/src/test/java/io/zeebe/distributedlog/DistributedLogRule.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/DistributedLogRule.java
@@ -19,6 +19,7 @@ import io.atomix.protocols.raft.partition.RaftPartitionGroup;
 import io.atomix.utils.net.Address;
 import io.zeebe.distributedlog.impl.DistributedLogstreamConfig;
 import io.zeebe.distributedlog.impl.DistributedLogstreamName;
+import io.zeebe.distributedlog.impl.DistributedLogstreamPartition;
 import io.zeebe.distributedlog.impl.LogstreamConfig;
 import io.zeebe.servicecontainer.ServiceContainer;
 import io.zeebe.servicecontainer.ServiceName;
@@ -208,6 +209,10 @@ public class DistributedLogRule extends ExternalResource {
     partitions.get(partitionId).becomeLeader();
   }
 
+  public DistributedLogstreamPartition getSpy(int partition) {
+    return partitions.get(partition).getCurrentLogSpy();
+  }
+
   public void becomeFollower(final int partitionId) {
     partitions.get(partitionId).becomeFollower();
   }
@@ -230,5 +235,9 @@ public class DistributedLogRule extends ExternalResource {
 
   public int getCommittedEventsCount(final int partitionId) {
     return partitions.get(partitionId).getCommittedEventsCount();
+  }
+
+  public boolean eventsInOrderAppended(int partitionId, Event[] events) {
+    return partitions.get(partitionId).eventsInOrder(events);
   }
 }

--- a/logstreams/src/test/java/io/zeebe/distributedlog/Event.java
+++ b/logstreams/src/test/java/io/zeebe/distributedlog/Event.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.distributedlog;
+
+class Event {
+  String message;
+  long position;
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/LogStorageAppenderTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams;
+
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.zeebe.dispatcher.Dispatcher;
+import io.zeebe.dispatcher.Dispatchers;
+import io.zeebe.dispatcher.Subscription;
+import io.zeebe.distributedlog.impl.DistributedLogstreamPartition;
+import io.zeebe.logstreams.impl.LogStorageAppender;
+import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.logstreams.log.LogStreamWriterImpl;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.test.util.TestUtil;
+import io.zeebe.util.ByteValue;
+import io.zeebe.util.exception.UncheckedExecutionException;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+import org.agrona.DirectBuffer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+public class LogStorageAppenderTest {
+  private static ByteValue maxFragmentSize = ByteValue.ofMegabytes(4);
+
+  @Rule public ActorSchedulerRule schedulerRule = new ActorSchedulerRule();
+
+  private DistributedLogstreamPartition primitiveMock;
+  private LogStorageAppender appender;
+  private LogStreamWriterImpl writer;
+
+  @Before
+  public void setup() {
+    primitiveMock = mock(DistributedLogstreamPartition.class);
+
+    when(primitiveMock.getLastAppendIndex()).thenReturn(CompletableFuture.completedFuture(0L));
+    when(primitiveMock.asyncAppend(anyLong(), any(byte[].class), anyLong()))
+        .thenReturn(CompletableFuture.completedFuture(1L));
+
+    final Dispatcher dispatcher =
+        Dispatchers.create("dispatcher")
+            .maxFragmentLength(maxFragmentSize)
+            .initialPartitionId(1)
+            .actorScheduler(schedulerRule.get())
+            .build();
+    final Subscription subscription = dispatcher.openSubscription("subscription");
+    appender =
+        new LogStorageAppender(
+            "appender", primitiveMock, subscription, (int) maxFragmentSize.toBytes());
+
+    final LogStream logStream = mock(LogStream.class);
+    when(logStream.getPartitionId()).thenReturn(1);
+    when(logStream.getWriteBuffer()).thenReturn(dispatcher);
+    writer = new LogStreamWriterImpl(logStream);
+  }
+
+  public long writeEvent(final String message) {
+    final AtomicLong writePosition = new AtomicLong();
+    final RecordMetadata metadata = new RecordMetadata();
+    final DirectBuffer value = wrapString(message);
+
+    TestUtil.doRepeatedly(
+            () -> writer.key(-1).metadataWriter(metadata.reset()).value(value).tryWrite())
+        .until(
+            position -> {
+              if (position != null && position >= 0) {
+                writePosition.set(position);
+                return true;
+              } else {
+                return false;
+              }
+            },
+            "Failed to write event with message {}",
+            message);
+    return writePosition.get();
+  }
+
+  @Test
+  public void shouldAppend() {
+    // given
+    schedulerRule.submitActor(appender).join();
+
+    // when
+    writeEvent("msg");
+
+    // then
+    verify(primitiveMock, timeout(1000)).asyncAppend(eq(1L), any(byte[].class), anyLong());
+  }
+
+  @Test
+  public void shouldAppendMultipleIncrementIndex() {
+    // given
+    schedulerRule.submitActor(appender).join();
+    writeEvent("msg");
+
+    // when
+    writeEvent("msg");
+
+    // then
+    final InOrder inOrder = Mockito.inOrder(primitiveMock);
+    inOrder.verify(primitiveMock, timeout(1000)).asyncAppend(eq(1L), any(byte[].class), anyLong());
+    inOrder.verify(primitiveMock, timeout(1000)).asyncAppend(eq(2L), any(byte[].class), anyLong());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldStartWithIndex() {
+    // given
+    when(primitiveMock.getLastAppendIndex()).thenReturn(CompletableFuture.completedFuture(12L));
+    schedulerRule.submitActor(appender).join();
+
+    // when
+    writeEvent("msg");
+
+    // then
+    verify(primitiveMock, timeout(1000)).asyncAppend(eq(13L), any(byte[].class), anyLong());
+  }
+
+  @Test
+  public void shouldFailToStartOnRequestLastIndexError() {
+    // given
+    when(primitiveMock.getLastAppendIndex())
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("failed")));
+
+    // when - expect exception
+    assertThatThrownBy(() -> schedulerRule.submitActor(appender).join())
+        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(UncheckedExecutionException.class);
+  }
+
+  @Test
+  public void shouldRetryOnError() {
+    // given
+    when(primitiveMock.asyncAppend(anyLong(), any(byte[].class), anyLong()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Failed to append!")))
+        .thenReturn(CompletableFuture.completedFuture(1L));
+    schedulerRule.submitActor(appender).join();
+
+    // when
+    writeEvent("msg");
+
+    // then
+    verify(primitiveMock, timeout(1000).times(2)).asyncAppend(eq(1L), any(byte[].class), anyLong());
+  }
+
+  @Test
+  public void shouldRetryOnFailedAppend() {
+    // given
+    when(primitiveMock.asyncAppend(anyLong(), any(byte[].class), anyLong()))
+        .thenReturn(CompletableFuture.completedFuture(-1L))
+        .thenReturn(CompletableFuture.completedFuture(1L));
+    schedulerRule.submitActor(appender).join();
+
+    // when
+    writeEvent("msg");
+
+    // then
+    verify(primitiveMock, timeout(1000).times(2)).asyncAppend(eq(1L), any(byte[].class), anyLong());
+  }
+
+  @Test
+  public void shouldRetryOnBothErrorTypes() {
+    // given
+    when(primitiveMock.asyncAppend(anyLong(), any(byte[].class), anyLong()))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Failed to append!")))
+        .thenReturn(CompletableFuture.completedFuture(-1L))
+        .thenReturn(CompletableFuture.completedFuture(1L));
+
+    schedulerRule.submitActor(appender).join();
+
+    // when
+    writeEvent("msg");
+
+    // then
+    verify(primitiveMock, timeout(1000).times(3)).asyncAppend(eq(1L), any(byte[].class), anyLong());
+  }
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamRule.java
@@ -11,6 +11,7 @@ import static io.zeebe.logstreams.impl.service.LogStreamServiceNames.distributed
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import io.zeebe.distributedlog.DistributedLogstreamService;
@@ -157,15 +158,18 @@ public final class LogStreamRule extends ExternalResource {
                       && arguments.length > 1
                       && arguments[0] != null
                       && arguments[1] != null) {
-                    final byte[] bytes = (byte[]) arguments[0];
-                    final long pos = (long) arguments[1];
+                    final long appendIndex = (long) arguments[0];
+                    final byte[] bytes = (byte[]) arguments[1];
+                    final long pos = (long) arguments[2];
                     return CompletableFuture.completedFuture(
-                        distributedLogImpl.append(nodeId, pos, bytes));
+                        distributedLogImpl.append(nodeId, appendIndex, pos, bytes));
                   }
                   return null;
                 })
         .when(mockDistLog)
-        .asyncAppend(any(), anyLong());
+        .asyncAppend(anyLong(), any(), anyLong());
+
+    doReturn(CompletableFuture.completedFuture(0L)).when(mockDistLog).getLastAppendIndex();
 
     serviceContainer
         .createService(distributedLogPartitionServiceName(builder.getLogName()), () -> mockDistLog)

--- a/logstreams/src/test/resources/log4j2-test.xml
+++ b/logstreams/src/test/resources/log4j2-test.xml
@@ -9,6 +9,7 @@
 
   <Loggers>
     <Logger name="io.zeebe" level="debug"/>
+    <Logger name="io.zeebe.logstreams" level="trace"/>
     <Logger name="io.atomix" level="info"/>
 
     <Root level="info">

--- a/util/src/main/java/io/zeebe/util/exception/UncheckedExecutionException.java
+++ b/util/src/main/java/io/zeebe/util/exception/UncheckedExecutionException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util.exception;
+
+/**
+ * Should be use to indicate an unexpected exception during execution. This exception extends {@link
+ * RuntimeException} to be unchecked.
+ */
+public class UncheckedExecutionException extends RuntimeException {
+
+  public UncheckedExecutionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
 The log storage appender will retry on failure. Failure means either
 an exception happened or a negative result was returned.

 The log storage appender will send an index with the append request such
 that the primitive is able to determine whether the requests are in
 order or not. The log appender will query the last index on restart.
 If the primitive detects an inconsistency it will return an negative
 result, such that the log appender retries and eventually the events
 are in order.

This problem was observed due to session timeouts on the primitive client.
This fix https://github.com/zeebe-io/atomix/pull/70 makes it less likely to fail, but it is still possible that is the reason we need to handle this case. 

In the following screenshot we see this fix in a benchmark.

![only-append-fix](https://user-images.githubusercontent.com/2758593/69058022-28991980-0a13-11ea-9800-f55a3203b312.png)

The the second screenshot both fixes are in use. The processing looks much more stable with these fixes.

![both-fixes](https://user-images.githubusercontent.com/2758593/69058021-28008300-0a13-11ea-8ec3-62b8b2cb58a2.png)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3370 


## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
