### PR TITLE
chore(logstreams): do not append more events until retries are success

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/LogStorageAppender.java
@@ -138,7 +138,7 @@ public class LogStorageAppender extends Actor {
               actor.run(
                   () -> {
                     if (error != null) {
-                      LOG.debug(
+                      LOG.trace(
                           "Append on partition {} failed with exception. Append index {} and event position {}. Retry...",
                           partitionId,
                           appendIndex,
@@ -148,7 +148,7 @@ public class LogStorageAppender extends Actor {
                       this.peekedBlockHandler = () -> {};
                       appendToPrimitive(appendIndex, bytesToAppend, lastEventPosition);
                     } else if (appendPosition < 0) {
-                      LOG.debug(
+                      LOG.trace(
                           "Append on partition {} failed with negative result {}. Append index {} and event position {}. This normally occurs when an previous append failed and events have been received out of order. This is the recovery strategy to get events in order again. Retry...",
                           partitionId,
                           appendPosition,


### PR DESCRIPTION
## Description

- When one append failed, stop appending more events until the appends are successful. This helps to prevent repeated retry of events.

## Related issues

closes #3398 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
