### PR TITLE
chore(ci): Fix cron trigger for chaos tests pipeline

### DIFF
--- a/.ci/jobs/chaos_test_zeebe.dsl
+++ b/.ci/jobs/chaos_test_zeebe.dsl
@@ -8,4 +8,15 @@ pipelineJob('chaos-test') {
             sandbox()
         }
     }
+
+    triggers {
+        cron('H 1 * * *')
+    }
+
+    logRotator {
+        numToKeep(10)
+        daysToKeep(-1)
+        artifactDaysToKeep(-1)
+        artifactNumToKeep(10)
+    }
 }

--- a/.ci/pipelines/chaos_test_zeebe.groovy
+++ b/.ci/pipelines/chaos_test_zeebe.groovy
@@ -3,17 +3,7 @@ final CHAOS_TEST_NAMESPACE = "zeebe-chaos-test"
 final NOTIFY_EMAIL = "christopher.zell@camunda.com"
 
 pipeline {
-    triggers {
-        cron('H 1 * * *')
-    }
-
     options {
-        buildDiscarder(
-                logRotator(
-                        numToKeepStr: '10',
-                        daysToKeepStr: '-1',
-                        artifactDaysToKeepStr: '-1',
-                        artifactNumToKeepStr: '10'))
         timeout(time: 1, unit: 'HOURS')
         skipDefaultCheckout()
         timestamps()


### PR DESCRIPTION
Related: SRE-688

## Description

Fix the CI chaos test job to include its settings one level above, in `pipelineJob`.
This way cron trigger is initialized after the seed job is run, otherwise the job at first does not have any trigger, and the trigger is set after the first successful job run only (which wouldn't happen automatically).

## Related issues

Chaos tests are not run daily in the CI: https://ci.zeebe.camunda.cloud/job/chaos-test/

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing