### PR TITLE
chore(pom): update surefire and failsaife to M4

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,7 +88,7 @@
     <plugin.version.checkstyle>3.1.0</plugin.version.checkstyle>
     <plugin.version.compiler>3.8.1</plugin.version.compiler>
     <plugin.version.exec>1.6.0</plugin.version.exec>
-    <plugin.version.failsafe>3.0.0-M3</plugin.version.failsafe>
+    <plugin.version.failsafe>3.0.0-M4</plugin.version.failsafe>
     <plugin.version.fmt>2.9</plugin.version.fmt>
     <plugin.version.license>3.0</plugin.version.license>
     <plugin.version.protobuf-maven-plugin>0.6.1</plugin.version.protobuf-maven-plugin>
@@ -98,7 +98,7 @@
     <plugin.version.resources>3.1.0</plugin.version.resources>
     <plugin.version.scala>4.3.0</plugin.version.scala>
     <plugin.version.shade>3.2.1</plugin.version.shade>
-    <plugin.version.surefire>3.0.0-M3</plugin.version.surefire>
+    <plugin.version.surefire>3.0.0-M4</plugin.version.surefire>
     <plugin.version.versions>2.7</plugin.version.versions>
     <plugin.version.enforcer>3.0.0-M2</plugin.version.enforcer>
     <plugin.version.dependency>3.1.1</plugin.version.dependency>


### PR DESCRIPTION
## Description
In order to update failsafe or surefire we need to update both simultaneously, otherwise we get class not found exceptions. See related failing PR's https://github.com/zeebe-io/zeebe/pull/3386 https://github.com/zeebe-io/zeebe/pull/3387

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3386
closes #3387

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
