### PR TITLE
fix(broker): don't correlate a message after its TTL is reached

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageCorrelator.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageCorrelator.java
@@ -54,11 +54,13 @@ public class MessageCorrelator {
   private boolean correlateMessage(final Message message) {
     // correlate the first message which is not correlated to the workflow instance yet
     messageKey = message.getKey();
-    final boolean isCorrelatedBefore =
-        messageState.existMessageCorrelation(
-            messageKey, subscriptionRecord.getBpmnProcessIdBuffer());
 
-    if (!isCorrelatedBefore) {
+    final boolean correlateMessage =
+        message.getDeadline() > ActorClock.currentTimeMillis()
+            && !messageState.existMessageCorrelation(
+                messageKey, subscriptionRecord.getBpmnProcessIdBuffer());
+
+    if (correlateMessage) {
       subscriptionState.updateToCorrelatingState(
           subscription, message.getVariables(), ActorClock.currentTimeMillis(), messageKey);
 
@@ -69,7 +71,7 @@ public class MessageCorrelator {
       messageState.putMessageCorrelation(messageKey, subscriptionRecord.getBpmnProcessIdBuffer());
     }
 
-    return isCorrelatedBefore;
+    return !correlateMessage;
   }
 
   private boolean sendCorrelateCommand() {

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStreamProcessorTest.java
@@ -28,6 +28,7 @@ import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.MessageIntent;
 import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
 import org.agrona.DirectBuffer;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
@@ -453,7 +454,7 @@ public class MessageStreamProcessorTest {
     message
         .setName(wrapString("order canceled"))
         .setCorrelationKey(wrapString("order-123"))
-        .setTimeToLive(1L)
+        .setTimeToLive(Duration.ofSeconds(10).toMillis())
         .setVariables(asMsgPack("orderId", "order-123"));
 
     return message;


### PR DESCRIPTION
## Description

* check the TTL of a buffered message before correlating it to an intermediate catch event or receive task

## Related issues

closes #3396 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
