### PR TITLE
docs(timer): fix infinite timer example

### DIFF
--- a/docs/src/bpmn-workflows/timer-events/timer-events.md
+++ b/docs/src/bpmn-workflows/timer-events/timer-events.md
@@ -51,7 +51,7 @@ If the duration is zero or negative then the timer will fire immediately.
 A cycle defined as ISO 8601 repeating intervals format. It contains the duration and the number of repetitions. If the repetitions are not defined then the timer will be repeated infinitely until it is canceled.
 
 * `R5/PT10S` - every 10 seconds, up to 5 times
-* `R/PT1D` - every day, infinitely
+* `R/P1D` - every day, infinitely
 
 ## Additional Resources
 


### PR DESCRIPTION
## Description
 * syntax is PnYnMnDTnHnMnS the T was on the wrong place
 https://en.wikipedia.org/wiki/ISO_8601#Dates

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->
none, but related slack question https://zeebe-io.slack.com/archives/C6WGNHV2A/p1574875544358200

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
