### PR TITLE
chore(dist): update golang version

### DIFF
--- a/.ci/pipelines/release_zeebe.groovy
+++ b/.ci/pipelines/release_zeebe.groovy
@@ -41,7 +41,7 @@ spec:
           cpu: 2
           memory: 1Gi
     - name: golang
-      image: golang:1.12.2
+      image: golang:1.13.4
       command: ["cat"]
       tty: true
       resources:

--- a/.ci/podSpecs/distribution.yml
+++ b/.ci/podSpecs/distribution.yml
@@ -52,7 +52,7 @@ spec:
           cpu: 2
           memory: 4Gi
     - name: golang
-      image: golang:1.12.2
+      image: golang:1.13.4
       command: ["cat"]
       tty: true
       resources:


### PR DESCRIPTION
## Description

The previous version was 1.12.x which had the behavior that if the project was inside the gopath it would not use go modules. Since 1.13, the go commands will use go modules if there is a go.mod file in the current or parent directories. The fix is just updating the Go version.

## Related issues

closes #3458 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
