### PR TITLE
Add zbctl integration tests

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -9,6 +9,11 @@ To regenerate the gateway mock `internal/mock_pb/mock_gateway.go` run [`mockgen`
 mockgen github.com/zeebe-io/zeebe/clients/go/pkg/pb GatewayClient,Gateway_ActivateJobsClient > internal/mock_pb/mock_gateway.go
 ```
 
+To run the integration tests, a Docker image for Zeebe must be built with the tag 'current-test'. To do that you can run:
+```
+docker build --build-arg DISTBALL=dist/target/zeebe-distribution*.tar.gz  -t camunda/zeebe:current-test .
+```
+
 ### Dependencies
 
 After making changes to the Go client, you can vendor the new dependencies with:

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -1,7 +1,9 @@
 # Zeebe Go Client
 
 
-### Testing
+## Testing
+
+### gRPC Mock
 
 To regenerate the gateway mock `internal/mock_pb/mock_gateway.go` run [`mockgen`](https://github.com/golang/mock#installation):
 
@@ -9,12 +11,23 @@ To regenerate the gateway mock `internal/mock_pb/mock_gateway.go` run [`mockgen`
 mockgen github.com/zeebe-io/zeebe/clients/go/pkg/pb GatewayClient,Gateway_ActivateJobsClient > internal/mock_pb/mock_gateway.go
 ```
 
+### Integration tests
+
 To run the integration tests, a Docker image for Zeebe must be built with the tag 'current-test'. To do that you can run:
+
 ```
 docker build --build-arg DISTBALL=dist/target/zeebe-distribution*.tar.gz  -t camunda/zeebe:current-test .
 ```
 
-### Dependencies
+To add new zbctl tests, you must generate a golden file with the expected output of the command you are testing. The tests ignore numbers so you can leave any keys or timestamps in your golden file, even though these will most likely be different from test command's output. However, non-numeric variables are not ignored. For instance, the help menu contains:
+
+``` 
+--clientCache string    Specify the path to use for the OAuth credentials cache. If omitted, will read from the environment variable 'ZEEBE_CLIENT_CONFIG_PATH' (default "YOUR_HOME/.camunda/credentials")
+```
+
+To make them host-independent, the tests replace the HOME environment variable with `/tmp` which means you must do the same in your golden file.
+
+## Dependencies
 
 After making changes to the Go client, you can vendor the new dependencies with:
 

--- a/clients/go/cmd/zbctl/build.sh
+++ b/clients/go/cmd/zbctl/build.sh
@@ -12,7 +12,9 @@ mkdir -p ${DIST_DIR}
 rm -rf ${DIST_DIR}/*
 
 for i in "${!OS[@]}"; do
-    CGO_ENABLED=0 GOOS="${OS[$i]}" GOARCH=amd64 go build -mod=vendor -a -tags netgo -ldflags "-w -X github.com/zeebe-io/zeebe/clients/go/cmd/zbctl/cmd.Version=${VERSION} -X github.com/zeebe-io/zeebe/clients/go/cmd/zbctl/cmd.Commit=${COMMIT}" -o "${DIST_DIR}/${BINARY[$i]}" "${SRC_DIR}/main.go" &
+	if [ $# -eq 0 ] || [ ${OS[$i]} = $1 ]; then
+	    CGO_ENABLED=0 GOOS="${OS[$i]}" GOARCH=amd64 go build -mod=vendor -a -tags netgo -ldflags "-w -X github.com/zeebe-io/zeebe/clients/go/cmd/zbctl/cmd.Version=${VERSION} -X github.com/zeebe-io/zeebe/clients/go/cmd/zbctl/cmd.Commit=${COMMIT}" -o "${DIST_DIR}/${BINARY[$i]}" "${SRC_DIR}/main.go" &
+	fi
 done
 
 wait

--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -1,0 +1,183 @@
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/suite"
+	"github.com/zeebe-io/zeebe/clients/go/internal/containerSuite"
+	"github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+var zbctl string
+
+type integrationTestSuite struct {
+	*containerSuite.ContainerSuite
+}
+
+var tests = []struct {
+	name       string
+	setupCmds  []string
+	envVars    []string
+	cmd        string
+	goldenFile string
+}{
+	{
+		name:       "print help",
+		cmd:        "help",
+		envVars:    []string{"HOME=/tmp"},
+		goldenFile: "testdata/help.golden",
+	},
+	{
+		name:       "missing insecure flag",
+		cmd:        "status",
+		envVars:    []string{"HOME=/tmp"},
+		goldenFile: "testdata/without_insecure.golden",
+	},
+	{
+		name: "using insecure env var",
+		cmd:  "status",
+		// we need to set the path so it evaluates $HOME before we overwrite it
+		envVars:    []string{fmt.Sprintf("%s=true", zbc.InsecureEnvVar), fmt.Sprintf("PATH=%s", os.Getenv("PATH"))},
+		goldenFile: "testdata/topology.golden",
+	},
+	{
+		name:       "deploy workflow",
+		cmd:        "--insecure deploy testdata/model.bpmn",
+		goldenFile: "testdata/deploy.golden",
+	},
+	{
+		name:       "create instance",
+		setupCmds:  []string{"--insecure deploy testdata/model.bpmn"},
+		cmd:        "--insecure create instance process",
+		goldenFile: "testdata/create_instance.golden",
+	},
+	{
+		name:       "create worker",
+		setupCmds:  []string{"--insecure deploy testdata/job_model.bpmn", "--insecure create instance jobProcess"},
+		cmd:        "create --insecure worker jobType --handler echo",
+		goldenFile: "testdata/create_worker.golden",
+	},
+	{
+		name:       "activate job",
+		setupCmds:  []string{"--insecure deploy testdata/job_model.bpmn", "--insecure create instance jobProcess"},
+		cmd:        "--insecure activate jobs jobType",
+		goldenFile: "testdata/activate_job.golden",
+	},
+}
+
+func TestZbctlWithInsecureGateway(t *testing.T) {
+	err := buildZbctl()
+	if err != nil {
+		t.Fatal(fmt.Errorf("couldn't build zbctl: %w", err))
+	}
+
+	suite.Run(t,
+		&integrationTestSuite{
+			ContainerSuite: &containerSuite.ContainerSuite{
+				WaitTime:       time.Second,
+				ContainerImage: "camunda/zeebe:current-test",
+			},
+		})
+}
+
+func (s *integrationTestSuite) TestCommonCommands() {
+	for _, test := range tests {
+		s.T().Run(test.name, func(t *testing.T) {
+			for _, cmd := range test.setupCmds {
+				if _, err := s.runCommand(cmd); err != nil {
+					t.Fatal(fmt.Errorf("failed while executing set up command '%s': %w", cmd, err))
+				}
+			}
+
+			cmdOut, _ := s.runCommand(test.cmd, test.envVars...)
+
+			goldenOut, err := ioutil.ReadFile(test.goldenFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := strings.Split(string(goldenOut), "\n")
+			got := strings.Split(string(cmdOut), "\n")
+
+			if diff := cmp.Diff(want, got, cmp.Comparer(compareStrIgnoreNumbers)); diff != "" {
+				t.Fatalf("%s: diff (-want +got):\n%s", test.name, diff)
+			}
+		})
+	}
+}
+
+func compareStrIgnoreNumbers(x, y string) bool {
+	reg, err := regexp.Compile(`\d`)
+	if err != nil {
+		panic(err)
+	}
+
+	newX := reg.ReplaceAllString(x, "")
+	newY := reg.ReplaceAllString(y, "")
+
+	return newX == newY
+}
+
+// runCommand runs the zbctl command and returns the combined output from stdout and stderr
+func (s *integrationTestSuite) runCommand(command string, envVars ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	args := append(strings.Fields(command), "--address", s.GatewayAddress)
+	cmd := exec.CommandContext(ctx, fmt.Sprintf("./dist/%s", zbctl), args...)
+
+	cmd.Env = append(cmd.Env, envVars...)
+	return cmd.CombinedOutput()
+}
+
+func buildZbctl() error {
+	if runtime.GOOS == "linux" {
+		zbctl = "zbctl"
+	} else {
+		return fmt.Errorf("Can't run zbctl tests on unsupported OS '%s'", runtime.GOOS)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	files, err := ioutil.ReadDir("dist")
+	if err != nil {
+		return err
+	}
+
+	var alreadyBuilt bool
+	for _, file := range files {
+		alreadyBuilt = strings.Contains(file.Name(), zbctl)
+		if alreadyBuilt {
+			break
+		}
+	}
+
+	if !alreadyBuilt {
+		return exec.CommandContext(ctx, "./build.sh", runtime.GOOS).Run()
+	}
+
+	return nil
+}

--- a/clients/go/cmd/zbctl/testdata/activate_job.golden
+++ b/clients/go/cmd/zbctl/testdata/activate_job.golden
@@ -1,0 +1,17 @@
+2019/11/21 17:01:53 Activated 1 for type jobType
+2019/11/21 17:01:53 Job 1 / 1
+{
+  "key": 2251799813685326,
+  "type": "jobType",
+  "workflowInstanceKey": 2251799813685321,
+  "bpmnProcessId": "jobProcess",
+  "workflowDefinitionVersion": 1,
+  "workflowKey": 2251799813685304,
+  "elementId": "ServiceTask_0drxnet",
+  "elementInstanceKey": 2251799813685325,
+  "customHeaders": "{}",
+  "worker": "zbctl",
+  "retries": 3,
+  "deadline": 1574352413604,
+  "variables": "{}"
+}

--- a/clients/go/cmd/zbctl/testdata/create_instance.golden
+++ b/clients/go/cmd/zbctl/testdata/create_instance.golden
@@ -1,0 +1,6 @@
+{
+  "workflowKey": 2251799813685251,
+  "bpmnProcessId": "process",
+  "version": 2,
+  "workflowInstanceKey": 2251799813685253
+}

--- a/clients/go/cmd/zbctl/testdata/create_worker.golden
+++ b/clients/go/cmd/zbctl/testdata/create_worker.golden
@@ -1,0 +1,2 @@
+2019/11/21 16:37:16 Activated job 2251799813685298 with variables {}
+2019/11/21 16:37:16 Handler completed job 2251799813685298 with variables {}

--- a/clients/go/cmd/zbctl/testdata/deploy.golden
+++ b/clients/go/cmd/zbctl/testdata/deploy.golden
@@ -1,0 +1,11 @@
+{
+  "key": 2251799813685250,
+  "workflows": [
+    {
+      "bpmnProcessId": "process",
+      "version": 1,
+      "workflowKey": 2251799813685249,
+      "resourceName": "testdata/model.bpmn"
+    }
+  ]
+}

--- a/clients/go/cmd/zbctl/testdata/help.golden
+++ b/clients/go/cmd/zbctl/testdata/help.golden
@@ -1,0 +1,39 @@
+zbctl is command line interface designed to create and read resources inside zeebe broker. 
+It is designed for regular maintenance jobs such as:
+	* deploying workflows,
+	* creating jobs and workflow instances
+	* activating, completing or failing jobs
+	* update variables and retries
+	* view cluster status
+
+Usage:
+  zbctl [command]
+
+Available Commands:
+  activate    Activate a resource
+  cancel      Cancel resource
+  complete    Complete a resource
+  create      Create resources
+  deploy      Creates new workflow defined by provided BPMN or YAML file as workflowPath
+  fail        Fail a resource
+  generate    Generate documentation
+  help        Help about any command
+  publish     Publish a message
+  resolve     Resolve a resource
+  set         Set a resource
+  status      Checks the current status of the cluster
+  update      Update a resource
+  version     Print the version of zbctl
+
+Flags:
+      --address string        Specify a contact point address. If omitted, will read from the environment variable 'ZEEBE_ADDRESS' (default '127.0.0.1:26500')
+      --audience string       Specify the resource that the access token should be valid for. If omitted, will read from the environment variable 'ZEEBE_TOKEN_AUDIENCE'
+      --authzUrl string       Specify an authorization server URL from which to request an access token. If omitted, will read from the environment variable 'ZEEBE_AUTHORIZATION_SERVER_URL' (default "https://login.cloud.camunda.io/oauth/token/")
+      --certPath string       Specify a path to a certificate with which to validate gateway requests. If omitted, will read from the environment variable 'ZEEBE_CA_CERTIFICATE_PATH'
+      --clientCache string    Specify the path to use for the OAuth credentials cache. If omitted, will read from the environment variable 'ZEEBE_CLIENT_CONFIG_PATH' (default "/tmp/.camunda/credentials")
+      --clientId string       Specify a client identifier to request an access token. If omitted, will read from the environment variable 'ZEEBE_CLIENT_ID'
+      --clientSecret string   Specify a client secret to request an access token. If omitted, will read from the environment variable 'ZEEBE_CLIENT_SECRET'
+  -h, --help                  help for zbctl
+      --insecure              Specify if zbctl should use an unsecured connection. If omitted, will read from the environment variable 'ZEEBE_INSECURE_CONNECTION'
+
+Use "zbctl [command] --help" for more information about a command.

--- a/clients/go/cmd/zbctl/testdata/job_model.bpmn
+++ b/clients/go/cmd/zbctl/testdata/job_model.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1x936g9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.7.0">
+  <bpmn:process id="jobProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1x86aoe</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="ServiceTask_0drxnet">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="jobType" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1x86aoe</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0ho53zi</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1x86aoe" sourceRef="StartEvent_1" targetRef="ServiceTask_0drxnet" />
+    <bpmn:endEvent id="EndEvent_118kuaq">
+      <bpmn:incoming>SequenceFlow_0ho53zi</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0ho53zi" sourceRef="ServiceTask_0drxnet" targetRef="EndEvent_118kuaq" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0drxnet_di" bpmnElement="ServiceTask_0drxnet">
+        <dc:Bounds x="250" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1x86aoe_di" bpmnElement="SequenceFlow_1x86aoe">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="250" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_118kuaq_di" bpmnElement="EndEvent_118kuaq">
+        <dc:Bounds x="412" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ho53zi_di" bpmnElement="SequenceFlow_0ho53zi">
+        <di:waypoint x="350" y="100" />
+        <di:waypoint x="412" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/clients/go/cmd/zbctl/testdata/model.bpmn
+++ b/clients/go/cmd/zbctl/testdata/model.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_01qewz4" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.7.0">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_01ntqzi</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_0vw27ts">
+      <bpmn:incoming>SequenceFlow_01ntqzi</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_01ntqzi" sourceRef="StartEvent_1" targetRef="EndEvent_0vw27ts" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0vw27ts_di" bpmnElement="EndEvent_0vw27ts">
+        <dc:Bounds x="272" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_01ntqzi_di" bpmnElement="SequenceFlow_01ntqzi">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="272" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/clients/go/cmd/zbctl/testdata/topology.golden
+++ b/clients/go/cmd/zbctl/testdata/topology.golden
@@ -1,0 +1,6 @@
+Cluster size: 1
+Partitions count: 1
+Replication factor: 1
+Brokers:
+  Broker 0 - 0.0.0.0:26501
+    Partition 1 : Leader

--- a/clients/go/cmd/zbctl/testdata/without_insecure.golden
+++ b/clients/go/cmd/zbctl/testdata/without_insecure.golden
@@ -1,0 +1,17 @@
+Error: rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = "transport: authentication handshake failed: tls: first record does not look like a TLS handshake"
+Usage:
+  zbctl status [flags]
+
+Flags:
+  -h, --help   help for status
+
+Global Flags:
+      --address string        Specify a contact point address. If omitted, will read from the environment variable 'ZEEBE_ADDRESS' (default '127.0.0.1:26500')
+      --audience string       Specify the resource that the access token should be valid for. If omitted, will read from the environment variable 'ZEEBE_TOKEN_AUDIENCE'
+      --authzUrl string       Specify an authorization server URL from which to request an access token. If omitted, will read from the environment variable 'ZEEBE_AUTHORIZATION_SERVER_URL' (default "https://login.cloud.camunda.io/oauth/token/")
+      --certPath string       Specify a path to a certificate with which to validate gateway requests. If omitted, will read from the environment variable 'ZEEBE_CA_CERTIFICATE_PATH'
+      --clientCache string    Specify the path to use for the OAuth credentials cache. If omitted, will read from the environment variable 'ZEEBE_CLIENT_CONFIG_PATH' (default "/tmp/.camunda/credentials")
+      --clientId string       Specify a client identifier to request an access token. If omitted, will read from the environment variable 'ZEEBE_CLIENT_ID'
+      --clientSecret string   Specify a client secret to request an access token. If omitted, will read from the environment variable 'ZEEBE_CLIENT_SECRET'
+      --insecure              Specify if zbctl should use an unsecured connection. If omitted, will read from the environment variable 'ZEEBE_INSECURE_CONNECTION'
+

--- a/clients/go/go.mod
+++ b/clients/go/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Microsoft/hcsshim v0.8.6 // indirect
 	github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/docker v0.7.3-0.20190506211059-b20a14b54661
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/go-ozzo/ozzo-validation/v3 v3.8.1

--- a/clients/go/internal/containerSuite/containerSuite.go
+++ b/clients/go/internal/containerSuite/containerSuite.go
@@ -138,9 +138,9 @@ func (s *ContainerSuite) TearDownSuite() {
 }
 
 func validateImageExists(ctx context.Context, image string) error {
-	dockerClient, err := client.NewClientWithOpts(client.FromEnv)
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
-		return err
+		return fmt.Errorf("failed creating docker client: %w", err)
 	}
 
 	_, _, err = dockerClient.ImageInspectWithRaw(ctx, image)

--- a/clients/go/internal/containerSuite/containerSuite.go
+++ b/clients/go/internal/containerSuite/containerSuite.go
@@ -11,15 +11,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package test
+package containerSuite
 
 import (
 	"context"
 	"fmt"
+	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/suite"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+	"github.com/zeebe-io/zeebe/clients/go/pkg/pb"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -27,7 +29,7 @@ import (
 )
 
 type zeebeWaitStrategy struct {
-	timeout time.Duration
+	waitTime time.Duration
 }
 
 func (s zeebeWaitStrategy) WaitUntilReady(ctx context.Context, target wait.StrategyTarget) error {
@@ -46,7 +48,7 @@ func (s zeebeWaitStrategy) WaitUntilReady(ctx context.Context, target wait.Strat
 		return err
 	}
 
-	client, err := zbc.NewClient(&zbc.ClientConfig{
+	zbClient, err := zbc.NewClient(&zbc.ClientConfig{
 		UsePlaintextConnection: true,
 		GatewayAddress:         fmt.Sprintf("%s:%d", host, mappedPort.Int()),
 	})
@@ -54,46 +56,62 @@ func (s zeebeWaitStrategy) WaitUntilReady(ctx context.Context, target wait.Strat
 		return err
 	}
 
-	defer func() {
-		err := client.Close()
-		if err != nil {
-			fmt.Println("Failed to close ZB client: ", err)
-		}
-	}()
-
-	_, err = client.NewTopologyCommand().Send()
-
-	for err != nil && status.Code(err) == codes.Unavailable {
-		time.Sleep(s.timeout)
-		_, err = client.NewTopologyCommand().Send()
+	res, err := zbClient.NewTopologyCommand().Send()
+	for (err != nil && status.Code(err) == codes.Unavailable) || !isStable(res) {
+		time.Sleep(s.waitTime)
+		res, err = zbClient.NewTopologyCommand().Send()
 	}
 
-	return err
+	if err != nil {
+		return err
+	}
+
+	return zbClient.Close()
 }
 
-type containerSuite struct {
-	// timeout specifies the wait period before checking if the container is up
-	timeout time.Duration
-	// containerImage is the ID of docker image to be used
-	containerImage string
+func isStable(res *pb.TopologyResponse) bool {
+	for _, broker := range res.GetBrokers() {
+		for _, partition := range broker.Partitions {
+			if partition.GetRole() == pb.Partition_LEADER {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// ContainerSuite sets up a container running Zeebe and tears it down afterwards.
+type ContainerSuite struct {
+	// WaitTime specifies the wait period before checking if the container is up
+	WaitTime time.Duration
+	// ContainerImage is the ID of docker image to be used
+	ContainerImage string
+
+	// GatewayAddress is the contact point of the spawned Zeebe container specified in the format 'host:port'
+	GatewayAddress string
 
 	suite.Suite
 	container testcontainers.Container
-	client    zbc.Client
 }
 
-func (s *containerSuite) SetupSuite() {
+func (s *ContainerSuite) SetupSuite() {
 	var err error
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        s.containerImage,
+			Image:        s.ContainerImage,
 			ExposedPorts: []string{"26500"},
-			WaitingFor:   zeebeWaitStrategy{timeout: s.timeout},
+			WaitingFor:   zeebeWaitStrategy{waitTime: s.WaitTime},
 		},
 		Started: true,
 	}
 
 	ctx := context.Background()
+	err = validateImageExists(ctx, s.ContainerImage)
+	if err != nil {
+		s.T().Fatal(err)
+	}
+
 	s.container, err = testcontainers.GenericContainer(ctx, req)
 	if err != nil {
 		s.T().Fatal(err)
@@ -109,24 +127,29 @@ func (s *containerSuite) SetupSuite() {
 		s.T().Fatal(err)
 	}
 
-	s.client, err = zbc.NewClient(&zbc.ClientConfig{
-		UsePlaintextConnection: true,
-		GatewayAddress:         fmt.Sprintf("%s:%d", host, port.Int()),
-	})
+	s.GatewayAddress = fmt.Sprintf("%s:%d", host, port.Int())
+}
 
+func (s *ContainerSuite) TearDownSuite() {
+	err := s.container.Terminate(context.Background())
 	if err != nil {
 		s.T().Fatal(err)
 	}
 }
 
-func (s *containerSuite) TearDownSuite() {
-	err := s.client.Close()
+func validateImageExists(ctx context.Context, image string) error {
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
-		s.T().Fatal(err)
+		return err
 	}
 
-	err = s.container.Terminate(context.Background())
+	_, _, err = dockerClient.ImageInspectWithRaw(ctx, image)
 	if err != nil {
-		s.T().Fatal(err)
+		if client.IsErrNotFound(err) {
+			return fmt.Errorf("a Docker image containing Zeebe must be built and named '%s'\n", image)
+		}
+
+		return err
 	}
+	return nil
 }

--- a/clients/go/test/integration_test.go
+++ b/clients/go/test/integration_test.go
@@ -29,7 +29,7 @@ type integrationTestSuite struct {
 func TestIntegration(t *testing.T) {
 	suite.Run(t, &integrationTestSuite{
 		ContainerSuite: &containerSuite.ContainerSuite{
-			Timeout:        time.Second,
+			WaitTime:       time.Second,
 			ContainerImage: "camunda/zeebe:current-test",
 		},
 	})

--- a/clients/go/test/integration_test.go
+++ b/clients/go/test/integration_test.go
@@ -15,23 +15,48 @@ package test
 
 import (
 	"github.com/stretchr/testify/suite"
+	"github.com/zeebe-io/zeebe/clients/go/internal/containerSuite"
+	"github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
 	"testing"
 	"time"
 )
 
 type integrationTestSuite struct {
-	*containerSuite
+	*containerSuite.ContainerSuite
+	client zbc.Client
 }
 
 func TestIntegration(t *testing.T) {
 	suite.Run(t, &integrationTestSuite{
-		&containerSuite{
-			timeout:        time.Second,
-			containerImage: "camunda/zeebe:current-test",
+		ContainerSuite: &containerSuite.ContainerSuite{
+			Timeout:        time.Second,
+			ContainerImage: "camunda/zeebe:current-test",
 		},
 	})
 }
 
+func (s *integrationTestSuite) SetupSuite() {
+	var err error
+	s.ContainerSuite.SetupSuite()
+
+	s.client, err = zbc.NewClient(&zbc.ClientConfig{
+
+		GatewayAddress:         s.GatewayAddress,
+		UsePlaintextConnection: true,
+	})
+	if err != nil {
+		s.T().Fatal(err)
+	}
+}
+
+func (s *integrationTestSuite) TearDownSuite() {
+	err := s.client.Close()
+	if err != nil {
+		s.T().Fatal(err)
+	}
+
+	s.ContainerSuite.TearDownSuite()
+}
 func (s *integrationTestSuite) TestTopology() {
 	// when
 	response, err := s.client.NewTopologyCommand().Send()


### PR DESCRIPTION
## Description

Contributions:
* Refactors the test container suite so we can use it in the zbctl integration tests 
* Tests a few common commands (e.g., deploy, create instance, etc) and configurations
* Changes the build script so we can build for one specific OS, in case a zbctl binary isn't found

## Related issues
There should be more tests to test the different auth related configuration options so I opened a follow-up issue #3472

closes #1555 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
