### PR TITLE
fix(broker): increase start up time out

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixJoinService.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixJoinService.java
@@ -38,7 +38,7 @@ public class AtomixJoinService implements Service<Atomix> {
               }
             });
 
-    startContext.async(started);
+    startContext.async(started, true);
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -158,7 +158,7 @@ public class SystemContext implements AutoCloseable {
 
     try {
       for (final ActorFuture<?> requiredStartAction : requiredStartActions) {
-        requiredStartAction.get(40, TimeUnit.SECONDS);
+        requiredStartAction.get(600, TimeUnit.SECONDS);
       }
     } catch (final Exception e) {
       LOG.error("Could not start broker", e);


### PR DESCRIPTION
## Description

 * atomix was added to the base layer composite install, this was the reason why it sometimes now timed out - before, the installing of atomix was not counted
 * we increased the timeout and made atomix join interruptible such that it can be closed during start up

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3456 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
