### PR TITLE
chore(dist): enable default metrics for standalone gateway

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -72,6 +72,11 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_hotspot</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
@@ -12,6 +12,7 @@ import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.core.Atomix;
 import io.atomix.utils.net.Address;
 import io.prometheus.client.exporter.HTTPServer;
+import io.prometheus.client.hotspot.DefaultExports;
 import io.zeebe.gateway.impl.broker.BrokerClient;
 import io.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.zeebe.gateway.impl.configuration.ClusterCfg;
@@ -73,6 +74,7 @@ public class StandaloneGateway {
       monitoringServer =
           new HTTPServer(
               gatewayCfg.getMonitoring().getHost(), gatewayCfg.getMonitoring().getPort());
+      DefaultExports.initialize();
     }
 
     gateway.listenAndServe();


### PR DESCRIPTION
## Description

Enable prometheus default exporters in standalone gateway to export JVM metrics. 


## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
