### PR TITLE
chore(gateway): allow to set the number of max messages buffered

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/EmbeddedGatewayCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/EmbeddedGatewayCfg.java
@@ -37,7 +37,9 @@ public class EmbeddedGatewayCfg extends GatewayCfg implements ConfigurationEntry
     // configure embedded gateway based on broker config
     getNetwork().setPort(getNetwork().getPort() + (networkCfg.getPortOffset() * 10));
 
-    getCluster().setMaxMessageSize(networkCfg.getMaxMessageSize().toString());
+    getCluster()
+        .setMaxMessageSize(networkCfg.getMaxMessageSize().toString())
+        .setMaxMessageCount(networkCfg.getMaxMessageCount());
   }
 
   public boolean isEnable() {

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/NetworkCfg.java
@@ -25,10 +25,12 @@ public class NetworkCfg implements ConfigurationEntry {
   public static final int DEFAULT_INTERNAL_API_PORT = 26502;
   public static final int DEFAULT_MONITORING_API_PORT = 9600;
   public static final String DEFAULT_MAX_MESSAGE_SIZE = "4M";
+  public static final int DEFAULT_MAX_MESSAGE_COUNT = 16;
 
   private String host = DEFAULT_HOST;
   private int portOffset = 0;
   private String maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
+  private int maxMessageCount = DEFAULT_MAX_MESSAGE_COUNT;
   private String advertisedHost;
 
   private CommandApiCfg commandApi = new CommandApiCfg();
@@ -82,6 +84,15 @@ public class NetworkCfg implements ConfigurationEntry {
     this.maxMessageSize = maxMessageSize;
   }
 
+  public int getMaxMessageCount() {
+    return maxMessageCount;
+  }
+
+  public NetworkCfg setMaxMessageCount(int maxMessageCount) {
+    this.maxMessageCount = maxMessageCount;
+    return this;
+  }
+
   public CommandApiCfg getCommandApi() {
     return commandApi;
   }
@@ -113,6 +124,8 @@ public class NetworkCfg implements ConfigurationEntry {
         + '\''
         + ", maxMessageSize="
         + maxMessageSize
+        + ", maxMessageCount="
+        + maxMessageCount
         + ", commandApi="
         + commandApi
         + ", internalApi="

--- a/broker/src/main/java/io/zeebe/broker/transport/ServerTransportService.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/ServerTransportService.java
@@ -24,14 +24,11 @@ import org.slf4j.Logger;
 public class ServerTransportService implements Service<ServerTransport> {
   public static final Logger LOG = Loggers.TRANSPORT_LOGGER;
 
-  // max message size * factor = transport buffer size
-  // - note that this factor is randomly chosen, feel free to change it
-  private static final int TRANSPORT_BUFFER_FACTOR = 16;
-
   private final String readableName;
   private final InetSocketAddress bindAddress;
 
   private final ByteValue maxMessageSize;
+  private final int maxMessageCount;
   private CommandApiMessageHandler commandApiMessageHandler;
   private ServerTransport serverTransport;
 
@@ -39,10 +36,12 @@ public class ServerTransportService implements Service<ServerTransport> {
       final String readableName,
       final InetSocketAddress bindAddress,
       final ByteValue maxMessageSize,
+      int maxMessageCount,
       final CommandApiMessageHandler commandApiMessageHandler) {
     this.readableName = readableName;
     this.bindAddress = bindAddress;
     this.maxMessageSize = maxMessageSize;
+    this.maxMessageCount = maxMessageCount;
     this.commandApiMessageHandler = commandApiMessageHandler;
   }
 
@@ -51,7 +50,7 @@ public class ServerTransportService implements Service<ServerTransport> {
     final ActorScheduler scheduler = serviceContext.getScheduler();
 
     final ByteValue transportBufferSize =
-        ByteValue.ofBytes(maxMessageSize.toBytes() * TRANSPORT_BUFFER_FACTOR);
+        ByteValue.ofBytes(maxMessageSize.toBytes() * maxMessageCount);
 
     serverTransport =
         Transports.newServerTransport()

--- a/broker/src/main/java/io/zeebe/broker/transport/TransportComponent.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/TransportComponent.java
@@ -83,6 +83,7 @@ public class TransportComponent implements Component {
         name,
         bindAddr.toInetSocketAddress(),
         networkCfg.getMaxMessageSize(),
+        networkCfg.getMaxMessageCount(),
         commandApiMessageHandler);
   }
 
@@ -92,9 +93,11 @@ public class TransportComponent implements Component {
       final String name,
       final InetSocketAddress bindAddress,
       final ByteValue maxMessageSize,
+      final int maxMessageCount,
       final CommandApiMessageHandler commandApiMessageHandler) {
     final ServerTransportService service =
-        new ServerTransportService(name, bindAddress, maxMessageSize, commandApiMessageHandler);
+        new ServerTransportService(
+            name, bindAddress, maxMessageSize, maxMessageCount, commandApiMessageHandler);
 
     systemContext.addResourceReleasingDelegate(service.getReleasingResourcesDelegate());
 

--- a/dist/src/main/config/gateway.cfg.toml
+++ b/dist/src/main/config/gateway.cfg.toml
@@ -45,10 +45,6 @@
 # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CONTACT_POINT.
 # contactPoint = "127.0.0.1:26502"
 
-# Sets size of the transport buffer to send and received messages between gateway and broker cluster
-# This setting can also be overridden using the environment variable ZEEBE_GATEWAY_TRANSPORT_BUFFER.
-# transportBuffer = "2M"
-
 # Sets the timeout of requests send to the broker cluster
 # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_REQUEST_TIMEOUT.
 # requestTimeout = "15s"
@@ -70,7 +66,13 @@
 # port = 26502
 
 # Sets the maximum size of the incoming and outgoing messages (i.e. commands and events).
+# This setting can also be overridden using the environment variable ZEEBE_GATEWAY_MAX_MESSAGE_SIZE.
 # maxMessageSize = "4M"
+
+# Sets the maximum number of the incoming and outgoing messages (i.e. commands and events) with
+# the maximum size which can be buffered.
+# This setting can also be overridden using the environment variable ZEEBE_GATEWAY_MAX_MESSAGE_COUNT.
+# maxMessageCount = 16
 
 [threads]
 # Sets the number of threads the gateway will use to communicate with the broker cluster

--- a/dist/src/main/config/zeebe.cfg.toml
+++ b/dist/src/main/config/zeebe.cfg.toml
@@ -54,10 +54,6 @@
 # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CONTACT_POINT.
 # contactPoint = "127.0.0.1:26501"
 
-# Sets size of the transport buffer to send and received messages between gateway and broker cluster.
-# This setting can also be overridden using the environment variable ZEEBE_GATEWAY_TRANSPORT_BUFFER.
-# transportBuffer = "128M"
-
 # Sets the timeout of requests send to the broker cluster
 # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_REQUEST_TIMEOUT.
 # requestTimeout = "15s"
@@ -114,6 +110,10 @@
 
 # Sets the maximum size of the incoming and outgoing messages (i.e. commands and events).
 # maxMessageSize = "4M"
+
+# Sets the maximum number of the incoming and outgoing messages (i.e. commands and events) with
+# the maximum size which can be buffered.
+# maxMessageCount = 16
 
 [network.commandApi]
 # Overrides the host used for gateway-to-broker communication

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClientImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClientImpl.java
@@ -42,10 +42,6 @@ import org.slf4j.Logger;
 public class BrokerClientImpl implements BrokerClient {
   public static final Logger LOG = Loggers.GATEWAY_LOGGER;
 
-  // max message size * factor = transport buffer size
-  // - note that this factor is randomly chosen, feel free to change it
-  private static final int TRANSPORT_BUFFER_FACTOR = 16;
-
   protected final ActorScheduler actorScheduler;
   protected final ClientTransport transport;
   protected final BrokerTopologyManagerImpl topologyManager;
@@ -92,8 +88,9 @@ public class BrokerClientImpl implements BrokerClient {
     final ClusterCfg clusterCfg = configuration.getCluster();
 
     final ByteValue maxMessageSize = clusterCfg.getMaxMessageSize();
+    final int maxMessageCount = clusterCfg.getMaxMessageCount();
     final ByteValue transportBufferSize =
-        ByteValue.ofBytes(maxMessageSize.toBytes() * TRANSPORT_BUFFER_FACTOR);
+        ByteValue.ofBytes(maxMessageSize.toBytes() * maxMessageCount);
 
     dataFrameReceiveBuffer =
         Dispatchers.create("gateway-receive-buffer")

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -13,6 +13,7 @@ import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_
 import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CLUSTER_PORT;
 import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CONTACT_POINT_HOST;
 import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CONTACT_POINT_PORT;
+import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_MAX_MESSAGE_COUNT;
 import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_MAX_MESSAGE_SIZE;
 import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_REQUEST_TIMEOUT;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_CLUSTER_HOST;
@@ -20,6 +21,7 @@ import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEW
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_CLUSTER_NAME;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_CLUSTER_PORT;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_CONTACT_POINT;
+import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_MAX_MESSAGE_COUNT;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_MAX_MESSAGE_SIZE;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_REQUEST_TIMEOUT;
 
@@ -32,6 +34,7 @@ import java.util.Objects;
 public class ClusterCfg {
   private String contactPoint = DEFAULT_CONTACT_POINT_HOST + ":" + DEFAULT_CONTACT_POINT_PORT;
   private String maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
+  private int maxMessageCount = DEFAULT_MAX_MESSAGE_COUNT;
   private String requestTimeout = DEFAULT_REQUEST_TIMEOUT;
   private String clusterName = DEFAULT_CLUSTER_NAME;
   private String memberId = DEFAULT_CLUSTER_MEMBER_ID;
@@ -49,6 +52,7 @@ public class ClusterCfg {
     environment.get(ENV_GATEWAY_CLUSTER_HOST).ifPresent(this::setHost);
     environment.getInt(ENV_GATEWAY_CLUSTER_PORT).ifPresent(this::setPort);
     environment.get(ENV_GATEWAY_MAX_MESSAGE_SIZE).ifPresent(this::setMaxMessageSize);
+    environment.getInt(ENV_GATEWAY_MAX_MESSAGE_COUNT).ifPresent(this::setMaxMessageCount);
   }
 
   public String getMemberId() {
@@ -114,10 +118,26 @@ public class ClusterCfg {
     return this;
   }
 
+  public int getMaxMessageCount() {
+    return maxMessageCount;
+  }
+
+  public ClusterCfg setMaxMessageCount(int maxMessageCount) {
+    this.maxMessageCount = maxMessageCount;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
-        contactPoint, maxMessageSize, requestTimeout, clusterName, memberId, host, port);
+        contactPoint,
+        maxMessageSize,
+        maxMessageCount,
+        requestTimeout,
+        clusterName,
+        memberId,
+        host,
+        port);
   }
 
   @Override
@@ -132,6 +152,7 @@ public class ClusterCfg {
     return port == that.port
         && Objects.equals(contactPoint, that.contactPoint)
         && Objects.equals(maxMessageSize, that.maxMessageSize)
+        && maxMessageCount == that.maxMessageCount
         && Objects.equals(requestTimeout, that.requestTimeout)
         && Objects.equals(clusterName, that.clusterName)
         && Objects.equals(memberId, that.memberId)
@@ -147,6 +168,8 @@ public class ClusterCfg {
         + ", maxMessageSize='"
         + maxMessageSize
         + '\''
+        + ", maxMessageCount="
+        + maxMessageCount
         + ", requestTimeout='"
         + requestTimeout
         + '\''

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ConfigurationDefaults.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ConfigurationDefaults.java
@@ -16,6 +16,7 @@ public class ConfigurationDefaults {
   public static final int DEFAULT_CONTACT_POINT_PORT = 26502;
 
   public static final String DEFAULT_MAX_MESSAGE_SIZE = "4M";
+  public static final int DEFAULT_MAX_MESSAGE_COUNT = 16;
   public static final String DEFAULT_REQUEST_TIMEOUT = "15s";
   public static final boolean DEFAULT_TLS_ENABLED = false;
 

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/EnvironmentConstants.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/EnvironmentConstants.java
@@ -12,6 +12,7 @@ public class EnvironmentConstants {
   public static final String ENV_GATEWAY_HOST = "ZEEBE_GATEWAY_HOST";
   public static final String ENV_GATEWAY_PORT = "ZEEBE_GATEWAY_PORT";
   public static final String ENV_GATEWAY_MAX_MESSAGE_SIZE = "ZEEBE_GATEWAY_MAX_MESSAGE_SIZE";
+  public static final String ENV_GATEWAY_MAX_MESSAGE_COUNT = "ZEEBE_GATEWAY_MAX_MESSAGE_COUNT";
   public static final String ENV_GATEWAY_REQUEST_TIMEOUT = "ZEEBE_GATEWAY_REQUEST_TIMEOUT";
   public static final String ENV_GATEWAY_MANAGEMENT_THREADS = "ZEEBE_GATEWAY_MANAGEMENT_THREADS";
   public static final String ENV_GATEWAY_CONTACT_POINT = "ZEEBE_GATEWAY_CONTACT_POINT";

--- a/gateway/src/test/java/io/zeebe/gateway/configuration/GatewayCfgTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/configuration/GatewayCfgTest.java
@@ -15,6 +15,7 @@ import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEW
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_CONTACT_POINT;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_HOST;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_MANAGEMENT_THREADS;
+import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_MAX_MESSAGE_COUNT;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_MAX_MESSAGE_SIZE;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_MONITORING_ENABLED;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_MONITORING_HOST;
@@ -50,6 +51,7 @@ public class GatewayCfgTest {
         .getCluster()
         .setContactPoint("foobar:1234")
         .setMaxMessageSize("4K")
+        .setMaxMessageCount(13)
         .setRequestTimeout("123h")
         .setClusterName("testCluster")
         .setMemberId("testMember")
@@ -94,6 +96,7 @@ public class GatewayCfgTest {
     setEnv(ENV_GATEWAY_PORT, "5432");
     setEnv(ENV_GATEWAY_CONTACT_POINT, "broker:432");
     setEnv(ENV_GATEWAY_MAX_MESSAGE_SIZE, "1G");
+    setEnv(ENV_GATEWAY_MAX_MESSAGE_COUNT, "123");
     setEnv(ENV_GATEWAY_MANAGEMENT_THREADS, "32");
     setEnv(ENV_GATEWAY_REQUEST_TIMEOUT, "43m");
     setEnv(ENV_GATEWAY_CLUSTER_NAME, "envCluster");
@@ -123,6 +126,7 @@ public class GatewayCfgTest {
         .getCluster()
         .setContactPoint("broker:432")
         .setMaxMessageSize("1G")
+        .setMaxMessageCount(123)
         .setRequestTimeout("43m")
         .setClusterName("envCluster")
         .setMemberId("envMember")

--- a/gateway/src/test/resources/configuration/gateway.custom.toml
+++ b/gateway/src/test/resources/configuration/gateway.custom.toml
@@ -5,6 +5,7 @@ port = 123
 [cluster]
 contactPoint = "foobar:1234"
 maxMessageSize = "4K"
+maxMessageCount = 13
 requestTimeout = "123h"
 clusterName = "testCluster"
 memberId = "testMember"


### PR DESCRIPTION
## Description
- adds maxMessageCount config option to define the transport buffer in the
gateway in combination with maxMessageSize
- removes the outdated transportBuffer setting from the example configs

## Related issues

related to #3005

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
