### PR TITLE
chore(project): customize Go linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,17 @@
+linters:
+  enable:  
+  - gofmt
+  - golint
+  - misspell
+  - dupl
+  - unused
+  - gosec
+  - gocritic
+
+issues:
+ exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck
+        - dupl
+        - gosec


### PR DESCRIPTION
## Description

Enabled some additional go linters, namely:
* gofmt
* golint
* misspell
* dupl
* unused
* gosec
* gocritic

Also excluded the following linters from running on tests:
* errcheck - we do stuff like `go grpcServer.Serve()` which ignores the error but is imo fine for a test. The alternative would make the tests more verbose
* dupl - this finds duplicate code by building an AST and ignoring the values. I don't think it's a big deal for tests to have a similar structure with different configs and small changes
* gosec - tests are likely to have insecure patterns which is fine

I also thought about enabling lll which reports lines that exceed a certain length. However, `gofmt` doesn't format them automatically which would for us to do it manually and we have some really long names (which is a different problem in itself) so it would flag a lot of stuff

## Related issues

closes #3420

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
