### PR TITLE
Add throw error command in Java client

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/api/command/ThrowErrorCommandStep1.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/command/ThrowErrorCommandStep1.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.api.command;
+
+public interface ThrowErrorCommandStep1 {
+  /**
+   * Set the errorCode for the error.
+   *
+   * <p>If the errorCode can't be matched to an error catch event in the workflow, an incident will
+   * be created.
+   *
+   * @param errorCode the errorCode that will be matched against an error catch event
+   * @return the builder for this command. Call {@link ThrowErrorCommandStep2#send()} to complete
+   *     the command and send it to the broker.
+   */
+  ThrowErrorCommandStep2 errorCode(String errorCode);
+
+  interface ThrowErrorCommandStep2 extends FinalCommandStep<Void> {
+    /**
+     * Provide an error message describing the reason for the non-technical error. If the error is
+     * not caught by an error catch event, this message will be a part of the raised incident.
+     *
+     * @param errorMsg error message
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    ThrowErrorCommandStep2 errorMessage(String errorMsg);
+  }
+}

--- a/clients/java/src/main/java/io/zeebe/client/api/worker/JobClient.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/worker/JobClient.java
@@ -17,6 +17,7 @@ package io.zeebe.client.api.worker;
 
 import io.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.zeebe.client.api.command.FailJobCommandStep1;
+import io.zeebe.client.api.command.ThrowErrorCommandStep1;
 
 /**
  * A client with access to all job-related operation:
@@ -65,4 +66,25 @@ public interface JobClient {
    * @return a builder for the command
    */
   FailJobCommandStep1 newFailCommand(long jobKey);
+
+  /**
+   * Command to report a business error (i.e. non-technical) that occurs while processing a job.
+   *
+   * <pre>
+   * long jobKey = ...;
+   * String code = ...;
+   *
+   * jobClient
+   *  .newThrowErrorCommand(jobKey)
+   *  .errorCode(code)
+   *  .send();
+   * </pre>
+   *
+   * <p>The error is handled in the workflow by an error catch event. If there is no error catch
+   * event with the specified errorCode then an incident will be raised instead.
+   *
+   * @param jobKey the key which identifies the job
+   * @return a builder for the command
+   */
+  ThrowErrorCommandStep1 newThrowErrorCommand(long jobKey);
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
@@ -34,6 +34,7 @@ import io.zeebe.client.api.command.FailJobCommandStep1;
 import io.zeebe.client.api.command.PublishMessageCommandStep1;
 import io.zeebe.client.api.command.ResolveIncidentCommandStep1;
 import io.zeebe.client.api.command.SetVariablesCommandStep1;
+import io.zeebe.client.api.command.ThrowErrorCommandStep1;
 import io.zeebe.client.api.command.TopologyRequestStep1;
 import io.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
 import io.zeebe.client.api.worker.JobClient;
@@ -308,5 +309,10 @@ public class ZeebeClientImpl implements ZeebeClient {
   @Override
   public FailJobCommandStep1 newFailCommand(long jobKey) {
     return jobClient.newFailCommand(jobKey);
+  }
+
+  @Override
+  public ThrowErrorCommandStep1 newThrowErrorCommand(long jobKey) {
+    return jobClient.newThrowErrorCommand(jobKey);
   }
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/ThrowErrorCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/ThrowErrorCommandImpl.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl.command;
+
+import io.grpc.stub.StreamObserver;
+import io.zeebe.client.api.ZeebeFuture;
+import io.zeebe.client.api.command.FinalCommandStep;
+import io.zeebe.client.api.command.ThrowErrorCommandStep1;
+import io.zeebe.client.api.command.ThrowErrorCommandStep1.ThrowErrorCommandStep2;
+import io.zeebe.client.impl.RetriableClientFutureImpl;
+import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest.Builder;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorResponse;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+public class ThrowErrorCommandImpl implements ThrowErrorCommandStep1, ThrowErrorCommandStep2 {
+
+  private final GatewayStub asyncStub;
+  private final Builder builder;
+  private final Predicate<Throwable> retryPredicate;
+  private Duration requestTimeout;
+
+  public ThrowErrorCommandImpl(
+      GatewayStub asyncStub,
+      long key,
+      Duration requestTimeout,
+      Predicate<Throwable> retryPredicate) {
+    this.asyncStub = asyncStub;
+    this.requestTimeout = requestTimeout;
+    this.retryPredicate = retryPredicate;
+    builder = ThrowErrorRequest.newBuilder();
+    builder.setJobKey(key);
+  }
+
+  @Override
+  public ThrowErrorCommandStep2 errorCode(String errorCode) {
+    builder.setErrorCode(errorCode);
+    return this;
+  }
+
+  @Override
+  public ThrowErrorCommandStep2 errorMessage(String errorMsg) {
+    builder.setErrorMessage(errorMsg);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<Void> requestTimeout(Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<Void> send() {
+    final ThrowErrorRequest request = builder.build();
+
+    final RetriableClientFutureImpl<Void, ThrowErrorResponse> future =
+        new RetriableClientFutureImpl<>(
+            retryPredicate, streamObserver -> send(request, streamObserver));
+
+    send(request, future);
+    return future;
+  }
+
+  private void send(ThrowErrorRequest request, StreamObserver<ThrowErrorResponse> streamObserver) {
+    asyncStub
+        .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
+        .throwError(request, streamObserver);
+  }
+}

--- a/clients/java/src/main/java/io/zeebe/client/impl/worker/JobClientImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/worker/JobClientImpl.java
@@ -18,10 +18,12 @@ package io.zeebe.client.impl.worker;
 import io.zeebe.client.ZeebeClientConfiguration;
 import io.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.zeebe.client.api.command.FailJobCommandStep1;
+import io.zeebe.client.api.command.ThrowErrorCommandStep1;
 import io.zeebe.client.api.worker.JobClient;
 import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.client.impl.command.CompleteJobCommandImpl;
 import io.zeebe.client.impl.command.FailJobCommandImpl;
+import io.zeebe.client.impl.command.ThrowErrorCommandImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import java.util.function.Predicate;
 
@@ -52,6 +54,12 @@ public class JobClientImpl implements JobClient {
   @Override
   public FailJobCommandStep1 newFailCommand(long jobKey) {
     return new FailJobCommandImpl(
+        asyncStub, jobKey, config.getDefaultRequestTimeout(), retryPredicate);
+  }
+
+  @Override
+  public ThrowErrorCommandStep1 newThrowErrorCommand(long jobKey) {
+    return new ThrowErrorCommandImpl(
         asyncStub, jobKey, config.getDefaultRequestTimeout(), retryPredicate);
   }
 }

--- a/clients/java/src/test/java/io/zeebe/client/job/ThrowErrorTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/job/ThrowErrorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.client.util.ClientTest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
+import java.time.Duration;
+import org.junit.Test;
+
+public class ThrowErrorTest extends ClientTest {
+
+  @Test
+  public void shouldThrowError() {
+    // given
+    final long jobKey = 12;
+    final String errorCode = "errorCode";
+
+    // when
+    client.newThrowErrorCommand(jobKey).errorCode(errorCode).send().join();
+
+    // then
+    final ThrowErrorRequest request = gatewayService.getLastRequest();
+    assertThat(request.getJobKey()).isEqualTo(jobKey);
+    assertThat(request.getErrorCode()).isEqualTo(errorCode);
+
+    rule.verifyDefaultRequestTimeout();
+  }
+
+  @Test
+  public void shouldThrowErrorWithMessage() {
+    // given
+    final long jobKey = 12;
+    final String errorCode = "errorCode";
+    final String errorMsg = "errorMsg";
+
+    // when
+    client.newThrowErrorCommand(jobKey).errorCode(errorCode).errorMessage(errorMsg).send().join();
+
+    // then
+    final ThrowErrorRequest request = gatewayService.getLastRequest();
+    assertThat(request.getJobKey()).isEqualTo(jobKey);
+    assertThat(request.getErrorCode()).isEqualTo(errorCode);
+    assertThat(request.getErrorMessage()).isEqualTo(errorMsg);
+
+    rule.verifyDefaultRequestTimeout();
+  }
+
+  @Test
+  public void shouldSetRequestTimeout() {
+    // given
+    final Duration requestTimeout = Duration.ofHours(124);
+
+    // when
+    client
+        .newThrowErrorCommand(123)
+        .errorCode("errorCode")
+        .requestTimeout(requestTimeout)
+        .send()
+        .join();
+
+    // then
+    rule.verifyRequestTimeout(requestTimeout);
+  }
+}

--- a/clients/java/src/test/java/io/zeebe/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/zeebe/client/util/RecordingGatewayService.java
@@ -44,6 +44,8 @@ import io.zeebe.gateway.protocol.GatewayOuterClass.ResolveIncidentRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ResolveIncidentResponse;
 import io.zeebe.gateway.protocol.GatewayOuterClass.SetVariablesRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.SetVariablesResponse;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorResponse;
 import io.zeebe.gateway.protocol.GatewayOuterClass.TopologyRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.TopologyResponse;
 import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
@@ -83,6 +85,7 @@ public class RecordingGatewayService extends GatewayImplBase {
     addRequestHandler(
         UpdateJobRetriesRequest.class, r -> UpdateJobRetriesResponse.getDefaultInstance());
     addRequestHandler(FailJobRequest.class, r -> FailJobResponse.getDefaultInstance());
+    addRequestHandler(ThrowErrorRequest.class, r -> ThrowErrorResponse.getDefaultInstance());
     addRequestHandler(CompleteJobRequest.class, r -> CompleteJobResponse.getDefaultInstance());
     addRequestHandler(ActivateJobsRequest.class, r -> ActivateJobsResponse.getDefaultInstance());
     addRequestHandler(
@@ -165,6 +168,12 @@ public class RecordingGatewayService extends GatewayImplBase {
 
   @Override
   public void failJob(FailJobRequest request, StreamObserver<FailJobResponse> responseObserver) {
+    handle(request, responseObserver);
+  }
+
+  @Override
+  public void throwError(
+      ThrowErrorRequest request, StreamObserver<ThrowErrorResponse> responseObserver) {
     handle(request, responseObserver);
   }
 

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -379,6 +379,29 @@
             "name": "FailJobResponse"
           },
           {
+            "name": "ThrowErrorRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobKey",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "errorCode",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "errorMessage",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ThrowErrorResponse"
+          },
+          {
             "name": "PublishMessageRequest",
             "fields": [
               {
@@ -582,6 +605,11 @@
                 "name": "FailJob",
                 "in_type": "FailJobRequest",
                 "out_type": "FailJobResponse"
+              },
+              {
+                "name": "ThrowError",
+                "in_type": "ThrowErrorRequest",
+                "out_type": "ThrowErrorResponse"
               },
               {
                 "name": "PublishMessage",


### PR DESCRIPTION
## Description

Implements the throw error command in the Java client.

## Related issues

closes #3506 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
