### PR TITLE
feat(clients/go): add throw error to zbctl

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/throwError.go
+++ b/clients/go/cmd/zbctl/internal/commands/throwError.go
@@ -1,0 +1,26 @@
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import "github.com/spf13/cobra"
+
+var throwErrorCmd = &cobra.Command{
+	Use:   "throwError",
+	Short: "Throw an error",
+}
+
+func init() {
+	rootCmd.AddCommand(throwErrorCmd)
+}

--- a/clients/go/cmd/zbctl/internal/commands/throwErrorJob.go
+++ b/clients/go/cmd/zbctl/internal/commands/throwErrorJob.go
@@ -1,0 +1,48 @@
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"github.com/spf13/cobra"
+	"log"
+)
+
+var (
+	jobKey       int64
+	errorCode    string
+	errorMessage string
+)
+
+var throwErrorJobCmd = &cobra.Command{
+	Use:     "job <jobKey>",
+	Short:   "Throw a non-technical error from an active job",
+	Args:    keyArg(&jobKey),
+	PreRunE: initClient,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_, err := client.NewThrowErrorCommand().JobKey(jobKey).ErrorCode(errorCode).ErrorMessage(errorMessage).Send()
+		if err == nil {
+			log.Printf("Threw error with code '%s' on job with key %d\n", errorCode, jobKey)
+		}
+
+		return err
+	},
+}
+
+func init() {
+	throwErrorCmd.AddCommand(throwErrorJobCmd)
+	throwErrorJobCmd.Flags().StringVar(&errorCode, "errorCode", "", "Specify an error code to which the error should be matched")
+	_ = throwErrorJobCmd.MarkFlagRequired("errorCode")
+	throwErrorJobCmd.Flags().StringVar(&errorMessage, "errorMessage", "", "Specify an error message with additional context")
+}

--- a/clients/go/cmd/zbctl/testdata/help.golden
+++ b/clients/go/cmd/zbctl/testdata/help.golden
@@ -22,6 +22,7 @@ Available Commands:
   resolve     Resolve a resource
   set         Set a resource
   status      Checks the current status of the cluster
+  throwError  Throw an error
   update      Update a resource
   version     Print the version of zbctl
 


### PR DESCRIPTION
## Description

Adds the errorThrow command to zbctl

## Related issues

closes #3508 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
