### PR TITLE
fix(broker): avoid SIGSEG on close

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -311,13 +311,12 @@ public class ZeebePartition extends Actor implements RaftCommitListener, Consume
 
   private void installProcessingPartition(CompletableActorFuture<Void> installFuture) {
     final StreamProcessor streamProcessor = createStreamProcessor(zeebeDb);
+    closeables.add(streamProcessor);
     streamProcessor
         .openAsync()
         .onComplete(
             (value, processorFail) -> {
               if (processorFail == null) {
-                closeables.add(streamProcessor);
-
                 final DataCfg dataCfg = brokerCfg.getData();
                 installSnapshotDirector(streamProcessor, dataCfg)
                     .onComplete(


### PR DESCRIPTION


## Description

 * processor is added to closables early such that we can close it and do not access the db concurrently
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3523 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
