### PR TITLE
feat(broker): support error boundary event

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/ModelUtil.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/ModelUtil.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 
 import io.zeebe.model.bpmn.instance.Activity;
+import io.zeebe.model.bpmn.instance.EventDefinition;
 import io.zeebe.model.bpmn.instance.Message;
 import io.zeebe.model.bpmn.instance.MessageEventDefinition;
 import java.util.List;
@@ -27,13 +28,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ModelUtil {
-  public static Stream<MessageEventDefinition> getActivityMessageBoundaryEvents(
-      final Activity activity) {
+
+  public static <E extends EventDefinition> Stream<E> getBoundaryEvents(
+      final Activity activity, final Class<E> definitionType) {
 
     return activity.getBoundaryEvents().stream()
         .flatMap(event -> event.getEventDefinitions().stream())
-        .filter(definition -> definition instanceof MessageEventDefinition)
-        .map(MessageEventDefinition.class::cast);
+        .filter(definitionType::isInstance)
+        .map(definitionType::cast);
   }
 
   public static List<String> getDuplicateMessageNames(

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ActivityValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ActivityValidator.java
@@ -15,10 +15,17 @@
  */
 package io.zeebe.model.bpmn.validation.zeebe;
 
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
+
 import io.zeebe.model.bpmn.instance.Activity;
+import io.zeebe.model.bpmn.instance.Error;
+import io.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.zeebe.model.bpmn.util.ModelUtil;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Stream;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
@@ -33,8 +40,15 @@ public class ActivityValidator implements ModelElementValidator<Activity> {
   public void validate(
       final Activity element, final ValidationResultCollector validationResultCollector) {
 
+    verifyNoDuplicatedMessageNames(element, validationResultCollector);
+    verifyNoDuplicatedErrorCodes(element, validationResultCollector);
+  }
+
+  private void verifyNoDuplicatedMessageNames(
+      final Activity element, final ValidationResultCollector validationResultCollector) {
+
     final Stream<MessageEventDefinition> boundaryEvents =
-        ModelUtil.getActivityMessageBoundaryEvents(element);
+        ModelUtil.getBoundaryEvents(element, MessageEventDefinition.class);
     final List<String> duplicateMessageNames = ModelUtil.getDuplicateMessageNames(boundaryEvents);
 
     duplicateMessageNames.forEach(
@@ -44,5 +58,27 @@ public class ActivityValidator implements ModelElementValidator<Activity> {
                 String.format(
                     "Multiple message boundary events with the same name '%s' are not allowed.",
                     name)));
+  }
+
+  private void verifyNoDuplicatedErrorCodes(
+      final Activity element, final ValidationResultCollector validationResultCollector) {
+
+    final Map<String, Long> presenceByErrorCode =
+        ModelUtil.getBoundaryEvents(element, ErrorEventDefinition.class)
+            .filter(e -> e.getError() != null)
+            .map(ErrorEventDefinition::getError)
+            .filter(error -> error.getErrorCode() != null && !error.getErrorCode().isEmpty())
+            .collect(groupingBy(Error::getErrorCode, counting()));
+
+    presenceByErrorCode.entrySet().stream()
+        .filter(e -> e.getValue() > 1)
+        .map(Entry::getKey)
+        .forEach(
+            errorCode ->
+                validationResultCollector.addError(
+                    0,
+                    String.format(
+                        "Multiple error boundary events with the same errorCode '%s' are not allowed.",
+                        errorCode)));
   }
 }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/BoundaryEventValidator.java
@@ -16,6 +16,7 @@
 package io.zeebe.model.bpmn.validation.zeebe;
 
 import io.zeebe.model.bpmn.instance.BoundaryEvent;
+import io.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.zeebe.model.bpmn.instance.EventDefinition;
 import io.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.zeebe.model.bpmn.instance.TimerEventDefinition;
@@ -72,6 +73,8 @@ public class BoundaryEventValidator implements ModelElementValidator<BoundaryEve
       } else {
         return SupportLevel.All;
       }
+    } else if (eventDefinition instanceof ErrorEventDefinition) {
+      return SupportLevel.Interrupting;
     } else {
       return SupportLevel.None;
     }
@@ -83,7 +86,8 @@ public class BoundaryEventValidator implements ModelElementValidator<BoundaryEve
       final SupportLevel supportLevel) {
     switch (supportLevel) {
       case None:
-        validationResultCollector.addError(0, "Boundary events must be one of: timer, message");
+        validationResultCollector.addError(
+            0, "Boundary events must be one of: timer, message, error");
         break;
       case Interrupting:
         if (!element.cancelActivity()) {

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ErrorEventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ErrorEventDefinitionValidator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.validation.zeebe;
+
+import io.zeebe.model.bpmn.instance.Error;
+import io.zeebe.model.bpmn.instance.ErrorEventDefinition;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ErrorEventDefinitionValidator implements ModelElementValidator<ErrorEventDefinition> {
+
+  @Override
+  public Class<ErrorEventDefinition> getElementType() {
+    return ErrorEventDefinition.class;
+  }
+
+  @Override
+  public void validate(
+      final ErrorEventDefinition element,
+      final ValidationResultCollector validationResultCollector) {
+
+    final Error error = element.getError();
+    if (error == null) {
+      validationResultCollector.addError(0, "Must reference an error");
+
+    } else {
+      final String errorCode = error.getErrorCode();
+      if (errorCode == null || errorCode.isEmpty()) {
+        validationResultCollector.addError(0, "ErrorCode must be present and not empty");
+      }
+    }
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
@@ -15,13 +15,25 @@
  */
 package io.zeebe.model.bpmn.validation.zeebe;
 
+import io.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.zeebe.model.bpmn.instance.EventDefinition;
 import io.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.zeebe.model.bpmn.instance.TimerEventDefinition;
+import java.util.HashSet;
+import java.util.Set;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
 public class EventDefinitionValidator implements ModelElementValidator<EventDefinition> {
+
+  private static final Set<Class<? extends EventDefinition>> SUPPORTED_EVENT_DEFINITIONS;
+
+  static {
+    SUPPORTED_EVENT_DEFINITIONS = new HashSet<>();
+    SUPPORTED_EVENT_DEFINITIONS.add(MessageEventDefinition.class);
+    SUPPORTED_EVENT_DEFINITIONS.add(TimerEventDefinition.class);
+    SUPPORTED_EVENT_DEFINITIONS.add(ErrorEventDefinition.class);
+  }
 
   @Override
   public Class<EventDefinition> getElementType() {
@@ -31,7 +43,9 @@ public class EventDefinitionValidator implements ModelElementValidator<EventDefi
   @Override
   public void validate(
       final EventDefinition element, final ValidationResultCollector validationResultCollector) {
-    if (!(element instanceof MessageEventDefinition || element instanceof TimerEventDefinition)) {
+
+    final Class<?> elementType = element.getElementType().getInstanceType();
+    if (!SUPPORTED_EVENT_DEFINITIONS.contains(elementType)) {
       validationResultCollector.addError(0, "Event definition of this type is not supported");
     }
   }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ReceiveTaskValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ReceiveTaskValidator.java
@@ -39,7 +39,7 @@ public class ReceiveTaskValidator implements ModelElementValidator<ReceiveTask> 
     }
 
     final Stream<String> messageNames =
-        ModelUtil.getActivityMessageBoundaryEvents(element)
+        ModelUtil.getBoundaryEvents(element, MessageEventDefinition.class)
             .map(MessageEventDefinition::getMessage)
             .filter(m -> m.getName() != null && !m.getName().isEmpty())
             .map(Message::getName);

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -44,6 +44,7 @@ public final class ZeebeDesignTimeValidators {
     validators.add(new EndEventValidator());
     validators.add(new EventDefinitionValidator());
     validators.add(new EventBasedGatewayValidator());
+    validators.add(new ErrorEventDefinitionValidator());
     validators.add(new ExclusiveGatewayValidator());
     validators.add(new FlowElementValidator());
     validators.add(new FlowNodeValidator());

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeBoundaryEventValidationTest.java
@@ -39,7 +39,7 @@ public class ZeebeBoundaryEventValidationTest extends AbstractZeebeValidationTes
             .done(),
         Arrays.asList(
             expect(SignalEventDefinition.class, "Event definition of this type is not supported"),
-            expect("boundary", "Boundary events must be one of: timer, message"))
+            expect("boundary", "Boundary events must be one of: timer, message, error"))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeErrorEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeErrorEventValidationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.validation;
+
+import static io.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+import static java.util.Collections.singletonList;
+
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.instance.BoundaryEvent;
+import io.zeebe.model.bpmn.instance.ErrorEventDefinition;
+import io.zeebe.model.bpmn.instance.ServiceTask;
+import io.zeebe.model.bpmn.instance.SubProcess;
+import org.junit.runners.Parameterized.Parameters;
+
+public class ZeebeErrorEventValidationTest extends AbstractZeebeValidationTest {
+
+  @Parameters(name = "{index}: {1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeTaskType("type"))
+            .boundaryEvent("catch", b -> b.error(""))
+            .endEvent()
+            .done(),
+        singletonList(expect(ErrorEventDefinition.class, "ErrorCode must be present and not empty"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeTaskType("type"))
+            .boundaryEvent("catch", b -> b.errorEventDefinition())
+            .endEvent()
+            .done(),
+        singletonList(expect(ErrorEventDefinition.class, "Must reference an error"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeTaskType("type"))
+            .boundaryEvent("catch", b -> b.error("ERROR").cancelActivity(false))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(BoundaryEvent.class, "Non-interrupting events of this type are not supported"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeTaskType("type"))
+            .boundaryEvent("catch-1", b -> b.error("ERROR").endEvent())
+            .moveToActivity("task")
+            .boundaryEvent("catch-2", b -> b.error("ERROR").endEvent())
+            .done(),
+        singletonList(
+            expect(
+                ServiceTask.class,
+                "Multiple error boundary events with the same errorCode 'ERROR' are not allowed."))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .subProcess("sub", s -> s.embeddedSubProcess().startEvent().endEvent())
+            .boundaryEvent("catch-1", b -> b.error("ERROR").endEvent())
+            .moveToActivity("sub")
+            .boundaryEvent("catch-2", b -> b.error("ERROR").endEvent())
+            .done(),
+        singletonList(
+            expect(
+                SubProcess.class,
+                "Multiple error boundary events with the same errorCode 'ERROR' are not allowed."))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .subProcess(
+                "sub",
+                s ->
+                    s.embeddedSubProcess()
+                        .startEvent()
+                        .serviceTask("task", t -> t.zeebeTaskType("type"))
+                        .boundaryEvent("catch", b -> b.error(""))
+                        .endEvent())
+            .done(),
+        singletonList(expect(ErrorEventDefinition.class, "ErrorCode must be present and not empty"))
+      },
+    };
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/metrics/JobMetrics.java
+++ b/engine/src/main/java/io/zeebe/engine/metrics/JobMetrics.java
@@ -31,7 +31,7 @@ public class JobMetrics {
   private final String partitionIdLabel;
 
   public JobMetrics(final int partitionId) {
-    this.partitionIdLabel = String.valueOf(partitionId);
+    partitionIdLabel = String.valueOf(partitionId);
   }
 
   private void jobEvent(final String action, final String type) {
@@ -66,6 +66,11 @@ public class JobMetrics {
 
   public void jobCanceled(final String type) {
     jobEvent("canceled", type);
+    jobFinished(type);
+  }
+
+  public void jobErrorThrown(final String type) {
+    jobEvent("error thrown", type);
     jobFinished(type);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableCatchEventElement.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableCatchEventElement.java
@@ -19,6 +19,7 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
 
   private ExecutableMessage message;
   private Timer timer;
+  private ExecutableError error;
   private boolean interrupting;
 
   public ExecutableCatchEventElement(final String id) {
@@ -33,6 +34,11 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
   @Override
   public boolean isMessage() {
     return message != null;
+  }
+
+  @Override
+  public boolean isError() {
+    return error != null;
   }
 
   @Override
@@ -51,6 +57,15 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
 
   public void setTimer(final Timer timer) {
     this.timer = timer;
+  }
+
+  @Override
+  public ExecutableError getError() {
+    return error;
+  }
+
+  public void setError(final ExecutableError error) {
+    this.error = error;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableError.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableError.java
@@ -7,27 +7,22 @@
  */
 package io.zeebe.engine.processor.workflow.deployment.model.element;
 
-import io.zeebe.model.bpmn.util.time.Timer;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
-public interface ExecutableCatchEvent extends ExecutableFlowElement {
+public class ExecutableError extends AbstractFlowElement {
 
-  boolean isTimer();
+  private final DirectBuffer errorCode = new UnsafeBuffer();
 
-  boolean isMessage();
-
-  boolean isError();
-
-  default boolean isNone() {
-    return !isTimer() && !isMessage() && !isError();
+  public ExecutableError(final String id) {
+    super(id);
   }
 
-  ExecutableMessage getMessage();
-
-  default boolean shouldCloseMessageSubscriptionOnCorrelate() {
-    return true;
+  public DirectBuffer getErrorCode() {
+    return errorCode;
   }
 
-  Timer getTimer();
-
-  ExecutableError getError();
+  public void setErrorCode(final DirectBuffer errorCode) {
+    this.errorCode.wrap(errorCode);
+  }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableReceiveTask.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableReceiveTask.java
@@ -17,7 +17,7 @@ public class ExecutableReceiveTask extends ExecutableActivity implements Executa
     super(id);
 
     getEvents().add(this);
-    getInterruptingElementIds().add(this.getId());
+    getInterruptingElementIds().add(getId());
   }
 
   @Override
@@ -31,12 +31,22 @@ public class ExecutableReceiveTask extends ExecutableActivity implements Executa
   }
 
   @Override
+  public boolean isError() {
+    return false;
+  }
+
+  @Override
   public ExecutableMessage getMessage() {
     return message;
   }
 
   @Override
   public RepeatingInterval getTimer() {
+    return null;
+  }
+
+  @Override
+  public ExecutableError getError() {
     return null;
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableWorkflow.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableWorkflow.java
@@ -7,7 +7,9 @@
  */
 package io.zeebe.engine.processor.workflow.deployment.model.element;
 
-import io.zeebe.util.buffer.BufferUtil;
+import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+
 import java.util.HashMap;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -33,8 +35,12 @@ public class ExecutableWorkflow extends ExecutableFlowElementContainer {
   /** convenience function for transformation */
   public <T extends ExecutableFlowElement> T getElementById(
       final String id, final Class<T> expectedType) {
-    final DirectBuffer buffer = BufferUtil.wrapString(id);
-    final ExecutableFlowElement element = flowElements.get(buffer);
+    return getElementById(wrapString(id), expectedType);
+  }
+
+  public <T extends ExecutableFlowElement> T getElementById(
+      final DirectBuffer id, final Class<T> expectedType) {
+    final ExecutableFlowElement element = flowElements.get(id);
     if (element == null) {
       return null;
     }
@@ -45,7 +51,9 @@ public class ExecutableWorkflow extends ExecutableFlowElementContainer {
       throw new RuntimeException(
           String.format(
               "Expected element with id '%s' to be instance of class '%s', but it is an instance of '%s'",
-              id, expectedType.getSimpleName(), element.getClass().getSimpleName()));
+              bufferAsString(id),
+              expectedType.getSimpleName(),
+              element.getClass().getSimpleName()));
     }
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformation/BpmnTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformation/BpmnTransformer.java
@@ -14,6 +14,7 @@ import io.zeebe.engine.processor.workflow.deployment.model.transformer.CallActiv
 import io.zeebe.engine.processor.workflow.deployment.model.transformer.CatchEventTransformer;
 import io.zeebe.engine.processor.workflow.deployment.model.transformer.ContextProcessTransformer;
 import io.zeebe.engine.processor.workflow.deployment.model.transformer.EndEventTransformer;
+import io.zeebe.engine.processor.workflow.deployment.model.transformer.ErrorTransformer;
 import io.zeebe.engine.processor.workflow.deployment.model.transformer.EventBasedGatewayTransformer;
 import io.zeebe.engine.processor.workflow.deployment.model.transformer.ExclusiveGatewayTransformer;
 import io.zeebe.engine.processor.workflow.deployment.model.transformer.FlowElementInstantiationTransformer;
@@ -59,6 +60,7 @@ public class BpmnTransformer {
 
   public BpmnTransformer() {
     step1Visitor = new TransformationVisitor();
+    step1Visitor.registerHandler(new ErrorTransformer());
     step1Visitor.registerHandler(new FlowElementInstantiationTransformer());
     step1Visitor.registerHandler(new MessageTransformer());
     step1Visitor.registerHandler(new ProcessTransformer());

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformation/TransformContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformation/TransformContext.java
@@ -7,10 +7,12 @@
  */
 package io.zeebe.engine.processor.workflow.deployment.model.transformation;
 
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableError;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableMessage;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableWorkflow;
 import io.zeebe.msgpack.jsonpath.JsonPathQueryCompiler;
-import io.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -21,6 +23,8 @@ public class TransformContext {
 
   private final Map<DirectBuffer, ExecutableWorkflow> workflows = new HashMap<>();
   private final Map<DirectBuffer, ExecutableMessage> messages = new HashMap<>();
+  private final Map<DirectBuffer, ExecutableError> errors = new HashMap<>();
+
   private JsonPathQueryCompiler jsonPathQueryCompiler;
 
   /*
@@ -41,7 +45,7 @@ public class TransformContext {
   }
 
   public ExecutableWorkflow getWorkflow(final String id) {
-    return workflows.get(BufferUtil.wrapString(id));
+    return workflows.get(wrapString(id));
   }
 
   public List<ExecutableWorkflow> getWorkflows() {
@@ -53,7 +57,15 @@ public class TransformContext {
   }
 
   public ExecutableMessage getMessage(final String id) {
-    return messages.get(BufferUtil.wrapString(id));
+    return messages.get(wrapString(id));
+  }
+
+  public void addError(final ExecutableError error) {
+    errors.put(error.getId(), error);
+  }
+
+  public ExecutableError getError(final String id) {
+    return errors.get(wrapString(id));
   }
 
   public JsonPathQueryCompiler getJsonPathQueryCompiler() {

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/CatchEventTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/CatchEventTransformer.java
@@ -14,6 +14,7 @@ import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableWor
 import io.zeebe.engine.processor.workflow.deployment.model.transformation.ModelElementTransformer;
 import io.zeebe.engine.processor.workflow.deployment.model.transformation.TransformContext;
 import io.zeebe.model.bpmn.instance.CatchEvent;
+import io.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.zeebe.model.bpmn.instance.EventDefinition;
 import io.zeebe.model.bpmn.instance.Message;
 import io.zeebe.model.bpmn.instance.MessageEventDefinition;
@@ -52,8 +53,13 @@ public class CatchEventTransformer implements ModelElementTransformer<CatchEvent
     if (eventDefinition instanceof MessageEventDefinition) {
       transformMessageEventDefinition(
           context, executableElement, (MessageEventDefinition) eventDefinition);
+
     } else if (eventDefinition instanceof TimerEventDefinition) {
       transformTimerEventDefinition(executableElement, (TimerEventDefinition) eventDefinition);
+
+    } else if (eventDefinition instanceof ErrorEventDefinition) {
+      transformErrorEventDefinition(
+          context, executableElement, (ErrorEventDefinition) eventDefinition);
     }
   }
 
@@ -84,5 +90,15 @@ public class CatchEventTransformer implements ModelElementTransformer<CatchEvent
     }
 
     executableElement.setTimer(timer);
+  }
+
+  private void transformErrorEventDefinition(
+      final TransformContext context,
+      final ExecutableCatchEventElement executableElement,
+      final ErrorEventDefinition errorEventDefinition) {
+
+    final var error = errorEventDefinition.getError();
+    final var executableError = context.getError(error.getId());
+    executableElement.setError(executableError);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/ErrorTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/ErrorTransformer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.deployment.model.transformer;
+
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableError;
+import io.zeebe.engine.processor.workflow.deployment.model.transformation.ModelElementTransformer;
+import io.zeebe.engine.processor.workflow.deployment.model.transformation.TransformContext;
+import io.zeebe.model.bpmn.instance.Error;
+
+public class ErrorTransformer implements ModelElementTransformer<Error> {
+
+  @Override
+  public Class<Error> getType() {
+    return Error.class;
+  }
+
+  @Override
+  public void transform(final Error element, final TransformContext context) {
+
+    final var error = new ExecutableError(element.getId());
+    error.setErrorCode(wrapString(element.getErrorCode()));
+
+    context.addError(error);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobErrorThrownProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobErrorThrownProcessor.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.job;
+
+import io.zeebe.engine.processor.KeyGenerator;
+import io.zeebe.engine.processor.TypedRecord;
+import io.zeebe.engine.processor.TypedRecordProcessor;
+import io.zeebe.engine.processor.TypedResponseWriter;
+import io.zeebe.engine.processor.TypedStreamWriter;
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableActivity;
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableBoundaryEvent;
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableWorkflow;
+import io.zeebe.engine.state.deployment.WorkflowState;
+import io.zeebe.engine.state.instance.ElementInstance;
+import io.zeebe.engine.state.instance.ElementInstanceState;
+import io.zeebe.engine.state.instance.EventScopeInstanceState;
+import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public class JobErrorThrownProcessor implements TypedRecordProcessor<JobRecord> {
+
+  private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
+
+  private final WorkflowState workflowState;
+  private final KeyGenerator keyGenerator;
+
+  private final CatchEventTuple catchEventTuple = new CatchEventTuple();
+  private final ElementInstanceState elementInstanceState;
+  private final EventScopeInstanceState eventScopeInstanceState;
+
+  public JobErrorThrownProcessor(
+      final WorkflowState workflowState, final KeyGenerator keyGenerator) {
+    this.keyGenerator = keyGenerator;
+    this.workflowState = workflowState;
+    elementInstanceState = workflowState.getElementInstanceState();
+    eventScopeInstanceState = workflowState.getEventScopeInstanceState();
+  }
+
+  @Override
+  public void processRecord(
+      final TypedRecord<JobRecord> record,
+      final TypedResponseWriter responseWriter,
+      final TypedStreamWriter streamWriter) {
+
+    final var job = record.getValue();
+    final var serviceTaskInstanceKey = job.getElementInstanceKey();
+    final var serviceTaskInstance = elementInstanceState.getInstance(serviceTaskInstanceKey);
+
+    if (serviceTaskInstance != null && serviceTaskInstance.isActive()) {
+
+      final var errorCode = job.getErrorCodeBuffer();
+      final var workflow = getWorkflow(job.getWorkflowKey());
+
+      final var foundCatchEvent = findCatchEvent(workflow, serviceTaskInstance, errorCode);
+      if (foundCatchEvent != null) {
+
+        triggerBoundaryEvent(streamWriter, foundCatchEvent.instance, foundCatchEvent.boundaryEvent);
+      }
+
+      // remove job reference to not cancel it while terminating the task
+      serviceTaskInstance.setJobKey(-1L);
+      elementInstanceState.updateInstance(serviceTaskInstance);
+    }
+  }
+
+  private ExecutableWorkflow getWorkflow(final long workflowKey) {
+
+    final var deployedWorkflow = workflowState.getWorkflowByKey(workflowKey);
+    if (deployedWorkflow == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected workflow with key '%d' to be deployed but not found", workflowKey));
+    }
+
+    return deployedWorkflow.getWorkflow();
+  }
+
+  private CatchEventTuple findCatchEvent(
+      final ExecutableWorkflow workflow,
+      final ElementInstance instance,
+      final DirectBuffer errorCode) {
+
+    // assuming that error events are used rarely
+    // - just walk through the scope hierarchy and look for a matching boundary event
+    final var elementId = instance.getValue().getElementIdBuffer();
+    final var activity = workflow.getElementById(elementId, ExecutableActivity.class);
+
+    for (final ExecutableBoundaryEvent boundaryEvent : activity.getBoundaryEvents()) {
+      if (hasErrorCode(boundaryEvent, errorCode)) {
+
+        catchEventTuple.instance = instance;
+        catchEventTuple.boundaryEvent = boundaryEvent;
+        return catchEventTuple;
+      }
+    }
+
+    // find catch event in parent scopes
+    final var instanceParentKey = instance.getParentKey();
+    if (instanceParentKey > 0) {
+      final var parentInstance = elementInstanceState.getInstance(instanceParentKey);
+
+      if (parentInstance != null && parentInstance.isActive()) {
+        return findCatchEvent(workflow, parentInstance, errorCode);
+      }
+    }
+
+    // no matching catch event found
+    return null;
+  }
+
+  private boolean hasErrorCode(
+      final ExecutableBoundaryEvent boundaryEvent, final DirectBuffer errorCode) {
+    return boundaryEvent.isError() && boundaryEvent.getError().getErrorCode().equals(errorCode);
+  }
+
+  private void triggerBoundaryEvent(
+      final TypedStreamWriter streamWriter,
+      final ElementInstance eventScopeInstance,
+      final ExecutableBoundaryEvent boundaryEvent) {
+
+    final var newElementInstanceKey = keyGenerator.nextKey();
+    eventScopeInstanceState.triggerEvent(
+        eventScopeInstance.getKey(), newElementInstanceKey, boundaryEvent.getId(), NO_VARIABLES);
+
+    streamWriter.appendFollowUpEvent(
+        eventScopeInstance.getKey(),
+        WorkflowInstanceIntent.EVENT_OCCURRED,
+        eventScopeInstance.getValue());
+  }
+
+  private static class CatchEventTuple {
+    private ExecutableBoundaryEvent boundaryEvent;
+    private ElementInstance instance;
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobEventProcessors.java
@@ -11,8 +11,6 @@ import io.zeebe.engine.processor.ReadonlyProcessingContext;
 import io.zeebe.engine.processor.StreamProcessorLifecycleAware;
 import io.zeebe.engine.processor.TypedRecordProcessors;
 import io.zeebe.engine.state.ZeebeState;
-import io.zeebe.engine.state.deployment.WorkflowState;
-import io.zeebe.engine.state.instance.JobState;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.JobBatchIntent;
 import io.zeebe.protocol.record.intent.JobIntent;
@@ -24,8 +22,10 @@ public class JobEventProcessors {
       final ZeebeState zeebeState,
       final Consumer<String> onJobsAvailableCallback,
       final int maxRecordSize) {
-    final WorkflowState workflowState = zeebeState.getWorkflowState();
-    final JobState jobState = zeebeState.getJobState();
+
+    final var workflowState = zeebeState.getWorkflowState();
+    final var jobState = zeebeState.getJobState();
+    final var keyGenerator = zeebeState.getKeyGenerator();
 
     typedRecordProcessors
         .onEvent(ValueType.JOB, JobIntent.CREATED, new JobCreatedProcessor(workflowState))
@@ -34,6 +34,11 @@ public class JobEventProcessors {
         .onCommand(ValueType.JOB, JobIntent.COMPLETE, new CompleteProcessor(jobState))
         .onCommand(ValueType.JOB, JobIntent.FAIL, new FailProcessor(jobState))
         .onEvent(ValueType.JOB, JobIntent.FAILED, new JobFailedProcessor())
+        .onCommand(ValueType.JOB, JobIntent.THROW_ERROR, new JobThrowErrorProcessor(jobState))
+        .onEvent(
+            ValueType.JOB,
+            JobIntent.ERROR_THROWN,
+            new JobErrorThrownProcessor(workflowState, keyGenerator))
         .onCommand(ValueType.JOB, JobIntent.TIME_OUT, new TimeOutProcessor(jobState))
         .onCommand(ValueType.JOB, JobIntent.UPDATE_RETRIES, new UpdateRetriesProcessor(jobState))
         .onCommand(ValueType.JOB, JobIntent.CANCEL, new CancelProcessor(jobState))
@@ -43,7 +48,7 @@ public class JobEventProcessors {
             new JobBatchActivateProcessor(
                 jobState,
                 workflowState.getElementInstanceState().getVariablesState(),
-                zeebeState.getKeyGenerator(),
+                keyGenerator,
                 maxRecordSize))
         .withListener(new JobTimeoutTrigger(jobState))
         .withListener(

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobThrowErrorProcessor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.job;
+
+import io.zeebe.engine.processor.CommandProcessor;
+import io.zeebe.engine.processor.TypedRecord;
+import io.zeebe.engine.state.instance.JobState;
+import io.zeebe.engine.state.instance.JobState.State;
+import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.record.RejectionType;
+import io.zeebe.protocol.record.intent.JobIntent;
+
+public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
+
+  private static final String NO_JOB_FOUND_MESSAGE =
+      "Expected to throw an error for job with key '%d', but no such job was found";
+  private static final String FAILED_JOB_MESSAGE =
+      "Expected to throw an error for job with key '%d', but the job is marked as failed";
+
+  private final JobState state;
+
+  public JobThrowErrorProcessor(final JobState state) {
+    this.state = state;
+  }
+
+  @Override
+  public boolean onCommand(
+      final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
+    final long jobKey = command.getKey();
+    final State jobState = state.getState(jobKey);
+
+    if (jobState == State.NOT_FOUND) {
+      commandControl.reject(RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, jobKey));
+    } else if (jobState == State.FAILED) {
+      commandControl.reject(RejectionType.INVALID_STATE, String.format(FAILED_JOB_MESSAGE, jobKey));
+    } else {
+      final JobRecord job = state.getJob(jobKey);
+      job.setErrorCode(command.getValue().getErrorCodeBuffer());
+      job.setErrorMessage(command.getValue().getErrorMessageBuffer());
+      state.throwError(jobKey, job);
+
+      commandControl.accept(JobIntent.ERROR_THROWN, job);
+    }
+    return true;
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
@@ -144,6 +144,11 @@ public class JobState {
     metrics.jobCanceled(record.getType());
   }
 
+  public void throwError(final long key, final JobRecord record) {
+    delete(key, record);
+    metrics.jobErrorThrown(record.getType());
+  }
+
   private void delete(final long key, final JobRecord record) {
     final DirectBuffer type = record.getTypeBuffer();
     final long deadline = record.getDeadline();
@@ -320,7 +325,7 @@ public class JobState {
     FAILED((byte) 2),
     NOT_FOUND((byte) 3);
 
-    final byte value;
+    byte value;
 
     State(final byte value) {
       this.value = value;

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/error/ErrorBoundaryEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/error/ErrorBoundaryEventTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.builder.ServiceTaskBuilder;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ErrorBoundaryEventTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "wf";
+  private static final String JOB_TYPE = "test";
+  private static final String ERROR_CODE = "ERROR";
+
+  private static final BpmnModelInstance SINGLE_BOUNDARY_EVENT =
+      workflow(
+          serviceTask -> serviceTask.boundaryEvent("error", b -> b.error(ERROR_CODE)).endEvent());
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private static BpmnModelInstance workflow(final Consumer<ServiceTaskBuilder> customizer) {
+    final var builder =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeTaskType(JOB_TYPE));
+
+    customizer.accept(builder);
+
+    return builder.endEvent().done();
+  }
+
+  @Test
+  public void shouldTriggerBoundaryEventOnServiceTask() {
+    // given
+    ENGINE.deployment().withXmlResource(SINGLE_BOUNDARY_EVENT).deploy();
+
+    final var workflowInstanceKey = ENGINE.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(workflowInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .throwError();
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .limitToWorkflowInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSequence(
+            tuple(BpmnElementType.SERVICE_TASK, WorkflowInstanceIntent.EVENT_OCCURRED),
+            tuple(BpmnElementType.SERVICE_TASK, WorkflowInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SERVICE_TASK, WorkflowInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, WorkflowInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.BOUNDARY_EVENT, WorkflowInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, WorkflowInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.BOUNDARY_EVENT, WorkflowInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldTriggerBoundaryEventOnSubprocess() {
+    // given
+    final var workflow =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "sub",
+                s ->
+                    s.embeddedSubProcess()
+                        .startEvent()
+                        .serviceTask("task", t -> t.zeebeTaskType(JOB_TYPE))
+                        .endEvent())
+            .boundaryEvent("error", b -> b.error(ERROR_CODE))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(workflow).deploy();
+
+    final var workflowInstanceKey = ENGINE.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(workflowInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .throwError();
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .limitToWorkflowInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSequence(
+            tuple(BpmnElementType.SUB_PROCESS, WorkflowInstanceIntent.EVENT_OCCURRED),
+            tuple(BpmnElementType.SUB_PROCESS, WorkflowInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SERVICE_TASK, WorkflowInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SERVICE_TASK, WorkflowInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.SUB_PROCESS, WorkflowInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, WorkflowInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.BOUNDARY_EVENT, WorkflowInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, WorkflowInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.BOUNDARY_EVENT, WorkflowInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldNotCancelJob() {
+    // given
+    ENGINE.deployment().withXmlResource(SINGLE_BOUNDARY_EVENT).deploy();
+
+    final var workflowInstanceKey = ENGINE.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(workflowInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .throwError();
+
+    // then
+    assertThat(
+            RecordingExporter.records().limitToWorkflowInstance(workflowInstanceKey).jobRecords())
+        .extracting(Record::getIntent)
+        .containsExactly(
+            JobIntent.CREATE, JobIntent.CREATED, JobIntent.THROW_ERROR, JobIntent.ERROR_THROWN);
+  }
+
+  @Test
+  public void shouldCatchErrorByErrorCode() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            workflow(
+                serviceTask -> {
+                  serviceTask.boundaryEvent("error-1", b -> b.error("error-1").endEvent());
+                  serviceTask.boundaryEvent("error-2", b -> b.error("error-2").endEvent());
+                }))
+        .deploy();
+
+    final var workflowInstanceKey1 = ENGINE.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var workflowInstanceKey2 = ENGINE.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(workflowInstanceKey1)
+        .withType(JOB_TYPE)
+        .withErrorCode("error-1")
+        .throwError();
+
+    ENGINE
+        .job()
+        .ofInstance(workflowInstanceKey2)
+        .withType(JOB_TYPE)
+        .withErrorCode("error-2")
+        .throwError();
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey1)
+                .limitToWorkflowInstanceCompleted()
+                .withElementType(BpmnElementType.BOUNDARY_EVENT))
+        .extracting(r -> r.getValue().getElementId())
+        .containsOnly("error-1");
+
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey2)
+                .limitToWorkflowInstanceCompleted()
+                .withElementType(BpmnElementType.BOUNDARY_EVENT))
+        .extracting(r -> r.getValue().getElementId())
+        .containsOnly("error-2");
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/client/JobClient.java
+++ b/engine/src/test/java/io/zeebe/engine/util/client/JobClient.java
@@ -7,6 +7,8 @@
  */
 package io.zeebe.engine.util.client;
 
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+
 import io.zeebe.engine.util.StreamProcessorRule;
 import io.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -90,6 +92,11 @@ public class JobClient {
     return this;
   }
 
+  public JobClient withErrorCode(final String errorCode) {
+    jobRecord.setErrorCode(wrapString(errorCode));
+    return this;
+  }
+
   public JobClient expectRejection() {
     expectation = REJECTION_SUPPLIER;
     return this;
@@ -126,6 +133,13 @@ public class JobClient {
   public Record<JobRecordValue> updateRetries() {
     final long jobKey = findJobKey();
     final long position = environmentRule.writeCommand(jobKey, JobIntent.UPDATE_RETRIES, jobRecord);
+    return expectation.apply(position);
+  }
+
+  public Record<JobRecordValue> throwError() {
+    final long jobKey = findJobKey();
+    final long position = environmentRule.writeCommand(jobKey, JobIntent.THROW_ERROR, jobRecord);
+
     return expectation.apply(position);
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -70,6 +70,9 @@
                 },
                 "errorMessage": {
                   "type": "text"
+                },
+                "errorCode": {
+                  "type": "text"
                 }
               }
             },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -54,6 +54,9 @@
             },
             "errorMessage": {
               "type": "text"
+            },
+            "errorCode": {
+              "type": "text"
             }
           }
         }

--- a/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -284,6 +284,7 @@ public class JsonSerializableToJsonTest {
                   .setVariables(VARIABLES_MSGPACK)
                   .setRetries(3)
                   .setErrorMessage("failed message")
+                  .setErrorCode(wrapString("error"))
                   .setDeadline(1000L)
                   .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setWorkflowKey(workflowKey)
@@ -294,7 +295,7 @@ public class JsonSerializableToJsonTest {
 
               return record;
             },
-        "{'maxJobsToActivate':1,'type':'type','worker':'worker','truncated':true,'jobKeys':[3],'jobs':[{'bpmnProcessId':'test-process','workflowKey':13,'workflowDefinitionVersion':12,'workflowInstanceKey':1234,'elementId':'activity','elementInstanceKey':123,'type':'type','worker':'worker','variables':{'foo':'bar'},'retries':3,'errorMessage':'failed message','customHeaders':{},'deadline':1000}],'timeout':2}"
+        "{'maxJobsToActivate':1,'type':'type','worker':'worker','truncated':true,'jobKeys':[3],'jobs':[{'bpmnProcessId':'test-process','workflowKey':13,'workflowDefinitionVersion':12,'workflowInstanceKey':1234,'elementId':'activity','elementInstanceKey':123,'type':'type','worker':'worker','variables':{'foo':'bar'},'retries':3,'errorMessage':'failed message','errorCode':'error','customHeaders':{},'deadline':1000}],'timeout':2}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////// Empty JobBatchRecord //////////////////////////////////////
@@ -338,6 +339,7 @@ public class JsonSerializableToJsonTest {
                       .setRetries(retries)
                       .setDeadline(deadline)
                       .setErrorMessage("failed message")
+                      .setErrorCode(wrapString("error"))
                       .setBpmnProcessId(wrapString(bpmnProcessId))
                       .setWorkflowKey(workflowKey)
                       .setWorkflowDefinitionVersion(workflowDefinitionVersion)
@@ -348,7 +350,7 @@ public class JsonSerializableToJsonTest {
               record.setCustomHeaders(wrapArray(MsgPackConverter.convertToMsgPack(customHeaders)));
               return record;
             },
-        "{'bpmnProcessId':'test-process','workflowKey':13,'workflowDefinitionVersion':12,'workflowInstanceKey':1234,'elementId':'activity','elementInstanceKey':123,'worker':'myWorker','type':'myType','variables':{'foo':'bar'},'retries':12,'errorMessage':'failed message','customHeaders':{'workerVersion':'42'},'deadline':13}"
+        "{'bpmnProcessId':'test-process','workflowKey':13,'workflowDefinitionVersion':12,'workflowInstanceKey':1234,'elementId':'activity','elementInstanceKey':123,'worker':'myWorker','type':'myType','variables':{'foo':'bar'},'retries':12,'errorMessage':'failed message','errorCode':'error','customHeaders':{'workerVersion':'42'},'deadline':13}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -357,7 +359,7 @@ public class JsonSerializableToJsonTest {
       {
         "Empty JobRecord",
         (Supplier<UnifiedRecordValue>) JobRecord::new,
-        "{'type':'','workflowDefinitionVersion':-1,'elementId':'','bpmnProcessId':'','workflowKey':-1,'workflowInstanceKey':-1,'elementInstanceKey':-1,'variables':{},'worker':'','retries':-1,'errorMessage':'','customHeaders':{},'deadline':-1}"
+        "{'type':'','workflowDefinitionVersion':-1,'elementId':'','bpmnProcessId':'','workflowKey':-1,'workflowInstanceKey':-1,'elementInstanceKey':-1,'variables':{},'worker':'','retries':-1,'errorMessage':'','errorCode':'','customHeaders':{},'deadline':-1}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////// MessageRecord /////////////////////////////////////////////

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/JobIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/JobIntent.java
@@ -34,7 +34,10 @@ public enum JobIntent implements WorkflowInstanceRelatedIntent {
   RETRIES_UPDATED((short) 10),
 
   CANCEL((short) 11),
-  CANCELED((short) 12);
+  CANCELED((short) 12),
+
+  THROW_ERROR((short) 13, false),
+  ERROR_THROWN((short) 14);
 
   private final short value;
   private final boolean shouldBlacklist;
@@ -80,6 +83,10 @@ public enum JobIntent implements WorkflowInstanceRelatedIntent {
         return CANCEL;
       case 12:
         return CANCELED;
+      case 13:
+        return THROW_ERROR;
+      case 14:
+        return ERROR_THROWN;
       default:
         return UNKNOWN;
     }

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/JobRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/JobRecordValue.java
@@ -46,8 +46,17 @@ public interface JobRecordValue extends RecordValueWithVariables, WorkflowInstan
    */
   long getDeadline();
 
-  /** @return the job worker error message if the job is failed */
+  /**
+   * @return the message that contains additional context of the failure/error. It is set by the job
+   *     worker then the processing fails because of a technical failure or a non-technical error.
+   */
   String getErrorMessage();
+
+  /**
+   * @return the error code to identify the business error. It is set by the job worker then the
+   *     processing fails because of a non-technical error that should be handled by the workflow.
+   */
+  String getErrorCode();
 
   /** @return the element id of the corresponding service task */
   String getElementId();

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordStream.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordStream.java
@@ -71,4 +71,9 @@ public class RecordStream extends ExporterRecordStream<RecordValue, RecordStream
     return new VariableRecordStream(
         filter(r -> r.getValueType() == ValueType.VARIABLE).map(Record.class::cast));
   }
+
+  public JobRecordStream jobRecords() {
+    return new JobRecordStream(
+        filter(r -> r.getValueType() == ValueType.JOB).map(Record.class::cast));
+  }
 }


### PR DESCRIPTION
## Description

* deploy workflow with error boundary events
* new job intents: THROW_ERROR, ERROR_THROWN
* accept job throw error command if job is activatable
* trigger error boundary event if error code matches
* update job metrics when an error is thrown

:warning: BREAKING CHANGES :warning: 
* add 'errorCode' property to job and job batch JSON serialization format
* add 'errorCode' to Elasticsearch job and job batch template

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3497 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
