### PR TITLE
feat(clients/go): add timeouts to OAuth requests

### DIFF
--- a/clients/go/pkg/commands/activateJobs_command.go
+++ b/clients/go/pkg/commands/activateJobs_command.go
@@ -92,7 +92,7 @@ func (cmd *ActivateJobsCommand) Send() ([]entities.Job, error) {
 
 	stream, err := cmd.gateway.ActivateJobs(ctx, &cmd.request)
 	if err != nil {
-		if cmd.retryPredicate(err) {
+		if cmd.retryPredicate(ctx, err) {
 			return cmd.Send()
 		}
 		return nil, err
@@ -116,7 +116,7 @@ func (cmd *ActivateJobsCommand) Send() ([]entities.Job, error) {
 	return activatedJobs, nil
 }
 
-func NewActivateJobsCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(error) bool) ActivateJobsCommandStep1 {
+func NewActivateJobsCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) ActivateJobsCommandStep1 {
 	return &ActivateJobsCommand{
 		request: pb.ActivateJobsRequest{
 			Timeout:        DefaultJobTimeoutInMs,

--- a/clients/go/pkg/commands/activateJobs_command_test.go
+++ b/clients/go/pkg/commands/activateJobs_command_test.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/golang/mock/gomock"
 	"github.com/zeebe-io/zeebe/clients/go/internal/mock_pb"
 	"github.com/zeebe-io/zeebe/clients/go/internal/utils"
@@ -112,7 +113,9 @@ func TestActivateJobsCommand(t *testing.T) {
 
 	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
 
-	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(error) bool { return false }).JobType("foo").MaxJobsToActivate(5).Send()
+	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+		return false
+	}).JobType("foo").MaxJobsToActivate(5).Send()
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -147,7 +150,9 @@ func TestActivateJobsCommandWithTimeout(t *testing.T) {
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
 
-	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(error) bool { return false }).JobType("foo").MaxJobsToActivate(5).Timeout(1 * time.Minute).Send()
+	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+		return false
+	}).JobType("foo").MaxJobsToActivate(5).Timeout(1 * time.Minute).Send()
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -176,7 +181,9 @@ func TestActivateJobsCommandWithWorkerName(t *testing.T) {
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
 
-	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(error) bool { return false }).JobType("foo").MaxJobsToActivate(5).WorkerName("bar").Send()
+	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+		return false
+	}).JobType("foo").MaxJobsToActivate(5).WorkerName("bar").Send()
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -208,7 +215,9 @@ func TestActivateJobsCommandWithFetchVariables(t *testing.T) {
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
 
-	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(error) bool { return false }).JobType("foo").MaxJobsToActivate(5).FetchVariables(fetchVariables...).Send()
+	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+		return false
+	}).JobType("foo").MaxJobsToActivate(5).FetchVariables(fetchVariables...).Send()
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/pkg/commands/cancelInstance_command.go
+++ b/clients/go/pkg/commands/cancelInstance_command.go
@@ -38,7 +38,7 @@ func (cmd CancelWorkflowInstanceCommand) Send() (*pb.CancelWorkflowInstanceRespo
 	defer cancel()
 
 	response, err := cmd.gateway.CancelWorkflowInstance(ctx, &cmd.request)
-	if cmd.retryPredicate(err) {
+	if cmd.retryPredicate(ctx, err) {
 		return cmd.Send()
 	}
 
@@ -50,7 +50,7 @@ func (cmd CancelWorkflowInstanceCommand) WorkflowInstanceKey(key int64) Dispatch
 	return cmd
 }
 
-func NewCancelInstanceCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(error) bool) CancelInstanceStep1 {
+func NewCancelInstanceCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) CancelInstanceStep1 {
 	return &CancelWorkflowInstanceCommand{
 		Command: Command{
 			gateway:        gateway,

--- a/clients/go/pkg/commands/cancelInstance_command_test.go
+++ b/clients/go/pkg/commands/cancelInstance_command_test.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/golang/mock/gomock"
 	"github.com/zeebe-io/zeebe/clients/go/internal/mock_pb"
 	"github.com/zeebe-io/zeebe/clients/go/internal/utils"
@@ -35,7 +36,9 @@ func TestCancelWorkflowInstanceCommand(t *testing.T) {
 
 	client.EXPECT().CancelWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCancelInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCancelInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+		return false
+	})
 
 	response, err := command.WorkflowInstanceKey(123).Send()
 

--- a/clients/go/pkg/commands/command.go
+++ b/clients/go/pkg/commands/command.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/zeebe-io/zeebe/clients/go/internal/utils"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/pb"
 	"time"
@@ -25,5 +26,5 @@ type Command struct {
 
 	gateway        pb.GatewayClient
 	requestTimeout time.Duration
-	retryPredicate func(error) bool
+	retryPredicate func(context.Context, error) bool
 }

--- a/clients/go/pkg/commands/completeJob_command.go
+++ b/clients/go/pkg/commands/completeJob_command.go
@@ -93,14 +93,14 @@ func (cmd *CompleteJobCommand) Send() (*pb.CompleteJobResponse, error) {
 	defer cancel()
 
 	response, err := cmd.gateway.CompleteJob(ctx, &cmd.request)
-	if cmd.retryPredicate(err) {
+	if cmd.retryPredicate(ctx, err) {
 		return cmd.Send()
 	}
 
 	return response, err
 }
 
-func NewCompleteJobCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(error) bool) CompleteJobCommandStep1 {
+func NewCompleteJobCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) CompleteJobCommandStep1 {
 	return &CompleteJobCommand{
 		Command: Command{
 			SerializerMixin: utils.NewJsonStringSerializer(),

--- a/clients/go/pkg/commands/completeJob_command_test.go
+++ b/clients/go/pkg/commands/completeJob_command_test.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/golang/mock/gomock"
 	"github.com/zeebe-io/zeebe/clients/go/internal/mock_pb"
 	"github.com/zeebe-io/zeebe/clients/go/internal/utils"
@@ -35,7 +36,9 @@ func TestCompleteJobCommand(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	response, err := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false }).JobKey(123).Send()
+	response, err := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+		return false
+	}).JobKey(123).Send()
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -62,7 +65,7 @@ func TestCompleteJobCommandWithVariablesFromString(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromString(variables)
 	if err != nil {
@@ -96,7 +99,9 @@ func TestCompleteJobCommandWithVariablesFromStringer(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+		return false
+	})
 
 	variablesCommand, err := command.JobKey(123).VariablesFromStringer(DataType{Foo: "bar"})
 	if err != nil {
@@ -130,7 +135,7 @@ func TestCompleteJobCommandWithVariablesFromObject(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
@@ -164,7 +169,7 @@ func TestCompleteJobCommandWithVariablesFromObjectOmitempty(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
@@ -198,7 +203,7 @@ func TestCompleteJobCommandWithVariablesFromObjectIgnoreOmitempty(t *testing.T) 
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
@@ -234,7 +239,7 @@ func TestCompleteJobCommandWithVariablesFromMap(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromMap(variableMaps)
 	if err != nil {

--- a/clients/go/pkg/commands/createInstance_command.go
+++ b/clients/go/pkg/commands/createInstance_command.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/zeebe-io/zeebe/clients/go/internal/utils"
-
 	"github.com/zeebe-io/zeebe/clients/go/pkg/pb"
 	"time"
 )
@@ -160,7 +159,7 @@ func (cmd *CreateInstanceCommand) Send() (*pb.CreateWorkflowInstanceResponse, er
 	defer cancel()
 
 	response, err := cmd.gateway.CreateWorkflowInstance(ctx, &cmd.request)
-	if cmd.retryPredicate(err) {
+	if cmd.retryPredicate(ctx, err) {
 		return cmd.Send()
 	}
 
@@ -173,14 +172,14 @@ func (cmd *CreateInstanceWithResultCommand) Send() (*pb.CreateWorkflowInstanceWi
 	defer cancel()
 
 	response, err := cmd.gateway.CreateWorkflowInstanceWithResult(ctx, &cmd.request)
-	if cmd.retryPredicate(err) {
+	if cmd.retryPredicate(ctx, err) {
 		return cmd.Send()
 	}
 
 	return response, err
 }
 
-func NewCreateInstanceCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(error) bool) CreateInstanceCommandStep1 {
+func NewCreateInstanceCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) CreateInstanceCommandStep1 {
 	return &CreateInstanceCommand{
 		Command: Command{
 			SerializerMixin: utils.NewJsonStringSerializer(),

--- a/clients/go/pkg/commands/createInstance_command_test.go
+++ b/clients/go/pkg/commands/createInstance_command_test.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/zeebe-io/zeebe/clients/go/internal/mock_pb"
@@ -49,7 +50,7 @@ func TestCreateWorkflowInstanceCommand(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.WorkflowKey(123).Send()
 
@@ -81,7 +82,7 @@ func TestCreateWorkflowInstanceCommandByBpmnProcessId(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.BPMNProcessId("foo").LatestVersion().Send()
 
@@ -113,7 +114,7 @@ func TestCreateWorkflowInstanceCommandByBpmnProcessIdAndVersion(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.BPMNProcessId("foo").Version(56).Send()
 
@@ -147,7 +148,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromString(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromString(variables)
 	if err != nil {
@@ -186,7 +187,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromStringer(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromStringer(DataType{Foo: "bar"})
 	if err != nil {
@@ -225,7 +226,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromObject(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
@@ -264,7 +265,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromObjectOmitempty(t *testin
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
@@ -303,7 +304,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromObjectIgnoreOmitempty(t *
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
@@ -344,7 +345,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromMap(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromMap(variablesMap)
 	if err != nil {
@@ -383,7 +384,7 @@ func TestCreateWorkflowInstanceWithResultCommand(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.WorkflowKey(123).WithResult().Send()
 
@@ -419,7 +420,7 @@ func TestCreateWorkflowInstanceWithResultCommandByBpmnProcessId(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.BPMNProcessId("foo").LatestVersion().WithResult().Send()
 
@@ -455,7 +456,7 @@ func TestCreateWorkflowInstanceWithResultCommandByBpmnProcessIdAndVersion(t *tes
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.BPMNProcessId("foo").Version(56).WithResult().Send()
 
@@ -493,7 +494,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromString(t *testi
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromString(variables)
 	if err != nil {
@@ -536,7 +537,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromStringer(t *tes
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromStringer(DataType{Foo: "bar"})
 	if err != nil {
@@ -579,7 +580,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObject(t *testi
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
@@ -622,7 +623,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObjectOmitempty
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
@@ -665,7 +666,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObjectIgnoreOmi
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
@@ -710,7 +711,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromMap(t *testing.
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromMap(variablesMap)
 	if err != nil {
@@ -750,7 +751,7 @@ func TestCreateWorkflowInstanceWithResultAndFetchVariablesCommand(t *testing.T) 
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.WorkflowKey(123).WithResult().FetchVariables("a", "b", "c").Send()
 
@@ -785,7 +786,7 @@ func TestCreateWorkflowInstanceWithResultAndFetchEmptyVariablesListCommand(t *te
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.WorkflowKey(123).WithResult().FetchVariables().Send()
 

--- a/clients/go/pkg/commands/deploy_command.go
+++ b/clients/go/pkg/commands/deploy_command.go
@@ -45,14 +45,14 @@ func (cmd *DeployCommand) Send() (*pb.DeployWorkflowResponse, error) {
 	defer cancel()
 
 	response, err := cmd.gateway.DeployWorkflow(ctx, &cmd.request)
-	if cmd.retryPredicate(err) {
+	if cmd.retryPredicate(ctx, err) {
 		return cmd.Send()
 	}
 
 	return response, err
 }
 
-func NewDeployCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(error) bool) *DeployCommand {
+func NewDeployCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) *DeployCommand {
 	return &DeployCommand{
 		Command: Command{
 			gateway:        gateway,

--- a/clients/go/pkg/commands/deploy_command_test.go
+++ b/clients/go/pkg/commands/deploy_command_test.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/golang/mock/gomock"
 	"github.com/zeebe-io/zeebe/clients/go/internal/mock_pb"
 	"github.com/zeebe-io/zeebe/clients/go/internal/utils"
@@ -59,7 +60,7 @@ func TestDeployCommand_AddResourceFile(t *testing.T) {
 
 	client.EXPECT().DeployWorkflow(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewDeployCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewDeployCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.
 		AddResourceFile(demoName).
@@ -98,7 +99,7 @@ func TestDeployCommand_AddResource(t *testing.T) {
 
 	client.EXPECT().DeployWorkflow(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewDeployCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewDeployCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.
 		AddResource(demoBytes, demoName, pb.WorkflowRequestObject_BPMN).

--- a/clients/go/pkg/commands/failJob_command.go
+++ b/clients/go/pkg/commands/failJob_command.go
@@ -62,10 +62,15 @@ func (cmd *FailJobCommand) Send() (*pb.FailJobResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), cmd.requestTimeout)
 	defer cancel()
 
-	return cmd.gateway.FailJob(ctx, &cmd.request)
+	response, err := cmd.gateway.FailJob(ctx, &cmd.request)
+	if cmd.retryPredicate(ctx, err) {
+		return cmd.Send()
+	}
+
+	return response, err
 }
 
-func NewFailJobCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(error) bool) FailJobCommandStep1 {
+func NewFailJobCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) FailJobCommandStep1 {
 	return &FailJobCommand{
 		Command: Command{gateway: gateway,
 			requestTimeout: requestTimeout,

--- a/clients/go/pkg/commands/failJob_command_test.go
+++ b/clients/go/pkg/commands/failJob_command_test.go
@@ -16,6 +16,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/golang/mock/gomock"
 	"github.com/zeebe-io/zeebe/clients/go/internal/mock_pb"
 	"github.com/zeebe-io/zeebe/clients/go/internal/utils"
@@ -37,7 +38,7 @@ func TestFailJobCommand(t *testing.T) {
 
 	client.EXPECT().FailJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewFailJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewFailJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.JobKey(123).Retries(12).Send()
 
@@ -67,7 +68,7 @@ func TestFailJobCommand_ErrorMessage(t *testing.T) {
 
 	client.EXPECT().FailJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewFailJobCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewFailJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.JobKey(123).Retries(12).ErrorMessage(errorMessage).Send()
 

--- a/clients/go/pkg/commands/publishMessage_command.go
+++ b/clients/go/pkg/commands/publishMessage_command.go
@@ -121,13 +121,13 @@ func (cmd *PublishMessageCommand) Send() (*pb.PublishMessageResponse, error) {
 	defer cancel()
 
 	response, err := cmd.gateway.PublishMessage(ctx, &cmd.request)
-	if cmd.retryPredicate(err) {
+	if cmd.retryPredicate(ctx, err) {
 		return cmd.Send()
 	}
 	return response, err
 }
 
-func NewPublishMessageCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(error) bool) PublishMessageCommandStep1 {
+func NewPublishMessageCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) PublishMessageCommandStep1 {
 	return &PublishMessageCommand{
 		Command: Command{
 			SerializerMixin: utils.NewJsonStringSerializer(),

--- a/clients/go/pkg/commands/publishMessage_command_test.go
+++ b/clients/go/pkg/commands/publishMessage_command_test.go
@@ -16,6 +16,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/golang/mock/gomock"
 	"github.com/zeebe-io/zeebe/clients/go/internal/mock_pb"
 	"github.com/zeebe-io/zeebe/clients/go/internal/utils"
@@ -38,7 +39,7 @@ func TestPublishMessageCommand(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.MessageName("foo").CorrelationKey("bar").Send()
 
@@ -66,7 +67,7 @@ func TestPublishMessageCommandWithMessageId(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.MessageName("foo").CorrelationKey("bar").MessageId("hello").Send()
 
@@ -94,7 +95,7 @@ func TestPublishMessageCommandWithTimeToLive(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.MessageName("foo").CorrelationKey("bar").TimeToLive(time.Duration(6 * time.Minute)).Send()
 
@@ -124,7 +125,7 @@ func TestPublishMessageCommandWithVariablesFromString(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromString(variables)
 	if err != nil {
@@ -159,7 +160,7 @@ func TestPublishMessageCommandWithVariablesFromStringer(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromStringer(DataType{Foo: "bar"})
 	if err != nil {
@@ -194,7 +195,7 @@ func TestPublishMessageCommandWithVariablesFromObject(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
@@ -229,7 +230,7 @@ func TestPublishMessageCommandWithVariablesFromObjectOmitempty(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
@@ -264,7 +265,7 @@ func TestPublishMessageCommandWithVariablesFromObjectIgnoreOmitEmpty(t *testing.
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
@@ -301,7 +302,7 @@ func TestPublishMessageCommandWithVariablesFromMap(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromMap(variablesMap)
 	if err != nil {

--- a/clients/go/pkg/commands/resolveIncident_command.go
+++ b/clients/go/pkg/commands/resolveIncident_command.go
@@ -49,14 +49,14 @@ func (cmd *ResolveIncidentCommand) Send() (*pb.ResolveIncidentResponse, error) {
 	defer cancel()
 
 	response, err := cmd.gateway.ResolveIncident(ctx, &cmd.request)
-	if cmd.retryPredicate(err) {
+	if cmd.retryPredicate(ctx, err) {
 		return cmd.Send()
 	}
 
 	return response, err
 }
 
-func NewResolveIncidentCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(error) bool) ResolveIncidentCommandStep1 {
+func NewResolveIncidentCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) ResolveIncidentCommandStep1 {
 	return &ResolveIncidentCommand{
 		Command: Command{
 			gateway:        gateway,

--- a/clients/go/pkg/commands/resolveIncident_command_test.go
+++ b/clients/go/pkg/commands/resolveIncident_command_test.go
@@ -16,6 +16,7 @@
 package commands
 
 import (
+	"context"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -37,7 +38,7 @@ func TestResolveIncidentCommand(t *testing.T) {
 
 	client.EXPECT().ResolveIncident(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewResolveIncidentCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewResolveIncidentCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.IncidentKey(123).Send()
 

--- a/clients/go/pkg/commands/setVariables_command.go
+++ b/clients/go/pkg/commands/setVariables_command.go
@@ -98,14 +98,14 @@ func (cmd *SetVariablesCommand) Send() (*pb.SetVariablesResponse, error) {
 	defer cancel()
 
 	response, err := cmd.gateway.SetVariables(ctx, &cmd.request)
-	if cmd.retryPredicate(err) {
+	if cmd.retryPredicate(ctx, err) {
 		return cmd.Send()
 	}
 
 	return response, err
 }
 
-func NewSetVariablesCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(error) bool) SetVariablesCommandStep1 {
+func NewSetVariablesCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) SetVariablesCommandStep1 {
 	return &SetVariablesCommand{
 		Command: Command{
 			SerializerMixin: utils.NewJsonStringSerializer(),

--- a/clients/go/pkg/commands/setVariables_command_test.go
+++ b/clients/go/pkg/commands/setVariables_command_test.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/golang/mock/gomock"
 	"github.com/zeebe-io/zeebe/clients/go/internal/mock_pb"
 	"github.com/zeebe-io/zeebe/clients/go/internal/utils"
@@ -40,7 +41,7 @@ func TestSetVariablesCommandWithVariablesFromString(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromString(variables)
 	if err != nil {
@@ -76,7 +77,7 @@ func TestSetVariablesCommandWithVariablesFromStringer(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromStringer(DataType{Foo: "bar"})
 	if err != nil {
@@ -112,7 +113,7 @@ func TestSetVariablesCommandWithVariablesFromObject(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
@@ -148,7 +149,7 @@ func TestSetVariablesCommandWithVariablesFromObjectOmitempty(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
@@ -184,7 +185,7 @@ func TestSetVariablesCommandWithVariablesFromObjectIgnoreOmitempty(t *testing.T)
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
@@ -222,7 +223,7 @@ func TestSetVariablesCommandWithVariablesFromMap(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromMap(variablesMap)
 	if err != nil {

--- a/clients/go/pkg/commands/throwError_command_test.go
+++ b/clients/go/pkg/commands/throwError_command_test.go
@@ -16,6 +16,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/golang/mock/gomock"
 	"github.com/zeebe-io/zeebe/clients/go/internal/mock_pb"
 	"github.com/zeebe-io/zeebe/clients/go/internal/utils"
@@ -38,7 +39,7 @@ func TestThrowErrorCommand(t *testing.T) {
 
 	client.EXPECT().ThrowError(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewThrowErrorCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewThrowErrorCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.JobKey(123).ErrorCode("someErrorCode").ErrorMessage("someErrorMessage").Send()
 

--- a/clients/go/pkg/commands/topology_command.go
+++ b/clients/go/pkg/commands/topology_command.go
@@ -28,15 +28,14 @@ func (cmd *TopologyCommand) Send() (*pb.TopologyResponse, error) {
 	defer cancel()
 
 	response, err := cmd.gateway.Topology(ctx, &pb.TopologyRequest{})
-
-	if cmd.retryPredicate(err) {
+	if cmd.retryPredicate(ctx, err) {
 		return cmd.Send()
 	}
 
 	return response, err
 }
 
-func NewTopologyCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(error) bool) *TopologyCommand {
+func NewTopologyCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) *TopologyCommand {
 	return &TopologyCommand{
 		gateway:        gateway,
 		requestTimeout: requestTimeout,

--- a/clients/go/pkg/commands/topology_command_test.go
+++ b/clients/go/pkg/commands/topology_command_test.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/golang/mock/gomock"
 	"github.com/zeebe-io/zeebe/clients/go/internal/mock_pb"
 	"github.com/zeebe-io/zeebe/clients/go/internal/utils"
@@ -69,7 +70,7 @@ func TestTopologyCommand(t *testing.T) {
 
 	client.EXPECT().Topology(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewTopologyCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewTopologyCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.Send()
 

--- a/clients/go/pkg/commands/updateJobRetries_command.go
+++ b/clients/go/pkg/commands/updateJobRetries_command.go
@@ -59,14 +59,14 @@ func (cmd *UpdateJobRetriesCommand) Send() (*pb.UpdateJobRetriesResponse, error)
 	defer cancel()
 
 	response, err := cmd.gateway.UpdateJobRetries(ctx, &cmd.request)
-	if cmd.retryPredicate(err) {
+	if cmd.retryPredicate(ctx, err) {
 		return cmd.Send()
 	}
 
 	return response, err
 }
 
-func NewUpdateJobRetriesCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(error) bool) UpdateJobRetriesCommandStep1 {
+func NewUpdateJobRetriesCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) UpdateJobRetriesCommandStep1 {
 	return &UpdateJobRetriesCommand{
 		request: pb.UpdateJobRetriesRequest{
 			Retries: DefaultJobRetries,

--- a/clients/go/pkg/commands/updateJobRetries_command_test.go
+++ b/clients/go/pkg/commands/updateJobRetries_command_test.go
@@ -16,6 +16,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/golang/mock/gomock"
 	"github.com/zeebe-io/zeebe/clients/go/internal/mock_pb"
 	"github.com/zeebe-io/zeebe/clients/go/internal/utils"
@@ -37,7 +38,7 @@ func TestUpdateJobRetriesCommand(t *testing.T) {
 
 	client.EXPECT().UpdateJobRetries(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewUpdateJobRetriesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewUpdateJobRetriesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.JobKey(123).Send()
 
@@ -64,7 +65,7 @@ func TestUpdateJobRetriesCommandWithRetries(t *testing.T) {
 
 	client.EXPECT().UpdateJobRetries(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewUpdateJobRetriesCommand(client, utils.DefaultTestTimeout, func(error) bool { return false })
+	command := NewUpdateJobRetriesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
 
 	response, err := command.JobKey(123).Retries(23).Send()
 

--- a/clients/go/pkg/zbc/callCredentials.go
+++ b/clients/go/pkg/zbc/callCredentials.go
@@ -22,9 +22,9 @@ type callCredentials struct {
 	credentialsProvider CredentialsProvider
 }
 
-func (cc *callCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+func (cc *callCredentials) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
 	headers := make(map[string]string)
-	cc.credentialsProvider.ApplyCredentials(headers)
+	cc.credentialsProvider.ApplyCredentials(ctx, headers)
 	return headers, nil
 }
 

--- a/clients/go/pkg/zbc/credentialsProvider.go
+++ b/clients/go/pkg/zbc/credentialsProvider.go
@@ -14,12 +14,14 @@
 
 package zbc
 
+import "context"
+
 // CredentialsProvider is responsible for adding credentials to each gRPC call's headers.
 type CredentialsProvider interface {
 	// Takes a map of gRPC headers as defined in credentials.PerRPCCredentials and adds credentials to them.
-	ApplyCredentials(headers map[string]string)
+	ApplyCredentials(ctx context.Context, headers map[string]string)
 	// Returns true if the request should be retried, false otherwise.
-	ShouldRetryRequest(err error) bool
+	ShouldRetryRequest(ctx context.Context, err error) bool
 }
 
 // NoopCredentialsProvider implements the CredentialsProvider interface but doesn't modify the authorization headers and
@@ -27,11 +29,11 @@ type CredentialsProvider interface {
 type NoopCredentialsProvider struct{}
 
 // ApplyCredentials does nothing.
-func (NoopCredentialsProvider) ApplyCredentials(headers map[string]string) {
+func (NoopCredentialsProvider) ApplyCredentials(ctx context.Context, headers map[string]string) {
 	// Noop
 }
 
 // ShouldRetryRequest always returns false.
-func (NoopCredentialsProvider) ShouldRetryRequest(err error) bool {
+func (NoopCredentialsProvider) ShouldRetryRequest(ctx context.Context, err error) bool {
 	return false
 }

--- a/clients/go/pkg/zbc/credentialsProvider_test.go
+++ b/clients/go/pkg/zbc/credentialsProvider_test.go
@@ -43,11 +43,11 @@ type customCredentialsProvider struct {
 	retryPredicate func(error) bool
 }
 
-func (t customCredentialsProvider) ApplyCredentials(headers map[string]string) {
+func (t customCredentialsProvider) ApplyCredentials(ctx context.Context, headers map[string]string) {
 	headers["Authorization"] = t.customToken
 }
 
-func (t customCredentialsProvider) ShouldRetryRequest(err error) bool {
+func (t customCredentialsProvider) ShouldRetryRequest(ctx context.Context, err error) bool {
 	if t.retryPredicate != nil {
 		return t.retryPredicate(err)
 	}


### PR DESCRIPTION
## Description

Adds timeouts to the OAuth requests and fixes the missing retry logic in a few commands. Currently, the timeout has to be set in the context passed at each request due to a bug in the http package. We can either change it once the fix is out or leave it as is. I opened an issue to keep track of that https://github.com/zeebe-io/zeebe/issues/3546

## Related issues


closes #3460 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
