### PR TITLE
docs(bpmn-workflows): remove mention of processIdExpression

### DIFF
--- a/docs/src/bpmn-workflows/call-activities/call-activities.md
+++ b/docs/src/bpmn-workflows/call-activities/call-activities.md
@@ -2,23 +2,21 @@
 
 A call activity (aka reusable subprocess) allows to call/invoke another workflow as part of this workflow. It is similar to an [embedded subprocess](/bpmn-workflows/embedded-subprocesses/embedded-subprocesses.html) but the workflow is externalized (i.e. stored as separated BPMN) and can be invoked by different workflows.
 
-![call-activity](/bpmn-workflows/call-activities/call-activities-example.png) 
+![call-activity](/bpmn-workflows/call-activities/call-activities-example.png)
 
 When a call activity is entered then a new workflow instance of the referenced workflow is created. The new workflow instance gets activated at the **none start event**. The workflow can have start events of other types but they are ignored.
- 
+
 When the created workflow instance is completed then the call activity is left and the outgoing sequence flow is taken.
- 
+
 ## Defining the Called Workflow
 
-A call activity must define the BPMN process id of the called workflow **either** as `processId` or as `processIdExpression`. The `processId` defines the BPMN process id statically on the design time of the workflow. 
-
-The `processIdExpression` instead defines the variable which holds the BPMN process id. The variable is read from the workflow instance on activating the call activity. It must be a string (e.g. `child-process-id`).
+A call activity must define the BPMN process id of the called workflow as `processId`. The `processId` defines the BPMN process id statically on the design time of the workflow.
 
 The new instance of the defined workflow will be created of its **latest version** - at the point when the call activity is activated.
 
 ## Boundary Events
 
-![call-activity-boundary-event](/bpmn-workflows/call-activities/call-activities-boundary-events.png) 
+![call-activity-boundary-event](/bpmn-workflows/call-activities/call-activities-boundary-events.png)
 
 Interrupting and non-interrupting boundary events can be attached to a call activity.
 
@@ -32,14 +30,14 @@ When the call activity is activated then **all variables** of the call activity 
 
 Input mappings can be used to create new local variables in the scope of the call activity. These variables are also copied to the created workflow instance.
 
-By default, all variables of the created workflow instance are propagated to the call activity. This behavior can be customized by defining output mappings at the call activity. The output mappings are applied on completing the call activity. 
+By default, all variables of the created workflow instance are propagated to the call activity. This behavior can be customized by defining output mappings at the call activity. The output mappings are applied on completing the call activity.
 
 ## Additional Resources
 
 <details>
   <summary>XML representation</summary>
   <p>A call activity with static process id:
-  
+
 ```xml
 <bpmn:callActivity id="task-A" name="A">
   <bpmn:extensionElements>
@@ -54,15 +52,15 @@ By default, all variables of the created workflow instance are propagated to the
 <details>
   <summary>Using the BPMN modeler</summary>
   <p>Adding a call activity with static process id:
-  
-![call-activity](/bpmn-workflows/call-activities/bpmn-modeler-call-activity.gif) 
+
+![call-activity](/bpmn-workflows/call-activities/bpmn-modeler-call-activity.gif)
 
   </p>
 </details>
 
 <details>
   <summary>Workflow Lifecycle</summary>
-  <p>Workflow instance records of a call activity: 
+  <p>Workflow instance records of a call activity:
 
 <table>
     <tr>


### PR DESCRIPTION
## Description

* remove mention of `processIdExpression` from call-activity section (currently, it is not clear in which way expressions will be supported)

## Related issues

none

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
