### PR TITLE
chore(engine): improve MessageMappingTest stability

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/ProcessBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/ProcessBuilder.java
@@ -23,6 +23,7 @@ import io.zeebe.model.bpmn.instance.SubProcess;
 import io.zeebe.model.bpmn.instance.bpmndi.BpmnShape;
 import io.zeebe.model.bpmn.instance.dc.Bounds;
 import java.util.Collection;
+import java.util.function.Consumer;
 
 /** @author Sebastian Menski */
 public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
@@ -60,6 +61,13 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
     resizeSubProcess(targetBpmnShape);
 
     return new EventSubProcessBuilder(modelInstance, subProcess);
+  }
+
+  public ProcessBuilder eventSubProcess(
+      final String id, final Consumer<EventSubProcessBuilder> consumer) {
+    final EventSubProcessBuilder builder = eventSubProcess(id);
+    consumer.accept(builder);
+    return this;
   }
 
   @Override

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageMappingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageMappingTest.java
@@ -12,7 +12,6 @@ import static io.zeebe.test.util.MsgPackUtil.asMsgPack;
 import io.zeebe.engine.util.EngineRule;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
-import io.zeebe.model.bpmn.builder.ProcessBuilder;
 import io.zeebe.model.bpmn.builder.ZeebeVariablesMappingBuilder;
 import io.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.zeebe.model.bpmn.instance.IntermediateCatchEvent;
@@ -44,18 +43,21 @@ public class MessageMappingTest {
   private static final String PROCESS_ID = "process";
   private static final String MESSAGE_NAME = "message";
   private static final String CORRELATION_VARIABLE = "key";
+
   private static final BpmnModelInstance CATCH_EVENT_WORKFLOW =
       Bpmn.createExecutableProcess(PROCESS_ID)
           .startEvent()
           .intermediateCatchEvent("catch")
           .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKey(CORRELATION_VARIABLE))
           .done();
+
   private static final BpmnModelInstance RECEIVE_TASK_WORKFLOW =
       Bpmn.createExecutableProcess(PROCESS_ID)
           .startEvent()
           .receiveTask("catch")
           .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKey(CORRELATION_VARIABLE))
           .done();
+
   private static final BpmnModelInstance INTERRUPTING_BOUNDARY_EVENT_WORKFLOW =
       Bpmn.createExecutableProcess(PROCESS_ID)
           .startEvent()
@@ -64,6 +66,7 @@ public class MessageMappingTest {
           .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKey(CORRELATION_VARIABLE))
           .endEvent()
           .done();
+
   private static final BpmnModelInstance NON_INTERRUPTING_BOUNDARY_EVENT_WORKFLOW =
       Bpmn.createExecutableProcess(PROCESS_ID)
           .startEvent()
@@ -72,6 +75,7 @@ public class MessageMappingTest {
           .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKey(CORRELATION_VARIABLE))
           .endEvent()
           .done();
+
   private static final BpmnModelInstance EVENT_BASED_GATEWAY_WORKFLOW =
       Bpmn.createExecutableProcess(PROCESS_ID)
           .startEvent("start")
@@ -88,6 +92,36 @@ public class MessageMappingTest {
           .endEvent("end2")
           .done();
 
+  private static final BpmnModelInstance INTERRUPTING_EVENT_SUBPROCESS_WORKFLOW =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .eventSubProcess(
+              "catch",
+              eventSubProcess ->
+                  eventSubProcess
+                      .startEvent()
+                      .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKey(CORRELATION_VARIABLE))
+                      .interrupting(true)
+                      .endEvent())
+          .startEvent()
+          .serviceTask("task", t -> t.zeebeTaskType("type"))
+          .endEvent()
+          .done();
+
+  private static final BpmnModelInstance NON_INTERRUPTING_EVENT_SUBPROCESS_WORKFLOW =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .eventSubProcess(
+              "catch",
+              eventSubProcess ->
+                  eventSubProcess
+                      .startEvent()
+                      .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKey(CORRELATION_VARIABLE))
+                      .interrupting(false)
+                      .endEvent())
+          .startEvent()
+          .serviceTask("task", t -> t.zeebeTaskType("type"))
+          .endEvent()
+          .done();
+
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
@@ -100,22 +134,6 @@ public class MessageMappingTest {
 
   private String correlationKey;
 
-  private static BpmnModelInstance createEventSubprocessModel() {
-    final ProcessBuilder builder = Bpmn.createExecutableProcess(PROCESS_ID);
-    builder
-        .eventSubProcess("catch")
-        .startEvent("event_sub_start_msg")
-        .interrupting(true)
-        .message(b -> b.name(MESSAGE_NAME).zeebeCorrelationKey(CORRELATION_VARIABLE))
-        .endEvent("event_sub_end_msg");
-
-    return builder
-        .startEvent("start_proc")
-        .serviceTask("task", t -> t.zeebeTaskType("type"))
-        .endEvent("end_proc")
-        .done();
-  }
-
   @Parameters(name = "{0}")
   public static Object[][] parameters() {
     return new Object[][] {
@@ -124,13 +142,22 @@ public class MessageMappingTest {
       {"event-based gateway", EVENT_BASED_GATEWAY_WORKFLOW},
       {"interrupting boundary event", INTERRUPTING_BOUNDARY_EVENT_WORKFLOW},
       {"non-interrupting boundary event", NON_INTERRUPTING_BOUNDARY_EVENT_WORKFLOW},
-      {"interrupting event subprocess", createEventSubprocessModel()}
+      {"interrupting event subprocess", INTERRUPTING_EVENT_SUBPROCESS_WORKFLOW},
+      // TODO (saig0): enable test case when fixing #3552
+      // {"non-interrupting event subprocess", NON_INTERRUPTING_EVENT_SUBPROCESS_WORKFLOW}
     };
   }
 
   @Before
   public void setUp() {
     correlationKey = UUID.randomUUID().toString();
+
+    ENGINE_RULE
+        .message()
+        .withCorrelationKey(correlationKey)
+        .withName(MESSAGE_NAME)
+        .withVariables(asMsgPack("foo", "bar"))
+        .publish();
   }
 
   @Test
@@ -138,20 +165,13 @@ public class MessageMappingTest {
     // given
     deployWorkflowWithMapping(e -> {});
 
+    // when
     final long workflowInstanceKey =
         ENGINE_RULE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
             .withVariable(CORRELATION_VARIABLE, correlationKey)
             .create();
-
-    // when
-    ENGINE_RULE
-        .message()
-        .withCorrelationKey(correlationKey)
-        .withName(MESSAGE_NAME)
-        .withVariables(asMsgPack("foo", "bar"))
-        .publish();
 
     // then
     final Record<VariableRecordValue> variableEvent =
@@ -170,20 +190,13 @@ public class MessageMappingTest {
     // given
     deployWorkflowWithMapping(e -> {});
 
+    // when
     final long workflowInstanceKey =
         ENGINE_RULE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
             .withVariable(CORRELATION_VARIABLE, correlationKey)
             .create();
-
-    // when
-    ENGINE_RULE
-        .message()
-        .withCorrelationKey(correlationKey)
-        .withName(MESSAGE_NAME)
-        .withVariables(asMsgPack("foo", "bar"))
-        .publish();
 
     // then
     final Record<VariableRecordValue> variableEvent =
@@ -201,20 +214,14 @@ public class MessageMappingTest {
   public void shouldMapMessageVariablesIntoInstanceVariables() {
     // given
     deployWorkflowWithMapping(e -> e.zeebeOutput("foo", MESSAGE_NAME));
+
+    // when
     final long workflowInstanceKey =
         ENGINE_RULE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
             .withVariable(CORRELATION_VARIABLE, correlationKey)
             .create();
-
-    // when
-    ENGINE_RULE
-        .message()
-        .withCorrelationKey(correlationKey)
-        .withName(MESSAGE_NAME)
-        .withVariables(asMsgPack("foo", "bar"))
-        .publish();
 
     // then
     final Record<VariableRecordValue> variableEvent =


### PR DESCRIPTION
## Description

* publish message before creating the instance to have always the same conditions how the message is correlated
* locally, the test case does not fail anymore

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2394 

Fixing the actual variable bug with #3552

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
