### PR TITLE
chore(ci): build and test Go in parallel stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,38 +46,42 @@ pipeline {
             }
         }
 
-        stage('Build (Go)') {
-            environment {
-                IMAGE = "camunda/zeebe"
-                VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
-                TAG = 'current-test'
-            }
-
-            steps {
-                container('golang') {
-                    sh '.ci/scripts/distribution/build-go.sh'
-                }
-
-                container('maven') {
-                    sh '.ci/scripts/docker/prepare.sh'
-                }
-
-                container('docker') {
-                    sh '.ci/scripts/docker/build.sh'
-                }
-            }
-        }
-
-        stage('Test (Go)') {
-            steps {
-                container('golang') {
-                    sh '.ci/scripts/distribution/test-go.sh'
-                }
-            }
-        }
-
-        stage('Test (Java)') {
+        stage('Tests') {
             parallel {
+                stage('Go') {
+                    stages {
+                        stage('Build') {
+                            environment {
+                                IMAGE = "camunda/zeebe"
+                                VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
+                                TAG = 'current-test'
+                            }
+
+                            steps {
+                                container('golang') {
+                                    sh '.ci/scripts/distribution/build-go.sh'
+                                }
+
+                                container('maven') {
+                                    sh '.ci/scripts/docker/prepare.sh'
+                                }
+
+                                container('docker') {
+                                    sh '.ci/scripts/docker/build.sh'
+                                }
+                            }
+                        }
+
+                        stage('Test') {
+                            steps {
+                                container('golang') {
+                                    sh '.ci/scripts/distribution/test-go.sh'
+                                }
+                            }
+                        }
+                    }
+                }
+
                 stage('Analyse (Java)') {
                       steps {
                           container('maven') {


### PR DESCRIPTION
## Description

Moves the Go build and test into the parallel stage.

## Related issues

closes #3511

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
