### PR TITLE
chore(qa): adds test to ensure positions always increase even with restarts

### DIFF
--- a/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -173,9 +173,9 @@ public final class EmbeddedBrokerRule extends ExternalResource {
     return controlledActorClock;
   }
 
-  public void restartBroker() {
+  public void restartBroker(final PartitionListener... listeners) {
     stopBroker();
-    startBroker();
+    startBroker(listeners);
   }
 
   public void stopBroker() {
@@ -186,7 +186,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
     }
   }
 
-  public void startBroker() {
+  public void startBroker(final PartitionListener... listeners) {
     if (brokerCfg == null) {
       try (final InputStream configStream = configSupplier.get()) {
         if (configStream == null) {
@@ -204,6 +204,10 @@ public final class EmbeddedBrokerRule extends ExternalResource {
 
     final CountDownLatch latch = new CountDownLatch(brokerCfg.getCluster().getPartitionsCount());
     broker.addPartitionListener(new LeaderPartitionListener(latch));
+    for (final PartitionListener listener : listeners) {
+      broker.addPartitionListener(listener);
+    }
+
     broker.start().join();
 
     try {

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRestartTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRestartTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.PartitionListener;
+import io.zeebe.broker.it.util.GrpcClientRule;
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.client.api.ZeebeFuture;
+import io.zeebe.logstreams.log.LogStream;
+import java.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class BrokerRestartTest {
+  private final EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule();
+  private final GrpcClientRule clientRule = new GrpcClientRule(brokerRule);
+
+  @Rule public final RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(clientRule);
+
+  @Test
+  public void shouldSortRecordsByPosition() {
+    // given
+    final var listener = new Listener();
+    brokerRule.getBroker().addPartitionListener(listener);
+
+    // when
+    generateLoad();
+    brokerRule.restartBroker(listener);
+    generateLoad();
+    brokerRule.restartBroker(listener);
+    generateLoad();
+
+    // then
+    final var log = listener.get();
+    final var reader = log.newLogStreamReader().join();
+    reader.seekToFirstEvent();
+    assertThat(reader.hasNext()).isTrue();
+
+    var previousPosition = -1L;
+    while (reader.hasNext()) {
+      final var position = reader.next().getPosition();
+      assertThat(position).isGreaterThan(previousPosition);
+      previousPosition = position;
+    }
+  }
+
+  private void generateLoad() {
+    publishMessage(1).join();
+    publishMessage(2).join();
+  }
+
+  private ZeebeFuture<Void> publishMessage(final int key) {
+    return clientRule
+        .getClient()
+        .newPublishMessageCommand()
+        .messageName("name")
+        .correlationKey(String.valueOf(key))
+        .timeToLive(Duration.ofMinutes(2))
+        .send();
+  }
+
+  private static final class Listener implements PartitionListener {
+    private volatile LogStream logStream;
+
+    private LogStream get() {
+      return logStream;
+    }
+
+    @Override
+    public void onBecomingFollower(
+        final int partitionId, final long term, final LogStream logStream) {
+      this.logStream = logStream;
+    }
+
+    @Override
+    public void onBecomingLeader(
+        final int partitionId, final long term, final LogStream logStream) {
+      this.logStream = logStream;
+    }
+  }
+}


### PR DESCRIPTION
## Description

- adds a test which restarts the broker three times to ensure that across restarts our positions are ever increasing

## Related issues

Related to [camunda/camunda-cloud-bugs#1](https://github.com/camunda/camunda-cloud-bugs/issues/1) and #3522 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
