### PR TITLE
fix(logstreams): fixes detection of empty log on seekToEnd

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
@@ -82,11 +82,9 @@ public final class LogStreamReaderImpl implements LogStreamReader {
     // invalidate events first as the buffer content may change
     invalidateBufferAndOffsets();
 
-    final long blockAddress = storageReader.getFirstBlockAddress();
-    if (blockAddress < 0) {
-      // no block found => empty log
+    if (storageReader.isEmpty()) {
       state = IteratorState.EMPTY_LOG_STREAM;
-      return -1;
+      return UNINITIALIZED;
     } else {
       if (readLastBlockIntoBuffer()) {
         do {

--- a/logstreams/src/main/java/io/zeebe/logstreams/spi/LogStorageReader.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/spi/LogStorageReader.java
@@ -11,11 +11,14 @@ import java.io.Closeable;
 import org.agrona.DirectBuffer;
 
 public interface LogStorageReader extends Closeable {
+
   /**
-   * Returns the address of the first block in the storage or {@link
-   * LogStorage#OP_RESULT_INVALID_ADDR} if the storage is empty.
+   * Returns true if nothing could be read from the log, regardless of the current position of the
+   * reader - meaning any seek operations would not change the result of this call.
+   *
+   * @return true no records are readable, false otherwise
    */
-  long getFirstBlockAddress();
+  boolean isEmpty();
 
   /**
    * Returns an operation result status code which is either

--- a/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
@@ -23,8 +23,8 @@ public final class AtomixLogStorageReader implements LogStorageReader {
   }
 
   @Override
-  public long getFirstBlockAddress() {
-    return reader.getFirstIndex();
+  public boolean isEmpty() {
+    return reader.isEmpty();
   }
 
   @Override

--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStreamReaderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStreamReaderTest.java
@@ -254,7 +254,7 @@ public final class LogStreamReaderTest {
   }
 
   @Test
-  public void shouldSeekToLastBigLoggedEvents() {
+  public void shouldSeekToEnd() {
     // given
     final int eventCount = 1000;
     final long lastPosition = writer.writeEvents(eventCount, BIG_EVENT_VALUE);
@@ -350,5 +350,17 @@ public final class LogStreamReaderTest {
 
     // then
     assertThat(reader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldReturnNegativeOnSeekToEndOfEmptyLog() {
+    // given
+    final var reader = logStreamRule.getLogStreamReader();
+
+    // when
+    final var result = reader.seekToEnd();
+
+    // then
+    assertThat(result).isLessThan(0);
   }
 }


### PR DESCRIPTION
## Description

- adds `LogStorageReader#isEmpty` as interface method
- fixes detection of empty log on `seekToEnd`
- removes `LogStorageReader#getFirstBlockAddress`, which was only used to detect an empty log

## Related issues

closes #3543 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
