### PR TITLE
feat(broker): trigger error event subprocess

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/EmbeddedSubProcessBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/EmbeddedSubProcessBuilder.java
@@ -22,13 +22,13 @@ import io.zeebe.model.bpmn.instance.StartEvent;
 import io.zeebe.model.bpmn.instance.SubProcess;
 import io.zeebe.model.bpmn.instance.bpmndi.BpmnShape;
 import io.zeebe.model.bpmn.instance.dc.Bounds;
+import java.util.function.Consumer;
 
 /** @author Sebastian Menski */
 public class EmbeddedSubProcessBuilder
     extends AbstractEmbeddedSubProcessBuilder<
         EmbeddedSubProcessBuilder, AbstractSubProcessBuilder<?>> {
 
-  @SuppressWarnings("rawtypes")
   protected EmbeddedSubProcessBuilder(final AbstractSubProcessBuilder subProcessBuilder) {
     super(subProcessBuilder, EmbeddedSubProcessBuilder.class);
   }
@@ -81,6 +81,13 @@ public class EmbeddedSubProcessBuilder
     final EventSubProcessBuilder eventSubProcessBuilder =
         new EventSubProcessBuilder(subProcessBuilder.modelInstance, subProcess);
     return eventSubProcessBuilder;
+  }
+
+  public EmbeddedSubProcessBuilder eventSubProcess(
+      final String id, final Consumer<EventSubProcessBuilder> consumer) {
+    final EventSubProcessBuilder builder = eventSubProcess(id);
+    consumer.accept(builder);
+    return this;
   }
 
   protected void setCoordinates(final BpmnShape targetBpmnShape) {

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/ModelUtil.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/ModelUtil.java
@@ -19,23 +19,43 @@ import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 
 import io.zeebe.model.bpmn.instance.Activity;
+import io.zeebe.model.bpmn.instance.BoundaryEvent;
+import io.zeebe.model.bpmn.instance.Error;
+import io.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.zeebe.model.bpmn.instance.EventDefinition;
 import io.zeebe.model.bpmn.instance.Message;
 import io.zeebe.model.bpmn.instance.MessageEventDefinition;
+import io.zeebe.model.bpmn.instance.StartEvent;
+import io.zeebe.model.bpmn.instance.SubProcess;
+import io.zeebe.model.bpmn.instance.TimerEventDefinition;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 
 public class ModelUtil {
 
-  public static <E extends EventDefinition> Stream<E> getBoundaryEvents(
-      final Activity activity, final Class<E> definitionType) {
+  private static final List<Class<? extends EventDefinition>> NON_INTERRUPTING_EVENT_DEFINITIONS =
+      Arrays.asList(MessageEventDefinition.class, TimerEventDefinition.class);
 
-    return activity.getBoundaryEvents().stream()
+  public static List<EventDefinition> getEventDefinitionsForBoundaryEvents(final Activity element) {
+    return element.getBoundaryEvents().stream()
         .flatMap(event -> event.getEventDefinitions().stream())
-        .filter(definitionType::isInstance)
-        .map(definitionType::cast);
+        .collect(Collectors.toList());
+  }
+
+  public static List<EventDefinition> getEventDefinitionsForEventSubprocesses(
+      final ModelElementInstance element) {
+    return element.getChildElementsByType(SubProcess.class).stream()
+        .filter(SubProcess::triggeredByEvent)
+        .flatMap(subProcess -> subProcess.getChildElementsByType(StartEvent.class).stream())
+        .flatMap(s -> s.getEventDefinitions().stream())
+        .collect(Collectors.toList());
   }
 
   public static List<String> getDuplicateMessageNames(
@@ -50,5 +70,106 @@ public class ModelUtil {
         .filter(e -> e.getValue() > 1)
         .map(Entry::getKey)
         .collect(Collectors.toList());
+  }
+
+  public static void verifyNoDuplicatedBoundaryEvents(
+      final Activity activity, final Consumer<String> errorCollector) {
+
+    final List<EventDefinition> definitions = getEventDefinitionsForBoundaryEvents(activity);
+
+    verifyNoDuplicatedEventDefinition(definitions, errorCollector);
+  }
+
+  public static void verifyEventDefinition(
+      final BoundaryEvent boundaryEvent, final Consumer<String> errorCollector) {
+    boundaryEvent
+        .getEventDefinitions()
+        .forEach(
+            definition ->
+                verifyEventDefinition(definition, boundaryEvent.cancelActivity(), errorCollector));
+  }
+
+  public static void verifyEventDefinition(
+      final StartEvent startEvent, final Consumer<String> errorCollector) {
+
+    startEvent
+        .getEventDefinitions()
+        .forEach(
+            definition ->
+                verifyEventDefinition(definition, startEvent.isInterrupting(), errorCollector));
+  }
+
+  public static void verifyNoDuplicatedEventSubprocesses(
+      final ModelElementInstance element, final Consumer<String> errorCollector) {
+
+    final List<EventDefinition> definitions = getEventDefinitionsForEventSubprocesses(element);
+
+    verifyNoDuplicatedEventDefinition(definitions, errorCollector);
+  }
+
+  public static void verifyNoDuplicatedEventDefinition(
+      final Collection<? extends EventDefinition> definitions,
+      final Consumer<String> errorCollector) {
+
+    final Stream<String> messageNames =
+        getEventDefinition(definitions, MessageEventDefinition.class)
+            .filter(def -> def.getMessage() != null)
+            .map(MessageEventDefinition::getMessage)
+            .filter(message -> message.getName() != null && !message.getName().isEmpty())
+            .map(Message::getName);
+
+    getDuplicatedEntries(messageNames)
+        .map(ModelUtil::duplicatedMessageNames)
+        .forEach(errorCollector);
+
+    final Stream<String> errorCodes =
+        getEventDefinition(definitions, ErrorEventDefinition.class)
+            .filter(def -> def.getError() != null)
+            .map(ErrorEventDefinition::getError)
+            .filter(error -> error.getErrorCode() != null && !error.getErrorCode().isEmpty())
+            .map(Error::getErrorCode);
+
+    getDuplicatedEntries(errorCodes).map(ModelUtil::duplicatedErrorCodes).forEach(errorCollector);
+  }
+
+  public static <T extends EventDefinition> Stream<T> getEventDefinition(
+      final Collection<? extends EventDefinition> collection, final Class<T> type) {
+    return collection.stream().filter(type::isInstance).map(type::cast);
+  }
+
+  public static Stream<String> getDuplicatedEntries(final Stream<String> stream) {
+    return stream.collect(groupingBy(Function.identity(), counting())).entrySet().stream()
+        .filter(e -> e.getValue() > 1)
+        .map(Entry::getKey);
+  }
+
+  private static String duplicatedMessageNames(final String messageName) {
+    return String.format(
+        "Multiple message event definitions with the same name '%s' are not allowed.", messageName);
+  }
+
+  private static String duplicatedErrorCodes(final String errorCode) {
+    return String.format(
+        "Multiple error event definitions with the same errorCode '%s' are not allowed.",
+        errorCode);
+  }
+
+  private static void verifyEventDefinition(
+      final EventDefinition definition,
+      final boolean isInterrupting,
+      final Consumer<String> errorCollector) {
+
+    if (!isInterrupting
+        && !NON_INTERRUPTING_EVENT_DEFINITIONS.contains(
+            definition.getElementType().getInstanceType())) {
+      errorCollector.accept("Non-Interrupting event of this type is not allowed");
+    }
+
+    if (isInterrupting && definition instanceof TimerEventDefinition) {
+      final TimerEventDefinition timerEventDefinition = (TimerEventDefinition) definition;
+      if (timerEventDefinition.getTimeCycle() != null) {
+        errorCollector.accept("Interrupting timer event with time cycle is not allowed.");
+      }
+    }
   }
 }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/EventBasedGatewayValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/EventBasedGatewayValidator.java
@@ -26,6 +26,7 @@ import io.zeebe.model.bpmn.util.ModelUtil;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
@@ -60,17 +61,11 @@ public class EventBasedGatewayValidator implements ModelElementValidator<EventBa
       validationResultCollector.addError(0, ERROR_UNSUPPORTED_TARGET_NODE);
     }
 
-    final Stream<MessageEventDefinition> messages =
-        getMessageEventDefinitions(outgoingSequenceFlows);
-    final List<String> duplicateMessageNames = ModelUtil.getDuplicateMessageNames(messages);
+    final List<MessageEventDefinition> messageEventDefinitions =
+        getMessageEventDefinitions(outgoingSequenceFlows).collect(Collectors.toList());
 
-    duplicateMessageNames.forEach(
-        name ->
-            validationResultCollector.addError(
-                0,
-                String.format(
-                    "Multiple message catch events with the same name '%s' are not allowed.",
-                    name)));
+    ModelUtil.verifyNoDuplicatedEventDefinition(
+        messageEventDefinitions, error -> validationResultCollector.addError(0, error));
 
     if (!succeedingNodesOnlyHaveEventBasedGatewayAsIncomingFlows(element)) {
       validationResultCollector.addError(

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/EventDefinitionValidator.java
@@ -19,21 +19,16 @@ import io.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.zeebe.model.bpmn.instance.EventDefinition;
 import io.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.zeebe.model.bpmn.instance.TimerEventDefinition;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Arrays;
+import java.util.List;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
 public class EventDefinitionValidator implements ModelElementValidator<EventDefinition> {
 
-  private static final Set<Class<? extends EventDefinition>> SUPPORTED_EVENT_DEFINITIONS;
-
-  static {
-    SUPPORTED_EVENT_DEFINITIONS = new HashSet<>();
-    SUPPORTED_EVENT_DEFINITIONS.add(MessageEventDefinition.class);
-    SUPPORTED_EVENT_DEFINITIONS.add(TimerEventDefinition.class);
-    SUPPORTED_EVENT_DEFINITIONS.add(ErrorEventDefinition.class);
-  }
+  private static final List<Class<? extends EventDefinition>> SUPPORTED_EVENT_DEFINITIONS =
+      Arrays.asList(
+          MessageEventDefinition.class, TimerEventDefinition.class, ErrorEventDefinition.class);
 
   @Override
   public Class<EventDefinition> getElementType() {

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ProcessValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ProcessValidator.java
@@ -17,6 +17,7 @@ package io.zeebe.model.bpmn.validation.zeebe;
 
 import io.zeebe.model.bpmn.instance.Process;
 import io.zeebe.model.bpmn.instance.StartEvent;
+import io.zeebe.model.bpmn.util.ModelUtil;
 import java.util.Collection;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
@@ -31,6 +32,7 @@ public class ProcessValidator implements ModelElementValidator<Process> {
   @Override
   public void validate(
       final Process element, final ValidationResultCollector validationResultCollector) {
+
     final Collection<StartEvent> topLevelStartEvents =
         element.getChildElementsByType(StartEvent.class);
     if (topLevelStartEvents.isEmpty()) {
@@ -38,6 +40,9 @@ public class ProcessValidator implements ModelElementValidator<Process> {
     } else if (topLevelStartEvents.stream().filter(this::isNoneEvent).count() > 1) {
       validationResultCollector.addError(0, "Multiple none start events are not allowed");
     }
+
+    ModelUtil.verifyNoDuplicatedEventSubprocesses(
+        element, error -> validationResultCollector.addError(0, error));
   }
 
   private boolean isNoneEvent(final StartEvent startEvent) {

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ReceiveTaskValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ReceiveTaskValidator.java
@@ -15,10 +15,12 @@
  */
 package io.zeebe.model.bpmn.validation.zeebe;
 
+import io.zeebe.model.bpmn.instance.EventDefinition;
 import io.zeebe.model.bpmn.instance.Message;
 import io.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.zeebe.model.bpmn.instance.ReceiveTask;
 import io.zeebe.model.bpmn.util.ModelUtil;
+import java.util.List;
 import java.util.stream.Stream;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
@@ -38,8 +40,11 @@ public class ReceiveTaskValidator implements ModelElementValidator<ReceiveTask> 
       validationResultCollector.addError(0, "Must reference a message");
     }
 
+    final List<EventDefinition> eventDefinitions =
+        ModelUtil.getEventDefinitionsForBoundaryEvents(element);
+
     final Stream<String> messageNames =
-        ModelUtil.getBoundaryEvents(element, MessageEventDefinition.class)
+        ModelUtil.getEventDefinition(eventDefinitions, MessageEventDefinition.class)
             .map(MessageEventDefinition::getMessage)
             .filter(m -> m.getName() != null && !m.getName().isEmpty())
             .map(Message::getName);

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeEventBasedGatewayValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeEventBasedGatewayValidationTest.java
@@ -71,7 +71,7 @@ public class ZeebeEventBasedGatewayValidationTest extends AbstractZeebeValidatio
         singletonList(
             expect(
                 EventBasedGateway.class,
-                "Multiple message catch events with the same name 'msg' are not allowed."))
+                "Multiple message event definitions with the same name 'msg' are not allowed."))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeStartEventValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeStartEventValidationTest.java
@@ -16,7 +16,6 @@
 package io.zeebe.model.bpmn.validation;
 
 import static io.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
 import io.zeebe.model.bpmn.Bpmn;
@@ -66,14 +65,12 @@ public class ZeebeStartEventValidationTest extends AbstractZeebeValidationTest {
         singletonList(expect(Process.class, "Multiple none start events are not allowed"))
       },
       {
-        cycleTimerStartEventSubprocess(false), emptyList(),
+        cycleTimerStartEventSubprocess(false), valid(),
       },
       {
         cycleTimerStartEventSubprocess(true),
         Collections.singletonList(
-            expect(
-                SubProcess.class,
-                "Interrupting timer start events in event subprocesses can't have time cycles")),
+            expect(SubProcess.class, "Interrupting timer event with time cycle is not allowed.")),
       },
       {processWithNoneStartEventAndMultipleOtherStartEvents(), valid()},
     };

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeTimerValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeTimerValidationTest.java
@@ -65,7 +65,7 @@ public class ZeebeTimerValidationTest extends AbstractZeebeValidationTest {
             .endEvent()
             .done(),
         singletonList(
-            expect(BoundaryEvent.class, "Interrupting events of this type are not supported"))
+            expect(BoundaryEvent.class, "Interrupting timer event with time cycle is not allowed."))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
@@ -99,21 +99,22 @@ public class ZeebeValidationTest extends AbstractZeebeValidationTest {
         singletonList(
             expect(
                 "task",
-                "Multiple message boundary events with the same name 'message' are not allowed."))
+                "Multiple message event definitions with the same name 'message' are not allowed."))
       },
       {
         eventSubprocWithNoneStart(),
         singletonList(
             expect(
                 "subprocess",
-                "Start events in event subprocesses must be of type message or timer"))
+                "Start events in event subprocesses must be one of: message, timer, error"))
       },
       {
         eventSubprocWithSignalStart(),
         Arrays.asList(
             expect(SignalEventDefinition.class, "Event definition of this type is not supported"),
             expect(
-                "subprocess", "Start events in event subprocesses must of type message or timer"))
+                "subprocess",
+                "Start events in event subprocesses must be one of: message, timer, error"))
       }
     };
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/BpmnStepHandlers.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/BpmnStepHandlers.java
@@ -69,7 +69,10 @@ public final class BpmnStepHandlers {
     final IncidentResolver incidentResolver = new IncidentResolver(state.getIncidentState());
     final CatchEventSubscriber catchEventSubscriber = new CatchEventSubscriber(catchEventBehavior);
     final BufferedMessageToStartEventCorrelator messageStartEventCorrelator =
-        new BufferedMessageToStartEventCorrelator(state.getKeyGenerator(), state.getMessageState());
+        new BufferedMessageToStartEventCorrelator(
+            state.getKeyGenerator(),
+            state.getMessageState(),
+            state.getWorkflowState().getEventScopeInstanceState());
 
     stepHandlers.put(BpmnStep.ELEMENT_ACTIVATING, new ElementActivatingHandler<>());
     stepHandlers.put(BpmnStep.ELEMENT_ACTIVATED, new ElementActivatedHandler<>());

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/EventHandle.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/EventHandle.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow;
+
+import io.zeebe.engine.processor.KeyGenerator;
+import io.zeebe.engine.processor.TypedStreamWriter;
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableFlowElement;
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableStartEvent;
+import io.zeebe.engine.state.instance.ElementInstance;
+import io.zeebe.engine.state.instance.EventScopeInstanceState;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import org.agrona.DirectBuffer;
+
+public final class EventHandle {
+
+  private final WorkflowInstanceRecord eventOccurredRecord = new WorkflowInstanceRecord();
+  private final KeyGenerator keyGenerator;
+  private final EventScopeInstanceState eventScopeInstanceState;
+
+  public EventHandle(
+      final KeyGenerator keyGenerator, final EventScopeInstanceState eventScopeInstanceState) {
+    this.keyGenerator = keyGenerator;
+    this.eventScopeInstanceState = eventScopeInstanceState;
+  }
+
+  public boolean triggerEvent(
+      final TypedStreamWriter streamWriter,
+      final ElementInstance eventScopeInstance,
+      final ExecutableFlowElement catchEvent,
+      final DirectBuffer variables) {
+
+    final var newElementInstanceKey = keyGenerator.nextKey();
+    final var triggered =
+        eventScopeInstanceState.triggerEvent(
+            eventScopeInstance.getKey(), newElementInstanceKey, catchEvent.getId(), variables);
+
+    if (triggered) {
+
+      final long eventOccurredKey;
+
+      if (isEventSubprocess(catchEvent)) {
+
+        eventOccurredKey = keyGenerator.nextKey();
+        eventOccurredRecord.wrap(eventScopeInstance.getValue());
+        eventOccurredRecord
+            .setElementId(catchEvent.getId())
+            .setBpmnElementType(BpmnElementType.START_EVENT)
+            .setFlowScopeKey(eventScopeInstance.getKey());
+
+      } else {
+        eventOccurredKey = eventScopeInstance.getKey();
+        eventOccurredRecord.wrap(eventScopeInstance.getValue());
+      }
+
+      streamWriter.appendFollowUpEvent(
+          eventOccurredKey, WorkflowInstanceIntent.EVENT_OCCURRED, eventOccurredRecord);
+    }
+
+    return triggered;
+  }
+
+  public long triggerStartEvent(
+      final TypedStreamWriter streamWriter,
+      final long workflowKey,
+      final DirectBuffer elementId,
+      final DirectBuffer variables) {
+
+    final var newElementInstanceKey = keyGenerator.nextKey();
+    final var triggered =
+        eventScopeInstanceState.triggerEvent(
+            workflowKey, newElementInstanceKey, elementId, variables);
+
+    if (triggered) {
+
+      final var workflowInstanceKey = keyGenerator.nextKey();
+      final var eventOccurredKey = keyGenerator.nextKey();
+
+      eventOccurredRecord
+          .setBpmnElementType(BpmnElementType.START_EVENT)
+          .setWorkflowKey(workflowKey)
+          .setWorkflowInstanceKey(workflowInstanceKey)
+          .setElementId(elementId);
+
+      streamWriter.appendFollowUpEvent(
+          eventOccurredKey, WorkflowInstanceIntent.EVENT_OCCURRED, eventOccurredRecord);
+
+      return workflowInstanceKey;
+
+    } else {
+      return -1L;
+    }
+  }
+
+  private boolean isEventSubprocess(final ExecutableFlowElement catchEvent) {
+    return catchEvent instanceof ExecutableStartEvent
+        && ((ExecutableStartEvent) catchEvent).getEventSubProcess() != null;
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableActivity.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableActivity.java
@@ -13,7 +13,10 @@ import java.util.List;
 import org.agrona.DirectBuffer;
 
 public class ExecutableActivity extends ExecutableFlowNode implements ExecutableCatchEventSupplier {
+
   private final List<ExecutableBoundaryEvent> boundaryEvents = new ArrayList<>();
+  private final List<ExecutableFlowElementContainer> eventSubprocesses = new ArrayList<>();
+
   private final List<ExecutableCatchEvent> catchEvents = new ArrayList<>();
   private final List<DirectBuffer> interruptingIds = new ArrayList<>();
 
@@ -30,8 +33,22 @@ public class ExecutableActivity extends ExecutableFlowNode implements Executable
     }
   }
 
+  public void attach(final ExecutableFlowElementContainer eventSubprocess) {
+    eventSubprocesses.add(eventSubprocess);
+
+    final var startEvent = eventSubprocess.getStartEvents().get(0);
+    catchEvents.add(0, startEvent);
+
+    if (startEvent.interrupting()) {
+      interruptingIds.add(startEvent.getId());
+    }
+  }
+
   @Override
   public List<ExecutableCatchEvent> getEvents() {
+    // the order defines the precedence
+    // 1. event subprocesses
+    // 2. boundary events
     return catchEvents;
   }
 
@@ -42,5 +59,9 @@ public class ExecutableActivity extends ExecutableFlowNode implements Executable
 
   public List<ExecutableBoundaryEvent> getBoundaryEvents() {
     return boundaryEvents;
+  }
+
+  public List<ExecutableFlowElementContainer> getEventSubprocesses() {
+    return eventSubprocesses;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/MultiInstanceActivityTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/MultiInstanceActivityTransformer.java
@@ -71,6 +71,7 @@ public final class MultiInstanceActivityTransformer implements ModelElementTrans
 
       // attach boundary events to the multi-instance body
       innerActivity.getBoundaryEvents().forEach(multiInstanceBody::attach);
+
       innerActivity.getEvents().removeAll(innerActivity.getBoundaryEvents());
       innerActivity.getInterruptingElementIds().clear();
 

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/SubProcessTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/SubProcessTransformer.java
@@ -8,7 +8,6 @@
 package io.zeebe.engine.processor.workflow.deployment.model.transformer;
 
 import io.zeebe.engine.processor.workflow.deployment.model.BpmnStep;
-import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableCatchEvent;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableFlowElementContainer;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableStartEvent;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableWorkflow;
@@ -17,7 +16,6 @@ import io.zeebe.engine.processor.workflow.deployment.model.transformation.Transf
 import io.zeebe.model.bpmn.instance.FlowNode;
 import io.zeebe.model.bpmn.instance.SubProcess;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
-import java.util.List;
 
 public final class SubProcessTransformer implements ModelElementTransformer<SubProcess> {
 
@@ -48,22 +46,20 @@ public final class SubProcessTransformer implements ModelElementTransformer<SubP
       final SubProcess element,
       final ExecutableWorkflow currentWorkflow,
       final ExecutableFlowElementContainer subprocess) {
-    final List<ExecutableCatchEvent> parentEvents;
 
     if (element.getScope() instanceof FlowNode) {
       final FlowNode scope = (FlowNode) element.getScope();
       final ExecutableFlowElementContainer parentSubProc =
           currentWorkflow.getElementById(scope.getId(), ExecutableFlowElementContainer.class);
 
-      parentEvents = parentSubProc.getEvents();
+      parentSubProc.attach(subprocess);
     } else {
       // top-level start event
-      parentEvents = currentWorkflow.getEvents();
+      currentWorkflow.attach(subprocess);
     }
 
     final ExecutableStartEvent startEvent = subprocess.getStartEvents().iterator().next();
 
-    parentEvents.add(startEvent);
     startEvent.setEventSubProcess(subprocess.getId());
     startEvent.bindLifecycleState(
         WorkflowInstanceIntent.EVENT_OCCURRED, BpmnStep.EVENT_SUBPROC_EVENT_OCCURRED);

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/CorrelateWorkflowInstanceSubscription.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/CorrelateWorkflowInstanceSubscription.java
@@ -14,21 +14,17 @@ import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.engine.processor.TypedRecordProcessor;
 import io.zeebe.engine.processor.TypedResponseWriter;
 import io.zeebe.engine.processor.TypedStreamWriter;
-import io.zeebe.engine.processor.workflow.deployment.model.element.AbstractFlowElement;
-import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableStartEvent;
+import io.zeebe.engine.processor.workflow.EventHandle;
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableFlowElement;
 import io.zeebe.engine.processor.workflow.message.command.SubscriptionCommandSender;
 import io.zeebe.engine.state.ZeebeState;
-import io.zeebe.engine.state.deployment.DeployedWorkflow;
 import io.zeebe.engine.state.deployment.WorkflowState;
-import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.engine.state.message.WorkflowInstanceSubscription;
 import io.zeebe.engine.state.message.WorkflowInstanceSubscriptionState;
 import io.zeebe.protocol.impl.record.value.message.WorkflowInstanceSubscriptionRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.RejectionType;
-import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceSubscriptionIntent;
-import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.util.buffer.BufferUtil;
 import io.zeebe.util.sched.ActorControl;
 import java.time.Duration;
@@ -55,6 +51,8 @@ public final class CorrelateWorkflowInstanceSubscription
   private final WorkflowState workflowState;
   private final KeyGenerator keyGenerator;
 
+  private final EventHandle eventHandle;
+
   private final WorkflowInstanceRecord eventSubprocessRecord = new WorkflowInstanceRecord();
   private WorkflowInstanceSubscriptionRecord subscriptionRecord;
   private DirectBuffer correlationKey;
@@ -67,6 +65,9 @@ public final class CorrelateWorkflowInstanceSubscription
     this.subscriptionCommandSender = subscriptionCommandSender;
     workflowState = zeebeState.getWorkflowState();
     keyGenerator = zeebeState.getKeyGenerator();
+
+    eventHandle =
+        new EventHandle(keyGenerator, zeebeState.getWorkflowState().getEventScopeInstanceState());
   }
 
   @Override
@@ -123,24 +124,15 @@ public final class CorrelateWorkflowInstanceSubscription
       subscriptionState.remove(subscription);
     }
 
-    final ElementInstance elementInstance =
-        workflowState.getElementInstanceState().getInstance(subscription.getElementInstanceKey());
-    final long eventKey = keyGenerator.nextKey();
-    final boolean isOccurred =
-        workflowState
-            .getEventScopeInstanceState()
-            .triggerEvent(
-                subscriptionRecord.getElementInstanceKey(),
-                eventKey,
-                subscription.getTargetElementId(),
-                record.getValue().getVariablesBuffer());
+    final boolean isTriggered =
+        triggerCatchEvent(streamWriter, subscription, record.getValue().getVariablesBuffer());
 
-    if (isOccurred) {
+    if (isTriggered) {
       sideEffect.accept(this::sendAcknowledgeCommand);
 
       streamWriter.appendFollowUpEvent(
           record.getKey(), WorkflowInstanceSubscriptionIntent.CORRELATED, subscriptionRecord);
-      writeEventOccurred(record, streamWriter, subscription, elementInstance);
+
     } else {
       correlationKey = subscription.getCorrelationKey();
       sideEffect.accept(this::sendRejectionCommand);
@@ -155,41 +147,23 @@ public final class CorrelateWorkflowInstanceSubscription
     }
   }
 
-  private void writeEventOccurred(
-      final TypedRecord<WorkflowInstanceSubscriptionRecord> record,
+  private boolean triggerCatchEvent(
       final TypedStreamWriter streamWriter,
       final WorkflowInstanceSubscription subscription,
-      final ElementInstance elementInstance) {
-    final long workflowKey = elementInstance.getValue().getWorkflowKey();
-    final DeployedWorkflow workflow = workflowState.getWorkflowByKey(workflowKey);
+      final DirectBuffer variables) {
 
-    if (isEventSubprocessStart(workflow, subscription.getTargetElementId())) {
-      eventSubprocessRecord.reset();
-      eventSubprocessRecord
-          .setWorkflowKey(workflowKey)
-          .setElementId(subscription.getTargetElementId())
-          .setWorkflowInstanceKey(record.getValue().getWorkflowInstanceKey())
-          .setBpmnElementType(BpmnElementType.START_EVENT)
-          .setBpmnProcessId(workflow.getBpmnProcessId())
-          .setVersion(workflow.getVersion())
-          .setFlowScopeKey(elementInstance.getKey());
-
-      streamWriter.appendFollowUpEvent(
-          keyGenerator.nextKey(), WorkflowInstanceIntent.EVENT_OCCURRED, eventSubprocessRecord);
-    } else {
-      streamWriter.appendFollowUpEvent(
-          subscriptionRecord.getElementInstanceKey(),
-          WorkflowInstanceIntent.EVENT_OCCURRED,
-          elementInstance.getValue());
+    final var elementInstance =
+        workflowState.getElementInstanceState().getInstance(subscription.getElementInstanceKey());
+    if (elementInstance == null) {
+      return false;
     }
-  }
 
-  private boolean isEventSubprocessStart(
-      final DeployedWorkflow workflow, final DirectBuffer catchEventId) {
-    final AbstractFlowElement catchEvent = workflow.getWorkflow().getElementById(catchEventId);
+    final var workflowKey = elementInstance.getValue().getWorkflowKey();
+    final var catchEvent =
+        workflowState.getFlowElement(
+            workflowKey, subscription.getTargetElementId(), ExecutableFlowElement.class);
 
-    return ExecutableStartEvent.class.isAssignableFrom(catchEvent.getClass())
-        && ((ExecutableStartEvent) catchEvent).getEventSubProcess() != null;
+    return eventHandle.triggerEvent(streamWriter, elementInstance, catchEvent, variables);
   }
 
   private boolean sendAcknowledgeCommand() {

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/timer/TriggerTimerProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/timer/TriggerTimerProcessor.java
@@ -7,34 +7,23 @@
  */
 package io.zeebe.engine.processor.workflow.timer;
 
-import static io.zeebe.engine.state.instance.TimerInstance.NO_ELEMENT_INSTANCE;
-import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
-
-import io.zeebe.engine.processor.KeyGenerator;
 import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.engine.processor.TypedRecordProcessor;
 import io.zeebe.engine.processor.TypedResponseWriter;
 import io.zeebe.engine.processor.TypedStreamWriter;
 import io.zeebe.engine.processor.workflow.CatchEventBehavior;
-import io.zeebe.engine.processor.workflow.deployment.model.element.AbstractFlowElement;
-import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableCatchEventElement;
-import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableStartEvent;
+import io.zeebe.engine.processor.workflow.EventHandle;
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableCatchEvent;
 import io.zeebe.engine.state.ZeebeState;
-import io.zeebe.engine.state.deployment.DeployedWorkflow;
 import io.zeebe.engine.state.deployment.WorkflowState;
-import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.engine.state.instance.TimerInstance;
 import io.zeebe.model.bpmn.util.time.RepeatingInterval;
-import io.zeebe.msgpack.value.DocumentValue;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
-import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.TimerIntent;
-import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
-import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.util.buffer.BufferUtil;
-import java.util.List;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRecord> {
   private static final String NO_TIMER_FOUND_MESSAGE =
@@ -42,16 +31,19 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
   private static final String NO_ACTIVE_TIMER_MESSAGE =
       "Expected to trigger a timer with key '%d', but the timer is not active anymore";
 
+  private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
+
   private final CatchEventBehavior catchEventBehavior;
   private final WorkflowState workflowState;
-  private final WorkflowInstanceRecord eventOccurredRecord = new WorkflowInstanceRecord();
-  private final KeyGenerator keyGenerator;
+  private final EventHandle eventHandle;
 
   public TriggerTimerProcessor(
       final ZeebeState zeebeState, final CatchEventBehavior catchEventBehavior) {
-    workflowState = zeebeState.getWorkflowState();
-    keyGenerator = zeebeState.getKeyGenerator();
     this.catchEventBehavior = catchEventBehavior;
+    workflowState = zeebeState.getWorkflowState();
+
+    eventHandle =
+        new EventHandle(zeebeState.getKeyGenerator(), workflowState.getEventScopeInstanceState());
   }
 
   @Override
@@ -79,26 +71,21 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
       final TypedStreamWriter streamWriter,
       final TimerRecord timer,
       final long elementInstanceKey) {
-    final long eventScopeKey =
-        isTimerStartEvent(elementInstanceKey)
-            ? record.getValue().getWorkflowKey()
-            : elementInstanceKey;
 
-    final boolean wasActiveTimer = tryTriggerTimer(eventScopeKey, timer);
-    if (wasActiveTimer) {
-      final long eventOccurredKey = prepareEventOccurredEvent(timer, elementInstanceKey);
+    final var workflowKey = timer.getWorkflowKey();
+    final var catchEvent =
+        workflowState.getFlowElement(
+            workflowKey, timer.getTargetElementIdBuffer(), ExecutableCatchEvent.class);
 
+    final boolean isTriggered =
+        triggerEvent(streamWriter, timer, elementInstanceKey, workflowKey, catchEvent);
+
+    if (isTriggered) {
       streamWriter.appendFollowUpEvent(record.getKey(), TimerIntent.TRIGGERED, timer);
-      streamWriter.appendFollowUpEvent(
-          eventOccurredKey, WorkflowInstanceIntent.EVENT_OCCURRED, eventOccurredRecord);
 
       // todo(npepinpe): migrate to bpmn step processor
       if (shouldReschedule(timer)) {
-        final ExecutableCatchEventElement timerEvent = getTimerEvent(elementInstanceKey, timer);
-
-        if (timerEvent != null && timerEvent.isTimer()) {
-          rescheduleTimer(timer, streamWriter, timerEvent);
-        }
+        rescheduleTimer(timer, streamWriter, catchEvent);
       }
     } else {
       streamWriter.appendRejection(
@@ -108,88 +95,34 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
     }
   }
 
-  private boolean tryTriggerTimer(final long eventScopeKey, final TimerRecord timer) {
-    final long eventKey = keyGenerator.nextKey();
-    return workflowState
-        .getEventScopeInstanceState()
-        .triggerEvent(
-            eventScopeKey,
-            eventKey,
-            timer.getTargetElementIdBuffer(),
-            DocumentValue.EMPTY_DOCUMENT);
-  }
+  private boolean triggerEvent(
+      final TypedStreamWriter streamWriter,
+      final TimerRecord timer,
+      final long elementInstanceKey,
+      final long workflowKey,
+      final ExecutableCatchEvent catchEvent) {
 
-  private long prepareEventOccurredEvent(final TimerRecord timer, final long elementInstanceKey) {
-    final long eventOccurredKey;
+    if (elementInstanceKey > 0) {
+      final var elementInstance =
+          workflowState.getElementInstanceState().getInstance(elementInstanceKey);
 
-    eventOccurredRecord.reset();
-    if (isTimerStartEvent(elementInstanceKey)) {
+      return eventHandle.triggerEvent(streamWriter, elementInstance, catchEvent, NO_VARIABLES);
 
-      eventOccurredKey = keyGenerator.nextKey();
-      eventOccurredRecord
-          .setBpmnElementType(BpmnElementType.START_EVENT)
-          .setWorkflowKey(timer.getWorkflowKey())
-          .setWorkflowInstanceKey(keyGenerator.nextKey())
-          .setElementId(timer.getTargetElementIdBuffer());
-    } else if (isInEventSubprocess(timer)) {
-      eventOccurredKey = keyGenerator.nextKey();
-      eventOccurredRecord.wrap(
-          workflowState.getElementInstanceState().getInstance(elementInstanceKey).getValue());
-      eventOccurredRecord
-          .setBpmnElementType(BpmnElementType.START_EVENT)
-          .setElementId(timer.getTargetElementIdBuffer())
-          .setFlowScopeKey(elementInstanceKey);
     } else {
-      eventOccurredKey = elementInstanceKey;
-      eventOccurredRecord.wrap(
-          workflowState.getElementInstanceState().getInstance(elementInstanceKey).getValue());
+      final var workflowInstanceKey =
+          eventHandle.triggerStartEvent(
+              streamWriter, workflowKey, timer.getTargetElementIdBuffer(), NO_VARIABLES);
+
+      return workflowInstanceKey > 0;
     }
-    return eventOccurredKey;
-  }
-
-  private boolean isTimerStartEvent(final long elementInstanceKey) {
-    return elementInstanceKey == NO_ELEMENT_INSTANCE;
-  }
-
-  private boolean isInEventSubprocess(final TimerRecord timer) {
-    final ExecutableCatchEventElement catchEvent =
-        getCatchEventById(timer.getWorkflowKey(), timer.getTargetElementIdBuffer());
-
-    return catchEvent instanceof ExecutableStartEvent
-        && ((ExecutableStartEvent) catchEvent).getEventSubProcess() != null;
   }
 
   private boolean shouldReschedule(final TimerRecord timer) {
     return timer.getRepetitions() == RepeatingInterval.INFINITE || timer.getRepetitions() > 1;
   }
 
-  private ExecutableCatchEventElement getTimerEvent(
-      final long elementInstanceKey, final TimerRecord timer) {
-    if (isTimerStartEvent(elementInstanceKey)) {
-      final List<ExecutableStartEvent> startEvents =
-          workflowState.getWorkflowByKey(timer.getWorkflowKey()).getWorkflow().getStartEvents();
-
-      for (final ExecutableCatchEventElement startEvent : startEvents) {
-        if (startEvent.getId().equals(timer.getTargetElementIdBuffer())) {
-          return startEvent;
-        }
-      }
-    } else {
-      final ElementInstance elementInstance =
-          workflowState.getElementInstanceState().getInstance(elementInstanceKey);
-
-      if (elementInstance != null) {
-        return getCatchEventById(
-            elementInstance.getValue().getWorkflowKey(), timer.getTargetElementIdBuffer());
-      }
-    }
-    return null;
-  }
-
   private void rescheduleTimer(
-      final TimerRecord record,
-      final TypedStreamWriter writer,
-      final ExecutableCatchEventElement event) {
+      final TimerRecord record, final TypedStreamWriter writer, final ExecutableCatchEvent event) {
     if (event.getTimer() == null) {
       final String message =
           String.format(
@@ -212,33 +145,5 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
         event.getId(),
         timer,
         writer);
-  }
-
-  private ExecutableCatchEventElement getCatchEventById(
-      final long workflowKey, final DirectBuffer id) {
-    final DeployedWorkflow workflow = workflowState.getWorkflowByKey(workflowKey);
-    if (workflow == null) {
-      throw new IllegalStateException(
-          String.format(
-              "Expected to reschedule timer in workflow with key '%d', but no such workflow was found",
-              workflowKey));
-    }
-
-    final AbstractFlowElement element = workflow.getWorkflow().getElementById(id);
-    if (element == null) {
-      throw new IllegalStateException(
-          String.format(
-              "Expected to reschedule timer for element with id '%s', but no such element was found",
-              bufferAsString(id)));
-    }
-
-    if (!(element instanceof ExecutableCatchEventElement)) {
-      throw new IllegalStateException(
-          String.format(
-              "Expected to reschedule timer for element with id '%s', but the element is not a timer catch event",
-              workflowKey));
-    }
-
-    return (ExecutableCatchEventElement) element;
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/boundary/BoundaryEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/boundary/BoundaryEventTest.java
@@ -128,8 +128,8 @@ public final class BoundaryEventTest {
     assertThat(records)
         .extracting(Record::getValueType, Record::getIntent)
         .containsSequence(
-            tuple(ValueType.TIMER, TimerIntent.TRIGGERED),
             tuple(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.EVENT_OCCURRED),
+            tuple(ValueType.TIMER, TimerIntent.TRIGGERED),
             tuple(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_TERMINATING),
             tuple(ValueType.JOB, JobIntent.CANCEL),
             tuple(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_TERMINATED),
@@ -252,8 +252,8 @@ public final class BoundaryEventTest {
     assertThat(records)
         .extracting(Record::getValueType, Record::getIntent)
         .endsWith(
-            tuple(ValueType.TIMER, TimerIntent.TRIGGERED),
             tuple(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.EVENT_OCCURRED),
+            tuple(ValueType.TIMER, TimerIntent.TRIGGERED),
             tuple(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_TERMINATING),
             tuple(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_TERMINATING),
             tuple(ValueType.JOB, JobIntent.CANCEL),
@@ -299,8 +299,8 @@ public final class BoundaryEventTest {
     assertThat(records)
         .extracting(Record::getValueType, Record::getIntent)
         .containsSubsequence(
-            tuple(ValueType.TIMER, TimerIntent.TRIGGERED),
             tuple(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.EVENT_OCCURRED),
+            tuple(ValueType.TIMER, TimerIntent.TRIGGERED),
             tuple(ValueType.TIMER, TimerIntent.CREATE),
             tuple(ValueType.JOB, JobIntent.COMPLETED),
             tuple(ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_COMPLETING),

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/error/ErrorCatchEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/error/ErrorCatchEventTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public final class ErrorCatchEventTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String TASK_ELEMENT_ID = "task";
+  private static final String PROCESS_ID = "wf";
+  private static final String JOB_TYPE = "test";
+  private static final String ERROR_CODE = "ERROR";
+
+  @Parameter(0)
+  public String description;
+
+  @Parameter(1)
+  public BpmnModelInstance workflow;
+
+  @Parameter(2)
+  public String expectedEventOccurredElementId;
+
+  @Parameter(3)
+  public String expectedActivatedElement;
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Parameters(name = "{0}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        "boundary event on service task",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(TASK_ELEMENT_ID, t -> t.zeebeTaskType(JOB_TYPE))
+            .boundaryEvent("error-boundary-event", b -> b.error(ERROR_CODE))
+            .endEvent()
+            .done(),
+        TASK_ELEMENT_ID,
+        "error-boundary-event"
+      },
+      {
+        "boundary event on subprocess",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.embeddedSubProcess()
+                        .startEvent()
+                        .serviceTask(TASK_ELEMENT_ID, t -> t.zeebeTaskType(JOB_TYPE))
+                        .endEvent())
+            .boundaryEvent("error-boundary-event", b -> b.error(ERROR_CODE))
+            .endEvent()
+            .done(),
+        "subprocess",
+        "error-boundary-event"
+      },
+      {
+        "error event subprocess",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess(
+                "error-event-subprocess",
+                s ->
+                    s.startEvent("error-start-event")
+                        .error(ERROR_CODE)
+                        .interrupting(true)
+                        .endEvent())
+            .startEvent()
+            .serviceTask(TASK_ELEMENT_ID, t -> t.zeebeTaskType(JOB_TYPE))
+            .endEvent()
+            .done(),
+        "error-start-event",
+        "error-event-subprocess"
+      },
+      {
+        "favor boundary event on task over boundary event on subprocess",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.embeddedSubProcess()
+                        .startEvent()
+                        .serviceTask(TASK_ELEMENT_ID, t -> t.zeebeTaskType(JOB_TYPE))
+                        .boundaryEvent("error-boundary-event", b -> b.error(ERROR_CODE))
+                        .endEvent())
+            .boundaryEvent("error-boundary-event-on-subprocess", b -> b.error(ERROR_CODE))
+            .endEvent()
+            .done(),
+        TASK_ELEMENT_ID,
+        "error-boundary-event"
+      },
+      {
+        "favor boundary event on task over error event subprocess",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess(
+                "error-event-subprocess",
+                s -> s.startEvent().error(ERROR_CODE).interrupting(true).endEvent())
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeTaskType(JOB_TYPE))
+            .boundaryEvent("error-boundary-event")
+            .error(ERROR_CODE)
+            .endEvent()
+            .done(),
+        TASK_ELEMENT_ID,
+        "error-boundary-event"
+      },
+      {
+        "favor error event subprocess over boundary event on subprocess",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "sub",
+                s ->
+                    s.embeddedSubProcess()
+                        .eventSubProcess(
+                            "error-event-subprocess",
+                            e ->
+                                e.startEvent("error-start-event")
+                                    .error(ERROR_CODE)
+                                    .interrupting(true)
+                                    .endEvent())
+                        .startEvent()
+                        .serviceTask("task", t -> t.zeebeTaskType(JOB_TYPE))
+                        .endEvent())
+            .boundaryEvent("error", b -> b.error(ERROR_CODE))
+            .endEvent()
+            .done(),
+        "error-start-event",
+        "error-event-subprocess"
+      },
+    };
+  }
+
+  @Test
+  public void shouldTriggerEvent() {
+    // given
+    ENGINE.deployment().withXmlResource(workflow).deploy();
+
+    final var workflowInstanceKey = ENGINE.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(workflowInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .throwError();
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .limitToWorkflowInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple(expectedEventOccurredElementId, WorkflowInstanceIntent.EVENT_OCCURRED),
+            tuple(TASK_ELEMENT_ID, WorkflowInstanceIntent.ELEMENT_TERMINATING),
+            tuple(TASK_ELEMENT_ID, WorkflowInstanceIntent.ELEMENT_TERMINATED),
+            tuple(expectedActivatedElement, WorkflowInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(expectedActivatedElement, WorkflowInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, WorkflowInstanceIntent.ELEMENT_COMPLETED));
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/subprocess/MultipleEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/subprocess/MultipleEventSubprocessTest.java
@@ -237,10 +237,7 @@ public final class MultipleEventSubprocessTest {
 
     // when
     triggerMessageStart(wfInstanceKey, helper.getMessageName());
-    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.EVENT_OCCURRED)
-        .withWorkflowInstanceKey(wfInstanceKey)
-        .withElementId("event_sub_start_msg")
-        .await();
+
     ENGINE.job().ofInstance(wfInstanceKey).withType("timerTask").complete();
 
     // then

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/subprocess/NonInterruptingEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/subprocess/NonInterruptingEventSubprocessTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.subprocess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.builder.ProcessBuilder;
+import io.zeebe.model.bpmn.builder.StartEventBuilder;
+import io.zeebe.protocol.record.Assertions;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.zeebe.protocol.record.intent.TimerIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
+import io.zeebe.protocol.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.protocol.record.value.deployment.DeployedWorkflow;
+import io.zeebe.test.util.BrokerClassRuleHelper;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class NonInterruptingEventSubprocessTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "proc";
+
+  private static String messageName;
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Parameterized.Parameter public String testName;
+
+  @Parameterized.Parameter(1)
+  public Function<StartEventBuilder, StartEventBuilder> builder;
+
+  @Parameterized.Parameter(2)
+  public Consumer<Long> triggerEventSubprocess;
+
+  private DeployedWorkflow currentWorkflow;
+
+  @Parameterized.Parameters(name = "{0} event subprocess")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        "timer",
+        eventSubprocess(s -> s.timerWithDuration("PT60S")),
+        eventTrigger(
+            key -> {
+              assertThat(
+                      RecordingExporter.timerRecords(TimerIntent.CREATED)
+                          .withWorkflowInstanceKey(key)
+                          .exists())
+                  .describedAs("Expected timer to exist")
+                  .isTrue();
+              ENGINE.increaseTime(Duration.ofSeconds(60));
+            })
+      },
+      {
+        "message",
+        eventSubprocess(s -> s.message(b -> b.name(messageName).zeebeCorrelationKey("key"))),
+        eventTrigger(
+            key -> {
+              RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+                  .withWorkflowInstanceKey(key)
+                  .withMessageName(messageName)
+                  .await();
+              ENGINE.message().withName(messageName).withCorrelationKey("123").publish();
+            })
+      },
+    };
+  }
+
+  private static Function<StartEventBuilder, StartEventBuilder> eventSubprocess(
+      final Function<StartEventBuilder, StartEventBuilder> consumer) {
+    return consumer;
+  }
+
+  private static Consumer<Long> eventTrigger(final Consumer<Long> eventTrigger) {
+    return eventTrigger;
+  }
+
+  @Before
+  public void init() {
+    messageName = helper.getMessageName();
+  }
+
+  @Test
+  public void shouldTriggerEventSubprocess() {
+    // when
+    final BpmnModelInstance model = eventSubprocModel(builder);
+    final long wfInstanceKey = createInstanceAndTriggerEvent(model);
+
+    // then
+    final Record<WorkflowInstanceRecordValue> eventOccurred =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.EVENT_OCCURRED)
+            .withWorkflowInstanceKey(wfInstanceKey)
+            .getFirst();
+    Assertions.assertThat(eventOccurred.getValue())
+        .hasWorkflowKey(currentWorkflow.getWorkflowKey())
+        .hasWorkflowInstanceKey(wfInstanceKey)
+        .hasBpmnElementType(BpmnElementType.START_EVENT)
+        .hasElementId("event_sub_start")
+        .hasVersion(currentWorkflow.getVersion())
+        .hasFlowScopeKey(wfInstanceKey);
+
+    assertEventSubprocessLifecycle(wfInstanceKey);
+  }
+
+  @Test
+  public void shouldNotInterruptParentProcess() {
+    // when
+    final BpmnModelInstance model = eventSubprocModel(builder);
+    final long wfInstanceKey = createInstanceAndTriggerEvent(model);
+
+    // then
+    assertEventSubprocessLifecycle(wfInstanceKey);
+    ENGINE.job().ofInstance(wfInstanceKey).withType("type").complete();
+
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(wfInstanceKey)
+                .limitToWorkflowInstanceCompleted())
+        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
+        .containsSubsequence(
+            tuple(BpmnElementType.START_EVENT, WorkflowInstanceIntent.EVENT_OCCURRED),
+            tuple(BpmnElementType.SUB_PROCESS, WorkflowInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.SUB_PROCESS, WorkflowInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.SERVICE_TASK, WorkflowInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.END_EVENT, WorkflowInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, WorkflowInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldNotPropagateVariablesToScope() {
+    // given
+    final BpmnModelInstance model = eventSubProcTaskModel(helper.getJobType(), "sub_type");
+    final long wfInstanceKey = createInstanceAndTriggerEvent(model);
+    final long eventSubprocKey =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .withWorkflowInstanceKey(wfInstanceKey)
+            .withElementType(BpmnElementType.SUB_PROCESS)
+            .getFirst()
+            .getKey();
+
+    ENGINE
+        .variables()
+        .ofScope(eventSubprocKey)
+        .withDocument(Map.of("y", 2))
+        .withUpdateSemantic(VariableDocumentUpdateSemantic.LOCAL)
+        .update();
+    ENGINE.job().ofInstance(wfInstanceKey).withType("sub_type").complete();
+
+    // then
+    final Record<JobBatchRecordValue> job = ENGINE.jobs().withType(helper.getJobType()).activate();
+    final Map<String, Object> jobVariables =
+        job.getValue().getJobs().iterator().next().getVariables();
+
+    // when
+    assertThat(jobVariables).containsOnly(Map.entry("key", 123));
+  }
+
+  private static void assertEventSubprocessLifecycle(final long workflowInstanceKey) {
+    final List<Record<WorkflowInstanceRecordValue>> events =
+        RecordingExporter.workflowInstanceRecords()
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .filter(r -> r.getValue().getElementId().startsWith("event_sub_"))
+            .limit(13)
+            .asList();
+
+    assertThat(events)
+        .extracting(Record::getIntent, e -> e.getValue().getElementId())
+        .containsExactly(
+            tuple(WorkflowInstanceIntent.EVENT_OCCURRED, "event_sub_start"),
+            tuple(WorkflowInstanceIntent.ELEMENT_ACTIVATING, "event_sub_proc"),
+            tuple(WorkflowInstanceIntent.ELEMENT_ACTIVATED, "event_sub_proc"),
+            tuple(WorkflowInstanceIntent.ELEMENT_ACTIVATING, "event_sub_start"),
+            tuple(WorkflowInstanceIntent.ELEMENT_ACTIVATED, "event_sub_start"),
+            tuple(WorkflowInstanceIntent.ELEMENT_COMPLETING, "event_sub_start"),
+            tuple(WorkflowInstanceIntent.ELEMENT_COMPLETED, "event_sub_start"),
+            tuple(WorkflowInstanceIntent.ELEMENT_ACTIVATING, "event_sub_end"),
+            tuple(WorkflowInstanceIntent.ELEMENT_ACTIVATED, "event_sub_end"),
+            tuple(WorkflowInstanceIntent.ELEMENT_COMPLETING, "event_sub_end"),
+            tuple(WorkflowInstanceIntent.ELEMENT_COMPLETED, "event_sub_end"),
+            tuple(WorkflowInstanceIntent.ELEMENT_COMPLETING, "event_sub_proc"),
+            tuple(WorkflowInstanceIntent.ELEMENT_COMPLETED, "event_sub_proc"));
+  }
+
+  private long createInstanceAndTriggerEvent(final BpmnModelInstance model) {
+    currentWorkflow =
+        ENGINE
+            .deployment()
+            .withXmlResource(model)
+            .deploy()
+            .getValue()
+            .getDeployedWorkflows()
+            .get(0);
+
+    final long wfInstanceKey =
+        ENGINE
+            .workflowInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariables(Map.of("key", 123))
+            .create();
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withWorkflowInstanceKey(wfInstanceKey)
+                .exists())
+        .describedAs("Expected job to be created")
+        .isTrue();
+
+    triggerEventSubprocess.accept(wfInstanceKey);
+    return wfInstanceKey;
+  }
+
+  private static BpmnModelInstance eventSubprocModel(
+      final Function<StartEventBuilder, StartEventBuilder> startBuilder) {
+    final ProcessBuilder builder = Bpmn.createExecutableProcess(PROCESS_ID);
+    startBuilder
+        .apply(
+            builder
+                .eventSubProcess("event_sub_proc")
+                .startEvent("event_sub_start")
+                .interrupting(false))
+        .endEvent("event_sub_end");
+
+    return builder
+        .startEvent("start_proc")
+        .serviceTask("task", t -> t.zeebeTaskType("type"))
+        .endEvent("end_proc")
+        .done();
+  }
+
+  private BpmnModelInstance eventSubProcTaskModel(
+      final String procTaskType, final String subprocTaskType) {
+    final ProcessBuilder modelBuilder = Bpmn.createExecutableProcess(PROCESS_ID);
+    builder
+        .apply(
+            modelBuilder
+                .eventSubProcess("event_sub_proc")
+                .startEvent("event_sub_start")
+                .interrupting(false))
+        .serviceTask("event_sub_task", t -> t.zeebeTaskType(subprocTaskType))
+        .endEvent("event_sub_end");
+
+    return modelBuilder
+        .startEvent("start_proc")
+        .serviceTask("task", t -> t.zeebeTaskType(procTaskType))
+        .endEvent("end_proc")
+        .done();
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/timer/TimerStartEventTest.java
@@ -135,13 +135,6 @@ public final class TimerStartEventTest {
         .hasVersion(deployedWorkflow.getVersion())
         .hasWorkflowKey(workflowKey);
 
-    final Record<WorkflowInstanceRecordValue> startEventOccurred =
-        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.EVENT_OCCURRED)
-            .withWorkflowKey(workflowKey)
-            .getFirst();
-    assertThat(startEventOccurred.getKey())
-        .isLessThan(startEventActivating.getWorkflowInstanceKey());
-
     final long triggerRecordPosition =
         RecordingExporter.timerRecords(TimerIntent.TRIGGER)
             .withWorkflowKey(workflowKey)


### PR DESCRIPTION
## Description

* an error event can be caught by an error event subprocess
* favor an error event subprocess over an error boundary event on an embedded subprocess
* extract validation logic from boundary event and event subprocess
* extract logic to trigger an event

## Related issues

closes #3498

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
