### PR TITLE
chore(client): ZeebeFuture extens CompletionStage

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/api/ZeebeFuture.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/ZeebeFuture.java
@@ -17,10 +17,11 @@ package io.zeebe.client.api;
 
 import io.zeebe.client.api.command.ClientException;
 import io.zeebe.client.api.command.ClientStatusException;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-public interface ZeebeFuture<T> extends Future<T> {
+public interface ZeebeFuture<T> extends Future<T>, CompletionStage<T> {
 
   /**
    * Like {@link #get()} but throws runtime exceptions.


### PR DESCRIPTION
## Description

It was not possible to chain ZeebeFutures nor add actions which are executed on future completeness. The implementation `ZeebeClientFutureImpl` extends `CompletableFuture`, but the `ZeebeFuture` didn't support CompletionStage. This is now fixed an preparation for https://github.com/zeebe-io/zeebe/issues/2970
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->
related to https://github.com/zeebe-io/zeebe/issues/2970

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
