### PR TITLE
feat(broker): raise incident if an error is not caught

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobEventProcessors.java
@@ -38,7 +38,7 @@ public final class JobEventProcessors {
         .onEvent(
             ValueType.JOB,
             JobIntent.ERROR_THROWN,
-            new JobErrorThrownProcessor(workflowState, keyGenerator))
+            new JobErrorThrownProcessor(workflowState, keyGenerator, jobState))
         .onCommand(ValueType.JOB, JobIntent.TIME_OUT, new TimeOutProcessor(jobState))
         .onCommand(ValueType.JOB, JobIntent.UPDATE_RETRIES, new UpdateRetriesProcessor(jobState))
         .onCommand(ValueType.JOB, JobIntent.CANCEL, new CancelProcessor(jobState))

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobThrowErrorProcessor.java
@@ -42,7 +42,6 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
       final JobRecord job = state.getJob(jobKey);
       job.setErrorCode(command.getValue().getErrorCodeBuffer());
       job.setErrorMessage(command.getValue().getErrorMessageBuffer());
-      state.throwError(jobKey, job);
 
       commandControl.accept(JobIntent.ERROR_THROWN, job);
     }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
@@ -109,7 +109,8 @@ public final class JobState {
     final DirectBuffer type = record.getTypeBuffer();
     final long deadline = record.getDeadline();
 
-    validateParameters(type, deadline);
+    validateParameters(type);
+    EnsureUtil.ensureGreaterThan("deadline", deadline, 0);
 
     resetVariablesAndUpdateJobRecord(key, record);
 
@@ -126,7 +127,9 @@ public final class JobState {
   public void timeout(final long key, final JobRecord record) {
     final DirectBuffer type = record.getTypeBuffer();
     final long deadline = record.getDeadline();
-    validateParameters(type, deadline);
+
+    validateParameters(type);
+    EnsureUtil.ensureGreaterThan("deadline", deadline, 0);
 
     createJob(key, record, type);
     removeJobDeadline(deadline);
@@ -167,7 +170,7 @@ public final class JobState {
     final DirectBuffer type = updatedValue.getTypeBuffer();
     final long deadline = updatedValue.getDeadline();
 
-    validateParameters(type, deadline);
+    validateParameters(type);
 
     resetVariablesAndUpdateJobRecord(key, updatedValue);
 
@@ -178,14 +181,15 @@ public final class JobState {
       makeJobActivatable(type, key);
     }
 
-    removeJobDeadline(deadline);
+    if (deadline > 0) {
+      removeJobDeadline(deadline);
+    }
 
     metrics.jobFailed(updatedValue.getType());
   }
 
-  private void validateParameters(final DirectBuffer type, final long deadline) {
+  private void validateParameters(final DirectBuffer type) {
     EnsureUtil.ensureNotNullOrEmpty("type", type);
-    EnsureUtil.ensureGreaterThan("deadline", deadline, 0);
   }
 
   public void resolve(final long key, final JobRecord updatedValue) {

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/ErrorEventIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/ErrorEventIncidentTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.record.Assertions;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.intent.IncidentIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.protocol.record.value.ErrorType;
+import io.zeebe.protocol.record.value.IncidentRecordValue;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class ErrorEventIncidentTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "wf";
+  private static final String JOB_TYPE = "test";
+  private static final String ERROR_CODE = "error";
+
+  private static final BpmnModelInstance WORKFLOW =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .serviceTask("task", t -> t.zeebeTaskType(JOB_TYPE))
+          .boundaryEvent("error", b -> b.error(ERROR_CODE))
+          .endEvent()
+          .done();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Before
+  public void init() {
+    ENGINE.deployment().withXmlResource(WORKFLOW).deploy();
+  }
+
+  @Test
+  public void shouldCreateIncident() {
+    // given
+    final long workflowInstanceKey = ENGINE.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    final var jobEvent =
+        ENGINE
+            .job()
+            .ofInstance(workflowInstanceKey)
+            .withType(JOB_TYPE)
+            .withErrorCode("other-error")
+            .withErrorMessage("error thrown")
+            .throwError();
+
+    // then
+    final Record<IncidentRecordValue> incidentEvent =
+        RecordingExporter.incidentRecords()
+            .withIntent(IncidentIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incidentEvent.getValue())
+        .hasErrorType(ErrorType.JOB_NO_RETRIES)
+        .hasErrorMessage("error thrown")
+        .hasBpmnProcessId(jobEvent.getValue().getBpmnProcessId())
+        .hasWorkflowKey(jobEvent.getValue().getWorkflowKey())
+        .hasWorkflowInstanceKey(jobEvent.getValue().getWorkflowInstanceKey())
+        .hasElementId(jobEvent.getValue().getElementId())
+        .hasElementInstanceKey(jobEvent.getValue().getElementInstanceKey())
+        .hasVariableScopeKey(jobEvent.getValue().getElementInstanceKey());
+  }
+
+  @Test
+  public void shouldCreateIncidentWithDefaultErrorMessage() {
+    // given
+    final long workflowInstanceKey = ENGINE.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(workflowInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode("other-error")
+        .throwError();
+
+    // then
+    final Record<IncidentRecordValue> incidentEvent =
+        RecordingExporter.incidentRecords()
+            .withIntent(IncidentIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incidentEvent.getValue())
+        .hasErrorType(ErrorType.JOB_NO_RETRIES)
+        .hasErrorMessage("An error was thrown with the code 'other-error' but not caught.");
+  }
+
+  @Test
+  public void shouldResolveIncident() {
+    // given
+    final long workflowInstanceKey = ENGINE.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var jobEvent =
+        ENGINE
+            .job()
+            .ofInstance(workflowInstanceKey)
+            .withType(JOB_TYPE)
+            .withErrorCode("other-error")
+            .throwError();
+
+    final Record<IncidentRecordValue> incidentEvent =
+        RecordingExporter.incidentRecords()
+            .withIntent(IncidentIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .getFirst();
+
+    // when
+    ENGINE.job().withKey(jobEvent.getKey()).withRetries(1).updateRetries();
+
+    ENGINE.incident().ofInstance(workflowInstanceKey).withKey(incidentEvent.getKey()).resolve();
+
+    // then
+    assertThat(ENGINE.jobs().withType(JOB_TYPE).activate().getValue().getJobKeys())
+        .contains(jobEvent.getKey());
+
+    ENGINE.job().withKey(jobEvent.getKey()).withErrorCode(ERROR_CODE).throwError();
+
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .limitToWorkflowInstanceCompleted()
+                .withElementType(BpmnElementType.BOUNDARY_EVENT))
+        .extracting(Record::getIntent)
+        .contains(WorkflowInstanceIntent.ELEMENT_COMPLETED);
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/instance/JobStateTest.java
@@ -494,8 +494,6 @@ public final class JobStateTest {
     // fail
     assertThatThrownBy(() -> jobState.fail(1L, jobWithoutType))
         .hasMessage("type must not be empty");
-    assertThatThrownBy(() -> jobState.fail(1L, jobWithoutDeadline))
-        .hasMessage("deadline must be greater than 0");
 
     // resolve
     assertThatThrownBy(() -> jobState.resolve(1L, jobWithoutType))


### PR DESCRIPTION
## Description

* create an incident and set the job retries to zero if an error is not caught by an error event
* this is just a temporal solution until we decided that is the expected solution for #3503 

## Related issues

related to #3503 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
