### PR TITLE
invalidate message event subprocess with no correlation key

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/MessageValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/MessageValidator.java
@@ -23,6 +23,7 @@ import io.zeebe.model.bpmn.instance.MessageEventDefinition;
 import io.zeebe.model.bpmn.instance.Process;
 import io.zeebe.model.bpmn.instance.ReceiveTask;
 import io.zeebe.model.bpmn.instance.StartEvent;
+import io.zeebe.model.bpmn.instance.SubProcess;
 import io.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription;
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -41,20 +42,31 @@ public class MessageValidator implements ModelElementValidator<Message> {
   @Override
   public void validate(
       final Message element, final ValidationResultCollector validationResultCollector) {
-    if (isReferedByCatchEvent(element) || isReferedByReceiveTask(element)) {
-      if (element.getName() == null || element.getName().isEmpty()) {
-        validationResultCollector.addError(0, "Name must be present and not empty");
-      }
-
-      final ExtensionElements extensionElements = element.getExtensionElements();
-
-      if (extensionElements == null
-          || extensionElements.getChildElementsByType(ZeebeSubscription.class).size() != 1) {
-        validationResultCollector.addError(
-            0, "Must have exactly one zeebe:subscription extension element");
-      }
+    if (isReferredByCatchEvent(element)
+        || isReferredByReceiveTask(element)
+        || isReferredByEventSubProcessStartEvent(element)) {
+      validateName(element, validationResultCollector);
+      validateSubscription(element, validationResultCollector);
     } else {
       validateIfReferredByStartEvent(element, validationResultCollector);
+    }
+  }
+
+  private void validateName(
+      final Message element, final ValidationResultCollector validationResultCollector) {
+    if (element.getName() == null || element.getName().isEmpty()) {
+      validationResultCollector.addError(0, "Name must be present and not empty");
+    }
+  }
+
+  private void validateSubscription(
+      final Message element, final ValidationResultCollector validationResultCollector) {
+    final ExtensionElements extensionElements = element.getExtensionElements();
+
+    if (extensionElements == null
+        || extensionElements.getChildElementsByType(ZeebeSubscription.class).size() != 1) {
+      validationResultCollector.addError(
+          0, "Must have exactly one zeebe:subscription extension element");
     }
   }
 
@@ -77,13 +89,11 @@ public class MessageValidator implements ModelElementValidator<Message> {
       validationResultCollector.addError(
           0, "A message cannot be referred by more than one start event");
     } else if (numReferredStartEvents == 1) {
-      if (element.getName() == null || element.getName().isEmpty()) {
-        validationResultCollector.addError(0, "Name must be present and not empty");
-      }
+      validateName(element, validationResultCollector);
     }
   }
 
-  private boolean isReferedByCatchEvent(final Message element) {
+  private boolean isReferredByCatchEvent(final Message element) {
     final Collection<IntermediateCatchEvent> intermediateCatchEvents =
         getAllElementsByType(element, IntermediateCatchEvent.class);
 
@@ -98,10 +108,27 @@ public class MessageValidator implements ModelElementValidator<Message> {
                     && ((MessageEventDefinition) e).getMessage() == element);
   }
 
-  private boolean isReferedByReceiveTask(final Message element) {
+  private boolean isReferredByReceiveTask(final Message element) {
     final Collection<ReceiveTask> receiveTasks = getAllElementsByType(element, ReceiveTask.class);
 
     return receiveTasks.stream().anyMatch(r -> r.getMessage() == element);
+  }
+
+  private boolean isReferredByEventSubProcessStartEvent(final Message element) {
+    final Collection<StartEvent> startEvents =
+        element.getParentElement().getChildElementsByType(Process.class).stream()
+            .flatMap(p -> p.getChildElementsByType(SubProcess.class).stream())
+            .flatMap(p -> p.getChildElementsByType(StartEvent.class).stream())
+            .collect(Collectors.toList());
+    final long numReferredSubProcessStartEvents =
+        startEvents.stream()
+            .flatMap(i -> i.getEventDefinitions().stream())
+            .filter(
+                e ->
+                    e instanceof MessageEventDefinition
+                        && ((MessageEventDefinition) e).getMessage() == element)
+            .count();
+    return numReferredSubProcessStartEvents == 1;
   }
 
   private <T extends ModelElementInstance> Collection<T> getAllElementsByType(

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeMessageValidationTest.java
@@ -172,6 +172,19 @@ public class ZeebeMessageValidationTest extends AbstractZeebeValidationTest {
             .done(),
         singletonList(expect(Message.class, "Name must be present and not empty"))
       },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .message(m -> m.name("message"))
+            .endEvent()
+            .done(),
+        valid()
+      },
+      {
+        getMessageEventSubProcessWithNoCorrelationKey(),
+        singletonList(
+            expect(Message.class, "Must have exactly one zeebe:subscription extension element"))
+      },
     };
   }
 
@@ -181,5 +194,17 @@ public class ZeebeMessageValidationTest extends AbstractZeebeValidationTest {
     process.startEvent("start1").message(m -> m.id("start-message").name(messageName)).endEvent();
     process.startEvent("start2").message(messageName).endEvent();
     return process.done();
+  }
+
+  private static BpmnModelInstance getMessageEventSubProcessWithNoCorrelationKey() {
+    final ProcessBuilder builder = Bpmn.createExecutableProcess("process");
+    builder
+        .eventSubProcess("subprocess")
+        .startEvent("substart")
+        .message(m -> m.name("message"))
+        .endEvent("subend")
+        .done();
+
+    return builder.startEvent("start").endEvent("end").done();
   }
 }


### PR DESCRIPTION
## Description

* validate messages if they are referred by an event subprocess

## Related issues

closes #3551

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
