### PR TITLE
chore(engine): merge message variables in event subprocess

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/eventsubproc/EventSubProcessEventOccurredHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/eventsubproc/EventSubProcessEventOccurredHandler.java
@@ -47,6 +47,7 @@ public final class EventSubProcessEventOccurredHandler<T extends ExecutableStart
     if (startEvent.interrupting()) {
       interruptingKey = handleInterrupting(context, triggeredEvent, scopeKey);
     } else {
+      processEventTrigger(context, context.getKey(), context.getKey(), triggeredEvent);
       context
           .getOutput()
           .appendFollowUpEvent(
@@ -73,9 +74,12 @@ public final class EventSubProcessEventOccurredHandler<T extends ExecutableStart
     if (waitForTermination) {
       return deferEvent(context, context.getKey(), scopeKey, containerRecord, triggeredEvent);
     } else {
-      return context
-          .getOutput()
-          .appendNewEvent(WorkflowInstanceIntent.ELEMENT_ACTIVATING, containerRecord);
+      final long eventKey =
+          context
+              .getOutput()
+              .appendNewEvent(WorkflowInstanceIntent.ELEMENT_ACTIVATING, containerRecord);
+      processEventTrigger(context, context.getKey(), eventKey, triggeredEvent);
+      return eventKey;
     }
   }
 

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageMappingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageMappingTest.java
@@ -143,8 +143,7 @@ public final class MessageMappingTest {
       {"interrupting boundary event", INTERRUPTING_BOUNDARY_EVENT_WORKFLOW},
       {"non-interrupting boundary event", NON_INTERRUPTING_BOUNDARY_EVENT_WORKFLOW},
       {"interrupting event subprocess", INTERRUPTING_EVENT_SUBPROCESS_WORKFLOW},
-      // TODO (saig0): enable test case when fixing #3552
-      // {"non-interrupting event subprocess", NON_INTERRUPTING_EVENT_SUBPROCESS_WORKFLOW}
+      {"non-interrupting event subprocess", NON_INTERRUPTING_EVENT_SUBPROCESS_WORKFLOW}
     };
   }
 


### PR DESCRIPTION
## Description

* process event triggers for non-interrupting event triggers so that the variables are merged.For interrupting event sub process, variables were merged due to invocation of `deferEvent`. 

## Related issues

closes #3552 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
