### PR TITLE
chore(broker): add correlationKey to correlate workflow instance command

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/CorrelateWorkflowInstanceSubscription.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/CorrelateWorkflowInstanceSubscription.java
@@ -105,7 +105,7 @@ public final class CorrelateWorkflowInstanceSubscription
         reason = ALREADY_CLOSING_MESSAGE;
         correlationKey = subscription.getCorrelationKey();
       } else {
-        correlationKey = null;
+        correlationKey = subscriptionRecord.getCorrelationKeyBuffer();
       }
 
       sideEffect.accept(this::sendRejectionCommand);

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageCorrelator.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageCorrelator.java
@@ -81,6 +81,7 @@ public final class MessageCorrelator {
         subscriptionRecord.getBpmnProcessIdBuffer(),
         subscriptionRecord.getMessageNameBuffer(),
         messageKey,
-        messageVariables);
+        messageVariables,
+        subscription.getCorrelationKey());
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/PendingMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/PendingMessageSubscriptionChecker.java
@@ -41,7 +41,8 @@ public final class PendingMessageSubscriptionChecker implements Runnable {
             subscription.getBpmnProcessId(),
             subscription.getMessageName(),
             subscription.getMessageKey(),
-            subscription.getMessageVariables());
+            subscription.getMessageVariables(),
+            subscription.getCorrelationKey());
 
     if (success) {
       subscriptionState.updateSentTimeInTransaction(subscription, ActorClock.currentTimeMillis());

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/PublishMessageProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/PublishMessageProcessor.java
@@ -226,7 +226,8 @@ public final class PublishMessageProcessor implements TypedRecordProcessor<Messa
                     subscription.getBpmnProcessId(),
                     messageRecord.getNameBuffer(),
                     messageKey,
-                    messageRecord.getVariablesBuffer()));
+                    messageRecord.getVariablesBuffer(),
+                    messageRecord.getCorrelationKeyBuffer()));
 
     return success ? responseWriter.flush() : false;
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/RejectMessageCorrelationProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/RejectMessageCorrelationProcessor.java
@@ -120,6 +120,7 @@ public final class RejectMessageCorrelationProcessor
         subscription.getBpmnProcessId(),
         subscription.getMessageName(),
         subscription.getMessageKey(),
-        subscription.getMessageVariables());
+        subscription.getMessageVariables(),
+        subscription.getCorrelationKey());
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/CorrelateWorkflowInstanceSubscriptionCommand.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/CorrelateWorkflowInstanceSubscriptionCommand.java
@@ -24,6 +24,7 @@ public final class CorrelateWorkflowInstanceSubscriptionCommand
   private final UnsafeBuffer messageName = new UnsafeBuffer(0, 0);
   private final UnsafeBuffer variables = new UnsafeBuffer(0, 0);
   private final UnsafeBuffer bpmnProcessId = new UnsafeBuffer(0, 0);
+  private final UnsafeBuffer correlationKey = new UnsafeBuffer(0, 0);
   private int subscriptionPartitionId;
   private long workflowInstanceKey;
   private long elementInstanceKey;
@@ -51,6 +52,7 @@ public final class CorrelateWorkflowInstanceSubscriptionCommand
     messageName.wrap(0, 0);
     variables.wrap(0, 0);
     bpmnProcessId.wrap(0, 0);
+    correlationKey.wrap(0, 0);
   }
 
   @Override
@@ -61,7 +63,9 @@ public final class CorrelateWorkflowInstanceSubscriptionCommand
         + CorrelateWorkflowInstanceSubscriptionDecoder.variablesHeaderLength()
         + variables.capacity()
         + CorrelateWorkflowInstanceSubscriptionDecoder.bpmnProcessIdHeaderLength()
-        + bpmnProcessId.capacity();
+        + bpmnProcessId.capacity()
+        + CorrelateWorkflowInstanceSubscriptionDecoder.correlationKeyHeaderLength()
+        + correlationKey.capacity();
   }
 
   @Override
@@ -75,7 +79,8 @@ public final class CorrelateWorkflowInstanceSubscriptionCommand
         .messageKey(messageKey)
         .putMessageName(messageName, 0, messageName.capacity())
         .putVariables(variables, 0, variables.capacity())
-        .putBpmnProcessId(bpmnProcessId, 0, bpmnProcessId.capacity());
+        .putBpmnProcessId(bpmnProcessId, 0, bpmnProcessId.capacity())
+        .putCorrelationKey(correlationKey, 0, correlationKey.capacity());
   }
 
   @Override
@@ -105,6 +110,12 @@ public final class CorrelateWorkflowInstanceSubscriptionCommand
     final int bpmnProcessIdLength = decoder.bpmnProcessIdLength();
     bpmnProcessId.wrap(buffer, offset, bpmnProcessIdLength);
     offset += bpmnProcessIdLength;
+    decoder.limit(offset);
+
+    offset += CorrelateWorkflowInstanceSubscriptionDecoder.correlationKeyHeaderLength();
+    final int correlationKeyLength = decoder.correlationKeyLength();
+    correlationKey.wrap(buffer, offset, correlationKeyLength);
+    offset += correlationKeyLength;
     decoder.limit(offset);
   }
 
@@ -150,5 +161,9 @@ public final class CorrelateWorkflowInstanceSubscriptionCommand
 
   public DirectBuffer getBpmnProcessId() {
     return bpmnProcessId;
+  }
+
+  public DirectBuffer getCorrelationKey() {
+    return correlationKey;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/SubscriptionCommandMessageHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/SubscriptionCommandMessageHandler.java
@@ -174,7 +174,8 @@ public final class SubscriptionCommandMessageHandler
         .setBpmnProcessId(correlateWorkflowInstanceSubscriptionCommand.getBpmnProcessId())
         .setMessageKey(correlateWorkflowInstanceSubscriptionCommand.getMessageKey())
         .setMessageName(correlateWorkflowInstanceSubscriptionCommand.getMessageName())
-        .setVariables(correlateWorkflowInstanceSubscriptionCommand.getVariables());
+        .setVariables(correlateWorkflowInstanceSubscriptionCommand.getVariables())
+        .setCorrelationKey(correlateWorkflowInstanceSubscriptionCommand.getCorrelationKey());
 
     return writeCommand(
         workflowInstancePartitionId,

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/command/SubscriptionCommandSender.java
@@ -107,7 +107,8 @@ public class SubscriptionCommandSender {
       final DirectBuffer bpmnProcessId,
       final DirectBuffer messageName,
       final long messageKey,
-      final DirectBuffer variables) {
+      final DirectBuffer variables,
+      final DirectBuffer correlationKey) {
 
     final int workflowInstancePartitionId = Protocol.decodePartitionId(workflowInstanceKey);
 
@@ -118,6 +119,7 @@ public class SubscriptionCommandSender {
     correlateWorkflowInstanceSubscriptionCommand.setMessageKey(messageKey);
     correlateWorkflowInstanceSubscriptionCommand.getMessageName().wrap(messageName);
     correlateWorkflowInstanceSubscriptionCommand.getVariables().wrap(variables);
+    correlateWorkflowInstanceSubscriptionCommand.getCorrelationKey().wrap(correlationKey);
 
     return partitionCommandSender.sendCommand(
         workflowInstancePartitionId, correlateWorkflowInstanceSubscriptionCommand);

--- a/engine/src/main/resources/subscription-schema.xml
+++ b/engine/src/main/resources/subscription-schema.xml
@@ -33,6 +33,7 @@
     <data name="messageName" id="4" type="varDataEncoding"/>
     <data name="variables" id="5" type="varDataEncoding"/>
     <data name="bpmnProcessId" id="6" type="varDataEncoding"/>
+    <data name="correlationKey" id="7" type="varDataEncoding"/>
   </sbe:message>
 
   <sbe:message name="CorrelateMessageSubscription" id="3">

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStreamProcessorTest.java
@@ -53,7 +53,7 @@ public final class MessageStreamProcessorTest {
         .thenReturn(true);
 
     when(mockSubscriptionCommandSender.correlateWorkflowInstanceSubscription(
-            anyLong(), anyLong(), any(), any(), anyLong(), any()))
+            anyLong(), anyLong(), any(), any(), anyLong(), any(), any()))
         .thenReturn(true);
 
     when(mockSubscriptionCommandSender.closeWorkflowInstanceSubscription(
@@ -118,7 +118,8 @@ public final class MessageStreamProcessorTest {
             subscription.getBpmnProcessIdBuffer(),
             subscription.getMessageNameBuffer(),
             messageKey,
-            message.getVariablesBuffer());
+            message.getVariablesBuffer(),
+            subscription.getCorrelationKeyBuffer());
   }
 
   @Test
@@ -153,7 +154,8 @@ public final class MessageStreamProcessorTest {
             subscription.getBpmnProcessIdBuffer(),
             subscription.getMessageNameBuffer(),
             messageKey,
-            message.getVariablesBuffer());
+            message.getVariablesBuffer(),
+            subscription.getCorrelationKeyBuffer());
   }
 
   @Test
@@ -238,6 +240,7 @@ public final class MessageStreamProcessorTest {
             any(),
             any(),
             eq(messageKey),
+            any(),
             any());
   }
 
@@ -276,6 +279,7 @@ public final class MessageStreamProcessorTest {
             eq(subscription.getBpmnProcessIdBuffer()),
             any(),
             eq(firstMessageKey),
+            any(),
             any());
 
     verify(mockSubscriptionCommandSender, timeout(5_000))
@@ -285,6 +289,7 @@ public final class MessageStreamProcessorTest {
             eq(subscription.getBpmnProcessIdBuffer()),
             any(),
             eq(lastMessageKey),
+            any(),
             any());
   }
 
@@ -374,7 +379,8 @@ public final class MessageStreamProcessorTest {
             eq(firstSubscription.getBpmnProcessIdBuffer()),
             any(DirectBuffer.class),
             eq(messageKey),
-            any(DirectBuffer.class));
+            any(DirectBuffer.class),
+            eq(firstSubscription.getCorrelationKeyBuffer()));
 
     verify(mockSubscriptionCommandSender, timeout(5_000))
         .correlateWorkflowInstanceSubscription(
@@ -383,7 +389,8 @@ public final class MessageStreamProcessorTest {
             eq(secondSubscription.getBpmnProcessIdBuffer()),
             any(DirectBuffer.class),
             eq(messageKey),
-            any(DirectBuffer.class));
+            any(DirectBuffer.class),
+            eq(secondSubscription.getCorrelationKeyBuffer()));
   }
 
   private void assertAllMessagesReceived(
@@ -415,7 +422,8 @@ public final class MessageStreamProcessorTest {
             eq(subscription.getBpmnProcessIdBuffer()),
             nameCaptor.capture(),
             eq(firstMessageKey),
-            variablesCaptor.capture());
+            variablesCaptor.capture(),
+            eq(subscription.getCorrelationKeyBuffer()));
 
     verify(mockSubscriptionCommandSender, timeout(5_000))
         .correlateWorkflowInstanceSubscription(
@@ -424,7 +432,8 @@ public final class MessageStreamProcessorTest {
             eq(subscription.getBpmnProcessIdBuffer()),
             nameCaptor.capture(),
             eq(lastMessageKey),
-            variablesCaptor.capture());
+            variablesCaptor.capture(),
+            eq(subscription.getCorrelationKeyBuffer()));
 
     assertThat(variablesCaptor.getAllValues().get(0)).isEqualTo(first.getVariablesBuffer());
     assertThat(nameCaptor.getValue()).isEqualTo(subscription.getMessageNameBuffer());

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-subscription-template.json
@@ -29,6 +29,9 @@
             },
             "messageKey": {
               "type": "long"
+            },
+            "correlationKey": {
+              "type": "keyword"
             }
           }
         }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/WorkflowInstanceSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/WorkflowInstanceSubscriptionRecord.java
@@ -35,6 +35,7 @@ public final class WorkflowInstanceSubscriptionRecord extends UnifiedRecordValue
   private final DocumentProperty variablesProp = new DocumentProperty("variables");
   private final BooleanProperty closeOnCorrelateProp =
       new BooleanProperty("closeOnCorrelate", true);
+  private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
 
   public WorkflowInstanceSubscriptionRecord() {
     declareProperty(subscriptionPartitionIdProp)
@@ -44,7 +45,8 @@ public final class WorkflowInstanceSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(messageNameProp)
         .declareProperty(variablesProp)
         .declareProperty(closeOnCorrelateProp)
-        .declareProperty(bpmnProcessIdProp);
+        .declareProperty(bpmnProcessIdProp)
+        .declareProperty(correlationKeyProp);
   }
 
   public boolean shouldCloseOnCorrelate() {
@@ -79,6 +81,16 @@ public final class WorkflowInstanceSubscriptionRecord extends UnifiedRecordValue
   @Override
   public String getMessageName() {
     return bufferAsString(messageNameProp.getValue());
+  }
+
+  @Override
+  public String getCorrelationKey() {
+    return bufferAsString(correlationKeyProp.getValue());
+  }
+
+  public WorkflowInstanceSubscriptionRecord setCorrelationKey(final DirectBuffer correlationKey) {
+    correlationKeyProp.setValue(correlationKey);
+    return this;
   }
 
   public WorkflowInstanceSubscriptionRecord setMessageName(final DirectBuffer messageName) {
@@ -139,5 +151,10 @@ public final class WorkflowInstanceSubscriptionRecord extends UnifiedRecordValue
   public WorkflowInstanceSubscriptionRecord setCloseOnCorrelate(final boolean closeOnCorrelate) {
     closeOnCorrelateProp.setValue(closeOnCorrelate);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getCorrelationKeyBuffer() {
+    return correlationKeyProp.getValue();
   }
 }

--- a/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -491,6 +491,7 @@ public final class JsonSerializableToJsonTest {
               final int subscriptionPartitionId = 2;
               final int messageKey = 3;
               final long workflowInstanceKey = 1345;
+              final String correlationKey = "key";
 
               return new WorkflowInstanceSubscriptionRecord()
                   .setElementInstanceKey(elementInstanceKey)
@@ -499,9 +500,10 @@ public final class JsonSerializableToJsonTest {
                   .setMessageKey(messageKey)
                   .setSubscriptionPartitionId(subscriptionPartitionId)
                   .setWorkflowInstanceKey(workflowInstanceKey)
-                  .setVariables(VARIABLES_MSGPACK);
+                  .setVariables(VARIABLES_MSGPACK)
+                  .setCorrelationKey(wrapString(correlationKey));
             },
-        "{'elementInstanceKey':123,'messageName':'test-message','workflowInstanceKey':1345,'variables':{'foo':'bar'},'bpmnProcessId':'workflow','messageKey':3}"
+        "{'elementInstanceKey':123,'messageName':'test-message','workflowInstanceKey':1345,'variables':{'foo':'bar'},'bpmnProcessId':'workflow','messageKey':3,'correlationKey':'key'}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -518,7 +520,7 @@ public final class JsonSerializableToJsonTest {
                   .setWorkflowInstanceKey(workflowInstanceKey)
                   .setElementInstanceKey(elementInstanceKey);
             },
-        "{'elementInstanceKey':123,'messageName':'','workflowInstanceKey':1345,'variables':{},'bpmnProcessId':'','messageKey':-1}"
+        "{'elementInstanceKey':123,'messageName':'','workflowInstanceKey':1345,'variables':{},'bpmnProcessId':'','messageKey':-1,'correlationKey':''}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/WorkflowInstanceSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/WorkflowInstanceSubscriptionRecordValue.java
@@ -38,4 +38,7 @@ public interface WorkflowInstanceSubscriptionRecordValue extends RecordValueWith
 
   /** @return the message name */
   String getMessageName();
+
+  /** @return the correlation key */
+  String getCorrelationKey();
 }


### PR DESCRIPTION
## Description

Rejecting a correlate command sometimes resulted in NPE, because correlation key is set to null when there is no subscription is opened. correlationKey is now added to the correlate command, so that it can be used to populate rejection message.

## Related issues
closes #3466 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
