### PR TITLE
fix(transport): fix response race condition

### DIFF
--- a/transport/src/main/java/io/zeebe/transport/impl/AtomixClientTransportAdapter.java
+++ b/transport/src/main/java/io/zeebe/transport/impl/AtomixClientTransportAdapter.java
@@ -86,6 +86,10 @@ public final class AtomixClientTransportAdapter extends Actor implements ClientT
 
   private void handleResponse(
       final RequestContext requestContext, final byte[] response, final Throwable errorOnRequest) {
+    if (requestContext.isDone()) {
+      return;
+    }
+
     final var currentFuture = requestContext.getCurrentFuture();
     if (errorOnRequest == null) {
       final var responseBuffer = new UnsafeBuffer(response);


### PR DESCRIPTION
## Description


On response it happens that the future have been tried to complete but it was already completed exceptionally, because of an timeout.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3601 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
