### PR TITLE
fix(broker): avoid unnecessary exporter director starting

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -365,13 +365,19 @@ public final class ZeebePartition extends Actor implements RaftCommitListener, C
   }
 
   private ActorFuture<Void> installExporter(final ZeebeDb zeebeDb) {
+    final var exporterDescriptors = exporterRepository.getExporters().values();
+
+    if (exporterDescriptors.isEmpty()) {
+      return CompletableActorFuture.completed(null);
+    }
+
     final ExporterDirectorContext context =
         new ExporterDirectorContext()
             .id(EXPORTER_PROCESSOR_ID)
             .name(String.format(EXPORTER_NAME, partitionId))
             .logStream(logStream)
             .zeebeDb(zeebeDb)
-            .descriptors(exporterRepository.getExporters().values());
+            .descriptors(exporterDescriptors);
 
     final var exporterDirector = new ExporterDirector(context);
     closeables.add(exporterDirector);


### PR DESCRIPTION
## Description

 * when no exporters have been configured then the exporter director do not need to run
 * before it run and read all events and update the exporter metrics which could be confusing

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3568 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
