### PR TITLE
chore(broker): introduce configurable step timeout

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
@@ -23,6 +23,8 @@ public final class BrokerCfg {
   private EmbeddedGatewayCfg gateway = new EmbeddedGatewayCfg();
   private BackpressureCfg backpressure = new BackpressureCfg();
 
+  private String stepTimeout = "5m";
+
   public void init(final String brokerBase) {
     init(brokerBase, new Environment());
   }
@@ -44,6 +46,7 @@ public final class BrokerCfg {
         .ifPresent(
             value ->
                 exporters.add(DebugLogExporter.defaultConfig("pretty".equalsIgnoreCase(value))));
+    environment.get(EnvironmentConstants.ENV_STEP_TIMEOUT_EXPORTER).ifPresent(this::setStepTimeout);
   }
 
   public NetworkCfg getNetwork() {
@@ -104,6 +107,14 @@ public final class BrokerCfg {
     return this;
   }
 
+  public String getStepTimeout() {
+    return stepTimeout;
+  }
+
+  public void setStepTimeout(String stepTimeout) {
+    this.stepTimeout = stepTimeout;
+  }
+
   @Override
   public String toString() {
     return "BrokerCfg{"
@@ -119,6 +130,11 @@ public final class BrokerCfg {
         + exporters
         + ", gateway="
         + gateway
+        + ", backpressure="
+        + backpressure
+        + ", stepTimeout='"
+        + stepTimeout
+        + '\''
         + '}';
   }
 

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
@@ -46,7 +46,7 @@ public final class BrokerCfg {
         .ifPresent(
             value ->
                 exporters.add(DebugLogExporter.defaultConfig("pretty".equalsIgnoreCase(value))));
-    environment.get(EnvironmentConstants.ENV_STEP_TIMEOUT_EXPORTER).ifPresent(this::setStepTimeout);
+    environment.get(EnvironmentConstants.ENV_STEP_TIMEOUT).ifPresent(this::setStepTimeout);
   }
 
   public NetworkCfg getNetwork() {
@@ -111,7 +111,7 @@ public final class BrokerCfg {
     return stepTimeout;
   }
 
-  public void setStepTimeout(String stepTimeout) {
+  public void setStepTimeout(final String stepTimeout) {
     this.stepTimeout = stepTimeout;
   }
 

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
@@ -21,4 +21,5 @@ public final class EnvironmentConstants {
   public static final String ENV_CLUSTER_NAME = "ZEEBE_CLUSTER_NAME";
   public static final String ENV_EMBED_GATEWAY = "ZEEBE_EMBED_GATEWAY";
   public static final String ENV_DEBUG_EXPORTER = "ZEEBE_DEBUG";
+  public static final String ENV_STEP_TIMEOUT_EXPORTER = "ZEEBE_STEP_TIMEOUT";
 }

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
@@ -21,5 +21,5 @@ public final class EnvironmentConstants {
   public static final String ENV_CLUSTER_NAME = "ZEEBE_CLUSTER_NAME";
   public static final String ENV_EMBED_GATEWAY = "ZEEBE_EMBED_GATEWAY";
   public static final String ENV_DEBUG_EXPORTER = "ZEEBE_DEBUG";
-  public static final String ENV_STEP_TIMEOUT_EXPORTER = "ZEEBE_STEP_TIMEOUT";
+  public static final String ENV_STEP_TIMEOUT = "ZEEBE_STEP_TIMEOUT";
 }

--- a/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.zeebe.broker.system.configuration.BrokerCfg;
+import io.zeebe.logstreams.log.LogStream;
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeoutException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public final class SimpleBrokerStartTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private File newTemporaryFolder;
+
+  @Before
+  public void setup() throws Exception {
+    newTemporaryFolder = temporaryFolder.newFolder();
+  }
+
+  @Test
+  public void shouldFailToStartBrokerWithSmallTimeout() {
+    // given
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.setStepTimeout("1ms");
+
+    final var broker = new Broker(brokerCfg, newTemporaryFolder.getAbsolutePath(), null);
+
+    // when
+    final var catchedThrownBy = assertThatThrownBy(() -> broker.start().join());
+
+    // then
+    catchedThrownBy.hasRootCauseInstanceOf(TimeoutException.class);
+  }
+
+  @Test
+  public void shouldFailToCreateBrokerWithInvalidTimeout() {
+    // given
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.setStepTimeout("invalid");
+
+    // when
+    final var catchedThrownBy =
+        assertThatThrownBy(() -> new Broker(brokerCfg, newTemporaryFolder.getAbsolutePath(), null));
+
+    // then
+    catchedThrownBy.isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void shouldCallPartitionListenerAfterStart() throws Exception {
+    // given
+    final var brokerCfg = new BrokerCfg();
+    final var broker = new Broker(brokerCfg, newTemporaryFolder.getAbsolutePath(), null);
+    final var leaderLatch = new CountDownLatch(1);
+    broker.addPartitionListener(
+        new PartitionListener() {
+          @Override
+          public void onBecomingFollower(int partitionId, long term, LogStream logStream) {}
+
+          @Override
+          public void onBecomingLeader(int partitionId, long term, LogStream logStream) {
+            leaderLatch.countDown();
+          }
+        });
+
+    // when
+    broker.start().join();
+
+    // then
+    leaderLatch.await();
+    broker.close();
+  }
+}

--- a/broker/src/test/java/io/zeebe/broker/system/ConfigurationTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/ConfigurationTest.java
@@ -25,6 +25,7 @@ import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_NODE
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_PARTITIONS_COUNT;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_PORT_OFFSET;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_REPLICATION_FACTOR;
+import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_STEP_TIMEOUT_EXPORTER;
 import static io.zeebe.broker.system.configuration.NetworkCfg.DEFAULT_COMMAND_API_PORT;
 import static io.zeebe.broker.system.configuration.NetworkCfg.DEFAULT_HOST;
 import static io.zeebe.broker.system.configuration.NetworkCfg.DEFAULT_INTERNAL_API_PORT;
@@ -73,6 +74,22 @@ public final class ConfigurationTest {
   public void shouldUseClusterNameFromEnvironment() {
     environment.put(ENV_CLUSTER_NAME, "test-cluster");
     assertDefaultClusterName("test-cluster");
+  }
+
+  @Test
+  public void shouldUseDefaultStepTimeout() {
+    assertDefaultStepTimeout("5m");
+  }
+
+  @Test
+  public void shouldUseStepTimeout() {
+    assertStepTimeout("step-timeout-cfg", "2m");
+  }
+
+  @Test
+  public void shouldUseStepTimeoutFromEnv() {
+    environment.put(ENV_STEP_TIMEOUT_EXPORTER, "1m");
+    assertDefaultStepTimeout("1m");
   }
 
   @Test
@@ -508,6 +525,16 @@ public final class ConfigurationTest {
   private void assertClusterName(final String configFileName, final String clusterName) {
     final BrokerCfg cfg = readConfig(configFileName);
     assertThat(cfg.getCluster().getClusterName()).isEqualTo(clusterName);
+  }
+
+  private void assertDefaultStepTimeout(final String stepTimeout) {
+    assertStepTimeout("default", stepTimeout);
+    assertStepTimeout("empty", stepTimeout);
+  }
+
+  private void assertStepTimeout(final String configFileName, final String stepTimeout) {
+    final BrokerCfg cfg = readConfig(configFileName);
+    assertThat(cfg.getStepTimeout()).isEqualTo(stepTimeout);
   }
 
   private void assertDefaultPorts(final int command, final int internal, final int monitoring) {

--- a/broker/src/test/java/io/zeebe/broker/system/ConfigurationTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/ConfigurationTest.java
@@ -25,7 +25,7 @@ import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_NODE
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_PARTITIONS_COUNT;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_PORT_OFFSET;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_REPLICATION_FACTOR;
-import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_STEP_TIMEOUT_EXPORTER;
+import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_STEP_TIMEOUT;
 import static io.zeebe.broker.system.configuration.NetworkCfg.DEFAULT_COMMAND_API_PORT;
 import static io.zeebe.broker.system.configuration.NetworkCfg.DEFAULT_HOST;
 import static io.zeebe.broker.system.configuration.NetworkCfg.DEFAULT_INTERNAL_API_PORT;
@@ -88,7 +88,7 @@ public final class ConfigurationTest {
 
   @Test
   public void shouldUseStepTimeoutFromEnv() {
-    environment.put(ENV_STEP_TIMEOUT_EXPORTER, "1m");
+    environment.put(ENV_STEP_TIMEOUT, "1m");
     assertDefaultStepTimeout("1m");
   }
 

--- a/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -51,8 +51,8 @@ import org.slf4j.Logger;
 public final class EmbeddedBrokerRule extends ExternalResource {
 
   public static final String DEFAULT_CONFIG_FILE = "zeebe.test.cfg.toml";
-  public static final int INSTALL_TIMEOUT = 15;
-  public static final TimeUnit INSTALL_TIMEOUT_UNIT = TimeUnit.SECONDS;
+  public static final int INSTALL_TIMEOUT = 5;
+  public static final TimeUnit INSTALL_TIMEOUT_UNIT = TimeUnit.MINUTES;
   protected static final Logger LOG = TestLoggers.TEST_LOGGER;
   private static final boolean ENABLE_DEBUG_EXPORTER = false;
   private static final boolean ENABLE_HTTP_EXPORTER = false;

--- a/broker/src/test/resources/system/step-timeout-cfg.toml
+++ b/broker/src/test/resources/system/step-timeout-cfg.toml
@@ -1,0 +1,1 @@
+stepTimeout = "2m"

--- a/dist/src/main/config/zeebe.cfg.toml
+++ b/dist/src/main/config/zeebe.cfg.toml
@@ -30,6 +30,13 @@
 
 # ----------------------------------------------------
 
+# Sets the timeout for each start and closing step.
+#
+# Broker bootstrap and closing is divided in several individual steps.
+# Each step should take at max the defined stepTimeout, otherwise the bootstrap is aborted.
+#
+# This setting can also be overridden using the environment variable ENV_STEP_TIMEOUT.
+# stepTimeout = 5m
 
 [gateway]
 # Enable the embedded gateway to start on broker startup.
@@ -50,8 +57,8 @@
 # port = 26500
 
 # Sets the minimum keep alive interval
-# This setting specifies the minimum accepted interval between keep alive pings. This value must be specified as a positive integer followed by 's' for seconds, 'm' for minutes or 'h' for hours. 
-# This setting can also be overriden using the environment variable ZEEBE_GATEWAY_KEEP_ALIVE_INTERVAL.
+# This setting specifies the minimum accepted interval between keep alive pings. This value must be specified as a positive integer followed by 's' for seconds, 'm' for minutes or 'h' for hours.
+# This setting can also be overwritten using the environment variable ZEEBE_GATEWAY_KEEP_ALIVE_INTERVAL.
 # minKeepAliveInterval = "30s"
 
 [gateway.cluster]

--- a/util/src/main/java/io/zeebe/util/sched/Actor.java
+++ b/util/src/main/java/io/zeebe/util/sched/Actor.java
@@ -13,6 +13,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 public abstract class Actor implements CloseableSilently {
+
+  private static final int MAX_CLOSE_TIMEOUT = 300;
   protected final ActorControl actor = new ActorControl(this);
 
   public String getName() {
@@ -55,7 +57,7 @@ public abstract class Actor implements CloseableSilently {
 
   @Override
   public void close() {
-    actor.close().join(30, TimeUnit.SECONDS);
+    actor.close().join(MAX_CLOSE_TIMEOUT, TimeUnit.SECONDS);
   }
 
   public ActorFuture<Void> closeAsync() {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
 * step timeout was limited by 30 seconds, which was often not enough - sometimes it took longer to start
 * default step timeout was increased to 5 minutes
 * it is now configurable via configuration and enviromnent variable

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/3609

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
