### PR TITLE
Uniform actor names

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
@@ -34,6 +34,7 @@ public final class TopologyManagerImpl extends Actor
   private final BrokerInfo localBroker;
 
   private final List<TopologyPartitionListener> topologyPartitionListeners = new ArrayList<>();
+  private final String actorName;
 
   public TopologyManagerImpl(
       final Atomix atomix, final BrokerInfo localBroker, final ClusterCfg clusterCfg) {
@@ -43,6 +44,7 @@ public final class TopologyManagerImpl extends Actor
         .setClusterSize(clusterCfg.getClusterSize())
         .setPartitionsCount(clusterCfg.getPartitionsCount())
         .setReplicationFactor(clusterCfg.getReplicationFactor());
+    this.actorName = actorNamePattern(localBroker.getNodeId(), "TopologyManager");
   }
 
   @Override
@@ -58,7 +60,7 @@ public final class TopologyManagerImpl extends Actor
 
   @Override
   public String getName() {
-    return actorNamePattern(localBroker.getNodeId(), "TopologyManager");
+    return actorName;
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
@@ -44,7 +44,7 @@ public final class TopologyManagerImpl extends Actor
         .setClusterSize(clusterCfg.getClusterSize())
         .setPartitionsCount(clusterCfg.getPartitionsCount())
         .setReplicationFactor(clusterCfg.getReplicationFactor());
-    this.actorName = actorNamePattern(localBroker.getNodeId(), "TopologyManager");
+    this.actorName = buildActorName(localBroker.getNodeId(), "TopologyManager");
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/engine/impl/StateReplication.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/StateReplication.java
@@ -7,6 +7,8 @@
  */
 package io.zeebe.broker.engine.impl;
 
+import static io.zeebe.util.sched.Actor.actorNamePattern;
+
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.cluster.messaging.Subscription;
 import io.zeebe.engine.Loggers;
@@ -29,13 +31,16 @@ public final class StateReplication implements SnapshotReplication {
 
   private final DirectBuffer readBuffer = new UnsafeBuffer(0, 0);
   private final ClusterEventService eventService;
+  private final String threadName;
 
   private ExecutorService executorService;
   private Subscription subscription;
 
-  public StateReplication(final ClusterEventService eventService, final int partitionId) {
+  public StateReplication(
+      final ClusterEventService eventService, final int partitionId, final int nodeId) {
     this.eventService = eventService;
     this.replicationTopic = String.format(REPLICATION_TOPIC_FORMAT, partitionId);
+    this.threadName = actorNamePattern(nodeId, "StateReplication-" + partitionId);
   }
 
   @Override
@@ -57,7 +62,7 @@ public final class StateReplication implements SnapshotReplication {
 
   @Override
   public void consume(final Consumer<SnapshotChunk> consumer) {
-    executorService = Executors.newSingleThreadExecutor((r) -> new Thread(r, replicationTopic));
+    executorService = Executors.newSingleThreadExecutor((r) -> new Thread(r, threadName));
 
     subscription =
         eventService

--- a/broker/src/main/java/io/zeebe/broker/engine/impl/StateReplication.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/StateReplication.java
@@ -7,7 +7,7 @@
  */
 package io.zeebe.broker.engine.impl;
 
-import static io.zeebe.util.sched.Actor.actorNamePattern;
+import static io.zeebe.util.sched.Actor.buildActorName;
 
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.cluster.messaging.Subscription;
@@ -40,7 +40,7 @@ public final class StateReplication implements SnapshotReplication {
       final ClusterEventService eventService, final int partitionId, final int nodeId) {
     this.eventService = eventService;
     this.replicationTopic = String.format(REPLICATION_TOPIC_FORMAT, partitionId);
-    this.threadName = actorNamePattern(nodeId, "StateReplication-" + partitionId);
+    this.threadName = buildActorName(nodeId, "StateReplication-" + partitionId);
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
@@ -23,17 +23,17 @@ public final class SubscriptionApiCommandMessageHandlerService extends Actor
   private final Int2ObjectHashMap<LogStreamRecordWriter> leaderPartitions =
       new Int2ObjectHashMap<>();
   private final Atomix atomix;
-  private final BrokerInfo localBroker;
+  private final String actorName;
 
   public SubscriptionApiCommandMessageHandlerService(
       final BrokerInfo localBroker, final Atomix atomix) {
-    this.localBroker = localBroker;
     this.atomix = atomix;
+    this.actorName = actorNamePattern(localBroker.getNodeId(), "SubscriptionApi");
   }
 
   @Override
   public String getName() {
-    return actorNamePattern(localBroker.getNodeId(), "SubscriptionApi");
+    return actorName;
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
@@ -28,7 +28,7 @@ public final class SubscriptionApiCommandMessageHandlerService extends Actor
   public SubscriptionApiCommandMessageHandlerService(
       final BrokerInfo localBroker, final Atomix atomix) {
     this.atomix = atomix;
-    this.actorName = actorNamePattern(localBroker.getNodeId(), "SubscriptionApi");
+    this.actorName = buildActorName(localBroker.getNodeId(), "SubscriptionApi");
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
@@ -21,13 +21,13 @@ public final class LeaderManagementRequestHandler extends Actor implements Parti
 
   private final Int2ObjectHashMap<LogStreamRecordWriter> leaderForPartitions =
       new Int2ObjectHashMap<>();
-  private final BrokerInfo localBroker;
+  private final String actorName;
   private PushDeploymentRequestHandler pushDeploymentRequestHandler;
   private final Atomix atomix;
 
   public LeaderManagementRequestHandler(final BrokerInfo localBroker, final Atomix atomix) {
-    this.localBroker = localBroker;
     this.atomix = atomix;
+    this.actorName = actorNamePattern(localBroker.getNodeId(), "ManagementRequestHandler");
   }
 
   @Override
@@ -58,7 +58,7 @@ public final class LeaderManagementRequestHandler extends Actor implements Parti
 
   @Override
   public String getName() {
-    return actorNamePattern(localBroker.getNodeId(), "ManagementRequestHandler");
+    return actorName;
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
@@ -27,7 +27,7 @@ public final class LeaderManagementRequestHandler extends Actor implements Parti
 
   public LeaderManagementRequestHandler(final BrokerInfo localBroker, final Atomix atomix) {
     this.atomix = atomix;
-    this.actorName = actorNamePattern(localBroker.getNodeId(), "ManagementRequestHandler");
+    this.actorName = buildActorName(localBroker.getNodeId(), "ManagementRequestHandler");
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -26,15 +26,15 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
 
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private final Atomix atomix;
-  private final BrokerInfo localBroker;
+  private final String actorName;
   private Map<Integer, Boolean> partitionInstallStatus;
   /* set to true when all partitions are installed. Once set to true, it is never
   changed. */
   private volatile boolean brokerStarted = false;
 
   public BrokerHealthCheckService(final BrokerInfo localBroker, final Atomix atomix) {
-    this.localBroker = localBroker;
     this.atomix = atomix;
+    this.actorName = actorNamePattern(localBroker.getNodeId(), "HealthCheckService");
     initializePartitionInstallStatus();
   }
 
@@ -81,6 +81,6 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
 
   @Override
   public String getName() {
-    return actorNamePattern(localBroker.getNodeId(), "HealthCheckService");
+    return actorName;
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -34,7 +34,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
 
   public BrokerHealthCheckService(final BrokerInfo localBroker, final Atomix atomix) {
     this.atomix = atomix;
-    this.actorName = actorNamePattern(localBroker.getNodeId(), "HealthCheckService");
+    this.actorName = buildActorName(localBroker.getNodeId(), "HealthCheckService");
     initializePartitionInstallStatus();
   }
 

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -115,7 +115,7 @@ public final class ZeebePartition extends Actor implements RaftCommitListener, C
       }
     }
 
-    this.actorName = actorNamePattern(localBroker.getNodeId(), "ZeebePartition-" + partitionId);
+    this.actorName = buildActorName(localBroker.getNodeId(), "ZeebePartition-" + partitionId);
   }
 
   /**
@@ -383,8 +383,7 @@ public final class ZeebePartition extends Actor implements RaftCommitListener, C
         new ExporterDirectorContext()
             .id(EXPORTER_PROCESSOR_ID)
             .name(
-                actorNamePattern(
-                    localBroker.getNodeId(), String.format(EXPORTER_NAME, partitionId)))
+                buildActorName(localBroker.getNodeId(), String.format(EXPORTER_NAME, partitionId)))
             .logStream(logStream)
             .zeebeDb(zeebeDb)
             .descriptors(exporterDescriptors);

--- a/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiService.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiService.java
@@ -28,7 +28,7 @@ public final class CommandApiService extends Actor implements PartitionListener 
   private final ServerTransport serverTransport;
   private final CommandApiRequestHandler requestHandler;
   private final IntHashSet leadPartitions = new IntHashSet();
-  private final BrokerInfo localBroker;
+  private final String actorName;
 
   public CommandApiService(
       final ServerTransport serverTransport,
@@ -37,12 +37,12 @@ public final class CommandApiService extends Actor implements PartitionListener 
     this.serverTransport = serverTransport;
     this.limiter = limiter;
     requestHandler = new CommandApiRequestHandler();
-    this.localBroker = localBroker;
+    this.actorName = actorNamePattern(localBroker.getNodeId(), "CommandApiService");
   }
 
   @Override
   public String getName() {
-    return actorNamePattern(localBroker.getNodeId(), "CommandApiService");
+    return actorName;
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiService.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiService.java
@@ -37,7 +37,7 @@ public final class CommandApiService extends Actor implements PartitionListener 
     this.serverTransport = serverTransport;
     this.limiter = limiter;
     requestHandler = new CommandApiRequestHandler();
-    this.actorName = actorNamePattern(localBroker.getNodeId(), "CommandApiService");
+    this.actorName = buildActorName(localBroker.getNodeId(), "CommandApiService");
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotDirector.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotDirector.java
@@ -38,7 +38,6 @@ public final class AsyncSnapshotDirector extends Actor {
 
   private final SnapshotController snapshotController;
   private final LogStream logStream;
-  private final String name;
   private final Duration snapshotRate;
   private final String processorName;
   private final StreamProcessor streamProcessor;
@@ -49,8 +48,10 @@ public final class AsyncSnapshotDirector extends Actor {
   private long lastValidSnapshotPosition;
   private boolean takingSnapshot;
   private final Runnable prepareTakingSnapshot = this::prepareTakingSnapshot;
+  private final String actorName;
 
   public AsyncSnapshotDirector(
+      final int nodeId,
       final StreamProcessor streamProcessor,
       final SnapshotController snapshotController,
       final LogStream logStream,
@@ -59,13 +60,13 @@ public final class AsyncSnapshotDirector extends Actor {
     this.snapshotController = snapshotController;
     this.logStream = logStream;
     this.processorName = streamProcessor.getName();
-    this.name = processorName + "-snapshot-director";
     this.snapshotRate = snapshotRate;
+    this.actorName = actorNamePattern(nodeId, "SnapshotDirector-" + logStream.getPartitionId());
   }
 
   @Override
   public String getName() {
-    return name;
+    return actorName;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotDirector.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotDirector.java
@@ -61,7 +61,7 @@ public final class AsyncSnapshotDirector extends Actor {
     this.logStream = logStream;
     this.processorName = streamProcessor.getName();
     this.snapshotRate = snapshotRate;
-    this.actorName = actorNamePattern(nodeId, "SnapshotDirector-" + logStream.getPartitionId());
+    this.actorName = buildActorName(nodeId, "SnapshotDirector-" + logStream.getPartitionId());
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -41,6 +41,7 @@ public class StreamProcessor extends Actor {
   // processing
   private final ProcessingContext processingContext;
   private final TypedRecordProcessorFactory typedRecordProcessorFactory;
+  private final int nodeId;
   private LogStreamReader logStreamReader;
   private ActorCondition onCommitPositionUpdatedCondition;
   private long snapshotPosition = -1L;
@@ -49,22 +50,25 @@ public class StreamProcessor extends Actor {
   private Phase phase = Phase.REPROCESSING;
   private CompletableActorFuture<Void> openFuture;
   private CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);
+  private final String actorName;
 
-  protected StreamProcessor(final StreamProcessorBuilder context) {
-    this.actorScheduler = context.getActorScheduler();
-    this.lifecycleAwareListeners = context.getLifecycleListeners();
+  protected StreamProcessor(final StreamProcessorBuilder processorBuilder) {
+    this.actorScheduler = processorBuilder.getActorScheduler();
+    this.lifecycleAwareListeners = processorBuilder.getLifecycleListeners();
 
-    this.typedRecordProcessorFactory = context.getTypedRecordProcessorFactory();
-    this.zeebeDb = context.getZeebeDb();
+    this.typedRecordProcessorFactory = processorBuilder.getTypedRecordProcessorFactory();
+    this.zeebeDb = processorBuilder.getZeebeDb();
 
     processingContext =
-        context
+        processorBuilder
             .getProcessingContext()
             .eventCache(new RecordValues())
             .actor(actor)
             .abortCondition(this::isClosed);
     this.logStream = processingContext.getLogStream();
     this.partitionId = logStream.getPartitionId();
+    this.nodeId = processorBuilder.getNodeId();
+    this.actorName = actorNamePattern(nodeId, "StreamProcessor-" + partitionId);
   }
 
   public static StreamProcessorBuilder builder() {
@@ -73,7 +77,7 @@ public class StreamProcessor extends Actor {
 
   @Override
   public String getName() {
-    return "partition-" + partitionId + "-processor";
+    return actorName;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -68,7 +68,7 @@ public class StreamProcessor extends Actor {
     this.logStream = processingContext.getLogStream();
     this.partitionId = logStream.getPartitionId();
     this.nodeId = processorBuilder.getNodeId();
-    this.actorName = actorNamePattern(nodeId, "StreamProcessor-" + partitionId);
+    this.actorName = buildActorName(nodeId, "StreamProcessor-" + partitionId);
   }
 
   public static StreamProcessorBuilder builder() {

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorBuilder.java
@@ -25,6 +25,7 @@ public final class StreamProcessorBuilder {
   private TypedRecordProcessorFactory typedRecordProcessorFactory;
   private ActorScheduler actorScheduler;
   private ZeebeDb zeebeDb;
+  private int nodeId;
 
   public StreamProcessorBuilder() {
     processingContext = new ProcessingContext();
@@ -38,6 +39,11 @@ public final class StreamProcessorBuilder {
 
   public StreamProcessorBuilder actorScheduler(final ActorScheduler actorScheduler) {
     this.actorScheduler = actorScheduler;
+    return this;
+  }
+
+  public StreamProcessorBuilder nodeId(int nodeId) {
+    this.nodeId = nodeId;
     return this;
   }
 
@@ -80,6 +86,10 @@ public final class StreamProcessorBuilder {
 
   public ZeebeDb getZeebeDb() {
     return zeebeDb;
+  }
+
+  public int getNodeId() {
+    return nodeId;
   }
 
   public StreamProcessor build() {

--- a/engine/src/test/java/io/zeebe/engine/processor/AsyncSnapshotingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/AsyncSnapshotingTest.java
@@ -112,7 +112,7 @@ public final class AsyncSnapshotingTest {
   private void createAsyncSnapshotDirector(final ActorScheduler actorScheduler) {
     asyncSnapshotDirector =
         new AsyncSnapshotDirector(
-            mockStreamProcessor, snapshotController, logStream, Duration.ofMinutes(1));
+            0, mockStreamProcessor, snapshotController, logStream, Duration.ofMinutes(1));
     actorScheduler.submitActor(this.asyncSnapshotDirector).join();
   }
 

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -247,6 +247,7 @@ public final class TestStreams {
 
     final var asyncSnapshotDirector =
         new AsyncSnapshotDirector(
+            0,
             streamProcessor,
             currentSnapshotController,
             stream.getAsyncLogStream(),

--- a/gateway/src/main/java/io/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -55,6 +55,11 @@ public final class LongPollingActivateJobsHandler extends Actor {
     metrics = new LongPollingMetrics();
   }
 
+  @Override
+  public String getName() {
+    return "GatewayLongPollingJobHandler";
+  }
+
   public void activateJobs(
       final ActivateJobsRequest request,
       final StreamObserver<ActivateJobsResponse> responseObserver) {

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
@@ -24,6 +24,7 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
   private ActorScheduler actorScheduler;
   private LogStorage logStorage;
   private String logName;
+  private int nodeId = 0;
 
   @Override
   public LogStreamBuilder withActorScheduler(final ActorScheduler actorScheduler) {
@@ -50,6 +51,12 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
   }
 
   @Override
+  public LogStreamBuilder withNodeId(int nodeId) {
+    this.nodeId = nodeId;
+    return this;
+  }
+
+  @Override
   public LogStreamBuilder withLogName(final String logName) {
     this.logName = logName;
     return this;
@@ -65,6 +72,7 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
             new ActorConditions(),
             logName,
             partitionId,
+            nodeId,
             ByteValue.ofBytes(maxFragmentSize),
             logStorage);
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -213,11 +213,11 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
     appenderFuture = appenderOpenFuture;
     final String logName = getLogName();
 
-    final int partitionId = determineInitialPartitionId();
+    final int initialDispatcherPartitionId = determineInitialPartitionId();
     writeBuffer =
-        Dispatchers.create(logName + "-write-buffer")
+        Dispatchers.create(actorNamePattern(nodeId, "dispatcher-" + partitionId))
             .maxFragmentLength(maxFrameLength)
-            .initialPartitionId(partitionId + 1)
+            .initialPartitionId(initialDispatcherPartitionId + 1)
             .name(logName + "-write-buffer")
             .actorScheduler(actorScheduler)
             .build();
@@ -230,7 +230,7 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
 
                 appender =
                     new LogStorageAppender(
-                        logName + "-appender",
+                        actorNamePattern(nodeId, "LogAppender-" + partitionId),
                         partitionId,
                         logStorage,
                         subscription,

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -44,6 +44,7 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
   private final LogStreamReaderImpl reader;
   private final LogStorage logStorage;
   private final CompletableActorFuture<Void> closeFuture;
+  private final int nodeId;
   private ActorFuture<LogStorageAppender> appenderFuture;
   private Dispatcher writeBuffer;
   private LogStorageAppender appender;
@@ -55,12 +56,14 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
       final ActorConditions onCommitPositionUpdatedConditions,
       final String logName,
       final int partitionId,
+      final int nodeId,
       final ByteValue maxFrameLength,
       final LogStorage logStorage) {
     this.actorScheduler = actorScheduler;
     this.onCommitPositionUpdatedConditions = onCommitPositionUpdatedConditions;
     this.logName = logName;
     this.partitionId = partitionId;
+    this.nodeId = nodeId;
     this.maxFrameLength = maxFrameLength;
     this.logStorage = logStorage;
     this.closeFuture = new CompletableActorFuture<>();
@@ -87,6 +90,11 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
   @Override
   public String getLogName() {
     return logName;
+  }
+
+  @Override
+  public String getName() {
+    return actorNamePattern(nodeId, "LogStream-" + partitionId);
   }
 
   @Override

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -50,6 +50,7 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
   private LogStorageAppender appender;
   private long commitPosition;
   private Throwable closeError; // set if any error occurred during closeAsync
+  private final String actorName;
 
   public LogStreamImpl(
       final ActorScheduler actorScheduler,
@@ -62,8 +63,11 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
     this.actorScheduler = actorScheduler;
     this.onCommitPositionUpdatedConditions = onCommitPositionUpdatedConditions;
     this.logName = logName;
+
     this.partitionId = partitionId;
     this.nodeId = nodeId;
+    this.actorName = actorNamePattern(nodeId, "LogStream-" + partitionId);
+
     this.maxFrameLength = maxFrameLength;
     this.logStorage = logStorage;
     this.closeFuture = new CompletableActorFuture<>();
@@ -94,7 +98,7 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
 
   @Override
   public String getName() {
-    return actorNamePattern(nodeId, "LogStream-" + partitionId);
+    return actorName;
   }
 
   @Override

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -66,7 +66,7 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
 
     this.partitionId = partitionId;
     this.nodeId = nodeId;
-    this.actorName = actorNamePattern(nodeId, "LogStream-" + partitionId);
+    this.actorName = buildActorName(nodeId, "LogStream-" + partitionId);
 
     this.maxFrameLength = maxFrameLength;
     this.logStorage = logStorage;
@@ -219,7 +219,7 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
 
     final int initialDispatcherPartitionId = determineInitialPartitionId();
     writeBuffer =
-        Dispatchers.create(actorNamePattern(nodeId, "dispatcher-" + partitionId))
+        Dispatchers.create(buildActorName(nodeId, "dispatcher-" + partitionId))
             .maxFragmentLength(maxFrameLength)
             .initialPartitionId(initialDispatcherPartitionId + 1)
             .name(logName + "-write-buffer")
@@ -234,7 +234,7 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
 
                 appender =
                     new LogStorageAppender(
-                        actorNamePattern(nodeId, "LogAppender-" + partitionId),
+                        buildActorName(nodeId, "LogAppender-" + partitionId),
                         partitionId,
                         logStorage,
                         subscription,

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamBuilder.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamBuilder.java
@@ -48,6 +48,14 @@ public interface LogStreamBuilder {
   LogStreamBuilder withPartitionId(int partitionId);
 
   /**
+   * The node ID - to indicate on which node the log stream is running
+   *
+   * @param nodeId the node id
+   * @return this builder
+   */
+  LogStreamBuilder withNodeId(int nodeId);
+
+  /**
    * The log stream name - primarily used for contextualizing as well, e.g. loggers, actor name,
    * etc.
    *

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/SyncLogStreamBuilder.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/SyncLogStreamBuilder.java
@@ -54,6 +54,12 @@ public final class SyncLogStreamBuilder implements LogStreamBuilder {
   }
 
   @Override
+  public LogStreamBuilder withNodeId(int nodeId) {
+    delegate.withNodeId(nodeId);
+    return this;
+  }
+
+  @Override
   public SyncLogStreamBuilder withLogName(final String logName) {
     delegate.withLogName(logName);
     return this;

--- a/transport/src/main/java/io/zeebe/transport/impl/AtomixServerTransport.java
+++ b/transport/src/main/java/io/zeebe/transport/impl/AtomixServerTransport.java
@@ -34,6 +34,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
   private final AtomicLong requestCount;
   private final DirectBuffer reusableRequestBuffer;
   private final MessagingService messagingService;
+  private final String actorName;
 
   public AtomixServerTransport(final int nodeId, final MessagingService messagingService) {
     this.messagingService = messagingService;
@@ -42,11 +43,12 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
     this.partitionsRequestMap = new Int2ObjectHashMap<>();
     this.requestCount = new AtomicLong(0);
     this.reusableRequestBuffer = new UnsafeBuffer(0, 0);
+    this.actorName = actorNamePattern(nodeId, "ServerTransport");
   }
 
   @Override
   public String getName() {
-    return actorNamePattern(nodeId, "ServerTransport");
+    return actorName;
   }
 
   @Override

--- a/transport/src/main/java/io/zeebe/transport/impl/AtomixServerTransport.java
+++ b/transport/src/main/java/io/zeebe/transport/impl/AtomixServerTransport.java
@@ -43,7 +43,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
     this.partitionsRequestMap = new Int2ObjectHashMap<>();
     this.requestCount = new AtomicLong(0);
     this.reusableRequestBuffer = new UnsafeBuffer(0, 0);
-    this.actorName = actorNamePattern(nodeId, "ServerTransport");
+    this.actorName = buildActorName(nodeId, "ServerTransport");
   }
 
   @Override

--- a/util/src/main/java/io/zeebe/util/sched/Actor.java
+++ b/util/src/main/java/io/zeebe/util/sched/Actor.java
@@ -64,7 +64,7 @@ public abstract class Actor implements CloseableSilently {
     return actor.close();
   }
 
-  public static String actorNamePattern(final int nodeId, final String name) {
+  public static String buildActorName(final int nodeId, final String name) {
     return String.format("Broker-%d-%s", nodeId, name);
   }
 }


### PR DESCRIPTION
## Description

On running benchmarks and investigating them, we normally have to scan and search our log. 
It  is really difficult to find issues or map log statements, because often it is not clear to which broker and which partition they belong to. With removing the service container and build the bootstrap and shutdown steps I already introduced a common actor name. But this was not used everywhere.


It is also not really useful if the actor class name is completely printed. For example:
```
I 2020-01-10T13:43:56.215252810Z 2020-01-10 13:43:56.214 [io.zeebe.logstreams.impl.log.LogStreamImpl] [Broker-0-zb-actors-0] DEBUG io.zeebe.logstreams - Configured log appender back pressure at partition 32602 as AppenderVegasCfg{initialLimit=1024, maxConcurrency=32768, alphaLimit=0.7, betaLimit=0.95}. Window limiting is disabled
```
These kind of lines are really hard to read in stack driver.


Other examples:
Snapshot replication before:

```
15:07:57.427 [] [replication-1] DEBUG io.zeebe.logstreams.snapshot - Consume snapshot chunk 000096.sst of snapshot 3-1-1578665277316-4294971584
15:07:57.427 [] [replication-1] DEBUG io.zeebe.logstreams.snapshot - Consume snapshot chunk OPTIONS-000090 of snapshot 3-1-1578665277316-4294971584
15:07:57.428 [] [replication-1] DEBUG io.zeebe.logstreams.snapshot - Consume snapshot chunk 000095.sst of snapshot 3-1-1578665277316-4294971584
15:07:57.428 [] [replication-1] DEBUG io.zeebe.logstreams.snapshot - Consume snapshot chunk 000094.sst of snapshot 3-1-1578665277316-4294971584
15:07:57.429 [] [replication-1] DEBUG io.zeebe.logstreams.snapshot - Consume snapshot chunk MANIFEST-000004 of snapshot 3-1-1578665277316-4294971584
15:07:57.429 [] [replication-1] DEBUG io.zeebe.logstreams.snapshot - Consume snapshot chunk 000093.sst of snapshot 3-1-1578665277316-4294971584
15:07:57.431 [] [replication-1] DEBUG io.zeebe.logstreams.snapshot - Consume snapshot chunk 000100.sst of snapshot 3-1-1578665277316-4294971584
15:07:57.431 [] [replication-1] DEBUG io.zeebe.logstreams.snapshot - Consume snapshot chunk 000092.sst of snapshot 3-1-1578665277316-4294971584
```

Now it looks like this:

```
14:50:02.257 [] [Broker-2-StateReplication-1] DEBUG io.zeebe.logstreams.snapshot - Consume snapshot chunk OPTIONS-000090 of snapshot 3-1-1578664202171-4294971584
14:50:02.257 [] [Broker-1-StateReplication-1] DEBUG io.zeebe.logstreams.snapshot - Consume snapshot chunk 000096.sst of snapshot 3-1-1578664202171-4294971584
14:50:02.263 [] [Broker-2-StateReplication-1] DEBUG io.zeebe.logstreams.snapshot - Consume snapshot chunk MANIFEST-000004 of snapshot 3-1-1578664202171-4294971584
```

Exporter and Processor had already the information in the Thread, but the name where not uniform.
```
15:06:07.334 [GatewayTopologyManager] [gateway-scheduler-zb-actors-0] DEBUG io.zeebe.gateway - Received metadata change from Broker 2, partitions {1=FOLLOWER, 2=FOLLOWER, 3=LEADER} and terms {3=1}.
15:06:08.109 [partition-1-processor] [Broker-0-zb-actors-0] INFO  io.zeebe.logstreams - Recovered state of partition 1 from snapshot at position -1
15:06:09.524 [partition-1-processor-snapshot-director] [Broker-0-zb-actors-1] DEBUG io.zeebe.logstreams.snapshot - The position of the last valid snapshot is '-1'. Taking snapshots beyond this position.
15:06:09.543 [exporter-1] [Broker-0-zb-fs-workers-1] DEBUG io.zeebe.broker.exporter - Recovering exporter from snapshot
15:06:09.546 [] [Thread-4] DEBUG io.zeebe.broker.system - Bootstrap Broker-0 partitions [3/3]: partition 1 started in 4636 ms
15:06:09.546 [] [Thread-4] INFO  io.zeebe.broker.system - Bootstrap Broker-0 partitions succeeded. Started 3 steps in 7661 ms.
15:06:09.546 [] [Thread-4] DEBUG io.zeebe.broker.system - Bootstrap Broker-0 [10/10]: zeebe partitions started in 7661 ms
15:06:09.547 [] [Thread-4] INFO  io.zeebe.broker.system - Bootstrap Broker-0 succeeded. Started 10 steps in 14650 ms.
15:06:09.547 [Broker-0-HealthCheckService] [Broker-0-zb-actors-1] DEBUG io.zeebe.broker.system - All partitions are installed. Broker is ready!
15:06:09.571 [exporter-1] [Broker-0-zb-fs-workers-1] DEBUG io.zeebe.broker.exporter - Recovered exporter 'exporter-1' from snapshot at lastExportedPosition -1
15:06:09.571 [exporter-1] [Broker-0-zb-fs-workers-1] DEBUG io.zeebe.broker.exporter - Configure exporter with id 'test-recorder'
```


Processor, Exporter and SnapshotDirector now. It is now easier to match the Broker and partition etc.
```
15:01:02.468 [Broker-0-ZeebePartition-1] [Broker-0-zb-actors-1] DEBUG io.zeebe.broker.system - Installing leader partition service for partition PartitionId{id=1, group=raft-partition}
15:01:02.518 [Broker-0-ZeebePartition-1] [Broker-0-zb-actors-1] DEBUG io.zeebe.logstreams.snapshot - Available snapshots: []
15:01:02.523 [Broker-0-StreamProcessor-3] [Broker-2-zb-actors-1] INFO  io.zeebe.logstreams - Recovered state of partition 3 from snapshot at position -1
15:01:02.698 [Broker-1-ZeebePartition-2] [Broker-1-zb-actors-1] DEBUG io.zeebe.logstreams.snapshot - Opened database from '/tmp/982557a1-4512-4d59-8ff4-73067d081696/data/raft-partition/partitions/2/runtime'.
15:01:02.717 [Broker-0-StreamProcessor-2] [Broker-1-zb-actors-1] DEBUG io.zeebe.logstreams - Recovering state of partition 2 from snapshot
15:01:02.801 [Broker-0-StreamProcessor-2] [Broker-1-zb-actors-1] INFO  io.zeebe.logstreams - Recovered state of partition 2 from snapshot at position -1
15:01:02.986 [Broker-1-SnapshotDirector-2] [Broker-1-zb-actors-0] DEBUG io.zeebe.logstreams.snapshot - The position of the last valid snapshot is '-1'. Taking snapshots beyond this position.
15:01:02.987 [Broker-2-SnapshotDirector-3] [Broker-2-zb-actors-0] DEBUG io.zeebe.logstreams.snapshot - The position of the last valid snapshot is '-1'. Taking snapshots beyond this position.
15:01:03.064 [Broker-1-Exporter-2] [Broker-1-zb-fs-workers-0] DEBUG io.zeebe.broker.exporter - Recovering exporter from snapshot
15:01:03.066 [Broker-2-Exporter-3] [Broker-2-zb-fs-workers-0] DEBUG io.zeebe.broker.exporter - Recovering exporter from snapshot

```


During making the names uniform I found the cause for https://github.com/zeebe-io/zeebe/issues/3626 . The problem was that the LogStorageAppender got not the right partitionId, which was the reason why the metrics didn't worked as expected.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/3626
closes https://github.com/zeebe-io/zeebe/issues/3001

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
