### PR TITLE
feat(clients/go): require context to send commands

### DIFF
--- a/.ci/scripts/distribution/test-go.sh
+++ b/.ci/scripts/distribution/test-go.sh
@@ -2,4 +2,4 @@
 ORG_DIR=${GOPATH}/src/github.com/zeebe-io
 
 cd ${ORG_DIR}/zeebe/clients/go
-go test -mod=vendor -v ./... | go-junit-report > TEST-go.xml
+go test -mod=vendor -v ./...  2>&1 | go-junit-report > TEST-go.xml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,6 +74,13 @@ pipeline {
                     sh '.ci/scripts/distribution/test-go.sh'
                 }
             }
+
+            post {
+                always {
+                    junit testResults: "**/*/TEST-*.xml", keepLongStdio: true
+                }
+            }
+ 
         }
 
         stage('Test (Java)') {

--- a/clients/go/cmd/zbctl/internal/commands/cancelInstance.go
+++ b/clients/go/cmd/zbctl/internal/commands/cancelInstance.go
@@ -14,6 +14,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 	"log"
 )
@@ -30,7 +31,10 @@ var cancelInstanceCmd = &cobra.Command{
 			NewCancelInstanceCommand().
 			WorkflowInstanceKey(cancelInstanceKey)
 
-		_, err := zbCmd.Send()
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		defer cancel()
+
+		_, err := zbCmd.Send(ctx)
 		if err == nil {
 			log.Println("Canceled workflow instance with key", cancelInstanceKey)
 		}

--- a/clients/go/cmd/zbctl/internal/commands/completeJob.go
+++ b/clients/go/cmd/zbctl/internal/commands/completeJob.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 	"log"
 )
@@ -35,7 +36,10 @@ var completeJobCmd = &cobra.Command{
 			return err
 		}
 
-		_, err = request.Send()
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		defer cancel()
+
+		_, err = request.Send(ctx)
 		if err == nil {
 			log.Println("Completed job with key", completeJobKey, "and variables", completeJobVariablesFlag)
 		}

--- a/clients/go/cmd/zbctl/internal/commands/createInstance.go
+++ b/clients/go/cmd/zbctl/internal/commands/createInstance.go
@@ -14,6 +14,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/commands"
 	"strings"
 
@@ -41,8 +42,11 @@ var createInstanceCmd = &cobra.Command{
 			return err
 		}
 
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		defer cancel()
+
 		if createInstanceWithResultFlag == nil {
-			response, err := zbCmd.Send()
+			response, err := zbCmd.Send(ctx)
 			if err != nil {
 				return err
 			}
@@ -56,13 +60,12 @@ var createInstanceCmd = &cobra.Command{
 					variableNames = append(variableNames, trimedVariableName)
 				}
 			}
-			response, err := zbCmd.WithResult().FetchVariables(variableNames...).Send()
+			response, err := zbCmd.WithResult().FetchVariables(variableNames...).Send(ctx)
 			if err != nil {
 				return err
 			}
 
 			return printJson(response)
-
 		}
 	},
 }

--- a/clients/go/cmd/zbctl/internal/commands/deployWorkflow.go
+++ b/clients/go/cmd/zbctl/internal/commands/deployWorkflow.go
@@ -14,6 +14,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +29,10 @@ var deployWorkflowCmd = &cobra.Command{
 			zbCmd = zbCmd.AddResourceFile(args[i])
 		}
 
-		response, err := zbCmd.Send()
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		defer cancel()
+
+		response, err := zbCmd.Send(ctx)
 		if err != nil {
 			return err
 		}

--- a/clients/go/cmd/zbctl/internal/commands/publishMessage.go
+++ b/clients/go/cmd/zbctl/internal/commands/publishMessage.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 	"time"
 )
@@ -43,7 +44,10 @@ var publishMessageCmd = &cobra.Command{
 			return err
 		}
 
-		_, err = request.Send()
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		defer cancel()
+
+		_, err = request.Send(ctx)
 		return err
 	},
 }

--- a/clients/go/cmd/zbctl/internal/commands/resolveIncident.go
+++ b/clients/go/cmd/zbctl/internal/commands/resolveIncident.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 	"log"
 )
@@ -29,7 +30,10 @@ var resolveIncidentCommand = &cobra.Command{
 	Args:    keyArg(&incidentKey),
 	PreRunE: initClient,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, err := client.NewResolveIncidentCommand().IncidentKey(incidentKey).Send()
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		defer cancel()
+
+		_, err := client.NewResolveIncidentCommand().IncidentKey(incidentKey).Send(ctx)
 		if err == nil {
 			log.Println("Resolved an incident of a workflow instance with key", incidentKey)
 		}

--- a/clients/go/cmd/zbctl/internal/commands/root.go
+++ b/clients/go/cmd/zbctl/internal/commands/root.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -29,6 +30,7 @@ const (
 	DefaultAddressHost = "127.0.0.1"
 	DefaultAddressPort = "26500"
 	AddressEnvVar      = "ZEEBE_ADDRESS"
+	defaultTimeout     = 10 * time.Second
 )
 
 var client zbc.Client

--- a/clients/go/cmd/zbctl/internal/commands/setVariables.go
+++ b/clients/go/cmd/zbctl/internal/commands/setVariables.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 	"log"
 )
@@ -37,7 +38,10 @@ var setVariablesCmd = &cobra.Command{
 		}
 
 		request.Local(setVariablesLocalFlag)
-		response, err := request.Send()
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		defer cancel()
+
+		response, err := request.Send(ctx)
 		if err == nil {
 			log.Println("Set the variables of element instance with key", setVariablesKey, "to", setVariablesVariablesFlag, "with command", response.GetKey())
 		}
@@ -50,7 +54,9 @@ func init() {
 	setCmd.AddCommand(setVariablesCmd)
 
 	setVariablesCmd.Flags().StringVar(&setVariablesVariablesFlag, "variables", "{}", "Specify the variables as JSON object string")
-	setVariablesCmd.MarkFlagRequired("variables")
+	if err := setVariablesCmd.MarkFlagRequired("variables"); err != nil {
+		panic(err)
+	}
 
 	setVariablesCmd.Flags().BoolVar(&setVariablesLocalFlag, "local", false, "Specify local or propagating update semantics")
 }

--- a/clients/go/cmd/zbctl/internal/commands/status.go
+++ b/clients/go/cmd/zbctl/internal/commands/status.go
@@ -14,6 +14,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/pb"
@@ -38,7 +39,10 @@ var statusCmd = &cobra.Command{
 	Args:    cobra.NoArgs,
 	PreRunE: initClient,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		response, err := client.NewTopologyCommand().Send()
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		defer cancel()
+
+		response, err := client.NewTopologyCommand().Send(ctx)
 		if err != nil {
 			return err
 		}

--- a/clients/go/cmd/zbctl/internal/commands/updateRetries.go
+++ b/clients/go/cmd/zbctl/internal/commands/updateRetries.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/spf13/cobra"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/commands"
 	"log"
@@ -31,7 +32,10 @@ var updateRetriesCmd = &cobra.Command{
 	Args:    keyArg(&updateRetriesKey),
 	PreRunE: initClient,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		_, err := client.NewUpdateJobRetriesCommand().JobKey(updateRetriesKey).Retries(updateRetriesFlag).Send()
+		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+		defer cancel()
+
+		_, err := client.NewUpdateJobRetriesCommand().JobKey(updateRetriesKey).Retries(updateRetriesFlag).Send(ctx)
 		if err == nil {
 			log.Println("Updated the retries of job with key", updateRetriesKey, "to", updateRetriesFlag)
 		}

--- a/clients/go/pkg/commands/activateJobs_command.go
+++ b/clients/go/pkg/commands/activateJobs_command.go
@@ -26,11 +26,10 @@ const (
 	DefaultJobTimeout     = 5 * time.Minute
 	DefaultJobTimeoutInMs = int64(DefaultJobTimeout / time.Millisecond)
 	DefaultJobWorkerName  = "default"
-	RequestTimeoutOffset  = 10 * time.Second
 )
 
 type DispatchActivateJobsCommand interface {
-	Send() ([]entities.Job, error)
+	Send(ctx context.Context) ([]entities.Job, error)
 }
 
 type ActivateJobsCommandStep1 interface {
@@ -47,7 +46,6 @@ type ActivateJobsCommandStep3 interface {
 	Timeout(time.Duration) ActivateJobsCommandStep3
 	WorkerName(string) ActivateJobsCommandStep3
 	FetchVariables(...string) ActivateJobsCommandStep3
-	RequestTimeout(time.Duration) ActivateJobsCommandStep3
 }
 
 type ActivateJobsCommand struct {
@@ -80,20 +78,13 @@ func (cmd *ActivateJobsCommand) FetchVariables(fetchVariables ...string) Activat
 	return cmd
 }
 
-func (cmd *ActivateJobsCommand) RequestTimeout(timeout time.Duration) ActivateJobsCommandStep3 {
-	cmd.request.RequestTimeout = int64(timeout / time.Millisecond)
-	cmd.requestTimeout = timeout + RequestTimeoutOffset
-	return cmd
-}
-
-func (cmd *ActivateJobsCommand) Send() ([]entities.Job, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), cmd.requestTimeout)
-	defer cancel()
+func (cmd *ActivateJobsCommand) Send(ctx context.Context) ([]entities.Job, error) {
+	cmd.request.RequestTimeout = getLongPollingMillis(ctx)
 
 	stream, err := cmd.gateway.ActivateJobs(ctx, &cmd.request)
 	if err != nil {
-		if cmd.retryPredicate(ctx, err) {
-			return cmd.Send()
+		if cmd.retryPred(ctx, err) {
+			return cmd.Send(ctx)
 		}
 		return nil, err
 	}
@@ -116,17 +107,15 @@ func (cmd *ActivateJobsCommand) Send() ([]entities.Job, error) {
 	return activatedJobs, nil
 }
 
-func NewActivateJobsCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) ActivateJobsCommandStep1 {
+func NewActivateJobsCommand(gateway pb.GatewayClient, pred retryPredicate) ActivateJobsCommandStep1 {
 	return &ActivateJobsCommand{
 		request: pb.ActivateJobsRequest{
-			Timeout:        DefaultJobTimeoutInMs,
-			Worker:         DefaultJobWorkerName,
-			RequestTimeout: int64(requestTimeout / time.Millisecond),
+			Timeout: DefaultJobTimeoutInMs,
+			Worker:  DefaultJobWorkerName,
 		},
 		Command: Command{
-			gateway:        gateway,
-			requestTimeout: requestTimeout + RequestTimeoutOffset,
-			retryPredicate: retryPredicate,
+			gateway:   gateway,
+			retryPred: pred,
 		},
 	}
 }

--- a/clients/go/pkg/commands/activateJobs_command_test.go
+++ b/clients/go/pkg/commands/activateJobs_command_test.go
@@ -27,6 +27,10 @@ import (
 	"time"
 )
 
+const (
+	longPollMillis = int64(float64(utils.DefaultTestTimeoutInMs) * (1.0 - longPollingOffsetPercent))
+)
+
 func TestActivateJobsCommand(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -39,7 +43,7 @@ func TestActivateJobsCommand(t *testing.T) {
 		MaxJobsToActivate: 5,
 		Timeout:           DefaultJobTimeoutInMs,
 		Worker:            DefaultJobWorkerName,
-		RequestTimeout:    int64(utils.DefaultTestTimeout / time.Millisecond),
+		RequestTimeout:    longPollMillis,
 	}
 
 	response1 := &pb.ActivateJobsResponse{
@@ -113,9 +117,12 @@ func TestActivateJobsCommand(t *testing.T) {
 
 	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
 
-	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	jobs, err := NewActivateJobsCommand(client, func(context.Context, error) bool {
 		return false
-	}).JobType("foo").MaxJobsToActivate(5).Send()
+	}).JobType("foo").MaxJobsToActivate(5).Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -144,15 +151,18 @@ func TestActivateJobsCommandWithTimeout(t *testing.T) {
 		MaxJobsToActivate: 5,
 		Timeout:           60 * 1000,
 		Worker:            DefaultJobWorkerName,
-		RequestTimeout:    int64(utils.DefaultTestTimeout / time.Millisecond),
+		RequestTimeout:    longPollMillis,
 	}
 
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
 
-	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	jobs, err := NewActivateJobsCommand(client, func(context.Context, error) bool {
 		return false
-	}).JobType("foo").MaxJobsToActivate(5).Timeout(1 * time.Minute).Send()
+	}).JobType("foo").MaxJobsToActivate(5).Timeout(1 * time.Minute).Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -175,15 +185,18 @@ func TestActivateJobsCommandWithWorkerName(t *testing.T) {
 		MaxJobsToActivate: 5,
 		Timeout:           DefaultJobTimeoutInMs,
 		Worker:            "bar",
-		RequestTimeout:    int64(utils.DefaultTestTimeout / time.Millisecond),
+		RequestTimeout:    longPollMillis,
 	}
 
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
 
-	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	jobs, err := NewActivateJobsCommand(client, func(context.Context, error) bool {
 		return false
-	}).JobType("foo").MaxJobsToActivate(5).WorkerName("bar").Send()
+	}).JobType("foo").MaxJobsToActivate(5).WorkerName("bar").Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -209,15 +222,18 @@ func TestActivateJobsCommandWithFetchVariables(t *testing.T) {
 		Worker:            DefaultJobWorkerName,
 		Timeout:           DefaultJobTimeoutInMs,
 		FetchVariable:     fetchVariables,
-		RequestTimeout:    int64(utils.DefaultTestTimeout / time.Millisecond),
+		RequestTimeout:    longPollMillis,
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
 
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
 
-	jobs, err := NewActivateJobsCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+	jobs, err := NewActivateJobsCommand(client, func(context.Context, error) bool {
 		return false
-	}).JobType("foo").MaxJobsToActivate(5).FetchVariables(fetchVariables...).Send()
+	}).JobType("foo").MaxJobsToActivate(5).FetchVariables(fetchVariables...).Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/pkg/commands/cancelInstance_command_test.go
+++ b/clients/go/pkg/commands/cancelInstance_command_test.go
@@ -36,11 +36,14 @@ func TestCancelWorkflowInstanceCommand(t *testing.T) {
 
 	client.EXPECT().CancelWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCancelInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+	command := NewCancelInstanceCommand(client, func(context.Context, error) bool {
 		return false
 	})
 
-	response, err := command.WorkflowInstanceKey(123).Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.WorkflowInstanceKey(123).Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/pkg/commands/completeJob_command_test.go
+++ b/clients/go/pkg/commands/completeJob_command_test.go
@@ -36,9 +36,12 @@ func TestCompleteJobCommand(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	response, err := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := NewCompleteJobCommand(client, func(context.Context, error) bool {
 		return false
-	}).JobKey(123).Send()
+	}).JobKey(123).Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -65,14 +68,17 @@ func TestCompleteJobCommandWithVariablesFromString(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCompleteJobCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromString(variables)
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -99,7 +105,7 @@ func TestCompleteJobCommandWithVariablesFromStringer(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool {
+	command := NewCompleteJobCommand(client, func(context.Context, error) bool {
 		return false
 	})
 
@@ -108,7 +114,10 @@ func TestCompleteJobCommandWithVariablesFromStringer(t *testing.T) {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -135,14 +144,17 @@ func TestCompleteJobCommandWithVariablesFromObject(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCompleteJobCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -169,14 +181,17 @@ func TestCompleteJobCommandWithVariablesFromObjectOmitempty(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCompleteJobCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -203,14 +218,17 @@ func TestCompleteJobCommandWithVariablesFromObjectIgnoreOmitempty(t *testing.T) 
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCompleteJobCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -239,14 +257,17 @@ func TestCompleteJobCommandWithVariablesFromMap(t *testing.T) {
 
 	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCompleteJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCompleteJobCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.JobKey(123).VariablesFromMap(variableMaps)
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/pkg/commands/createInstance_command_test.go
+++ b/clients/go/pkg/commands/createInstance_command_test.go
@@ -50,9 +50,9 @@ func TestCreateWorkflowInstanceCommand(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.WorkflowKey(123).Send()
+	response, err := command.WorkflowKey(123).Send(context.Background())
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -82,9 +82,9 @@ func TestCreateWorkflowInstanceCommandByBpmnProcessId(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.BPMNProcessId("foo").LatestVersion().Send()
+	response, err := command.BPMNProcessId("foo").LatestVersion().Send(context.Background())
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -114,9 +114,9 @@ func TestCreateWorkflowInstanceCommandByBpmnProcessIdAndVersion(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.BPMNProcessId("foo").Version(56).Send()
+	response, err := command.BPMNProcessId("foo").Version(56).Send(context.Background())
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -148,14 +148,14 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromString(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromString(variables)
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	response, err := variablesCommand.Send(context.Background())
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -187,14 +187,14 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromStringer(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromStringer(DataType{Foo: "bar"})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	response, err := variablesCommand.Send(context.Background())
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -226,14 +226,14 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromObject(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	response, err := variablesCommand.Send(context.Background())
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -265,14 +265,14 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromObjectOmitempty(t *testin
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	response, err := variablesCommand.Send(context.Background())
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -304,14 +304,14 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromObjectIgnoreOmitempty(t *
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	response, err := variablesCommand.Send(context.Background())
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -345,14 +345,14 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromMap(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromMap(variablesMap)
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	response, err := variablesCommand.Send(context.Background())
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -372,7 +372,7 @@ func TestCreateWorkflowInstanceWithResultCommand(t *testing.T) {
 		Request: &pb.CreateWorkflowInstanceRequest{
 			WorkflowKey: 123,
 		},
-		RequestTimeout: utils.DefaultTestTimeoutInMs,
+		RequestTimeout: longPollMillis,
 	}
 	stub := &pb.CreateWorkflowInstanceWithResultResponse{
 		WorkflowKey:         123,
@@ -384,9 +384,12 @@ func TestCreateWorkflowInstanceWithResultCommand(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.WorkflowKey(123).WithResult().Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.WorkflowKey(123).WithResult().Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -408,7 +411,7 @@ func TestCreateWorkflowInstanceWithResultCommandByBpmnProcessId(t *testing.T) {
 			BpmnProcessId: "foo",
 			Version:       LatestVersion,
 		},
-		RequestTimeout: utils.DefaultTestTimeoutInMs,
+		RequestTimeout: longPollMillis,
 	}
 	stub := &pb.CreateWorkflowInstanceWithResultResponse{
 		WorkflowKey:         123,
@@ -420,9 +423,12 @@ func TestCreateWorkflowInstanceWithResultCommandByBpmnProcessId(t *testing.T) {
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.BPMNProcessId("foo").LatestVersion().WithResult().Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.BPMNProcessId("foo").LatestVersion().WithResult().Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -444,7 +450,7 @@ func TestCreateWorkflowInstanceWithResultCommandByBpmnProcessIdAndVersion(t *tes
 			BpmnProcessId: "foo",
 			Version:       56,
 		},
-		RequestTimeout: utils.DefaultTestTimeoutInMs,
+		RequestTimeout: longPollMillis,
 	}
 	stub := &pb.CreateWorkflowInstanceWithResultResponse{
 		WorkflowKey:         123,
@@ -456,9 +462,12 @@ func TestCreateWorkflowInstanceWithResultCommandByBpmnProcessIdAndVersion(t *tes
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.BPMNProcessId("foo").Version(56).WithResult().Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.BPMNProcessId("foo").Version(56).WithResult().Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -474,7 +483,6 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromString(t *testi
 	defer ctrl.Finish()
 
 	client := mock_pb.NewMockGatewayClient(ctrl)
-
 	variables := "{\"foo\":\"bar\"}"
 
 	request := &pb.CreateWorkflowInstanceWithResultRequest{
@@ -482,7 +490,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromString(t *testi
 			WorkflowKey: 123,
 			Variables:   variables,
 		},
-		RequestTimeout: utils.DefaultTestTimeoutInMs,
+		RequestTimeout: longPollMillis,
 	}
 	stub := &pb.CreateWorkflowInstanceWithResultResponse{
 		WorkflowKey:         123,
@@ -494,14 +502,17 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromString(t *testi
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromString(variables)
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.WithResult().Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.WithResult().Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -517,7 +528,6 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromStringer(t *tes
 	defer ctrl.Finish()
 
 	client := mock_pb.NewMockGatewayClient(ctrl)
-
 	variables := "{\"foo\":\"bar\"}"
 
 	request := &pb.CreateWorkflowInstanceWithResultRequest{
@@ -525,7 +535,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromStringer(t *tes
 			WorkflowKey: 123,
 			Variables:   variables,
 		},
-		RequestTimeout: utils.DefaultTestTimeoutInMs,
+		RequestTimeout: longPollMillis,
 	}
 	stub := &pb.CreateWorkflowInstanceWithResultResponse{
 		WorkflowKey:         123,
@@ -537,14 +547,17 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromStringer(t *tes
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromStringer(DataType{Foo: "bar"})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.WithResult().Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.WithResult().Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -560,7 +573,6 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObject(t *testi
 	defer ctrl.Finish()
 
 	client := mock_pb.NewMockGatewayClient(ctrl)
-
 	variables := "{\"foo\":\"bar\"}"
 
 	request := &pb.CreateWorkflowInstanceWithResultRequest{
@@ -568,7 +580,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObject(t *testi
 			WorkflowKey: 123,
 			Variables:   variables,
 		},
-		RequestTimeout: utils.DefaultTestTimeoutInMs,
+		RequestTimeout: longPollMillis,
 	}
 	stub := &pb.CreateWorkflowInstanceWithResultResponse{
 		WorkflowKey:         123,
@@ -580,14 +592,17 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObject(t *testi
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.WithResult().Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.WithResult().Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -603,7 +618,6 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObjectOmitempty
 	defer ctrl.Finish()
 
 	client := mock_pb.NewMockGatewayClient(ctrl)
-
 	variables := "{}"
 
 	request := &pb.CreateWorkflowInstanceWithResultRequest{
@@ -611,7 +625,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObjectOmitempty
 			WorkflowKey: 123,
 			Variables:   variables,
 		},
-		RequestTimeout: utils.DefaultTestTimeoutInMs,
+		RequestTimeout: longPollMillis,
 	}
 	stub := &pb.CreateWorkflowInstanceWithResultResponse{
 		WorkflowKey:         123,
@@ -623,14 +637,17 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObjectOmitempty
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.WithResult().Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.WithResult().Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -646,7 +663,6 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObjectIgnoreOmi
 	defer ctrl.Finish()
 
 	client := mock_pb.NewMockGatewayClient(ctrl)
-
 	variables := "{\"foo\":\"\"}"
 
 	request := &pb.CreateWorkflowInstanceWithResultRequest{
@@ -654,7 +670,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObjectIgnoreOmi
 			WorkflowKey: 123,
 			Variables:   variables,
 		},
-		RequestTimeout: utils.DefaultTestTimeoutInMs,
+		RequestTimeout: longPollMillis,
 	}
 	stub := &pb.CreateWorkflowInstanceWithResultResponse{
 		WorkflowKey:         123,
@@ -666,14 +682,17 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObjectIgnoreOmi
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.WithResult().Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.WithResult().Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -699,7 +718,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromMap(t *testing.
 			WorkflowKey: 123,
 			Variables:   variables,
 		},
-		RequestTimeout: utils.DefaultTestTimeoutInMs,
+		RequestTimeout: longPollMillis,
 	}
 	stub := &pb.CreateWorkflowInstanceWithResultResponse{
 		WorkflowKey:         123,
@@ -711,14 +730,17 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromMap(t *testing.
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.WorkflowKey(123).VariablesFromMap(variablesMap)
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.WithResult().Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.WithResult().Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -738,7 +760,7 @@ func TestCreateWorkflowInstanceWithResultAndFetchVariablesCommand(t *testing.T) 
 		Request: &pb.CreateWorkflowInstanceRequest{
 			WorkflowKey: 123,
 		},
-		RequestTimeout: utils.DefaultTestTimeoutInMs,
+		RequestTimeout: longPollMillis,
 		FetchVariables: []string{"a", "b", "c"},
 	}
 	stub := &pb.CreateWorkflowInstanceWithResultResponse{
@@ -751,9 +773,12 @@ func TestCreateWorkflowInstanceWithResultAndFetchVariablesCommand(t *testing.T) 
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.WorkflowKey(123).WithResult().FetchVariables("a", "b", "c").Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.WorkflowKey(123).WithResult().FetchVariables("a", "b", "c").Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -773,8 +798,7 @@ func TestCreateWorkflowInstanceWithResultAndFetchEmptyVariablesListCommand(t *te
 		Request: &pb.CreateWorkflowInstanceRequest{
 			WorkflowKey: 123,
 		},
-		RequestTimeout: utils.DefaultTestTimeoutInMs,
-		FetchVariables: []string{},
+		RequestTimeout: longPollMillis,
 	}
 	stub := &pb.CreateWorkflowInstanceWithResultResponse{
 		WorkflowKey:         123,
@@ -786,9 +810,12 @@ func TestCreateWorkflowInstanceWithResultAndFetchEmptyVariablesListCommand(t *te
 
 	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewCreateInstanceCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.WorkflowKey(123).WithResult().FetchVariables().Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.WorkflowKey(123).WithResult().FetchVariables().Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/pkg/commands/deploy_command_test.go
+++ b/clients/go/pkg/commands/deploy_command_test.go
@@ -60,13 +60,13 @@ func TestDeployCommand_AddResourceFile(t *testing.T) {
 
 	client.EXPECT().DeployWorkflow(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewDeployCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewDeployCommand(client, func(context.Context, error) bool { return false })
 
 	response, err := command.
 		AddResourceFile(demoName).
 		AddResourceFile(anotherName).
 		AddResourceFile(yamlName).
-		Send()
+		Send(context.Background())
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -99,11 +99,14 @@ func TestDeployCommand_AddResource(t *testing.T) {
 
 	client.EXPECT().DeployWorkflow(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewDeployCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewDeployCommand(client, func(context.Context, error) bool { return false })
+
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
 
 	response, err := command.
 		AddResource(demoBytes, demoName, pb.WorkflowRequestObject_BPMN).
-		Send()
+		Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/pkg/commands/failJob_command.go
+++ b/clients/go/pkg/commands/failJob_command.go
@@ -18,11 +18,10 @@ package commands
 import (
 	"context"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/pb"
-	"time"
 )
 
 type DispatchFailJobCommand interface {
-	Send() (*pb.FailJobResponse, error)
+	Send(context.Context) (*pb.FailJobResponse, error)
 }
 
 type FailJobCommandStep1 interface {
@@ -58,23 +57,19 @@ func (cmd *FailJobCommand) ErrorMessage(errorMessage string) FailJobCommandStep3
 	return cmd
 }
 
-func (cmd *FailJobCommand) Send() (*pb.FailJobResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), cmd.requestTimeout)
-	defer cancel()
-
+func (cmd *FailJobCommand) Send(ctx context.Context) (*pb.FailJobResponse, error) {
 	response, err := cmd.gateway.FailJob(ctx, &cmd.request)
-	if cmd.retryPredicate(ctx, err) {
-		return cmd.Send()
+	if cmd.retryPred(ctx, err) {
+		return cmd.Send(ctx)
 	}
 
 	return response, err
 }
 
-func NewFailJobCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) FailJobCommandStep1 {
+func NewFailJobCommand(gateway pb.GatewayClient, pred retryPredicate) FailJobCommandStep1 {
 	return &FailJobCommand{
 		Command: Command{gateway: gateway,
-			requestTimeout: requestTimeout,
-			retryPredicate: retryPredicate,
+			retryPred: pred,
 		},
 	}
 }

--- a/clients/go/pkg/commands/failJob_command_test.go
+++ b/clients/go/pkg/commands/failJob_command_test.go
@@ -38,9 +38,12 @@ func TestFailJobCommand(t *testing.T) {
 
 	client.EXPECT().FailJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewFailJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewFailJobCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.JobKey(123).Retries(12).Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.JobKey(123).Retries(12).Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -68,9 +71,12 @@ func TestFailJobCommand_ErrorMessage(t *testing.T) {
 
 	client.EXPECT().FailJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewFailJobCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewFailJobCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.JobKey(123).Retries(12).ErrorMessage(errorMessage).Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.JobKey(123).Retries(12).ErrorMessage(errorMessage).Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/pkg/commands/publishMessage_command_test.go
+++ b/clients/go/pkg/commands/publishMessage_command_test.go
@@ -39,9 +39,12 @@ func TestPublishMessageCommand(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.MessageName("foo").CorrelationKey("bar").Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.MessageName("foo").CorrelationKey("bar").Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -67,9 +70,12 @@ func TestPublishMessageCommandWithMessageId(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.MessageName("foo").CorrelationKey("bar").MessageId("hello").Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.MessageName("foo").CorrelationKey("bar").MessageId("hello").Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -95,9 +101,12 @@ func TestPublishMessageCommandWithTimeToLive(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.MessageName("foo").CorrelationKey("bar").TimeToLive(time.Duration(6 * time.Minute)).Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.MessageName("foo").CorrelationKey("bar").TimeToLive(6 * time.Minute).Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -125,14 +134,17 @@ func TestPublishMessageCommandWithVariablesFromString(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromString(variables)
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -160,14 +172,17 @@ func TestPublishMessageCommandWithVariablesFromStringer(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromStringer(DataType{Foo: "bar"})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -195,14 +210,17 @@ func TestPublishMessageCommandWithVariablesFromObject(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -230,14 +248,17 @@ func TestPublishMessageCommandWithVariablesFromObjectOmitempty(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -265,14 +286,17 @@ func TestPublishMessageCommandWithVariablesFromObjectIgnoreOmitEmpty(t *testing.
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -302,14 +326,17 @@ func TestPublishMessageCommandWithVariablesFromMap(t *testing.T) {
 
 	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewPublishMessageCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.MessageName("foo").CorrelationKey("bar").VariablesFromMap(variablesMap)
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/pkg/commands/resolveIncident_command_test.go
+++ b/clients/go/pkg/commands/resolveIncident_command_test.go
@@ -38,9 +38,12 @@ func TestResolveIncidentCommand(t *testing.T) {
 
 	client.EXPECT().ResolveIncident(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewResolveIncidentCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewResolveIncidentCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.IncidentKey(123).Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.IncidentKey(123).Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/pkg/commands/setVariables_command_test.go
+++ b/clients/go/pkg/commands/setVariables_command_test.go
@@ -41,14 +41,17 @@ func TestSetVariablesCommandWithVariablesFromString(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewSetVariablesCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromString(variables)
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -77,14 +80,17 @@ func TestSetVariablesCommandWithVariablesFromStringer(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewSetVariablesCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromStringer(DataType{Foo: "bar"})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -113,14 +119,17 @@ func TestSetVariablesCommandWithVariablesFromObject(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewSetVariablesCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromObject(DataType{Foo: "bar"})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -149,14 +158,17 @@ func TestSetVariablesCommandWithVariablesFromObjectOmitempty(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewSetVariablesCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromObject(DataType{Foo: ""})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -185,14 +197,17 @@ func TestSetVariablesCommandWithVariablesFromObjectIgnoreOmitempty(t *testing.T)
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewSetVariablesCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromObjectIgnoreOmitempty(DataType{Foo: ""})
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -223,14 +238,17 @@ func TestSetVariablesCommandWithVariablesFromMap(t *testing.T) {
 
 	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewSetVariablesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewSetVariablesCommand(client, func(context.Context, error) bool { return false })
 
 	variablesCommand, err := command.ElementInstanceKey(123).VariablesFromMap(variablesMap)
 	if err != nil {
 		t.Error("Failed to set variables: ", err)
 	}
 
-	response, err := variablesCommand.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := variablesCommand.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/pkg/commands/throwError_command_test.go
+++ b/clients/go/pkg/commands/throwError_command_test.go
@@ -39,9 +39,12 @@ func TestThrowErrorCommand(t *testing.T) {
 
 	client.EXPECT().ThrowError(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewThrowErrorCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewThrowErrorCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.JobKey(123).ErrorCode("someErrorCode").ErrorMessage("someErrorMessage").Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.JobKey(123).ErrorCode("someErrorCode").ErrorMessage("someErrorMessage").Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/pkg/commands/topology_command.go
+++ b/clients/go/pkg/commands/topology_command.go
@@ -18,27 +18,26 @@ package commands
 import (
 	"context"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/pb"
-	"time"
 )
 
-type TopologyCommand Command
+type TopologyCommand struct {
+	Command
+}
 
-func (cmd *TopologyCommand) Send() (*pb.TopologyResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), cmd.requestTimeout)
-	defer cancel()
-
+func (cmd *TopologyCommand) Send(ctx context.Context) (*pb.TopologyResponse, error) {
 	response, err := cmd.gateway.Topology(ctx, &pb.TopologyRequest{})
-	if cmd.retryPredicate(ctx, err) {
-		return cmd.Send()
+	if cmd.retryPred(ctx, err) {
+		return cmd.Send(ctx)
 	}
 
 	return response, err
 }
 
-func NewTopologyCommand(gateway pb.GatewayClient, requestTimeout time.Duration, retryPredicate func(context.Context, error) bool) *TopologyCommand {
+func NewTopologyCommand(gateway pb.GatewayClient, pred retryPredicate) *TopologyCommand {
 	return &TopologyCommand{
-		gateway:        gateway,
-		requestTimeout: requestTimeout,
-		retryPredicate: retryPredicate,
+		Command{
+			gateway:   gateway,
+			retryPred: pred,
+		},
 	}
 }

--- a/clients/go/pkg/commands/topology_command_test.go
+++ b/clients/go/pkg/commands/topology_command_test.go
@@ -70,9 +70,12 @@ func TestTopologyCommand(t *testing.T) {
 
 	client.EXPECT().Topology(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewTopologyCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewTopologyCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/pkg/commands/updateJobRetries_command_test.go
+++ b/clients/go/pkg/commands/updateJobRetries_command_test.go
@@ -38,9 +38,9 @@ func TestUpdateJobRetriesCommand(t *testing.T) {
 
 	client.EXPECT().UpdateJobRetries(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewUpdateJobRetriesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewUpdateJobRetriesCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.JobKey(123).Send()
+	response, err := command.JobKey(123).Send(context.Background())
 
 	if err != nil {
 		t.Errorf("Failed to send request")
@@ -65,9 +65,12 @@ func TestUpdateJobRetriesCommandWithRetries(t *testing.T) {
 
 	client.EXPECT().UpdateJobRetries(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
 
-	command := NewUpdateJobRetriesCommand(client, utils.DefaultTestTimeout, func(context.Context, error) bool { return false })
+	command := NewUpdateJobRetriesCommand(client, func(context.Context, error) bool { return false })
 
-	response, err := command.JobKey(123).Retries(23).Send()
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	response, err := command.JobKey(123).Retries(23).Send(ctx)
 
 	if err != nil {
 		t.Errorf("Failed to send request")

--- a/clients/go/pkg/worker/jobWorker_builder.go
+++ b/clients/go/pkg/worker/jobWorker_builder.go
@@ -31,6 +31,7 @@ const (
 	DefaultJobWorkerPollInterval  = 100 * time.Millisecond
 	DefaultJobWorkerPollThreshold = 0.3
 	RequestTimeoutOffset          = 10 * time.Second
+	DefaultRequestTimeout         = 10 * time.Second
 )
 
 type JobWorkerBuilder struct {
@@ -180,7 +181,7 @@ func (builder *JobWorkerBuilder) Open() JobWorker {
 	}
 }
 
-func NewJobWorkerBuilder(gatewayClient pb.GatewayClient, jobClient JobClient, requestTimeout time.Duration) JobWorkerBuilderStep1 {
+func NewJobWorkerBuilder(gatewayClient pb.GatewayClient, jobClient JobClient) JobWorkerBuilderStep1 {
 	return &JobWorkerBuilder{
 		gatewayClient: gatewayClient,
 		jobClient:     jobClient,
@@ -191,8 +192,8 @@ func NewJobWorkerBuilder(gatewayClient pb.GatewayClient, jobClient JobClient, re
 		request: pb.ActivateJobsRequest{
 			Timeout:        commands.DefaultJobTimeoutInMs,
 			Worker:         commands.DefaultJobWorkerName,
-			RequestTimeout: int64(requestTimeout / time.Millisecond),
+			RequestTimeout: DefaultRequestTimeout.Milliseconds(),
 		},
-		requestTimeout: requestTimeout + RequestTimeoutOffset,
+		requestTimeout: DefaultRequestTimeout + RequestTimeoutOffset,
 	}
 }

--- a/clients/go/pkg/worker/jobWorker_test.go
+++ b/clients/go/pkg/worker/jobWorker_test.go
@@ -74,9 +74,9 @@ func TestJobWorkerActivateJobsDefault(t *testing.T) {
 
 	jobs := make(chan entities.Job, 1)
 
-	NewJobWorkerBuilder(client, nil, utils.DefaultTestTimeout).JobType("foo").Handler(func(client JobClient, job entities.Job) {
+	NewJobWorkerBuilder(client, nil).JobType("foo").Handler(func(client JobClient, job entities.Job) {
 		jobs <- job
-	}).Open()
+	}).RequestTimeout(utils.DefaultTestTimeout).Open()
 
 	select {
 	case job := <-jobs:
@@ -120,9 +120,9 @@ func TestJobWorkerActivateJobsCustom(t *testing.T) {
 
 	jobs := make(chan entities.Job, 1)
 
-	NewJobWorkerBuilder(client, nil, utils.DefaultTestTimeout).JobType("foo").Handler(func(client JobClient, job entities.Job) {
+	NewJobWorkerBuilder(client, nil).JobType("foo").Handler(func(client JobClient, job entities.Job) {
 		jobs <- job
-	}).MaxJobsActive(123).Timeout(timeout).Name("fooWorker").Open()
+	}).MaxJobsActive(123).Timeout(timeout).RequestTimeout(utils.DefaultTestTimeout).Name("fooWorker").Open()
 
 	select {
 	case job := <-jobs:

--- a/clients/go/pkg/zbc/api.go
+++ b/clients/go/pkg/zbc/api.go
@@ -16,8 +16,6 @@
 package zbc
 
 import (
-	"time"
-
 	"github.com/zeebe-io/zeebe/clients/go/pkg/commands"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/worker"
 )
@@ -40,8 +38,6 @@ type Client interface {
 	NewThrowErrorCommand() commands.ThrowErrorCommandStep1
 
 	NewJobWorker() worker.JobWorkerBuilderStep1
-
-	SetRequestTimeout(time.Duration) Client
 
 	Close() error
 }

--- a/clients/go/pkg/zbc/client.go
+++ b/clients/go/pkg/zbc/client.go
@@ -40,7 +40,6 @@ const KeepAliveEnvVar = "ZEEBE_KEEP_ALIVE"
 
 type ClientImpl struct {
 	gateway             pb.GatewayClient
-	requestTimeout      time.Duration
 	connection          *grpc.ClientConn
 	credentialsProvider CredentialsProvider
 }
@@ -50,6 +49,7 @@ type ClientConfig struct {
 	UsePlaintextConnection bool
 	CaCertificatePath      string
 	CredentialsProvider    CredentialsProvider
+
 	// KeepAlive can be used configure how often keep alive messages should be sent to the gateway. These will be sent
 	// whether or not there are active requests. Negative values will result in error and zero will result in the default
 	// of 45 seconds being used
@@ -66,60 +66,55 @@ func (e Error) Error() string {
 }
 
 func (client *ClientImpl) NewTopologyCommand() *commands.TopologyCommand {
-	return commands.NewTopologyCommand(client.gateway, client.requestTimeout, client.credentialsProvider.ShouldRetryRequest)
+	return commands.NewTopologyCommand(client.gateway, client.credentialsProvider.ShouldRetryRequest)
 }
 
 func (client *ClientImpl) NewDeployWorkflowCommand() *commands.DeployCommand {
-	return commands.NewDeployCommand(client.gateway, client.requestTimeout, client.credentialsProvider.ShouldRetryRequest)
+	return commands.NewDeployCommand(client.gateway, client.credentialsProvider.ShouldRetryRequest)
 }
 
 func (client *ClientImpl) NewPublishMessageCommand() commands.PublishMessageCommandStep1 {
-	return commands.NewPublishMessageCommand(client.gateway, client.requestTimeout, client.credentialsProvider.ShouldRetryRequest)
+	return commands.NewPublishMessageCommand(client.gateway, client.credentialsProvider.ShouldRetryRequest)
 }
 
 func (client *ClientImpl) NewResolveIncidentCommand() commands.ResolveIncidentCommandStep1 {
-	return commands.NewResolveIncidentCommand(client.gateway, client.requestTimeout, client.credentialsProvider.ShouldRetryRequest)
+	return commands.NewResolveIncidentCommand(client.gateway, client.credentialsProvider.ShouldRetryRequest)
 }
 
 func (client *ClientImpl) NewCreateInstanceCommand() commands.CreateInstanceCommandStep1 {
-	return commands.NewCreateInstanceCommand(client.gateway, client.requestTimeout, client.credentialsProvider.ShouldRetryRequest)
+	return commands.NewCreateInstanceCommand(client.gateway, client.credentialsProvider.ShouldRetryRequest)
 }
 
 func (client *ClientImpl) NewCancelInstanceCommand() commands.CancelInstanceStep1 {
-	return commands.NewCancelInstanceCommand(client.gateway, client.requestTimeout, client.credentialsProvider.ShouldRetryRequest)
+	return commands.NewCancelInstanceCommand(client.gateway, client.credentialsProvider.ShouldRetryRequest)
 }
 
 func (client *ClientImpl) NewCompleteJobCommand() commands.CompleteJobCommandStep1 {
-	return commands.NewCompleteJobCommand(client.gateway, client.requestTimeout, client.credentialsProvider.ShouldRetryRequest)
+	return commands.NewCompleteJobCommand(client.gateway, client.credentialsProvider.ShouldRetryRequest)
 }
 
 func (client *ClientImpl) NewFailJobCommand() commands.FailJobCommandStep1 {
-	return commands.NewFailJobCommand(client.gateway, client.requestTimeout, client.credentialsProvider.ShouldRetryRequest)
+	return commands.NewFailJobCommand(client.gateway, client.credentialsProvider.ShouldRetryRequest)
 }
 
 func (client *ClientImpl) NewUpdateJobRetriesCommand() commands.UpdateJobRetriesCommandStep1 {
-	return commands.NewUpdateJobRetriesCommand(client.gateway, client.requestTimeout, client.credentialsProvider.ShouldRetryRequest)
+	return commands.NewUpdateJobRetriesCommand(client.gateway, client.credentialsProvider.ShouldRetryRequest)
 }
 
 func (client *ClientImpl) NewSetVariablesCommand() commands.SetVariablesCommandStep1 {
-	return commands.NewSetVariablesCommand(client.gateway, client.requestTimeout, client.credentialsProvider.ShouldRetryRequest)
+	return commands.NewSetVariablesCommand(client.gateway, client.credentialsProvider.ShouldRetryRequest)
 }
 
 func (client *ClientImpl) NewActivateJobsCommand() commands.ActivateJobsCommandStep1 {
-	return commands.NewActivateJobsCommand(client.gateway, client.requestTimeout, client.credentialsProvider.ShouldRetryRequest)
+	return commands.NewActivateJobsCommand(client.gateway, client.credentialsProvider.ShouldRetryRequest)
 }
 
 func (client *ClientImpl) NewThrowErrorCommand() commands.ThrowErrorCommandStep1 {
-	return commands.NewThrowErrorCommand(client.gateway, client.requestTimeout, client.credentialsProvider.ShouldRetryRequest)
+	return commands.NewThrowErrorCommand(client.gateway, client.credentialsProvider.ShouldRetryRequest)
 }
 
 func (client *ClientImpl) NewJobWorker() worker.JobWorkerBuilderStep1 {
-	return worker.NewJobWorkerBuilder(client.gateway, client, client.requestTimeout)
-}
-
-func (client *ClientImpl) SetRequestTimeout(requestTimeout time.Duration) Client {
-	client.requestTimeout = requestTimeout
-	return client
+	return worker.NewJobWorkerBuilder(client.gateway, client)
 }
 
 func (client *ClientImpl) Close() error {
@@ -155,7 +150,6 @@ func NewClient(config *ClientConfig) (Client, error) {
 
 	return &ClientImpl{
 		gateway:             pb.NewGatewayClient(conn),
-		requestTimeout:      DefaultRequestTimeout,
 		connection:          conn,
 		credentialsProvider: config.CredentialsProvider,
 	}, nil

--- a/clients/go/pkg/zbc/client_test.go
+++ b/clients/go/pkg/zbc/client_test.go
@@ -15,6 +15,7 @@
 package zbc
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"github.com/stretchr/testify/suite"
@@ -57,7 +58,7 @@ func (s *clientTestSuite) TestClientWithTls() {
 	s.NoError(err)
 
 	// when
-	_, err = client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send(context.Background())
 
 	// then
 	s.Error(err)
@@ -136,7 +137,7 @@ func (s *clientTestSuite) TestClientWithoutTls() {
 	s.NoError(err)
 
 	// when
-	_, err = client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send(context.Background())
 
 	// then
 	s.Error(err)
@@ -163,7 +164,7 @@ func (s *clientTestSuite) TestClientWithDefaultRootCa() {
 	s.NoError(err)
 
 	// then
-	_, err = client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send(context.Background())
 
 	// when
 	s.Error(err)
@@ -223,7 +224,7 @@ func (s *clientTestSuite) TestClientWithDefaultCredentialsProvider() {
 	s.NoError(err)
 
 	// when
-	_, err = client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send(context.Background())
 
 	// then
 	s.Error(err)
@@ -298,6 +299,47 @@ func (s *clientTestSuite) TestRejectNegativeDurationAsEnvVar() {
 	// then
 	s.Error(err)
 }
+
+func (s *clientTestSuite) TestCommandExpireWithContext() {
+	// given
+	blockReq := make(chan struct{})
+	defer close(blockReq)
+	lis, server := createServerWithInterceptor(func(_ context.Context, _ interface{}, _ *grpc.UnaryServerInfo, _ grpc.UnaryHandler) (interface{}, error) {
+		<-blockReq
+		return nil, nil
+	})
+	go server.Serve(lis)
+	defer server.Stop()
+
+	client, err := NewClient(&ClientConfig{
+		GatewayAddress:         lis.Addr().String(),
+		UsePlaintextConnection: true,
+	})
+	s.NoError(err)
+
+	// when
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	cmdFinished := make(chan struct{})
+	go func() {
+		_, err = client.NewTopologyCommand().Send(ctx)
+		close(cmdFinished)
+	}()
+
+	// then
+	select {
+	case <-cmdFinished:
+	case <-time.After(2 * time.Second):
+		s.FailNow("expected command to fail with deadline exceeded, but blocked instead")
+	}
+
+	code := status.Code(err)
+	if code != codes.DeadlineExceeded {
+		s.FailNow(fmt.Sprintf("expected command to fail with deadline exceeded, but got %s instead", code.String()))
+	}
+}
+
 func createSecureServer() (net.Listener, *grpc.Server) {
 	creds, _ := credentials.NewServerTLSFromFile("../../test/testdata/chain.cert.pem", "../../test/testdata/private.key.pem")
 	return createServer(grpc.Creds(creds))

--- a/clients/go/pkg/zbc/credentialsProvider_test.go
+++ b/clients/go/pkg/zbc/credentialsProvider_test.go
@@ -78,7 +78,7 @@ func TestCustomCredentialsProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	// when
-	_, err = client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send(context.Background())
 
 	// then
 	require.Error(t, err)
@@ -120,7 +120,7 @@ func TestRetryMoreThanOnce(t *testing.T) {
 	require.NoError(t, err)
 
 	// when
-	_, err = client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send(context.Background())
 
 	// then
 	require.Error(t, err)
@@ -153,7 +153,7 @@ func TestNoRetryWithoutProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	// when
-	_, err = client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send(context.Background())
 
 	// then
 	require.Error(t, err)

--- a/clients/go/pkg/zbc/oauthCredentialsProvider_test.go
+++ b/clients/go/pkg/zbc/oauthCredentialsProvider_test.go
@@ -77,7 +77,7 @@ func (s *oauthCredsProviderTestSuite) TestOAuthCredentialsProvider() {
 	s.NoError(err)
 
 	// when
-	_, err = client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send(context.Background())
 
 	// then
 	s.Error(err)
@@ -130,7 +130,7 @@ func (s *oauthCredsProviderTestSuite) TestOAuthProviderRetry() {
 	s.NoError(err)
 
 	// when
-	_, err = client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send(context.Background())
 
 	// then
 	s.Error(err)
@@ -177,7 +177,7 @@ func (s *oauthCredsProviderTestSuite) TestNotRetryWithSameCredentials() {
 	s.NoError(err)
 
 	// when
-	_, err = client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send(context.Background())
 
 	// then
 	s.Error(err)
@@ -348,7 +348,7 @@ func (s *oauthCredsProviderTestSuite) TestOAuthCredentialsProviderCachesCredenti
 	s.NoError(err)
 
 	// when
-	_, err = client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send(context.Background())
 
 	// then
 	s.NoError(err)
@@ -403,7 +403,7 @@ func (s *oauthCredsProviderTestSuite) TestOAuthCredentialsProviderUsesCachedCred
 	s.NoError(err)
 
 	// when
-	_, err = client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send(context.Background())
 
 	// then
 	s.NoError(err)
@@ -414,7 +414,7 @@ func (s *oauthCredsProviderTestSuite) TestOAuthCredentialsProviderUsesCachedCred
 	s.False(authServerCalled)
 
 	// when we do it again
-	_, err = client.NewTopologyCommand().Send()
+	_, err = client.NewTopologyCommand().Send(context.Background())
 
 	// then
 	s.NoError(err)
@@ -458,12 +458,15 @@ func (s *oauthCredsProviderTestSuite) TestOAuthTimeout() {
 		CredentialsProvider:    credsProvider,
 	})
 	s.NoError(err)
-	client.SetRequestTimeout(time.Hour)
 
 	// when
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+
 	finishCmd := make(chan struct{})
 	go func() {
-		_, err = client.NewTopologyCommand().Send()
+
+		_, err = client.NewTopologyCommand().Send(ctx)
 		finishCmd <- struct{}{}
 	}()
 

--- a/clients/go/test/integration_test.go
+++ b/clients/go/test/integration_test.go
@@ -14,21 +14,22 @@
 package test
 
 import (
+	"context"
 	"github.com/stretchr/testify/suite"
-	"github.com/zeebe-io/zeebe/clients/go/internal/containerSuite"
+	"github.com/zeebe-io/zeebe/clients/go/internal/containersuite"
 	"github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
 	"testing"
 	"time"
 )
 
 type integrationTestSuite struct {
-	*containerSuite.ContainerSuite
+	*containersuite.ContainerSuite
 	client zbc.Client
 }
 
 func TestIntegration(t *testing.T) {
 	suite.Run(t, &integrationTestSuite{
-		ContainerSuite: &containerSuite.ContainerSuite{
+		ContainerSuite: &containersuite.ContainerSuite{
 			WaitTime:       time.Second,
 			ContainerImage: "camunda/zeebe:current-test",
 		},
@@ -40,7 +41,6 @@ func (s *integrationTestSuite) SetupSuite() {
 	s.ContainerSuite.SetupSuite()
 
 	s.client, err = zbc.NewClient(&zbc.ClientConfig{
-
 		GatewayAddress:         s.GatewayAddress,
 		UsePlaintextConnection: true,
 	})
@@ -59,7 +59,10 @@ func (s *integrationTestSuite) TearDownSuite() {
 }
 func (s *integrationTestSuite) TestTopology() {
 	// when
-	response, err := s.client.NewTopologyCommand().Send()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	response, err := s.client.NewTopologyCommand().Send(ctx)
 	if err != nil {
 		s.T().Fatal(err)
 	}
@@ -72,7 +75,10 @@ func (s *integrationTestSuite) TestTopology() {
 
 func (s *integrationTestSuite) TestDeployWorkflow() {
 	// when
-	deployment, err := s.client.NewDeployWorkflowCommand().AddResourceFile("testdata/service_task.bpmn").Send()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	deployment, err := s.client.NewDeployWorkflowCommand().AddResourceFile("testdata/service_task.bpmn").Send(ctx)
 	if err != nil {
 		s.T().Fatal(err)
 	}
@@ -89,14 +95,20 @@ func (s *integrationTestSuite) TestDeployWorkflow() {
 
 func (s *integrationTestSuite) TestCreateInstance() {
 	// given
-	deployment, err := s.client.NewDeployWorkflowCommand().AddResourceFile("testdata/service_task.bpmn").Send()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	deployment, err := s.client.NewDeployWorkflowCommand().AddResourceFile("testdata/service_task.bpmn").Send(ctx)
 	if err != nil {
 		s.T().Fatal(err)
 	}
 
 	// when
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	workflow := deployment.GetWorkflows()[0]
-	workflowInstance, err := s.client.NewCreateInstanceCommand().BPMNProcessId("deploy_process").Version(workflow.GetVersion()).Send()
+	workflowInstance, err := s.client.NewCreateInstanceCommand().BPMNProcessId("deploy_process").Version(workflow.GetVersion()).Send(ctx)
 	if err != nil {
 		s.T().Fatal(err)
 	}
@@ -110,19 +122,28 @@ func (s *integrationTestSuite) TestCreateInstance() {
 
 func (s *integrationTestSuite) TestActivateJobs() {
 	// given
-	deployment, err := s.client.NewDeployWorkflowCommand().AddResourceFile("testdata/service_task.bpmn").Send()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	deployment, err := s.client.NewDeployWorkflowCommand().AddResourceFile("testdata/service_task.bpmn").Send(ctx)
 	if err != nil {
 		s.T().Fatal(err)
 	}
 
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	workflow := deployment.GetWorkflows()[0]
-	_, err = s.client.NewCreateInstanceCommand().WorkflowKey(workflow.GetWorkflowKey()).Send()
+	_, err = s.client.NewCreateInstanceCommand().WorkflowKey(workflow.GetWorkflowKey()).Send(ctx)
 	if err != nil {
 		s.T().Fatal(err)
 	}
 
 	// when
-	jobs, err := s.client.NewActivateJobsCommand().JobType("task").MaxJobsToActivate(1).Timeout(time.Minute * 5).WorkerName("worker").Send()
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	jobs, err := s.client.NewActivateJobsCommand().JobType("task").MaxJobsToActivate(1).Timeout(time.Minute * 5).WorkerName("worker").Send(ctx)
 	if err != nil {
 		s.T().Fatal(err)
 	}
@@ -134,7 +155,10 @@ func (s *integrationTestSuite) TestActivateJobs() {
 		s.EqualValues("service_task", job.GetElementId())
 		s.Greater(job.GetRetries(), int32(0))
 
-		jobResponse, err := s.client.NewCompleteJobCommand().JobKey(job.Key).Send()
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		jobResponse, err := s.client.NewCompleteJobCommand().JobKey(job.Key).Send(ctx)
 		if err != nil {
 			s.T().Fatal(err)
 		}
@@ -147,26 +171,38 @@ func (s *integrationTestSuite) TestActivateJobs() {
 
 func (s *integrationTestSuite) TestFailJob() {
 	// given
-	deployment, err := s.client.NewDeployWorkflowCommand().AddResourceFile("testdata/service_task.bpmn").Send()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	deployment, err := s.client.NewDeployWorkflowCommand().AddResourceFile("testdata/service_task.bpmn").Send(ctx)
 	if err != nil {
 		s.T().Fatal(err)
 	}
 
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	workflow := deployment.GetWorkflows()[0]
-	_, err = s.client.NewCreateInstanceCommand().WorkflowKey(workflow.GetWorkflowKey()).Send()
+	_, err = s.client.NewCreateInstanceCommand().WorkflowKey(workflow.GetWorkflowKey()).Send(ctx)
 	if err != nil {
 		s.T().Fatal(err)
 	}
 
 	// when
-	jobs, err := s.client.NewActivateJobsCommand().JobType("task").MaxJobsToActivate(1).Timeout(time.Minute * 5).WorkerName("worker").Send()
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	jobs, err := s.client.NewActivateJobsCommand().JobType("task").MaxJobsToActivate(1).Timeout(time.Minute * 5).WorkerName("worker").Send(ctx)
 	if err != nil {
 		s.T().Fatal(err)
 	}
 
 	// then
 	for _, job := range jobs {
-		failedJob, err := s.client.NewFailJobCommand().JobKey(job.GetKey()).Retries(0).Send()
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		failedJob, err := s.client.NewFailJobCommand().JobKey(job.GetKey()).Retries(0).Send(ctx)
 		if err != nil {
 			s.T().Fatal(err)
 		}

--- a/clients/go/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
+++ b/clients/go/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
@@ -1,0 +1,89 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+// Package cmpopts provides common options for the cmp package.
+package cmpopts
+
+import (
+	"math"
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func equateAlways(_, _ interface{}) bool { return true }
+
+// EquateEmpty returns a Comparer option that determines all maps and slices
+// with a length of zero to be equal, regardless of whether they are nil.
+//
+// EquateEmpty can be used in conjunction with SortSlices and SortMaps.
+func EquateEmpty() cmp.Option {
+	return cmp.FilterValues(isEmpty, cmp.Comparer(equateAlways))
+}
+
+func isEmpty(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Slice || vx.Kind() == reflect.Map) &&
+		(vx.Len() == 0 && vy.Len() == 0)
+}
+
+// EquateApprox returns a Comparer option that determines float32 or float64
+// values to be equal if they are within a relative fraction or absolute margin.
+// This option is not used when either x or y is NaN or infinite.
+//
+// The fraction determines that the difference of two values must be within the
+// smaller fraction of the two values, while the margin determines that the two
+// values must be within some absolute margin.
+// To express only a fraction or only a margin, use 0 for the other parameter.
+// The fraction and margin must be non-negative.
+//
+// The mathematical expression used is equivalent to:
+//	|x-y| ≤ max(fraction*min(|x|, |y|), margin)
+//
+// EquateApprox can be used in conjunction with EquateNaNs.
+func EquateApprox(fraction, margin float64) cmp.Option {
+	if margin < 0 || fraction < 0 || math.IsNaN(margin) || math.IsNaN(fraction) {
+		panic("margin or fraction must be a non-negative number")
+	}
+	a := approximator{fraction, margin}
+	return cmp.Options{
+		cmp.FilterValues(areRealF64s, cmp.Comparer(a.compareF64)),
+		cmp.FilterValues(areRealF32s, cmp.Comparer(a.compareF32)),
+	}
+}
+
+type approximator struct{ frac, marg float64 }
+
+func areRealF64s(x, y float64) bool {
+	return !math.IsNaN(x) && !math.IsNaN(y) && !math.IsInf(x, 0) && !math.IsInf(y, 0)
+}
+func areRealF32s(x, y float32) bool {
+	return areRealF64s(float64(x), float64(y))
+}
+func (a approximator) compareF64(x, y float64) bool {
+	relMarg := a.frac * math.Min(math.Abs(x), math.Abs(y))
+	return math.Abs(x-y) <= math.Max(a.marg, relMarg)
+}
+func (a approximator) compareF32(x, y float32) bool {
+	return a.compareF64(float64(x), float64(y))
+}
+
+// EquateNaNs returns a Comparer option that determines float32 and float64
+// NaN values to be equal.
+//
+// EquateNaNs can be used in conjunction with EquateApprox.
+func EquateNaNs() cmp.Option {
+	return cmp.Options{
+		cmp.FilterValues(areNaNsF64s, cmp.Comparer(equateAlways)),
+		cmp.FilterValues(areNaNsF32s, cmp.Comparer(equateAlways)),
+	}
+}
+
+func areNaNsF64s(x, y float64) bool {
+	return math.IsNaN(x) && math.IsNaN(y)
+}
+func areNaNsF32s(x, y float32) bool {
+	return areNaNsF64s(float64(x), float64(y))
+}

--- a/clients/go/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
+++ b/clients/go/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
@@ -1,0 +1,207 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/internal/function"
+)
+
+// IgnoreFields returns an Option that ignores exported fields of the
+// given names on a single struct type.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to ignore a
+// specific sub-field that is embedded or nested within the parent struct.
+//
+// This does not handle unexported fields; use IgnoreUnexported instead.
+func IgnoreFields(typ interface{}, names ...string) cmp.Option {
+	sf := newStructFilter(typ, names...)
+	return cmp.FilterPath(sf.filter, cmp.Ignore())
+}
+
+// IgnoreTypes returns an Option that ignores all values assignable to
+// certain types, which are specified by passing in a value of each type.
+func IgnoreTypes(typs ...interface{}) cmp.Option {
+	tf := newTypeFilter(typs...)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type typeFilter []reflect.Type
+
+func newTypeFilter(typs ...interface{}) (tf typeFilter) {
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil {
+			// This occurs if someone tries to pass in sync.Locker(nil)
+			panic("cannot determine type; consider using IgnoreInterfaces")
+		}
+		tf = append(tf, t)
+	}
+	return tf
+}
+func (tf typeFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p.Last().Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreInterfaces returns an Option that ignores all values or references of
+// values assignable to certain interface types. These interfaces are specified
+// by passing in an anonymous struct with the interface types embedded in it.
+// For example, to ignore sync.Locker, pass in struct{sync.Locker}{}.
+func IgnoreInterfaces(ifaces interface{}) cmp.Option {
+	tf := newIfaceFilter(ifaces)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type ifaceFilter []reflect.Type
+
+func newIfaceFilter(ifaces interface{}) (tf ifaceFilter) {
+	t := reflect.TypeOf(ifaces)
+	if ifaces == nil || t.Name() != "" || t.Kind() != reflect.Struct {
+		panic("input must be an anonymous struct")
+	}
+	for i := 0; i < t.NumField(); i++ {
+		fi := t.Field(i)
+		switch {
+		case !fi.Anonymous:
+			panic("struct cannot have named fields")
+		case fi.Type.Kind() != reflect.Interface:
+			panic("embedded field must be an interface type")
+		case fi.Type.NumMethod() == 0:
+			// This matches everything; why would you ever want this?
+			panic("cannot ignore empty interface")
+		default:
+			tf = append(tf, fi.Type)
+		}
+	}
+	return tf
+}
+func (tf ifaceFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p.Last().Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+		if t.Kind() != reflect.Ptr && reflect.PtrTo(t).AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreUnexported returns an Option that only ignores the immediate unexported
+// fields of a struct, including anonymous fields of unexported types.
+// In particular, unexported fields within the struct's exported fields
+// of struct types, including anonymous fields, will not be ignored unless the
+// type of the field itself is also passed to IgnoreUnexported.
+//
+// Avoid ignoring unexported fields of a type which you do not control (i.e. a
+// type from another repository), as changes to the implementation of such types
+// may change how the comparison behaves. Prefer a custom Comparer instead.
+func IgnoreUnexported(typs ...interface{}) cmp.Option {
+	ux := newUnexportedFilter(typs...)
+	return cmp.FilterPath(ux.filter, cmp.Ignore())
+}
+
+type unexportedFilter struct{ m map[reflect.Type]bool }
+
+func newUnexportedFilter(typs ...interface{}) unexportedFilter {
+	ux := unexportedFilter{m: make(map[reflect.Type]bool)}
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil || t.Kind() != reflect.Struct {
+			panic(fmt.Sprintf("invalid struct type: %T", typ))
+		}
+		ux.m[t] = true
+	}
+	return ux
+}
+func (xf unexportedFilter) filter(p cmp.Path) bool {
+	sf, ok := p.Index(-1).(cmp.StructField)
+	if !ok {
+		return false
+	}
+	return xf.m[p.Index(-2).Type()] && !isExported(sf.Name())
+}
+
+// isExported reports whether the identifier is exported.
+func isExported(id string) bool {
+	r, _ := utf8.DecodeRuneInString(id)
+	return unicode.IsUpper(r)
+}
+
+// IgnoreSliceElements returns an Option that ignores elements of []V.
+// The discard function must be of the form "func(T) bool" which is used to
+// ignore slice elements of type V, where V is assignable to T.
+// Elements are ignored if the function reports true.
+func IgnoreSliceElements(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.ValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		si, ok := p.Index(-1).(cmp.SliceIndex)
+		if !ok {
+			return false
+		}
+		if !si.Type().AssignableTo(vf.Type().In(0)) {
+			return false
+		}
+		vx, vy := si.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
+}
+
+// IgnoreMapEntries returns an Option that ignores entries of map[K]V.
+// The discard function must be of the form "func(T, R) bool" which is used to
+// ignore map entries of type K and V, where K and V are assignable to T and R.
+// Entries are ignored if the function reports true.
+func IgnoreMapEntries(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.KeyValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		mi, ok := p.Index(-1).(cmp.MapIndex)
+		if !ok {
+			return false
+		}
+		if !mi.Key().Type().AssignableTo(vf.Type().In(0)) || !mi.Type().AssignableTo(vf.Type().In(1)) {
+			return false
+		}
+		k := mi.Key()
+		vx, vy := mi.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{k, vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{k, vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
+}

--- a/clients/go/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
+++ b/clients/go/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
@@ -1,0 +1,147 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/internal/function"
+)
+
+// SortSlices returns a Transformer option that sorts all []V.
+// The less function must be of the form "func(T, T) bool" which is used to
+// sort any slice with element type V that is assignable to T.
+//
+// The less function must be:
+//	• Deterministic: less(x, y) == less(x, y)
+//	• Irreflexive: !less(x, x)
+//	• Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//
+// The less function does not have to be "total". That is, if !less(x, y) and
+// !less(y, x) for two elements x and y, their relative order is maintained.
+//
+// SortSlices can be used in conjunction with EquateEmpty.
+func SortSlices(lessFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessFunc)
+	if !function.IsType(vf.Type(), function.Less) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less function: %T", lessFunc))
+	}
+	ss := sliceSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ss.filter, cmp.Transformer("cmpopts.SortSlices", ss.sort))
+}
+
+type sliceSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ss sliceSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	if !(x != nil && y != nil && vx.Type() == vy.Type()) ||
+		!(vx.Kind() == reflect.Slice && vx.Type().Elem().AssignableTo(ss.in)) ||
+		(vx.Len() <= 1 && vy.Len() <= 1) {
+		return false
+	}
+	// Check whether the slices are already sorted to avoid an infinite
+	// recursion cycle applying the same transform to itself.
+	ok1 := sort.SliceIsSorted(x, func(i, j int) bool { return ss.less(vx, i, j) })
+	ok2 := sort.SliceIsSorted(y, func(i, j int) bool { return ss.less(vy, i, j) })
+	return !ok1 || !ok2
+}
+func (ss sliceSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	dst := reflect.MakeSlice(src.Type(), src.Len(), src.Len())
+	for i := 0; i < src.Len(); i++ {
+		dst.Index(i).Set(src.Index(i))
+	}
+	sort.SliceStable(dst.Interface(), func(i, j int) bool { return ss.less(dst, i, j) })
+	ss.checkSort(dst)
+	return dst.Interface()
+}
+func (ss sliceSorter) checkSort(v reflect.Value) {
+	start := -1 // Start of a sequence of equal elements.
+	for i := 1; i < v.Len(); i++ {
+		if ss.less(v, i-1, i) {
+			// Check that first and last elements in v[start:i] are equal.
+			if start >= 0 && (ss.less(v, start, i-1) || ss.less(v, i-1, start)) {
+				panic(fmt.Sprintf("incomparable values detected: want equal elements: %v", v.Slice(start, i)))
+			}
+			start = -1
+		} else if start == -1 {
+			start = i
+		}
+	}
+}
+func (ss sliceSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i), v.Index(j)
+	return ss.fnc.Call([]reflect.Value{vx, vy})[0].Bool()
+}
+
+// SortMaps returns a Transformer option that flattens map[K]V types to be a
+// sorted []struct{K, V}. The less function must be of the form
+// "func(T, T) bool" which is used to sort any map with key K that is
+// assignable to T.
+//
+// Flattening the map into a slice has the property that cmp.Equal is able to
+// use Comparers on K or the K.Equal method if it exists.
+//
+// The less function must be:
+//	• Deterministic: less(x, y) == less(x, y)
+//	• Irreflexive: !less(x, x)
+//	• Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//	• Total: if x != y, then either less(x, y) or less(y, x)
+//
+// SortMaps can be used in conjunction with EquateEmpty.
+func SortMaps(lessFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessFunc)
+	if !function.IsType(vf.Type(), function.Less) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less function: %T", lessFunc))
+	}
+	ms := mapSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ms.filter, cmp.Transformer("cmpopts.SortMaps", ms.sort))
+}
+
+type mapSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ms mapSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Map && vx.Type().Key().AssignableTo(ms.in)) &&
+		(vx.Len() != 0 || vy.Len() != 0)
+}
+func (ms mapSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	outType := reflect.StructOf([]reflect.StructField{
+		{Name: "K", Type: src.Type().Key()},
+		{Name: "V", Type: src.Type().Elem()},
+	})
+	dst := reflect.MakeSlice(reflect.SliceOf(outType), src.Len(), src.Len())
+	for i, k := range src.MapKeys() {
+		v := reflect.New(outType).Elem()
+		v.Field(0).Set(k)
+		v.Field(1).Set(src.MapIndex(k))
+		dst.Index(i).Set(v)
+	}
+	sort.Slice(dst.Interface(), func(i, j int) bool { return ms.less(dst, i, j) })
+	ms.checkSort(dst)
+	return dst.Interface()
+}
+func (ms mapSorter) checkSort(v reflect.Value) {
+	for i := 1; i < v.Len(); i++ {
+		if !ms.less(v, i-1, i) {
+			panic(fmt.Sprintf("partial order detected: want %v < %v", v.Index(i-1), v.Index(i)))
+		}
+	}
+}
+func (ms mapSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i).Field(0), v.Index(j).Field(0)
+	return ms.fnc.Call([]reflect.Value{vx, vy})[0].Bool()
+}

--- a/clients/go/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
+++ b/clients/go/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
@@ -1,0 +1,182 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// filterField returns a new Option where opt is only evaluated on paths that
+// include a specific exported field on a single struct type.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to select a
+// specific sub-field that is embedded or nested within the parent struct.
+func filterField(typ interface{}, name string, opt cmp.Option) cmp.Option {
+	// TODO: This is currently unexported over concerns of how helper filters
+	// can be composed together easily.
+	// TODO: Add tests for FilterField.
+
+	sf := newStructFilter(typ, name)
+	return cmp.FilterPath(sf.filter, opt)
+}
+
+type structFilter struct {
+	t  reflect.Type // The root struct type to match on
+	ft fieldTree    // Tree of fields to match on
+}
+
+func newStructFilter(typ interface{}, names ...string) structFilter {
+	// TODO: Perhaps allow * as a special identifier to allow ignoring any
+	// number of path steps until the next field match?
+	// This could be useful when a concrete struct gets transformed into
+	// an anonymous struct where it is not possible to specify that by type,
+	// but the transformer happens to provide guarantees about the names of
+	// the transformed fields.
+
+	t := reflect.TypeOf(typ)
+	if t == nil || t.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("%T must be a struct", typ))
+	}
+	var ft fieldTree
+	for _, name := range names {
+		cname, err := canonicalName(t, name)
+		if err != nil {
+			panic(fmt.Sprintf("%s: %v", strings.Join(cname, "."), err))
+		}
+		ft.insert(cname)
+	}
+	return structFilter{t, ft}
+}
+
+func (sf structFilter) filter(p cmp.Path) bool {
+	for i, ps := range p {
+		if ps.Type().AssignableTo(sf.t) && sf.ft.matchPrefix(p[i+1:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// fieldTree represents a set of dot-separated identifiers.
+//
+// For example, inserting the following selectors:
+//	Foo
+//	Foo.Bar.Baz
+//	Foo.Buzz
+//	Nuka.Cola.Quantum
+//
+// Results in a tree of the form:
+//	{sub: {
+//		"Foo": {ok: true, sub: {
+//			"Bar": {sub: {
+//				"Baz": {ok: true},
+//			}},
+//			"Buzz": {ok: true},
+//		}},
+//		"Nuka": {sub: {
+//			"Cola": {sub: {
+//				"Quantum": {ok: true},
+//			}},
+//		}},
+//	}}
+type fieldTree struct {
+	ok  bool                 // Whether this is a specified node
+	sub map[string]fieldTree // The sub-tree of fields under this node
+}
+
+// insert inserts a sequence of field accesses into the tree.
+func (ft *fieldTree) insert(cname []string) {
+	if ft.sub == nil {
+		ft.sub = make(map[string]fieldTree)
+	}
+	if len(cname) == 0 {
+		ft.ok = true
+		return
+	}
+	sub := ft.sub[cname[0]]
+	sub.insert(cname[1:])
+	ft.sub[cname[0]] = sub
+}
+
+// matchPrefix reports whether any selector in the fieldTree matches
+// the start of path p.
+func (ft fieldTree) matchPrefix(p cmp.Path) bool {
+	for _, ps := range p {
+		switch ps := ps.(type) {
+		case cmp.StructField:
+			ft = ft.sub[ps.Name()]
+			if ft.ok {
+				return true
+			}
+			if len(ft.sub) == 0 {
+				return false
+			}
+		case cmp.Indirect:
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// canonicalName returns a list of identifiers where any struct field access
+// through an embedded field is expanded to include the names of the embedded
+// types themselves.
+//
+// For example, suppose field "Foo" is not directly in the parent struct,
+// but actually from an embedded struct of type "Bar". Then, the canonical name
+// of "Foo" is actually "Bar.Foo".
+//
+// Suppose field "Foo" is not directly in the parent struct, but actually
+// a field in two different embedded structs of types "Bar" and "Baz".
+// Then the selector "Foo" causes a panic since it is ambiguous which one it
+// refers to. The user must specify either "Bar.Foo" or "Baz.Foo".
+func canonicalName(t reflect.Type, sel string) ([]string, error) {
+	var name string
+	sel = strings.TrimPrefix(sel, ".")
+	if sel == "" {
+		return nil, fmt.Errorf("name must not be empty")
+	}
+	if i := strings.IndexByte(sel, '.'); i < 0 {
+		name, sel = sel, ""
+	} else {
+		name, sel = sel[:i], sel[i:]
+	}
+
+	// Type must be a struct or pointer to struct.
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("%v must be a struct", t)
+	}
+
+	// Find the canonical name for this current field name.
+	// If the field exists in an embedded struct, then it will be expanded.
+	if !isExported(name) {
+		// Disallow unexported fields:
+		//	* To discourage people from actually touching unexported fields
+		//	* FieldByName is buggy (https://golang.org/issue/4876)
+		return []string{name}, fmt.Errorf("name must be exported")
+	}
+	sf, ok := t.FieldByName(name)
+	if !ok {
+		return []string{name}, fmt.Errorf("does not exist")
+	}
+	var ss []string
+	for i := range sf.Index {
+		ss = append(ss, t.FieldByIndex(sf.Index[:i+1]).Name)
+	}
+	if sel == "" {
+		return ss, nil
+	}
+	ssPost, err := canonicalName(sf.Type, sel)
+	return append(ss, ssPost...), err
+}

--- a/clients/go/vendor/github.com/google/go-cmp/cmp/cmpopts/xform.go
+++ b/clients/go/vendor/github.com/google/go-cmp/cmp/cmpopts/xform.go
@@ -1,0 +1,35 @@
+// Copyright 2018, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"github.com/google/go-cmp/cmp"
+)
+
+type xformFilter struct{ xform cmp.Option }
+
+func (xf xformFilter) filter(p cmp.Path) bool {
+	for _, ps := range p {
+		if t, ok := ps.(cmp.Transform); ok && t.Option() == xf.xform {
+			return false
+		}
+	}
+	return true
+}
+
+// AcyclicTransformer returns a Transformer with a filter applied that ensures
+// that the transformer cannot be recursively applied upon its own output.
+//
+// An example use case is a transformer that splits a string by lines:
+//	AcyclicTransformer("SplitLines", func(s string) []string{
+//		return strings.Split(s, "\n")
+//	})
+//
+// Had this been an unfiltered Transformer instead, this would result in an
+// infinite cycle converting a string to []string to [][]string and so on.
+func AcyclicTransformer(name string, xformFunc interface{}) cmp.Option {
+	xf := xformFilter{cmp.Transformer(name, xformFunc)}
+	return cmp.FilterPath(xf.filter, xf.xform)
+}

--- a/clients/go/vendor/modules.txt
+++ b/clients/go/vendor/modules.txt
@@ -66,6 +66,7 @@ github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
 # github.com/google/go-cmp v0.4.0
 github.com/google/go-cmp/cmp
+github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function


### PR DESCRIPTION
## Description

Changes:
* every command requires a context.Context to be sent and the timeout for that command is the one present in the context, if any
* CI now posts Go test results as soon as they finish
* renamed 'containerSuite' package to 'containersuite' (golint)
* the long-polling timeout is now set as 90% or 10 seconds less than the context timeout, whichever is longest

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3530

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
