### PR TITLE
chore(clients/go): fix set zbctl version and commit during build

### DIFF
--- a/clients/go/cmd/zbctl/build.sh
+++ b/clients/go/cmd/zbctl/build.sh
@@ -6,14 +6,14 @@ SRC_DIR=$(dirname "${BASH_SOURCE[0]}")
 DIST_DIR="$SRC_DIR/dist"
 
 VERSION=${RELEASE_VERSION:-development}
-COMMIT=$(git rev-parse HEAD)
+COMMIT=${RELEASE_HASH:-$(git rev-parse HEAD)}
 
 mkdir -p ${DIST_DIR}
 rm -rf ${DIST_DIR}/*
 
 for i in "${!OS[@]}"; do
 	if [ $# -eq 0 ] || [ ${OS[$i]} = $1 ]; then
-	    CGO_ENABLED=0 GOOS="${OS[$i]}" GOARCH=amd64 go build -mod=vendor -a -tags netgo -ldflags "-w -X github.com/zeebe-io/zeebe/clients/go/cmd/zbctl/cmd.Version=${VERSION} -X github.com/zeebe-io/zeebe/clients/go/cmd/zbctl/cmd.Commit=${COMMIT}" -o "${DIST_DIR}/${BINARY[$i]}" "${SRC_DIR}/main.go" &
+	    CGO_ENABLED=0 GOOS="${OS[$i]}" GOARCH=amd64 go build -mod=vendor -a -tags netgo -ldflags "-w -X github.com/zeebe-io/zeebe/clients/go/cmd/zbctl/internal/commands.Version=${VERSION} -X github.com/zeebe-io/zeebe/clients/go/cmd/zbctl/internal/commands.Commit=${COMMIT}" -o "${DIST_DIR}/${BINARY[$i]}" "${SRC_DIR}/main.go" &
 	fi
 done
 

--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -17,10 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/suite"
-	"github.com/zeebe-io/zeebe/clients/go/internal/containersuite"
-	"github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -29,6 +25,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/suite"
+	"github.com/zeebe-io/zeebe/clients/go/internal/containersuite"
+	"github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
 )
 
 var zbctl string
@@ -49,6 +50,12 @@ var tests = []struct {
 		cmd:        "help",
 		envVars:    []string{"HOME=/tmp"},
 		goldenFile: "testdata/help.golden",
+	},
+	{
+		name:       "print version",
+		cmd:        "version",
+		envVars:    []string{"HOME=/tmp"},
+		goldenFile: "testdata/version.golden",
 	},
 	{
 		name:       "missing insecure flag",
@@ -158,5 +165,7 @@ func buildZbctl() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	return exec.CommandContext(ctx, "./build.sh", runtime.GOOS).Run()
+	cmd := exec.CommandContext(ctx, "./build.sh", runtime.GOOS)
+	cmd.Env = append(cmd.Env, "HOME=/tmp", "RELEASE_VERSION=release-test", "RELEASE_HASH=1234567890")
+	return cmd.Run()
 }

--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -96,8 +96,9 @@ var tests = []struct {
 }
 
 func TestZbctlWithInsecureGateway(t *testing.T) {
-	err := buildZbctl()
+	output, err := buildZbctl()
 	if err != nil {
+		fmt.Println(string(output))
 		t.Fatal(fmt.Errorf("couldn't build zbctl: %w", err))
 	}
 
@@ -155,17 +156,17 @@ func (s *integrationTestSuite) runCommand(command string, envVars ...string) ([]
 	return cmd.CombinedOutput()
 }
 
-func buildZbctl() error {
+func buildZbctl() ([]byte, error) {
 	if runtime.GOOS == "linux" {
 		zbctl = "zbctl"
 	} else {
-		return fmt.Errorf("can't run zbctl tests on unsupported OS '%s'", runtime.GOOS)
+		return nil, fmt.Errorf("can't run zbctl tests on unsupported OS '%s'", runtime.GOOS)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "./build.sh", runtime.GOOS)
-	cmd.Env = append(cmd.Env, "HOME=/tmp", "RELEASE_VERSION=release-test", "RELEASE_HASH=1234567890")
-	return cmd.Run()
+	cmd.Env = append(os.Environ(), "RELEASE_VERSION=release-test", "RELEASE_HASH=1234567890")
+	return cmd.CombinedOutput()
 }

--- a/clients/go/cmd/zbctl/testdata/version.golden
+++ b/clients/go/cmd/zbctl/testdata/version.golden
@@ -1,0 +1,1 @@
+zbctl release-test (commit: 12345678)


### PR DESCRIPTION
## Description

- allow to override the git hash in build script
- add test case to verify version is correctly set

## Related issues

closes #3647 


## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
