### PR TITLE
chore(clients/java): enforce API stability in Java code

### DIFF
--- a/.ci/pipelines/release_zeebe.groovy
+++ b/.ci/pipelines/release_zeebe.groovy
@@ -89,6 +89,7 @@ spec:
                 container('maven') {
                     sh '.ci/scripts/release/prepare.sh'
                     sh '.ci/scripts/release/changelog.sh'
+                    sh '.ci/scripts/release/compat-update.sh'
                 }
             }
         }

--- a/.ci/scripts/release/compat-update.sh
+++ b/.ci/scripts/release/compat-update.sh
@@ -1,0 +1,3 @@
+mvn versions:set-property -DgenerateBackupPoms=false -Dproperty=backwards.compat.version -DnewVersion=${RELEASE_VERSION}
+
+git commit -am "chore(project): update backwards compatibility version"

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -150,6 +150,11 @@
           </ignoredDependencies>
         </configuration>
       </plugin>
+
+      <plugin> 
+        <groupId>org.codehaus.mojo</groupId> 
+        <artifactId>clirr-maven-plugin</artifactId> 
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/exporter-api/pom.xml
+++ b/exporter-api/pom.xml
@@ -22,7 +22,15 @@
   <properties>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
   </properties>
-
+  
+  <build>
+    <plugins>
+      <plugin> 
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -102,9 +102,13 @@
     <plugin.version.dependency>3.1.1</plugin.version.dependency>
     <plugin.version.spotbugs>3.1.12.2</plugin.version.spotbugs>
     <plugin.version.sonar>3.7.0.1746</plugin.version.sonar>
+    <plugin.version.clirr>2.8</plugin.version.clirr>
 
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.6.2</extension.version.os-maven-plugin>
+    
+    <!-- version against which backwards compatibility is checked -->
+    <backwards.compat.version>0.22.0</backwards.compat.version>
   </properties>
 
   <dependencyManagement>
@@ -571,6 +575,23 @@
           </configuration>
         </plugin>
 
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>clirr-maven-plugin</artifactId>
+          <version>${plugin.version.clirr}</version>
+          <configuration>
+            <comparisonVersion>${backwards.compat.version}</comparisonVersion>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>verify</phase>
+            </execution>
+          </executions>
+        </plugin>
+ 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -112,6 +112,10 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin> 
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -13,6 +13,15 @@
     <relativePath>../parent</relativePath>
   </parent>
 
+  <build>
+    <plugins>
+      <plugin> 
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>io.zeebe</groupId>


### PR DESCRIPTION
## Description

Checks for backwards compatibility against 0.22.0
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3656 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
