### PR TITLE
fix(transport): cancel timer after response

### DIFF
--- a/transport/src/main/java/io/zeebe/transport/impl/RequestContext.java
+++ b/transport/src/main/java/io/zeebe/transport/impl/RequestContext.java
@@ -10,9 +10,11 @@ package io.zeebe.transport.impl;
 import static io.zeebe.transport.impl.AtomixServerTransport.topicName;
 
 import io.atomix.utils.net.Address;
+import io.zeebe.util.sched.ScheduledTimer;
 import io.zeebe.util.sched.clock.ActorClock;
 import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.agrona.DirectBuffer;
@@ -26,6 +28,8 @@ final class RequestContext {
   private final long startTime;
   private final Duration timeout;
   private final Predicate<DirectBuffer> responseValidator;
+
+  private ScheduledTimer scheduledTimer;
 
   RequestContext(
       final CompletableActorFuture<DirectBuffer> currentFuture,
@@ -45,10 +49,6 @@ final class RequestContext {
 
   public boolean isDone() {
     return currentFuture.isDone();
-  }
-
-  CompletableActorFuture<DirectBuffer> getCurrentFuture() {
-    return currentFuture;
   }
 
   Address getNodeAddress() {
@@ -82,5 +82,30 @@ final class RequestContext {
   boolean verifyResponse(final DirectBuffer response) {
     // the predicate returns true when the response is valid and the request should not be retried
     return responseValidator.test(response);
+  }
+
+  public void complete(DirectBuffer buffer) {
+    currentFuture.complete(buffer);
+    cancelTimer();
+  }
+
+  public void completeExceptionally(Throwable throwable) {
+    currentFuture.completeExceptionally(throwable);
+    cancelTimer();
+  }
+
+  private void cancelTimer() {
+    if (scheduledTimer != null) {
+      scheduledTimer.cancel();
+    }
+  }
+
+  public void setScheduledTimer(ScheduledTimer scheduledTimer) {
+    this.scheduledTimer = scheduledTimer;
+  }
+
+  public void timeout() {
+    currentFuture.completeExceptionally(
+        new TimeoutException("Request timed out after " + timeout.toString()));
   }
 }


### PR DESCRIPTION
## Description

Timers where not canceled after receiving response. This could cause OOM Errors on higher load.


Benchmark:
![fix-process](https://user-images.githubusercontent.com/2758593/72409752-f54ede80-3766-11ea-858a-00682ab253bd.png)

Resource consumption looks quite stable now

![fix-resources](https://user-images.githubusercontent.com/2758593/72409753-f54ede80-3766-11ea-85de-ddc7ad5b106b.png)

**Before:**

![before-processing](https://user-images.githubusercontent.com/2758593/72409780-07308180-3767-11ea-992c-402ad9267416.png)
![before-resources](https://user-images.githubusercontent.com/2758593/72409782-07308180-3767-11ea-8fea-43997cc0c1d1.png)

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3653 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
