### PR TITLE
Fix inconsistent position creation

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
@@ -39,7 +39,13 @@ public final class SubscriptionApiCommandMessageHandlerService extends Actor
   @Override
   public void onBecomingFollower(
       final int partitionId, final long term, final LogStream logStream) {
-    actor.submit(() -> leaderPartitions.remove(partitionId));
+    actor.submit(
+        () -> {
+          final var recordWriter = leaderPartitions.remove(partitionId);
+          if (recordWriter != null) {
+            recordWriter.close();
+          }
+        });
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
@@ -33,7 +33,14 @@ public final class LeaderManagementRequestHandler extends Actor implements Parti
   @Override
   public void onBecomingFollower(
       final int partitionId, final long term, final LogStream logStream) {
-    actor.submit(() -> leaderForPartitions.remove(partitionId));
+    actor.submit(
+        () -> {
+          final var recordWriter = leaderForPartitions.remove(partitionId);
+
+          if (recordWriter != null) {
+            recordWriter.close();
+          }
+        });
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -197,7 +197,11 @@ final class CommandApiRequestHandler implements RequestHandler {
   void removePartition(final LogStream logStream) {
     cmdQueue.add(
         () -> {
-          leadingStreams.remove(logStream.getPartitionId());
+          final var recordWriter = leadingStreams.remove(logStream.getPartitionId());
+          if (recordWriter != null) {
+            recordWriter.close();
+          }
+
           partitionLimiters.remove(logStream.getPartitionId());
         });
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
@@ -373,5 +373,8 @@ public final class ReProcessingStateMachine {
     public long flush() {
       return 0;
     }
+
+    @Override
+    public void close() {}
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -153,6 +153,7 @@ public class StreamProcessor extends Actor {
   @Override
   protected void onActorClosing() {
     processingContext.getLogStreamReader().close();
+    processingContext.getLogStreamWriter().close();
 
     if (onCommitPositionUpdatedCondition != null) {
       logStream.removeOnCommitPositionUpdatedCondition(onCommitPositionUpdatedCondition);

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriter.java
@@ -10,10 +10,11 @@ package io.zeebe.engine.processor;
 import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.intent.Intent;
+import io.zeebe.util.CloseableSilently;
 import java.util.function.Consumer;
 
 /** Things that any actor can write to a partition. */
-public interface TypedCommandWriter {
+public interface TypedCommandWriter extends CloseableSilently {
 
   void appendNewCommand(Intent intent, UnpackedObject value);
 

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
@@ -119,4 +119,9 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
   public long flush() {
     return batchWriter.tryWrite();
   }
+
+  @Override
+  public void close() {
+    batchWriter.close();
+  }
 }

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -388,6 +388,7 @@ public final class TestStreams {
 
     @Override
     public void close() {
+      logStreamWriter.close();
       logStream.close();
       logStorageRule.close();
     }

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamBatchWriterImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamBatchWriterImpl.java
@@ -60,10 +60,13 @@ public final class LogStreamBatchWriterImpl implements LogStreamBatchWriter, Log
 
   private BufferWriter metadataWriter;
   private BufferWriter valueWriter;
+  private final Runnable closeCallback;
 
-  LogStreamBatchWriterImpl(final int partitionId, final Dispatcher dispatcher) {
+  LogStreamBatchWriterImpl(
+      final int partitionId, final Dispatcher dispatcher, final Runnable closeCallback) {
     this.logWriteBuffer = dispatcher;
     this.logId = partitionId;
+    this.closeCallback = closeCallback;
 
     reset();
   }
@@ -290,5 +293,10 @@ public final class LogStreamBatchWriterImpl implements LogStreamBatchWriter, Log
 
     bufferWriterInstance.reset();
     metadataWriterInstance.reset();
+  }
+
+  @Override
+  public void close() {
+    closeCallback.run();
   }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -193,6 +193,11 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
 
   @Override
   public ActorFuture<LogStreamRecordWriter> newLogStreamRecordWriter() {
+    // this should be replaced after refactoring the actor control
+    if (actor.isClosed()) {
+      return CompletableActorFuture.completedExceptionally(new RuntimeException("Actor is closed"));
+    }
+
     final var writerFuture = new CompletableActorFuture<LogStreamRecordWriter>();
     actor.run(() -> createWriter(writerFuture, LogStreamWriterImpl::new));
     return writerFuture;
@@ -200,6 +205,11 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
 
   @Override
   public ActorFuture<LogStreamBatchWriter> newLogStreamBatchWriter() {
+    // this should be replaced after refactoring the actor control
+    if (actor.isClosed()) {
+      return CompletableActorFuture.completedExceptionally(new RuntimeException("Actor is closed"));
+    }
+
     final var writerFuture = new CompletableActorFuture<LogStreamBatchWriter>();
     actor.run(() -> createWriter(writerFuture, LogStreamBatchWriterImpl::new));
     return writerFuture;

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -194,14 +194,14 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
   @Override
   public ActorFuture<LogStreamRecordWriter> newLogStreamRecordWriter() {
     final var writerFuture = new CompletableActorFuture<LogStreamRecordWriter>();
-    actor.call(() -> createWriter(writerFuture, LogStreamWriterImpl::new));
+    actor.run(() -> createWriter(writerFuture, LogStreamWriterImpl::new));
     return writerFuture;
   }
 
   @Override
   public ActorFuture<LogStreamBatchWriter> newLogStreamBatchWriter() {
     final var writerFuture = new CompletableActorFuture<LogStreamBatchWriter>();
-    actor.call(() -> createWriter(writerFuture, LogStreamBatchWriterImpl::new));
+    actor.run(() -> createWriter(writerFuture, LogStreamBatchWriterImpl::new));
     return writerFuture;
   }
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamWriterImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamWriterImpl.java
@@ -39,10 +39,13 @@ public final class LogStreamWriterImpl implements LogStreamRecordWriter {
   private long sourceRecordPosition = -1L;
   private BufferWriter metadataWriter;
   private BufferWriter valueWriter;
+  private final Runnable closeCallback;
 
-  LogStreamWriterImpl(final int partitionId, final Dispatcher logWriteBuffer) {
+  LogStreamWriterImpl(
+      final int partitionId, final Dispatcher logWriteBuffer, final Runnable closeCallback) {
     this.logWriteBuffer = logWriteBuffer;
     this.partitionId = partitionId;
+    this.closeCallback = closeCallback;
 
     reset();
   }
@@ -167,5 +170,10 @@ public final class LogStreamWriterImpl implements LogStreamRecordWriter {
     } while (claimedPosition == RESULT_PADDING_AT_END_OF_PARTITION);
 
     return claimedPosition - DataFrameDescriptor.alignedFramedLength(framedLength);
+  }
+
+  @Override
+  public void close() {
+    closeCallback.run();
   }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamWriter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamWriter.java
@@ -7,7 +7,9 @@
  */
 package io.zeebe.logstreams.log;
 
-public interface LogStreamWriter {
+import io.zeebe.util.CloseableSilently;
+
+public interface LogStreamWriter extends CloseableSilently {
 
   /**
    * Attempts to write the event to the underlying stream.

--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -71,7 +71,7 @@ public final class LogStorageAppenderTest {
     appender =
         new LogStorageAppender(
             "appender", PARTITION_ID, logStorage, subscription, MAX_FRAGMENT_SIZE);
-    writer = new LogStreamWriterImpl(PARTITION_ID, dispatcher);
+    writer = new LogStreamWriterImpl(PARTITION_ID, dispatcher, () -> {});
     reader = new LogStreamReaderImpl(logStorage);
   }
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamWriterRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamWriterRule.java
@@ -31,8 +31,15 @@ public final class LogStreamWriterRule extends ExternalResource {
 
   @Override
   protected void after() {
-    logStreamWriter = null;
+    closeWriter();
     logStream = null;
+  }
+
+  public void closeWriter() {
+    if (logStreamWriter != null) {
+      logStreamWriter.close();
+      logStreamWriter = null;
+    }
   }
 
   public long writeEvents(final int count, final DirectBuffer event) {


### PR DESCRIPTION
## Description


As I wrote here https://github.com/zeebe-io/zeebe/issues/3651#issuecomment-574259240


> On partition bootstrap the LogStream is created and on becoming a leader only the related actors, like processor, exporter etc. are created. This makes sense since the log stream has the same life time as the partition.

> On LogStream starting the Appender and WriteBuffer are created/opened.
https://github.com/zeebe-io/zeebe/blob/develop/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java#L194

> To open the Writebuffer we need to determine the partition ID and scan the log. All nodes will start there write buffer and on leader change the log is not scanned again. This means the next leader will probably start to append on a lower position. We have currently a test which verifies that our log is consistent between restarts, but this test only checks this for a single node. This issue will only happen in a cluster.

To solve this issue we introduced reference counting for log stream writers 
 * on first writer creation the log appender and write buffer is created and the initial position is determined
 * on last writer closing the appender and write buffer is closed again

This also solves the issue, where we saw that the appender still runs after an leader change (https://github.com/zeebe-io/zeebe/issues/3652).



**Note:** I will setup a benchmark and add the results here.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3651 
closes https://github.com/zeebe-io/zeebe/issues/3652
closes https://github.com/zeebe-io/zeebe/issues/3667

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
