### PR TITLE
chore(clients/java): remove interceptors from ZeebeClientConfiguration interface

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientConfiguration.java
@@ -15,9 +15,7 @@
  */
 package io.zeebe.client;
 
-import io.grpc.ClientInterceptor;
 import java.time.Duration;
-import java.util.List;
 
 public interface ZeebeClientConfiguration {
   /** @see ZeebeClientBuilder#brokerContactPoint(String) */
@@ -55,6 +53,4 @@ public interface ZeebeClientConfiguration {
 
   /** @see ZeebeClientBuilder#keepAlive(Duration) */
   Duration getKeepAlive();
-
-  List<ClientInterceptor> getInterceptors();
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -53,7 +53,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private String certificatePath;
   private CredentialsProvider credentialsProvider;
   private Duration keepAlive = Duration.ofSeconds(45);
-  private final List interceptors = new ArrayList();
+  private final List<ClientInterceptor> interceptors = new ArrayList<>();
 
   @Override
   public String getBrokerContactPoint() {
@@ -115,8 +115,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     return keepAlive;
   }
 
-  @Override
-  public List getInterceptors() {
+  public List<ClientInterceptor> getInterceptors() {
     return interceptors;
   }
 

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
@@ -166,9 +166,12 @@ public final class ZeebeClientImpl implements ZeebeClient {
       final ManagedChannel channel, final ZeebeClientConfiguration config) {
     final CallCredentials credentials = buildCallCredentials(config);
     final GatewayStub gatewayStub = GatewayGrpc.newStub(channel).withCallCredentials(credentials);
-    if (!config.getInterceptors().isEmpty()) {
-      return gatewayStub.withInterceptors(
-          config.getInterceptors().toArray(new ClientInterceptor[] {}));
+    if (config instanceof ZeebeClientBuilderImpl) {
+      final List<ClientInterceptor> interceptors =
+          ((ZeebeClientBuilderImpl) config).getInterceptors();
+      if (!interceptors.isEmpty()) {
+        return gatewayStub.withInterceptors(interceptors.toArray(new ClientInterceptor[] {}));
+      }
     }
     return gatewayStub;
   }


### PR DESCRIPTION
## Description

Remove gRPC interceptor list from ZeebeClientConfiguration interface. See this comment https://github.com/zeebe-io/zeebe/commit/7e3f3783b33531b7cec8aacc2e4b591033ba8add#commitcomment-36789603


## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
