### PR TITLE
chore(broker): adds snapshot metrics

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/AtomixSnapshotStorage.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/AtomixSnapshotStorage.java
@@ -13,8 +13,10 @@ import io.atomix.utils.time.WallClockTimestamp;
 import io.zeebe.broker.clustering.atomix.storage.AtomixRecordEntrySupplier;
 import io.zeebe.logstreams.state.Snapshot;
 import io.zeebe.logstreams.state.SnapshotDeletionListener;
+import io.zeebe.logstreams.state.SnapshotMetrics;
 import io.zeebe.logstreams.state.SnapshotStorage;
 import io.zeebe.util.ZbLogger;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
@@ -32,19 +34,24 @@ public final class AtomixSnapshotStorage implements SnapshotStorage, SnapshotLis
   private final SnapshotStore store;
   private final int maxSnapshotCount;
   private final Set<SnapshotDeletionListener> deletionListeners;
+  private final SnapshotMetrics metrics;
 
   public AtomixSnapshotStorage(
       final Path runtimeDirectory,
       final SnapshotStore store,
       final AtomixRecordEntrySupplier entrySupplier,
-      final int maxSnapshotCount) {
+      final int maxSnapshotCount,
+      final SnapshotMetrics metrics) {
     this.runtimeDirectory = runtimeDirectory;
     this.entrySupplier = entrySupplier;
     this.store = store;
     this.maxSnapshotCount = maxSnapshotCount;
+    this.metrics = metrics;
 
     this.deletionListeners = new CopyOnWriteArraySet<>();
     this.store.addListener(this);
+
+    observeExistingSnapshots();
   }
 
   @Override
@@ -132,10 +139,18 @@ public final class AtomixSnapshotStorage implements SnapshotStorage, SnapshotLis
   }
 
   @Override
+  public SnapshotMetrics getMetrics() {
+    return metrics;
+  }
+
+  @Override
   public void onNewSnapshot(
       final io.atomix.protocols.raft.storage.snapshot.Snapshot snapshot,
       final SnapshotStore store) {
     final var snapshots = store.getSnapshots();
+    metrics.incrementSnapshotCount();
+    observeSnapshotSize(snapshot);
+
     if (snapshots.size() >= maxSnapshotCount) {
       // by the condition it's guaranteed there be a snapshot after skipping maxSnapshotCount - 1
       @SuppressWarnings("squid:S3655")
@@ -160,6 +175,14 @@ public final class AtomixSnapshotStorage implements SnapshotStorage, SnapshotLis
     }
   }
 
+  @Override
+  public void onSnapshotDeletion(
+      final io.atomix.protocols.raft.storage.snapshot.Snapshot snapshot,
+      final SnapshotStore store) {
+    metrics.decrementSnapshotCount();
+    LOGGER.debug("Snapshot {} removed from store {}", snapshot, store);
+  }
+
   private Path getPendingDirectoryFor(
       final long index, final long term, final WallClockTimestamp timestamp, final long position) {
     final var pending = store.newPendingSnapshot(index, term, timestamp);
@@ -170,5 +193,34 @@ public final class AtomixSnapshotStorage implements SnapshotStorage, SnapshotLis
   private Optional<Snapshot> toSnapshot(final Path path) {
     return DbSnapshotMetadata.ofPath(path)
         .map(metadata -> new SnapshotImpl(metadata.getPosition(), path));
+  }
+
+  private void observeExistingSnapshots() {
+    final var snapshots = store.getSnapshots();
+
+    for (final var snapshot : snapshots) {
+      observeSnapshotSize(snapshot);
+    }
+
+    metrics.setSnapshotCount(snapshots.size());
+  }
+
+  private void observeSnapshotSize(
+      final io.atomix.protocols.raft.storage.snapshot.Snapshot snapshot) {
+    try (final var contents = Files.newDirectoryStream(snapshot.getPath())) {
+      var totalSize = 0L;
+
+      for (final var path : contents) {
+        if (Files.isRegularFile(path)) {
+          final var size = Files.size(path);
+          metrics.observeSnapshotFileSize(size);
+          totalSize += size;
+        }
+      }
+
+      metrics.observeSnapshotSize(totalSize);
+    } catch (IOException e) {
+      LOGGER.warn("Failed to observe size for snapshot {}", snapshot, e);
+    }
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbPendingSnapshot.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbPendingSnapshot.java
@@ -45,7 +45,7 @@ public final class DbPendingSnapshot implements PendingSnapshot {
    * @param directory the snapshot's working directory (i.e. where we should write chunks)
    * @param snapshotStore the store which will be called when the snapshot is to be committed
    */
-  public DbPendingSnapshot(
+  DbPendingSnapshot(
       final long index,
       final long term,
       final WallClockTimestamp timestamp,

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshot.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshot.java
@@ -41,7 +41,7 @@ public final class DbSnapshot implements Snapshot {
     this.metadata = new DbSnapshotMetadata(index, term, timestamp, position);
   }
 
-  public DbSnapshot(final Path directory, final DbSnapshotMetadata metadata) {
+  DbSnapshot(final Path directory, final DbSnapshotMetadata metadata) {
     this.directory = directory;
     this.metadata = metadata;
   }
@@ -103,7 +103,7 @@ public final class DbSnapshot implements Snapshot {
 
   @Override
   public Path getPath() {
-    return directory;
+    return getDirectory();
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshotStore.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshotStore.java
@@ -46,7 +46,7 @@ public final class DbSnapshotStore implements SnapshotStore {
   private final ReusableSnapshotId lowerBoundId;
   private final ReusableSnapshotId upperBoundId;
 
-  public DbSnapshotStore(
+  DbSnapshotStore(
       final Path snapshotsDirectory,
       final Path pendingDirectory,
       final ConcurrentNavigableMap<DbSnapshotId, DbSnapshot> snapshots) {
@@ -97,6 +97,9 @@ public final class DbSnapshotStore implements SnapshotStore {
 
   @Override
   public void delete() {
+    // currently only called by Atomix when permanently leaving a cluster - it should be safe here
+    // to not update the metrics, as they will simply disappear as time moves on. Once we have a
+    // single store/replication mechanism, we can consider updating the metrics here
     snapshots.clear();
 
     try {
@@ -220,6 +223,7 @@ public final class DbSnapshotStore implements SnapshotStore {
     LOGGER.debug("Deleting snapshot {}", snapshot);
     snapshot.delete();
     snapshots.remove(snapshot.getMetadata());
+    listeners.forEach(l -> l.onSnapshotDeletion(snapshot, this));
     LOGGER.trace("Snapshots count: {}", snapshots.size());
   }
 

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshotStoreFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshotStoreFactory.java
@@ -35,7 +35,7 @@ public final class DbSnapshotStoreFactory implements SnapshotStoreFactory {
   private static final Logger LOGGER = new ZbLogger(DbSnapshotStoreFactory.class);
 
   @Override
-  public SnapshotStore createSnapshotStore(final Path root, final String prefix) {
+  public SnapshotStore createSnapshotStore(final Path root, final String partitionName) {
     final var snapshots = new ConcurrentSkipListMap<DbSnapshotId, DbSnapshot>();
     final var snapshotDirectory = root.resolve(SNAPSHOTS_DIRECTORY);
     final var pendingDirectory = root.resolve(PENDING_DIRECTORY);

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -38,6 +38,7 @@ import io.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.state.NoneSnapshotReplication;
+import io.zeebe.logstreams.state.SnapshotMetrics;
 import io.zeebe.logstreams.state.SnapshotReplication;
 import io.zeebe.logstreams.state.SnapshotStorage;
 import io.zeebe.logstreams.state.StateSnapshotController;
@@ -304,7 +305,8 @@ public final class ZeebePartition extends Actor implements RaftCommitListener, C
         runtimeDirectory,
         atomixRaftPartition.getServer().getSnapshotStore(),
         new AtomixRecordEntrySupplierImpl(reader),
-        brokerCfg.getData().getMaxSnapshots());
+        brokerCfg.getData().getMaxSnapshots(),
+        new SnapshotMetrics(partitionId));
   }
 
   private boolean shouldReplicateSnapshots() {

--- a/broker/src/test/java/io/zeebe/broker/clustering/atomix/storage/snapshot/AtomixSnapshotStorageTest.java
+++ b/broker/src/test/java/io/zeebe/broker/clustering/atomix/storage/snapshot/AtomixSnapshotStorageTest.java
@@ -22,6 +22,7 @@ import io.atomix.storage.journal.Indexed;
 import io.zeebe.broker.clustering.atomix.storage.AtomixRecordEntrySupplier;
 import io.zeebe.logstreams.state.Snapshot;
 import io.zeebe.logstreams.state.SnapshotDeletionListener;
+import io.zeebe.logstreams.state.SnapshotMetrics;
 import io.zeebe.logstreams.state.SnapshotStorage;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -185,7 +186,9 @@ public final class AtomixSnapshotStorageTest {
 
   private AtomixSnapshotStorage newStorage(final int maxSnapshotsCount) {
     final var runtimeDirectory = temporaryFolder.getRoot().toPath().resolve("runtime");
-    storage = new AtomixSnapshotStorage(runtimeDirectory, store, entrySupplier, maxSnapshotsCount);
+    storage =
+        new AtomixSnapshotStorage(
+            runtimeDirectory, store, entrySupplier, maxSnapshotsCount, new SnapshotMetrics(0));
     return storage;
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotDirector.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotDirector.java
@@ -159,13 +159,8 @@ public final class AsyncSnapshotDirector extends Actor {
   }
 
   private Snapshot createSnapshot(final Supplier<Snapshot> snapshotCreation) {
-    final var start = System.currentTimeMillis();
     final var snapshot = snapshotCreation.get();
-
-    final long end = System.currentTimeMillis();
-    final long snapshotCreationTime = end - start;
-
-    LOG.debug("Creation of snapshot for {} took {} ms.", processorName, snapshotCreationTime);
+    LOG.debug("Created snapshot for {}", processorName);
     return snapshot;
   }
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/ReplicationController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/ReplicationController.java
@@ -11,32 +11,28 @@ import io.zeebe.logstreams.impl.Loggers;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
-import org.agrona.collections.Object2LongHashMap;
+import org.agrona.collections.Object2NullableObjectHashMap;
 import org.slf4j.Logger;
 
-public final class ReplicationController {
-
+final class ReplicationController {
   private static final Logger LOG = Loggers.SNAPSHOT_LOGGER;
-
-  private static final long START_VALUE = 0L;
-  private static final long INVALID_SNAPSHOT = -1;
-  private static final long MISSING_SNAPSHOT = Long.MIN_VALUE;
+  private static final ReplicationContext INVALID_SNAPSHOT = new ReplicationContext(-1, -1);
 
   private final SnapshotReplication replication;
-  private final Map<String, Long> receivedSnapshots = new Object2LongHashMap<>(MISSING_SNAPSHOT);
-  private final SnapshotStorage storage;
+  private final Map<String, ReplicationContext> receivedSnapshots =
+      new Object2NullableObjectHashMap<>();
+  private final SnapshotReplicationMetrics metrics;
 
   private final SnapshotConsumer snapshotConsumer;
 
-  public ReplicationController(
-      final SnapshotReplication replication, final SnapshotStorage storage) {
+  ReplicationController(final SnapshotReplication replication, final SnapshotStorage storage) {
     this.replication = replication;
-    this.storage = storage;
     this.snapshotConsumer = new FileSnapshotConsumer(storage, LOG);
+    this.metrics = storage.getMetrics().getReplication();
+    this.metrics.setCount(0);
   }
 
-  public void replicate(
-      final String snapshotId, final int totalCount, final File snapshotChunkFile) {
+  void replicate(final String snapshotId, final int totalCount, final File snapshotChunkFile) {
     try {
       final SnapshotChunk chunkToReplicate =
           SnapshotChunkUtil.createSnapshotChunkFromFile(snapshotChunkFile, snapshotId, totalCount);
@@ -48,7 +44,7 @@ public final class ReplicationController {
   }
 
   /** Registering for consuming snapshot chunks. */
-  public void consumeReplicatedSnapshots() {
+  void consumeReplicatedSnapshots() {
     replication.consume(this::consumeSnapshotChunk);
   }
 
@@ -61,8 +57,9 @@ public final class ReplicationController {
     final String snapshotId = snapshotChunk.getSnapshotId();
     final String chunkName = snapshotChunk.getChunkName();
 
-    final long snapshotCounter = receivedSnapshots.computeIfAbsent(snapshotId, k -> START_VALUE);
-    if (snapshotCounter == INVALID_SNAPSHOT) {
+    final ReplicationContext context =
+        receivedSnapshots.computeIfAbsent(snapshotId, this::newReplication);
+    if (context == INVALID_SNAPSHOT) {
       LOG.trace(
           "Ignore snapshot chunk {}, because snapshot {} is marked as invalid.",
           chunkName,
@@ -71,7 +68,7 @@ public final class ReplicationController {
     }
 
     if (snapshotConsumer.consumeSnapshotChunk(snapshotChunk)) {
-      validateWhenReceivedAllChunks(snapshotChunk);
+      validateWhenReceivedAllChunks(snapshotChunk, context);
     } else {
       markSnapshotAsInvalid(snapshotChunk);
     }
@@ -80,42 +77,58 @@ public final class ReplicationController {
   private void markSnapshotAsInvalid(final SnapshotChunk chunk) {
     snapshotConsumer.invalidateSnapshot(chunk.getSnapshotId());
     receivedSnapshots.put(chunk.getSnapshotId(), INVALID_SNAPSHOT);
+    metrics.decrementCount();
   }
 
-  private void validateWhenReceivedAllChunks(final SnapshotChunk snapshotChunk) {
+  private void validateWhenReceivedAllChunks(
+      final SnapshotChunk snapshotChunk, final ReplicationContext context) {
     final int totalChunkCount = snapshotChunk.getTotalCount();
-    final long currentChunks = incrementAndGetChunkCount(snapshotChunk);
+    context.chunkCount++;
 
-    if (currentChunks == totalChunkCount) {
+    if (context.chunkCount == totalChunkCount) {
       LOG.debug(
           "Received all snapshot chunks ({}/{}), snapshot is valid",
-          currentChunks,
+          context.chunkCount,
           totalChunkCount);
-      if (!tryToMarkSnapshotAsValid(snapshotChunk)) {
+      if (!tryToMarkSnapshotAsValid(snapshotChunk, context)) {
         LOG.debug("Failed to mark snapshot {} as valid", snapshotChunk.getSnapshotId());
       }
     } else {
-      LOG.trace(
-          "Waiting for more snapshot chunks, currently have {}/{}", currentChunks, totalChunkCount);
+      LOG.debug(
+          "Waiting for more snapshot chunks, currently have {}/{}",
+          context.chunkCount,
+          totalChunkCount);
     }
   }
 
-  private long incrementAndGetChunkCount(final SnapshotChunk snapshotChunk) {
-    final String snapshotId = snapshotChunk.getSnapshotId();
-    final long oldCount = receivedSnapshots.get(snapshotId);
-    final long newCount = oldCount + 1;
-    receivedSnapshots.put(snapshotId, newCount);
-    return newCount;
-  }
-
-  private boolean tryToMarkSnapshotAsValid(final SnapshotChunk snapshotChunk) {
+  private boolean tryToMarkSnapshotAsValid(
+      final SnapshotChunk snapshotChunk, final ReplicationContext context) {
     if (snapshotConsumer.completeSnapshot(snapshotChunk.getSnapshotId())) {
+      final var elapsed = System.currentTimeMillis() - context.startTimestamp;
       receivedSnapshots.remove(snapshotChunk.getSnapshotId());
-      return true;
+      metrics.decrementCount();
+      metrics.observeDuration(elapsed);
 
+      return true;
     } else {
       markSnapshotAsInvalid(snapshotChunk);
       return false;
+    }
+  }
+
+  private ReplicationContext newReplication(final String ignored) {
+    final var context = new ReplicationContext(0L, System.currentTimeMillis());
+    metrics.incrementCount();
+    return context;
+  }
+
+  private static final class ReplicationContext {
+    private final long startTimestamp;
+    private long chunkCount;
+
+    private ReplicationContext(final long chunkCount, final long startTimestamp) {
+      this.chunkCount = chunkCount;
+      this.startTimestamp = startTimestamp;
     }
   }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotMetrics.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotMetrics.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.state;
+
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+
+public final class SnapshotMetrics {
+  private static final String NAMESPACE = "zeebe";
+  private static final String PARTITION_LABEL_NAME = "partition";
+
+  private static final Gauge SNAPSHOT_COUNT =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .labelNames(PARTITION_LABEL_NAME)
+          .name("snapshot_count")
+          .help("Total count of committed snapshots on disk")
+          .register();
+  private static final Gauge SNAPSHOT_SIZE =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .labelNames(PARTITION_LABEL_NAME)
+          .name("snapshot_size_bytes")
+          .help("Estimated snapshot size on disk")
+          .register();
+  private static final Gauge SNAPSHOT_DURATION =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .labelNames(PARTITION_LABEL_NAME)
+          .name("snapshot_duration_milliseconds")
+          .help("Approximate duration of snapshot operation")
+          .register();
+  private static final Histogram SNAPSHOT_FILE_SIZE =
+      Histogram.build()
+          .namespace(NAMESPACE)
+          .labelNames(PARTITION_LABEL_NAME)
+          .help("Approximate size of snapshot files")
+          .name("snapshot_file_size_megabytes")
+          .buckets(.01, .1, .5, 1, 5, 10, 25, 50, 100, 250, 500)
+          .register();
+
+  private final String partitionId;
+  private final SnapshotReplicationMetrics replication;
+
+  public SnapshotMetrics(final int partitionId) {
+    this.partitionId = String.valueOf(partitionId);
+    this.replication = new SnapshotReplicationMetrics(this.partitionId);
+  }
+
+  public void incrementSnapshotCount() {
+    SNAPSHOT_COUNT.labels(partitionId).inc();
+  }
+
+  public void decrementSnapshotCount() {
+    SNAPSHOT_COUNT.labels(partitionId).dec();
+  }
+
+  public void setSnapshotCount(final int count) {
+    SNAPSHOT_COUNT.labels(partitionId).set(count);
+  }
+
+  public void observeSnapshotSize(final long sizeInBytes) {
+    SNAPSHOT_SIZE.labels(partitionId).set(sizeInBytes);
+  }
+
+  public void observeSnapshotFileSize(final long sizeInBytes) {
+    SNAPSHOT_FILE_SIZE.labels(partitionId).observe(sizeInBytes / 1_000_000f);
+  }
+
+  public void observeSnapshotOperation(final long elapsedMillis) {
+    SNAPSHOT_DURATION.labels(partitionId).set(elapsedMillis);
+  }
+
+  public SnapshotReplicationMetrics getReplication() {
+    return replication;
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotReplicationMetrics.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotReplicationMetrics.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.state;
+
+import io.prometheus.client.Gauge;
+
+/** Snapshot replication metrics to be used on the consumer side */
+public class SnapshotReplicationMetrics {
+  private static final String NAMESPACE = "zeebe";
+  private static final String PARTITION_LABEL_NAME = "partition";
+
+  private static final Gauge COUNT =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .labelNames(PARTITION_LABEL_NAME)
+          .help("Count of ongoing snapshot replication")
+          .name("snapshot_replication_count")
+          .register();
+  private static final Gauge DURATION =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .labelNames(PARTITION_LABEL_NAME)
+          .help("Approximate duration of replication in milliseconds")
+          .name("snapshot_replication_duration_milliseconds")
+          .register();
+
+  private final String partitionId;
+
+  public SnapshotReplicationMetrics(final String partitionId) {
+    this.partitionId = partitionId;
+  }
+
+  public void incrementCount() {
+    COUNT.labels(partitionId).inc();
+  }
+
+  public void decrementCount() {
+    COUNT.labels(partitionId).dec();
+  }
+
+  public void setCount(final long value) {
+    COUNT.labels(partitionId).set(value);
+  }
+
+  public void observeDuration(final long durationMillis) {
+    DURATION.labels(partitionId).set(durationMillis);
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotStorage.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotStorage.java
@@ -103,4 +103,12 @@ public interface SnapshotStorage extends AutoCloseable {
    * @param listener the listener to remove
    */
   void removeDeletionListener(SnapshotDeletionListener listener);
+
+  /**
+   * Returns a collection of snapshot related metrics, useful to observe snapshot and replication
+   * operations.
+   *
+   * @return a pre-instantiated metrics interface
+   */
+  SnapshotMetrics getMetrics();
 }

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/TestSnapshotStorage.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/TestSnapshotStorage.java
@@ -9,6 +9,7 @@ package io.zeebe.logstreams.util;
 
 import io.zeebe.logstreams.state.Snapshot;
 import io.zeebe.logstreams.state.SnapshotDeletionListener;
+import io.zeebe.logstreams.state.SnapshotMetrics;
 import io.zeebe.logstreams.state.SnapshotStorage;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -30,6 +31,7 @@ public final class TestSnapshotStorage implements SnapshotStorage {
   private final Path runtimeDirectory;
   private final SortedSet<Snapshot> snapshots;
   private final Set<SnapshotDeletionListener> deletionListeners;
+  private final SnapshotMetrics metrics;
 
   public TestSnapshotStorage(final Path rootDirectory) {
     this.pendingDirectory = rootDirectory.resolve("pending");
@@ -38,6 +40,7 @@ public final class TestSnapshotStorage implements SnapshotStorage {
 
     this.snapshots = new ConcurrentSkipListSet<>();
     this.deletionListeners = new CopyOnWriteArraySet<>();
+    this.metrics = new SnapshotMetrics(0);
 
     open();
   }
@@ -124,6 +127,11 @@ public final class TestSnapshotStorage implements SnapshotStorage {
   @Override
   public void removeDeletionListener(final SnapshotDeletionListener listener) {
     deletionListeners.remove(listener);
+  }
+
+  @Override
+  public SnapshotMetrics getMetrics() {
+    return metrics;
   }
 
   private static final class SnapshotImpl implements Snapshot {


### PR DESCRIPTION
## Description

Adds the following snapshot-related metrics per partition:

- Snapshot count (gauge)
- Snapshot size (gauge)
- Snapshot file size (histogram) for a distribution of file sizes
- Snapshot operation duration (gauge) (i.e. `RocksDB#checkpoint`)
- Ongoing snapshot replication (gauge), from the POV of the consumer
- Snapshot replication duration (gauge), measured on completion by the consumer

## Related issues

closes #3447 
blocked by [zeebe-io/atomix#141](https://github.com/zeebe-io/atomix/pull/141)

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
