### PR TITLE
Don't use writer on reprocessing

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
@@ -323,6 +323,9 @@ public final class ReProcessingStateMachine {
   private static final class NoopStreamWriter implements TypedStreamWriter {
 
     @Override
+    public void setDisabled(boolean disabled) {}
+
+    @Override
     public void appendRejection(
         final TypedRecord<? extends UnpackedObject> command,
         final RejectionType type,

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -135,6 +135,7 @@ public class StreamProcessor extends Actor {
       final ReProcessingStateMachine reProcessingStateMachine =
           new ReProcessingStateMachine(processingContext);
 
+      processingContext.getLogStreamWriter().setDisabled(true);
       final ActorFuture<Void> recoverFuture =
           reProcessingStateMachine.startRecover(snapshotPosition);
 
@@ -145,6 +146,7 @@ public class StreamProcessor extends Actor {
               LOG.error("Unexpected error on recovery happens.", throwable);
               onFailure(throwable);
             } else {
+              processingContext.getLogStreamWriter().setDisabled(false);
               onRecovered();
             }
           });

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriter.java
@@ -16,6 +16,8 @@ import java.util.function.Consumer;
 /** Things that any actor can write to a partition. */
 public interface TypedCommandWriter extends CloseableSilently {
 
+  void setDisabled(boolean disabled);
+
   void appendNewCommand(Intent intent, UnpackedObject value);
 
   void appendFollowUpCommand(long key, Intent intent, UnpackedObject value);

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
@@ -29,6 +29,7 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
   protected final LogStreamBatchWriter batchWriter;
 
   protected long sourceRecordPosition = -1;
+  private boolean disabled = false;
 
   public TypedCommandWriterImpl(final LogStreamBatchWriter batchWriter) {
     metadata.protocolVersion(Protocol.PROTOCOL_VERSION);
@@ -70,6 +71,8 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
       final String rejectionReason,
       final UnpackedObject value,
       final Consumer<RecordMetadata> additionalMetadata) {
+    assert !disabled : "Command writer called in disabled mode, probably during reprocessing";
+
     final LogEntryBuilder event = batchWriter.event();
 
     if (sourceRecordPosition >= 0) {
@@ -88,6 +91,11 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
     }
 
     event.metadataWriter(metadata).valueWriter(value).done();
+  }
+
+  @Override
+  public void setDisabled(boolean disabled) {
+    this.disabled = disabled;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/state/instance/WorkflowEngineState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/WorkflowEngineState.java
@@ -32,9 +32,12 @@ public final class WorkflowEngineState implements StreamProcessorLifecycleAware 
     this.elementInstanceState = workflowState.getElementInstanceState();
 
     this.metrics = new WorkflowEngineMetrics(processingContext.getLogStream().getPartitionId());
+  }
 
+  @Override
+  public void onRecovered(ReadonlyProcessingContext context) {
     final UpdateVariableStreamWriter updateVariableStreamWriter =
-        new UpdateVariableStreamWriter(processingContext.getLogStreamWriter());
+        new UpdateVariableStreamWriter(context.getLogStreamWriter());
 
     elementInstanceState.getVariablesState().setListener(updateVariableStreamWriter);
   }

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -185,7 +185,11 @@ public final class EngineRule extends ExternalResource {
     RecordingExporter.reset();
 
     startProcessors();
-    TestUtil.waitUntil(() -> RecordingExporter.getRecords().size() >= lastSize);
+    TestUtil.waitUntil(
+        () -> RecordingExporter.getRecords().size() >= lastSize,
+        "Failed to reprocess all events, only re-exported %d but expected %d",
+        RecordingExporter.getRecords().size(),
+        lastSize);
   }
 
   public List<Integer> getPartitionIds() {


### PR DESCRIPTION
## Description

There were situations where the reprocessing was using a real log stream writer which just buffered but never flushed as we are only reprocessing. This fix tries to add a save guard (assert) to prevent this and fix two found issues in the deployment reprocessing and variable state listeners. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3686 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
