### PR TITLE
chore(gateway): return DEADLINE_EXCEEDED on transport timeout

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
@@ -59,6 +59,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 public final class EndpointManager extends GatewayGrpc.GatewayImplBase {
@@ -363,6 +364,10 @@ public final class EndpointManager extends GatewayGrpc.GatewayImplBase {
       status = mapRejectionToStatus(((BrokerRejectionException) cause).getRejection());
     } else if (cause instanceof ClientOutOfMemoryException) {
       status = Status.UNAVAILABLE.augmentDescription(cause.getMessage());
+    } else if (cause instanceof TimeoutException) { // can be thrown by transport
+      status =
+          Status.DEADLINE_EXCEEDED.augmentDescription(
+              "Time out between gateway and broker: " + cause.getMessage());
     } else if (cause instanceof GrpcStatusException) {
       status = ((GrpcStatusException) cause).getGrpcStatus();
     } else {

--- a/gateway/src/test/java/io/zeebe/gateway/broker/BrokerClientTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/broker/BrokerClientTest.java
@@ -169,11 +169,13 @@ public final class BrokerClientTest {
 
     // then
     exception.expect(ExecutionException.class);
-    exception.expectMessage(containsString("Request timed out after PT3S"));
+    exception.expectMessage(containsString("timed out"));
     // when the partition is repeatedly not found, the client loops
     // over refreshing the topology and making a request that fails and so on. The timeout
     // kicks in at any point in that loop, so we cannot assert the exact error message any more
-    // specifically.
+    // specifically. It is also possible that Atomix times out before hand if we calculated a very
+    // small time out for the request, e.g. < 50ms, so we also cannot assert the value of the
+    // timeout
 
     // when
     client.sendRequest(new BrokerCreateWorkflowInstanceRequest()).join();


### PR DESCRIPTION
## Description

- sets gRPC error to `DEADLINE_EXCEEDED` when a request from the Gateway to the Broker times out

## Related issues

closes #3699

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
