### PR TITLE
Add gateway version cmd in Java client

### DIFF
--- a/clients/java/ignored-changes.xml
+++ b/clients/java/ignored-changes.xml
@@ -1,0 +1,7 @@
+<differences>
+  <difference>
+    <className>io/zeebe/client/ZeebeClient</className>
+    <method>io.zeebe.client.impl.command.GatewayVersionCommandImpl newGatewayVersionCommand()</method>
+    <differenceType>7012</differenceType>
+  </difference>
+</differences>

--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClient.java
@@ -28,6 +28,7 @@ import io.zeebe.client.api.worker.JobClient;
 import io.zeebe.client.api.worker.JobWorkerBuilderStep1;
 import io.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.zeebe.client.impl.ZeebeClientImpl;
+import io.zeebe.client.impl.command.GatewayVersionCommandImpl;
 
 /** The client to communicate with a Zeebe broker/cluster. */
 public interface ZeebeClient extends AutoCloseable, JobClient {
@@ -252,4 +253,11 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   ActivateJobsCommandStep1 newActivateJobsCommand();
+
+  /**
+   * Command to get the version of the gateway.
+   *
+   * @return
+   */
+  GatewayVersionCommandImpl newGatewayVersionCommand();
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
@@ -44,6 +44,7 @@ import io.zeebe.client.impl.command.ActivateJobsCommandImpl;
 import io.zeebe.client.impl.command.CancelWorkflowInstanceCommandImpl;
 import io.zeebe.client.impl.command.CreateWorkflowInstanceCommandImpl;
 import io.zeebe.client.impl.command.DeployWorkflowCommandImpl;
+import io.zeebe.client.impl.command.GatewayVersionCommandImpl;
 import io.zeebe.client.impl.command.JobUpdateRetriesCommandImpl;
 import io.zeebe.client.impl.command.PublishMessageCommandImpl;
 import io.zeebe.client.impl.command.ResolveIncidentCommandImpl;
@@ -301,6 +302,12 @@ public final class ZeebeClientImpl implements ZeebeClient {
   public ActivateJobsCommandStep1 newActivateJobsCommand() {
     return new ActivateJobsCommandImpl(
         asyncStub, config, objectMapper, credentialsProvider::shouldRetryRequest);
+  }
+
+  @Override
+  public GatewayVersionCommandImpl newGatewayVersionCommand() {
+    return new GatewayVersionCommandImpl(
+        asyncStub, config.getDefaultRequestTimeout(), credentialsProvider::shouldRetryRequest);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/GatewayVersionCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/GatewayVersionCommandImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl.command;
+
+import io.grpc.stub.StreamObserver;
+import io.zeebe.client.api.ZeebeFuture;
+import io.zeebe.client.api.command.FinalCommandStep;
+import io.zeebe.client.impl.RetriableClientFutureImpl;
+import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.zeebe.gateway.protocol.GatewayOuterClass.GatewayVersionRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.GatewayVersionResponse;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+public class GatewayVersionCommandImpl implements FinalCommandStep<String> {
+
+  private final GatewayStub asyncStub;
+  private final Predicate<Throwable> retryPredicate;
+  private Duration timeout;
+  private GatewayVersionRequest.Builder builder;
+
+  public GatewayVersionCommandImpl(
+      GatewayStub asyncStub, Duration defaultTimeout, Predicate<Throwable> retryPredicate) {
+    this.asyncStub = asyncStub;
+    this.timeout = defaultTimeout;
+    this.retryPredicate = retryPredicate;
+    this.builder = GatewayVersionRequest.newBuilder();
+  }
+
+  @Override
+  public FinalCommandStep<String> requestTimeout(Duration requestTimeout) {
+    timeout = requestTimeout;
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<String> send() {
+    final GatewayVersionRequest request = builder.build();
+
+    final RetriableClientFutureImpl<String, GatewayVersionResponse> future =
+        new RetriableClientFutureImpl<>(
+            GatewayVersionResponse::getVersion,
+            retryPredicate,
+            streamObserver -> send(request, streamObserver));
+
+    send(request, future);
+    return future;
+  }
+
+  private void send(
+      final GatewayVersionRequest request, final StreamObserver<GatewayVersionResponse> future) {
+    asyncStub
+        .withDeadlineAfter(timeout.toMillis(), TimeUnit.MILLISECONDS)
+        .gatewayVersion(request, future);
+  }
+}

--- a/clients/java/src/test/java/io/zeebe/client/GatewayVersionTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/GatewayVersionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.client.util.ClientTest;
+import java.time.Duration;
+import org.junit.Test;
+
+public class GatewayVersionTest extends ClientTest {
+
+  @Test
+  public void shouldSendCommand() {
+    // given
+    final String expected = "expected";
+    gatewayService.onGatewayVersion(expected);
+
+    // when
+    final String version = client.newGatewayVersionCommand().send().join();
+
+    // then
+    rule.verifyDefaultRequestTimeout();
+    assertThat(version).isEqualTo(expected);
+  }
+
+  @Test
+  public void shouldSetRequestTimeout() {
+    // given
+    final Duration requestTimeout = Duration.ofHours(124);
+
+    // when
+    client.newGatewayVersionCommand().requestTimeout(requestTimeout).send().join();
+
+    // then
+    rule.verifyRequestTimeout(requestTimeout);
+  }
+}

--- a/clients/java/src/test/java/io/zeebe/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/zeebe/client/util/RecordingGatewayService.java
@@ -36,6 +36,8 @@ import io.zeebe.gateway.protocol.GatewayOuterClass.DeployWorkflowRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.DeployWorkflowResponse;
 import io.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.FailJobResponse;
+import io.zeebe.gateway.protocol.GatewayOuterClass.GatewayVersionRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.GatewayVersionResponse;
 import io.zeebe.gateway.protocol.GatewayOuterClass.Partition;
 import io.zeebe.gateway.protocol.GatewayOuterClass.Partition.PartitionBrokerRole;
 import io.zeebe.gateway.protocol.GatewayOuterClass.PublishMessageRequest;
@@ -90,6 +92,8 @@ public final class RecordingGatewayService extends GatewayImplBase {
     addRequestHandler(ActivateJobsRequest.class, r -> ActivateJobsResponse.getDefaultInstance());
     addRequestHandler(
         ResolveIncidentRequest.class, r -> ResolveIncidentResponse.getDefaultInstance());
+    addRequestHandler(
+        GatewayVersionRequest.class, r -> GatewayVersionResponse.getDefaultInstance());
   }
 
   public static Partition partition(final int partitionId, final PartitionBrokerRole role) {
@@ -219,6 +223,13 @@ public final class RecordingGatewayService extends GatewayImplBase {
     handle(request, responseObserver);
   }
 
+  @Override
+  public void gatewayVersion(
+      final GatewayVersionRequest request,
+      final StreamObserver<GatewayVersionResponse> responseObserver) {
+    handle(request, responseObserver);
+  }
+
   public void onTopologyRequest(
       final int clusterSize,
       final int partitionsCount,
@@ -290,6 +301,12 @@ public final class RecordingGatewayService extends GatewayImplBase {
     addRequestHandler(
         SetVariablesRequest.class,
         request -> SetVariablesResponse.newBuilder().setKey(key).build());
+  }
+
+  public void onGatewayVersion(final String version) {
+    addRequestHandler(
+        GatewayVersionRequest.class,
+        request -> GatewayVersionResponse.newBuilder().setVersion(version).build());
   }
 
   public void errorOnRequest(

--- a/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
@@ -290,10 +290,17 @@ public final class EndpointManager extends GatewayGrpc.GatewayImplBase {
   public void gatewayVersion(
       final GatewayVersionRequest request,
       final StreamObserver<GatewayVersionResponse> responseObserver) {
+    final String version = getClass().getPackage().getImplementationVersion();
+    if (version == null || version.isBlank()) {
+      responseObserver.onError(
+          Status.NOT_FOUND
+              .augmentDescription("Failed to read gateway version, none was defined")
+              .asException());
+      return;
+    }
+
     final GatewayVersionResponse response =
-        GatewayVersionResponse.newBuilder()
-            .setVersion(getClass().getPackage().getImplementationVersion())
-            .build();
+        GatewayVersionResponse.newBuilder().setVersion(version).build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();
   }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/GatewayVersionTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/GatewayVersionTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.it.util.GrpcClientRule;
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.test.util.BrokerClassRuleHelper;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class GatewayVersionTest {
+
+  private static final EmbeddedBrokerRule BROKER_RULE = new EmbeddedBrokerRule();
+  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+
+  @ClassRule
+  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldReturnGatewayVersion() {
+    final String version = CLIENT_RULE.getClient().newGatewayVersionCommand().send().join();
+    assertThat(version).isNotBlank();
+  }
+}


### PR DESCRIPTION
## Description

Adds the gateway version command to the Java client

Based on https://github.com/zeebe-io/zeebe/pull/3706

## Related issues

closes #3692 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
