### PR TITLE
chore(broker): get role and term on raft role change

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -9,6 +9,7 @@ package io.zeebe.broker.system.partitions;
 
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.protocols.raft.RaftCommitListener;
+import io.atomix.protocols.raft.RaftRoleChangeListener;
 import io.atomix.protocols.raft.RaftServer.Role;
 import io.atomix.protocols.raft.partition.RaftPartition;
 import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
@@ -58,7 +59,8 @@ import java.util.List;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 
-public final class ZeebePartition extends Actor implements RaftCommitListener, Consumer<Role> {
+public final class ZeebePartition extends Actor
+    implements RaftCommitListener, RaftRoleChangeListener {
 
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private static final int EXPORTER_PROCESSOR_ID = 1003;
@@ -125,15 +127,15 @@ public final class ZeebePartition extends Actor implements RaftCommitListener, C
    * @param newRole the new role of the raft partition
    */
   @Override
-  public void accept(final Role newRole) {
-    actor.run(() -> onRoleChange(newRole));
+  public void onNewRole(final Role newRole, final long newTerm) {
+    actor.run(() -> onRoleChange(newRole, newTerm));
   }
 
-  private void onRoleChange(final Role newRole) {
+  private void onRoleChange(final Role newRole, final long newTerm) {
     switch (newRole) {
       case LEADER:
         if (raftRole != Role.LEADER) {
-          leaderTransition();
+          leaderTransition(newTerm);
         }
         break;
       case INACTIVE:
@@ -143,7 +145,7 @@ public final class ZeebePartition extends Actor implements RaftCommitListener, C
       case FOLLOWER:
       default:
         if (raftRole == null || raftRole == Role.LEADER) {
-          followerTransition();
+          followerTransition(newTerm);
         }
         break;
     }
@@ -152,13 +154,13 @@ public final class ZeebePartition extends Actor implements RaftCommitListener, C
     raftRole = newRole;
   }
 
-  private void leaderTransition() {
+  private void leaderTransition(final long newTerm) {
     onTransitionTo(this::transitionToLeader)
         .onComplete(
             (success, error) -> {
               if (error == null) {
                 partitionListeners.forEach(
-                    l -> l.onBecomingLeader(partitionId, atomixRaftPartition.term(), logStream));
+                    l -> l.onBecomingLeader(partitionId, newTerm, logStream));
               } else {
                 LOG.error("Failed to install leader partition {}", partitionId, error);
                 // TODO https://github.com/zeebe-io/zeebe/issues/3499
@@ -166,13 +168,13 @@ public final class ZeebePartition extends Actor implements RaftCommitListener, C
             });
   }
 
-  private void followerTransition() {
+  private void followerTransition(final long newTerm) {
     onTransitionTo(this::transitionToFollower)
         .onComplete(
             (success, error) -> {
               if (error == null) {
                 partitionListeners.forEach(
-                    l -> l.onBecomingFollower(partitionId, atomixRaftPartition.term(), logStream));
+                    l -> l.onBecomingFollower(partitionId, newTerm, logStream));
               } else {
                 LOG.error("Failed to install follower partition {}", partitionId, error);
                 // TODO https://github.com/zeebe-io/zeebe/issues/3499
@@ -530,7 +532,7 @@ public final class ZeebePartition extends Actor implements RaftCommitListener, C
                 this.logStream = log;
                 atomixRaftPartition.getServer().addCommitListener(this);
                 atomixRaftPartition.addRoleChangeListener(this);
-                onRoleChange(atomixRaftPartition.getRole());
+                onRoleChange(atomixRaftPartition.getRole(), atomixRaftPartition.term());
               } else {
                 LOG.error(
                     "Failed to install log stream service for partition {}",


### PR DESCRIPTION
## Description

When the term was read later after all the transitions are done, it might not reflect the term of the role. This sometimes resulted in inconsistent state in topology. In this pr:
* Use the RoleChangeListener interface from atomix
* Use the term provided by the listener for transitions

## Related issue

closes #3697 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
