### PR TITLE
fix(broker): raise incident if error catch event is interrupted

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractEventSubProcessBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractEventSubProcessBuilder.java
@@ -21,6 +21,7 @@ import io.zeebe.model.bpmn.instance.StartEvent;
 import io.zeebe.model.bpmn.instance.SubProcess;
 import io.zeebe.model.bpmn.instance.bpmndi.BpmnShape;
 import io.zeebe.model.bpmn.instance.dc.Bounds;
+import java.util.function.Consumer;
 
 public class AbstractEventSubProcessBuilder<B extends AbstractEventSubProcessBuilder<B>>
     extends AbstractFlowElementBuilder<B, SubProcess> {
@@ -54,5 +55,11 @@ public class AbstractEventSubProcessBuilder<B extends AbstractEventSubProcessBui
     }
 
     return start.builder();
+  }
+
+  public StartEventBuilder startEvent(final String id, final Consumer<StartEventBuilder> consumer) {
+    final StartEventBuilder builder = startEvent(id);
+    consumer.accept(builder);
+    return builder;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/element/ElementTerminatedHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/element/ElementTerminatedHandler.java
@@ -54,7 +54,7 @@ public class ElementTerminatedHandler<T extends ExecutableFlowNode>
               flowScopeInstance.getKey(),
               WorkflowInstanceIntent.ELEMENT_TERMINATED,
               flowScopeInstance.getValue());
-    } else if (wasInterrupted(context, flowScopeInstance)) {
+    } else if (wasInterrupted(flowScopeInstance)) {
       publishInterruptingEventSubproc(context, flowScopeInstance);
     }
 
@@ -79,11 +79,10 @@ public class ElementTerminatedHandler<T extends ExecutableFlowNode>
     }
   }
 
-  private boolean wasInterrupted(
-      final BpmnStepContext<T> context, final ElementInstance flowScopeInstance) {
+  private boolean wasInterrupted(final ElementInstance flowScopeInstance) {
     return flowScopeInstance != null
         && flowScopeInstance.getNumberOfActiveTokens() == 2
-        && context.getFlowScopeInstance().getInterruptingEventKey() != -1
+        && flowScopeInstance.isInterrupted()
         && flowScopeInstance.isActive();
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobErrorThrownProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobErrorThrownProcessor.java
@@ -107,7 +107,7 @@ public class JobErrorThrownProcessor implements TypedRecordProcessor<JobRecord> 
     // assuming that error events are used rarely
     // - just walk through the scope hierarchy and look for a matching catch event
 
-    do {
+    while (instance != null && instance.isActive()) {
       final var instanceRecord = instance.getValue();
       final var workflow = getWorkflow(instanceRecord.getWorkflowKey());
 
@@ -119,8 +119,7 @@ public class JobErrorThrownProcessor implements TypedRecordProcessor<JobRecord> 
       // find in parent workflow instance if exists
       final var parentElementInstanceKey = instanceRecord.getParentElementInstanceKey();
       instance = elementInstanceState.getInstance(parentElementInstanceKey);
-
-    } while (instance != null && instance.isActive());
+    }
 
     // no matching catch event found
     return null;
@@ -129,7 +128,7 @@ public class JobErrorThrownProcessor implements TypedRecordProcessor<JobRecord> 
   private CatchEventTuple findCatchEventInWorkflow(
       final DirectBuffer errorCode, final ExecutableWorkflow workflow, ElementInstance instance) {
 
-    do {
+    while (instance != null && instance.isActive() && !instance.isInterrupted()) {
       final var found = findCatchEventInScope(errorCode, workflow, instance);
       if (found != null) {
         return found;
@@ -138,8 +137,7 @@ public class JobErrorThrownProcessor implements TypedRecordProcessor<JobRecord> 
       // find in parent scope if exists
       final var instanceParentKey = instance.getParentKey();
       instance = elementInstanceState.getInstance(instanceParentKey);
-
-    } while (instance != null && instance.isActive());
+    }
 
     return null;
   }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstance.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstance.java
@@ -88,10 +88,6 @@ public final class ElementInstance implements DbValue {
     }
   }
 
-  public void incrementChildCount() {
-    childCount++;
-  }
-
   public boolean canTerminate() {
     return WorkflowInstanceLifecycle.canTerminate(getState());
   }
@@ -158,7 +154,11 @@ public final class ElementInstance implements DbValue {
   }
 
   public void setInterruptingEventKey(final long key) {
-    this.interruptingEventKey = key;
+    interruptingEventKey = key;
+  }
+
+  public boolean isInterrupted() {
+    return getInterruptingEventKey() > 0;
   }
 
   @Override

--- a/test-util/src/main/java/io/zeebe/test/util/record/JobRecordStream.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/JobRecordStream.java
@@ -34,4 +34,8 @@ public final class JobRecordStream
   public JobRecordStream withWorkflowInstanceKey(final long workflowInstanceKey) {
     return valueFilter(v -> v.getWorkflowInstanceKey() == workflowInstanceKey);
   }
+
+  public JobRecordStream withElementId(final String elementId) {
+    return valueFilter(v -> v.getElementId().equals(elementId));
+  }
 }


### PR DESCRIPTION
## Description

* before catching an error event check if the element is interrupted (e.g. in case of an interrupting event subprocess)
* removed unused method `ElementInstance.incrementChildCount()`

## Related issues

closes #3678 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
