### PR TITLE
chore(broker): use actor name on LogStreamDeletionService

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/logstreams/LogStreamDeletionService.java
+++ b/broker/src/main/java/io/zeebe/broker/logstreams/LogStreamDeletionService.java
@@ -18,14 +18,23 @@ public final class LogStreamDeletionService extends Actor implements SnapshotDel
   private final LogStream logStream;
   private final StatePositionSupplier positionSupplier;
   private final SnapshotStorage snapshotStorage;
+  private final String actorName;
 
   public LogStreamDeletionService(
+      final int nodeId,
+      final int partitionId,
       final LogStream logStream,
       final SnapshotStorage snapshotStorage,
       final StatePositionSupplier positionSupplier) {
     this.snapshotStorage = snapshotStorage;
     this.logStream = logStream;
     this.positionSupplier = positionSupplier;
+    actorName = buildActorName(nodeId, "DeletionService-" + partitionId);
+  }
+
+  @Override
+  public String getName() {
+    return actorName;
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -283,7 +283,8 @@ public final class ZeebePartition extends Actor
 
     final StatePositionSupplier positionSupplier = new StatePositionSupplier(partitionId, LOG);
     final LogStreamDeletionService deletionService =
-        new LogStreamDeletionService(logStream, snapshotStorage, positionSupplier);
+        new LogStreamDeletionService(
+            localBroker.getNodeId(), partitionId, logStream, snapshotStorage, positionSupplier);
     closeables.add(deletionService);
 
     return scheduler.submitActor(deletionService);

--- a/broker/src/test/java/io/zeebe/broker/logstreams/LogStreamDeletionTest.java
+++ b/broker/src/test/java/io/zeebe/broker/logstreams/LogStreamDeletionTest.java
@@ -42,7 +42,8 @@ public final class LogStreamDeletionTest {
     final SnapshotStorage mockSnapshotStorage = mock(SnapshotStorage.class);
 
     deletionService =
-        new LogStreamDeletionService(mockLogStream, mockSnapshotStorage, mockPositionSupplier);
+        new LogStreamDeletionService(
+            0, 1, mockLogStream, mockSnapshotStorage, mockPositionSupplier);
     actorScheduler.submitActor(deletionService).join();
   }
 


### PR DESCRIPTION

## Description
 * per default the actors use the class name as actor name, which is not really helpful on debugging and
  looking at the looks
 * we now use the unified actor name

<!-- Please explain the changes you made here. -->


## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
