### PR TITLE
chore(broker): use node id on stream processor

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -350,6 +350,7 @@ public final class ZeebePartition extends Actor
         .logStream(logStream)
         .actorScheduler(scheduler)
         .zeebeDb(zeebeDb)
+        .nodeId(localBroker.getNodeId())
         .commandResponseWriter(commandApiService.newCommandResponseWriter())
         .onProcessedListener(commandApiService.getOnProcessedListener(partitionId))
         .streamProcessorFactory(

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -41,7 +41,6 @@ public class StreamProcessor extends Actor {
   // processing
   private final ProcessingContext processingContext;
   private final TypedRecordProcessorFactory typedRecordProcessorFactory;
-  private final int nodeId;
   private LogStreamReader logStreamReader;
   private ActorCondition onCommitPositionUpdatedCondition;
   private long snapshotPosition = -1L;
@@ -67,8 +66,7 @@ public class StreamProcessor extends Actor {
             .abortCondition(this::isClosed);
     this.logStream = processingContext.getLogStream();
     this.partitionId = logStream.getPartitionId();
-    this.nodeId = processorBuilder.getNodeId();
-    this.actorName = buildActorName(nodeId, "StreamProcessor-" + partitionId);
+    this.actorName = buildActorName(processorBuilder.getNodeId(), "StreamProcessor-" + partitionId);
   }
 
   public static StreamProcessorBuilder builder() {


### PR DESCRIPTION
## Description

The node Id was not set, which was the reason why it was always zero.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3688 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
