### PR TITLE
Engine close resources

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
@@ -537,11 +537,11 @@ public final class StreamProcessorTest {
     streamProcessorRule.writeWorkflowInstanceEvent(WorkflowInstanceIntent.ELEMENT_ACTIVATING);
     streamProcessorRule.writeWorkflowInstanceEvent(WorkflowInstanceIntent.ELEMENT_ACTIVATING);
     processingLatch.await();
+    final StateSnapshotController stateSnapshotController =
+        streamProcessorRule.getStateSnapshotController();
     streamProcessorRule.closeStreamProcessor();
 
     // then
-    final StateSnapshotController stateSnapshotController =
-        streamProcessorRule.getStateSnapshotController();
     final InOrder inOrder = Mockito.inOrder(stateSnapshotController);
 
     inOrder.verify(stateSnapshotController, TIMEOUT.times(1)).openDb();
@@ -568,11 +568,11 @@ public final class StreamProcessorTest {
 
     // when
     recoveredLatch.await();
+    final StateSnapshotController stateSnapshotController =
+      streamProcessorRule.getStateSnapshotController();
     streamProcessorRule.closeStreamProcessor();
 
     // then
-    final StateSnapshotController stateSnapshotController =
-        streamProcessorRule.getStateSnapshotController();
     final InOrder inOrder = Mockito.inOrder(stateSnapshotController);
 
     inOrder.verify(stateSnapshotController, TIMEOUT.times(1)).openDb();

--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
@@ -569,7 +569,7 @@ public final class StreamProcessorTest {
     // when
     recoveredLatch.await();
     final StateSnapshotController stateSnapshotController =
-      streamProcessorRule.getStateSnapshotController();
+        streamProcessorRule.getStateSnapshotController();
     streamProcessorRule.closeStreamProcessor();
 
     // then

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -168,9 +168,10 @@ public final class EngineRule extends ExternalResource {
     forEachPartition(
         partitionId -> {
           try {
-            environmentRule.closeStreamProcessor(partitionId);
 
             final var snapshotController = environmentRule.getStateSnapshotController(partitionId);
+
+            environmentRule.closeStreamProcessor(partitionId);
 
             if (snapshotController.getValidSnapshotsCount() > 0) {
               FileUtil.deleteFolder(snapshotController.getLastValidSnapshotDirectory().toPath());

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -20,13 +20,10 @@ import io.zeebe.db.ZeebeDb;
 import io.zeebe.db.ZeebeDbFactory;
 import io.zeebe.engine.processor.AsyncSnapshotDirector;
 import io.zeebe.engine.processor.CommandResponseWriter;
-import io.zeebe.engine.processor.ReadonlyProcessingContext;
 import io.zeebe.engine.processor.StreamProcessor;
-import io.zeebe.engine.processor.StreamProcessorLifecycleAware;
 import io.zeebe.engine.processor.TypedEventRegistry;
 import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.engine.processor.TypedRecordProcessorFactory;
-import io.zeebe.engine.processor.TypedRecordProcessors;
 import io.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.zeebe.logstreams.log.LogStreamReader;
 import io.zeebe.logstreams.log.LogStreamRecordWriter;
@@ -230,21 +227,9 @@ public final class TestStreams {
             .actorScheduler(actorScheduler)
             .commandResponseWriter(mockCommandResponseWriter)
             .onProcessedListener(mockOnProcessedListener)
-            .streamProcessorFactory(
-                (context) -> {
-                  final TypedRecordProcessors processors = factory.createProcessors(context);
-                  processors.withListener(
-                      new StreamProcessorLifecycleAware() {
-                        @Override
-                        public void onOpen(final ReadonlyProcessingContext context) {
-                          openFuture.complete(null);
-                        }
-                      });
-                  return processors;
-                })
+            .streamProcessorFactory(factory)
             .build();
     streamProcessor.openAsync().join();
-    openFuture.join();
 
     final var asyncSnapshotDirector =
         new AsyncSnapshotDirector(

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -143,6 +143,7 @@ public final class TestStreams {
     final LogContext logContext = LogContext.createLogContext(logStream, logStorageRule);
     logContextMap.put(name, logContext);
     closeables.manage(logContext);
+    closeables.manage(() -> logContextMap.remove(name));
 
     return logStream;
   }
@@ -270,7 +271,7 @@ public final class TestStreams {
   }
 
   public void closeProcessor(final String streamName) throws Exception {
-    streamContextMap.get(streamName).close();
+    streamContextMap.remove(streamName).close();
     LOG.info("Closed stream {}", streamName);
   }
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
@@ -156,7 +156,15 @@ public final class AtomixLogStorageRule extends ExternalResource
 
   public void close() {
     Optional.ofNullable(raftLog).ifPresent(RaftLog::close);
+    raftLog = null;
     Optional.ofNullable(snapshotStore).ifPresent(SnapshotStore::close);
+    snapshotStore = null;
+    Optional.ofNullable(metaStore).ifPresent(MetaStore::close);
+    metaStore = null;
+    Optional.ofNullable(storage).ifPresent(AtomixLogStorage::close);
+    storage = null;
+    Optional.ofNullable(raftStorage).ifPresent(RaftStorage::deleteLog);
+    raftStorage = null;
   }
 
   public int getPartitionId() {


### PR DESCRIPTION
## Description

Fixes an out of direct memory error, which occurs during test execution and closes more resources on close.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->


## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
