### PR TITLE
Fix out of direct memory issue on running engine tests 

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -69,7 +69,7 @@ public final class EngineRule extends ExternalResource {
 
   private static final int PARTITION_ID = Protocol.DEPLOYMENT_PARTITION;
   private static final RecordingExporter RECORDING_EXPORTER = new RecordingExporter();
-  protected final StreamProcessorRule environmentRule;
+  private StreamProcessorRule environmentRule;
   private final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
   private final int partitionCount;
@@ -112,6 +112,11 @@ public final class EngineRule extends ExternalResource {
     if (!explicitStart) {
       startProcessors();
     }
+  }
+
+  @Override
+  protected void after() {
+    environmentRule = null;
   }
 
   public void start() {

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
@@ -165,6 +165,7 @@ public final class AtomixLogStorageRule extends ExternalResource
     storage = null;
     Optional.ofNullable(raftStorage).ifPresent(RaftStorage::deleteLog);
     raftStorage = null;
+    positionListener = null;
   }
 
   public int getPartitionId() {


### PR DESCRIPTION
## Description
On my old machine I had still the problem that I got out of direct memory after running around ~400 engine tests.

Since we use class rules in most of our engine tests, they are long lived references, which also hold the stream processor rule. This means they also hold logstream, dispatcher etc which caused OOM's on running all tests.


Here we can see that the AtomixLogStorageRule hold after closing still a reference of the TestStream:
![screenshot2020-01-2407:57:29](https://user-images.githubusercontent.com/2758593/73052347-3f317600-3e85-11ea-9978-6591e72d8309.png)
I removed that.

Furthermore in the other screenshots we see that we had a lot of StreamProcessorRule, Dispatcher and LogPartition references hanging. 

![screenshot2020-01-2408:01:32](https://user-images.githubusercontent.com/2758593/73052353-3fca0c80-3e85-11ea-80ce-e5cb35ed36a4.png)
![screenshot2020-01-2407:57:37](https://user-images.githubusercontent.com/2758593/73052348-3f317600-3e85-11ea-88c1-49261d65e9c0.png)
![screenshot2020-01-2407:58:43](https://user-images.githubusercontent.com/2758593/73052350-3f317600-3e85-11ea-9c2a-4a9f5c4ef9ee.png)
![screenshot2020-01-2408:00:05](https://user-images.githubusercontent.com/2758593/73052351-3fca0c80-3e85-11ea-8c40-37ea1e9aa4b2.png)

The log partition was the part which holds the direct buffer memory.
After the fix we can see that the references are cleaned up correctly.
![screenshot2020-01-2408:00:44](https://user-images.githubusercontent.com/2758593/73052352-3fca0c80-3e85-11ea-8a68-c52d85d31360.png)


## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
