### PR TITLE
chore(monitor): adjust pod variables to helm usage

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -58,7 +58,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1579186112364,
+  "iteration": 1579873290265,
   "links": [],
   "panels": [
     {
@@ -4372,7 +4372,7 @@
         "useTags": false
       },
       {
-        "allValue": "(bench-broker-[0-9]+)|(zeebe-[0-9]+)",
+        "allValue": "(.*-zeebe-[0-9]+$)",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(jvm_info{namespace=~\"$namespace\"}, pod)",
@@ -4418,7 +4418,7 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
@@ -4449,5 +4449,5 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "I4lo7_EZk",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
## Description

Since we now using the helm charts in our benchmarks we need to use the same pattern in the pod variables.

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
