### PR TITLE
chore(broker): distribute broker version in topology

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
@@ -44,6 +44,12 @@ public final class TopologyManagerImpl extends Actor
         .setClusterSize(clusterCfg.getClusterSize())
         .setPartitionsCount(clusterCfg.getPartitionsCount())
         .setReplicationFactor(clusterCfg.getReplicationFactor());
+
+    final String version = getClass().getPackage().getImplementationVersion();
+    if (version != null && !version.isBlank()) {
+      localBroker.setVersion(version);
+    }
+
     this.actorName = buildActorName(localBroker.getNodeId(), "TopologyManager");
   }
 

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -261,6 +261,8 @@ message BrokerInfo {
   int32 port = 3;
   // list of partitions managed or replicated on this broker
   repeated Partition partitions = 4;
+  // broker version
+  string version = 5;
 }
 
 message Partition {

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -504,6 +504,11 @@
                 "name": "partitions",
                 "type": "Partition",
                 "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "version",
+                "type": "string"
               }
             ]
           },

--- a/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
@@ -82,7 +82,8 @@ public final class EndpointManager extends GatewayGrpc.GatewayImplBase {
     brokerInfo
         .setNodeId(brokerId)
         .setHost(addressParts[0])
-        .setPort(Integer.parseInt(addressParts[1]));
+        .setPort(Integer.parseInt(addressParts[1]))
+        .setVersion(topology.getBrokerVersion(brokerId));
   }
 
   private void addPartitionInfoToBrokerInfo(
@@ -243,7 +244,6 @@ public final class EndpointManager extends GatewayGrpc.GatewayImplBase {
     final BrokerClusterState topology = topologyManager.getTopology();
 
     if (topology != null) {
-
       topologyResponseBuilder
           .setClusterSize(topology.getClusterSize())
           .setPartitionsCount(topology.getPartitionsCount())

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerClusterState.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerClusterState.java
@@ -35,4 +35,6 @@ public interface BrokerClusterState {
   String getBrokerAddress(int brokerId);
 
   int getPartition(int index);
+
+  String getBrokerVersion(int brokerId);
 }

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
@@ -136,5 +136,7 @@ public final class BrokerTopologyManagerImpl extends Actor
     if (clientAddress != null) {
       newTopology.setBrokerAddressIfPresent(nodeId, clientAddress);
     }
+
+    newTopology.setBrokerVersionIfPresent(nodeId, distributedBrokerInfo.getVersion());
   }
 }

--- a/gateway/src/test/java/io/zeebe/gateway/topology/TopologyUpdateTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/topology/TopologyUpdateTest.java
@@ -58,6 +58,7 @@ public final class TopologyUpdateTest {
     topologyManager.event(createMemberUpdateEvent(brokerUpdated));
     waitUntil(() -> topologyManager.getTopology().getFollowersForPartition(1) != null);
     assertThat(topologyManager.getTopology().getFollowersForPartition(1).contains(0)).isTrue();
+    assertThat(topologyManager.getTopology().getBrokerVersion(0)).isEqualTo(broker.getVersion());
   }
 
   @Test
@@ -162,6 +163,7 @@ public final class TopologyUpdateTest {
             .setClusterSize(3)
             .setReplicationFactor(3);
     broker.setCommandApiAddress("localhost:1000");
+    broker.setVersion("0.23.0-SNAPSHOT");
     return broker;
   }
 

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -11,6 +11,7 @@ import static io.zeebe.protocol.record.BrokerInfoEncoder.clusterSizeNullValue;
 import static io.zeebe.protocol.record.BrokerInfoEncoder.nodeIdNullValue;
 import static io.zeebe.protocol.record.BrokerInfoEncoder.partitionsCountNullValue;
 import static io.zeebe.protocol.record.BrokerInfoEncoder.replicationFactorNullValue;
+import static io.zeebe.protocol.record.BrokerInfoEncoder.versionHeaderLength;
 import static io.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.zeebe.protocol.impl.Loggers;
@@ -68,6 +69,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   private int partitionsCount;
   private int clusterSize;
   private int replicationFactor;
+  private DirectBuffer version = new UnsafeBuffer();
 
   public BrokerInfo() {
     reset();
@@ -85,6 +87,7 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     clusterSize = clusterSizeNullValue();
     replicationFactor = replicationFactorNullValue();
     addresses.clear();
+    version.wrap(0, 0);
     clearPartitions();
 
     return this;
@@ -129,6 +132,18 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   public BrokerInfo setReplicationFactor(final int replicationFactor) {
     this.replicationFactor = replicationFactor;
     return this;
+  }
+
+  public String getVersion() {
+    return BufferUtil.bufferAsString(version);
+  }
+
+  public void setVersion(final String version) {
+    this.version = BufferUtil.wrapString(version);
+  }
+
+  public void setVersion(final DirectBuffer buffer, final int offset, final int length) {
+    this.version.wrap(buffer, offset, length);
   }
 
   public Map<DirectBuffer, DirectBuffer> getAddresses() {
@@ -225,6 +240,12 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
           partitionLeaderTermsDecoder.partitionId(), partitionLeaderTermsDecoder.term());
     }
 
+    if (bodyDecoder.versionLength() > 0) {
+      bodyDecoder.wrapVersion(version);
+    } else {
+      bodyDecoder.skipVersion();
+    }
+
     assert bodyDecoder.limit() == frameEnd
         : "Decoder read only to position "
             + bodyDecoder.limit()
@@ -240,7 +261,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
             + bodyEncoder.sbeBlockLength()
             + AddressesEncoder.sbeHeaderSize()
             + PartitionRolesEncoder.sbeHeaderSize()
-            + PartitionLeaderTermsEncoder.sbeHeaderSize();
+            + PartitionLeaderTermsEncoder.sbeHeaderSize()
+            + versionHeaderLength()
+            + version.capacity();
 
     for (final Entry<DirectBuffer, DirectBuffer> entry : addresses.entrySet()) {
       length +=
@@ -308,6 +331,8 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
         partitionLeaderTermsEncoder.next().partitionId(entry.getKey()).term(entry.getValue());
       }
     }
+
+    bodyEncoder.putVersion(version, 0, version.capacity());
   }
 
   public static BrokerInfo fromProperties(final Properties properties) {
@@ -381,6 +406,8 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
         + partitionRoles
         + ", partitionLeaderTerms="
         + partitionLeaderTerms
+        + ", version="
+        + BufferUtil.bufferAsString(version)
         + '}';
   }
 }

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe" xmlns:xi="http://www.w3.org/2001/XInclude" package="io.zeebe.protocol.record"
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+  xmlns:xi="http://www.w3.org/2001/XInclude" package="io.zeebe.protocol.record"
   id="0" version="${protocol.version}" semanticVersion="${project.version}"
   description="Zeebe Protocol" byteOrder="littleEndian">
 
@@ -117,6 +118,7 @@
       <field name="partitionId" id="12" type="int32"/>
       <field name="term" id="13" type="int64"/>
     </group>
+    <data name="version" id="14" type="varDataEncoding"/>
   </sbe:message>
 
 </sbe:messageSchema>


### PR DESCRIPTION
## Description

Adds the broker's version to the topology information that is distributed between brokers and gateway.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3732 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
