### PR TITLE
chore(dist): suppress Kryo illegal access warnings

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -87,7 +87,9 @@
           <configurationDirectory>conf</configurationDirectory>
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
-          <extraJvmArguments>-Xms128m -Dlog4j.configurationFile=../conf/log4j2.xml
+          <extraJvmArguments>
+            -Xms128m -Dlog4j.configurationFile=../conf/log4j2.xml
+            --illegal-access=deny
           </extraJvmArguments>
           <repositoryLayout>flat</repositoryLayout>
           <useWildcardClassPath>true</useWildcardClassPath>


### PR DESCRIPTION
## Description

- opens Java 9 modules for reflection access required by Kryo, suppressing the illegal access warnings at start up

## Related issues

closes #3711

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
