### PR TITLE
feat(broker): resolve incident for unhandled error

### DIFF
--- a/docs/src/bpmn-workflows/error-events/error-events.md
+++ b/docs/src/bpmn-workflows/error-events/error-events.md
@@ -10,7 +10,7 @@ An error indicates that some kind of business error has occurred which should be
 
 An error can be referenced by one or more error events. It must define the `errorCode` (e.g. `Invalid Credit Card`) of the error.
 
-The `errorCode` is a `string` that must match to the error code that is sent by the client command.
+The `errorCode` is a `string` that must match to the error code that is sent by the client command or from the error end event.
 
 ## Catching the Error
 
@@ -32,15 +32,15 @@ Alternatively, an error can also be thrown inside a workflow using an error **en
 
 ## Unhandled Errors
 
-When an error is triggered then it should be handled in the workflow. If it is not handled (e.g. unexpected error code) then an **incident** is raised to indicate the failure. The incident is attached to the corresponding service task of the processed job.
+When an error is triggered then it should be handled in the workflow. If it is not handled (e.g. unexpected error code) then an **incident** is raised to indicate the failure. The incident is attached to the corresponding service task of the processed job or the error end event.
 
-The incident can be solved by increasing the retries of the processed job.
+The incident can not be solved by the user because the failure is in the workflow itself that can not be changed to handle the error for this workflow instance.
 
 ## Business Error vs. Technical Error
 
 While processing a job, two different types of errors can be occurred: a technical error (e.g. database connection interrupted) and a business error (e.g. invalid credit card).
 
-A technical error is unexpected and cannot be handled in the workflow. The error may disappear when the job is retried, or an incident is created to indicate that user interaction is required.
+A technical error is usually unexpected and should not be handled in the workflow. The error may disappear when the job is retried, or an incident is created to indicate that an user interaction is required.
 
 A business error is expected and is handled in the workflow. The workflow may take a different path to compensate the error or undo previous actions.
 

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/BpmnStepHandlers.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/BpmnStepHandlers.java
@@ -75,7 +75,7 @@ public final class BpmnStepHandlers {
             state.getKeyGenerator(),
             state.getMessageState(),
             state.getWorkflowState().getEventScopeInstanceState());
-    final var errorEventHandle =
+    final var errorEventHandler =
         new ErrorEventHandler(state.getWorkflowState(), state.getKeyGenerator());
 
     stepHandlers.put(BpmnStep.ELEMENT_ACTIVATING, new ElementActivatingHandler<>());
@@ -202,7 +202,7 @@ public final class BpmnStepHandlers {
         BpmnStep.CALL_ACTIVITY_TERMINATING,
         new CallActivityTerminatingHandler(catchEventSubscriber));
 
-    stepHandlers.put(BpmnStep.THROW_ERROR, new ThrowErrorHandler(errorEventHandle));
+    stepHandlers.put(BpmnStep.THROW_ERROR, new ThrowErrorHandler(errorEventHandler));
   }
 
   public void handle(final BpmnStepContext context) {

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/incident/IncidentEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/incident/IncidentEventProcessors.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.processor.workflow.incident;
 
 import io.zeebe.engine.processor.TypedRecordProcessors;
 import io.zeebe.engine.processor.workflow.BpmnStepProcessor;
+import io.zeebe.engine.processor.workflow.job.JobErrorThrownProcessor;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.IncidentIntent;
@@ -18,13 +19,14 @@ public final class IncidentEventProcessors {
   public static void addProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final ZeebeState zeebeState,
-      final BpmnStepProcessor bpmnStepProcessor) {
+      final BpmnStepProcessor bpmnStepProcessor,
+      final JobErrorThrownProcessor jobErrorThrownProcessor) {
     typedRecordProcessors
         .onCommand(
             ValueType.INCIDENT, IncidentIntent.CREATE, new CreateIncidentProcessor(zeebeState))
         .onCommand(
             ValueType.INCIDENT,
             IncidentIntent.RESOLVE,
-            new ResolveIncidentProcessor(bpmnStepProcessor, zeebeState));
+            new ResolveIncidentProcessor(zeebeState, bpmnStepProcessor, jobErrorThrownProcessor));
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/FailProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/FailProcessor.java
@@ -16,8 +16,13 @@ import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.JobIntent;
 
 public final class FailProcessor implements CommandProcessor<JobRecord> {
-  public static final String NOT_ACTIVATED_JOB_MESSAGE =
-      "Expected to fail activated job with key '%d', but it %s";
+
+  private static final String JOB_NOT_FOUND_MESSAGE =
+      "Expected to fail job with key '%d', but it does not exist";
+
+  private static final String INVALID_JOB_STATE_MESSAGE =
+      "Expected to fail job with key '%d', but it is in state '%s'";
+
   private final JobState state;
 
   public FailProcessor(final JobState state) {
@@ -37,17 +42,13 @@ public final class FailProcessor implements CommandProcessor<JobRecord> {
       state.fail(key, failedJob);
 
       commandControl.accept(JobIntent.FAILED, failedJob);
-    } else if (jobState == State.ACTIVATABLE) {
-      commandControl.reject(
-          RejectionType.INVALID_STATE,
-          String.format(NOT_ACTIVATED_JOB_MESSAGE, key, "must be activated first"));
-    } else if (jobState == State.FAILED) {
-      commandControl.reject(
-          RejectionType.INVALID_STATE,
-          String.format(NOT_ACTIVATED_JOB_MESSAGE, key, "is marked as failed"));
+
+    } else if (jobState == State.NOT_FOUND) {
+      commandControl.reject(RejectionType.NOT_FOUND, String.format(JOB_NOT_FOUND_MESSAGE, key));
+
     } else {
       commandControl.reject(
-          RejectionType.NOT_FOUND, String.format(NOT_ACTIVATED_JOB_MESSAGE, key, "does not exist"));
+          RejectionType.INVALID_STATE, String.format(INVALID_JOB_STATE_MESSAGE, key, jobState));
     }
     return true;
   }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
@@ -147,12 +147,14 @@ public final class JobState {
     metrics.jobCanceled(record.getType());
   }
 
-  public void throwError(final long key, final JobRecord record) {
-    delete(key, record);
-    metrics.jobErrorThrown(record.getType());
+  public void throwError(final long key, final JobRecord updatedValue) {
+    updateJob(key, updatedValue, State.ERROR_THROWN);
+    makeJobNotActivatable(updatedValue.getTypeBuffer());
+
+    metrics.jobErrorThrown(updatedValue.getType());
   }
 
-  private void delete(final long key, final JobRecord record) {
+  public void delete(final long key, final JobRecord record) {
     final DirectBuffer type = record.getTypeBuffer();
     final long deadline = record.getDeadline();
 
@@ -167,6 +169,13 @@ public final class JobState {
   }
 
   public void fail(final long key, final JobRecord updatedValue) {
+    final State newState = updatedValue.getRetries() > 0 ? State.ACTIVATABLE : State.FAILED;
+    updateJob(key, updatedValue, newState);
+
+    metrics.jobFailed(updatedValue.getType());
+  }
+
+  private void updateJob(final long key, final JobRecord updatedValue, final State newState) {
     final DirectBuffer type = updatedValue.getTypeBuffer();
     final long deadline = updatedValue.getDeadline();
 
@@ -174,7 +183,6 @@ public final class JobState {
 
     resetVariablesAndUpdateJobRecord(key, updatedValue);
 
-    final State newState = updatedValue.getRetries() > 0 ? State.ACTIVATABLE : State.FAILED;
     updateJobState(newState);
 
     if (newState == State.ACTIVATABLE) {
@@ -184,8 +192,6 @@ public final class JobState {
     if (deadline > 0) {
       removeJobDeadline(deadline);
     }
-
-    metrics.jobFailed(updatedValue.getType());
   }
 
   private void validateParameters(final DirectBuffer type) {
@@ -193,11 +199,7 @@ public final class JobState {
   }
 
   public void resolve(final long key, final JobRecord updatedValue) {
-    final DirectBuffer type = updatedValue.getTypeBuffer();
-
-    resetVariablesAndUpdateJobRecord(key, updatedValue);
-    updateJobState(State.ACTIVATABLE);
-    makeJobActivatable(type, key);
+    updateJob(key, updatedValue, State.ACTIVATABLE);
   }
 
   public void forEachTimedOutEntry(
@@ -327,7 +329,8 @@ public final class JobState {
     ACTIVATABLE((byte) 0),
     ACTIVATED((byte) 1),
     FAILED((byte) 2),
-    NOT_FOUND((byte) 3);
+    NOT_FOUND((byte) 3),
+    ERROR_THROWN((byte) 4);
 
     byte value;
 
@@ -343,6 +346,10 @@ public final class JobState {
           return ACTIVATED;
         case 2:
           return FAILED;
+        case 3:
+          return NOT_FOUND;
+        case 4:
+          return ERROR_THROWN;
         default:
           return NOT_FOUND;
       }

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/IncidentStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/IncidentStreamProcessorRule.java
@@ -75,7 +75,7 @@ public final class IncidentStreamProcessorRule extends ExternalResource {
 
     environmentRule.startTypedStreamProcessor(
         (typedRecordProcessors, processingContext) -> {
-          this.zeebeState = processingContext.getZeebeState();
+          zeebeState = processingContext.getZeebeState();
           workflowState = zeebeState.getWorkflowState();
           final BpmnStepProcessor stepProcessor =
               WorkflowEventProcessors.addWorkflowProcessors(
@@ -85,9 +85,13 @@ public final class IncidentStreamProcessorRule extends ExternalResource {
                   new CatchEventBehavior(zeebeState, mockSubscriptionCommandSender, 1),
                   mockTimerEventScheduler);
 
-          IncidentEventProcessors.addProcessors(typedRecordProcessors, zeebeState, stepProcessor);
-          JobEventProcessors.addJobProcessors(
-              typedRecordProcessors, zeebeState, type -> {}, Integer.MAX_VALUE);
+          final var jobErrorThrownProcessor =
+              JobEventProcessors.addJobProcessors(
+                  typedRecordProcessors, zeebeState, type -> {}, Integer.MAX_VALUE);
+
+          IncidentEventProcessors.addProcessors(
+              typedRecordProcessors, zeebeState, stepProcessor, jobErrorThrownProcessor);
+
           return typedRecordProcessors;
         });
   }

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/job/FailJobTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/job/FailJobTest.java
@@ -190,7 +190,7 @@ public final class FailJobTest {
 
     // then
     Assertions.assertThat(jobRecord).hasRejectionType(RejectionType.INVALID_STATE);
-    assertThat(jobRecord.getRejectionReason()).contains("is marked as failed");
+    assertThat(jobRecord.getRejectionReason()).contains("it is in state 'FAILED'");
   }
 
   @Test
@@ -204,7 +204,7 @@ public final class FailJobTest {
 
     // then
     Assertions.assertThat(jobRecord).hasRejectionType(RejectionType.INVALID_STATE);
-    assertThat(jobRecord.getRejectionReason()).contains("must be activated first");
+    assertThat(jobRecord.getRejectionReason()).contains("it is in state 'ACTIVATABLE'");
   }
 
   @Test
@@ -223,5 +223,21 @@ public final class FailJobTest {
 
     // then
     Assertions.assertThat(jobRecord).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldRejectFailIfErrorThrown() {
+    // given
+    final var job = ENGINE.createJob(jobType, PROCESS_ID);
+
+    ENGINE.job().withKey(job.getKey()).withErrorCode("error").throwError();
+
+    // when
+    final Record<JobRecordValue> jobRecord =
+        ENGINE.job().withKey(job.getKey()).withRetries(3).expectRejection().fail();
+
+    // then
+    Assertions.assertThat(jobRecord).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(jobRecord.getRejectionReason()).contains("is in state 'ERROR_THROWN'");
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/job/JobThrowErrorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/job/JobThrowErrorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.job;
+
+import static io.zeebe.protocol.record.intent.JobIntent.ERROR_THROWN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.protocol.record.Assertions;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.RejectionType;
+import io.zeebe.protocol.record.value.JobRecordValue;
+import io.zeebe.test.util.BrokerClassRuleHelper;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class JobThrowErrorTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static String jobType;
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Before
+  public void setup() {
+    jobType = helper.getJobType();
+  }
+
+  @Test
+  public void shouldThrowError() {
+    // given
+    final var job = ENGINE.createJob(jobType, PROCESS_ID);
+
+    // when
+    final Record<JobRecordValue> result =
+        ENGINE
+            .job()
+            .withKey(job.getKey())
+            .withErrorCode("error")
+            .withErrorMessage("error-message")
+            .throwError();
+
+    // then
+    Assertions.assertThat(result).hasRecordType(RecordType.EVENT).hasIntent(ERROR_THROWN);
+    Assertions.assertThat(result.getValue()).hasErrorCode("error").hasErrorMessage("error-message");
+  }
+
+  @Test
+  public void shouldRejectIfJobNotFound() {
+    // given
+    final int key = 123;
+
+    // when
+    final Record<JobRecordValue> result =
+        ENGINE.job().withKey(key).withErrorCode("error").throwError();
+
+    // then
+    Assertions.assertThat(result).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldRejectIfJobIsFailed() {
+    // given
+    final var job = ENGINE.createJob(jobType, PROCESS_ID);
+
+    ENGINE.jobs().withType(jobType).activate();
+    ENGINE.job().withKey(job.getKey()).withRetries(0).fail();
+
+    // when
+    final Record<JobRecordValue> result =
+        ENGINE.job().withKey(job.getKey()).withErrorCode("error").throwError();
+
+    // then
+    Assertions.assertThat(result).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(result.getRejectionReason()).contains("it is in state 'FAILED'");
+  }
+
+  @Test
+  public void shouldRejectIfErrorIsThrown() {
+    // given
+    final var job = ENGINE.createJob(jobType, PROCESS_ID);
+
+    ENGINE.job().withKey(job.getKey()).withErrorCode("error").throwError();
+
+    // when
+    final Record<JobRecordValue> result =
+        ENGINE.job().withKey(job.getKey()).withErrorCode("error").throwError();
+
+    // then
+    Assertions.assertThat(result).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(result.getRejectionReason()).contains("it is in state 'ERROR_THROWN'");
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/instance/JobStateTest.java
@@ -98,6 +98,24 @@ public final class JobStateTest {
   }
 
   @Test
+  public void shouldDeleteJob() {
+    // given
+    final long key = 1L;
+    final JobRecord jobRecord = newJobRecord();
+
+    // when
+    jobState.create(key, jobRecord);
+    jobState.delete(key, jobRecord);
+
+    // then
+    Assertions.assertThat(jobState.exists(key)).isFalse();
+    Assertions.assertThat(jobState.isInState(key, State.NOT_FOUND)).isTrue();
+    Assertions.assertThat(jobState.getJob(key)).isNull();
+    refuteListedAsActivatable(key, jobRecord.getTypeBuffer());
+    refuteListedAsTimedOut(key, jobRecord.getDeadline() + 1);
+  }
+
+  @Test
   public void shouldNeverPersistJobVariables() {
     // given
     final long key = 1L;
@@ -167,9 +185,9 @@ public final class JobStateTest {
     jobState.throwError(key, jobRecord);
 
     // then
-    Assertions.assertThat(jobState.exists(key)).isFalse();
-    Assertions.assertThat(jobState.isInState(key, State.NOT_FOUND)).isTrue();
-    Assertions.assertThat(jobState.getJob(key)).isNull();
+    Assertions.assertThat(jobState.exists(key)).isTrue();
+    assertJobState(key, State.ERROR_THROWN);
+    assertJobRecordIsEqualTo(jobState.getJob(key), jobRecord);
     refuteListedAsActivatable(key, jobRecord.getTypeBuffer());
     refuteListedAsTimedOut(key, jobRecord.getDeadline() + 1);
   }
@@ -224,9 +242,9 @@ public final class JobStateTest {
     jobState.throwError(key, jobRecord);
 
     // then
-    Assertions.assertThat(jobState.exists(key)).isFalse();
-    Assertions.assertThat(jobState.isInState(key, State.NOT_FOUND)).isTrue();
-    Assertions.assertThat(jobState.getJob(key)).isNull();
+    Assertions.assertThat(jobState.exists(key)).isTrue();
+    assertJobState(key, State.ERROR_THROWN);
+    assertJobRecordIsEqualTo(jobState.getJob(key), jobRecord);
     refuteListedAsActivatable(key, jobRecord.getTypeBuffer());
     refuteListedAsTimedOut(key, jobRecord.getDeadline() + 1);
   }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/FailJobTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/FailJobTest.java
@@ -80,8 +80,7 @@ public final class FailJobTest {
 
     // when
     final var expectedMessage =
-        String.format(
-            "Expected to fail activated job with key '%d', but it does not exist", jobKey);
+        String.format("Expected to fail job with key '%d', but it does not exist", jobKey);
 
     assertThatThrownBy(
             () -> CLIENT_RULE.getClient().newFailCommand(jobKey).retries(1).send().join())

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordStream.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordStream.java
@@ -76,4 +76,9 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return new JobRecordStream(
         filter(r -> r.getValueType() == ValueType.JOB).map(Record.class::cast));
   }
+
+  public IncidentRecordStream incidentRecords() {
+    return new IncidentRecordStream(
+        filter(r -> r.getValueType() == ValueType.INCIDENT).map(Record.class::cast));
+  }
 }


### PR DESCRIPTION
## Description

* when resolving an incident of an unhandled error then the error is propagated again
* since there is currently no way to fix the problem so that the error is handled, a new incident is created
* same behavior for an error that is thrown from a job and from an error end event
* new job state 'ERROR_THROWN' to indicate that an error was thrown for this job and no further command is accepted
* adjust unhandled errors section

## Related issues

closes #3503

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
