### PR TITLE
chore(upgrade-tests): add basic upgradability test

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -13,10 +13,10 @@ GO111MODULE=off mockgen github.com/zeebe-io/zeebe/clients/go/pkg/pb GatewayClien
 
 ### Integration tests
 
-To run the integration tests, a Docker image for Zeebe must be built with the tag 'current-test'. To do that you can run:
+To run the integration tests, a Docker image for Zeebe must be built with the tag 'current-test'. To do that you can run (in the zeebe-io/zeebe dir):
 
 ```
-docker build --build-arg DISTBALL=dist/target/zeebe-distribution*.tar.gz  -t camunda/zeebe:current-test .
+docker build --build-arg DISTBALL=dist/target/zeebe-distribution*.tar.gz -t camunda/zeebe:current-test .
 ```
 
 To add new zbctl tests, you must generate a golden file with the expected output of the command you are testing. The tests ignore numbers so you can leave any keys or timestamps in your golden file, even though these will most likely be different from test command's output. However, non-numeric variables are not ignored. For instance, the help menu contains:

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Parent</name>
@@ -78,6 +80,7 @@
     <version.asm>7.3.1</version.asm>
     <version.testcontainers>1.12.5</version.testcontainers>
     <version.netflix.concurrency>0.3.6</version.netflix.concurrency>
+    <version.zeebe-test-container>0.30.0</version.zeebe-test-container>
 
     <!-- maven plugins -->
     <plugin.version.antrun>1.8</plugin.version.antrun>
@@ -384,6 +387,12 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${version.gson}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.zeebe</groupId>
+        <artifactId>zeebe-test-container</artifactId>
+        <version>${version.zeebe-test-container}</version>
       </dependency>
 
       <dependency>
@@ -831,7 +840,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -924,7 +933,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <dependencyConvergence />
+                  <dependencyConvergence/>
                 </rules>
               </configuration>
             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <module>exporters/elasticsearch-exporter</module>
     <module>protocol-impl</module>
     <module>zb-db</module>
+    <module>upgrade-tests</module>
   </modules>
 
   <scm>

--- a/upgrade-tests/README.md
+++ b/upgrade-tests/README.md
@@ -1,0 +1,6 @@
+To run the upgradability tests, a Docker image for Zeebe must be built with the tag 'current-test'. To do that you can run (in the zeebe-io/zeebe dir):
+
+```
+docker build --build-arg DISTBALL=dist/target/zeebe-distribution*.tar.gz -t camunda/zeebe:current-test .
+```
+

--- a/upgrade-tests/pom.xml
+++ b/upgrade-tests/pom.xml
@@ -1,0 +1,71 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <name>Zeebe Upgradability Tests</name>
+  <artifactId>zeebe-upgrade-tests</artifactId>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>io.zeebe</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>0.23.0-SNAPSHOT</version>
+    <relativePath>../parent</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-test-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-test-container</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <property>
+              <name>lastVersion</name>
+              <value>${backwards.compat.version}</value>
+            </property>
+          </systemProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+
+
+
+

--- a/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.test;
+
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.api.response.ActivateJobsResponse;
+import io.zeebe.containers.ZeebeBrokerContainer;
+import io.zeebe.containers.ZeebePort;
+import io.zeebe.containers.ZeebeStandaloneGatewayContainer;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.test.util.TestUtil;
+import java.util.concurrent.TimeUnit;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestWatcher;
+import org.junit.rules.Timeout;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+import org.testcontainers.containers.Network;
+
+public class UpgradeTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UpgradeTest.class);
+  private static final String CURRENT_VERSION = "current-test";
+  private static final String PROCESS_ID = "process";
+  private static final String TASK = "task";
+  private static final BpmnModelInstance WORKFLOW =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .serviceTask(TASK, t -> t.zeebeTaskType(TASK))
+          .endEvent()
+          .done();
+  private static String lastVersion = "0.22.1";
+
+  @Rule public Timeout timeout = new Timeout(2, TimeUnit.MINUTES);
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  @Rule public TestWatcher watchman = new ContainerTestWatcher();
+
+  private ZeebeBrokerContainer container;
+  private ZeebeStandaloneGatewayContainer gateway;
+  private ZeebeClient client;
+  private Network network;
+
+  @BeforeClass
+  public static void beforeClass() {
+    final String version = System.getProperty("lastVersion");
+    if (version != null) {
+      lastVersion = version;
+    } else {
+      LOG.info(
+          "Expected last version property to be set but none was found. Running test with default version {}",
+          lastVersion);
+    }
+  }
+
+  @Test
+  public void shouldCompleteJobAfterUpgrade() {
+    // given
+    startZeebe(lastVersion);
+
+    // when
+    client.newDeployCommand().addWorkflowModel(WORKFLOW, PROCESS_ID + ".bpmn").send().join();
+    client.newCreateInstanceCommand().bpmnProcessId(PROCESS_ID).latestVersion().send().join();
+
+    final ActivateJobsResponse jobsResponse =
+        client.newActivateJobsCommand().jobType(TASK).maxJobsToActivate(1).send().join();
+
+    TestUtil.waitUntil(() -> findElementInState(TASK, "ACTIVATED"));
+    close();
+
+    startZeebe(CURRENT_VERSION);
+    client.newCompleteCommand(jobsResponse.getJobs().get(0).getKey()).send().join();
+
+    // then
+    TestUtil.waitUntil(() -> findElementInState(PROCESS_ID, "ELEMENT_COMPLETED"));
+  }
+
+  @Test
+  public void shouldSupportOlderVersionedGateway() {
+    // given
+    startZeebe(false, CURRENT_VERSION, lastVersion);
+
+    // when
+    client.newDeployCommand().addWorkflowModel(WORKFLOW, PROCESS_ID + ".bpmn").send().join();
+    client.newCreateInstanceCommand().bpmnProcessId(PROCESS_ID).latestVersion().send().join();
+
+    final ActivateJobsResponse jobsResponse =
+        client.newActivateJobsCommand().jobType(TASK).maxJobsToActivate(1).send().join();
+
+    client.newCompleteCommand(jobsResponse.getJobs().get(0).getKey()).send().join();
+
+    // then
+    TestUtil.waitUntil(() -> findElementInState(PROCESS_ID, "ELEMENT_COMPLETED"));
+  }
+
+  private void startZeebe(final String version) {
+    startZeebe(true, version, null);
+  }
+
+  private void startZeebe(
+      final boolean embeddedGateway, final String brokerVersion, final String gatewayVersion) {
+    network = Network.newNetwork();
+
+    container =
+        new ZeebeBrokerContainer(brokerVersion)
+            .withFileSystemBind(temp.getRoot().getPath(), "/usr/local/zeebe/data")
+            .withNetwork(network)
+            .withEmbeddedGateway(embeddedGateway)
+            .withDebug(true)
+            .withLogLevel(Level.DEBUG);
+    container.start();
+
+    String contactPoint = container.getExternalAddress(ZeebePort.GATEWAY);
+
+    if (!embeddedGateway) {
+      gateway =
+          new ZeebeStandaloneGatewayContainer(gatewayVersion)
+              .withContactPoint(container.getContactPoint())
+              .withNetwork(network)
+              .withLogLevel(Level.DEBUG);
+      gateway.start();
+      contactPoint = gateway.getExternalAddress(ZeebePort.GATEWAY);
+    }
+
+    client = ZeebeClient.newClientBuilder().brokerContactPoint(contactPoint).usePlaintext().build();
+  }
+
+  private boolean findElementInState(final String element, final String intent) {
+    final String[] lines = container.getLogs().split("\n");
+
+    for (int i = lines.length - 1; i >= 0; --i) {
+      if (lines[i].contains(String.format("\"elementId\":\"%s\"", element))
+          && lines[i].contains(String.format("\"intent\":\"%s\"", intent))) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private void close() {
+    if (client != null) {
+      client.close();
+      client = null;
+    }
+
+    if (gateway != null) {
+      gateway.close();
+      gateway = null;
+    }
+
+    if (container != null) {
+      container.close();
+      container = null;
+    }
+
+    if (network != null) {
+      network.close();
+      network = null;
+    }
+  }
+
+  private class ContainerTestWatcher extends TestWatcher {
+
+    @Override
+    protected void succeeded(Description description) {
+      close();
+    }
+
+    @Override
+    protected void failed(Throwable e, Description description) {
+      if (container != null && LOG.isErrorEnabled()) {
+        LOG.error(
+            String.format(
+                "===============================================%nBroker logs%n===============================================%n%s",
+                container.getLogs()));
+      }
+
+      if (gateway != null && LOG.isErrorEnabled()) {
+        LOG.error(
+            String.format(
+                "===============================================%nGateway logs%n===============================================%n%s",
+                gateway.getLogs()));
+      }
+
+      close();
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds two tests cases to check that:
* a pending workflow instance can be continued after updating a broker with a embedded gateway
* a gateway with an older version can contact a newer broker and complete an instance

## Related issues

closes #3743 
closes #3791 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
