### PR TITLE
chore(broker): removed raftSegmentSize from config

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -117,7 +117,7 @@ public final class AtomixFactory {
     final ByteValue maxMessageSize = networkCfg.getMaxMessageSize();
     partitionGroupBuilder.withMaxEntrySize((int) maxMessageSize.toBytes());
 
-    Optional.ofNullable(dataCfg.getRaftSegmentSize())
+    Optional.ofNullable(dataCfg.getLogSegmentSize())
         .map(ByteValue::new)
         .ifPresent(
             segmentSize -> {

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -10,7 +10,6 @@ package io.zeebe.broker.system.configuration;
 import io.zeebe.util.Environment;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 public final class DataCfg implements ConfigurationEntry {
   public static final String DEFAULT_DIRECTORY = "data";
@@ -22,14 +21,11 @@ public final class DataCfg implements ConfigurationEntry {
 
   private String snapshotPeriod = "15m";
 
-  private String raftSegmentSize;
-
   private int maxSnapshots = 3;
 
   @Override
   public void init(
       final BrokerCfg globalConfig, final String brokerBase, final Environment environment) {
-    raftSegmentSize = Optional.ofNullable(raftSegmentSize).orElse(logSegmentSize);
 
     applyEnvironment(environment);
     directories.replaceAll(d -> ConfigurationUtil.toAbsolutePath(d, brokerBase));
@@ -71,14 +67,6 @@ public final class DataCfg implements ConfigurationEntry {
     this.maxSnapshots = maxSnapshots;
   }
 
-  public String getRaftSegmentSize() {
-    return raftSegmentSize;
-  }
-
-  public void setRaftSegmentSize(final String raftSegmentSize) {
-    this.raftSegmentSize = raftSegmentSize;
-  }
-
   @Override
   public String toString() {
     return "DataCfg{"
@@ -89,9 +77,6 @@ public final class DataCfg implements ConfigurationEntry {
         + '\''
         + ", snapshotPeriod='"
         + snapshotPeriod
-        + '\''
-        + ", raftSegmentSize='"
-        + raftSegmentSize
         + '\''
         + ", maxSnapshots="
         + maxSnapshots

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
@@ -38,7 +38,7 @@ public final class RestoreTest {
           cfg -> {
             cfg.getData().setMaxSnapshots(1);
             cfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD_MIN + "m");
-            cfg.getData().setRaftSegmentSize(ByteValue.ofBytes(ATOMIX_SEGMENT_SIZE).toString());
+            cfg.getData().setLogSegmentSize(ByteValue.ofBytes(ATOMIX_SEGMENT_SIZE).toString());
             cfg.getNetwork().setMaxMessageSize(ByteValue.ofBytes(ATOMIX_SEGMENT_SIZE).toString());
           });
   private final GrpcClientRule clientRule =


### PR DESCRIPTION
## Description

Removed raftSegmentSize parameter from config. It was redundant to logSegmentSize. Changed callers of raftSegmentSize to use logSegmentSize instead. 

No additional tests because config mechanism is scheduled to change soon.

## Related issues
closes #3759

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
