### PR TITLE
feat(clients/java): removed setTimeout(long)

### DIFF
--- a/clients/java/ignored-changes.xml
+++ b/clients/java/ignored-changes.xml
@@ -9,4 +9,14 @@
     <method>java.lang.String getVersion()</method>
     <differenceType>7012</differenceType>
   </difference>
+  <difference>
+    <className>io/zeebe/client/api/command/ActivateJobsCommandStep1$ActivateJobsCommandStep3</className>
+    <method>io.zeebe.client.api.command.ActivateJobsCommandStep1$ActivateJobsCommandStep3 timeout(long)</method>
+    <differenceType>7002</differenceType>
+  </difference>
+  <difference>
+    <className>io/zeebe/client/impl/command/ActivateJobsCommandImpl</className>
+    <method>io.zeebe.client.api.command.ActivateJobsCommandStep1$ActivateJobsCommandStep3 timeout(long)</method>
+    <differenceType>7002</differenceType>
+  </difference>
 </differences>

--- a/clients/java/src/main/java/io/zeebe/client/api/command/ActivateJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/command/ActivateJobsCommandStep1.java
@@ -50,21 +50,6 @@ public interface ActivateJobsCommandStep1 {
      * subscription work on the job. When the time is over then the job can be assigned again by
      * this or other subscription if it's not completed yet.
      *
-     * <p>If no timeout is set, then the default is used from the configuration.
-     *
-     * @param timeout the time in milliseconds
-     * @return the builder for this command. Call {@link #send()} to complete the command and send
-     *     it to the broker.
-     */
-    ActivateJobsCommandStep3 timeout(long timeout);
-
-    /**
-     * Set the time for how long a job is exclusively assigned for this subscription.
-     *
-     * <p>In this time, the job can not be assigned by other subscriptions to ensure that only one
-     * subscription work on the job. When the time is over then the job can be assigned again by
-     * this or other subscription if it's not completed yet.
-     *
      * <p>If no time is set then the default is used from the configuration.
      *
      * @param timeout the time as duration (e.g. "Duration.ofMinutes(5)")

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/ActivateJobsCommandImpl.java
@@ -73,14 +73,9 @@ public final class ActivateJobsCommandImpl
   }
 
   @Override
-  public ActivateJobsCommandStep3 timeout(final long timeout) {
-    builder.setTimeout(timeout);
-    return this;
-  }
-
-  @Override
   public ActivateJobsCommandStep3 timeout(final Duration timeout) {
-    return timeout(timeout.toMillis());
+    builder.setTimeout(timeout.toMillis());
+    return this;
   }
 
   @Override

--- a/clients/java/src/test/java/io/zeebe/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/job/ActivateJobsTest.java
@@ -78,7 +78,7 @@ public final class ActivateJobsTest extends ClientTest {
             .newActivateJobsCommand()
             .jobType("foo")
             .maxJobsToActivate(3)
-            .timeout(1000)
+            .timeout(Duration.ofMillis(1000))
             .workerName("worker1")
             .send()
             .join();


### PR DESCRIPTION
## Description
BREAKING CHANGE:
Method was considered amibiguous as it was not clear in which time unit the timeout shall be specified.
Instead it was opted to only use the method setTimeout(Duration duration) instead.

## Related issues

closes #3049

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
