### PR TITLE
fix(clients/java): fix refresh condition

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/CredentialsProvider.java
+++ b/clients/java/src/main/java/io/zeebe/client/CredentialsProvider.java
@@ -18,6 +18,7 @@ package io.zeebe.client;
 import io.grpc.Metadata;
 import io.zeebe.client.impl.oauth.OAuthCredentialsProvider;
 import io.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import java.io.IOException;
 
 public interface CredentialsProvider {
 
@@ -27,7 +28,7 @@ public interface CredentialsProvider {
    *
    * @param headers gRPC headers to be modified
    */
-  void applyCredentials(Metadata headers);
+  void applyCredentials(Metadata headers) throws IOException;
 
   /**
    * Returns true if the request should be retried; otherwise returns false. For an example of this,

--- a/clients/java/src/main/java/io/zeebe/client/impl/oauth/OAuthCredentialsCache.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/oauth/OAuthCredentialsCache.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.zeebe.client.impl.ZeebeClientCredentials;
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
@@ -83,17 +82,13 @@ public final class OAuthCredentialsCache {
     return audiences.size();
   }
 
-  private void ensureCacheFileExists() {
+  private void ensureCacheFileExists() throws IOException {
     if (cacheFile.exists()) {
       return;
     }
 
-    try {
-      Files.createDirectories(cacheFile.getParentFile().toPath());
-      Files.createFile(cacheFile.toPath());
-    } catch (final IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    Files.createDirectories(cacheFile.getParentFile().toPath());
+    Files.createFile(cacheFile.toPath());
   }
 
   private static final class OAuthCachedCredentials {

--- a/clients/java/src/test/java/io/zeebe/client/OAuthCredentialsProviderTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/OAuthCredentialsProviderTest.java
@@ -36,6 +36,7 @@ import io.grpc.Metadata.Key;
 import io.grpc.ServerCall;
 import io.grpc.ServerInterceptors;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 import io.grpc.testing.GrpcServerRule;
 import io.zeebe.client.api.command.ClientException;
 import io.zeebe.client.impl.ZeebeClientBuilderImpl;
@@ -144,7 +145,9 @@ public final class OAuthCredentialsProviderTest {
               public void accept(final ServerCall call, final Metadata headers) {
                 mockCredentials(ACCESS_TOKEN);
                 recordingInterceptor.reset();
-                call.close(Status.UNAUTHENTICATED, headers);
+                call.close(
+                    Status.fromCode(Code.UNAUTHENTICATED).augmentDescription("Stale token"),
+                    headers);
               }
             });
 


### PR DESCRIPTION
## Description

The issue was that in the retry condition the error's status was being incorrectly compared to the source ~~UNAVAILABLE~~ UNAUTHENTICATED Status. The fix was to compare codes instead.
This PR also changes the exception handling so a failure when requesting/retrieving tokens now results in the request being immediately canceled (which makes failures faster/clearer).  

## Related issues

closes #3768

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
