### PR TITLE
chore(deps): tidy deps after Go updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,7 @@
     "config:base"
   ],
 
-  "ignoreDeps": ["docker/engine"]
+  "ignoreDeps": ["docker/engine"],
+
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
## Description

Configure Renovate to run `go mod tidy` after updating deps. This will update the go.sum so we do have to do it manually every time and also it will remove unnecessary dependencies.

## Related issues

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
