### PR TITLE
chore(broker): use correct fallback if no position available

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/logstreams/state/StatePositionSupplier.java
+++ b/broker/src/main/java/io/zeebe/broker/logstreams/state/StatePositionSupplier.java
@@ -30,40 +30,53 @@ public class StatePositionSupplier {
     long exportedPosition = -1;
 
     try (final var db = open(directory)) {
-      processedPosition = getLastProcessedPosition(db);
-      exportedPosition = getMinimumExportedPosition(db);
+      processedPosition = getLastProcessedPosition(directory, db);
+      exportedPosition = getMinimumExportedPosition(directory, db);
     } catch (final Exception e) {
       logger.error(
-          "Unexpected error occurred while obtaining the processed and exported position for partition {}",
-          partitionId,
+          "Unexpected error occurred while obtaining the processed and exported position from the snapshot {}",
+          directory,
           e);
     }
 
     return Math.min(processedPosition, exportedPosition);
   }
 
-  private long getMinimumExportedPosition(final ZeebeDb<ZbColumnFamilies> zeebeDb) {
+  public long getLastProcessedPosition(final Path directory) {
+    long processedPosition = -1;
+
+    try (final var db = open(directory)) {
+      processedPosition = getLastProcessedPosition(directory, db);
+    } catch (final Exception e) {
+      logger.error(
+          "Unexpected error occurred while obtaining the processed position from the given snapshot {}",
+          directory,
+          e);
+    }
+
+    return processedPosition;
+  }
+
+  private long getMinimumExportedPosition(
+      final Path directory, final ZeebeDb<ZbColumnFamilies> zeebeDb) {
     final ExportersState exporterState = new ExportersState(zeebeDb, zeebeDb.createContext());
 
     if (exporterState.hasExporters()) {
       final long lowestPosition = exporterState.getLowestPosition();
-
-      logger.debug(
-          "The lowest exported position for partition {} is {}", partitionId, lowestPosition);
+      logger.debug("The lowest exported position for snapshot {} is {}", directory, lowestPosition);
 
       return lowestPosition;
     } else {
-      logger.debug("No exporters present in snapshot for partition {}", partitionId);
+      logger.debug("No exporters present in snapshot {}", directory);
       return Long.MAX_VALUE;
     }
   }
 
-  private long getLastProcessedPosition(final ZeebeDb<ZbColumnFamilies> zeebeDb) {
+  private long getLastProcessedPosition(
+      final Path directory, final ZeebeDb<ZbColumnFamilies> zeebeDb) {
     final ZeebeState processorState = new ZeebeState(partitionId, zeebeDb, zeebeDb.createContext());
     final long lowestPosition = processorState.getLastSuccessfulProcessedRecordPosition();
-
-    logger.debug("The last processed position for partition {} is {}", partitionId, lowestPosition);
-
+    logger.debug("The last processed position for snapshot {} is {}", directory, lowestPosition);
     return lowestPosition;
   }
 

--- a/broker/src/test/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshotStoreFactoryTest.java
+++ b/broker/src/test/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshotStoreFactoryTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.protocols.raft.storage.snapshot.Snapshot;
 import io.atomix.utils.time.WallClockTimestamp;
 import java.util.ArrayList;
+import org.agrona.IoUtil;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -55,9 +56,9 @@ public final class DbSnapshotStoreFactoryTest {
     final var directory =
         store
             .getPath()
-            .resolveSibling(DbSnapshotStoreFactory.PENDING_DIRECTORY)
+            .resolveSibling(DbSnapshotStoreFactory.SNAPSHOTS_DIRECTORY)
             .resolve(String.format("%d-1-1-1", index));
-    store.newPendingSnapshot(index, 1, WallClockTimestamp.from(1), directory).commit();
-    return store.getCurrentSnapshot();
+    IoUtil.ensureDirectoryExists(directory.toFile(), "snapshot directory " + index);
+    return store.newSnapshot(index, 1, WallClockTimestamp.from(1), directory);
   }
 }


### PR DESCRIPTION
## Description

In case of missing snapshot metadata when receiving a new snapshot, use the correct fallback of reading the latest processed position as the snapshot position, such that it is consistent with when we take one in `AsyncSnapshotDirector`. Previous usage was to pick the lowest position, which could be the exporter position; while not technically wrong (as both are acceptable lower bounds), we should keep it consistent.

## Related issues


## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
