### PR TITLE
feat(util): unify usage of implementation version

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -49,6 +49,7 @@ import io.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.zeebe.transport.ServerTransport;
 import io.zeebe.transport.TransportFactory;
 import io.zeebe.util.LogUtil;
+import io.zeebe.util.VersionUtil;
 import io.zeebe.util.exception.UncheckedExecutionException;
 import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.ActorControl;
@@ -65,18 +66,12 @@ import org.slf4j.Logger;
 public final class Broker implements AutoCloseable {
 
   public static final Logger LOG = Loggers.SYSTEM_LOGGER;
-  private static final String VERSION;
 
   private static final CollectorRegistry METRICS_REGISTRY = CollectorRegistry.defaultRegistry;
 
   static {
     // enable hotspot prometheus metric collection
     DefaultExports.initialize();
-  }
-
-  static {
-    final String version = Broker.class.getPackage().getImplementationVersion();
-    VERSION = version != null ? version : "development";
   }
 
   private final SystemContext brokerContext;
@@ -150,7 +145,7 @@ public final class Broker implements AutoCloseable {
             clusterCfg.getNodeId(), networkCfg.getCommandApi().getAdvertisedAddress().toString());
 
     if (LOG.isInfoEnabled()) {
-      LOG.info("Version: {}", VERSION);
+      LOG.info("Version: {}", VersionUtil.getVersion());
       LOG.info(
           "Starting broker {} with configuration {}", localBroker.getNodeId(), brokerCfg.toJson());
     }

--- a/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
@@ -18,6 +18,7 @@ import io.zeebe.broker.system.configuration.ClusterCfg;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.zeebe.util.LogUtil;
+import io.zeebe.util.VersionUtil;
 import io.zeebe.util.sched.Actor;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +46,7 @@ public final class TopologyManagerImpl extends Actor
         .setPartitionsCount(clusterCfg.getPartitionsCount())
         .setReplicationFactor(clusterCfg.getReplicationFactor());
 
-    final String version = getClass().getPackage().getImplementationVersion();
+    final String version = VersionUtil.getVersion();
     if (version != null && !version.isBlank()) {
       localBroker.setVersion(version);
     }

--- a/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
@@ -55,6 +55,7 @@ import io.zeebe.gateway.protocol.GatewayOuterClass.TopologyResponse;
 import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesResponse;
 import io.zeebe.msgpack.MsgpackPropertyException;
+import io.zeebe.util.VersionUtil;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -249,7 +250,7 @@ public final class EndpointManager extends GatewayGrpc.GatewayImplBase {
           .setPartitionsCount(topology.getPartitionsCount())
           .setReplicationFactor(topology.getReplicationFactor());
 
-      final String gatewayVersion = getClass().getPackage().getImplementationVersion();
+      final String gatewayVersion = VersionUtil.getVersion();
       if (gatewayVersion != null && !gatewayVersion.isBlank()) {
         topologyResponseBuilder.setGatewayVersion(gatewayVersion);
       }

--- a/gateway/src/main/java/io/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/zeebe/gateway/Gateway.java
@@ -19,6 +19,7 @@ import io.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.zeebe.gateway.impl.configuration.SecurityCfg;
 import io.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.zeebe.util.DurationUtil;
+import io.zeebe.util.VersionUtil;
 import io.zeebe.util.sched.ActorScheduler;
 import java.io.File;
 import java.io.IOException;
@@ -31,15 +32,9 @@ import me.dinowernli.grpc.prometheus.MonitoringServerInterceptor;
 import org.slf4j.Logger;
 
 public final class Gateway {
-  private static final String VERSION;
   private static final Logger LOG = Loggers.GATEWAY_LOGGER;
   private static final Function<GatewayCfg, ServerBuilder> DEFAULT_SERVER_BUILDER_FACTORY =
       cfg -> setNetworkConfig(cfg.getNetwork());
-
-  static {
-    final String version = Gateway.class.getPackage().getImplementationVersion();
-    VERSION = version != null ? version : "development";
-  }
 
   private final Function<GatewayCfg, ServerBuilder> serverBuilderFactory;
   private final Function<GatewayCfg, BrokerClient> brokerClientFactory;
@@ -88,7 +83,7 @@ public final class Gateway {
 
   public void start() throws IOException {
     if (LOG.isInfoEnabled()) {
-      LOG.info("Version: {}", VERSION);
+      LOG.info("Version: {}", VersionUtil.getVersion());
       LOG.info("Starting gateway with configuration {}", gatewayCfg.toJson());
     }
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -47,4 +47,12 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
 </project>

--- a/util/src/main/java/io/zeebe/util/VersionUtil.java
+++ b/util/src/main/java/io/zeebe/util/VersionUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.slf4j.Logger;
+
+public final class VersionUtil {
+
+  public static final Logger LOG = Loggers.FILE_LOGGER;
+
+  private static final String VERSION_PROPERTIES_PATH = "/version.properties";
+  private static final String VERSION_PROPERTY_NAME = "zeebe.version";
+  private static final String VERSION_DEV = "development";
+
+  private static String version;
+
+  public static String getVersion() {
+    if (version == null) {
+      // read version from file
+      try (InputStream versionFileStream =
+          VersionUtil.class.getResourceAsStream(VERSION_PROPERTIES_PATH)) {
+        final Properties props = new Properties();
+        props.load(versionFileStream);
+        version = props.getProperty(VERSION_PROPERTY_NAME);
+        if (version == null) {
+          LOG.warn("Version is not found in version file.");
+        }
+      } catch (IOException e) {
+        LOG.error(String.format("Can't read version file: %s", VERSION_PROPERTIES_PATH), e);
+      }
+      if (version == null) {
+        version = VersionUtil.class.getPackage().getImplementationVersion();
+      }
+      if (version == null) {
+        version = VERSION_DEV;
+      }
+    }
+    return version;
+  }
+}

--- a/util/src/main/resources/version.properties
+++ b/util/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+zeebe.version=${project.version}

--- a/util/src/test/java/io/zeebe/util/VersionUtilTest.java
+++ b/util/src/test/java/io/zeebe/util/VersionUtilTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public final class VersionUtilTest {
+
+  @Test
+  public void shouldGetTheVersionFromFile() {
+    final String version = VersionUtil.getVersion();
+    assertThat(version).isNotNull();
+  }
+}


### PR DESCRIPTION
## Description

* create new utility class VersionUtil to access version when needed
* read version from properties file (which is a filtered resource and is populatied from Maven project version)

## Related issues

closes #3793 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
