### PR TITLE
chore(clients/go): time out container wait strategy and output container logs

### DIFF
--- a/clients/go/internal/utils/test_utils.go
+++ b/clients/go/internal/utils/test_utils.go
@@ -25,6 +25,7 @@ import (
 
 const DefaultTestTimeout = 5 * time.Second
 const DefaultTestTimeoutInMs = int64(DefaultTestTimeout / time.Millisecond)
+const DefaultContainerWaitTimeout = 2 * time.Minute
 
 // RpcTestMsg implements the gomock.Matcher interface
 type RpcTestMsg struct {


### PR DESCRIPTION
## Description

- times out container start up and outputs container logs when it happens

## Related issues

closes #3641

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
