### PR TITLE
chore(gateway): prevent exceptions on already cancelled calls

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClient.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClient.java
@@ -25,8 +25,6 @@ public interface BrokerClient extends AutoCloseable {
       BrokerResponseConsumer<T> responseConsumer,
       Consumer<Throwable> throwableConsumer);
 
-  <T> ActorFuture<BrokerResponse<T>> sendRequest(BrokerRequest<T> request, Duration requestTimeout);
-
   <T> void sendRequest(
       BrokerRequest<T> request,
       BrokerResponseConsumer<T> responseConsumer,

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClientImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClientImpl.java
@@ -147,12 +147,6 @@ public final class BrokerClientImpl implements BrokerClient {
   }
 
   @Override
-  public <T> ActorFuture<BrokerResponse<T>> sendRequest(
-      final BrokerRequest<T> request, final Duration requestTimeout) {
-    return requestManager.sendRequest(request, requestTimeout);
-  }
-
-  @Override
   public <T> void sendRequest(
       final BrokerRequest<T> request,
       final BrokerResponseConsumer<T> responseConsumer,

--- a/gateway/src/main/java/io/zeebe/gateway/impl/job/LongPollingActivateJobsRequest.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/job/LongPollingActivateJobsRequest.java
@@ -54,7 +54,7 @@ public final class LongPollingActivateJobsRequest {
     this.responseObserver = responseObserver;
 
     if (responseObserver instanceof ServerCallStreamObserver) {
-      cancelCheck = () -> ((ServerCallStreamObserver) responseObserver).isCancelled();
+      cancelCheck = ((ServerCallStreamObserver) responseObserver)::isCancelled;
     }
     this.jobType = jobType;
     this.maxJobsToActivate = maxJobstoActivate;
@@ -63,7 +63,7 @@ public final class LongPollingActivateJobsRequest {
   }
 
   public void complete() {
-    if (isCompleted()) {
+    if (isCompleted() || isCanceled()) {
       return;
     }
     if (scheduledTimer != null) {
@@ -82,7 +82,7 @@ public final class LongPollingActivateJobsRequest {
   }
 
   public void onResponse(final ActivateJobsResponse grpcResponse) {
-    if (!isCompleted) {
+    if (!(isCompleted() || isCanceled())) {
       try {
         responseObserver.onNext(grpcResponse);
       } catch (final Exception e) {

--- a/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -70,12 +70,6 @@ public final class StubbedBrokerClient implements BrokerClient {
   }
 
   @Override
-  public <T> ActorFuture<BrokerResponse<T>> sendRequest(
-      final BrokerRequest<T> request, final Duration requestTimeout) {
-    throw new UnsupportedOperationException("not implemented");
-  }
-
-  @Override
   public <T> void sendRequest(
       final BrokerRequest<T> request,
       final BrokerResponseConsumer<T> responseConsumer,


### PR DESCRIPTION
## Description

- adds a check in the long polling request context to avoid completing cancelled requests
- prevents throwing an exception on cancelled calls and instead log it at TRACE level

## Related issues

closes #3767

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
