### PR TITLE
chore(logstreams): fix empty log detection

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
@@ -24,7 +24,18 @@ public final class AtomixLogStorageReader implements LogStorageReader {
 
   @Override
   public boolean isEmpty() {
-    return reader.isEmpty();
+    if (!reader.isEmpty()) {
+      // although seemingly inefficient, the log will contain mostly ZeebeEntry entries and a few
+      // InitialEntry, so this should be rather fast in practice
+      reader.reset();
+      while (reader.hasNext()) {
+        if (reader.next().type() == ZeebeEntry.class) {
+          return false;
+        }
+      }
+    }
+
+    return true;
   }
 
   @Override


### PR DESCRIPTION
## Description

- correctly detects if a log is empty by scanning for ZeebeEntry
- while slow in the worst case, in practice the log is almost entirely ZeebeEntry entries and should be fast enough

## Related issues

closes #3543

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
