### PR TITLE
chore(broker): remove atomix listeners on partition close

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -401,7 +401,6 @@ public final class ZeebePartition extends Actor
   }
 
   private CompletableActorFuture<Void> closePartition() {
-
     Collections.reverse(closeables);
     final var closeActorsFuture = new CompletableActorFuture<Void>();
     stepByStepClosing(closeActorsFuture, closeables);
@@ -554,6 +553,9 @@ public final class ZeebePartition extends Actor
             closePartition()
                 .onComplete(
                     (v, t) -> {
+                      atomixRaftPartition.removeRoleChangeListener(this);
+                      atomixRaftPartition.getServer().removeCommitListener(this);
+
                       final ActorFuture<Void> logStreamCloseFuture = logStream.closeAsync();
                       if (t == null) {
                         logStreamCloseFuture.onComplete(closeFuture);


### PR DESCRIPTION
## Description

There was a race condition where, on closing the `ZeebePartition`, we might receive a role transition event and attempt to transition to the Role. Transitioning to a new role means scheduling the transition on the actor scheduler, so this was only an issue if the transition occurred between closing and before the actor was closed. While I don't think it is currently a major problem (the way the code is), it could become one, and it anyways pepper the logs with uncaught exceptions (on top of being completely unexpected).

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
