### PR TITLE
feat(clients/java): new response objects for java client API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,9 +6,6 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.java]
-indent_size = 2
-
 [*.xml]
 indent_size = 2
 

--- a/clients/java/ignored-changes.xml
+++ b/clients/java/ignored-changes.xml
@@ -1,0 +1,6 @@
+<differences>
+  <difference>
+    <className>io/zeebe/client/api/response/JobEvent</className>
+    <differenceType>8001</differenceType>
+  </difference>
+</differences>

--- a/clients/java/src/main/java/io/zeebe/client/api/command/CancelWorkflowInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/command/CancelWorkflowInstanceCommandStep1.java
@@ -15,7 +15,10 @@
  */
 package io.zeebe.client.api.command;
 
-public interface CancelWorkflowInstanceCommandStep1 extends FinalCommandStep<Void> {
+import io.zeebe.client.api.response.CancelWorkflowInstanceResponse;
+
+public interface CancelWorkflowInstanceCommandStep1
+    extends FinalCommandStep<CancelWorkflowInstanceResponse> {
   // the place for new optional parameters
 
 }

--- a/clients/java/src/main/java/io/zeebe/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/command/CompleteJobCommandStep1.java
@@ -15,10 +15,11 @@
  */
 package io.zeebe.client.api.command;
 
+import io.zeebe.client.api.response.CompleteJobResponse;
 import java.io.InputStream;
 import java.util.Map;
 
-public interface CompleteJobCommandStep1 extends FinalCommandStep<Void> {
+public interface CompleteJobCommandStep1 extends FinalCommandStep<CompleteJobResponse> {
 
   /**
    * Set the variables to complete the job with.

--- a/clients/java/src/main/java/io/zeebe/client/api/command/FailJobCommandStep1.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/command/FailJobCommandStep1.java
@@ -15,6 +15,8 @@
  */
 package io.zeebe.client.api.command;
 
+import io.zeebe.client.api.response.FailJobResponse;
+
 public interface FailJobCommandStep1 {
 
   /**
@@ -29,7 +31,7 @@ public interface FailJobCommandStep1 {
    */
   FailJobCommandStep2 retries(int remainingRetries);
 
-  interface FailJobCommandStep2 extends FinalCommandStep<Void> {
+  interface FailJobCommandStep2 extends FinalCommandStep<FailJobResponse> {
     // the place for new optional parameters
 
     /**

--- a/clients/java/src/main/java/io/zeebe/client/api/command/PublishMessageCommandStep1.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/command/PublishMessageCommandStep1.java
@@ -15,6 +15,7 @@
  */
 package io.zeebe.client.api.command;
 
+import io.zeebe.client.api.response.PublishMessageResponse;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Map;
@@ -42,7 +43,7 @@ public interface PublishMessageCommandStep1 {
     PublishMessageCommandStep3 correlationKey(String correlationKey);
   }
 
-  interface PublishMessageCommandStep3 extends FinalCommandStep<Void> {
+  interface PublishMessageCommandStep3 extends FinalCommandStep<PublishMessageResponse> {
     /**
      * Set the id of the message. The message is rejected if another message is already published
      * with the same id, name and correlation-key.

--- a/clients/java/src/main/java/io/zeebe/client/api/command/UpdateRetriesJobCommandStep1.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/command/UpdateRetriesJobCommandStep1.java
@@ -15,6 +15,8 @@
  */
 package io.zeebe.client.api.command;
 
+import io.zeebe.client.api.response.UpdateRetriesJobResponse;
+
 public interface UpdateRetriesJobCommandStep1 {
   /**
    * Set the retries of this job.
@@ -28,7 +30,7 @@ public interface UpdateRetriesJobCommandStep1 {
    */
   UpdateRetriesJobCommandStep2 retries(int retries);
 
-  interface UpdateRetriesJobCommandStep2 extends FinalCommandStep<Void> {
+  interface UpdateRetriesJobCommandStep2 extends FinalCommandStep<UpdateRetriesJobResponse> {
     // the place for new optional parameters
   }
 }

--- a/clients/java/src/main/java/io/zeebe/client/api/response/CancelWorkflowInstanceResponse.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/response/CancelWorkflowInstanceResponse.java
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.client.api.command;
+package io.zeebe.client.api.response;
 
-import io.zeebe.client.api.response.ResolveIncidentResponse;
-
-public interface ResolveIncidentCommandStep1 extends FinalCommandStep<ResolveIncidentResponse> {
-  // the place for new optional parameters
-}
+public interface CancelWorkflowInstanceResponse {}

--- a/clients/java/src/main/java/io/zeebe/client/api/response/CompleteJobResponse.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/response/CompleteJobResponse.java
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.client.api.command;
+package io.zeebe.client.api.response;
 
-import io.zeebe.client.api.response.ResolveIncidentResponse;
-
-public interface ResolveIncidentCommandStep1 extends FinalCommandStep<ResolveIncidentResponse> {
-  // the place for new optional parameters
-}
+public interface CompleteJobResponse {}

--- a/clients/java/src/main/java/io/zeebe/client/api/response/FailJobResponse.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/response/FailJobResponse.java
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.client.api.command;
+package io.zeebe.client.api.response;
 
-import io.zeebe.client.api.response.ResolveIncidentResponse;
-
-public interface ResolveIncidentCommandStep1 extends FinalCommandStep<ResolveIncidentResponse> {
-  // the place for new optional parameters
-}
+public interface FailJobResponse {}

--- a/clients/java/src/main/java/io/zeebe/client/api/response/PublishMessageResponse.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/response/PublishMessageResponse.java
@@ -15,7 +15,4 @@
  */
 package io.zeebe.client.api.response;
 
-public interface JobEvent {
-  /** Unique key of the created job on the partition */
-  long getKey();
-}
+public interface PublishMessageResponse {}

--- a/clients/java/src/main/java/io/zeebe/client/api/response/ResolveIncidentResponse.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/response/ResolveIncidentResponse.java
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.client.api.command;
+package io.zeebe.client.api.response;
 
-import io.zeebe.client.api.response.ResolveIncidentResponse;
-
-public interface ResolveIncidentCommandStep1 extends FinalCommandStep<ResolveIncidentResponse> {
-  // the place for new optional parameters
-}
+public interface ResolveIncidentResponse {}

--- a/clients/java/src/main/java/io/zeebe/client/api/response/UpdateRetriesJobResponse.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/response/UpdateRetriesJobResponse.java
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.client.api.command;
+package io.zeebe.client.api.response;
 
-import io.zeebe.client.api.response.ResolveIncidentResponse;
-
-public interface ResolveIncidentCommandStep1 extends FinalCommandStep<ResolveIncidentResponse> {
-  // the place for new optional parameters
-}
+public interface UpdateRetriesJobResponse {}

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/CancelWorkflowInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/CancelWorkflowInstanceCommandImpl.java
@@ -19,11 +19,12 @@ import io.grpc.stub.StreamObserver;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.CancelWorkflowInstanceCommandStep1;
 import io.zeebe.client.api.command.FinalCommandStep;
+import io.zeebe.client.api.response.CancelWorkflowInstanceResponse;
 import io.zeebe.client.impl.RetriableClientFutureImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.zeebe.gateway.protocol.GatewayOuterClass;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CancelWorkflowInstanceRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CancelWorkflowInstanceRequest.Builder;
-import io.zeebe.gateway.protocol.GatewayOuterClass.CancelWorkflowInstanceResponse;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -48,18 +49,21 @@ public final class CancelWorkflowInstanceCommandImpl implements CancelWorkflowIn
   }
 
   @Override
-  public FinalCommandStep<Void> requestTimeout(final Duration requestTimeout) {
+  public FinalCommandStep<CancelWorkflowInstanceResponse> requestTimeout(
+      final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
     return this;
   }
 
   @Override
-  public ZeebeFuture<Void> send() {
+  public ZeebeFuture<CancelWorkflowInstanceResponse> send() {
     final CancelWorkflowInstanceRequest request = builder.build();
 
-    final RetriableClientFutureImpl<Void, CancelWorkflowInstanceResponse> future =
-        new RetriableClientFutureImpl<>(
-            retryPredicate, streamObserver -> send(request, streamObserver));
+    final RetriableClientFutureImpl<
+            CancelWorkflowInstanceResponse, GatewayOuterClass.CancelWorkflowInstanceResponse>
+        future =
+            new RetriableClientFutureImpl<>(
+                retryPredicate, streamObserver -> send(request, streamObserver));
 
     send(request, future);
     return future;
@@ -67,7 +71,7 @@ public final class CancelWorkflowInstanceCommandImpl implements CancelWorkflowIn
 
   private void send(
       final CancelWorkflowInstanceRequest request,
-      final StreamObserver<CancelWorkflowInstanceResponse> future) {
+      final StreamObserver<GatewayOuterClass.CancelWorkflowInstanceResponse> future) {
     asyncStub
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .cancelWorkflowInstance(request, future);

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/CompleteJobCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/CompleteJobCommandImpl.java
@@ -19,12 +19,13 @@ import io.grpc.stub.StreamObserver;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.zeebe.client.api.command.FinalCommandStep;
+import io.zeebe.client.api.response.CompleteJobResponse;
 import io.zeebe.client.impl.RetriableClientFutureImpl;
 import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.zeebe.gateway.protocol.GatewayOuterClass;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest.Builder;
-import io.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobResponse;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -52,25 +53,27 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   }
 
   @Override
-  public FinalCommandStep<Void> requestTimeout(final Duration requestTimeout) {
+  public FinalCommandStep<CompleteJobResponse> requestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
     return this;
   }
 
   @Override
-  public ZeebeFuture<Void> send() {
+  public ZeebeFuture<CompleteJobResponse> send() {
     final CompleteJobRequest request = builder.build();
 
-    final RetriableClientFutureImpl<Void, CompleteJobResponse> future =
-        new RetriableClientFutureImpl<>(
-            retryPredicate, streamObserver -> send(request, streamObserver));
+    final RetriableClientFutureImpl<CompleteJobResponse, GatewayOuterClass.CompleteJobResponse>
+        future =
+            new RetriableClientFutureImpl<>(
+                retryPredicate, streamObserver -> send(request, streamObserver));
 
     send(request, future);
     return future;
   }
 
   private void send(
-      final CompleteJobRequest request, final StreamObserver<CompleteJobResponse> streamObserver) {
+      final CompleteJobRequest request,
+      final StreamObserver<GatewayOuterClass.CompleteJobResponse> streamObserver) {
     asyncStub
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .completeJob(request, streamObserver);

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/CreateWorkflowInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/CreateWorkflowInstanceCommandImpl.java
@@ -26,9 +26,9 @@ import io.zeebe.client.impl.RetriableClientFutureImpl;
 import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.client.impl.response.CreateWorkflowInstanceResponseImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.zeebe.gateway.protocol.GatewayOuterClass;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CreateWorkflowInstanceRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CreateWorkflowInstanceRequest.Builder;
-import io.zeebe.gateway.protocol.GatewayOuterClass.CreateWorkflowInstanceResponse;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Map;
@@ -121,11 +121,13 @@ public final class CreateWorkflowInstanceCommandImpl
   public ZeebeFuture<WorkflowInstanceEvent> send() {
     final CreateWorkflowInstanceRequest request = builder.build();
 
-    final RetriableClientFutureImpl<WorkflowInstanceEvent, CreateWorkflowInstanceResponse> future =
-        new RetriableClientFutureImpl<>(
-            CreateWorkflowInstanceResponseImpl::new,
-            retryPredicate,
-            streamObserver -> send(request, streamObserver));
+    final RetriableClientFutureImpl<
+            WorkflowInstanceEvent, GatewayOuterClass.CreateWorkflowInstanceResponse>
+        future =
+            new RetriableClientFutureImpl<>(
+                CreateWorkflowInstanceResponseImpl::new,
+                retryPredicate,
+                streamObserver -> send(request, streamObserver));
 
     send(request, future);
     return future;
@@ -133,7 +135,7 @@ public final class CreateWorkflowInstanceCommandImpl
 
   private void send(
       final CreateWorkflowInstanceRequest request,
-      final StreamObserver<CreateWorkflowInstanceResponse> future) {
+      final StreamObserver<GatewayOuterClass.CreateWorkflowInstanceResponse> future) {
     asyncStub
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .createWorkflowInstance(request, future);

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/CreateWorkflowInstanceWithResultCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/CreateWorkflowInstanceWithResultCommandImpl.java
@@ -24,10 +24,10 @@ import io.zeebe.client.impl.RetriableClientFutureImpl;
 import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.client.impl.response.CreateWorkflowInstanceWithResultResponseImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.zeebe.gateway.protocol.GatewayOuterClass;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CreateWorkflowInstanceRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CreateWorkflowInstanceWithResultRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CreateWorkflowInstanceWithResultRequest.Builder;
-import io.zeebe.gateway.protocol.GatewayOuterClass.CreateWorkflowInstanceWithResultResponse;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -75,7 +75,7 @@ public final class CreateWorkflowInstanceWithResultCommandImpl
             .build();
 
     final RetriableClientFutureImpl<
-            WorkflowInstanceResult, CreateWorkflowInstanceWithResultResponse>
+            WorkflowInstanceResult, GatewayOuterClass.CreateWorkflowInstanceWithResultResponse>
         future =
             new RetriableClientFutureImpl<>(
                 response ->
@@ -89,7 +89,7 @@ public final class CreateWorkflowInstanceWithResultCommandImpl
 
   private void send(
       final CreateWorkflowInstanceWithResultRequest request,
-      final StreamObserver<CreateWorkflowInstanceWithResultResponse> future) {
+      final StreamObserver<GatewayOuterClass.CreateWorkflowInstanceWithResultResponse> future) {
     asyncStub
         .withDeadlineAfter(requestTimeout.plus(DEADLINE_OFFSET).toMillis(), TimeUnit.MILLISECONDS)
         .createWorkflowInstanceWithResult(request, future);

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/DeployWorkflowCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/DeployWorkflowCommandImpl.java
@@ -29,8 +29,8 @@ import io.zeebe.client.api.response.DeploymentEvent;
 import io.zeebe.client.impl.RetriableClientFutureImpl;
 import io.zeebe.client.impl.response.DeploymentEventImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.zeebe.gateway.protocol.GatewayOuterClass;
 import io.zeebe.gateway.protocol.GatewayOuterClass.DeployWorkflowRequest;
-import io.zeebe.gateway.protocol.GatewayOuterClass.DeployWorkflowResponse;
 import io.zeebe.gateway.protocol.GatewayOuterClass.WorkflowRequestObject;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
@@ -156,11 +156,12 @@ public final class DeployWorkflowCommandImpl
   public ZeebeFuture<DeploymentEvent> send() {
     final DeployWorkflowRequest request = requestBuilder.build();
 
-    final RetriableClientFutureImpl<DeploymentEvent, DeployWorkflowResponse> future =
-        new RetriableClientFutureImpl<>(
-            DeploymentEventImpl::new,
-            retryPredicate,
-            streamObserver -> send(request, streamObserver));
+    final RetriableClientFutureImpl<DeploymentEvent, GatewayOuterClass.DeployWorkflowResponse>
+        future =
+            new RetriableClientFutureImpl<>(
+                DeploymentEventImpl::new,
+                retryPredicate,
+                streamObserver -> send(request, streamObserver));
 
     send(request, future);
 

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/FailJobCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/FailJobCommandImpl.java
@@ -20,11 +20,12 @@ import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.FailJobCommandStep1;
 import io.zeebe.client.api.command.FailJobCommandStep1.FailJobCommandStep2;
 import io.zeebe.client.api.command.FinalCommandStep;
+import io.zeebe.client.api.response.FailJobResponse;
 import io.zeebe.client.impl.RetriableClientFutureImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.zeebe.gateway.protocol.GatewayOuterClass;
 import io.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest.Builder;
-import io.zeebe.gateway.protocol.GatewayOuterClass.FailJobResponse;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -61,16 +62,16 @@ public final class FailJobCommandImpl implements FailJobCommandStep1, FailJobCom
   }
 
   @Override
-  public FinalCommandStep<Void> requestTimeout(final Duration requestTimeout) {
+  public FinalCommandStep<FailJobResponse> requestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
     return this;
   }
 
   @Override
-  public ZeebeFuture<Void> send() {
+  public ZeebeFuture<FailJobResponse> send() {
     final FailJobRequest request = builder.build();
 
-    final RetriableClientFutureImpl<Void, FailJobResponse> future =
+    final RetriableClientFutureImpl<FailJobResponse, GatewayOuterClass.FailJobResponse> future =
         new RetriableClientFutureImpl<>(
             retryPredicate, streamObserver -> send(request, streamObserver));
 
@@ -79,7 +80,8 @@ public final class FailJobCommandImpl implements FailJobCommandStep1, FailJobCom
   }
 
   private void send(
-      final FailJobRequest request, final StreamObserver<FailJobResponse> streamObserver) {
+      final FailJobRequest request,
+      final StreamObserver<GatewayOuterClass.FailJobResponse> streamObserver) {
     asyncStub
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .failJob(request, streamObserver);

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/JobUpdateRetriesCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/JobUpdateRetriesCommandImpl.java
@@ -20,11 +20,12 @@ import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.FinalCommandStep;
 import io.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
 import io.zeebe.client.api.command.UpdateRetriesJobCommandStep1.UpdateRetriesJobCommandStep2;
+import io.zeebe.client.api.response.UpdateRetriesJobResponse;
 import io.zeebe.client.impl.RetriableClientFutureImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.zeebe.gateway.protocol.GatewayOuterClass;
 import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest.Builder;
-import io.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesResponse;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -56,18 +57,20 @@ public final class JobUpdateRetriesCommandImpl
   }
 
   @Override
-  public FinalCommandStep<Void> requestTimeout(final Duration requestTimeout) {
+  public FinalCommandStep<UpdateRetriesJobResponse> requestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
     return this;
   }
 
   @Override
-  public ZeebeFuture<Void> send() {
+  public ZeebeFuture<UpdateRetriesJobResponse> send() {
     final UpdateJobRetriesRequest request = builder.build();
 
-    final RetriableClientFutureImpl<Void, UpdateJobRetriesResponse> future =
-        new RetriableClientFutureImpl<>(
-            retryPredicate, streamObserver -> send(request, streamObserver));
+    final RetriableClientFutureImpl<
+            UpdateRetriesJobResponse, GatewayOuterClass.UpdateJobRetriesResponse>
+        future =
+            new RetriableClientFutureImpl<>(
+                retryPredicate, streamObserver -> send(request, streamObserver));
 
     send(request, future);
     return future;
@@ -75,7 +78,7 @@ public final class JobUpdateRetriesCommandImpl
 
   private void send(
       final UpdateJobRetriesRequest request,
-      final StreamObserver<UpdateJobRetriesResponse> streamObserver) {
+      final StreamObserver<GatewayOuterClass.UpdateJobRetriesResponse> streamObserver) {
     asyncStub
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .updateJobRetries(request, streamObserver);

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/ResolveIncidentCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/ResolveIncidentCommandImpl.java
@@ -19,11 +19,12 @@ import io.grpc.stub.StreamObserver;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.FinalCommandStep;
 import io.zeebe.client.api.command.ResolveIncidentCommandStep1;
+import io.zeebe.client.api.response.ResolveIncidentResponse;
 import io.zeebe.client.impl.RetriableClientFutureImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.zeebe.gateway.protocol.GatewayOuterClass;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ResolveIncidentRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ResolveIncidentRequest.Builder;
-import io.zeebe.gateway.protocol.GatewayOuterClass.ResolveIncidentResponse;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -47,18 +48,20 @@ public final class ResolveIncidentCommandImpl implements ResolveIncidentCommandS
   }
 
   @Override
-  public FinalCommandStep<Void> requestTimeout(final Duration requestTimeout) {
+  public FinalCommandStep<ResolveIncidentResponse> requestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
     return this;
   }
 
   @Override
-  public ZeebeFuture<Void> send() {
+  public ZeebeFuture<ResolveIncidentResponse> send() {
     final ResolveIncidentRequest request = builder.build();
 
-    final RetriableClientFutureImpl<Void, ResolveIncidentResponse> future =
-        new RetriableClientFutureImpl<>(
-            retryPredicate, streamObserver -> send(request, streamObserver));
+    final RetriableClientFutureImpl<
+            ResolveIncidentResponse, GatewayOuterClass.ResolveIncidentResponse>
+        future =
+            new RetriableClientFutureImpl<>(
+                retryPredicate, streamObserver -> send(request, streamObserver));
 
     send(request, future);
     return future;
@@ -66,7 +69,7 @@ public final class ResolveIncidentCommandImpl implements ResolveIncidentCommandS
 
   private void send(
       final ResolveIncidentRequest request,
-      final StreamObserver<ResolveIncidentResponse> streamObserver) {
+      final StreamObserver<GatewayOuterClass.ResolveIncidentResponse> streamObserver) {
     asyncStub
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .resolveIncident(request, streamObserver);

--- a/docs/src/clients/java-client/testing.md
+++ b/docs/src/clients/java-client/testing.md
@@ -39,8 +39,8 @@ public class MyTest {
         .newDeployCommand()
         .addResourceFromClasspath("process.bpmn")
         .send()
-        .join();  	
-  
+        .join();
+
     final WorkflowInstanceEvent workflowInstance =
         client
             .newCreateInstanceCommand()
@@ -54,7 +54,7 @@ public class MyTest {
 
 ## Verify the Result
 
-The `ZeebeTestRule` provides also some basic assertions in AssertJ style. The entry point of the assertions is `ZeebeTestRule.assertThat(...)`. 
+The `ZeebeTestRule` provides also some basic assertions in AssertJ style. The entry point of the assertions is `ZeebeTestRule.assertThat(...)`.
 
 ```java
 final WorkflowInstanceEvent workflowInstance = ...

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/MessageCorrelationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/MessageCorrelationTest.java
@@ -15,6 +15,7 @@ import io.zeebe.broker.it.util.GrpcClientRule;
 import io.zeebe.broker.test.EmbeddedBrokerRule;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.ClientException;
+import io.zeebe.client.api.response.PublishMessageResponse;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.protocol.record.Assertions;
 import io.zeebe.protocol.record.Record;
@@ -155,7 +156,7 @@ public final class MessageCorrelationTest {
         .join();
 
     // when
-    final ZeebeFuture<Void> future =
+    final ZeebeFuture<PublishMessageResponse> future =
         CLIENT_RULE
             .getClient()
             .newPublishMessageCommand()

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRestartTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRestartTest.java
@@ -13,6 +13,7 @@ import io.zeebe.broker.PartitionListener;
 import io.zeebe.broker.it.util.GrpcClientRule;
 import io.zeebe.broker.test.EmbeddedBrokerRule;
 import io.zeebe.client.api.ZeebeFuture;
+import io.zeebe.client.api.response.PublishMessageResponse;
 import io.zeebe.logstreams.log.LogStream;
 import java.time.Duration;
 import org.junit.Rule;
@@ -57,7 +58,7 @@ public class BrokerRestartTest {
     publishMessage(2).join();
   }
 
-  private ZeebeFuture<Void> publishMessage(final int key) {
+  private ZeebeFuture<PublishMessageResponse> publishMessage(final int key) {
     return clientRule
         .getClient()
         .newPublishMessageCommand()

--- a/test/README.md
+++ b/test/README.md
@@ -20,7 +20,7 @@ Add `zeebe-test` as test dependency to your project.
 </dependencyManagement>
 
 <dependencies>
-  
+
   <dependency>
     <groupId>io.zeebe</groupId>
     <artifactId>zeebe-client-java</artifactId>
@@ -31,7 +31,7 @@ Add `zeebe-test` as test dependency to your project.
     <artifactId>zeebe-test</artifactId>
     <scope>test</scope>
   </dependency>
-  
+
 </dependencies>
 ```
 


### PR DESCRIPTION
## Description
Introduced response objects for all commands in the java API client. The response objects replace the `Void` response in the existing interface. The purpose of this is to have placeholder empty responses now, which we could extend with fields in the future, if needed. 

Extending the response objects with new fields will not be a breaking change. Keeping the `Void` response type and introducing response types later would be a breaking change.

Note that this also led to renaming of existing response types. In particular responses of the pattern `*Event` were renamed to `*Response` and their naming was aligned with the name of the command.

Note that there are remaining inconsistencies in the naming. It was decided that these should be dealt with in a new issue: #3819

## Related issues
closes #3755 

## Pull Request Checklist
- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing