### PR TITLE
Use different tool to convert Go test output to XML

### DIFF
--- a/.ci/scripts/distribution/build-go.sh
+++ b/.ci/scripts/distribution/build-go.sh
@@ -8,8 +8,6 @@ ORG_DIR=${GOPATH}/src/github.com/zeebe-io
 mkdir -p ${ORG_DIR}
 ln -s ${PWD} ${ORG_DIR}/zeebe
 
-go get -u github.com/jstemmer/go-junit-report
-
 cd ${ORG_DIR}/zeebe/clients/go
 
 PREFIX=github.com/zeebe-io/zeebe/clients/go

--- a/.ci/scripts/distribution/prepare-go.sh
+++ b/.ci/scripts/distribution/prepare-go.sh
@@ -1,8 +1,10 @@
 #!/bin/sh -eux
 
 GOCOMPAT_VERSION="v0.2.0"
+GOTESTSUM_VERSION="0.4.0"
 
 curl -sL https://github.com/smola/gocompat/releases/download/${GOCOMPAT_VERSION}/gocompat_linux_amd64.tar.gz | tar xzvf - -C /usr/bin gocompat_linux_amd64
 
 mv /usr/bin/gocompat_linux_amd64 /usr/bin/gocompat
 
+curl -sL https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz | tar xfzv - -C /usr/bin gotestsum

--- a/.ci/scripts/distribution/test-go.sh
+++ b/.ci/scripts/distribution/test-go.sh
@@ -2,4 +2,5 @@
 ORG_DIR=${GOPATH}/src/github.com/zeebe-io
 
 cd ${ORG_DIR}/zeebe/clients/go
-go test -mod=vendor -v ./...  2>&1 | go-junit-report > TEST-go.xml
+
+gotestsum --raw-command --junitfile TEST-go.xml go test -mod=vendor -v -json ./... 2>&1

--- a/clients/go/internal/containersuite/containerSuite.go
+++ b/clients/go/internal/containersuite/containerSuite.go
@@ -77,6 +77,8 @@ func (s zeebeWaitStrategy) WaitUntilReady(ctx context.Context, target wait.Strat
 		if err != nil {
 			return fmt.Errorf("timed out awaiting container, and failed to obtain container logs: %w", err)
 		}
+
+		defer reader.Close()
 		if bytes, err := ioutil.ReadAll(reader); err == nil {
 			_, _ = fmt.Fprintln(os.Stderr, "=====================================")
 			_, _ = fmt.Fprintln(os.Stderr, "Container logs")

--- a/clients/go/internal/containersuite/containerSuite.go
+++ b/clients/go/internal/containersuite/containerSuite.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/status"
 	"io/ioutil"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -83,13 +84,31 @@ func (s zeebeWaitStrategy) WaitUntilReady(ctx context.Context, target wait.Strat
 			_, _ = fmt.Fprintln(os.Stderr, "=====================================")
 			_, _ = fmt.Fprintln(os.Stderr, "Container logs")
 			_, _ = fmt.Fprintln(os.Stderr, "=====================================")
-			_, _ = fmt.Fprintf(os.Stderr, "%s", bytes)
+			_, _ = fmt.Fprint(os.Stderr, sanitizeDockerLogs(string(bytes)))
 
 			return errors.New("timed out awaiting container")
 		}
 
 		return fmt.Errorf("timed out awaiting container, but failed to read container logs: %w", err)
 	}
+}
+
+// remove the message header (8 bytes) from the docker logs
+// https://docs.docker.com/engine/api/v1.26/#operation/ContainerAttach
+func sanitizeDockerLogs(log string) string {
+	lines := strings.Split(log, "\n")
+	builder := strings.Builder{}
+
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+
+		builder.WriteString(line[8:])
+		builder.WriteString("\n")
+	}
+
+	return builder.String()
 }
 
 func (s zeebeWaitStrategy) waitForTopology(zbClient zbc.Client) error {
@@ -126,7 +145,6 @@ type ContainerSuite struct {
 	WaitTime time.Duration
 	// ContainerImage is the ID of docker image to be used
 	ContainerImage string
-
 	// GatewayAddress is the contact point of the spawned Zeebe container specified in the format 'host:port'
 	GatewayAddress string
 


### PR DESCRIPTION
## Description

Drops `go-junit-report` in favor of `gotestsum`. This should improve the output of failed tests in the CI (the previous tool often mangled error output and made it impossible to understand errors that sometimes can't be reproduced locally).
This PR also sanitizes the Docker logs since they were being printed with a message header that looked like garbage in test failures.

## Related issues


closes #3807

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
