### PR TITLE
chore(clients/go): output container logs on failure

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/root.go
+++ b/clients/go/cmd/zbctl/internal/commands/root.go
@@ -54,6 +54,13 @@ It is designed for regular maintenance jobs such as:
 	* activating, completing or failing jobs
 	* update variables and retries
 	* view cluster status`,
+	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		if client != nil {
+			return client.Close()
+		}
+
+		return nil
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
## Description

- outputs container logs on failure to help with diagnostics
- increase zbctl command timeout to 5 seconds

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
