### PR TITLE
3836, 3837, 3838 - several minor refactorings

### DIFF
--- a/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.0. You may not use this file
  * except in compliance with the Zeebe Community License 1.0.
  */
-package io.zeebe.broker.system;
+package io.zeebe.broker.system.configuration;
 
 import static io.zeebe.broker.system.configuration.ClusterCfg.DEFAULT_CLUSTER_SIZE;
 import static io.zeebe.broker.system.configuration.ClusterCfg.DEFAULT_CONTACT_POINTS;
@@ -34,14 +34,7 @@ import static io.zeebe.protocol.Protocol.START_PARTITION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.zeebe.broker.exporter.debug.DebugLogExporter;
-import io.zeebe.broker.system.configuration.BackpressureCfg;
 import io.zeebe.broker.system.configuration.BackpressureCfg.LimitAlgorithm;
-import io.zeebe.broker.system.configuration.BrokerCfg;
-import io.zeebe.broker.system.configuration.ClusterCfg;
-import io.zeebe.broker.system.configuration.DataCfg;
-import io.zeebe.broker.system.configuration.EmbeddedGatewayCfg;
-import io.zeebe.broker.system.configuration.ExporterCfg;
-import io.zeebe.broker.system.configuration.NetworkCfg;
 import io.zeebe.util.Environment;
 import io.zeebe.util.TomlConfigurationReader;
 import java.io.ByteArrayInputStream;
@@ -58,7 +51,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public final class ConfigurationTest {
+public final class BrokerCfgTest {
 
   public static final String BROKER_BASE = "test";
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -497,7 +490,7 @@ public final class ConfigurationTest {
 
   private BrokerCfg readConfig(final String name) {
     final String configPath = "/system/" + name + ".toml";
-    final InputStream resourceAsStream = ConfigurationTest.class.getResourceAsStream(configPath);
+    final InputStream resourceAsStream = BrokerCfgTest.class.getResourceAsStream(configPath);
     assertThat(resourceAsStream)
         .withFailMessage("Unable to read configuration file %s", configPath)
         .isNotNull();

--- a/dist/src/main/config/gateway.cfg.toml
+++ b/dist/src/main/config/gateway.cfg.toml
@@ -74,11 +74,6 @@
 # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_MAX_MESSAGE_SIZE.
 # maxMessageSize = "4M"
 
-# Sets the maximum number of the incoming and outgoing messages (i.e. commands and events) with
-# the maximum size which can be buffered.
-# This setting can also be overridden using the environment variable ZEEBE_GATEWAY_MAX_MESSAGE_COUNT.
-# maxMessageCount = 16
-
 [threads]
 # Sets the number of threads the gateway will use to communicate with the broker cluster
 # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_MANAGEMENT_THREADS.

--- a/dist/src/main/config/zeebe.cfg.toml
+++ b/dist/src/main/config/zeebe.cfg.toml
@@ -62,10 +62,6 @@
 # minKeepAliveInterval = "30s"
 
 [gateway.cluster]
-# Sets the broker the gateway should initial contact.
-# This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CONTACT_POINT.
-# contactPoint = "127.0.0.1:26501"
-
 # Sets the timeout of requests send to the broker cluster
 # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_REQUEST_TIMEOUT.
 # requestTimeout = "15s"

--- a/dist/src/main/config/zeebe.cfg.toml
+++ b/dist/src/main/config/zeebe.cfg.toml
@@ -123,10 +123,6 @@
 # Sets the maximum size of the incoming and outgoing messages (i.e. commands and events).
 # maxMessageSize = "4M"
 
-# Sets the maximum number of the incoming and outgoing messages (i.e. commands and events) with
-# the maximum size which can be buffered.
-# maxMessageCount = 16
-
 [network.commandApi]
 # Overrides the host used for gateway-to-broker communication
 # host = "localhost"

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/EnvironmentConstants.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/EnvironmentConstants.java
@@ -12,7 +12,6 @@ public final class EnvironmentConstants {
   public static final String ENV_GATEWAY_HOST = "ZEEBE_GATEWAY_HOST";
   public static final String ENV_GATEWAY_PORT = "ZEEBE_GATEWAY_PORT";
   public static final String ENV_GATEWAY_MAX_MESSAGE_SIZE = "ZEEBE_GATEWAY_MAX_MESSAGE_SIZE";
-  public static final String ENV_GATEWAY_MAX_MESSAGE_COUNT = "ZEEBE_GATEWAY_MAX_MESSAGE_COUNT";
   public static final String ENV_GATEWAY_REQUEST_TIMEOUT = "ZEEBE_GATEWAY_REQUEST_TIMEOUT";
   public static final String ENV_GATEWAY_MANAGEMENT_THREADS = "ZEEBE_GATEWAY_MANAGEMENT_THREADS";
   public static final String ENV_GATEWAY_CONTACT_POINT = "ZEEBE_GATEWAY_CONTACT_POINT";

--- a/gateway/src/test/java/io/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.0. You may not use this file
  * except in compliance with the Zeebe Community License 1.0.
  */
-package io.zeebe.gateway.configuration;
+package io.zeebe.gateway.impl.configuration;
 
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_CERTIFICATE_PATH;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_CLUSTER_HOST;
@@ -25,15 +25,14 @@ import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEW
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_PRIVATE_KEY_PATH;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_REQUEST_TIMEOUT;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_SECURITY_ENABLED;
-import static org.assertj.core.api.Assertions.assertThat;
 
-import io.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.zeebe.util.Environment;
 import io.zeebe.util.TomlConfigurationReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public final class GatewayCfgTest {
@@ -68,7 +67,7 @@ public final class GatewayCfgTest {
     final GatewayCfg gatewayCfg = readDefaultConfig();
 
     // then
-    assertThat(gatewayCfg).isEqualTo(DEFAULT_CFG);
+    Assertions.assertThat(gatewayCfg).isEqualTo(DEFAULT_CFG);
   }
 
   @Test
@@ -77,7 +76,7 @@ public final class GatewayCfgTest {
     final GatewayCfg gatewayCfg = readEmptyConfig();
 
     // then
-    assertThat(gatewayCfg).isEqualTo(DEFAULT_CFG);
+    Assertions.assertThat(gatewayCfg).isEqualTo(DEFAULT_CFG);
   }
 
   @Test
@@ -86,7 +85,7 @@ public final class GatewayCfgTest {
     final GatewayCfg gatewayCfg = readCustomConfig();
 
     // then
-    assertThat(gatewayCfg).isEqualTo(CUSTOM_CFG);
+    Assertions.assertThat(gatewayCfg).isEqualTo(CUSTOM_CFG);
   }
 
   @Test
@@ -146,7 +145,7 @@ public final class GatewayCfgTest {
     final GatewayCfg gatewayCfg = readCustomConfig();
 
     // then
-    assertThat(gatewayCfg).isEqualTo(expected);
+    Assertions.assertThat(gatewayCfg).isEqualTo(expected);
   }
 
   private void setEnv(final String key, final String value) {

--- a/gateway/src/test/java/io/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -16,7 +16,6 @@ import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEW
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_HOST;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_KEEP_ALIVE_INTERVAL;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_MANAGEMENT_THREADS;
-import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_MAX_MESSAGE_COUNT;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_MAX_MESSAGE_SIZE;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_MONITORING_ENABLED;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_MONITORING_HOST;
@@ -95,7 +94,6 @@ public final class GatewayCfgTest {
     setEnv(ENV_GATEWAY_PORT, "5432");
     setEnv(ENV_GATEWAY_CONTACT_POINT, "broker:432");
     setEnv(ENV_GATEWAY_MAX_MESSAGE_SIZE, "1G");
-    setEnv(ENV_GATEWAY_MAX_MESSAGE_COUNT, "123");
     setEnv(ENV_GATEWAY_MANAGEMENT_THREADS, "32");
     setEnv(ENV_GATEWAY_REQUEST_TIMEOUT, "43m");
     setEnv(ENV_GATEWAY_CLUSTER_NAME, "envCluster");

--- a/gateway/src/test/resources/configuration/gateway.custom.toml
+++ b/gateway/src/test/resources/configuration/gateway.custom.toml
@@ -5,7 +5,6 @@ port = 123
 [cluster]
 contactPoint = "foobar:1234"
 maxMessageSize = "4K"
-maxMessageCount = 13
 requestTimeout = "123h"
 clusterName = "testCluster"
 memberId = "testMember"


### PR DESCRIPTION
## Description
* moved unit tests for configuration classes into the same package as the classes under test
* renamed one unit test
* removed apparently outdated setting `maxMessageCount` from templates and code
* removed reference to ineffective setting `contactPoint`from configuration template for broker

## Related issues

closes #3836 
closes #3837
closes #3838

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
