### PR TITLE
chore(exporter): include version in index names

### DIFF
--- a/exporters/elasticsearch-exporter/pom.xml
+++ b/exporters/elasticsearch-exporter/pom.xml
@@ -99,7 +99,6 @@
     <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-util</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
@@ -157,8 +157,9 @@ public class ElasticsearchExporter implements Exporter {
 
   private void createRootIndexTemplate() {
     final String templateName = configuration.index.prefix;
+    final String aliasName = configuration.index.prefix;
     final String filename = ZEEBE_RECORD_TEMPLATE_JSON;
-    if (!client.putIndexTemplate(templateName, filename, "-")) {
+    if (!client.putIndexTemplate(templateName, aliasName, filename)) {
       log.warn("Put index template {} from file {} was not acknowledged", templateName, filename);
     }
   }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record-deployment_*"
+    "zeebe-record_deployment_*"
   ],
   "order": 20,
   "aliases": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-error-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-error-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record-error_*"
+    "zeebe-record_error_*"
   ],
   "order": 20,
   "aliases": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record-incident_*"
+    "zeebe-record_incident_*"
   ],
   "order": 20,
   "aliases": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record-job-batch_*"
+    "zeebe-record_job-batch_*"
   ],
   "order": 20,
   "aliases": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record-job_*"
+    "zeebe-record_job_*"
   ],
   "order": 20,
   "settings": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record-message-subscription_*"
+    "zeebe-record_message-subscription_*"
   ],
   "order": 20,
   "aliases": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record-message_*"
+    "zeebe-record_message_*"
   ],
   "order": 20,
   "aliases": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record-*"
+    "zeebe-record_*"
   ],
   "order": 10,
   "settings": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-document-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-document-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record-variable-document_*"
+    "zeebe-record_variable-document_*"
   ],
   "order": 20,
   "aliases": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record-variable_*"
+    "zeebe-record_variable_*"
   ],
   "order": 20,
   "aliases": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-creation-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-creation-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record-workflow-instance-creation_*"
+    "zeebe-record_workflow-instance-creation_*"
   ],
   "order": 20,
   "aliases": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-subscription-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record-workflow-instance-subscription_*"
+    "zeebe-record_workflow-instance-subscription_*"
   ],
   "order": 20,
   "aliases": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-workflow-instance-template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "zeebe-record-workflow-instance_*"
+    "zeebe-record_workflow-instance_*"
   ],
   "order": 20,
   "settings": {

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
@@ -80,7 +80,7 @@ public class ElasticsearchExporterTest {
     testHarness.export();
 
     // then
-    verify(esClient).putIndexTemplate("foo-bar", ZEEBE_RECORD_TEMPLATE_JSON, "-");
+    verify(esClient).putIndexTemplate("foo-bar", "foo-bar", ZEEBE_RECORD_TEMPLATE_JSON);
 
     verify(esClient).putIndexTemplate(ValueType.DEPLOYMENT);
     verify(esClient).putIndexTemplate(ValueType.ERROR);

--- a/util/src/main/java/io/zeebe/util/VersionUtil.java
+++ b/util/src/main/java/io/zeebe/util/VersionUtil.java
@@ -21,6 +21,7 @@ public final class VersionUtil {
   private static final String VERSION_DEV = "development";
 
   private static String version;
+  private static String versionLowerCase;
 
   public static String getVersion() {
     if (version == null) {
@@ -44,5 +45,12 @@ public final class VersionUtil {
       }
     }
     return version;
+  }
+
+  public static String getVersionLowerCase() {
+    if (versionLowerCase == null) {
+      versionLowerCase = getVersion().toLowerCase();
+    }
+    return versionLowerCase;
   }
 }

--- a/util/src/test/java/io/zeebe/util/VersionUtilTest.java
+++ b/util/src/test/java/io/zeebe/util/VersionUtilTest.java
@@ -18,4 +18,11 @@ public final class VersionUtilTest {
     final String version = VersionUtil.getVersion();
     assertThat(version).isNotNull();
   }
+
+  @Test
+  public void shouldGetVersionLowerCase() {
+    final String version = VersionUtil.getVersion();
+    final String versionLowerCase = VersionUtil.getVersionLowerCase();
+    assertThat(version.toLowerCase()).isEqualTo(versionLowerCase);
+  }
 }


### PR DESCRIPTION
## Description

- all ELS indices contain Zeebe version in names
- new template/index name style: prefix_name_version[_date] (undescores!)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3785 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
