### PR TITLE
chore(broker): add top level health monitor

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -16,6 +16,10 @@ import io.zeebe.broker.Loggers;
 import io.zeebe.broker.PartitionListener;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.zeebe.util.health.CriticalComponentsHealthMonitor;
+import io.zeebe.util.health.HealthMonitor;
+import io.zeebe.util.health.HealthMonitorable;
+import io.zeebe.util.health.HealthStatus;
 import io.zeebe.util.sched.Actor;
 import java.util.Map;
 import java.util.function.Function;
@@ -24,6 +28,7 @@ import org.slf4j.Logger;
 
 public final class BrokerHealthCheckService extends Actor implements PartitionListener {
 
+  private static final String PARTITION_COMPONENT_NAME_FORMAT = "Partition-%d";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private final Atomix atomix;
   private final String actorName;
@@ -31,14 +36,31 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
   /* set to true when all partitions are installed. Once set to true, it is never
   changed. */
   private volatile boolean brokerStarted = false;
+  private final HealthMonitor healthMonitor;
 
   public BrokerHealthCheckService(final BrokerInfo localBroker, final Atomix atomix) {
     this.atomix = atomix;
     this.actorName = buildActorName(localBroker.getNodeId(), "HealthCheckService");
+    this.healthMonitor = new CriticalComponentsHealthMonitor(actor, LOG);
     initializePartitionInstallStatus();
+    initializePartitionHealthStatus();
   }
 
-  public boolean isBrokerReady() {
+  private void initializePartitionHealthStatus() {
+    final RaftPartitionGroup partitionGroup =
+        (RaftPartitionGroup) atomix.getPartitionService().getPartitionGroup(GROUP_NAME);
+    final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
+
+    partitionGroup.getPartitions().stream()
+        .filter(partition -> partition.members().contains(nodeId))
+        .map(partition -> partition.id().id())
+        .forEach(
+            partitionId ->
+                healthMonitor.monitorComponent(
+                    String.format(PARTITION_COMPONENT_NAME_FORMAT, partitionId)));
+  }
+
+  boolean isBrokerReady() {
     return brokerStarted;
   }
 
@@ -82,5 +104,30 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
   @Override
   public String getName() {
     return actorName;
+  }
+
+  @Override
+  protected void onActorStarted() {
+    healthMonitor.startMonitoring();
+  }
+
+  private void registerComponent(final String componentName, final HealthMonitorable component) {
+    actor.run(() -> healthMonitor.registerComponent(componentName, component));
+  }
+
+  public void registerMonitoredPartition(final int partitionId, final HealthMonitorable partition) {
+    final String componentName = String.format(PARTITION_COMPONENT_NAME_FORMAT, partitionId);
+    registerComponent(componentName, partition);
+  }
+
+  public boolean isBrokerHealthy() {
+    return !actor.isClosed() && getBrokerHealth() == HealthStatus.HEALTHY;
+  }
+
+  private HealthStatus getBrokerHealth() {
+    if (!isBrokerReady()) {
+      return HealthStatus.UNHEALTHY;
+    }
+    return healthMonitor.getHealthStatus();
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -212,7 +212,7 @@ public final class ClusteringRule extends ExternalResource {
     brokerCfgs.clear();
   }
 
-  Broker getBroker(final int nodeId) {
+  public Broker getBroker(final int nodeId) {
     return brokers.computeIfAbsent(nodeId, this::createBroker);
   }
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/HealthMonitoringTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/HealthMonitoringTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.health;
+
+import static io.zeebe.test.util.TestUtil.waitUntil;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.Broker;
+import io.zeebe.broker.it.clustering.ClusteringRule;
+import io.zeebe.broker.it.util.GrpcClientRule;
+import io.zeebe.protocol.Protocol;
+import java.io.File;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+
+public class HealthMonitoringTest {
+  public static final String JOB_TYPE = "testTask";
+  private static final long SNAPSHOT_PERIOD_MINUTES = 5;
+  public final Timeout testTimeout = Timeout.seconds(120);
+  public final ClusteringRule clusteringRule =
+      new ClusteringRule(
+          1, 3, 3, cfg -> cfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD_MINUTES + "m"));
+  public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(testTimeout).around(clusteringRule).around(clientRule);
+
+  @Test
+  public void shouldReportFailureWhenLeaderTransitionFailed() {
+    // given
+    final int partition = Protocol.START_PARTITION_ID;
+    final int leaderNodeId = clusteringRule.getLeaderForPartition(partition).getNodeId();
+    final Broker leader = clusteringRule.getBroker(leaderNodeId);
+    final Collection<Broker> followers = new ArrayList<>(clusteringRule.getBrokers());
+    followers.remove(leader);
+    followers.forEach(follower -> assertThat(follower.isHealthy()).isTrue());
+
+    // do some work to create a snapshot
+    clientRule.createSingleJob(JOB_TYPE);
+    clusteringRule.getClock().addTime(Duration.ofMinutes(SNAPSHOT_PERIOD_MINUTES));
+    clusteringRule.waitForValidSnapshotAtBroker(leader);
+    followers.forEach(clusteringRule::waitForValidSnapshotAtBroker);
+
+    // when
+    // corrupt snapshot on all followers because we cannot control which one will become leader
+    followers.stream().forEach(this::corruptAllSnapshots);
+    // cannot use clusteringRule.stopbroker() as it waits for new leader to be installed.
+    leader.close();
+
+    // then
+    // TODO: Use http endpoint to query health status when it is available
+    // https://github.com/zeebe-io/zeebe/issues/3833
+    waitUntil(() -> followers.stream().anyMatch(follower -> !follower.isHealthy()));
+  }
+
+  private void corruptAllSnapshots(final Broker leader) {
+    final File snapshotsDir = clusteringRule.getSnapshotsDirectory(leader);
+    Arrays.stream(snapshotsDir.listFiles())
+        .filter(File::isDirectory)
+        .forEach(
+            snapshot -> {
+              final var filesInSnapshot = snapshot.listFiles();
+              Arrays.stream(filesInSnapshot)
+                  .filter(f -> f.getName().contains("MANIFEST"))
+                  .forEach(file -> file.delete());
+            });
+  }
+}

--- a/util/src/main/java/io/zeebe/util/health/CriticalComponentsHealthMonitor.java
+++ b/util/src/main/java/io/zeebe/util/health/CriticalComponentsHealthMonitor.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util.health;
+
+import io.zeebe.util.sched.ActorControl;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+
+/** Healthy only if all components are healthy */
+public class CriticalComponentsHealthMonitor implements HealthMonitor {
+  private static final Duration HEALTH_MONITORING_PERIOD = Duration.ofSeconds(60);
+  private final Map<String, HealthMonitorable> monitoredComponents = new HashMap<>();
+  private final Map<String, HealthStatus> componentHealth = new HashMap<>();
+  private volatile HealthStatus healthStatus = HealthStatus.UNHEALTHY;
+  private final ActorControl actor;
+  private final Logger log;
+  private FailureListener failureListener;
+
+  public CriticalComponentsHealthMonitor(final ActorControl actor, final Logger log) {
+    this.actor = actor;
+    this.log = log;
+  }
+
+  public void startMonitoring() {
+    actor.runAtFixedRate(HEALTH_MONITORING_PERIOD, this::updateHealth);
+  }
+
+  @Override
+  public void monitorComponent(final String componentName) {
+    actor.run(() -> componentHealth.put(componentName, HealthStatus.UNHEALTHY));
+  }
+
+  @Override
+  public void removeComponent(final String componentName) {
+    actor.run(
+        () -> {
+          monitoredComponents.remove(componentName);
+          componentHealth.remove(componentName);
+        });
+  }
+
+  @Override
+  public void registerComponent(final String componentName, final HealthMonitorable component) {
+    actor.run(
+        () -> {
+          monitoredComponents.put(componentName, component);
+          component.addFailureListener(new ComponentFailureListener(componentName));
+          componentHealth.put(componentName, component.getHealthStatus());
+          calculateHealth();
+        });
+  }
+
+  @Override
+  public HealthStatus getHealthStatus() {
+    return healthStatus;
+  }
+
+  @Override
+  public void addFailureListener(final FailureListener failureListener) {
+    actor.run(() -> this.failureListener = failureListener);
+  }
+
+  private void onComponentFailure(final String componentName) {
+    actor.run(
+        () -> {
+          log.error("{} failed, marking it as unhealthy", componentName);
+          componentHealth.put(componentName, HealthStatus.UNHEALTHY);
+          calculateHealth();
+        });
+  }
+
+  private void onComponentRecovered(final String componentName) {
+    actor.run(
+        () -> {
+          log.error("{} recovered, marking it as healthy", componentName);
+          componentHealth.put(componentName, HealthStatus.HEALTHY);
+        });
+  }
+
+  private void updateHealth() {
+    componentHealth
+        .keySet()
+        .forEach(component -> componentHealth.put(component, getHealth(component)));
+    calculateHealth();
+  }
+
+  private void calculateHealth() {
+    final var status =
+        componentHealth.containsValue(HealthStatus.UNHEALTHY)
+            ? HealthStatus.UNHEALTHY
+            : HealthStatus.HEALTHY;
+    final var previousStatus = healthStatus;
+    healthStatus = status;
+
+    if (failureListener != null && previousStatus != status) {
+      switch (status) {
+        case HEALTHY:
+          failureListener.onRecovered();
+          break;
+        case UNHEALTHY:
+          failureListener.onFailure();
+          break;
+        default:
+          log.warn("Unknown health status {}", status);
+          break;
+      }
+    }
+  }
+
+  private HealthStatus getHealth(final String componentName) {
+    final HealthMonitorable component = monitoredComponents.get(componentName);
+    if (component != null) {
+      return component.getHealthStatus();
+    }
+    return HealthStatus.UNHEALTHY;
+  }
+
+  class ComponentFailureListener implements FailureListener {
+    private final String componentName;
+
+    ComponentFailureListener(final String componentName) {
+      this.componentName = componentName;
+    }
+
+    @Override
+    public void onFailure() {
+      onComponentFailure(componentName);
+    }
+
+    @Override
+    public void onRecovered() {
+      onComponentRecovered(componentName);
+    }
+  }
+}

--- a/util/src/main/java/io/zeebe/util/health/FailureListener.java
+++ b/util/src/main/java/io/zeebe/util/health/FailureListener.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util.health;
+
+/** Failure Listener invoked by a {@link HealthMonitorable} component. */
+public interface FailureListener {
+
+  /** Invoked when the health status becomes unhealthy. */
+  void onFailure();
+
+  /**
+   * Invoked when health status becomes healthy after being unhealthy for some time. A component can
+   * be marked unhealthy initially and set to healthy only after start up is complete. It is
+   * expected to call {#onRecovered} when it is marked as healthy.
+   */
+  void onRecovered();
+}

--- a/util/src/main/java/io/zeebe/util/health/HealthMonitor.java
+++ b/util/src/main/java/io/zeebe/util/health/HealthMonitor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util.health;
+
+/**
+ * A HealthMonitor keeps tracks of all components it should monitor and calculates aggregate health
+ * status.
+ */
+public interface HealthMonitor extends HealthMonitorable {
+
+  /**
+   * Starts necessary services for monitoring. Typically implemented by a monitor to start periodic
+   * monitoring.
+   */
+  void startMonitoring();
+
+  /**
+   * Add a component name to be monitored. The component will be marked not healthy until the
+   * component is registered using {@link #registerComponent(String, HealthMonitorable)}
+   */
+  void monitorComponent(String componentName);
+
+  /**
+   * Stop monitoring the component.
+   *
+   * @param componentName
+   */
+  void removeComponent(String componentName);
+
+  /**
+   * Register the component to be monitored
+   *
+   * @param componentName
+   * @param component
+   */
+  void registerComponent(String componentName, HealthMonitorable component);
+}

--- a/util/src/main/java/io/zeebe/util/health/HealthMonitorable.java
+++ b/util/src/main/java/io/zeebe/util/health/HealthMonitorable.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util.health;
+
+/** Any component that can be monitored for health should implement this interface. */
+public interface HealthMonitorable {
+
+  /**
+   * Used by a HealthMonitor to get the health status of this component, typically invoked
+   * periodically.
+   *
+   * @return health status
+   */
+  HealthStatus getHealthStatus();
+
+  /**
+   * Register a failure observer.
+   *
+   * @param failureListener failure observer to be invoked when a failure that affects the health
+   *     status of this component occurs
+   */
+  void addFailureListener(FailureListener failureListener);
+}

--- a/util/src/main/java/io/zeebe/util/health/HealthStatus.java
+++ b/util/src/main/java/io/zeebe/util/health/HealthStatus.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util.health;
+
+public enum HealthStatus {
+  HEALTHY,
+  UNHEALTHY
+}


### PR DESCRIPTION
## Description
- set up a health monitor that can monitor partitions
- make ZeebePartition report some failures to the health monitor
- Note that it cannot detect all failures until all components are monitorable

## Related issues

closes #3832 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
