### PR TITLE
3841 replace byte value in signatures with long

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -25,6 +25,7 @@ import io.zeebe.broker.system.configuration.ClusterCfg;
 import io.zeebe.broker.system.configuration.DataCfg;
 import io.zeebe.broker.system.configuration.NetworkCfg;
 import io.zeebe.util.ByteValue;
+import io.zeebe.util.ByteValueParser;
 import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -118,7 +119,7 @@ public final class AtomixFactory {
     partitionGroupBuilder.withMaxEntrySize((int) maxMessageSize.toBytes());
 
     Optional.ofNullable(dataCfg.getLogSegmentSize())
-        .map(ByteValue::new)
+        .map(ByteValueParser::fromString)
         .ifPresent(
             segmentSize -> {
               if (segmentSize.toBytes() < maxMessageSize.toBytes()) {

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -24,8 +24,6 @@ import io.zeebe.broker.system.configuration.BrokerCfg;
 import io.zeebe.broker.system.configuration.ClusterCfg;
 import io.zeebe.broker.system.configuration.DataCfg;
 import io.zeebe.broker.system.configuration.NetworkCfg;
-import io.zeebe.util.ByteValue;
-import io.zeebe.util.ByteValueParser;
 import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -115,21 +113,20 @@ public final class AtomixFactory {
             .withFlushOnCommit();
 
     // by default, the Atomix max entry size is 1 MB
-    final ByteValue maxMessageSize = networkCfg.getMaxMessageSize();
-    partitionGroupBuilder.withMaxEntrySize((int) maxMessageSize.toBytes());
+    final int maxMessageSize = (int) networkCfg.getMaxMessageSizeInBytes();
+    partitionGroupBuilder.withMaxEntrySize(maxMessageSize);
 
-    Optional.ofNullable(dataCfg.getLogSegmentSize())
-        .map(ByteValueParser::fromString)
+    Optional.ofNullable(dataCfg.getLogSegmentSizeInBytes())
         .ifPresent(
             segmentSize -> {
-              if (segmentSize.toBytes() < maxMessageSize.toBytes()) {
+              if (segmentSize < maxMessageSize) {
                 throw new IllegalArgumentException(
                     String.format(
                         "Expected the raft segment size greater than the max message size of %s, but was %s.",
                         maxMessageSize, segmentSize));
               }
 
-              partitionGroupBuilder.withSegmentSize(segmentSize.toBytes());
+              partitionGroupBuilder.withSegmentSize(segmentSize);
             });
 
     return partitionGroupBuilder.build();

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.broker.system.configuration;
 
+import io.zeebe.util.ByteValueParser;
 import io.zeebe.util.DurationUtil;
 import io.zeebe.util.Environment;
 import java.time.Duration;
@@ -45,11 +46,24 @@ public final class DataCfg implements ConfigurationEntry {
     this.directories = directories;
   }
 
+  public Long getLogSegmentSizeInBytes() {
+    if (logSegmentSize != null) {
+      return ByteValueParser.fromString(logSegmentSize).toBytes();
+    } else {
+      return null;
+    }
+  }
+
   public String getLogSegmentSize() {
     return logSegmentSize;
   }
 
   public void setLogSegmentSize(final String logSegmentSize) {
+    if (logSegmentSize != null) {
+      // call parsing logic to provoke any exceptions that might occur during parsing
+      ByteValueParser.fromString(logSegmentSize);
+    }
+
     this.logSegmentSize = logSegmentSize;
   }
 

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/EmbeddedGatewayCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/EmbeddedGatewayCfg.java
@@ -36,8 +36,6 @@ public final class EmbeddedGatewayCfg extends GatewayCfg implements Configuratio
 
     // configure embedded gateway based on broker config
     getNetwork().setPort(getNetwork().getPort() + (networkCfg.getPortOffset() * 10));
-
-    getCluster().setMaxMessageSize(networkCfg.getMaxMessageSize().toString());
   }
 
   public boolean isEnable() {

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/NetworkCfg.java
@@ -14,7 +14,6 @@ import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_PORT
 import io.zeebe.broker.system.configuration.SocketBindingCfg.CommandApiCfg;
 import io.zeebe.broker.system.configuration.SocketBindingCfg.InternalApiCfg;
 import io.zeebe.broker.system.configuration.SocketBindingCfg.MonitoringApiCfg;
-import io.zeebe.util.ByteValue;
 import io.zeebe.util.ByteValueParser;
 import io.zeebe.util.Environment;
 import java.util.Optional;
@@ -75,11 +74,18 @@ public final class NetworkCfg implements ConfigurationEntry {
     this.portOffset = portOffset;
   }
 
-  public ByteValue getMaxMessageSize() {
-    return ByteValueParser.fromString(maxMessageSize);
+  public String getMaxMessageSize() {
+    return maxMessageSize;
+  }
+
+  public long getMaxMessageSizeInBytes() {
+    return ByteValueParser.fromString(maxMessageSize).toBytes();
   }
 
   public void setMaxMessageSize(final String maxMessageSize) {
+    // call parsing logic to provoke any exceptions that might occur during parsing
+    ByteValueParser.fromString(maxMessageSize);
+
     this.maxMessageSize = maxMessageSize;
   }
 

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/NetworkCfg.java
@@ -15,6 +15,7 @@ import io.zeebe.broker.system.configuration.SocketBindingCfg.CommandApiCfg;
 import io.zeebe.broker.system.configuration.SocketBindingCfg.InternalApiCfg;
 import io.zeebe.broker.system.configuration.SocketBindingCfg.MonitoringApiCfg;
 import io.zeebe.util.ByteValue;
+import io.zeebe.util.ByteValueParser;
 import io.zeebe.util.Environment;
 import java.util.Optional;
 
@@ -75,7 +76,7 @@ public final class NetworkCfg implements ConfigurationEntry {
   }
 
   public ByteValue getMaxMessageSize() {
-    return new ByteValue(maxMessageSize);
+    return ByteValueParser.fromString(maxMessageSize);
   }
 
   public void setMaxMessageSize(final String maxMessageSize) {

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -105,7 +105,7 @@ public final class ZeebePartition extends Actor
     this.partitionListeners = Collections.unmodifiableList(partitionListeners);
     this.partitionId = atomixRaftPartition.id().id();
     this.scheduler = actorScheduler;
-    this.maxFragmentSize = (int) brokerCfg.getNetwork().getMaxMessageSize().toBytes();
+    this.maxFragmentSize = (int) brokerCfg.getNetwork().getMaxMessageSizeInBytes();
 
     // load and validate exporters
     for (final ExporterCfg exporterCfg : brokerCfg.getExporters()) {

--- a/dispatcher/src/main/java/io/zeebe/dispatcher/DispatcherBuilder.java
+++ b/dispatcher/src/main/java/io/zeebe/dispatcher/DispatcherBuilder.java
@@ -24,7 +24,7 @@ import org.agrona.BitUtil;
 /** Builder for a {@link Dispatcher} */
 public final class DispatcherBuilder {
 
-  private static final int DEFAULT_BUFFER_SIZE = (int) ByteValue.ofMegabytes(1).toBytes();
+  private static final int DEFAULT_BUFFER_SIZE = (int) ByteValue.ofMegabytes(1);
 
   private int bufferSize = -1;
   private int maxFragmentLength = -1;
@@ -49,8 +49,8 @@ public final class DispatcherBuilder {
    * The number of bytes the buffer is be able to contain. Represents the size of the data section.
    * Additional space will be allocated for the meta-data sections
    */
-  public DispatcherBuilder bufferSize(final ByteValue byteValue) {
-    bufferSize = (int) byteValue.toBytes();
+  public DispatcherBuilder bufferSize(final int bufferSize) {
+    this.bufferSize = bufferSize;
     return this;
   }
 
@@ -60,8 +60,8 @@ public final class DispatcherBuilder {
   }
 
   /** The max length of the data section of a frame */
-  public DispatcherBuilder maxFragmentLength(final ByteValue maxFragmentLength) {
-    this.maxFragmentLength = (int) maxFragmentLength.toBytes();
+  public DispatcherBuilder maxFragmentLength(final int maxFragmentLength) {
+    this.maxFragmentLength = maxFragmentLength;
     return this;
   }
 

--- a/dispatcher/src/test/java/io/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
+++ b/dispatcher/src/test/java/io/zeebe/dispatcher/integration/ActorFrameworkIntegrationTest.java
@@ -31,7 +31,7 @@ public final class ActorFrameworkIntegrationTest {
     final Dispatcher dispatcher =
         Dispatchers.create("default")
             .actorScheduler(actorSchedulerRule.get())
-            .bufferSize(ByteValue.ofMegabytes(10))
+            .bufferSize((int) ByteValue.ofMegabytes(10))
             .build();
 
     actorSchedulerRule.submitActor(new Consumer(dispatcher));
@@ -47,7 +47,7 @@ public final class ActorFrameworkIntegrationTest {
     final Dispatcher dispatcher =
         Dispatchers.create("default")
             .actorScheduler(actorSchedulerRule.get())
-            .bufferSize(ByteValue.ofMegabytes(10))
+            .bufferSize((int) ByteValue.ofMegabytes(10))
             .build();
 
     actorSchedulerRule.submitActor(new PeekingConsumer(dispatcher));

--- a/dispatcher/src/test/java/io/zeebe/dispatcher/integration/DispatcherIntegrationTest.java
+++ b/dispatcher/src/test/java/io/zeebe/dispatcher/integration/DispatcherIntegrationTest.java
@@ -42,7 +42,7 @@ public final class DispatcherIntegrationTest {
     final Dispatcher dispatcher =
         Dispatchers.create("default")
             .actorScheduler(actorSchedulerRule.get())
-            .bufferSize(ByteValue.ofMegabytes(10))
+            .bufferSize((int) ByteValue.ofMegabytes(10))
             .build();
 
     final Consumer consumer = new Consumer();
@@ -73,7 +73,7 @@ public final class DispatcherIntegrationTest {
     final Dispatcher dispatcher =
         Dispatchers.create("default")
             .actorScheduler(actorSchedulerRule.get())
-            .bufferSize(ByteValue.ofMegabytes(10))
+            .bufferSize((int) ByteValue.ofMegabytes(10))
             .build();
 
     final Consumer consumer = new Consumer();
@@ -110,7 +110,7 @@ public final class DispatcherIntegrationTest {
     final Dispatcher dispatcher =
         Dispatchers.create("default")
             .actorScheduler(actorSchedulerRule.get())
-            .bufferSize(ByteValue.ofMegabytes(10))
+            .bufferSize((int) ByteValue.ofMegabytes(10))
             .build();
 
     final Subscription subscription = dispatcher.openSubscription("test");
@@ -156,7 +156,7 @@ public final class DispatcherIntegrationTest {
     final Dispatcher dispatcher =
         Dispatchers.create("default")
             .actorScheduler(actorSchedulerRule.get())
-            .bufferSize(ByteValue.ofMegabytes(10))
+            .bufferSize((int) ByteValue.ofMegabytes(10))
             .initialPartitionId(2)
             .build();
 
@@ -193,7 +193,7 @@ public final class DispatcherIntegrationTest {
     final Dispatcher dispatcher =
         Dispatchers.create("default")
             .actorScheduler(actorSchedulerRule.get())
-            .bufferSize(ByteValue.ofKilobytes(10))
+            .bufferSize((int) ByteValue.ofKilobytes(10))
             .build();
 
     // when
@@ -206,8 +206,8 @@ public final class DispatcherIntegrationTest {
 
   @Test
   public void shouldFailToCreateDispatcherIfBufferTooSmall() {
-    final ByteValue frameLength = ByteValue.ofMegabytes(1);
-    final int requiredBufferSize = (int) frameLength.toBytes() * 2 * 3;
+    final int frameLength = (int) ByteValue.ofMegabytes(1);
+    final long requiredBufferSize = frameLength * 2 * 3;
 
     final var builder =
         Dispatchers.create("test")
@@ -219,13 +219,13 @@ public final class DispatcherIntegrationTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Expected the buffer size to be greater than %s, but was %s. The max fragment length is set to %s.",
-            requiredBufferSize, frameLength.toBytes(), frameLength.toBytes());
+            requiredBufferSize, frameLength, frameLength);
   }
 
   @Test
   public void shouldSetBufferSizeDependingOnMaxFrameLength() {
-    final ByteValue frameLength = ByteValue.ofMegabytes(4);
-    final int expectedPartitionSize = (int) frameLength.toBytes() * 2;
+    final int frameLength = (int) ByteValue.ofMegabytes(4);
+    final long expectedPartitionSize = frameLength * 2;
 
     final Dispatcher dispatcher =
         Dispatchers.create("test")
@@ -233,7 +233,7 @@ public final class DispatcherIntegrationTest {
             .maxFragmentLength(frameLength)
             .build();
 
-    assertThat(dispatcher.getMaxFragmentLength()).isEqualTo(frameLength.toBytes());
+    assertThat(dispatcher.getMaxFragmentLength()).isEqualTo(frameLength);
     assertThat(dispatcher.getLogBuffer().getPartitionSize()).isEqualTo(expectedPartitionSize);
   }
 

--- a/dispatcher/src/test/java/io/zeebe/dispatcher/integration/FragmentBatchIntegrationTest.java
+++ b/dispatcher/src/test/java/io/zeebe/dispatcher/integration/FragmentBatchIntegrationTest.java
@@ -45,7 +45,7 @@ public final class FragmentBatchIntegrationTest {
   public void init() {
     dispatcher =
         Dispatchers.create("default")
-            .bufferSize(ByteValue.ofKilobytes(32))
+            .bufferSize((int) ByteValue.ofKilobytes(32))
             .actorScheduler(actorSchedulerRule.get())
             .build();
 

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/job/ActivateJobsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/job/ActivateJobsTest.java
@@ -381,13 +381,13 @@ public final class ActivateJobsTest {
     final int jobCount = 3;
     final int expectedJobsInBatch = 2;
 
-    final ByteValue maxMessageSize = ByteValue.ofMegabytes(4);
-    final ByteValue headerSize = ByteValue.ofKilobytes(2);
-    final int maxRecordSize = (int) maxMessageSize.toBytes() - (int) headerSize.toBytes();
+    final long maxMessageSize = ByteValue.ofMegabytes(4);
+    final long headerSize = ByteValue.ofKilobytes(2);
+    final long maxRecordSize = maxMessageSize - headerSize;
     // the variable size only the half of the record size because two events are written on creation
-    final int maxVariableSize = maxRecordSize / 2;
+    final long maxVariableSize = maxRecordSize / 2;
 
-    final int variablesSize = maxVariableSize / expectedJobsInBatch;
+    final int variablesSize = (int) maxVariableSize / expectedJobsInBatch;
     final String variables = "{'key': '" + "x".repeat(variablesSize) + "'}";
 
     // when

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -24,6 +24,7 @@ import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEW
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_REQUEST_TIMEOUT;
 
 import io.zeebe.util.ByteValue;
+import io.zeebe.util.ByteValueParser;
 import io.zeebe.util.DurationUtil;
 import io.zeebe.util.Environment;
 import java.time.Duration;
@@ -32,6 +33,7 @@ import java.util.Objects;
 public final class ClusterCfg {
   private String contactPoint = DEFAULT_CONTACT_POINT_HOST + ":" + DEFAULT_CONTACT_POINT_PORT;
   private String maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
+
   private String requestTimeout = DEFAULT_REQUEST_TIMEOUT;
   private String clusterName = DEFAULT_CLUSTER_NAME;
   private String memberId = DEFAULT_CLUSTER_MEMBER_ID;
@@ -109,7 +111,7 @@ public final class ClusterCfg {
   }
 
   public ByteValue getMaxMessageSize() {
-    return new ByteValue(maxMessageSize);
+    return ByteValueParser.fromString(maxMessageSize);
   }
 
   public ClusterCfg setMaxMessageSize(final String maxMessageSize) {

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -13,18 +13,14 @@ import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_
 import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CLUSTER_PORT;
 import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CONTACT_POINT_HOST;
 import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_CONTACT_POINT_PORT;
-import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_MAX_MESSAGE_SIZE;
 import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_REQUEST_TIMEOUT;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_CLUSTER_HOST;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_CLUSTER_MEMBER_ID;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_CLUSTER_NAME;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_CLUSTER_PORT;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_CONTACT_POINT;
-import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_MAX_MESSAGE_SIZE;
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_REQUEST_TIMEOUT;
 
-import io.zeebe.util.ByteValue;
-import io.zeebe.util.ByteValueParser;
 import io.zeebe.util.DurationUtil;
 import io.zeebe.util.Environment;
 import java.time.Duration;
@@ -32,7 +28,6 @@ import java.util.Objects;
 
 public final class ClusterCfg {
   private String contactPoint = DEFAULT_CONTACT_POINT_HOST + ":" + DEFAULT_CONTACT_POINT_PORT;
-  private String maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
 
   private String requestTimeout = DEFAULT_REQUEST_TIMEOUT;
   private String clusterName = DEFAULT_CLUSTER_NAME;
@@ -50,7 +45,6 @@ public final class ClusterCfg {
     environment.get(ENV_GATEWAY_CLUSTER_MEMBER_ID).ifPresent(this::setMemberId);
     environment.get(ENV_GATEWAY_CLUSTER_HOST).ifPresent(this::setHost);
     environment.getInt(ENV_GATEWAY_CLUSTER_PORT).ifPresent(this::setPort);
-    environment.get(ENV_GATEWAY_MAX_MESSAGE_SIZE).ifPresent(this::setMaxMessageSize);
   }
 
   public String getMemberId() {
@@ -110,19 +104,9 @@ public final class ClusterCfg {
     return this;
   }
 
-  public ByteValue getMaxMessageSize() {
-    return ByteValueParser.fromString(maxMessageSize);
-  }
-
-  public ClusterCfg setMaxMessageSize(final String maxMessageSize) {
-    this.maxMessageSize = maxMessageSize;
-    return this;
-  }
-
   @Override
   public int hashCode() {
-    return Objects.hash(
-        contactPoint, maxMessageSize, requestTimeout, clusterName, memberId, host, port);
+    return Objects.hash(contactPoint, requestTimeout, clusterName, memberId, host, port);
   }
 
   @Override
@@ -136,7 +120,6 @@ public final class ClusterCfg {
     final ClusterCfg that = (ClusterCfg) o;
     return port == that.port
         && Objects.equals(contactPoint, that.contactPoint)
-        && Objects.equals(maxMessageSize, that.maxMessageSize)
         && Objects.equals(requestTimeout, that.requestTimeout)
         && Objects.equals(clusterName, that.clusterName)
         && Objects.equals(memberId, that.memberId)
@@ -148,9 +131,6 @@ public final class ClusterCfg {
     return "ClusterCfg{"
         + "contactPoint='"
         + contactPoint
-        + '\''
-        + ", maxMessageSize='"
-        + maxMessageSize
         + '\''
         + ", requestTimeout='"
         + requestTimeout

--- a/gateway/src/test/java/io/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -49,7 +49,6 @@ public final class GatewayCfgTest {
     CUSTOM_CFG
         .getCluster()
         .setContactPoint("foobar:1234")
-        .setMaxMessageSize("4K")
         .setRequestTimeout("123h")
         .setClusterName("testCluster")
         .setMemberId("testMember")
@@ -123,7 +122,6 @@ public final class GatewayCfgTest {
     expected
         .getCluster()
         .setContactPoint("broker:432")
-        .setMaxMessageSize("1G")
         .setRequestTimeout("43m")
         .setClusterName("envCluster")
         .setMemberId("envMember")

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
@@ -10,7 +10,6 @@ package io.zeebe.logstreams.impl.log;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamBuilder;
 import io.zeebe.logstreams.spi.LogStorage;
-import io.zeebe.util.ByteValue;
 import io.zeebe.util.sched.ActorScheduler;
 import io.zeebe.util.sched.channel.ActorConditions;
 import io.zeebe.util.sched.future.ActorFuture;
@@ -73,7 +72,7 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
             logName,
             partitionId,
             nodeId,
-            ByteValue.ofBytes(maxFragmentSize),
+            maxFragmentSize,
             logStorage);
 
     final var logstreamInstallFuture = new CompletableActorFuture<LogStream>();

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -17,7 +17,6 @@ import io.zeebe.logstreams.log.LogStreamReader;
 import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.logstreams.log.LogStreamWriter;
 import io.zeebe.logstreams.spi.LogStorage;
-import io.zeebe.util.ByteValue;
 import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.ActorCondition;
 import io.zeebe.util.sched.ActorScheduler;
@@ -41,7 +40,7 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
   private final ActorConditions onCommitPositionUpdatedConditions;
   private final String logName;
   private final int partitionId;
-  private final ByteValue maxFrameLength;
+  private final int maxFrameLength;
   private final ActorScheduler actorScheduler;
   private final List<LogStreamReader> readers;
   private final LogStreamReaderImpl reader;
@@ -63,7 +62,7 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
       final String logName,
       final int partitionId,
       final int nodeId,
-      final ByteValue maxFrameLength,
+      final int maxFrameLength,
       final LogStorage logStorage) {
     this.actorScheduler = actorScheduler;
     this.onCommitPositionUpdatedConditions = onCommitPositionUpdatedConditions;
@@ -322,7 +321,7 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
                         partitionId,
                         logStorage,
                         subscription,
-                        (int) maxFrameLength.toBytes());
+                        maxFrameLength);
 
                 actorScheduler
                     .submitActor(appender)

--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -63,8 +63,8 @@ public final class LogStorageAppenderTest {
     dispatcher =
         Dispatchers.create("0")
             .actorScheduler(schedulerRule.get())
-            .bufferSize(ByteValue.ofMegabytes(100 * MAX_FRAGMENT_SIZE))
-            .maxFragmentLength(ByteValue.ofBytes(MAX_FRAGMENT_SIZE))
+            .bufferSize((int) ByteValue.ofMegabytes(100 * MAX_FRAGMENT_SIZE))
+            .maxFragmentLength(MAX_FRAGMENT_SIZE)
             .initialPartitionId(0)
             .build();
     final var subscription = dispatcher.openSubscription("log");

--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStreamReaderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStreamReaderTest.java
@@ -28,7 +28,7 @@ import org.junit.rules.TemporaryFolder;
 
 public final class LogStreamReaderTest {
   private static final UnsafeBuffer EVENT_VALUE = new UnsafeBuffer(getBytes("test"));
-  private static final int LOG_SEGMENT_SIZE = (int) ByteValue.ofMegabytes(4).toBytes();
+  private static final int LOG_SEGMENT_SIZE = (int) ByteValue.ofMegabytes(4);
   private static final UnsafeBuffer BIG_EVENT_VALUE = new UnsafeBuffer(new byte[64 * 1024]);
 
   @Rule public final ExpectedException expectedException = ExpectedException.none();

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/ActivateJobsTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/ActivateJobsTest.java
@@ -16,7 +16,6 @@ import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.response.ActivateJobsResponse;
 import io.zeebe.client.api.response.ActivatedJob;
 import io.zeebe.test.util.BrokerClassRuleHelper;
-import io.zeebe.util.ByteValue;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -67,8 +66,9 @@ public final class ActivateJobsTest {
     // given
     final int availableJobs = 10;
 
-    final ByteValue maxMessageSize = BROKER_RULE.getBrokerCfg().getNetwork().getMaxMessageSize();
-    final var largeVariableValue = "x".repeat((int) maxMessageSize.toBytes() / 4);
+    final int maxMessageSize =
+        (int) BROKER_RULE.getBrokerCfg().getNetwork().getMaxMessageSizeInBytes();
+    final var largeVariableValue = "x".repeat(maxMessageSize / 4);
     final String variablesJson = String.format("{\"variablesJson\":\"%s\"}", largeVariableValue);
 
     CLIENT_RULE.createJobs(jobType, b -> {}, variablesJson, availableJobs);

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
@@ -15,6 +15,7 @@ import io.zeebe.broker.it.util.GrpcClientRule;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.util.ByteValue;
+import io.zeebe.util.ByteValueParser;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.concurrent.ThreadLocalRandom;
@@ -24,8 +25,8 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 
 public final class RestoreTest {
-  private static final int ATOMIX_SEGMENT_SIZE = (int) ByteValue.ofMegabytes(2).toBytes();
-  private static final int LARGE_PAYLOAD_BYTESIZE = (int) ByteValue.ofKilobytes(32).toBytes();
+  private static final long ATOMIX_SEGMENT_SIZE = ByteValue.ofMegabytes(2);
+  private static final long LARGE_PAYLOAD_BYTESIZE = ByteValue.ofKilobytes(32);
   private static final String LARGE_PAYLOAD =
       "{\"blob\": \"" + getRandomBase64Bytes(LARGE_PAYLOAD_BYTESIZE) + "\"}";
 
@@ -38,8 +39,10 @@ public final class RestoreTest {
           cfg -> {
             cfg.getData().setMaxSnapshots(1);
             cfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD_MIN + "m");
-            cfg.getData().setLogSegmentSize(ByteValue.ofBytes(ATOMIX_SEGMENT_SIZE).toString());
-            cfg.getNetwork().setMaxMessageSize(ByteValue.ofBytes(ATOMIX_SEGMENT_SIZE).toString());
+            cfg.getData()
+                .setLogSegmentSize(ByteValueParser.ofBytes(ATOMIX_SEGMENT_SIZE).toString());
+            cfg.getNetwork()
+                .setMaxMessageSize(ByteValueParser.ofBytes(ATOMIX_SEGMENT_SIZE).toString());
           });
   private final GrpcClientRule clientRule =
       new GrpcClientRule(
@@ -131,7 +134,8 @@ public final class RestoreTest {
     final BpmnModelInstance workflow =
         Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
     final long workflowKey = clientRule.deployWorkflow(workflow);
-    final int requiredInstances = Math.floorDiv(ATOMIX_SEGMENT_SIZE, LARGE_PAYLOAD_BYTESIZE) + 1;
+    final int requiredInstances =
+        (int) Math.floorDiv(ATOMIX_SEGMENT_SIZE, LARGE_PAYLOAD_BYTESIZE) + 1;
     IntStream.range(0, requiredInstances)
         .forEach(i -> clientRule.createWorkflowInstance(workflowKey, LARGE_PAYLOAD));
   }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/network/LargeMessageSizeTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/network/LargeMessageSizeTest.java
@@ -14,6 +14,7 @@ import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.test.util.BrokerClassRuleHelper;
 import io.zeebe.util.ByteValue;
+import io.zeebe.util.ByteValueParser;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -23,16 +24,18 @@ import org.junit.rules.RuleChain;
 
 public final class LargeMessageSizeTest {
 
-  private static final ByteValue MAX_MESSAGE_SIZE = ByteValue.ofMegabytes(4);
+  private static final long MAX_MESSAGE_SIZE = ByteValue.ofMegabytes(4);
   // only use half of the max message size because some commands produce two events
-  private static final ByteValue LARGE_SIZE = ByteValue.ofMegabytes(2);
-  private static final ByteValue METADATA_SIZE = ByteValue.ofBytes(512);
+  private static final long LARGE_SIZE = ByteValue.ofMegabytes(2);
+  private static final long METADATA_SIZE = 512;
 
-  private static final String LARGE_TEXT =
-      "x".repeat((int) LARGE_SIZE.toBytes() - (int) METADATA_SIZE.toBytes());
+  private static final String LARGE_TEXT = "x".repeat((int) (LARGE_SIZE - METADATA_SIZE));
 
   private static final EmbeddedBrokerRule BROKER_RULE =
-      new EmbeddedBrokerRule(b -> b.getNetwork().setMaxMessageSize(MAX_MESSAGE_SIZE.toString()));
+      new EmbeddedBrokerRule(
+          b ->
+              b.getNetwork()
+                  .setMaxMessageSize(ByteValueParser.ofBytes(MAX_MESSAGE_SIZE).toString()));
   private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
 
   @ClassRule

--- a/util/src/main/java/io/zeebe/util/ByteUnit.java
+++ b/util/src/main/java/io/zeebe/util/ByteUnit.java
@@ -9,6 +9,9 @@ package io.zeebe.util;
 
 import java.util.Arrays;
 
+@Deprecated(
+    forRemoval = true,
+    since = "0.23.0-alpha2") // Should be replaced when an alternative is found.
 public enum ByteUnit {
   BYTES(0, ""),
   KILOBYTES(1, "K"),

--- a/util/src/main/java/io/zeebe/util/ByteValue.java
+++ b/util/src/main/java/io/zeebe/util/ByteValue.java
@@ -7,58 +7,23 @@
  */
 package io.zeebe.util;
 
-import static io.zeebe.util.ByteUnit.BYTES;
-import static io.zeebe.util.ByteUnit.KILOBYTES;
-import static io.zeebe.util.ByteUnit.MEGABYTES;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+@Deprecated(
+    forRemoval = true,
+    since =
+        "0.23.0-alpha2") // Should be replaced when an alternative is found. For now, please refrain
+// from using this class outside configuration and use a long (size in
+// bytes) instead
 public final class ByteValue {
-  private static final Pattern PATTERN =
-      Pattern.compile("(\\d+)([K|M|G]?)", Pattern.CASE_INSENSITIVE);
+  private static final int CONVERSION_FACTOR_KB = 1024;
+  private static final int CONVERSION_FACTOR_MB = CONVERSION_FACTOR_KB * 1024;
+  private static final int CONVERSION_FACTOR_GB = CONVERSION_FACTOR_MB * 1024;
 
   private final ByteUnit unit;
   private final long value;
 
-  public ByteValue(final long value, final ByteUnit unit) {
+  protected ByteValue(final long value, final ByteUnit unit) {
     this.value = value;
     this.unit = unit;
-  }
-
-  public ByteValue(final String humanReadable) {
-    final Matcher matcher = PATTERN.matcher(humanReadable);
-
-    if (!matcher.matches()) {
-      final String err =
-          String.format(
-              "Illegal byte value '%s'. Must match '%s'. Valid examples: 100M, 4K, ...",
-              humanReadable, PATTERN.pattern());
-      throw new IllegalArgumentException(err);
-    }
-
-    final String valueString = matcher.group(1);
-    value = Long.parseLong(valueString);
-
-    final String unitString = matcher.group(2).toUpperCase();
-
-    unit = ByteUnit.getUnit(unitString);
-  }
-
-  public static ByteValue ofBytes(final long value) {
-    return new ByteValue(value, BYTES).normalize();
-  }
-
-  public static ByteValue ofKilobytes(final long value) {
-    return new ByteValue(value, ByteUnit.KILOBYTES);
-  }
-
-  public static ByteValue ofMegabytes(final long value) {
-    return new ByteValue(value, ByteUnit.MEGABYTES);
-  }
-
-  public static ByteValue ofGigabytes(final long value) {
-    return new ByteValue(value, ByteUnit.GIGABYTES);
   }
 
   public ByteUnit getUnit() {
@@ -69,36 +34,8 @@ public final class ByteValue {
     return value;
   }
 
-  public ByteValue normalize() {
-    if (toGigabytesValue().getValue() > 0) {
-      return toGigabytesValue();
-    } else if (toMegabytesValue().getValue() > 0) {
-      return toMegabytesValue();
-    } else if (toKilobytesValue().getValue() > 0) {
-      return toKilobytesValue();
-    } else {
-      return this;
-    }
-  }
-
   public long toBytes() {
     return unit.toBytes(value);
-  }
-
-  public ByteValue toBytesValue() {
-    return new ByteValue(unit.toBytes(value), BYTES);
-  }
-
-  public ByteValue toKilobytesValue() {
-    return new ByteValue(unit.toKilobytes(value), KILOBYTES);
-  }
-
-  public ByteValue toMegabytesValue() {
-    return new ByteValue(unit.toMegabytes(value), MEGABYTES);
-  }
-
-  public ByteValue toGigabytesValue() {
-    return new ByteValue(unit.toGigabytes(value), ByteUnit.GIGABYTES);
   }
 
   @Override
@@ -134,5 +71,35 @@ public final class ByteValue {
   @Override
   public String toString() {
     return String.format("%d%s", value, unit.metric());
+  }
+
+  /**
+   * Converts the {@code value} kilobytes into bytes
+   *
+   * @param value value in kilobytes
+   * @return {@code value} converted into bytes
+   */
+  public static long ofKilobytes(final long value) {
+    return value * CONVERSION_FACTOR_KB;
+  }
+
+  /**
+   * Converts the {@code value} megabytes into bytes
+   *
+   * @param value value in megabytes
+   * @return {@code value} converted into bytes
+   */
+  public static long ofMegabytes(final long value) {
+    return value * CONVERSION_FACTOR_MB;
+  }
+
+  /**
+   * Converts the {@code value} gigabytes into bytes
+   *
+   * @param value value in gigabytes
+   * @return {@code value} converted into bytes
+   */
+  public static long ofGigabytes(final long value) {
+    return value * CONVERSION_FACTOR_GB;
   }
 }

--- a/util/src/main/java/io/zeebe/util/ByteValueParser.java
+++ b/util/src/main/java/io/zeebe/util/ByteValueParser.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ByteValueParser {
+  private static final Pattern PATTERN =
+      Pattern.compile("(\\d+)([K|M|G]?)", Pattern.CASE_INSENSITIVE);
+
+  public static ByteValue fromString(final String humanReadable) {
+
+    final Matcher matcher = PATTERN.matcher(humanReadable);
+
+    if (!matcher.matches()) {
+      final String err =
+          String.format(
+              "Illegal byte value '%s'. Must match '%s'. Valid examples: 100M, 4K, ...",
+              humanReadable, PATTERN.pattern());
+      throw new IllegalArgumentException(err);
+    }
+
+    final String valueString = matcher.group(1);
+    final long value = Long.parseLong(valueString);
+
+    final String unitString = matcher.group(2).toUpperCase();
+
+    final ByteUnit unit = ByteUnit.getUnit(unitString);
+
+    return new ByteValue(value, unit);
+  }
+
+  @Deprecated
+  public static ByteValue ofBytes(final long value) {
+    return new ByteValue(value, ByteUnit.BYTES);
+  }
+}

--- a/util/src/test/java/io/zeebe/util/ByteValueParserTest.java
+++ b/util/src/test/java/io/zeebe/util/ByteValueParserTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util;
+
+import static io.zeebe.util.ByteUnit.BYTES;
+import static io.zeebe.util.ByteUnit.GIGABYTES;
+import static io.zeebe.util.ByteUnit.KILOBYTES;
+import static io.zeebe.util.ByteUnit.MEGABYTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+public class ByteValueParserTest {
+
+  @Test
+  public void shouldParseValidStringValues() {
+    assertThat(ByteValueParser.fromString("10").getUnit()).isEqualTo(BYTES);
+    assertThat(ByteValueParser.fromString("10").getValue()).isEqualTo(10);
+
+    assertThat(ByteValueParser.fromString("11K").getUnit()).isEqualTo(KILOBYTES);
+    assertThat(ByteValueParser.fromString("11").getValue()).isEqualTo(11);
+
+    assertThat(ByteValueParser.fromString("12M").getUnit()).isEqualTo(MEGABYTES);
+    assertThat(ByteValueParser.fromString("12").getValue()).isEqualTo(12);
+
+    assertThat(ByteValueParser.fromString("13G").getUnit()).isEqualTo(GIGABYTES);
+    assertThat(ByteValueParser.fromString("13").getValue()).isEqualTo(13);
+  }
+
+  @Test
+  public void shouldParseValidStringValuesCaseInsensitive() {
+    assertThat(ByteValueParser.fromString("11k").getUnit()).isEqualTo(KILOBYTES);
+    assertThat(ByteValueParser.fromString("12m").getUnit()).isEqualTo(MEGABYTES);
+    assertThat(ByteValueParser.fromString("13g").getUnit()).isEqualTo(GIGABYTES);
+  }
+
+  @Test
+  public void shouldThrowOnInvalidUnit() {
+    assertThatThrownBy(() -> ByteValueParser.fromString("99f"))
+        .isExactlyInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Illegal byte value");
+  }
+
+  @Test
+  public void shouldParseOutputOfToStringMethod() {
+    final ByteValue value = new ByteValue(71, ByteUnit.KILOBYTES);
+
+    assertThat(ByteValueParser.fromString(value.toString())).isEqualTo(value);
+  }
+}

--- a/util/src/test/java/io/zeebe/util/ByteValueTest.java
+++ b/util/src/test/java/io/zeebe/util/ByteValueTest.java
@@ -12,66 +12,33 @@ import static io.zeebe.util.ByteUnit.GIGABYTES;
 import static io.zeebe.util.ByteUnit.KILOBYTES;
 import static io.zeebe.util.ByteUnit.MEGABYTES;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
 public final class ByteValueTest {
-  @Test
-  public void shouldParseValidStringValues() {
-    assertThat(new ByteValue("10").getUnit()).isEqualTo(BYTES);
-    assertThat(new ByteValue("10").getValue()).isEqualTo(10);
-
-    assertThat(new ByteValue("11K").getUnit()).isEqualTo(KILOBYTES);
-    assertThat(new ByteValue("11").getValue()).isEqualTo(11);
-
-    assertThat(new ByteValue("12M").getUnit()).isEqualTo(MEGABYTES);
-    assertThat(new ByteValue("12").getValue()).isEqualTo(12);
-
-    assertThat(new ByteValue("13G").getUnit()).isEqualTo(GIGABYTES);
-    assertThat(new ByteValue("13").getValue()).isEqualTo(13);
-  }
-
-  @Test
-  public void shouldParseValidStringValuesCaseInsensitive() {
-    assertThat(new ByteValue("11k").getUnit()).isEqualTo(KILOBYTES);
-    assertThat(new ByteValue("12m").getUnit()).isEqualTo(MEGABYTES);
-    assertThat(new ByteValue("13g").getUnit()).isEqualTo(GIGABYTES);
-  }
-
-  @Test
-  public void shouldThrowOnInvalidUnit() {
-    assertThatThrownBy(() -> new ByteValue("99f"))
-        .isExactlyInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("Illegal byte value");
-  }
 
   @Test
   public void shouldConvertUnitBytes() {
     final long byteValue = 1_000_000_000L;
     assertThat(new ByteValue(byteValue, BYTES).toBytes()).isEqualTo(byteValue);
-    assertThat(new ByteValue(byteValue, BYTES).toBytesValue())
-        .isEqualTo(new ByteValue(byteValue, BYTES));
-    assertThat(new ByteValue(byteValue, BYTES).toKilobytesValue())
-        .isEqualTo(new ByteValue(byteValue / 1024, KILOBYTES));
-    assertThat(new ByteValue(byteValue, BYTES).toMegabytesValue())
-        .isEqualTo(new ByteValue(byteValue / (1024 * 1024), MEGABYTES));
-    assertThat(new ByteValue(byteValue, BYTES).toGigabytesValue())
-        .isEqualTo(new ByteValue(byteValue / (1024 * 1024 * 1024), GIGABYTES));
   }
 
   @Test
-  public void shouldConvertUnitKilobytes() {
+  public void shouldConvertUnitKilobytesInConstructor() {
     final long kiloByteValue = 1_000_000L;
     assertThat(new ByteValue(kiloByteValue, KILOBYTES).toBytes()).isEqualTo(kiloByteValue * 1024);
-    assertThat(new ByteValue(kiloByteValue, KILOBYTES).toBytesValue())
-        .isEqualTo(new ByteValue(kiloByteValue * 1024, BYTES));
-    assertThat(new ByteValue(kiloByteValue, KILOBYTES).toKilobytesValue())
-        .isEqualTo(new ByteValue(kiloByteValue, KILOBYTES));
-    assertThat(new ByteValue(kiloByteValue, KILOBYTES).toMegabytesValue())
-        .isEqualTo(new ByteValue(kiloByteValue / 1024, MEGABYTES));
-    assertThat(new ByteValue(kiloByteValue, KILOBYTES).toGigabytesValue())
-        .isEqualTo(new ByteValue(kiloByteValue / (1024 * 1024), GIGABYTES));
+  }
+
+  @Test
+  public void shouldConvertUnitKilobytesInStaticMethod() {
+    // given
+    final long kiloByteValue = 5;
+
+    // when
+    final long actual = ByteValue.ofKilobytes(kiloByteValue);
+
+    // then
+    assertThat(actual).isEqualTo(kiloByteValue * 1024);
   }
 
   @Test
@@ -79,14 +46,18 @@ public final class ByteValueTest {
     final long megaByteValue = 1_000L;
     assertThat(new ByteValue(megaByteValue, MEGABYTES).toBytes())
         .isEqualTo(megaByteValue * (1024 * 1024));
-    assertThat(new ByteValue(megaByteValue, MEGABYTES).toBytesValue())
-        .isEqualTo(new ByteValue(megaByteValue * (1024 * 1024), BYTES));
-    assertThat(new ByteValue(megaByteValue, MEGABYTES).toKilobytesValue())
-        .isEqualTo(new ByteValue(megaByteValue * 1024, KILOBYTES));
-    assertThat(new ByteValue(megaByteValue, MEGABYTES).toMegabytesValue())
-        .isEqualTo(new ByteValue(megaByteValue, MEGABYTES));
-    assertThat(new ByteValue(megaByteValue, MEGABYTES).toGigabytesValue())
-        .isEqualTo(new ByteValue(megaByteValue / 1024, GIGABYTES));
+  }
+
+  @Test
+  public void shouldConvertUnitMegabytesInStaticMethod() {
+    // given
+    final long megaByteValue = 7;
+
+    // when
+    final long actual = ByteValue.ofMegabytes(megaByteValue);
+
+    // then
+    assertThat(actual).isEqualTo(megaByteValue * 1024 * 1024);
   }
 
   @Test
@@ -94,44 +65,17 @@ public final class ByteValueTest {
     final long gigaBytes = 100L;
     assertThat(new ByteValue(gigaBytes, GIGABYTES).toBytes())
         .isEqualTo(gigaBytes * (1024 * 1024 * 1024));
-    assertThat(new ByteValue(gigaBytes, GIGABYTES).toBytesValue())
-        .isEqualTo(new ByteValue(gigaBytes * (1024 * 1024 * 1024), BYTES));
-    assertThat(new ByteValue(gigaBytes, GIGABYTES).toKilobytesValue())
-        .isEqualTo(new ByteValue(gigaBytes * (1024 * 1024), KILOBYTES));
-    assertThat(new ByteValue(gigaBytes, GIGABYTES).toMegabytesValue())
-        .isEqualTo(new ByteValue(gigaBytes * 1024, MEGABYTES));
-    assertThat(new ByteValue(gigaBytes, GIGABYTES).toGigabytesValue())
-        .isEqualTo(new ByteValue(gigaBytes, GIGABYTES));
   }
 
   @Test
-  public void shouldParseToString() {
-    final ByteValue value = new ByteValue(71, ByteUnit.KILOBYTES);
+  public void shouldConvertUnitGigabytesInStaticMethod() {
+    // given
+    final long gigaByteValue = 5;
 
-    assertThat(new ByteValue(value.toString())).isEqualTo(value);
-  }
+    // when
+    final long actual = ByteValue.ofGigabytes(gigaByteValue);
 
-  @Test
-  public void shouldNormalizeBytesValue() {
-    assertThat(ByteValue.ofBytes(128)).isEqualTo(ByteValue.ofBytes(128));
-    assertThat(ByteValue.ofBytes(1023)).isEqualTo(ByteValue.ofBytes(1023));
-    assertThat(ByteValue.ofBytes(1024)).isEqualTo(ByteValue.ofKilobytes(1));
-    assertThat(ByteValue.ofBytes(512 * 1024)).isEqualTo(ByteValue.ofKilobytes(512));
-    assertThat(ByteValue.ofBytes(1024 * 1024)).isEqualTo(ByteValue.ofMegabytes(1));
-    assertThat(ByteValue.ofBytes(64 * 1024 * 1024)).isEqualTo(ByteValue.ofMegabytes(64));
-    assertThat(ByteValue.ofBytes(1024 * 1024 * 1024)).isEqualTo(ByteValue.ofGigabytes(1));
-    assertThat(ByteValue.ofBytes(4L * 1024 * 1024 * 1024)).isEqualTo(ByteValue.ofGigabytes(4));
-  }
-
-  @Test
-  public void shouldNormalizeValue() {
-    assertThat(ByteValue.ofBytes(512 * 1024).normalize()).isEqualTo(ByteValue.ofKilobytes(512));
-    assertThat(ByteValue.ofKilobytes(64 * 1024).normalize()).isEqualTo(ByteValue.ofMegabytes(64));
-    assertThat(ByteValue.ofMegabytes(4 * 1024).normalize()).isEqualTo(ByteValue.ofGigabytes(4));
-
-    assertThat(ByteValue.ofBytes(128).normalize()).isEqualTo(ByteValue.ofBytes(128));
-    assertThat(ByteValue.ofKilobytes(512).normalize()).isEqualTo(ByteValue.ofKilobytes(512));
-    assertThat(ByteValue.ofMegabytes(128).normalize()).isEqualTo(ByteValue.ofMegabytes(128));
-    assertThat(ByteValue.ofGigabytes(4).normalize()).isEqualTo(ByteValue.ofGigabytes(4));
+    // then
+    assertThat(actual).isEqualTo(gigaByteValue * 1024 * 1024 * 1024);
   }
 }


### PR DESCRIPTION
## Description

This change adds a dedicated class for the parsing of ByteValue objects. Usage of this parsing method is then restricted to the configuration classes. 

All other classes user either:
* a long value for the size
* or the static methods to convert sizes to long

Note that there is one unresolved issue about places which expect a size in long vs. places which expect a size in int. To that end, I tried to make as minimal changes as possible.

## Related issues

closes #3841

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
