### PR TITLE
IGNORE: testing LGTM fix

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,4 +1,4 @@
 extraction:
  java:
    index:
-     java_version: "11"
+     java_version: "13"

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,4 +1,4 @@
 extraction:
  java:
    index:
-     java_version: "13"
+     java_version: "11"

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,7 +71,7 @@
     <version.rocksdbjni>6.6.4</version.rocksdbjni>
     <version.sbe>1.16.1</version.sbe>
     <version.scala-parser>1.1.2</version.scala-parser>
-    <version.scala>2.13.1</version.scala>
+    <version.scala>2.13.0</version.scala>
     <version.slf4j>1.7.30</version.slf4j>
     <version.snakeyaml>1.25</version.snakeyaml>
     <version.toml>0.7.2</version.toml>


### PR DESCRIPTION
## Description

Seems some versions of Java 11 (depending on the distro) have trouble properly linking scala files, which is a known issue (? https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html#jdk-11-compatibility-notes)

This sets the JRE version to 13 which hopefully has better support.