### PR TITLE
chore(broker): Add methods to configuration objects that return Duration objects

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -11,7 +11,6 @@ import io.zeebe.broker.Loggers;
 import io.zeebe.broker.system.configuration.BrokerCfg;
 import io.zeebe.broker.system.configuration.ClusterCfg;
 import io.zeebe.broker.system.configuration.ThreadsCfg;
-import io.zeebe.util.DurationUtil;
 import io.zeebe.util.TomlConfigurationReader;
 import io.zeebe.util.sched.ActorScheduler;
 import io.zeebe.util.sched.clock.ActorClock;
@@ -64,7 +63,7 @@ public final class SystemContext {
     brokerCfg.init(basePath);
     validateConfiguration();
 
-    stepTimeout = DurationUtil.parse(brokerCfg.getStepTimeout());
+    stepTimeout = brokerCfg.getStepTimeoutAsDuration();
 
     final var cluster = brokerCfg.getCluster();
     final String brokerId = String.format("Broker-%d", cluster.getNodeId());

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
@@ -9,7 +9,9 @@ package io.zeebe.broker.system.configuration;
 
 import com.google.gson.GsonBuilder;
 import io.zeebe.broker.exporter.debug.DebugLogExporter;
+import io.zeebe.util.DurationUtil;
 import io.zeebe.util.Environment;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -107,11 +109,18 @@ public final class BrokerCfg {
     return this;
   }
 
+  public Duration getStepTimeoutAsDuration() {
+    return DurationUtil.parse(stepTimeout);
+  }
+
   public String getStepTimeout() {
     return stepTimeout;
   }
 
   public void setStepTimeout(final String stepTimeout) {
+    // call parsing code to provoke any exceptions that might occur during parsing
+    DurationUtil.parse(stepTimeout);
+
     this.stepTimeout = stepTimeout;
   }
 

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -7,7 +7,9 @@
  */
 package io.zeebe.broker.system.configuration;
 
+import io.zeebe.util.DurationUtil;
 import io.zeebe.util.Environment;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
@@ -56,7 +58,14 @@ public final class DataCfg implements ConfigurationEntry {
   }
 
   public void setSnapshotPeriod(final String snapshotPeriod) {
+    // call parsing to provoke any exceptions that might occur during parsing
+    DurationUtil.parse(snapshotPeriod);
+
     this.snapshotPeriod = snapshotPeriod;
+  }
+
+  public Duration getSnapshotPeriodAsDuration() {
+    return DurationUtil.parse(snapshotPeriod);
   }
 
   public int getMaxSnapshots() {

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -46,7 +46,6 @@ import io.zeebe.logstreams.state.StateSnapshotController;
 import io.zeebe.logstreams.storage.atomix.AtomixLogStorage;
 import io.zeebe.logstreams.storage.atomix.AtomixLogStorageReader;
 import io.zeebe.protocol.impl.encoding.BrokerInfo;
-import io.zeebe.util.DurationUtil;
 import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.ActorControl;
 import io.zeebe.util.sched.ActorScheduler;
@@ -366,7 +365,7 @@ public final class ZeebePartition extends Actor
 
   private ActorFuture<Void> installSnapshotDirector(
       final StreamProcessor streamProcessor, final DataCfg dataCfg) {
-    final Duration snapshotPeriod = DurationUtil.parse(dataCfg.getSnapshotPeriod());
+    final Duration snapshotPeriod = dataCfg.getSnapshotPeriodAsDuration();
     final var asyncSnapshotDirector =
         new AsyncSnapshotDirector(
             localBroker.getNodeId(),

--- a/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
@@ -45,20 +45,6 @@ public final class SimpleBrokerStartTest {
   }
 
   @Test
-  public void shouldFailToCreateBrokerWithInvalidTimeout() {
-    // given
-    final var brokerCfg = new BrokerCfg();
-    brokerCfg.setStepTimeout("invalid");
-
-    // when
-    final var catchedThrownBy =
-        assertThatThrownBy(() -> new Broker(brokerCfg, newTemporaryFolder.getAbsolutePath(), null));
-
-    // then
-    catchedThrownBy.isInstanceOf(IllegalArgumentException.class);
-  }
-
-  @Test
   public void shouldCallPartitionListenerAfterStart() throws Exception {
     // given
     final var brokerCfg = new BrokerCfg();

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -32,6 +32,7 @@ import static io.zeebe.broker.system.configuration.NetworkCfg.DEFAULT_INTERNAL_A
 import static io.zeebe.broker.system.configuration.NetworkCfg.DEFAULT_MONITORING_API_PORT;
 import static io.zeebe.protocol.Protocol.START_PARTITION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.zeebe.broker.exporter.debug.DebugLogExporter;
 import io.zeebe.broker.system.configuration.BackpressureCfg.LimitAlgorithm;
@@ -40,6 +41,7 @@ import io.zeebe.util.TomlConfigurationReader;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -83,6 +85,32 @@ public final class BrokerCfgTest {
   public void shouldUseStepTimeoutFromEnv() {
     environment.put(ENV_STEP_TIMEOUT, "1m");
     assertDefaultStepTimeout("1m");
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenTryingToSetInvalidStepTimeout() {
+    // given
+    final var sutBrokerCfg = new BrokerCfg();
+
+    // when
+    final var catchedThrownBy = assertThatThrownBy(() -> sutBrokerCfg.setStepTimeout("invalid"));
+
+    // then
+    catchedThrownBy.isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void shouldConvertStepTimeoutToDuration() {
+    // given
+    final Duration expected = Duration.ofMinutes(13);
+    final var sutBrokerCfg = new BrokerCfg();
+    sutBrokerCfg.setStepTimeout("13m");
+
+    // when
+    final Duration actual = sutBrokerCfg.getStepTimeoutAsDuration();
+
+    // then
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.Test;
+
+public class DataCfgTest {
+
+  @Test
+  public void shouldThrowExceptionWhenTryingToSetInvalidSnaphotPeriod() {
+    // given
+    final var sutDataCfg = new DataCfg();
+
+    // when
+    final var catchedThrownBy = assertThatThrownBy(() -> sutDataCfg.setSnapshotPeriod("invalid"));
+
+    // then
+    catchedThrownBy.isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void shouldConvertSnapshotPeriodToDuration() {
+    // given
+    final Duration expected = Duration.ofMinutes(13);
+    final var sutDataCfg = new DataCfg();
+    sutDataCfg.setSnapshotPeriod("13m");
+
+    // when
+    final Duration actual = sutDataCfg.getSnapshotPeriodAsDuration();
+
+    // then
+    assertThat(actual).isEqualTo(expected);
+  }
+}

--- a/gateway/src/main/java/io/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/zeebe/gateway/Gateway.java
@@ -18,7 +18,6 @@ import io.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.zeebe.gateway.impl.configuration.SecurityCfg;
 import io.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
-import io.zeebe.util.DurationUtil;
 import io.zeebe.util.VersionUtil;
 import io.zeebe.util.sched.ActorScheduler;
 import java.io.File;
@@ -116,7 +115,7 @@ public final class Gateway {
   }
 
   private static NettyServerBuilder setNetworkConfig(final NetworkCfg cfg) {
-    final Duration minKeepAliveInterval = DurationUtil.parse(cfg.getMinKeepAliveInterval());
+    final Duration minKeepAliveInterval = cfg.getMinKeepAliveIntervalAsDuration();
 
     if (minKeepAliveInterval.isNegative() || minKeepAliveInterval.isZero()) {
       throw new IllegalArgumentException("Minimum keep alive interval must be positive.");

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -92,6 +92,9 @@ public final class ClusterCfg {
   }
 
   public ClusterCfg setRequestTimeout(final String requestTimeout) {
+    // call parsing logic to provoke any exceptions that might occur during parsing
+    DurationUtil.parse(requestTimeout);
+
     this.requestTimeout = requestTimeout;
     return this;
   }

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/NetworkCfg.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/NetworkCfg.java
@@ -13,7 +13,9 @@ import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEW
 import static io.zeebe.gateway.impl.configuration.EnvironmentConstants.ENV_GATEWAY_PORT;
 
 import io.zeebe.transport.impl.SocketAddress;
+import io.zeebe.util.DurationUtil;
 import io.zeebe.util.Environment;
+import java.time.Duration;
 import java.util.Objects;
 
 public final class NetworkCfg {
@@ -50,11 +52,18 @@ public final class NetworkCfg {
     return this;
   }
 
+  public Duration getMinKeepAliveIntervalAsDuration() {
+    return DurationUtil.parse(minKeepAliveInterval);
+  }
+
   public String getMinKeepAliveInterval() {
     return minKeepAliveInterval;
   }
 
   public NetworkCfg setMinKeepAliveInterval(final String keepAlive) {
+    // call parsing logic to provoke any exceptions that might happen during parsing
+    DurationUtil.parse(keepAlive);
+
     this.minKeepAliveInterval = keepAlive;
     return this;
   }

--- a/gateway/src/test/java/io/zeebe/gateway/impl/configuration/ClusterCfgTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/impl/configuration/ClusterCfgTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.impl.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.Test;
+
+public class ClusterCfgTest {
+
+  @Test
+  public void shouldThrowExceptionWhenTryingToSetInvalidRequestTimeout() {
+    // given
+    final var sutClusterCfg = new ClusterCfg();
+
+    // when
+    final var catchedThrownBy =
+        assertThatThrownBy(() -> sutClusterCfg.setRequestTimeout("invalid"));
+
+    // then
+    catchedThrownBy.isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void shouldConvertRequestTimeoutToDuration() {
+    // given
+    final Duration expected = Duration.ofMinutes(13);
+    final var sutClusterCfg = new ClusterCfg();
+    sutClusterCfg.setRequestTimeout("13m");
+
+    // when
+    final Duration actual = sutClusterCfg.getRequestTimeout();
+
+    // then
+    assertThat(actual).isEqualTo(expected);
+  }
+}

--- a/gateway/src/test/java/io/zeebe/gateway/impl/configuration/NetworkCfgTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/impl/configuration/NetworkCfgTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.impl.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.Test;
+
+public class NetworkCfgTest {
+
+  @Test
+  public void shouldThrowExceptionWhenTryingToSetInvalidMinKeepAliveInterval() {
+    // given
+    final var sutNetworkCfg = new NetworkCfg();
+
+    // when
+    final var catchedThrownBy =
+        assertThatThrownBy(() -> sutNetworkCfg.setMinKeepAliveInterval("invalid"));
+
+    // then
+    catchedThrownBy.isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void shouldConvertMinKeepAliveInterval() {
+    // given
+    final Duration expected = Duration.ofMinutes(13);
+    final var sutNetworkCfg = new NetworkCfg();
+    sutNetworkCfg.setMinKeepAliveInterval("13m");
+
+    // when
+    final Duration actual = sutNetworkCfg.getMinKeepAliveIntervalAsDuration();
+
+    // then
+    assertThat(actual).isEqualTo(expected);
+  }
+}

--- a/util/src/main/java/io/zeebe/util/DurationUtil.java
+++ b/util/src/main/java/io/zeebe/util/DurationUtil.java
@@ -10,6 +10,7 @@ package io.zeebe.util;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 
+@Deprecated(forRemoval = true, since = "0.23.0-alpha2") // to be removed if an alternative is found
 public final class DurationUtil {
   /**
    * Input format expected to be [value][unit], where: - value is a number {@link


### PR DESCRIPTION
## Description

Adds methods to configuration objects that return `Duration` objects. These methods are the preferred way to read duration values from the configuration. 

## Related issues

closes #3842 

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
