### PR TITLE
chore(ci): move Go tests to parallel stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,24 +71,25 @@ pipeline {
             }
         }
 
-        stage('Test (Go)') {
-            steps {
-                container('golang') {
-                    sh '.ci/scripts/distribution/test-go.sh'
-                }
-            }
+        
 
-            post {
-                always {
-                    junit testResults: "**/*/TEST-*.xml", keepLongStdio: true
-                }
-            }
- 
-        }
-
-        stage('Test (Java)') {
+        stage('Test') {
             parallel {
-                stage('Analyse (Java)') {
+               stage('Test (Go)') {
+                    steps {
+                        container('golang') {
+                            sh '.ci/scripts/distribution/test-go.sh'
+                        }
+                    }
+
+                    post {
+                        always {
+                            junit testResults: "**/*/TEST-*.xml", keepLongStdio: true
+                        }
+                    }
+               }
+
+               stage('Analyse (Java)') {
                       steps {
                           container('maven') {
                                configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
             }
         }
 
-        stage('Build (Go)') {
+        stage('Prepare Tests') {
             environment {
                 IMAGE = "camunda/zeebe"
                 VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
@@ -57,10 +57,6 @@ pipeline {
             }
 
             steps {
-                container('golang') {
-                    sh '.ci/scripts/distribution/build-go.sh'
-                }
-
                 container('maven') {
                     sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
                 }
@@ -75,8 +71,12 @@ pipeline {
 
         stage('Test') {
             parallel {
-               stage('Test (Go)') {
+                stage('Go') {
                     steps {
+                        container('golang') {
+                            sh '.ci/scripts/distribution/build-go.sh'
+                        }
+
                         container('golang') {
                             sh '.ci/scripts/distribution/test-go.sh'
                         }
@@ -84,7 +84,7 @@ pipeline {
 
                     post {
                         always {
-                            junit testResults: "**/*/TEST-*.xml", keepLongStdio: true
+                            junit testResults: "**/*/TEST-go.xml", keepLongStdio: true
                         }
                     }
                }

--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -196,7 +196,8 @@ func buildZbctl() ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "./build.sh", runtime.GOOS)
+	// we need to build all binaries, because this is run after the go build stage on CI and will overwrite the binaries
+	cmd := exec.CommandContext(ctx, "./build.sh")
 	cmd.Env = append(os.Environ(), "RELEASE_VERSION=release-test", "RELEASE_HASH=1234567890")
 	return cmd.CombinedOutput()
 }


### PR DESCRIPTION
## Description

Moves the Go tests into the parallel "Test" stage.

## Related issues

closes #3511 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
