### PR TITLE
fix(clients/go): suppress usage on zbctl error

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/root.go
+++ b/clients/go/cmd/zbctl/internal/commands/root.go
@@ -54,6 +54,11 @@ It is designed for regular maintenance jobs such as:
 	* activating, completing or failing jobs
 	* update variables and retries
 	* view cluster status`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// silence help here instead of as a parameter because we only want to suppress it on a 'Zeebe' error and not if
+		// parsing args fails
+		cmd.SilenceUsage = true
+	},
 	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 		if client != nil {
 			return client.Close()

--- a/clients/go/cmd/zbctl/testdata/without_insecure.golden
+++ b/clients/go/cmd/zbctl/testdata/without_insecure.golden
@@ -1,17 +1,1 @@
 Error: rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: tls: first record does not look like a TLS handshake"
-Usage:
-  zbctl status [flags]
-
-Flags:
-  -h, --help   help for status
-
-Global Flags:
-      --address string        Specify a contact point address. If omitted, will read from the environment variable 'ZEEBE_ADDRESS' (default '127.0.0.1:26500')
-      --audience string       Specify the resource that the access token should be valid for. If omitted, will read from the environment variable 'ZEEBE_TOKEN_AUDIENCE'
-      --authzUrl string       Specify an authorization server URL from which to request an access token. If omitted, will read from the environment variable 'ZEEBE_AUTHORIZATION_SERVER_URL' (default "https://login.cloud.camunda.io/oauth/token/")
-      --certPath string       Specify a path to a certificate with which to validate gateway requests. If omitted, will read from the environment variable 'ZEEBE_CA_CERTIFICATE_PATH'
-      --clientCache string    Specify the path to use for the OAuth credentials cache. If omitted, will read from the environment variable 'ZEEBE_CLIENT_CONFIG_PATH' (default "/tmp/.camunda/credentials")
-      --clientId string       Specify a client identifier to request an access token. If omitted, will read from the environment variable 'ZEEBE_CLIENT_ID'
-      --clientSecret string   Specify a client secret to request an access token. If omitted, will read from the environment variable 'ZEEBE_CLIENT_SECRET'
-      --insecure              Specify if zbctl should use an unsecured connection. If omitted, will read from the environment variable 'ZEEBE_INSECURE_CONNECTION'
-


### PR DESCRIPTION
## Description

Configures cobra library so that the usage isn't printed on actual "Zeebe" errors. The usage is only suppressed in the client init instead of the root command initialization, because otherwise it would also suppress the usage if an error occurs when parsing arguments (and there it's useful to print the help).

## Related issues

closes #3776 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
