### PR TITLE
[BACKPORT] Log warning for variable values exceeding 32KB 

### DIFF
--- a/dist/src/main/config/zeebe.cfg.toml
+++ b/dist/src/main/config/zeebe.cfg.toml
@@ -325,3 +325,5 @@
 #  workflowInstance = true
 #  workflowInstanceCreation = false
 #  workflowInstanceSubscription = false
+#
+#  ignoreVariablesAbove = 32677

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
@@ -10,6 +10,7 @@ package io.zeebe.exporter;
 import io.prometheus.client.Histogram;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.value.VariableRecordValue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -68,11 +69,36 @@ public class ElasticsearchClient {
       metrics = new ElasticsearchMetrics(record.getPartitionId());
     }
 
+    checkRecord(record);
+
     final IndexRequest request =
         new IndexRequest(indexFor(record), typeFor(record), idFor(record))
             .source(record.toJson(), XContentType.JSON)
             .routing(String.valueOf(record.getPartitionId()));
     bulk(request);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void checkRecord(Record<?> record) {
+    if (record.getValueType() == ValueType.VARIABLE) {
+      checkVariableRecordValue((Record<VariableRecordValue>) record);
+    }
+  }
+
+  private void checkVariableRecordValue(Record<VariableRecordValue> record) {
+    final VariableRecordValue value = record.getValue();
+    final int size = value.getValue().getBytes().length;
+
+    if (size > configuration.index.ignoreVariablesAbove) {
+      log.warn(
+          "Variable {key: {}, name: {}, variableScope: {}, workflowInstanceKey: {}} exceeded max size of {} bytes with a size of {} bytes. As a consequence this variable is not index by elasticsearch.",
+          record.getKey(),
+          value.getName(),
+          value.getScopeKey(),
+          value.getWorkflowInstanceKey(),
+          configuration.index.ignoreVariablesAbove,
+          size);
+    }
   }
 
   public void bulk(final IndexRequest indexRequest) {

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -110,6 +110,9 @@ public class ElasticsearchExporterConfiguration {
     public boolean workflowInstanceCreation = false;
     public boolean workflowInstanceSubscription = false;
 
+    // size limits
+    public int ignoreVariablesAbove = 32677;
+
     @Override
     public String toString() {
       return "IndexConfiguration{"
@@ -146,6 +149,8 @@ public class ElasticsearchExporterConfiguration {
           + workflowInstanceCreation
           + ", workflowInstanceSubscription="
           + workflowInstanceSubscription
+          + ", ignoreVariablesAbove="
+          + ignoreVariablesAbove
           + '}';
     }
   }

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchClientTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchClientTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.value.VariableRecordValue;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ElasticsearchClientTest {
+
+  private static final long RECORD_KEY = 1234L;
+  private ElasticsearchExporterConfiguration configuration;
+  private Logger logSpy;
+  private ElasticsearchClient client;
+
+  @Before
+  public void setUp() {
+    configuration = new ElasticsearchExporterConfiguration();
+    logSpy = spy(LoggerFactory.getLogger(ElasticsearchClientTest.class));
+    client = new ElasticsearchClient(configuration, logSpy);
+  }
+
+  @Test
+  public void shouldNotLogWarningWhenIndexingSmallVariableValue() {
+    // given
+    final String variableValue = "x".repeat(configuration.index.ignoreVariablesAbove);
+
+    final Record<VariableRecordValue> recordMock = mock(Record.class);
+    when(recordMock.getPartitionId()).thenReturn(1);
+    when(recordMock.getKey()).thenReturn(RECORD_KEY);
+    when(recordMock.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(recordMock.toJson()).thenReturn("{}");
+
+    final VariableRecordValue value = mock(VariableRecordValue.class);
+    when(value.getValue()).thenReturn(variableValue);
+    when(recordMock.getValue()).thenReturn(value);
+
+    // when
+    client.index(recordMock);
+
+    // then
+    verify(logSpy, never()).warn(anyString(), ArgumentMatchers.<Object[]>any());
+  }
+
+  @Test
+  public void shouldLogWarnWhenIndexingLargeVariableValue() {
+    // given
+    final String variableName = "varName";
+    final String variableValue = "x".repeat(configuration.index.ignoreVariablesAbove + 1);
+    final long scopeKey = 1234L;
+    final long workflowInstanceKey = 5678L;
+
+    final Record<VariableRecordValue> recordMock = mock(Record.class);
+    when(recordMock.getPartitionId()).thenReturn(1);
+    when(recordMock.getKey()).thenReturn(RECORD_KEY);
+    when(recordMock.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(recordMock.toJson()).thenReturn("{}");
+
+    final VariableRecordValue value = mock(VariableRecordValue.class);
+    when(value.getName()).thenReturn(variableName);
+    when(value.getValue()).thenReturn(variableValue);
+    when(value.getScopeKey()).thenReturn(scopeKey);
+    when(value.getWorkflowInstanceKey()).thenReturn(workflowInstanceKey);
+
+    when(recordMock.getValue()).thenReturn(value);
+
+    // when
+    client.index(recordMock);
+
+    // then
+    final ArgumentCaptor<Object[]> argumentCaptor = ArgumentCaptor.forClass(Object[].class);
+
+    verify(logSpy).warn(anyString(), argumentCaptor.capture());
+
+    // required to explicitly cast List<Objects[]> to List<Object>
+    final List<Object> args = new ArrayList<>(argumentCaptor.getAllValues());
+    assertThat(args)
+        .contains(
+            RECORD_KEY,
+            variableName,
+            variableValue.getBytes().length,
+            scopeKey,
+            workflowInstanceKey);
+  }
+}


### PR DESCRIPTION
## Description

To notify users that we discourage usage of big variable values we log a warning for variables which exceed 32KB

## Related issues

related to #3891 (backport)

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
