### PR TITLE
chore(dist): disable log4j shutdown hook

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -77,6 +77,12 @@
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_hotspot</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.13.0</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/dist/src/main/config/log4j2.xml
+++ b/dist/src/main/config/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration status="WARN" shutdownHook="disable">
 
   <Properties>
     <Property name="log.path">${sys:app.home}/logs</Property>

--- a/dist/src/main/java/io/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/zeebe/broker/StandaloneBroker.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.concurrent.CountDownLatch;
+import org.apache.logging.log4j.LogManager;
 
 public class StandaloneBroker {
   private static final CountDownLatch WAITING_LATCH = new CountDownLatch(1);
@@ -36,11 +37,10 @@ public class StandaloneBroker {
               @Override
               public void run() {
                 try {
-                  if (broker != null) {
-                    broker.close();
-                  }
+                  broker.close();
                 } finally {
                   deleteTempDirectory();
+                  LogManager.shutdown();
                 }
               }
             });

--- a/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
@@ -7,6 +7,8 @@
  */
 package io.zeebe.gateway;
 
+import static java.lang.Runtime.getRuntime;
+
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.core.Atomix;
@@ -22,6 +24,7 @@ import io.zeebe.util.sched.ActorScheduler;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.function.Function;
+import org.apache.logging.log4j.LogManager;
 
 public class StandaloneGateway {
 
@@ -89,6 +92,16 @@ public class StandaloneGateway {
   public static void main(final String[] args) throws Exception {
     final GatewayCfg gatewayCfg = initConfiguration(args);
     gatewayCfg.init();
+
+    getRuntime()
+        .addShutdownHook(
+            new Thread("Gateway close thread") {
+              @Override
+              public void run() {
+                LogManager.shutdown();
+              }
+            });
+
     new StandaloneGateway(gatewayCfg).run();
   }
 


### PR DESCRIPTION
## Description

Shutdown log4j in our shutdown hooks so there is no race condition between zeebe and the log manager shutting down.

## Related issues

closes #3857 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
