### PR TITLE
Fix inconsistencies and bad practices in internal pkgs

### DIFF
--- a/.ci/scripts/distribution/build-go.sh
+++ b/.ci/scripts/distribution/build-go.sh
@@ -14,10 +14,10 @@ PREFIX=github.com/zeebe-io/zeebe/clients/go
 EXCLUDE=""
 
 for file in {internal,cmd/zbctl/internal}/*; do
-  EXCLUDE=$EXCLUDE$PREFIX/$file,
+  EXCLUDE="$EXCLUDE --exclude-package $PREFIX/$file"
 done
 
-/usr/bin/gocompat compare --go1compat --exclude-package=$EXCLUDE ./...
+/usr/bin/gocompat compare --go1compat $EXCLUDE ./...
 
 cd ${ORG_DIR}/zeebe/clients/go/cmd/zbctl
 

--- a/clients/go/cmd/zbctl/internal/commands/activateJobs.go
+++ b/clients/go/cmd/zbctl/internal/commands/activateJobs.go
@@ -66,7 +66,7 @@ var activateJobsCmd = &cobra.Command{
 			log.Println("Activated", jobsCount, "for type", jobType)
 			for index, job := range jobs {
 				log.Println("Job", index+1, "/", jobsCount)
-				if err := printJson(job); err != nil {
+				if err := printJSON(job); err != nil {
 					return err
 				}
 			}

--- a/clients/go/cmd/zbctl/internal/commands/createInstance.go
+++ b/clients/go/cmd/zbctl/internal/commands/createInstance.go
@@ -51,22 +51,22 @@ var createInstanceCmd = &cobra.Command{
 				return err
 			}
 
-			return printJson(response)
-		} else {
-			variableNames := []string{}
-			for _, variableName := range createInstanceWithResultFlag {
-				trimedVariableName := strings.TrimSpace(variableName)
-				if trimedVariableName != "" {
-					variableNames = append(variableNames, trimedVariableName)
-				}
-			}
-			response, err := zbCmd.WithResult().FetchVariables(variableNames...).Send(ctx)
-			if err != nil {
-				return err
-			}
-
-			return printJson(response)
+			return printJSON(response)
 		}
+
+		variableNames := []string{}
+		for _, variableName := range createInstanceWithResultFlag {
+			trimmedVariableName := strings.TrimSpace(variableName)
+			if trimmedVariableName != "" {
+				variableNames = append(variableNames, trimmedVariableName)
+			}
+		}
+		response, err := zbCmd.WithResult().FetchVariables(variableNames...).Send(ctx)
+		if err != nil {
+			return err
+		}
+
+		return printJSON(response)
 	},
 }
 

--- a/clients/go/cmd/zbctl/internal/commands/deployWorkflow.go
+++ b/clients/go/cmd/zbctl/internal/commands/deployWorkflow.go
@@ -37,7 +37,7 @@ var deployWorkflowCmd = &cobra.Command{
 			return err
 		}
 
-		return printJson(response)
+		return printJSON(response)
 	},
 }
 

--- a/clients/go/cmd/zbctl/internal/commands/generateCompletion.go
+++ b/clients/go/cmd/zbctl/internal/commands/generateCompletion.go
@@ -31,11 +31,15 @@ var generateCompletionCmd = &cobra.Command{
 		var err error
 		switch generateCompletionShellFlag {
 		case "bash":
-			rootCmd.GenBashCompletion(os.Stdout)
-			break
+			if err := rootCmd.GenBashCompletion(os.Stdout); err != nil {
+				return err
+			}
+
 		case "zsh":
-			rootCmd.GenZshCompletion(os.Stdout)
-			break
+			if err := rootCmd.GenZshCompletion(os.Stdout); err != nil {
+				return err
+			}
+
 		default:
 			err = errors.New(fmt.Sprint("Generating completion for shell", generateCompletionShellFlag, "not supported"))
 		}

--- a/clients/go/cmd/zbctl/internal/commands/publishMessage.go
+++ b/clients/go/cmd/zbctl/internal/commands/publishMessage.go
@@ -22,8 +22,8 @@ import (
 
 var (
 	publishMessageCorrelationKey string
-	publishMessageId             string
-	publishMessageTtl            time.Duration
+	publishMessageID             string
+	publishMessageTTL            time.Duration
 	publishMessageVariables      string
 )
 
@@ -36,8 +36,8 @@ var publishMessageCmd = &cobra.Command{
 		request, err := client.NewPublishMessageCommand().
 			MessageName(args[0]).
 			CorrelationKey(publishMessageCorrelationKey).
-			MessageId(publishMessageId).
-			TimeToLive(publishMessageTtl).
+			MessageId(publishMessageID).
+			TimeToLive(publishMessageTTL).
 			VariablesFromString(publishMessageVariables)
 
 		if err != nil {
@@ -56,9 +56,11 @@ func init() {
 	publishCmd.AddCommand(publishMessageCmd)
 
 	publishMessageCmd.Flags().StringVar(&publishMessageCorrelationKey, "correlationKey", "", "Specify message correlation key")
-	publishMessageCmd.Flags().StringVar(&publishMessageId, "messageId", "", "Specify the unique id of the message")
-	publishMessageCmd.Flags().DurationVar(&publishMessageTtl, "ttl", 5*time.Second, "Specify the time to live of the message")
+	publishMessageCmd.Flags().StringVar(&publishMessageID, "messageId", "", "Specify the unique id of the message")
+	publishMessageCmd.Flags().DurationVar(&publishMessageTTL, "ttl", 5*time.Second, "Specify the time to live of the message")
 	publishMessageCmd.Flags().StringVar(&publishMessageVariables, "variables", "{}", "Specify message variables as JSON string")
 
-	publishMessageCmd.MarkFlagRequired("correlationKey")
+	if err := publishMessageCmd.MarkFlagRequired("correlationKey"); err != nil {
+		panic(err)
+	}
 }

--- a/clients/go/cmd/zbctl/internal/commands/root.go
+++ b/clients/go/cmd/zbctl/internal/commands/root.go
@@ -203,10 +203,10 @@ func keyArg(key *int64) cobra.PositionalArgs {
 	}
 }
 
-func printJson(value interface{}) error {
-	valueJson, err := json.MarshalIndent(value, "", "  ")
+func printJSON(value interface{}) error {
+	valueJSON, err := json.MarshalIndent(value, "", "  ")
 	if err == nil {
-		fmt.Println(string(valueJson))
+		fmt.Println(string(valueJSON))
 	}
 	return err
 }

--- a/clients/go/cmd/zbctl/internal/commands/status.go
+++ b/clients/go/cmd/zbctl/internal/commands/status.go
@@ -21,17 +21,17 @@ import (
 	"sort"
 )
 
-type ByNodeId []*pb.BrokerInfo
+type ByNodeID []*pb.BrokerInfo
 
-func (a ByNodeId) Len() int           { return len(a) }
-func (a ByNodeId) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a ByNodeId) Less(i, j int) bool { return a[i].NodeId < a[j].NodeId }
+func (a ByNodeID) Len() int           { return len(a) }
+func (a ByNodeID) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByNodeID) Less(i, j int) bool { return a[i].NodeId < a[j].NodeId }
 
-type ByPartitionId []*pb.Partition
+type ByPartitionID []*pb.Partition
 
-func (a ByPartitionId) Len() int           { return len(a) }
-func (a ByPartitionId) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a ByPartitionId) Less(i, j int) bool { return a[i].PartitionId < a[j].PartitionId }
+func (a ByPartitionID) Len() int           { return len(a) }
+func (a ByPartitionID) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByPartitionID) Less(i, j int) bool { return a[i].PartitionId < a[j].PartitionId }
 
 var statusCmd = &cobra.Command{
 	Use:     "status",
@@ -49,11 +49,7 @@ var statusCmd = &cobra.Command{
 			return err
 		}
 
-		ctx, cancel = context.WithTimeout(context.Background(), defaultTimeout)
-		defer cancel()
-
 		printStatus(resp)
-
 		return nil
 	},
 }
@@ -70,7 +66,7 @@ func printStatus(resp *pb.TopologyResponse) {
 	fmt.Println("Gateway version:", gatewayVersion)
 	fmt.Println("Brokers:")
 
-	sort.Sort(ByNodeId(resp.Brokers))
+	sort.Sort(ByNodeID(resp.Brokers))
 
 	for _, broker := range resp.Brokers {
 		fmt.Printf("  Broker %d - %s:%d\n", broker.NodeId, broker.Host, broker.Port)
@@ -82,7 +78,7 @@ func printStatus(resp *pb.TopologyResponse) {
 
 		fmt.Printf("    Version: %s\n", version)
 
-		sort.Sort(ByPartitionId(broker.Partitions))
+		sort.Sort(ByPartitionID(broker.Partitions))
 		for _, partition := range broker.Partitions {
 			fmt.Printf("    Partition %d : %s\n", partition.PartitionId, roleToString(partition.Role))
 		}

--- a/clients/go/internal/utils/jsonString_mixin.go
+++ b/clients/go/internal/utils/jsonString_mixin.go
@@ -21,14 +21,14 @@ import (
 
 type SerializerMixin interface {
 	Validate(string, string) error
-	AsJson(string, interface{}, bool) (string, error)
+	AsJSON(string, interface{}, bool) (string, error)
 }
 
-type JsonStringSerializer struct {
+type JSONStringSerializer struct {
 	valueMap map[string]interface{}
 }
 
-func (validator *JsonStringSerializer) Validate(name string, value string) error {
+func (validator *JSONStringSerializer) Validate(name string, value string) error {
 	err := json.Unmarshal([]byte(value), &validator.valueMap)
 	if err != nil {
 		return fmt.Errorf("parameter %q requires a JSON object, got %q: %s", name, value, err)
@@ -36,7 +36,7 @@ func (validator *JsonStringSerializer) Validate(name string, value string) error
 	return nil
 }
 
-func (validator *JsonStringSerializer) AsJson(name string, value interface{}, ignoreOmitempty bool) (string, error) {
+func (validator *JSONStringSerializer) AsJSON(name string, value interface{}, ignoreOmitempty bool) (string, error) {
 	if ignoreOmitempty {
 		value = MapMarshal(value, "json", false, true)
 	}
@@ -47,8 +47,8 @@ func (validator *JsonStringSerializer) AsJson(name string, value interface{}, ig
 	return string(b), nil
 }
 
-func NewJsonStringSerializer() SerializerMixin {
-	return &JsonStringSerializer{
+func NewJSONStringSerializer() SerializerMixin {
+	return &JSONStringSerializer{
 		valueMap: make(map[string]interface{}),
 	}
 }

--- a/clients/go/internal/utils/structmap_test.go
+++ b/clients/go/internal/utils/structmap_test.go
@@ -505,9 +505,7 @@ func TestMapMarshal_EmbeddedTagged(t *testing.T) {
 	}
 	if v, ok := res["inner"]; !ok {
 		t.Fatal("inner struct is missing")
-	} else {
-		if v, ok := v.(map[string]interface{})["bar"]; !ok || v != "bar" {
-			t.Fatal("bar member of inner struct is missing or invalid")
-		}
+	} else if v, ok := v.(map[string]interface{})["bar"]; !ok || v != "bar" {
+		t.Fatal("bar member of inner struct is missing or invalid")
 	}
 }

--- a/clients/go/internal/utils/test_utils.go
+++ b/clients/go/internal/utils/test_utils.go
@@ -27,12 +27,12 @@ const DefaultTestTimeout = 5 * time.Second
 const DefaultTestTimeoutInMs = int64(DefaultTestTimeout / time.Millisecond)
 const DefaultContainerWaitTimeout = 2 * time.Minute
 
-// RpcTestMsg implements the gomock.Matcher interface
-type RpcTestMsg struct {
+// RPCTestMsg implements the gomock.Matcher interface
+type RPCTestMsg struct {
 	Msg proto.Message
 }
 
-func (r *RpcTestMsg) Matches(msg interface{}) bool {
+func (r *RPCTestMsg) Matches(msg interface{}) bool {
 	m, ok := msg.(proto.Message)
 	if !ok {
 		return false
@@ -60,6 +60,6 @@ func (r *RpcTestMsg) Matches(msg interface{}) bool {
 	return proto.Equal(m, r.Msg)
 }
 
-func (r *RpcTestMsg) String() string {
+func (r *RPCTestMsg) String() string {
 	return fmt.Sprintf("is %s", r.Msg)
 }

--- a/clients/go/pkg/commands/activate_jobs_test.go
+++ b/clients/go/pkg/commands/activate_jobs_test.go
@@ -99,13 +99,13 @@ func TestActivateJobsCommand(t *testing.T) {
 
 	var expectedJobs []entities.Job
 	for _, job := range response1.Jobs {
-		expectedJobs = append(expectedJobs, entities.Job{*job})
+		expectedJobs = append(expectedJobs, entities.Job{ActivatedJob: *job})
 	}
 	for _, job := range response2.Jobs {
-		expectedJobs = append(expectedJobs, entities.Job{*job})
+		expectedJobs = append(expectedJobs, entities.Job{ActivatedJob: *job})
 	}
 	for _, job := range response3.Jobs {
-		expectedJobs = append(expectedJobs, entities.Job{*job})
+		expectedJobs = append(expectedJobs, entities.Job{ActivatedJob: *job})
 	}
 
 	gomock.InOrder(
@@ -115,7 +115,7 @@ func TestActivateJobsCommand(t *testing.T) {
 		stream.EXPECT().Recv().Return(nil, io.EOF),
 	)
 
-	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
+	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stream, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
 	defer cancel()
@@ -132,9 +132,9 @@ func TestActivateJobsCommand(t *testing.T) {
 		t.Error("Failed to receive all jobs: ", jobs, expectedJobs)
 	}
 
-	for i := range jobs {
-		if !reflect.DeepEqual(jobs[i], expectedJobs[i]) {
-			t.Error("Failed to receive job: ", jobs[i], expectedJobs[i])
+	for i, job := range jobs {
+		if !reflect.DeepEqual(job, expectedJobs[i]) {
+			t.Error("Failed to receive job: ", job, expectedJobs[i])
 		}
 	}
 }
@@ -155,7 +155,7 @@ func TestActivateJobsCommandWithTimeout(t *testing.T) {
 	}
 
 	stream.EXPECT().Recv().Return(nil, io.EOF)
-	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
+	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stream, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
 	defer cancel()
@@ -189,7 +189,7 @@ func TestActivateJobsCommandWithWorkerName(t *testing.T) {
 	}
 
 	stream.EXPECT().Recv().Return(nil, io.EOF)
-	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
+	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stream, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
 	defer cancel()
@@ -229,7 +229,7 @@ func TestActivateJobsCommandWithFetchVariables(t *testing.T) {
 	defer cancel()
 
 	stream.EXPECT().Recv().Return(nil, io.EOF)
-	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stream, nil)
+	client.EXPECT().ActivateJobs(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stream, nil)
 
 	jobs, err := NewActivateJobsCommand(client, func(context.Context, error) bool {
 		return false

--- a/clients/go/pkg/commands/cancel_instance_test.go
+++ b/clients/go/pkg/commands/cancel_instance_test.go
@@ -34,7 +34,7 @@ func TestCancelWorkflowInstanceCommand(t *testing.T) {
 	}
 	stub := &pb.CancelWorkflowInstanceResponse{}
 
-	client.EXPECT().CancelWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CancelWorkflowInstance(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCancelInstanceCommand(client, func(context.Context, error) bool {
 		return false

--- a/clients/go/pkg/commands/complete_job.go
+++ b/clients/go/pkg/commands/complete_job.go
@@ -64,7 +64,7 @@ func (cmd *CompleteJobCommand) VariablesFromStringer(variables fmt.Stringer) (Di
 }
 
 func (cmd *CompleteJobCommand) VariablesFromObject(variables interface{}) (DispatchCompleteJobCommand, error) {
-	value, err := cmd.mixin.AsJson("variables", variables, false)
+	value, err := cmd.mixin.AsJSON("variables", variables, false)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (cmd *CompleteJobCommand) VariablesFromObject(variables interface{}) (Dispa
 }
 
 func (cmd *CompleteJobCommand) VariablesFromObjectIgnoreOmitempty(variables interface{}) (DispatchCompleteJobCommand, error) {
-	value, err := cmd.mixin.AsJson("variables", variables, true)
+	value, err := cmd.mixin.AsJSON("variables", variables, true)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (cmd *CompleteJobCommand) Send(ctx context.Context) (*pb.CompleteJobRespons
 func NewCompleteJobCommand(gateway pb.GatewayClient, pred retryPredicate) CompleteJobCommandStep1 {
 	return &CompleteJobCommand{
 		Command: Command{
-			mixin:       utils.NewJsonStringSerializer(),
+			mixin:       utils.NewJSONStringSerializer(),
 			gateway:     gateway,
 			shouldRetry: pred,
 		},

--- a/clients/go/pkg/commands/complete_job_test.go
+++ b/clients/go/pkg/commands/complete_job_test.go
@@ -34,7 +34,7 @@ func TestCompleteJobCommand(t *testing.T) {
 	}
 	stub := &pb.CompleteJobResponse{}
 
-	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CompleteJob(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
 	defer cancel()
@@ -66,7 +66,7 @@ func TestCompleteJobCommandWithVariablesFromString(t *testing.T) {
 	}
 	stub := &pb.CompleteJobResponse{}
 
-	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CompleteJob(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCompleteJobCommand(client, func(context.Context, error) bool { return false })
 
@@ -103,7 +103,7 @@ func TestCompleteJobCommandWithVariablesFromStringer(t *testing.T) {
 	}
 	stub := &pb.CompleteJobResponse{}
 
-	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CompleteJob(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCompleteJobCommand(client, func(context.Context, error) bool {
 		return false
@@ -142,7 +142,7 @@ func TestCompleteJobCommandWithVariablesFromObject(t *testing.T) {
 	}
 	stub := &pb.CompleteJobResponse{}
 
-	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CompleteJob(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCompleteJobCommand(client, func(context.Context, error) bool { return false })
 
@@ -179,7 +179,7 @@ func TestCompleteJobCommandWithVariablesFromObjectOmitempty(t *testing.T) {
 	}
 	stub := &pb.CompleteJobResponse{}
 
-	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CompleteJob(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCompleteJobCommand(client, func(context.Context, error) bool { return false })
 
@@ -216,7 +216,7 @@ func TestCompleteJobCommandWithVariablesFromObjectIgnoreOmitempty(t *testing.T) 
 	}
 	stub := &pb.CompleteJobResponse{}
 
-	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CompleteJob(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCompleteJobCommand(client, func(context.Context, error) bool { return false })
 
@@ -255,7 +255,7 @@ func TestCompleteJobCommandWithVariablesFromMap(t *testing.T) {
 	}
 	stub := &pb.CompleteJobResponse{}
 
-	client.EXPECT().CompleteJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CompleteJob(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCompleteJobCommand(client, func(context.Context, error) bool { return false })
 

--- a/clients/go/pkg/commands/create_instance.go
+++ b/clients/go/pkg/commands/create_instance.go
@@ -89,7 +89,7 @@ func (cmd *CreateInstanceCommand) VariablesFromStringer(variables fmt.Stringer) 
 }
 
 func (cmd *CreateInstanceCommand) VariablesFromObject(variables interface{}) (CreateInstanceCommandStep3, error) {
-	value, err := cmd.mixin.AsJson("variables", variables, false)
+	value, err := cmd.mixin.AsJSON("variables", variables, false)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (cmd *CreateInstanceCommand) VariablesFromObject(variables interface{}) (Cr
 }
 
 func (cmd *CreateInstanceCommand) VariablesFromObjectIgnoreOmitempty(variables interface{}) (CreateInstanceCommandStep3, error) {
-	value, err := cmd.mixin.AsJson("variables", variables, true)
+	value, err := cmd.mixin.AsJSON("variables", variables, true)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (cmd *CreateInstanceWithResultCommand) Send(ctx context.Context) (*pb.Creat
 func NewCreateInstanceCommand(gateway pb.GatewayClient, pred retryPredicate) CreateInstanceCommandStep1 {
 	return &CreateInstanceCommand{
 		Command: Command{
-			mixin:       utils.NewJsonStringSerializer(),
+			mixin:       utils.NewJSONStringSerializer(),
 			gateway:     gateway,
 			shouldRetry: pred,
 		},

--- a/clients/go/pkg/commands/create_instance_test.go
+++ b/clients/go/pkg/commands/create_instance_test.go
@@ -48,7 +48,7 @@ func TestCreateWorkflowInstanceCommand(t *testing.T) {
 		WorkflowInstanceKey: 5632,
 	}
 
-	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -80,7 +80,7 @@ func TestCreateWorkflowInstanceCommandByBpmnProcessId(t *testing.T) {
 		WorkflowInstanceKey: 5632,
 	}
 
-	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -112,7 +112,7 @@ func TestCreateWorkflowInstanceCommandByBpmnProcessIdAndVersion(t *testing.T) {
 		WorkflowInstanceKey: 5632,
 	}
 
-	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -146,7 +146,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromString(t *testing.T) {
 		WorkflowInstanceKey: 5632,
 	}
 
-	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -185,7 +185,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromStringer(t *testing.T) {
 		WorkflowInstanceKey: 5632,
 	}
 
-	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -224,7 +224,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromObject(t *testing.T) {
 		WorkflowInstanceKey: 5632,
 	}
 
-	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -263,7 +263,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromObjectOmitempty(t *testin
 		WorkflowInstanceKey: 5632,
 	}
 
-	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -302,7 +302,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromObjectIgnoreOmitempty(t *
 		WorkflowInstanceKey: 5632,
 	}
 
-	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -343,7 +343,7 @@ func TestCreateWorkflowInstanceCommandWithVariablesFromMap(t *testing.T) {
 		WorkflowInstanceKey: 5632,
 	}
 
-	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstance(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -382,7 +382,7 @@ func TestCreateWorkflowInstanceWithResultCommand(t *testing.T) {
 		Variables:           "{}",
 	}
 
-	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -421,7 +421,7 @@ func TestCreateWorkflowInstanceWithResultCommandByBpmnProcessId(t *testing.T) {
 		Variables:           "{}",
 	}
 
-	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -460,7 +460,7 @@ func TestCreateWorkflowInstanceWithResultCommandByBpmnProcessIdAndVersion(t *tes
 		Variables:           "{}",
 	}
 
-	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -500,7 +500,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromString(t *testi
 		Variables:           variables,
 	}
 
-	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -545,7 +545,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromStringer(t *tes
 		Variables:           variables,
 	}
 
-	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -590,7 +590,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObject(t *testi
 		Variables:           variables,
 	}
 
-	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -635,7 +635,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObjectOmitempty
 		Variables:           variables,
 	}
 
-	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -680,7 +680,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromObjectIgnoreOmi
 		Variables:           variables,
 	}
 
-	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -728,7 +728,7 @@ func TestCreateWorkflowInstanceWithResultCommandWithVariablesFromMap(t *testing.
 		Variables:           variables,
 	}
 
-	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -771,7 +771,7 @@ func TestCreateWorkflowInstanceWithResultAndFetchVariablesCommand(t *testing.T) 
 		Variables:           "{}",
 	}
 
-	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 
@@ -808,7 +808,7 @@ func TestCreateWorkflowInstanceWithResultAndFetchEmptyVariablesListCommand(t *te
 		Variables:           "{}",
 	}
 
-	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().CreateWorkflowInstanceWithResult(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewCreateInstanceCommand(client, func(context.Context, error) bool { return false })
 

--- a/clients/go/pkg/commands/deploy_test.go
+++ b/clients/go/pkg/commands/deploy_test.go
@@ -58,7 +58,7 @@ func TestDeployCommand_AddResourceFile(t *testing.T) {
 	}
 	stub := &pb.DeployWorkflowResponse{}
 
-	client.EXPECT().DeployWorkflow(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().DeployWorkflow(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewDeployCommand(client, func(context.Context, error) bool { return false })
 
@@ -97,7 +97,7 @@ func TestDeployCommand_AddResource(t *testing.T) {
 	}
 	stub := &pb.DeployWorkflowResponse{}
 
-	client.EXPECT().DeployWorkflow(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().DeployWorkflow(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewDeployCommand(client, func(context.Context, error) bool { return false })
 

--- a/clients/go/pkg/commands/fail_job_test.go
+++ b/clients/go/pkg/commands/fail_job_test.go
@@ -36,7 +36,7 @@ func TestFailJobCommand(t *testing.T) {
 	}
 	stub := &pb.FailJobResponse{}
 
-	client.EXPECT().FailJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().FailJob(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewFailJobCommand(client, func(context.Context, error) bool { return false })
 
@@ -69,7 +69,7 @@ func TestFailJobCommand_ErrorMessage(t *testing.T) {
 	}
 	stub := &pb.FailJobResponse{}
 
-	client.EXPECT().FailJob(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().FailJob(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewFailJobCommand(client, func(context.Context, error) bool { return false })
 

--- a/clients/go/pkg/commands/publish_message.go
+++ b/clients/go/pkg/commands/publish_message.go
@@ -64,7 +64,7 @@ func (cmd *PublishMessageCommand) MessageId(messageId string) PublishMessageComm
 }
 
 func (cmd *PublishMessageCommand) VariablesFromObject(variables interface{}) (PublishMessageCommandStep3, error) {
-	value, err := cmd.mixin.AsJson("variables", variables, false)
+	value, err := cmd.mixin.AsJSON("variables", variables, false)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (cmd *PublishMessageCommand) VariablesFromObject(variables interface{}) (Pu
 }
 
 func (cmd *PublishMessageCommand) VariablesFromObjectIgnoreOmitempty(variables interface{}) (PublishMessageCommandStep3, error) {
-	value, err := cmd.mixin.AsJson("variables", variables, true)
+	value, err := cmd.mixin.AsJSON("variables", variables, true)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (cmd *PublishMessageCommand) Send(ctx context.Context) (*pb.PublishMessageR
 func NewPublishMessageCommand(gateway pb.GatewayClient, pred retryPredicate) PublishMessageCommandStep1 {
 	return &PublishMessageCommand{
 		Command: Command{
-			mixin:       utils.NewJsonStringSerializer(),
+			mixin:       utils.NewJSONStringSerializer(),
 			gateway:     gateway,
 			shouldRetry: pred,
 		},

--- a/clients/go/pkg/commands/publish_message_test.go
+++ b/clients/go/pkg/commands/publish_message_test.go
@@ -37,7 +37,7 @@ func TestPublishMessageCommand(t *testing.T) {
 	}
 	stub := &pb.PublishMessageResponse{}
 
-	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().PublishMessage(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
@@ -68,7 +68,7 @@ func TestPublishMessageCommandWithMessageId(t *testing.T) {
 	}
 	stub := &pb.PublishMessageResponse{}
 
-	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().PublishMessage(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
@@ -99,7 +99,7 @@ func TestPublishMessageCommandWithTimeToLive(t *testing.T) {
 	}
 	stub := &pb.PublishMessageResponse{}
 
-	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().PublishMessage(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
@@ -132,7 +132,7 @@ func TestPublishMessageCommandWithVariablesFromString(t *testing.T) {
 	}
 	stub := &pb.PublishMessageResponse{}
 
-	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().PublishMessage(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
@@ -170,7 +170,7 @@ func TestPublishMessageCommandWithVariablesFromStringer(t *testing.T) {
 	}
 	stub := &pb.PublishMessageResponse{}
 
-	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().PublishMessage(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
@@ -208,7 +208,7 @@ func TestPublishMessageCommandWithVariablesFromObject(t *testing.T) {
 	}
 	stub := &pb.PublishMessageResponse{}
 
-	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().PublishMessage(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
@@ -246,7 +246,7 @@ func TestPublishMessageCommandWithVariablesFromObjectOmitempty(t *testing.T) {
 	}
 	stub := &pb.PublishMessageResponse{}
 
-	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().PublishMessage(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
@@ -284,7 +284,7 @@ func TestPublishMessageCommandWithVariablesFromObjectIgnoreOmitEmpty(t *testing.
 	}
 	stub := &pb.PublishMessageResponse{}
 
-	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().PublishMessage(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 
@@ -324,7 +324,7 @@ func TestPublishMessageCommandWithVariablesFromMap(t *testing.T) {
 	}
 	stub := &pb.PublishMessageResponse{}
 
-	client.EXPECT().PublishMessage(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().PublishMessage(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewPublishMessageCommand(client, func(context.Context, error) bool { return false })
 

--- a/clients/go/pkg/commands/resolve_incident_test.go
+++ b/clients/go/pkg/commands/resolve_incident_test.go
@@ -36,7 +36,7 @@ func TestResolveIncidentCommand(t *testing.T) {
 	}
 	stub := &pb.ResolveIncidentResponse{}
 
-	client.EXPECT().ResolveIncident(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().ResolveIncident(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewResolveIncidentCommand(client, func(context.Context, error) bool { return false })
 

--- a/clients/go/pkg/commands/set_variables.go
+++ b/clients/go/pkg/commands/set_variables.go
@@ -64,7 +64,7 @@ func (cmd *SetVariablesCommand) VariablesFromStringer(variables fmt.Stringer) (D
 }
 
 func (cmd *SetVariablesCommand) VariablesFromObject(variables interface{}) (DispatchSetVariablesCommand, error) {
-	value, err := cmd.mixin.AsJson("variables", variables, false)
+	value, err := cmd.mixin.AsJSON("variables", variables, false)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (cmd *SetVariablesCommand) VariablesFromObject(variables interface{}) (Disp
 }
 
 func (cmd *SetVariablesCommand) VariablesFromObjectIgnoreOmitempty(variables interface{}) (DispatchSetVariablesCommand, error) {
-	value, err := cmd.mixin.AsJson("variables", variables, true)
+	value, err := cmd.mixin.AsJSON("variables", variables, true)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (cmd *SetVariablesCommand) Send(ctx context.Context) (*pb.SetVariablesRespo
 func NewSetVariablesCommand(gateway pb.GatewayClient, pred retryPredicate) SetVariablesCommandStep1 {
 	return &SetVariablesCommand{
 		Command: Command{
-			mixin:       utils.NewJsonStringSerializer(),
+			mixin:       utils.NewJSONStringSerializer(),
 			gateway:     gateway,
 			shouldRetry: pred,
 		},

--- a/clients/go/pkg/commands/set_variables_test.go
+++ b/clients/go/pkg/commands/set_variables_test.go
@@ -39,7 +39,7 @@ func TestSetVariablesCommandWithVariablesFromString(t *testing.T) {
 		Key: 523,
 	}
 
-	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().SetVariables(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewSetVariablesCommand(client, func(context.Context, error) bool { return false })
 
@@ -78,7 +78,7 @@ func TestSetVariablesCommandWithVariablesFromStringer(t *testing.T) {
 		Key: 523,
 	}
 
-	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().SetVariables(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewSetVariablesCommand(client, func(context.Context, error) bool { return false })
 
@@ -117,7 +117,7 @@ func TestSetVariablesCommandWithVariablesFromObject(t *testing.T) {
 		Key: 523,
 	}
 
-	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().SetVariables(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewSetVariablesCommand(client, func(context.Context, error) bool { return false })
 
@@ -156,7 +156,7 @@ func TestSetVariablesCommandWithVariablesFromObjectOmitempty(t *testing.T) {
 		Key: 523,
 	}
 
-	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().SetVariables(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewSetVariablesCommand(client, func(context.Context, error) bool { return false })
 
@@ -195,7 +195,7 @@ func TestSetVariablesCommandWithVariablesFromObjectIgnoreOmitempty(t *testing.T)
 		Key: 523,
 	}
 
-	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().SetVariables(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewSetVariablesCommand(client, func(context.Context, error) bool { return false })
 
@@ -236,7 +236,7 @@ func TestSetVariablesCommandWithVariablesFromMap(t *testing.T) {
 		Key: 523,
 	}
 
-	client.EXPECT().SetVariables(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().SetVariables(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewSetVariablesCommand(client, func(context.Context, error) bool { return false })
 

--- a/clients/go/pkg/commands/throw_error_test.go
+++ b/clients/go/pkg/commands/throw_error_test.go
@@ -37,7 +37,7 @@ func TestThrowErrorCommand(t *testing.T) {
 	}
 	stub := &pb.ThrowErrorResponse{}
 
-	client.EXPECT().ThrowError(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().ThrowError(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewThrowErrorCommand(client, func(context.Context, error) bool { return false })
 

--- a/clients/go/pkg/commands/topology_test.go
+++ b/clients/go/pkg/commands/topology_test.go
@@ -71,7 +71,7 @@ func TestTopologyCommand(t *testing.T) {
 		},
 	}
 
-	client.EXPECT().Topology(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().Topology(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewTopologyCommand(client, func(context.Context, error) bool { return false })
 

--- a/clients/go/pkg/commands/update_job_retries_test.go
+++ b/clients/go/pkg/commands/update_job_retries_test.go
@@ -36,7 +36,7 @@ func TestUpdateJobRetriesCommand(t *testing.T) {
 	}
 	stub := &pb.UpdateJobRetriesResponse{}
 
-	client.EXPECT().UpdateJobRetries(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().UpdateJobRetries(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewUpdateJobRetriesCommand(client, func(context.Context, error) bool { return false })
 
@@ -63,7 +63,7 @@ func TestUpdateJobRetriesCommandWithRetries(t *testing.T) {
 	}
 	stub := &pb.UpdateJobRetriesResponse{}
 
-	client.EXPECT().UpdateJobRetries(gomock.Any(), &utils.RpcTestMsg{Msg: request}).Return(stub, nil)
+	client.EXPECT().UpdateJobRetries(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
 
 	command := NewUpdateJobRetriesCommand(client, func(context.Context, error) bool { return false })
 

--- a/clients/go/pkg/entities/job.go
+++ b/clients/go/pkg/entities/job.go
@@ -28,7 +28,7 @@ type Job struct {
 	pb.ActivatedJob
 }
 
-// GetVariablesAsMap retuns a map of a workflow instance's variables.
+// GetVariablesAsMap returns a map of a workflow instance's variables.
 //
 // See https://docs.zeebe.io/reference/variables.html for details on workflow
 // variables.

--- a/clients/go/pkg/worker/jobPoller_test.go
+++ b/clients/go/pkg/worker/jobPoller_test.go
@@ -89,10 +89,10 @@ func (suite *JobPollerSuite) TestShouldPollAfterPollIntervalIfThresholdIsReached
 	suite.poller.threshold = 4
 
 	gomock.InOrder(
-		suite.client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: &pb.ActivateJobsRequest{
+		suite.client.EXPECT().ActivateJobs(gomock.Any(), &utils.RPCTestMsg{Msg: &pb.ActivateJobsRequest{
 			MaxJobsToActivate: 10,
 		}}).Return(suite.singleJobStream(), nil),
-		suite.client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: &pb.ActivateJobsRequest{
+		suite.client.EXPECT().ActivateJobs(gomock.Any(), &utils.RPCTestMsg{Msg: &pb.ActivateJobsRequest{
 			MaxJobsToActivate: 9,
 		}}).Return(suite.singleJobStream(), nil),
 	)
@@ -112,7 +112,7 @@ func (suite *JobPollerSuite) TestShouldNotPollAfterIntervalIfNotThreshold() {
 	suite.poller.remaining = 6
 	suite.poller.threshold = 4
 
-	suite.client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: &pb.ActivateJobsRequest{
+	suite.client.EXPECT().ActivateJobs(gomock.Any(), &utils.RPCTestMsg{Msg: &pb.ActivateJobsRequest{
 		MaxJobsToActivate: 4,
 	}}).Return(suite.singleJobStream(), nil)
 
@@ -129,10 +129,10 @@ func (suite *JobPollerSuite) TestShoulPolldAfterJobFinsihedIfThresholdIsReached(
 	suite.poller.threshold = 4
 
 	gomock.InOrder(
-		suite.client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: &pb.ActivateJobsRequest{
+		suite.client.EXPECT().ActivateJobs(gomock.Any(), &utils.RPCTestMsg{Msg: &pb.ActivateJobsRequest{
 			MaxJobsToActivate: 10,
 		}}).Return(suite.singleJobStream(), nil),
-		suite.client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: &pb.ActivateJobsRequest{
+		suite.client.EXPECT().ActivateJobs(gomock.Any(), &utils.RPCTestMsg{Msg: &pb.ActivateJobsRequest{
 			MaxJobsToActivate: 10,
 		}}).Return(suite.singleJobStream(), nil),
 	)
@@ -151,7 +151,7 @@ func (suite *JobPollerSuite) TestShouldNotPollAfterJobIsFinishedIfNotThreshold()
 	suite.poller.remaining = 6
 	suite.poller.threshold = 4
 
-	suite.client.EXPECT().ActivateJobs(gomock.Any(), &utils.RpcTestMsg{Msg: &pb.ActivateJobsRequest{
+	suite.client.EXPECT().ActivateJobs(gomock.Any(), &utils.RPCTestMsg{Msg: &pb.ActivateJobsRequest{
 		MaxJobsToActivate: 4,
 	}}).Return(suite.singleJobStream(), nil)
 

--- a/clients/go/pkg/zbc/envWrapper.go
+++ b/clients/go/pkg/zbc/envWrapper.go
@@ -39,9 +39,7 @@ func (w *envWrapper) get(variable string) string {
 }
 
 func (w *envWrapper) unset(variable string) {
-	if _, present := w.vars[variable]; present {
-		delete(w.vars, variable)
-	}
+	delete(w.vars, variable)
 }
 
 func (w *envWrapper) lookup(variable string) (string, bool) {

--- a/clients/go/pkg/zbc/oauthCredentialsProvider.go
+++ b/clients/go/pkg/zbc/oauthCredentialsProvider.go
@@ -31,7 +31,11 @@ import (
 )
 
 const OAuthClientIdEnvVar = "ZEEBE_CLIENT_ID"
+
+// #nosec 101
 const OAuthClientSecretEnvVar = "ZEEBE_CLIENT_SECRET"
+
+// #nosec 101
 const OAuthTokenAudienceEnvVar = "ZEEBE_TOKEN_AUDIENCE"
 const OAuthAuthorizationUrlEnvVar = "ZEEBE_AUTHORIZATION_SERVER_URL"
 const OAuthRequestTimeoutEnvVar = "ZEEBE_AUTH_REQUEST_TIMEOUT"


### PR DESCRIPTION
## Description

This PR fixes some warnings flagged by golangci, including all those in the `internal` pkg (the remaining will be fixed in a separate PR, to keep them small). Most changes are due to renames from json -> JSON but a few fix potentially problematic issues. For instance, in the createWorker.go file we had very inconsistent error handling, some errors were ignored, others were passed into `log.Fatal` and other failed the job. 

## Related issues

related to #3004

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
