### PR TITLE
[BACKPORT] Ignore variable values larger then 32766 bytes in elasticsearch exporter

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
@@ -16,7 +16,8 @@
               "type": "keyword"
             },
             "value": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 32766
             },
             "scopeKey": {
               "type": "long"

--- a/test/src/main/java/io/zeebe/test/exporter/ExporterIntegrationRule.java
+++ b/test/src/main/java/io/zeebe/test/exporter/ExporterIntegrationRule.java
@@ -30,6 +30,7 @@ import io.zeebe.test.util.TestUtil;
 import io.zeebe.test.util.record.RecordingExporter;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -250,8 +251,12 @@ public class ExporterIntegrationRule extends ExternalResource {
   /** Runs a sample workload on the broker, exporting several records of different types. */
   public void performSampleWorkload() {
     deployWorkflow(SAMPLE_WORKFLOW, "sample_workflow.bpmn");
-    final long workflowInstanceKey =
-        createWorkflowInstance("testProcess", Collections.singletonMap("orderId", "foo-bar-123"));
+
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("orderId", "foo-bar-123");
+    variables.put("largeValue", "x".repeat(40_000));
+
+    final long workflowInstanceKey = createWorkflowInstance("testProcess", variables);
 
     // create job worker which fails on first try and sets retries to 0 to create an incident
     final AtomicBoolean fail = new AtomicBoolean(true);


### PR DESCRIPTION
## Description

The type keyword in elasticsearch has a default max length of 32766 bytes. A large variable value can exceed that limit. If we don't ignore these large values the es exporter fails and loops on exporting the variable value.
    
By ignoring the value it is exported and stored in the _source attribute in elasticsearch but not index anymore.
    
For more information see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/ignore-above.html

In the patch version, we also push a fix to existing indices to prevent failing exports for them.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3892 (backport)

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
