### PR TITLE
fix(broker): broadcast snapshots to static set of followers

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -38,6 +38,7 @@ import io.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.zeebe.broker.system.monitoring.BrokerHttpServer;
 import io.zeebe.broker.system.partitions.TypedRecordProcessorsFactory;
 import io.zeebe.broker.system.partitions.ZeebePartition;
+import io.zeebe.broker.system.partitions.impl.AtomixPartitionMessagingService;
 import io.zeebe.broker.transport.backpressure.PartitionAwareRequestLimiter;
 import io.zeebe.broker.transport.commandapi.CommandApiService;
 import io.zeebe.engine.processor.ProcessingContext;
@@ -313,12 +314,17 @@ public final class Broker implements AutoCloseable {
       partitionStartProcess.addStep(
           "partition " + partitionId,
           () -> {
+            final var messagingService =
+                new AtomixPartitionMessagingService(
+                    atomix.getCommunicationService(),
+                    atomix.getMembershipService(),
+                    owningPartition.members());
             final ZeebePartition zeebePartition =
                 new ZeebePartition(
                     localBroker,
                     owningPartition,
                     partitionListeners,
-                    atomix.getEventService(),
+                    messagingService,
                     scheduler,
                     brokerCfg,
                     commandHandler,

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshotMetadata.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshotMetadata.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
 
-final class DbSnapshotMetadata implements DbSnapshotId {
+public final class DbSnapshotMetadata implements DbSnapshotId {
   private static final Logger LOGGER = new ZbLogger(DbSnapshotMetadata.class);
   private static final int METADATA_PARTS = 3;
 
@@ -28,7 +28,7 @@ final class DbSnapshotMetadata implements DbSnapshotId {
     this.timestamp = timestamp;
   }
 
-  static Optional<DbSnapshotMetadata> ofPath(final Path path) {
+  public static Optional<DbSnapshotMetadata> ofPath(final Path path) {
     return ofFileName(path.getFileName().toString());
   }
 

--- a/broker/src/main/java/io/zeebe/broker/engine/impl/StateReplication.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/StateReplication.java
@@ -9,7 +9,6 @@ package io.zeebe.broker.engine.impl;
 
 import static io.zeebe.util.sched.Actor.buildActorName;
 
-import io.atomix.cluster.messaging.Subscription;
 import io.zeebe.broker.system.partitions.PartitionMessagingService;
 import io.zeebe.engine.Loggers;
 import io.zeebe.logstreams.state.SnapshotChunk;
@@ -35,7 +34,6 @@ public final class StateReplication implements SnapshotReplication {
   private final String threadName;
 
   private ExecutorService executorService;
-  private Subscription subscription;
 
   public StateReplication(
       final PartitionMessagingService messagingService, final int partitionId, final int nodeId) {

--- a/broker/src/main/java/io/zeebe/broker/engine/impl/StateReplication.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/StateReplication.java
@@ -9,11 +9,12 @@ package io.zeebe.broker.engine.impl;
 
 import static io.zeebe.util.sched.Actor.buildActorName;
 
-import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.cluster.messaging.Subscription;
+import io.zeebe.broker.system.partitions.PartitionMessagingService;
 import io.zeebe.engine.Loggers;
 import io.zeebe.logstreams.state.SnapshotChunk;
 import io.zeebe.logstreams.state.SnapshotReplication;
+import java.nio.ByteBuffer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -30,71 +31,68 @@ public final class StateReplication implements SnapshotReplication {
   private final String replicationTopic;
 
   private final DirectBuffer readBuffer = new UnsafeBuffer(0, 0);
-  private final ClusterEventService eventService;
+  private final PartitionMessagingService messagingService;
   private final String threadName;
 
   private ExecutorService executorService;
   private Subscription subscription;
 
   public StateReplication(
-      final ClusterEventService eventService, final int partitionId, final int nodeId) {
-    this.eventService = eventService;
+      final PartitionMessagingService messagingService, final int partitionId, final int nodeId) {
+    this.messagingService = messagingService;
     this.replicationTopic = String.format(REPLICATION_TOPIC_FORMAT, partitionId);
     this.threadName = buildActorName(nodeId, "StateReplication-" + partitionId);
   }
 
   @Override
-  public void replicate(final SnapshotChunk snapshot) {
-    eventService.broadcast(
+  public void replicate(final SnapshotChunk chunk) {
+    LOG.trace(
+        "Replicate on topic {} snapshot chunk {} for snapshot {}.",
         replicationTopic,
-        snapshot,
-        s -> {
-          LOG.trace(
-              "Replicate on topic {} snapshot chunk {} for snapshot {}.",
-              replicationTopic,
-              s.getChunkName(),
-              s.getSnapshotId());
+        chunk.getChunkName(),
+        chunk.getSnapshotId());
 
-          final SnapshotChunkImpl chunkImpl = new SnapshotChunkImpl(s);
-          return chunkImpl.toBytes();
-        });
+    messagingService.broadcast(replicationTopic, serializeSnapshotChunk(chunk));
   }
 
   @Override
   public void consume(final Consumer<SnapshotChunk> consumer) {
     executorService = Executors.newSingleThreadExecutor(r -> new Thread(r, threadName));
+    messagingService.subscribe(
+        replicationTopic,
+        message -> {
+          final var chunk = deserializeChunk(message);
+          LOG.trace(
+              "Received on topic {} replicated snapshot chunk {} for snapshot {}.",
+              replicationTopic,
+              chunk.getChunkName(),
+              chunk.getSnapshotId());
 
-    subscription =
-        eventService
-            .subscribe(
-                replicationTopic,
-                (bytes -> {
-                  readBuffer.wrap(bytes);
-                  final SnapshotChunkImpl chunk = new SnapshotChunkImpl();
-                  chunk.wrap(readBuffer, 0, bytes.length);
-                  LOG.trace(
-                      "Received on topic {} replicated snapshot chunk {} for snapshot {}.",
-                      replicationTopic,
-                      chunk.getChunkName(),
-                      chunk.getSnapshotId());
-                  return chunk;
-                }),
-                consumer,
-                executorService)
-            .join();
+          consumer.accept(chunk);
+        },
+        executorService);
   }
 
   @Override
   public void close() throws Exception {
-    if (subscription != null) {
-      subscription.close().join();
-      subscription = null;
-    }
+    messagingService.unsubscribe(replicationTopic);
 
     if (executorService != null) {
       executorService.shutdownNow();
       executorService.awaitTermination(10, TimeUnit.SECONDS);
       executorService = null;
     }
+  }
+
+  private ByteBuffer serializeSnapshotChunk(final SnapshotChunk chunk) {
+    return new SnapshotChunkImpl(chunk).toByteBuffer();
+  }
+
+  private SnapshotChunk deserializeChunk(final ByteBuffer buffer) {
+    final var chunk = new SnapshotChunkImpl();
+    readBuffer.wrap(buffer);
+    chunk.wrap(readBuffer, 0, readBuffer.capacity());
+
+    return chunk;
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/PartitionMessagingService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/PartitionMessagingService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.partitions;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+/** Abstracts away messaging to other members of a partition - add operations as needed. */
+public interface PartitionMessagingService {
+
+  /**
+   * Subscribes to a given subject - if another member of the partition sends a message on this
+   * topic, the consumer will be notified with the given payload. Each call is considered a new
+   * subscription.
+   *
+   * @param subject the subject to subscribe to
+   * @param consumer the consumer which handles the payload
+   * @param executor the executor on which the consumer is called
+   */
+  void subscribe(
+      final String subject, final Consumer<ByteBuffer> consumer, final Executor executor);
+
+  /**
+   * Broadcasts the given payload to all other members of the partition; should log if a member is
+   * not subscribed to a given topic, but not fail.
+   *
+   * @param subject the subject on which to broadcast the payload
+   * @param payload the payload to send
+   */
+  void broadcast(final String subject, final ByteBuffer payload);
+
+  /**
+   * Unsubcribes from the given subject, such that no messages after this call are handled by any
+   * previously registered consumer. If none registered, does nothing.
+   *
+   * @param subject the subject from which to unsubscribe
+   */
+  void unsubscribe(final String subject);
+}

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/AtomixPartitionMessagingService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/AtomixPartitionMessagingService.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.partitions.impl;
+
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.Member;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.zeebe.broker.system.partitions.PartitionMessagingService;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class AtomixPartitionMessagingService implements PartitionMessagingService {
+  private final ClusterCommunicationService communicationService;
+  private final ClusterMembershipService clusterMembershipService;
+  private final Set<MemberId> otherMembers;
+
+  public AtomixPartitionMessagingService(
+      final ClusterCommunicationService communicationService,
+      final ClusterMembershipService clusterMembershipService,
+      final Collection<MemberId> members) {
+    this.communicationService = communicationService;
+    this.clusterMembershipService = clusterMembershipService;
+    this.otherMembers = getOtherMemberIds(clusterMembershipService, members);
+  }
+
+  @Override
+  public void subscribe(
+      final String subject, final Consumer<ByteBuffer> consumer, final Executor executor) {
+    communicationService.subscribe(subject, consumer, executor);
+  }
+
+  @Override
+  public void broadcast(final String subject, final ByteBuffer payload) {
+    final var reachableMembers =
+        otherMembers.stream().filter(this::isReachable).collect(Collectors.toUnmodifiableSet());
+
+    communicationService.multicast(subject, payload, reachableMembers);
+  }
+
+  @Override
+  public void unsubscribe(final String subject) {
+    communicationService.unsubscribe(subject);
+  }
+
+  private Set<MemberId> getOtherMemberIds(
+      final ClusterMembershipService clusterMembershipService, final Collection<MemberId> members) {
+    final var localMemberId = clusterMembershipService.getLocalMember().id();
+    final var eligibleMembers = new HashSet<>(members);
+    eligibleMembers.remove(localMemberId);
+
+    return Collections.unmodifiableSet(eligibleMembers);
+  }
+
+  private boolean isReachable(final MemberId memberId) {
+    return Optional.ofNullable(clusterMembershipService.getMember(memberId))
+        .map(Member::isReachable)
+        .orElse(false);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/util/SbeBufferWriterReader.java
+++ b/engine/src/main/java/io/zeebe/engine/util/SbeBufferWriterReader.java
@@ -11,6 +11,7 @@ import io.zeebe.engine.processor.workflow.message.command.MessageHeaderDecoder;
 import io.zeebe.engine.processor.workflow.message.command.MessageHeaderEncoder;
 import io.zeebe.util.buffer.BufferReader;
 import io.zeebe.util.buffer.BufferWriter;
+import java.nio.ByteBuffer;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -72,6 +73,14 @@ public abstract class SbeBufferWriterReader<
 
     return headerDecoder.schemaId() == getBodyDecoder().sbeSchemaId()
         && headerDecoder.templateId() == getBodyDecoder().sbeTemplateId();
+  }
+
+  public ByteBuffer toByteBuffer() {
+    final ByteBuffer byteBuffer = ByteBuffer.allocate(getLength());
+    final MutableDirectBuffer buffer = new UnsafeBuffer(byteBuffer);
+    write(buffer, 0);
+
+    return byteBuffer;
   }
 
   public byte[] toBytes() {


### PR DESCRIPTION
## Description

Removes our dependency on the buggy `ClusterEventService` for snapshot replication, and instead broadcasting is changed to sending to all other reachable nodes in our Raft for the given topic. Removing this dependency fixes known issues where topic subscriptions are not propagated in certain cases, resulting in missed snapshots.

This keeps the same guarantees as the previous implementation, insofar as it may still fail to send some chunks as we perform UDP unicast.

This introduces a very thin abstraction over messaging to other Raft nodes such that our services do not need to know much about Atomix.

## Related issues

closes #3763 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
