### PR TITLE
chore(ci): switches pod spec to use new node pool

### DIFF
--- a/.ci/podSpecs/distribution.yml
+++ b/.ci/podSpecs/distribution.yml
@@ -3,9 +3,9 @@ metadata:
     agent: zeebe-ci-build
 spec:
   nodeSelector:
-    cloud.google.com/gke-nodepool: slaves
+    cloud.google.com/gke-nodepool: agents-n1-standard-32-netssd-preempt
   tolerations:
-    - key: "slaves"
+    - key: "agents-n1-standard-32-netssd-preempt"
       operator: "Exists"
       effect: "NoSchedule"
   volumes:
@@ -80,7 +80,7 @@ spec:
           memory: 2Gi
         requests:
           cpu: 3
-          memory: 1Gi
+          memory: 2Gi
       env:
         - name: DOCKER_HOST
           value: tcp://localhost:2375


### PR DESCRIPTION
## Description

Switches builds to use the new SSD enabled nodes. Also sets the resource requests to limits everywhere in order to have more stable scheduling (as per infra recommendation).

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
