### PR TITLE
Introduce new ZeebeIndex

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -45,6 +45,7 @@ import io.zeebe.engine.processor.workflow.EngineProcessors;
 import io.zeebe.engine.processor.workflow.message.command.SubscriptionCommandSender;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.logstreams.storage.atomix.ZeebeIndexAdapter;
 import io.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.zeebe.transport.ServerTransport;
 import io.zeebe.transport.TransportFactory;
@@ -56,7 +57,9 @@ import io.zeebe.util.sched.ActorControl;
 import io.zeebe.util.sched.ActorScheduler;
 import io.zeebe.util.sched.clock.ActorClock;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -87,6 +90,7 @@ public final class Broker implements AutoCloseable {
   private EmbeddedGatewayService embeddedGatewayService;
   private ServerTransport serverTransport;
   private BrokerHealthCheckService healthCheckService;
+  private Map<Integer, ZeebeIndexAdapter> partitionIndexes;
 
   public Broker(final SystemContext systemContext) {
     this.brokerContext = systemContext;
@@ -189,6 +193,22 @@ public final class Broker implements AutoCloseable {
 
   private AutoCloseable atomixCreateStep(final BrokerCfg brokerCfg) {
     atomix = AtomixFactory.fromConfiguration(brokerCfg);
+
+    final var partitionGroup =
+        (RaftPartitionGroup)
+            atomix.getPartitionService().getPartitionGroup(AtomixFactory.GROUP_NAME);
+
+    partitionIndexes = new HashMap<>();
+    final var logIndexDensity = brokerCfg.getData().getLogIndexDensity();
+    partitionGroup.getPartitions().stream()
+        .map(RaftPartition.class::cast)
+        .forEach(
+            raftPartition -> {
+              final var zeebeIndex = ZeebeIndexAdapter.ofDensity(logIndexDensity);
+              partitionIndexes.put(raftPartition.id().id(), zeebeIndex);
+              raftPartition.setJournalIndexFactory(() -> zeebeIndex);
+            });
+
     return () ->
         atomix.stop().get(brokerContext.getStepTimeout().toMillis(), TimeUnit.MILLISECONDS);
   }
@@ -296,8 +316,9 @@ public final class Broker implements AutoCloseable {
     final StartProcess partitionStartProcess = new StartProcess("Broker-" + nodeId + " partitions");
 
     for (final RaftPartition owningPartition : owningPartitions) {
+      final var partitionId = owningPartition.id().id();
       partitionStartProcess.addStep(
-          "partition " + owningPartition.id().id(),
+          "partition " + partitionId,
           () -> {
             final ZeebePartition zeebePartition =
                 new ZeebePartition(
@@ -308,6 +329,7 @@ public final class Broker implements AutoCloseable {
                     scheduler,
                     brokerCfg,
                     commandHandler,
+                    partitionIndexes.get(partitionId),
                     createFactory(topologyManager, clusterCfg, atomix, managementRequestHandler));
             scheduleActor(zeebePartition);
             healthCheckService.registerMonitoredPartition(

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/AtomixSnapshotStorage.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/AtomixSnapshotStorage.java
@@ -57,6 +57,7 @@ public final class AtomixSnapshotStorage implements SnapshotStorage, SnapshotLis
   @Override
   public Snapshot getPendingSnapshotFor(final long snapshotPosition) {
     final var optionalIndexed = entrySupplier.getIndexedEntry(snapshotPosition);
+
     if (optionalIndexed.isPresent()) {
       final var indexed = optionalIndexed.get();
       final var pending =

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -25,6 +25,7 @@ public final class DataCfg implements ConfigurationEntry {
   private Duration snapshotPeriod = Duration.ofMinutes(15);
 
   private int maxSnapshots = 3;
+  private int logIndexDensity = 100;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -68,6 +69,14 @@ public final class DataCfg implements ConfigurationEntry {
     this.maxSnapshots = maxSnapshots;
   }
 
+  public int getLogIndexDensity() {
+    return logIndexDensity;
+  }
+
+  public void setLogIndexDensity(int logIndexDensity) {
+    this.logIndexDensity = logIndexDensity;
+  }
+
   @Override
   public String toString() {
     return "DataCfg{"
@@ -81,6 +90,8 @@ public final class DataCfg implements ConfigurationEntry {
         + '\''
         + ", maxSnapshots="
         + maxSnapshots
+        + ", logIndexDensity="
+        + logIndexDensity
         + '}';
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -44,6 +44,7 @@ import io.zeebe.logstreams.state.SnapshotStorage;
 import io.zeebe.logstreams.state.StateSnapshotController;
 import io.zeebe.logstreams.storage.atomix.AtomixLogStorage;
 import io.zeebe.logstreams.storage.atomix.AtomixLogStorageReader;
+import io.zeebe.logstreams.storage.atomix.ZeebeIndexMapping;
 import io.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.zeebe.util.health.CriticalComponentsHealthMonitor;
 import io.zeebe.util.health.FailureListener;
@@ -93,6 +94,7 @@ public final class ZeebePartition extends Actor
   private FailureListener failureListener;
   private volatile HealthStatus healthStatus = HealthStatus.UNHEALTHY;
   private final HealthMonitor criticalComponentsHealthMonitor;
+  private final ZeebeIndexMapping zeebeIndexMapping;
 
   public ZeebePartition(
       final BrokerInfo localBroker,
@@ -102,6 +104,7 @@ public final class ZeebePartition extends Actor
       final ActorScheduler actorScheduler,
       final BrokerCfg brokerCfg,
       final CommandApiService commandApiService,
+      final ZeebeIndexMapping zeebeIndexMapping,
       final TypedRecordProcessorsFactory typedRecordProcessorsFactory) {
     this.localBroker = localBroker;
     this.atomixRaftPartition = atomixRaftPartition;
@@ -113,6 +116,7 @@ public final class ZeebePartition extends Actor
     this.partitionId = atomixRaftPartition.id().id();
     this.scheduler = actorScheduler;
     this.maxFragmentSize = (int) brokerCfg.getNetwork().getMaxMessageSizeInBytes();
+    this.zeebeIndexMapping = zeebeIndexMapping;
 
     final var exporterEntries = brokerCfg.getExporters().entrySet();
     // load and validate exporters
@@ -314,8 +318,10 @@ public final class ZeebePartition extends Actor
   }
 
   private SnapshotStorage createSnapshotStorage() {
+
     final var reader =
-        new AtomixLogStorageReader(atomixRaftPartition.getServer().openReader(-1, Mode.COMMITS));
+        new AtomixLogStorageReader(
+            zeebeIndexMapping, atomixRaftPartition.getServer().openReader(-1, Mode.COMMITS));
     final var runtimeDirectory = atomixRaftPartition.dataDirectory().toPath().resolve("runtime");
     return new AtomixSnapshotStorage(
         runtimeDirectory,
@@ -531,10 +537,11 @@ public final class ZeebePartition extends Actor
 
   @Override
   public void onActorStarting() {
-    final var storage = AtomixLogStorage.ofPartition(atomixRaftPartition);
+    final var atomixLogStorage =
+        AtomixLogStorage.ofPartition(zeebeIndexMapping, atomixRaftPartition);
 
     LogStream.builder()
-        .withLogStorage(storage)
+        .withLogStorage(atomixLogStorage)
         .withLogName(atomixRaftPartition.name())
         .withNodeId(localBroker.getNodeId())
         .withPartitionId(atomixRaftPartition.id().id())

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -56,7 +56,6 @@ public final class LogStorageAppender extends Actor {
     this.logStorage = logStorage;
     this.writeBufferSubscription = writeBufferSubscription;
     this.maxAppendBlockSize = maxBlockSize;
-
     appendBackpressureMetrics = new AppendBackpressureMetrics(partitionId);
 
     final boolean isBackpressureEnabled =

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -164,21 +164,8 @@ public final class LogStreamImpl extends Actor implements LogStream, AutoCloseab
   public void delete(final long position) {
     actor.call(
         () -> {
-          final boolean positionNotExist = !reader.seek(position);
-          if (positionNotExist) {
-            LOG.debug(
-                "Tried to delete from log stream, but found no corresponding address for the given position {}.",
-                position);
-            return;
-          }
-
-          final long blockAddress = reader.lastReadAddress();
-          LOG.debug(
-              "Delete data from log stream until position '{}' (address: '{}').",
-              position,
-              blockAddress);
-
-          logStorage.delete(blockAddress);
+          final long address = reader.lookupAddress(position);
+          logStorage.delete(address);
         });
   }
 

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
@@ -35,7 +35,6 @@ public final class LogStreamReaderImpl implements LogStreamReader {
   // state
   private IteratorState state;
   private long nextLogStorageReadAddress;
-  private long lastReadAddress;
   private int bufferOffset;
 
   public LogStreamReaderImpl(final LogStorage logStorage) {
@@ -117,8 +116,8 @@ public final class LogStreamReaderImpl implements LogStreamReader {
   }
 
   @Override
-  public long lastReadAddress() {
-    return lastReadAddress;
+  public long lookupAddress(long position) {
+    return storageReader.lookUpApproximateAddress(position);
   }
 
   private boolean seekFrom(final long blockAddress, final long position) {
@@ -204,7 +203,6 @@ public final class LogStreamReaderImpl implements LogStreamReader {
       state = IteratorState.NOT_ENOUGH_DATA;
       return false;
     } else {
-      this.lastReadAddress = blockAddress;
       this.nextLogStorageReadAddress = result;
       return true;
     }

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamReader.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamReader.java
@@ -64,14 +64,14 @@ public interface LogStreamReader extends Iterator<LoggedEvent>, CloseableSilentl
   long getPosition();
 
   /**
-   * The last log storage address, from which the last block of events was read.
-   *
-   * <p>Useful if you want to found out the related block address, then just seek to a given
-   * position and call this method.
+   * Look up the nearest log storage address, where the entry with the given position can be found.
+   * The implementation do not need to provide the exact log event address, it is more about an
+   * approximation, which can then be used to find the entry.
    *
    * <p>*Note:* The returned address is not the exact log event address.
    *
-   * @return the last log storage address, from which the last block of events was read.
+   * @param position the position, for which the look up should made
+   * @return the approximated address in the log storage
    */
-  long lastReadAddress();
+  long lookupAddress(long position);
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorage.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorage.java
@@ -19,24 +19,28 @@ public class AtomixLogStorage implements LogStorage {
   private final AtomixAppenderSupplier appenderSupplier;
 
   private boolean opened;
+  private final ZeebeIndexMapping zeebeIndexMapping;
 
   public AtomixLogStorage(
+      final ZeebeIndexMapping zeebeIndexMapping,
       final AtomixReaderFactory readerFactory,
       final AtomixLogCompactor logCompacter,
       final AtomixAppenderSupplier appenderSupplier) {
+    this.zeebeIndexMapping = zeebeIndexMapping;
     this.readerFactory = readerFactory;
     this.logCompacter = logCompacter;
     this.appenderSupplier = appenderSupplier;
   }
 
-  public static AtomixLogStorage ofPartition(final RaftPartition partition) {
+  public static AtomixLogStorage ofPartition(
+      final ZeebeIndexMapping zeebeIndexMapping, final RaftPartition partition) {
     final var server = new AtomixRaftServer(partition.getServer());
-    return new AtomixLogStorage(server, server, server);
+    return new AtomixLogStorage(zeebeIndexMapping, server, server, server);
   }
 
   @Override
   public LogStorageReader newReader() {
-    return new AtomixLogStorageReader(readerFactory.create());
+    return new AtomixLogStorageReader(zeebeIndexMapping, readerFactory.create());
   }
 
   @Override

--- a/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
@@ -17,9 +17,12 @@ import org.agrona.DirectBuffer;
 
 public final class AtomixLogStorageReader implements LogStorageReader {
   private final RaftLogReader reader;
+  private final ZeebeIndexMapping zeebeIndexMapping;
 
-  public AtomixLogStorageReader(final RaftLogReader reader) {
+  public AtomixLogStorageReader(
+      final ZeebeIndexMapping zeebeIndexMapping, final RaftLogReader reader) {
     this.reader = reader;
+    this.zeebeIndexMapping = zeebeIndexMapping;
   }
 
   @Override
@@ -98,8 +101,8 @@ public final class AtomixLogStorageReader implements LogStorageReader {
    */
   @Override
   public long lookUpApproximateAddress(final long position) {
-    var low = reader.getFirstIndex();
-    var high = reader.getLastIndex();
+    final var low = reader.getFirstIndex();
+    final var high = reader.getLastIndex();
 
     if (position == Long.MIN_VALUE) {
       final var optionalEntry = findEntry(reader.getFirstIndex());
@@ -116,32 +119,15 @@ public final class AtomixLogStorageReader implements LogStorageReader {
       return low;
     }
 
-    // binary search over index range, assuming we have no missing indexes
-    boolean atLeastOneZeebeEntry = false;
-    while (low <= high) {
-      final var pivotIndex = (low + high) >>> 1;
-      final var pivotEntry = findEntry(pivotIndex);
-
-      if (pivotEntry.isPresent()) {
-        final Indexed<ZeebeEntry> entry = pivotEntry.get();
-        // using the entry index to reset high/low can lead to infinite loops as `findEntry`
-        // actually seeks to the next entry
-        if (position < entry.entry().lowestPosition()) {
-          high = pivotIndex - 1;
-        } else if (position > entry.entry().highestPosition()) {
-          low = pivotIndex + 1;
-        } else {
-          return entry.index();
-        }
-        atLeastOneZeebeEntry = true;
-      } else {
-        high = pivotIndex - 1;
-      }
+    final var index = zeebeIndexMapping.lookupPosition(position);
+    final long result;
+    if (index == -1) {
+      result = low;
+    } else {
+      result = index;
     }
 
-    return atLeastOneZeebeEntry
-        ? Math.max(high, reader.getFirstIndex())
-        : LogStorage.OP_RESULT_NO_DATA;
+    return result;
   }
 
   @Override

--- a/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/ZeebeIndexAdapter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/ZeebeIndexAdapter.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.storage.atomix;
+
+import io.atomix.protocols.raft.zeebe.ZeebeEntry;
+import io.atomix.storage.journal.Indexed;
+import io.atomix.storage.journal.index.JournalIndex;
+import io.atomix.storage.journal.index.Position;
+import io.atomix.storage.journal.index.SparseJournalIndex;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+public final class ZeebeIndexAdapter implements JournalIndex, ZeebeIndexMapping {
+
+  private final ConcurrentNavigableMap<Long, Long> positionIndexMapping =
+      new ConcurrentSkipListMap<>();
+  private final ConcurrentNavigableMap<Long, Long> indexPositionMapping =
+      new ConcurrentSkipListMap<>();
+  private final SparseJournalIndex sparseJournalIndex;
+  private final int density;
+
+  private ZeebeIndexAdapter(int density) {
+    this.density = density;
+    sparseJournalIndex = new SparseJournalIndex(density);
+  }
+
+  public static ZeebeIndexAdapter ofDensity(int density) {
+    return new ZeebeIndexAdapter(density);
+  }
+
+  @Override
+  public void index(final Indexed indexedEntry, final int position) {
+    final var index = indexedEntry.index();
+    if (index % density == 0) {
+      if (indexedEntry.type() == ZeebeEntry.class) {
+        final ZeebeEntry zeebeEntry = (ZeebeEntry) indexedEntry.entry();
+        final var lowestPosition = zeebeEntry.lowestPosition();
+
+        positionIndexMapping.put(lowestPosition, index);
+        indexPositionMapping.put(index, lowestPosition);
+      }
+    }
+
+    sparseJournalIndex.index(indexedEntry, position);
+  }
+
+  @Override
+  public long lookupPosition(final long position) {
+    var index = positionIndexMapping.getOrDefault(position, -1L);
+
+    if (index == -1) {
+      final var lowerEntry = positionIndexMapping.lowerEntry(position);
+      if (lowerEntry != null) {
+        index = lowerEntry.getValue();
+      }
+    }
+
+    return index;
+  }
+
+  @Override
+  public Position lookup(final long index) {
+    return sparseJournalIndex.lookup(index);
+  }
+
+  @Override
+  public void truncate(final long index) {
+    final var higherEntry = indexPositionMapping.higherEntry(index);
+
+    if (higherEntry != null) {
+
+      final var higherIndex = higherEntry.getKey();
+      final var higherPosition = higherEntry.getValue();
+
+      indexPositionMapping.tailMap(higherIndex).clear();
+      positionIndexMapping.tailMap(higherPosition).clear();
+    }
+
+    sparseJournalIndex.truncate(index);
+  }
+
+  @Override
+  public void compact(long index) {
+    final var lowerEntry = indexPositionMapping.lowerEntry(index);
+
+    if (lowerEntry != null) {
+
+      final var lowerIndex = lowerEntry.getKey();
+      final var lowerPosition = lowerEntry.getValue();
+
+      indexPositionMapping.headMap(lowerIndex).clear();
+      positionIndexMapping.headMap(lowerPosition).clear();
+    }
+
+    sparseJournalIndex.compact(index);
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/ZeebeIndexAdapter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/ZeebeIndexAdapter.java
@@ -24,12 +24,12 @@ public final class ZeebeIndexAdapter implements JournalIndex, ZeebeIndexMapping 
   private final SparseJournalIndex sparseJournalIndex;
   private final int density;
 
-  private ZeebeIndexAdapter(int density) {
+  private ZeebeIndexAdapter(final int density) {
     this.density = density;
     sparseJournalIndex = new SparseJournalIndex(density);
   }
 
-  public static ZeebeIndexAdapter ofDensity(int density) {
+  public static ZeebeIndexAdapter ofDensity(final int density) {
     return new ZeebeIndexAdapter(density);
   }
 
@@ -51,13 +51,11 @@ public final class ZeebeIndexAdapter implements JournalIndex, ZeebeIndexMapping 
 
   @Override
   public long lookupPosition(final long position) {
-    var index = positionIndexMapping.getOrDefault(position, -1L);
+    long index = -1L;
 
-    if (index == -1) {
-      final var lowerEntry = positionIndexMapping.lowerEntry(position);
-      if (lowerEntry != null) {
-        index = lowerEntry.getValue();
-      }
+    final var lowerEntry = positionIndexMapping.floorEntry(position);
+    if (lowerEntry != null) {
+      index = lowerEntry.getValue();
     }
 
     return index;
@@ -85,7 +83,7 @@ public final class ZeebeIndexAdapter implements JournalIndex, ZeebeIndexMapping 
   }
 
   @Override
-  public void compact(long index) {
+  public void compact(final long index) {
     final var lowerEntry = indexPositionMapping.lowerEntry(index);
 
     if (lowerEntry != null) {

--- a/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/ZeebeIndexMapping.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/ZeebeIndexMapping.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.storage.atomix;
+
+public interface ZeebeIndexMapping {
+
+  /**
+   * Takes a position and returns the corresponding index, where this entry with the given position
+   * is stored.
+   *
+   * @param position
+   * @return
+   */
+  long lookupPosition(long position);
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -68,6 +68,7 @@ public final class LogStorageAppenderTest {
             .initialPartitionId(0)
             .build();
     final var subscription = dispatcher.openSubscription("log");
+
     appender =
         new LogStorageAppender(
             "appender", PARTITION_ID, logStorage, subscription, MAX_FRAGMENT_SIZE);

--- a/logstreams/src/test/java/io/zeebe/logstreams/storage/atomix/AtomixIndexTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/storage/atomix/AtomixIndexTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.storage.atomix;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import io.atomix.protocols.raft.storage.log.entry.InitializeEntry;
+import io.atomix.storage.journal.Indexed;
+import io.atomix.storage.journal.index.JournalIndex;
+import io.atomix.storage.journal.index.Position;
+import org.junit.Test;
+
+public class AtomixIndexTest {
+
+  @Test
+  public void shouldNotFindIndexWhenNotReachedDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = ZeebeIndexAdapter.ofDensity(5);
+
+    // when
+    final Position position = index.lookup(1);
+
+    // then
+    assertNull(position);
+  }
+
+  @Test
+  public void shouldFindIndexWhenReachedDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = ZeebeIndexAdapter.ofDensity(5);
+
+    // when
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+
+    // then
+    assertEquals(5, index.lookup(5).index());
+    assertEquals(10, index.lookup(5).position());
+  }
+
+  @Test
+  public void shouldFindLowerIndexWhenNotReachedDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = ZeebeIndexAdapter.ofDensity(5);
+    // index entries
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+
+    // when
+    index.index(asIndexedEntry(6), 12);
+    index.index(asIndexedEntry(7), 14);
+    index.index(asIndexedEntry(8), 16);
+
+    // then
+    assertEquals(5, index.lookup(8).index());
+    assertEquals(10, index.lookup(8).position());
+  }
+
+  @Test
+  public void shouldFindNextIndexWhenReachedDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = ZeebeIndexAdapter.ofDensity(5);
+    // index entries
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+    index.index(asIndexedEntry(6), 12);
+    index.index(asIndexedEntry(7), 14);
+    index.index(asIndexedEntry(8), 16);
+
+    // when
+    index.index(asIndexedEntry(9), 18);
+    index.index(asIndexedEntry(10), 20);
+
+    // then
+    assertEquals(10, index.lookup(10).index());
+    assertEquals(20, index.lookup(10).position());
+  }
+
+  @Test
+  public void shouldTruncateIndex() {
+    // given - every 5 index is added
+    final JournalIndex index = ZeebeIndexAdapter.ofDensity(5);
+    // index entries
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+    index.index(asIndexedEntry(6), 12);
+    index.index(asIndexedEntry(7), 14);
+    index.index(asIndexedEntry(8), 16);
+    index.index(asIndexedEntry(9), 18);
+    index.index(asIndexedEntry(10), 20);
+
+    // when
+    index.truncate(8);
+
+    // then
+    assertEquals(5, index.lookup(8).index());
+    assertEquals(10, index.lookup(8).position());
+    assertEquals(5, index.lookup(10).index());
+    assertEquals(10, index.lookup(10).position());
+  }
+
+  @Test
+  public void shouldTruncateCompleteIndex() {
+    // given - every 5 index is added
+    final JournalIndex index = ZeebeIndexAdapter.ofDensity(5);
+    // index entries
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+    index.index(asIndexedEntry(6), 12);
+    index.index(asIndexedEntry(7), 14);
+    index.index(asIndexedEntry(8), 16);
+    index.index(asIndexedEntry(9), 18);
+    index.index(asIndexedEntry(10), 20);
+    index.truncate(8);
+
+    // when
+    index.truncate(4);
+
+    // then
+    assertNull(index.lookup(4));
+    assertNull(index.lookup(5));
+    assertNull(index.lookup(8));
+    assertNull(index.lookup(10));
+  }
+
+  @Test
+  public void shouldNotCompactIndex() {
+    // given - every 5 index is added
+    final JournalIndex index = ZeebeIndexAdapter.ofDensity(5);
+    // index entries
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+    index.index(asIndexedEntry(6), 12);
+    index.index(asIndexedEntry(7), 14);
+    index.index(asIndexedEntry(8), 16);
+    index.index(asIndexedEntry(9), 18);
+    index.index(asIndexedEntry(10), 20);
+
+    // when
+    index.compact(8);
+
+    // then
+    assertEquals(5, index.lookup(8).index());
+    assertEquals(10, index.lookup(8).position());
+    assertEquals(10, index.lookup(10).index());
+    assertEquals(20, index.lookup(10).position());
+  }
+
+  @Test
+  public void shouldCompactIndex() {
+    // given - every 5 index is added
+    final JournalIndex index = ZeebeIndexAdapter.ofDensity(5);
+    // index entries
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+    index.index(asIndexedEntry(6), 12);
+    index.index(asIndexedEntry(7), 14);
+    index.index(asIndexedEntry(8), 16);
+    index.index(asIndexedEntry(9), 18);
+    index.index(asIndexedEntry(10), 20);
+
+    // when
+    index.compact(11);
+
+    // then
+    assertNull(index.lookup(4));
+    assertNull(index.lookup(5));
+    assertNull(index.lookup(8));
+
+    assertEquals(10, index.lookup(10).index());
+    assertEquals(20, index.lookup(10).position());
+    assertEquals(10, index.lookup(12).index());
+    assertEquals(20, index.lookup(12).position());
+  }
+
+  private static Indexed asIndexedEntry(long index) {
+    return new Indexed(index, new InitializeEntry(0, System.currentTimeMillis()), 0);
+  }
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/storage/atomix/ZeebeIndexTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/storage/atomix/ZeebeIndexTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.storage.atomix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.protocols.raft.storage.log.entry.InitializeEntry;
+import io.atomix.protocols.raft.zeebe.ZeebeEntry;
+import io.atomix.storage.journal.Indexed;
+import java.nio.ByteBuffer;
+import org.junit.Test;
+
+public class ZeebeIndexTest {
+
+  @Test
+  public void shouldNotFindIndexWhenNotReachedDensity() {
+    // given - every 5 index is added
+    final ZeebeIndexAdapter zeebeIndexAdapter = ZeebeIndexAdapter.ofDensity(5);
+
+    // when
+    final var index = zeebeIndexAdapter.lookupPosition(1L);
+
+    // then
+    assertThat(index).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldFindIndexWhenReachedDensity() {
+    // given - every 5 index is added
+    final ZeebeIndexAdapter zeebeIndexAdapter = ZeebeIndexAdapter.ofDensity(5);
+
+    // when
+    zeebeIndexAdapter.index(asZeebeEntry(1, 1), 2);
+    zeebeIndexAdapter.index(asZeebeEntry(2, 5), 4);
+    zeebeIndexAdapter.index(asZeebeEntry(3, 10), 6);
+    zeebeIndexAdapter.index(asZeebeEntry(4, 15), 8);
+    zeebeIndexAdapter.index(asZeebeEntry(5, 20), 10);
+
+    // then
+    assertThat(zeebeIndexAdapter.lookupPosition(1)).isEqualTo(-1);
+    assertThat(zeebeIndexAdapter.lookupPosition(16)).isEqualTo(-1);
+    assertThat(zeebeIndexAdapter.lookupPosition(21)).isEqualTo(5);
+  }
+
+  @Test
+  public void shouldNotAddToIndexWhenNotCorrectType() {
+    // given - every 5 index is added
+    final ZeebeIndexAdapter zeebeIndexAdapter = ZeebeIndexAdapter.ofDensity(5);
+
+    // when
+    zeebeIndexAdapter.index(
+        new Indexed(5, new InitializeEntry(0, System.currentTimeMillis()), 10), 10);
+
+    // then
+    assertThat(zeebeIndexAdapter.lookupPosition(1)).isEqualTo(-1);
+    assertThat(zeebeIndexAdapter.lookupPosition(16)).isEqualTo(-1);
+    assertThat(zeebeIndexAdapter.lookupPosition(21)).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldFindLowerIndexWhenNotReachedDensity() {
+    // given - every 5 index is added
+    final ZeebeIndexAdapter zeebeIndexAdapter = ZeebeIndexAdapter.ofDensity(5);
+    // index entries
+    zeebeIndexAdapter.index(asZeebeEntry(1, 1), 2);
+    zeebeIndexAdapter.index(asZeebeEntry(2, 5), 4);
+    zeebeIndexAdapter.index(asZeebeEntry(3, 10), 6);
+    zeebeIndexAdapter.index(asZeebeEntry(4, 15), 8);
+    zeebeIndexAdapter.index(asZeebeEntry(5, 20), 10);
+
+    // when
+    zeebeIndexAdapter.index(asZeebeEntry(6, 25), 12);
+    zeebeIndexAdapter.index(asZeebeEntry(7, 30), 14);
+    zeebeIndexAdapter.index(asZeebeEntry(8, 35), 16);
+
+    // then
+    assertThat(zeebeIndexAdapter.lookupPosition(21)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(31)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(35)).isEqualTo(5);
+  }
+
+  @Test
+  public void shouldFindNextIndexWhenReachedDensity() {
+    // given - every 5 index is added
+    final ZeebeIndexAdapter zeebeIndexAdapter = ZeebeIndexAdapter.ofDensity(5);
+    // index entries
+    zeebeIndexAdapter.index(asZeebeEntry(1, 1), 2);
+    zeebeIndexAdapter.index(asZeebeEntry(2, 5), 4);
+    zeebeIndexAdapter.index(asZeebeEntry(3, 10), 6);
+    zeebeIndexAdapter.index(asZeebeEntry(4, 15), 8);
+    zeebeIndexAdapter.index(asZeebeEntry(5, 20), 10);
+    zeebeIndexAdapter.index(asZeebeEntry(6, 25), 12);
+    zeebeIndexAdapter.index(asZeebeEntry(7, 30), 14);
+    zeebeIndexAdapter.index(asZeebeEntry(8, 35), 16);
+
+    // when
+    zeebeIndexAdapter.index(asZeebeEntry(9, 40), 18);
+    zeebeIndexAdapter.index(asZeebeEntry(10, 45), 20);
+
+    // then
+    assertThat(zeebeIndexAdapter.lookupPosition(21)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(45)).isEqualTo(10);
+    assertThat(zeebeIndexAdapter.lookupPosition(46)).isEqualTo(10);
+  }
+
+  @Test
+  public void shouldTruncateIndex() {
+    // given - every 5 index is added
+    final ZeebeIndexAdapter zeebeIndexAdapter = ZeebeIndexAdapter.ofDensity(5);
+    // index entries
+    zeebeIndexAdapter.index(asZeebeEntry(1, 1), 2);
+    zeebeIndexAdapter.index(asZeebeEntry(2, 5), 4);
+    zeebeIndexAdapter.index(asZeebeEntry(3, 10), 6);
+    zeebeIndexAdapter.index(asZeebeEntry(4, 15), 8);
+    zeebeIndexAdapter.index(asZeebeEntry(5, 20), 10);
+    zeebeIndexAdapter.index(asZeebeEntry(6, 25), 12);
+    zeebeIndexAdapter.index(asZeebeEntry(7, 30), 14);
+    zeebeIndexAdapter.index(asZeebeEntry(8, 35), 16);
+    zeebeIndexAdapter.index(asZeebeEntry(9, 40), 18);
+    zeebeIndexAdapter.index(asZeebeEntry(10, 45), 20);
+
+    // when
+    zeebeIndexAdapter.truncate(8);
+
+    // then
+    assertThat(zeebeIndexAdapter.lookupPosition(21)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(31)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(35)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(45)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(46)).isEqualTo(5);
+  }
+
+  @Test
+  public void shouldTruncateCompleteIndex() {
+    // given - every 5 index is added
+    final ZeebeIndexAdapter zeebeIndexAdapter = ZeebeIndexAdapter.ofDensity(5);
+    // index entries
+    zeebeIndexAdapter.index(asZeebeEntry(1, 1), 2);
+    zeebeIndexAdapter.index(asZeebeEntry(2, 5), 4);
+    zeebeIndexAdapter.index(asZeebeEntry(3, 10), 6);
+    zeebeIndexAdapter.index(asZeebeEntry(4, 15), 8);
+    zeebeIndexAdapter.index(asZeebeEntry(5, 20), 10);
+    zeebeIndexAdapter.index(asZeebeEntry(6, 25), 12);
+    zeebeIndexAdapter.index(asZeebeEntry(7, 30), 14);
+    zeebeIndexAdapter.index(asZeebeEntry(8, 35), 16);
+    zeebeIndexAdapter.index(asZeebeEntry(9, 40), 18);
+    zeebeIndexAdapter.index(asZeebeEntry(10, 45), 20);
+    zeebeIndexAdapter.truncate(8);
+
+    // when
+    zeebeIndexAdapter.truncate(4);
+
+    // then
+    assertThat(zeebeIndexAdapter.lookupPosition(5)).isEqualTo(-1);
+    assertThat(zeebeIndexAdapter.lookupPosition(20)).isEqualTo(-1);
+    assertThat(zeebeIndexAdapter.lookupPosition(35)).isEqualTo(-1);
+    assertThat(zeebeIndexAdapter.lookupPosition(50)).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldNotCompactIndex() {
+    // given - every 5 index is added
+    final ZeebeIndexAdapter zeebeIndexAdapter = ZeebeIndexAdapter.ofDensity(5);
+    // index entries
+    zeebeIndexAdapter.index(asZeebeEntry(1, 1), 2);
+    zeebeIndexAdapter.index(asZeebeEntry(2, 5), 4);
+    zeebeIndexAdapter.index(asZeebeEntry(3, 10), 6);
+    zeebeIndexAdapter.index(asZeebeEntry(4, 15), 8);
+    zeebeIndexAdapter.index(asZeebeEntry(5, 20), 10);
+    zeebeIndexAdapter.index(asZeebeEntry(6, 25), 12);
+    zeebeIndexAdapter.index(asZeebeEntry(7, 30), 14);
+    zeebeIndexAdapter.index(asZeebeEntry(8, 35), 16);
+    zeebeIndexAdapter.index(asZeebeEntry(9, 40), 18);
+    zeebeIndexAdapter.index(asZeebeEntry(10, 45), 20);
+
+    // when
+    zeebeIndexAdapter.compact(8);
+
+    // then
+    assertThat(zeebeIndexAdapter.lookupPosition(21)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(31)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(35)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(45)).isEqualTo(10);
+    assertThat(zeebeIndexAdapter.lookupPosition(46)).isEqualTo(10);
+  }
+
+  @Test
+  public void shouldCompactIndex() {
+    // given - every 5 index is added
+    final ZeebeIndexAdapter zeebeIndexAdapter = ZeebeIndexAdapter.ofDensity(5);
+    // index entries
+    zeebeIndexAdapter.index(asZeebeEntry(1, 1), 2);
+    zeebeIndexAdapter.index(asZeebeEntry(2, 5), 4);
+    zeebeIndexAdapter.index(asZeebeEntry(3, 10), 6);
+    zeebeIndexAdapter.index(asZeebeEntry(4, 15), 8);
+    zeebeIndexAdapter.index(asZeebeEntry(5, 20), 10);
+    zeebeIndexAdapter.index(asZeebeEntry(6, 25), 12);
+    zeebeIndexAdapter.index(asZeebeEntry(7, 30), 14);
+    zeebeIndexAdapter.index(asZeebeEntry(8, 35), 16);
+    zeebeIndexAdapter.index(asZeebeEntry(9, 40), 18);
+    zeebeIndexAdapter.index(asZeebeEntry(10, 45), 20);
+
+    // when
+    zeebeIndexAdapter.compact(11);
+
+    // then
+    assertThat(zeebeIndexAdapter.lookupPosition(21)).isEqualTo(-1);
+    assertThat(zeebeIndexAdapter.lookupPosition(31)).isEqualTo(-1);
+    assertThat(zeebeIndexAdapter.lookupPosition(35)).isEqualTo(-1);
+    assertThat(zeebeIndexAdapter.lookupPosition(45)).isEqualTo(10);
+    assertThat(zeebeIndexAdapter.lookupPosition(46)).isEqualTo(10);
+  }
+
+  private static Indexed asZeebeEntry(long index, long lowestPos) {
+    return new Indexed(
+        index,
+        new ZeebeEntry(0, System.currentTimeMillis(), lowestPos, lowestPos, ByteBuffer.allocate(0)),
+        0);
+  }
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/storage/atomix/ZeebeIndexTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/storage/atomix/ZeebeIndexTest.java
@@ -44,7 +44,8 @@ public class ZeebeIndexTest {
     // then
     assertThat(zeebeIndexAdapter.lookupPosition(1)).isEqualTo(-1);
     assertThat(zeebeIndexAdapter.lookupPosition(16)).isEqualTo(-1);
-    assertThat(zeebeIndexAdapter.lookupPosition(21)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(20)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(26)).isEqualTo(5);
   }
 
   @Test
@@ -54,11 +55,12 @@ public class ZeebeIndexTest {
 
     // when
     zeebeIndexAdapter.index(
-        new Indexed(5, new InitializeEntry(0, System.currentTimeMillis()), 10), 10);
+        new Indexed<>(5, new InitializeEntry(0, System.currentTimeMillis()), 10), 10);
 
     // then
     assertThat(zeebeIndexAdapter.lookupPosition(1)).isEqualTo(-1);
     assertThat(zeebeIndexAdapter.lookupPosition(16)).isEqualTo(-1);
+    assertThat(zeebeIndexAdapter.lookupPosition(20)).isEqualTo(-1);
     assertThat(zeebeIndexAdapter.lookupPosition(21)).isEqualTo(-1);
   }
 
@@ -79,6 +81,7 @@ public class ZeebeIndexTest {
     zeebeIndexAdapter.index(asZeebeEntry(8, 35), 16);
 
     // then
+    assertThat(zeebeIndexAdapter.lookupPosition(20)).isEqualTo(5);
     assertThat(zeebeIndexAdapter.lookupPosition(21)).isEqualTo(5);
     assertThat(zeebeIndexAdapter.lookupPosition(31)).isEqualTo(5);
     assertThat(zeebeIndexAdapter.lookupPosition(35)).isEqualTo(5);
@@ -103,7 +106,8 @@ public class ZeebeIndexTest {
     zeebeIndexAdapter.index(asZeebeEntry(10, 45), 20);
 
     // then
-    assertThat(zeebeIndexAdapter.lookupPosition(21)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(20)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(31)).isEqualTo(5);
     assertThat(zeebeIndexAdapter.lookupPosition(45)).isEqualTo(10);
     assertThat(zeebeIndexAdapter.lookupPosition(46)).isEqualTo(10);
   }
@@ -128,7 +132,7 @@ public class ZeebeIndexTest {
     zeebeIndexAdapter.truncate(8);
 
     // then
-    assertThat(zeebeIndexAdapter.lookupPosition(21)).isEqualTo(5);
+    assertThat(zeebeIndexAdapter.lookupPosition(20)).isEqualTo(5);
     assertThat(zeebeIndexAdapter.lookupPosition(31)).isEqualTo(5);
     assertThat(zeebeIndexAdapter.lookupPosition(35)).isEqualTo(5);
     assertThat(zeebeIndexAdapter.lookupPosition(45)).isEqualTo(5);
@@ -216,7 +220,7 @@ public class ZeebeIndexTest {
     assertThat(zeebeIndexAdapter.lookupPosition(46)).isEqualTo(10);
   }
 
-  private static Indexed asZeebeEntry(long index, long lowestPos) {
+  private static Indexed asZeebeEntry(final long index, final long lowestPos) {
     return new Indexed(
         index,
         new ZeebeEntry(0, System.currentTimeMillis(), lowestPos, lowestPos, ByteBuffer.allocate(0)),

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
@@ -63,6 +63,7 @@ public final class ClusteredDataDeletionTest {
     data.setMaxSnapshots(MAX_SNAPSHOTS);
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
     data.setLogSegmentSize(DataSize.ofKilobytes(8));
+    data.setLogIndexDensity(50);
     brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(8));
 
     brokerCfg.setExporters(Collections.emptyMap());
@@ -73,6 +74,7 @@ public final class ClusteredDataDeletionTest {
     data.setMaxSnapshots(MAX_SNAPSHOTS);
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
     data.setLogSegmentSize(DataSize.ofKilobytes(8));
+    data.setLogIndexDensity(50);
     brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(8));
 
     final ExporterCfg exporterCfg = new ExporterCfg();

--- a/util/src/main/java/io/zeebe/util/sched/future/CompletableActorFuture.java
+++ b/util/src/main/java/io/zeebe/util/sched/future/CompletableActorFuture.java
@@ -181,7 +181,7 @@ public final class CompletableActorFuture<V> implements ActorFuture<V>, BiConsum
               + (state == COMPLETED_EXCEPTIONALLY
                   ? ("exceptionally with '" + failure + "' ")
                   : " with value " + value);
-      throw new IllegalStateException(err);
+      throw new IllegalStateException(err, throwable);
     }
   }
 


### PR DESCRIPTION
## Description

**NOTE:** The build will fail until https://github.com/zeebe-io/atomix/pull/165 is merged

 In order to improve seek performance and reduce log deletion time,
 we introducing a new ZeebeIndex. This index wraps the Atomix
 SparseJournalIndex and builds an own map of position to index.

 With this index it is easily and in a performant way possible to look
 up an index/address for a given position. This look up is used
 for example on deletion instead of the old seek strategy. This treats
 time against space, which means we need to use more space in memory but
 are fast to find an index/position.

 The ZeebeIndex is on startup injected into the RaftPartition such that
 is filled on leader and follower on appending new entries.

 The underlying data structure needs to be thread safe, since we access
 it on different threads.

Be aware that it is currently just created on Broker startup and injected into the partition before opening them. I plan to refactor the Broker bootstrap and ZeebePartition with https://github.com/zeebe-io/zeebe/issues/3519 and https://github.com/zeebe-io/zeebe/issues/3518 where I then also rewrite this a bit.




### Benchmark

I run a benchmarks with the final changes and it looks like this:


#### General

![run](https://user-images.githubusercontent.com/2758593/75366545-320e0980-58bf-11ea-8c63-bff5ceec815d.png)

We can see that it looks more stable then the latest benchmarks.

#### Resources

![mem](https://user-images.githubusercontent.com/2758593/75366605-43efac80-58bf-11ea-97d2-1fcbb3a10a63.png)

The memory consumption is as expected and shows that the map is correctly cleaned up on every deletion/compaction.

![cpu](https://user-images.githubusercontent.com/2758593/75366652-5964d680-58bf-11ea-9fcd-bcb10d650acd.png)

No changes in CPU usage.

![disk](https://user-images.githubusercontent.com/2758593/75366668-61247b00-58bf-11ea-93dd-191372d2b0ee.png)

The disk space is correctly cleaned up.

![io](https://user-images.githubusercontent.com/2758593/75366681-697cb600-58bf-11ea-8946-d8e27f6a611a.png)

We can see much less IO load or at least much less read bytes per second every 15 min (which is the snapshot interval). Before we had between 60 - 100 Mb/s now we have between 1 to 8 Mb/s.

In benchmarks before I logged how much time it takes to seeking/find the right index. In the first benchmarks it took from 4  to 22 seconds. With introducing the map we can find an approximate index in ~ 1 ms. I also removed the seek to position before deletion since it is not really necessary.


### Benchmark without the map

![run](https://user-images.githubusercontent.com/2758593/75367218-443c7780-58c0-11ea-8dc3-426d3598991d.png)

In this benchmark we seeing much more the recurring throughput pattern. I'm not 100% sure why in this benchmark the throughput is in general higher as in the other. I probably need to investigate that.

![mem](https://user-images.githubusercontent.com/2758593/75367392-8c5b9a00-58c0-11ea-9cf4-80db7c4de71c.png)

Memory consumption looks different without the mapping.

![io](https://user-images.githubusercontent.com/2758593/75367461-a39a8780-58c0-11ea-9977-8b4d254b036f.png)

Here we can see the high spikes of read bytes per s.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/3918
closes https://github.com/zeebe-io/zeebe/issues/3623


## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
