### PR TITLE
chore(broker): set nodeId on LogStream

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -534,6 +534,7 @@ public final class ZeebePartition extends Actor
     LogStream.builder()
         .withLogStorage(storage)
         .withLogName(atomixRaftPartition.name())
+        .withNodeId(localBroker.getNodeId())
         .withPartitionId(atomixRaftPartition.id().id())
         .withMaxFragmentSize(maxFragmentSize)
         .withActorScheduler(scheduler)


### PR DESCRIPTION
## Description


Before the nodeId was not correctly set, which was a bit misleading on reading the logs.

**Example:**

```
[Broker-0-LogStream-1] [Broker-1-zb-actors-0] ERROR io.zeebe.util.actor - Actor failed in phase 'STARTED'. Continue with next job.
```

Now:

```
09:00:31.896 [Broker-1-LogStream-1] [Broker-1-zb-actors-1] DEBUG io.zeebe.logstreams
```

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3886

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
