### PR TITLE
Improve upgradability test coverage

### DIFF
--- a/upgrade-tests/src/test/java/io/zeebe/test/ContainerStateRule.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/ContainerStateRule.java
@@ -13,14 +13,17 @@ import io.zeebe.containers.ZeebePort;
 import io.zeebe.containers.ZeebeStandaloneGatewayContainer;
 import java.time.Duration;
 import java.util.Arrays;
-import org.junit.rules.ExternalResource;
+import java.util.regex.Pattern;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 import org.testcontainers.containers.Network;
 
-class ContainerStateRule extends ExternalResource {
+class ContainerStateRule extends TestWatcher {
 
+  private static final Pattern doubleNewline = Pattern.compile("\n\n");
   private static final Duration CLOSE_TIMEOUT = Duration.ofSeconds(30);
   private static final Logger LOG = LoggerFactory.getLogger(ContainerStateRule.class);
   private ZeebeBrokerContainer broker;
@@ -37,7 +40,8 @@ class ContainerStateRule extends ExternalResource {
   }
 
   @Override
-  public void after() {
+  protected void failed(Throwable e, Description description) {
+    super.failed(e, description);
     if (broker != null) {
       log("Broker", broker.getLogs());
     }
@@ -45,7 +49,10 @@ class ContainerStateRule extends ExternalResource {
     if (gateway != null) {
       log("Gateway", gateway.getLogs());
     }
+  }
 
+  @Override
+  protected void finished(Description description) {
     close();
   }
 
@@ -91,7 +98,7 @@ class ContainerStateRule extends ExternalResource {
       LOG.error(
           String.format(
               "%n===============================================%n%s logs%n===============================================%n%s",
-              type, log.replaceAll("\n\n", "\n")));
+              type, log.replaceAll(doubleNewline.pattern(), "\n")));
     }
   }
 
@@ -100,19 +107,19 @@ class ContainerStateRule extends ExternalResource {
    *     false
    */
   public boolean hasElementInState(final String elementId, final String intent) {
-    return findLogContaining(
+    return hasLogContaining(
         String.format("\"elementId\":\"%s\"", elementId),
         String.format("\"intent\":\"%s\"", intent));
   }
 
   /** @return true if the message was found in the specified intent. Otherwise, returns false */
   public boolean hasMessageInState(final String name, final String intent) {
-    return findLogContaining(
+    return hasLogContaining(
         String.format("\"name\":\"%s\"", name), String.format("\"intent\":\"%s\"", intent));
   }
 
   // returns true if it finds a line that contains every piece.
-  boolean findLogContaining(final String... pieces) {
+  boolean hasLogContaining(final String... pieces) {
     final String[] lines = broker.getLogs().split("\n");
     return Arrays.stream(lines).anyMatch(line -> Arrays.stream(pieces).allMatch(line::contains));
   }

--- a/upgrade-tests/src/test/java/io/zeebe/test/ContainerStateRule.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/ContainerStateRule.java
@@ -24,7 +24,7 @@ import org.testcontainers.containers.Network;
 
 class ContainerStateRule extends TestWatcher {
 
-  private static final Pattern doubleNewline = Pattern.compile("\n\n");
+  private static final Pattern DOUBLE_NEWLINE = Pattern.compile("\n\n");
   private static final Duration CLOSE_TIMEOUT = Duration.ofSeconds(30);
   private static final Logger LOG = LoggerFactory.getLogger(ContainerStateRule.class);
   private ZeebeBrokerContainer broker;
@@ -99,7 +99,7 @@ class ContainerStateRule extends TestWatcher {
       LOG.error(
           String.format(
               "%n===============================================%n%s logs%n===============================================%n%s",
-              type, log.replaceAll(doubleNewline.pattern(), "\n")));
+              type, log.replaceAll(DOUBLE_NEWLINE.pattern(), "\n")));
     }
   }
 

--- a/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
@@ -93,6 +93,14 @@ public class UpgradeTest {
                 .beforeUpgrade(UpgradeTest::startMsgSubscription)
                 .afterUpgrade(UpgradeTest::publishMessage)
                 .done()
+          },
+          {
+            "timer",
+            scenario()
+                .deployWorkflow(timerWorkflow())
+                .beforeUpgrade(UpgradeTest::timerCreated)
+                .afterUpgrade(UpgradeTest::timerTriggered)
+                .done()
           }
         });
   }
@@ -203,6 +211,23 @@ public class UpgradeTest {
   private static long startMsgSubscription(final ContainerStateRule state) {
     TestUtil.waitUntil(() -> state.hasLogContaining("MESSAGE_START_EVENT_SUBSCRIPTION", "OPENED"));
     return -1L;
+  }
+
+  private static BpmnModelInstance timerWorkflow() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .timerWithCycle("R/PT1S")
+        .endEvent()
+        .done();
+  }
+
+  private static long timerCreated(final ContainerStateRule state) {
+    TestUtil.waitUntil(() -> state.hasLogContaining("TIMER", "CREATED"));
+    return -1L;
+  }
+
+  private static void timerTriggered(final ContainerStateRule state, final long key) {
+    TestUtil.waitUntil(() -> state.hasLogContaining("TIMER", "TRIGGERED"));
   }
 
   private static TestCaseBuilder scenario() {

--- a/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
@@ -86,6 +86,14 @@ public class UpgradeTest {
                 .afterUpgrade(UpgradeTest::publishMessage)
                 .done()
           },
+          {
+            "message start event",
+            scenario()
+                .deployWorkflow(msgStartWorkflow())
+                .beforeUpgrade(UpgradeTest::startMsgSubscription)
+                .afterUpgrade(UpgradeTest::publishMessage)
+                .done()
+          }
         });
   }
 
@@ -182,6 +190,19 @@ public class UpgradeTest {
         .join();
 
     TestUtil.waitUntil(() -> state.hasMessageInState(MESSAGE, "PUBLISHED"));
+  }
+
+  private static BpmnModelInstance msgStartWorkflow() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .message(b -> b.zeebeCorrelationKey("key").name(MSG))
+        .endEvent()
+        .done();
+  }
+
+  private static long startMsgSubscription(final ContainerStateRule state) {
+    TestUtil.waitUntil(() -> state.hasLogContaining("MESSAGE_START_EVENT_SUBSCRIPTION", "OPENED"));
+    return -1L;
   }
 
   private static TestCaseBuilder scenario() {

--- a/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
@@ -10,11 +10,13 @@ package io.zeebe.test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.zeebe.client.api.response.ActivateJobsResponse;
+import io.zeebe.client.api.response.ActivatedJob;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.test.UpgradeTestCase.TestCaseBuilder;
 import io.zeebe.test.util.TestUtil;
 import io.zeebe.util.VersionUtil;
+import io.zeebe.util.collection.Tuple;
 import java.io.File;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -39,6 +41,7 @@ import org.junit.runners.Parameterized.Parameters;
 public class UpgradeTest {
 
   public static final String PROCESS_ID = "process";
+  public static final String CHILD_PROCESS_ID = "childProc";
   private static final String CURRENT_VERSION = "current-test";
   private static final String TASK = "task";
   private static final String MESSAGE = "message";
@@ -83,7 +86,7 @@ public class UpgradeTest {
             "message subscription",
             scenario()
                 .deployWorkflow(messageWorkflow())
-                .createInstance()
+                .createInstance(Map.of("key", "123"))
                 .beforeUpgrade(UpgradeTest::awaitOpenMessageSubscription)
                 .afterUpgrade(UpgradeTest::publishMessage)
                 .done()
@@ -92,7 +95,7 @@ public class UpgradeTest {
             "message start event",
             scenario()
                 .deployWorkflow(msgStartWorkflow())
-                .beforeUpgrade(UpgradeTest::startMsgSubscription)
+                .beforeUpgrade(UpgradeTest::awaitStartMessageSubscription)
                 .afterUpgrade(UpgradeTest::publishMessage)
                 .done()
           },
@@ -100,7 +103,7 @@ public class UpgradeTest {
             "timer",
             scenario()
                 .deployWorkflow(timerWorkflow())
-                .beforeUpgrade(UpgradeTest::timerCreated)
+                .beforeUpgrade(UpgradeTest::awaitTimerCreation)
                 .afterUpgrade(UpgradeTest::timerTriggered)
                 .done()
           },
@@ -109,7 +112,7 @@ public class UpgradeTest {
             scenario()
                 .deployWorkflow(incidentWorkflow())
                 .createInstance()
-                .beforeUpgrade(UpgradeTest::createIncident)
+                .beforeUpgrade(UpgradeTest::awaitIncidentCreation)
                 .afterUpgrade(UpgradeTest::resolveIncident)
                 .done()
           },
@@ -117,9 +120,49 @@ public class UpgradeTest {
             "publish message",
             scenario()
                 .deployWorkflow(messageWorkflow())
+                .beforeUpgrade(
+                    state -> {
+                      publishMessage(state, -1L, -1L);
+                      return -1L;
+                    })
+                .afterUpgrade(
+                    (state, l1, l2) -> {
+                      state
+                          .client()
+                          .newCreateInstanceCommand()
+                          .bpmnProcessId(PROCESS_ID)
+                          .latestVersion()
+                          .variables(Map.of("key", "123"))
+                          .send();
+                      TestUtil.waitUntil(() -> state.hasLogContaining(MESSAGE, "CORRELATED"));
+                    })
+                .done()
+          },
+          {
+            "call activity",
+            scenario()
+                .deployWorkflow(
+                    new Tuple<>(parentWorkflow(), PROCESS_ID),
+                    new Tuple<>(childWorkflow(), CHILD_PROCESS_ID))
                 .createInstance()
-                .beforeUpgrade(UpgradeTest::awaitOpenMessageSubscription)
-                .afterUpgrade(UpgradeTest::publishMessage)
+                .afterUpgrade(
+                    (state, wfKey, key) -> {
+                      final ActivatedJob job =
+                          state
+                              .client()
+                              .newActivateJobsCommand()
+                              .jobType(TASK)
+                              .maxJobsToActivate(1)
+                              .send()
+                              .join()
+                              .getJobs()
+                              .iterator()
+                              .next();
+
+                      state.client().newCompleteCommand(job.getKey()).send().join();
+                      TestUtil.waitUntil(
+                          () -> state.hasLogContaining(CHILD_PROCESS_ID, "COMPLETED"));
+                    })
                 .done()
           }
         });
@@ -205,7 +248,7 @@ public class UpgradeTest {
   }
 
   private static long awaitOpenMessageSubscription(final ContainerStateRule state) {
-    TestUtil.waitUntil(() -> state.hasLogContaining("WORKFLOW_INSTANCE_SUBSCRIPTION", "OPENED"));
+    TestUtil.waitUntil(() -> state.hasLogContaining("MESSAGE_SUBSCRIPTION", "OPENED"));
     return -1L;
   }
 
@@ -231,7 +274,7 @@ public class UpgradeTest {
         .done();
   }
 
-  private static long startMsgSubscription(final ContainerStateRule state) {
+  private static long awaitStartMessageSubscription(final ContainerStateRule state) {
     TestUtil.waitUntil(() -> state.hasLogContaining("MESSAGE_START_EVENT_SUBSCRIPTION", "OPENED"));
     return -1L;
   }
@@ -244,7 +287,7 @@ public class UpgradeTest {
         .done();
   }
 
-  private static long timerCreated(final ContainerStateRule state) {
+  private static long awaitTimerCreation(final ContainerStateRule state) {
     TestUtil.waitUntil(() -> state.hasLogContaining("TIMER", "CREATED"));
     return -1L;
   }
@@ -261,7 +304,7 @@ public class UpgradeTest {
         .done();
   }
 
-  private static long createIncident(final ContainerStateRule state) {
+  private static long awaitIncidentCreation(final ContainerStateRule state) {
     TestUtil.waitUntil(() -> state.hasLogContaining("INCIDENT", "CREATED"));
     return state.getIncidentKey();
   }
@@ -279,6 +322,22 @@ public class UpgradeTest {
     final ActivateJobsResponse job =
         state.client().newActivateJobsCommand().jobType(TASK).maxJobsToActivate(1).send().join();
     state.client().newCompleteCommand(job.getJobs().get(0).getKey()).send().join();
+  }
+
+  private static BpmnModelInstance parentWorkflow() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .callActivity("c", b -> b.zeebeProcessId(CHILD_PROCESS_ID))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance childWorkflow() {
+    return Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+        .startEvent()
+        .serviceTask(TASK, b -> b.zeebeTaskType(TASK))
+        .endEvent()
+        .done();
   }
 
   private static TestCaseBuilder scenario() {

--- a/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
@@ -17,6 +17,7 @@ import io.zeebe.test.util.TestUtil;
 import io.zeebe.util.VersionUtil;
 import java.io.File;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -79,7 +80,7 @@ public class UpgradeTest {
                 .done()
           },
           {
-            "message",
+            "message subscription",
             scenario()
                 .deployWorkflow(messageWorkflow())
                 .createInstance()
@@ -110,6 +111,15 @@ public class UpgradeTest {
                 .createInstance()
                 .beforeUpgrade(UpgradeTest::createIncident)
                 .afterUpgrade(UpgradeTest::resolveIncident)
+                .done()
+          },
+          {
+            "publish message",
+            scenario()
+                .deployWorkflow(messageWorkflow())
+                .createInstance()
+                .beforeUpgrade(UpgradeTest::awaitOpenMessageSubscription)
+                .afterUpgrade(UpgradeTest::publishMessage)
                 .done()
           }
         });
@@ -206,6 +216,7 @@ public class UpgradeTest {
         .newPublishMessageCommand()
         .messageName(MESSAGE)
         .correlationKey("123")
+        .timeToLive(Duration.ofMinutes(5))
         .send()
         .join();
 

--- a/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTestCase.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTestCase.java
@@ -1,0 +1,89 @@
+package io.zeebe.test;
+
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+class UpgradeTestCase {
+  private TestCaseBuilder builder;
+
+  private UpgradeTestCase(final TestCaseBuilder builder) {
+    this.builder = builder;
+  }
+
+  static TestCaseBuilder builder() {
+    return new TestCaseBuilder();
+  }
+
+  void setUp(final ZeebeClient client) {
+    builder.deployWorkflow.accept(client);
+
+    if (builder.createInstance != null) {
+      builder.createInstance.accept(client);
+    }
+  }
+
+  Long runBefore(final ContainerStateRule state) {
+    return builder.before.apply(state);
+  }
+
+  void runAfter(final ContainerStateRule state, final Long key) {
+    builder.after.accept(state, key);
+  }
+
+  static class TestCaseBuilder {
+    private Consumer<ZeebeClient> deployWorkflow;
+    private Consumer<ZeebeClient> createInstance;
+    private Function<ContainerStateRule, Long> before;
+    private BiConsumer<ContainerStateRule, Long> after;
+
+    TestCaseBuilder deployWorkflow(final BpmnModelInstance model) {
+      deployWorkflow =
+          client ->
+              client
+                  .newDeployCommand()
+                  .addWorkflowModel(model, UpgradeTest.PROCESS_ID + ".bpmn")
+                  .send()
+                  .join();
+      return this;
+    }
+
+    TestCaseBuilder createInstance() {
+      createInstance =
+          client ->
+              client
+                  .newCreateInstanceCommand()
+                  .bpmnProcessId(UpgradeTest.PROCESS_ID)
+                  .latestVersion()
+                  .variables(Map.of("key", "123"))
+                  .send()
+                  .join();
+      return this;
+    }
+    /**
+     * Should make zeebe write records and write to state of the feature being tested (e.g., jobs,
+     * messages). The workflow should be left in a waiting state so Zeebe can be restarted and
+     * execution can be continued after. Takes the container rule as input and outputs a long which
+     * can be used after the upgrade to continue the execution.
+     */
+    TestCaseBuilder beforeUpgrade(final Function<ContainerStateRule, Long> func) {
+      before = func;
+      return this;
+    }
+    /**
+     * Should continue the instance after the upgrade in a way that will complete the workflow.
+     * Takes the container rule and a long (e.g., a key) as input.
+     */
+    TestCaseBuilder afterUpgrade(final BiConsumer<ContainerStateRule, Long> func) {
+      after = func;
+      return this;
+    }
+
+    UpgradeTestCase done() {
+      return new UpgradeTestCase(this);
+    }
+  }
+}

--- a/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTestCase.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTestCase.java
@@ -9,11 +9,12 @@ package io.zeebe.test;
 
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.util.collection.Tuple;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.ToLongFunction;
 
-final class UpgradeTestCase {
+public final class UpgradeTestCase {
   private TestCaseBuilder builder;
 
   private UpgradeTestCase(final TestCaseBuilder builder) {
@@ -26,16 +27,11 @@ final class UpgradeTestCase {
 
   long setUp(final ZeebeClient client) {
     builder.deployWorkflow.accept(client);
-
-    if (builder.createInstance == null) {
-      return -1;
-    }
-
-    return builder.createInstance.apply(client);
+    return builder.createInstance.applyAsLong(client);
   }
 
   Long runBefore(final ContainerStateRule state) {
-    return builder.before.apply(state);
+    return builder.before.applyAsLong(state);
   }
 
   void runAfter(final ContainerStateRule state, final long wfInstanceKey, final long key) {
@@ -43,42 +39,55 @@ final class UpgradeTestCase {
   }
 
   static class TestCaseBuilder {
-    private Consumer<ZeebeClient> deployWorkflow;
-    private Function<ZeebeClient, Long> createInstance;
-    private Function<ContainerStateRule, Long> before;
-    private TriConsumer<ContainerStateRule, Long, Long> after;
+    private Consumer<ZeebeClient> deployWorkflow = c -> {};
+    private ToLongFunction<ZeebeClient> createInstance = c -> -1L;
+    private ToLongFunction<ContainerStateRule> before = r -> -1L;
+    private TriConsumer<ContainerStateRule, Long, Long> after = (r, wfKey, k) -> {};
 
     TestCaseBuilder deployWorkflow(final BpmnModelInstance model) {
-      deployWorkflow =
-          client ->
-              client
-                  .newDeployCommand()
-                  .addWorkflowModel(model, UpgradeTest.PROCESS_ID + ".bpmn")
-                  .send()
-                  .join();
+      return deployWorkflow(new Tuple<>(model, UpgradeTest.PROCESS_ID));
+    }
+
+    @SafeVarargs
+    final TestCaseBuilder deployWorkflow(final Tuple<BpmnModelInstance, String>... models) {
+      for (final Tuple<BpmnModelInstance, String> model : models) {
+        deployWorkflow =
+            deployWorkflow.andThen(
+                client ->
+                    client
+                        .newDeployCommand()
+                        .addWorkflowModel(model.getLeft(), model.getRight() + ".bpmn")
+                        .send()
+                        .join());
+      }
       return this;
     }
 
     TestCaseBuilder createInstance() {
+      return createInstance(Map.of());
+    }
+
+    TestCaseBuilder createInstance(final Map<String, Object> variables) {
       createInstance =
           client ->
               client
                   .newCreateInstanceCommand()
                   .bpmnProcessId(UpgradeTest.PROCESS_ID)
                   .latestVersion()
-                  .variables(Map.of("key", "123"))
+                  .variables(variables)
                   .send()
                   .join()
                   .getWorkflowInstanceKey();
       return this;
     }
+
     /**
      * Should make zeebe write records and write to state of the feature being tested (e.g., jobs,
      * messages). The workflow should be left in a waiting state so Zeebe can be restarted and
      * execution can be continued after. Takes the container rule as input and outputs a long which
      * can be used after the upgrade to continue the execution.
      */
-    TestCaseBuilder beforeUpgrade(final Function<ContainerStateRule, Long> func) {
+    TestCaseBuilder beforeUpgrade(final ToLongFunction<ContainerStateRule> func) {
       before = func;
       return this;
     }


### PR DESCRIPTION
## Description

Changes:
* Refactors test case builder to make it more intuitive to add test cases
* added test cases for start message event, timers, incidents, messages published before subscriptions are opened and call activities

This PR depends on https://github.com/zeebe-io/zeebe/pull/3911

## Related issues

closes #3929, closes #3919, closes #3922, closes #3938

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
