### PR TITLE
Ignore variables above 8191 characters

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -111,7 +111,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean workflowInstanceSubscription = false;
 
     // size limits
-    public int ignoreVariablesAbove = 32677;
+    public int ignoreVariablesAbove = 8191;
 
     @Override
     public String toString() {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
@@ -17,7 +17,7 @@
             },
             "value": {
               "type": "keyword",
-              "ignore_above": 32766
+              "ignore_above": 8191
             },
             "scopeKey": {
               "type": "long"

--- a/test/src/main/java/io/zeebe/test/exporter/ExporterIntegrationRule.java
+++ b/test/src/main/java/io/zeebe/test/exporter/ExporterIntegrationRule.java
@@ -254,7 +254,7 @@ public class ExporterIntegrationRule extends ExternalResource {
 
     final Map<String, Object> variables = new HashMap<>();
     variables.put("orderId", "foo-bar-123");
-    variables.put("largeValue", "x".repeat(40_000));
+    variables.put("largeValue", "x".repeat(8192));
 
     final long workflowInstanceKey = createWorkflowInstance("testProcess", variables);
 


### PR DESCRIPTION
## Description

Variable values with more than 8191 characters will not be indexed by elasticsearch. 

## Related issues

closes #3945 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
