### PR TITLE
Don't create ZeebeState on compaction

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshotStore.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshotStore.java
@@ -54,7 +54,7 @@ public final class DbSnapshotStore implements SnapshotStore {
     this.pendingDirectory = pendingDirectory;
     this.snapshots = snapshots;
 
-    this.positionSupplier = new StatePositionSupplier(-1, LOGGER);
+    this.positionSupplier = new StatePositionSupplier(LOGGER);
     this.lowerBoundId = new ReusableSnapshotId(Long.MIN_VALUE);
     this.upperBoundId = new ReusableSnapshotId(Long.MAX_VALUE);
     this.listeners = new CopyOnWriteArraySet<>();

--- a/broker/src/main/java/io/zeebe/broker/logstreams/state/StatePositionSupplier.java
+++ b/broker/src/main/java/io/zeebe/broker/logstreams/state/StatePositionSupplier.java
@@ -10,18 +10,16 @@ package io.zeebe.broker.logstreams.state;
 import io.zeebe.broker.exporter.stream.ExportersState;
 import io.zeebe.db.ZeebeDb;
 import io.zeebe.engine.state.DefaultZeebeDbFactory;
+import io.zeebe.engine.state.LastProcessedPositionState;
 import io.zeebe.engine.state.ZbColumnFamilies;
-import io.zeebe.engine.state.ZeebeState;
 import java.nio.file.Path;
 import org.slf4j.Logger;
 
 public class StatePositionSupplier {
 
-  private final int partitionId;
   private final Logger logger;
 
-  public StatePositionSupplier(final int partitionId, final Logger log) {
-    this.partitionId = partitionId;
+  public StatePositionSupplier(final Logger log) {
     this.logger = log;
   }
 
@@ -74,8 +72,8 @@ public class StatePositionSupplier {
 
   private long getLastProcessedPosition(
       final Path directory, final ZeebeDb<ZbColumnFamilies> zeebeDb) {
-    final ZeebeState processorState = new ZeebeState(partitionId, zeebeDb, zeebeDb.createContext());
-    final long lowestPosition = processorState.getLastSuccessfulProcessedRecordPosition();
+    final var lastProcessedState = new LastProcessedPositionState(zeebeDb, zeebeDb.createContext());
+    final long lowestPosition = lastProcessedState.getPosition();
     logger.debug("The last processed position for snapshot {} is {}", directory, lowestPosition);
     return lowestPosition;
   }

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -292,7 +292,7 @@ public final class ZeebePartition extends Actor
           e);
     }
 
-    final StatePositionSupplier positionSupplier = new StatePositionSupplier(partitionId, LOG);
+    final StatePositionSupplier positionSupplier = new StatePositionSupplier(LOG);
     final LogStreamDeletionService deletionService =
         new LogStreamDeletionService(
             localBroker.getNodeId(), partitionId, logStream, snapshotStorage, positionSupplier);

--- a/engine/src/main/java/io/zeebe/engine/state/LastProcessedPositionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/LastProcessedPositionState.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state;
+
+import io.zeebe.db.ColumnFamily;
+import io.zeebe.db.DbContext;
+import io.zeebe.db.ZeebeDb;
+import io.zeebe.db.impl.DbLong;
+import io.zeebe.db.impl.DbString;
+
+public final class LastProcessedPositionState {
+
+  private static final String LAST_PROCESSED_EVENT_KEY = "LAST_PROCESSED_EVENT_KEY";
+  private static final long NO_EVENTS_PROCESSED = -1L;
+
+  private final DbString positionKey;
+  private final DbLong position;
+  private final ColumnFamily<DbString, DbLong> positionColumnFamily;
+
+  public LastProcessedPositionState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final DbContext dbContext) {
+    positionKey = new DbString();
+    positionKey.wrapString(LAST_PROCESSED_EVENT_KEY);
+    position = new DbLong();
+    positionColumnFamily =
+        zeebeDb.createColumnFamily(ZbColumnFamilies.DEFAULT, dbContext, positionKey, position);
+  }
+
+  public void setPosition(final long position) {
+    this.position.wrapLong(position);
+    positionColumnFamily.put(positionKey, this.position);
+  }
+
+  public long getPosition() {
+    final DbLong position = positionColumnFamily.get(positionKey);
+    return position != null ? position.getValue() : NO_EVENTS_PROCESSED;
+  }
+}


### PR DESCRIPTION

## Description

 Introduces a LastProcessState, which can be used by the ZeebeState and the StatePositionSupplier.
 This avoids to creating the ZeebeState in the StatePositionSupplier, which does a lot other things like creating FeelEngine etc. 

It caused on compaction log messages like:

```
I 2020-02-19T01:03:24.736209104Z 2020-02-19 01:03:24.736 [] [Broker-0-StateReplication-3] DEBUG io.zeebe.broker.clustering.atomix.storage.snapshot.DbSnapshotStore - Committed new snapshot DbSnapshot{directory=/usr/local/zeebe/data/raft-partition/partitions/3/snapshots/48099528-2-1582074203540-112094357523920, metadata=DbSnapshotMetadata{index=48099528, term=2, timestamp=2020-02-19 01:03:23,540, position=112094357523920}}
 
I 2020-02-19T01:03:24.893153639Z 2020-02-19 01:03:24.892 [Broker-0-DeletionService-3] [Broker-0-zb-actors-3] INFO  org.camunda.feel.FeelEngine - Engine created. [value-mapper: CompositeValueMapper(List(org.camunda.feel.spi.JavaValueMapper@ffd271f)), function-provider: org.camunda.feel.interpreter.FunctionProvider$EmptyFunctionProvider$@7b94b62b]
 
I 2020-02-19T01:03:24.895182940Z 2020-02-19 01:03:24.894 [Broker-0-DeletionService-3] [Broker-0-zb-actors-3] DEBUG io.zeebe.broker.system - The last processed position for snapshot /usr/local/zeebe/data/raft-partition/partitions/3/snapshots/46771469-2-1582072401300-109019157358104 is 109049227545992
 
I 2020-02-19T01:03:24.895691869Z 2020-02-19 01:03:24.895 [Broker-0-DeletionService-3] [Broker-0-zb-actors-3] DEBUG io.zeebe.broker.system - The lowest exported position for snapshot /usr/local/zeebe/data/raft-partition/partitions/3/snapshots/46771469-2-1582072401300-109019157358104 is 109049226466064
 ```

Which is really confusing. 

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3877 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
