### PR TITLE
fix(broker): Fix wrong config prefix in test rules

### DIFF
--- a/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -194,7 +194,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
         } else {
           brokerCfg =
               new TestConfigurationFactory()
-                  .create(null, "zeebe-broker", configStream, BrokerCfg.class);
+                  .create(null, "zeebe.broker", configStream, BrokerCfg.class);
         }
         configureBroker(brokerCfg);
       } catch (final IOException e) {

--- a/test/src/main/java/io/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/zeebe/test/EmbeddedBrokerRule.java
@@ -91,7 +91,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
       } else {
         brokerCfg =
             new TestConfigurationFactory()
-                .create(null, "zeebe-broker", configStream, BrokerCfg.class);
+                .create(null, "zeebe.broker", configStream, BrokerCfg.class);
       }
       configureBroker(brokerCfg);
     } catch (final IOException e) {

--- a/test/src/main/java/io/zeebe/test/exporter/ExporterTestHarness.java
+++ b/test/src/main/java/io/zeebe/test/exporter/ExporterTestHarness.java
@@ -68,12 +68,13 @@ public class ExporterTestHarness {
    *
    * <p>The given YAML document can be a partial document which contains strictly the exporter
    * definition. For example: <code>
-   * zeebe-broker:
-   *   exporters:
-   *     elasticsearsch:
-   *       className = "io.zeebe.exporter.ElasticsearchExporter"
-   *       args:
-   *       ...
+   * zeebe:
+   *   broker:
+   *     exporters:
+   *       elasticsearsch:
+   *         className: io.zeebe.exporter.ElasticsearchExporter
+   *         args:
+   *         ...
    * </code>
    *
    * <p>NOTE: the ID of the exporter in the YAML document MUST match the given ID here to avoid any


### PR DESCRIPTION
## Description
Fixed wrong prefix in test rules. The wrong prefix was overlooked when making the changes during the config topic review.

## Related issues
closes #3974

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
