### PR TITLE
chore(broker): close and reopen logstream appender on role transition

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStream.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStream.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.logstreams.log;
 
+import io.zeebe.logstreams.impl.log.LogStorageAppender;
 import io.zeebe.logstreams.impl.log.LogStreamBuilderImpl;
 import io.zeebe.util.sched.ActorCondition;
 import io.zeebe.util.sched.future.ActorFuture;
@@ -82,4 +83,8 @@ public interface LogStream extends AutoCloseable {
    * @param condition the condition which should be removed
    */
   void removeOnCommitPositionUpdatedCondition(ActorCondition condition);
+
+  ActorFuture<Void> closeWriters();
+
+  ActorFuture<LogStorageAppender> enableWriters();
 }

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamRule.java
@@ -130,6 +130,7 @@ public final class LogStreamRule extends ExternalResource {
   private void openLogStream() {
     logStream = SyncLogStream.builder(builder).withActorScheduler(actorSchedulerRule.get()).build();
     logStorageRule.setPositionListener(logStream::setCommitPosition);
+    logStream.getAsyncLogStream().enableWriters().join();
   }
 
   public LogStreamReader newLogStreamReader() {

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe QA Integration Tests</name>
@@ -129,6 +131,20 @@
       <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>atomix-primitive</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>atomix-raft</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>atomix-storage</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -431,6 +431,13 @@ public final class ClusteringRule extends ExternalResource {
     waitForPartitionReplicationFactor();
   }
 
+  public void restartBrokerNoWait(final int nodeId) {
+    stopBroker(nodeId);
+    final Broker broker = getBroker(nodeId).start().join();
+    final SocketAddress commandApi = broker.getConfig().getNetwork().getCommandApi().getAddress();
+    waitUntilBrokerIsAddedToTopology(commandApi);
+  }
+
   private void waitUntilBrokerIsAddedToTopology(final SocketAddress socketAddress) {
     waitForTopology(
         topology ->


### PR DESCRIPTION
## Description

- Exposed an api to open and close logstream appender. 
- On role transitions, always close the appender. Only on leader transition open appender.

Alternative solution is to close and reopen LogStream on role transitions. Opening a draft PR so that we can discuss the alternatives.

## Related issues

closes #3966

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
