### PR TITLE
chore(broker): expose health status via http endpoint

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -210,18 +210,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-workflow-engine</artifactId>
       <type>test-jar</type>

--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -109,15 +109,6 @@ public final class Broker implements AutoCloseable {
     return startFuture;
   }
 
-  // TODO: Added this API for testing. When http endpoint is available, this can be removed.
-  // https://github.com/zeebe-io/zeebe/issues/3833
-  public boolean isHealthy() {
-    if (healthCheckService != null) {
-      return healthCheckService.isBrokerHealthy();
-    }
-    return false;
-  }
-
   private void internalStart() {
     final BrokerCfg brokerCfg = getConfig();
     final StartProcess startProcess = initStart();

--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHttpServerHandler.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHttpServerHandler.java
@@ -34,6 +34,7 @@ public final class BrokerHttpServerHandler extends ChannelInboundHandlerAdapter 
 
   private static final String BROKER_READY_STATUS_URI = "/ready";
   private static final String METRICS_URI = "/metrics";
+  private static final String BROKER_HEALTH_STATUS_URI = "/health";
 
   private final CollectorRegistry metricsRegistry;
   private final BrokerHealthCheckService brokerHealthCheckService;
@@ -73,6 +74,8 @@ public final class BrokerHttpServerHandler extends ChannelInboundHandlerAdapter 
       response = getReadyStatus();
     } else if (METRICS_URI.equals(queryStringDecoder.path())) {
       response = getMetrics(queryStringDecoder);
+    } else if (BROKER_HEALTH_STATUS_URI.equals(queryStringDecoder.path())) {
+      response = getHealthStatus();
     } else {
       response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
     }
@@ -84,6 +87,18 @@ public final class BrokerHttpServerHandler extends ChannelInboundHandlerAdapter 
     final boolean brokerReady = brokerHealthCheckService.isBrokerReady();
     final DefaultFullHttpResponse response;
     if (brokerReady) {
+      response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NO_CONTENT);
+    } else {
+      response =
+          new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.SERVICE_UNAVAILABLE);
+    }
+    return response;
+  }
+
+  private DefaultFullHttpResponse getHealthStatus() {
+    final boolean brokerHealthy = brokerHealthCheckService.isBrokerHealthy();
+    final DefaultFullHttpResponse response;
+    if (brokerHealthy) {
       response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NO_CONTENT);
     } else {
       response =

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/HealthMonitoringTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/HealthMonitoringTest.java
@@ -14,7 +14,13 @@ import io.zeebe.broker.Broker;
 import io.zeebe.broker.it.clustering.ClusteringRule;
 import io.zeebe.broker.it.util.GrpcClientRule;
 import io.zeebe.protocol.Protocol;
+import io.zeebe.util.LangUtil;
 import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,12 +31,12 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
 
 public class HealthMonitoringTest {
-  public static final String JOB_TYPE = "testTask";
-  private static final Duration SNAPSHOT_PERIOD_MINUTES = Duration.ofMinutes(5);
-  public final Timeout testTimeout = Timeout.seconds(120);
-  public final ClusteringRule clusteringRule =
-      new ClusteringRule(1, 3, 3, cfg -> cfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD_MINUTES));
-  public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
+  private static final String JOB_TYPE = "testTask";
+  private static final Duration SNAPSHOT_PERIOD = Duration.ofMinutes(5);
+  private final Timeout testTimeout = Timeout.seconds(120);
+  private final ClusteringRule clusteringRule =
+      new ClusteringRule(1, 3, 3, cfg -> cfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD));
+  private final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 
   @Rule
   public RuleChain ruleChain =
@@ -44,24 +50,22 @@ public class HealthMonitoringTest {
     final Broker leader = clusteringRule.getBroker(leaderNodeId);
     final Collection<Broker> followers = new ArrayList<>(clusteringRule.getBrokers());
     followers.remove(leader);
-    followers.forEach(follower -> assertThat(follower.isHealthy()).isTrue());
+    followers.forEach(follower -> assertThat(isBrokerHealthy(follower)).isTrue());
 
     // do some work to create a snapshot
     clientRule.createSingleJob(JOB_TYPE);
-    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD_MINUTES);
+    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
     clusteringRule.waitForValidSnapshotAtBroker(leader);
     followers.forEach(clusteringRule::waitForValidSnapshotAtBroker);
 
     // when
     // corrupt snapshot on all followers because we cannot control which one will become leader
-    followers.stream().forEach(this::corruptAllSnapshots);
+    followers.forEach(this::corruptAllSnapshots);
     // cannot use clusteringRule.stopbroker() as it waits for new leader to be installed.
     leader.close();
 
     // then
-    // TODO: Use http endpoint to query health status when it is available
-    // https://github.com/zeebe-io/zeebe/issues/3833
-    waitUntil(() -> followers.stream().anyMatch(follower -> !follower.isHealthy()));
+    waitUntil(() -> followers.stream().anyMatch(follower -> !isBrokerHealthy(follower)));
   }
 
   private void corruptAllSnapshots(final Broker leader) {
@@ -73,7 +77,22 @@ public class HealthMonitoringTest {
               final var filesInSnapshot = snapshot.listFiles();
               Arrays.stream(filesInSnapshot)
                   .filter(f -> f.getName().contains("MANIFEST"))
-                  .forEach(file -> file.delete());
+                  .forEach(File::delete);
             });
+  }
+
+  private boolean isBrokerHealthy(final Broker broker) {
+    final var monitoringApi = broker.getConfig().getNetwork().getMonitoringApi();
+    final var host = monitoringApi.getHost();
+    final var port = monitoringApi.getPort();
+    final var uri = URI.create(String.format("http://%s:%d/health", host, port));
+    final var client = HttpClient.newHttpClient();
+    final var request = HttpRequest.newBuilder(uri).build();
+    try {
+      return client.send(request, BodyHandlers.discarding()).statusCode() == 204;
+    } catch (final InterruptedException | IOException e) {
+      LangUtil.rethrowUnchecked(e);
+      return false; // should not happen
+    }
   }
 }


### PR DESCRIPTION
## Description

Exposes broker health status via http endpoint `/health`. Similar to ready endpoint, it respond with an empty content when broker is healthy and respond with 'SERVICE_UNAVAILABLE' when it is not healthy.

## Related issues

closes #3833

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
