### PR TITLE
Respond NOT_FOUND when partition cannot be found

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
@@ -17,6 +17,7 @@ import io.zeebe.gateway.cmd.BrokerRejectionException;
 import io.zeebe.gateway.cmd.ClientOutOfMemoryException;
 import io.zeebe.gateway.cmd.GrpcStatusException;
 import io.zeebe.gateway.cmd.GrpcStatusExceptionImpl;
+import io.zeebe.gateway.cmd.PartitionNotFoundException;
 import io.zeebe.gateway.impl.broker.BrokerClient;
 import io.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
@@ -387,6 +388,8 @@ public final class EndpointManager extends GatewayGrpc.GatewayImplBase {
               "Time out between gateway and broker: " + cause.getMessage());
     } else if (cause instanceof GrpcStatusException) {
       status = ((GrpcStatusException) cause).getGrpcStatus();
+    } else if (cause instanceof PartitionNotFoundException) {
+      status = Status.NOT_FOUND.augmentDescription(cause.getMessage());
     } else {
       status = status.augmentDescription("Unexpected error occurred during the request processing");
     }

--- a/gateway/src/main/java/io/zeebe/gateway/cmd/PartitionNotFoundException.java
+++ b/gateway/src/main/java/io/zeebe/gateway/cmd/PartitionNotFoundException.java
@@ -13,11 +13,7 @@ package io.zeebe.gateway.cmd;
  */
 public class PartitionNotFoundException extends ClientException {
 
-  public static final String MESSAGE_TEMPLATE =
-      "This command refers to an element that doesn't exist. The request targeted an element on "
-          + "partition '%d', which cannot be found in the cluster. Check the command arguments.";
-
-  public PartitionNotFoundException(final int partitionId) {
-    super(String.format(MESSAGE_TEMPLATE, partitionId));
+  public PartitionNotFoundException() {
+    super("Expected to execute command, but this command refers to an element that doesn't exist.");
   }
 }

--- a/gateway/src/main/java/io/zeebe/gateway/cmd/PartitionNotFoundException.java
+++ b/gateway/src/main/java/io/zeebe/gateway/cmd/PartitionNotFoundException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.cmd;
+
+/**
+ * Represents an exceptional error that occurs when a partition can not be found. For example this
+ * can happen when the element instance key does not refer to a known partition.
+ */
+public class PartitionNotFoundException extends ClientException {
+
+  public PartitionNotFoundException(final int partitionId) {
+    super(String.format("Unknown partition '%d'", partitionId));
+  }
+}

--- a/gateway/src/main/java/io/zeebe/gateway/cmd/PartitionNotFoundException.java
+++ b/gateway/src/main/java/io/zeebe/gateway/cmd/PartitionNotFoundException.java
@@ -13,7 +13,11 @@ package io.zeebe.gateway.cmd;
  */
 public class PartitionNotFoundException extends ClientException {
 
+  public static final String MESSAGE_TEMPLATE =
+      "This command refers to an element that doesn't exist. The request targeted an element on "
+          + "partition '%d', which cannot be found in the cluster. Check the command arguments.";
+
   public PartitionNotFoundException(final int partitionId) {
-    super(String.format("Unknown partition '%d'", partitionId));
+    super(String.format(MESSAGE_TEMPLATE, partitionId));
   }
 }

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClient.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClient.java
@@ -25,6 +25,8 @@ public interface BrokerClient extends AutoCloseable {
       BrokerResponseConsumer<T> responseConsumer,
       Consumer<Throwable> throwableConsumer);
 
+  <T> ActorFuture<BrokerResponse<T>> sendRequest(BrokerRequest<T> request, Duration requestTimeout);
+
   <T> void sendRequest(
       BrokerRequest<T> request,
       BrokerResponseConsumer<T> responseConsumer,

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClientImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClientImpl.java
@@ -147,6 +147,12 @@ public final class BrokerClientImpl implements BrokerClient {
   }
 
   @Override
+  public <T> ActorFuture<BrokerResponse<T>> sendRequest(
+      final BrokerRequest<T> request, final Duration requestTimeout) {
+    return requestManager.sendRequest(request, requestTimeout);
+  }
+
+  @Override
   public <T> void sendRequest(
       final BrokerRequest<T> request,
       final BrokerResponseConsumer<T> responseConsumer,

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerRequestManager.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerRequestManager.java
@@ -203,7 +203,7 @@ public final class BrokerRequestManager extends Actor {
     if (request.addressesSpecificPartition()) {
       final BrokerClusterState topology = topologyManager.getTopology();
       if (topology != null && !topology.getPartitions().contains(request.getPartitionId())) {
-        throw new PartitionNotFoundException(request.getPartitionId());
+        throw new PartitionNotFoundException();
       }
       // already know partition id
       return new BrokerAddressProvider(request.getPartitionId());

--- a/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -70,6 +70,12 @@ public final class StubbedBrokerClient implements BrokerClient {
   }
 
   @Override
+  public <T> ActorFuture<BrokerResponse<T>> sendRequest(
+      final BrokerRequest<T> request, final Duration requestTimeout) {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
   public <T> void sendRequest(
       final BrokerRequest<T> request,
       final BrokerResponseConsumer<T> responseConsumer,

--- a/gateway/src/test/java/io/zeebe/gateway/broker/BrokerClientTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/broker/BrokerClientTest.java
@@ -225,11 +225,11 @@ public final class BrokerClientTest {
     final var async = client.sendRequest(request);
 
     // then
-    final String expectedMessage =
-        "The request targeted an element on partition '0', which cannot be found in the cluster.";
+    final String expected =
+        "Expected to execute command, but this command refers to an element that doesn't exist.";
     assertThatThrownBy(async::join)
         .isInstanceOf(ExecutionException.class)
-        .hasMessageContaining(expectedMessage);
+        .hasMessageContaining(expected);
   }
 
   @Test

--- a/gateway/src/test/java/io/zeebe/gateway/broker/BrokerClientTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/broker/BrokerClientTest.java
@@ -9,6 +9,7 @@ package io.zeebe.gateway.broker;
 
 import static io.zeebe.protocol.Protocol.START_PARTITION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.hamcrest.CoreMatchers.containsString;
 
@@ -22,6 +23,7 @@ import io.zeebe.gateway.impl.broker.cluster.BrokerClusterStateImpl;
 import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManagerImpl;
 import io.zeebe.gateway.impl.broker.request.BrokerCompleteJobRequest;
 import io.zeebe.gateway.impl.broker.request.BrokerCreateWorkflowInstanceRequest;
+import io.zeebe.gateway.impl.broker.request.BrokerSetVariablesRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerError;
 import io.zeebe.gateway.impl.broker.response.BrokerRejection;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
@@ -206,6 +208,23 @@ public final class BrokerClientTest {
 
     // when
     client.sendRequest(new BrokerCompleteJobRequest(1, DocumentValue.EMPTY_DOCUMENT)).join();
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenPartitionNotFound() {
+    // given
+    final var request = new BrokerSetVariablesRequest();
+    request.setElementInstanceKey(0);
+    request.setPartitionId(0);
+    request.setLocal(false);
+
+    // when
+    final var async = client.sendRequest(request);
+
+    // then
+    assertThatThrownBy(async::join)
+        .isInstanceOf(ExecutionException.class)
+        .hasMessageContaining("Unknown partition '0'");
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/SetVariablesTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/SetVariablesTest.java
@@ -157,8 +157,7 @@ public final class SetVariablesTest {
         .isInstanceOf(ClientException.class)
         .hasMessageContaining("This command refers to an element that doesn't exist.")
         .hasRootCauseMessage(
-            "NOT_FOUND: This command refers to an element that doesn't exist. "
-                + "The request targeted an element on partition '0', "
-                + "which cannot be found in the cluster. Check the command arguments.");
+            "NOT_FOUND: This command refers to an element that doesn't exist."
+                + " Check the command arguments.");
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/SetVariablesTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/SetVariablesTest.java
@@ -153,11 +153,11 @@ public final class SetVariablesTest {
             .send();
 
     // then
+    final String expectedMessage =
+        "Expected to execute command, but this command refers to an element that doesn't exist.";
     assertThatThrownBy(command::join)
         .isInstanceOf(ClientException.class)
-        .hasMessageContaining("This command refers to an element that doesn't exist.")
-        .hasRootCauseMessage(
-            "NOT_FOUND: This command refers to an element that doesn't exist."
-                + " Check the command arguments.");
+        .hasMessageContaining(expectedMessage)
+        .hasRootCauseMessage("NOT_FOUND: " + expectedMessage);
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/SetVariablesTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/SetVariablesTest.java
@@ -155,7 +155,10 @@ public final class SetVariablesTest {
     // then
     assertThatThrownBy(command::join)
         .isInstanceOf(ClientException.class)
-        .hasMessageContaining("Unknown partition '0'")
-        .hasRootCauseMessage("NOT_FOUND: Unknown partition '0'");
+        .hasMessageContaining("This command refers to an element that doesn't exist.")
+        .hasRootCauseMessage(
+            "NOT_FOUND: This command refers to an element that doesn't exist. "
+                + "The request targeted an element on partition '0', "
+                + "which cannot be found in the cluster. Check the command arguments.");
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/SetVariablesTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/SetVariablesTest.java
@@ -22,6 +22,7 @@ import io.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.zeebe.test.util.BrokerClassRuleHelper;
 import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -105,7 +106,7 @@ public final class SetVariablesTest {
         CLIENT_RULE.getClient().newSetVariablesCommand(workflowInstanceKey).variables("[]").send();
 
     // then
-    assertThatThrownBy(() -> command.join())
+    assertThatThrownBy(command::join)
         .isInstanceOf(ClientException.class)
         .hasMessageContaining(
             "Property 'variables' is invalid: Expected document to be a root level object, but was 'ARRAY'");
@@ -132,8 +133,29 @@ public final class SetVariablesTest {
             "Expected to update variables for element with key '%d', but no such element was found",
             workflowInstanceKey);
 
-    assertThatThrownBy(() -> command.join())
+    assertThatThrownBy(command::join)
         .isInstanceOf(ClientException.class)
         .hasMessageContaining(expectedMessage);
+  }
+
+  @Test
+  public void shouldRejectIfPartitionNotFound() {
+    // given
+
+    // when
+    final int workflowInstanceKey = 0;
+    final var command =
+        CLIENT_RULE
+            .getClient()
+            .newSetVariablesCommand(workflowInstanceKey)
+            .variables(Map.of("foo", "bar"))
+            .requestTimeout(Duration.ofSeconds(60))
+            .send();
+
+    // then
+    assertThatThrownBy(command::join)
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("Unknown partition '0'")
+        .hasRootCauseMessage("NOT_FOUND: Unknown partition '0'");
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/gateway/GatewayIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/gateway/GatewayIntegrationTest.java
@@ -8,7 +8,6 @@
 package io.zeebe.broker.it.gateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.core.StringContains.containsString;
 
 import io.atomix.cluster.AtomixCluster;
 import io.zeebe.broker.test.EmbeddedBrokerRule;
@@ -22,7 +21,6 @@ import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.test.util.socket.SocketUtil;
 import io.zeebe.util.sched.clock.ControlledActorClock;
 import java.time.Duration;
-import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -76,21 +74,5 @@ public final class GatewayIntegrationTest {
     assertThat(error.getType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
     assertThat(error.getReason())
         .isEqualTo("Expected at least a bpmnProcessId or a key greater than -1, but none given");
-  }
-
-  @Test
-  public void shouldThrowExceptionIfPartitionNotFoundResponse() {
-    // given
-
-    // then
-    exception.expect(ExecutionException.class);
-    exception.expectMessage(containsString("Request timed out after PT3S"));
-    // when no one is subscribed to that partition, then the client retries. After the timeout
-    // the retry loop will be canceled and the future completed.
-
-    // when
-    final var createWFRequest = new BrokerCreateWorkflowInstanceRequest();
-    createWFRequest.setPartitionId(0);
-    client.sendRequest(createWFRequest).join();
   }
 }


### PR DESCRIPTION
## Description

When a request from a client refers to an elementInstanceKey that does
not encapsulate a partition (or encapsulates a non-existing partition),
then the gateway now responds with NOT_FOUND.

The gateway simply checks that the partitionId is part of the known partitions of
the topology.

## Related issues

closes #3961 