### PR TITLE
Allow to fail activatable jobs

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/DefaultJobCommandProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/DefaultJobCommandProcessor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.job;
+
+import io.zeebe.engine.processor.CommandProcessor;
+import io.zeebe.engine.processor.TypedRecord;
+import io.zeebe.engine.state.instance.JobState;
+import io.zeebe.engine.state.instance.JobState.State;
+import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.record.RejectionType;
+import java.util.function.BiConsumer;
+
+/**
+ * Default implementation to process JobCommands to reduce duplication in CommandProcessor
+ * implementations.
+ */
+final class DefaultJobCommandProcessor<J extends JobRecord> implements CommandProcessor<J> {
+
+  private static final String NO_JOB_FOUND_MESSAGE =
+      "Expected to %s job with key '%d', but no such job was found";
+  private static final String INVALID_JOB_STATE_MESSAGE =
+      "Expected to %s job with key '%d', but it is in state '%s'";
+
+  private final String intent;
+  private final JobState state;
+  private final BiConsumer<TypedRecord<J>, CommandControl<J>> acceptCommand;
+
+  public DefaultJobCommandProcessor(
+      final String intent,
+      final JobState state,
+      final BiConsumer<TypedRecord<J>, CommandControl<J>> acceptCommand) {
+    this.intent = intent;
+    this.state = state;
+    this.acceptCommand = acceptCommand;
+  }
+
+  @Override
+  public boolean onCommand(final TypedRecord<J> command, final CommandControl<J> commandControl) {
+    final long jobKey = command.getKey();
+    final State jobState = state.getState(jobKey);
+
+    if (jobState == State.ACTIVATABLE || jobState == State.ACTIVATED) {
+      acceptCommand.accept(command, commandControl);
+
+    } else if (jobState == State.NOT_FOUND) {
+      final String message = String.format(NO_JOB_FOUND_MESSAGE, intent, jobKey);
+      commandControl.reject(RejectionType.NOT_FOUND, message);
+
+    } else {
+      final String message = String.format(INVALID_JOB_STATE_MESSAGE, intent, jobKey, jobState);
+      commandControl.reject(RejectionType.INVALID_STATE, message);
+    }
+
+    return true;
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/FailProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/FailProcessor.java
@@ -10,46 +10,33 @@ package io.zeebe.engine.processor.workflow.job;
 import io.zeebe.engine.processor.CommandProcessor;
 import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.engine.state.instance.JobState;
-import io.zeebe.engine.state.instance.JobState.State;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
-import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.JobIntent;
 
 public final class FailProcessor implements CommandProcessor<JobRecord> {
 
-  private static final String JOB_NOT_FOUND_MESSAGE =
-      "Expected to fail job with key '%d', but it does not exist";
-
-  private static final String INVALID_JOB_STATE_MESSAGE =
-      "Expected to fail job with key '%d', but it is in state '%s'";
-
   private final JobState state;
+  private final DefaultJobCommandProcessor<JobRecord> defaultProcessor;
 
   public FailProcessor(final JobState state) {
     this.state = state;
+    this.defaultProcessor =
+        new DefaultJobCommandProcessor<>("fail", this.state, this::acceptCommand);
   }
 
   @Override
   public boolean onCommand(
       final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
+    return defaultProcessor.onCommand(command, commandControl);
+  }
+
+  private void acceptCommand(
+      final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
     final long key = command.getKey();
-    final JobState.State jobState = state.getState(key);
-
-    if (jobState == State.ACTIVATED) {
-      final JobRecord failedJob = state.getJob(key);
-      failedJob.setRetries(command.getValue().getRetries());
-      failedJob.setErrorMessage(command.getValue().getErrorMessageBuffer());
-      state.fail(key, failedJob);
-
-      commandControl.accept(JobIntent.FAILED, failedJob);
-
-    } else if (jobState == State.NOT_FOUND) {
-      commandControl.reject(RejectionType.NOT_FOUND, String.format(JOB_NOT_FOUND_MESSAGE, key));
-
-    } else {
-      commandControl.reject(
-          RejectionType.INVALID_STATE, String.format(INVALID_JOB_STATE_MESSAGE, key, jobState));
-    }
-    return true;
+    final JobRecord failedJob = state.getJob(key);
+    failedJob.setRetries(command.getValue().getRetries());
+    failedJob.setErrorMessage(command.getValue().getErrorMessageBuffer());
+    state.fail(key, failedJob);
+    commandControl.accept(JobIntent.FAILED, failedJob);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobThrowErrorProcessor.java
@@ -10,48 +10,29 @@ package io.zeebe.engine.processor.workflow.job;
 import io.zeebe.engine.processor.CommandProcessor;
 import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.engine.state.instance.JobState;
-import io.zeebe.engine.state.instance.JobState.State;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
-import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.JobIntent;
 
 public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
 
-  private static final String NO_JOB_FOUND_MESSAGE =
-      "Expected to throw an error for job with key '%d', but no such job was found";
-  private static final String INVALID_JOB_STATE_MESSAGE =
-      "Expected to throw an error for job with key '%d', but it is in state '%s'";
-
   private final JobState state;
+  private final DefaultJobCommandProcessor<JobRecord> defaultProcessor;
 
   public JobThrowErrorProcessor(final JobState state) {
     this.state = state;
+    this.defaultProcessor =
+        new DefaultJobCommandProcessor<>("throw an error for", this.state, this::acceptCommand);
   }
 
   @Override
   public boolean onCommand(
       final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
-    final long jobKey = command.getKey();
-    final State jobState = state.getState(jobKey);
-
-    if (jobState == State.ACTIVATABLE || jobState == State.ACTIVATED) {
-      acceptCommand(jobKey, command, commandControl);
-
-    } else if (jobState == State.NOT_FOUND) {
-      commandControl.reject(RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, jobKey));
-
-    } else {
-      commandControl.reject(
-          RejectionType.INVALID_STATE, String.format(INVALID_JOB_STATE_MESSAGE, jobKey, jobState));
-    }
-
-    return true;
+    return defaultProcessor.onCommand(command, commandControl);
   }
 
   private void acceptCommand(
-      final long jobKey,
-      final TypedRecord<JobRecord> command,
-      final CommandControl<JobRecord> commandControl) {
+      final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
+    final long jobKey = command.getKey();
 
     final JobRecord job = state.getJob(jobKey);
     job.setErrorCode(command.getValue().getErrorCodeBuffer());

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/job/FailJobTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/job/FailJobTest.java
@@ -164,6 +164,18 @@ public final class FailJobTest {
   }
 
   @Test
+  public void shouldFailIfJobCreated() {
+    // given
+    final Record<JobRecordValue> job = ENGINE.createJob(jobType, PROCESS_ID);
+
+    // when
+    final Record<JobRecordValue> jobRecord = ENGINE.job().withKey(job.getKey()).fail();
+
+    // then
+    Assertions.assertThat(jobRecord).hasRecordType(RecordType.EVENT).hasIntent(FAILED);
+  }
+
+  @Test
   public void shouldRejectFailIfJobNotFound() {
     // given
     final int key = 123;
@@ -191,20 +203,6 @@ public final class FailJobTest {
     // then
     Assertions.assertThat(jobRecord).hasRejectionType(RejectionType.INVALID_STATE);
     assertThat(jobRecord.getRejectionReason()).contains("it is in state 'FAILED'");
-  }
-
-  @Test
-  public void shouldRejectFailIfJobCreated() {
-    // given
-    final Record<JobRecordValue> job = ENGINE.createJob(jobType, PROCESS_ID);
-
-    // when
-    final Record<JobRecordValue> jobRecord =
-        ENGINE.job().withKey(job.getKey()).withRetries(3).expectRejection().fail();
-
-    // then
-    Assertions.assertThat(jobRecord).hasRejectionType(RejectionType.INVALID_STATE);
-    assertThat(jobRecord.getRejectionReason()).contains("it is in state 'ACTIVATABLE'");
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/FailJobTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/FailJobTest.java
@@ -80,7 +80,7 @@ public final class FailJobTest {
 
     // when
     final var expectedMessage =
-        String.format("Expected to fail job with key '%d', but it does not exist", jobKey);
+        String.format("Expected to fail job with key '%d', but no such job was found", jobKey);
 
     assertThatThrownBy(
             () -> CLIENT_RULE.getClient().newFailCommand(jobKey).retries(1).send().join())


### PR DESCRIPTION
## Description

Fail job commands are always rejected if the job state is not `ACTIVATED`. This is inconsistent with the complete job command, where it is also allowed to have an `ACTIVATABLE` job state as precondition.

This change allows to send a fail job command for a job in the activatable state.

## Related issues

closes #3757 