### PR TITLE
chore(logstream): enable health check on logstorage appender

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -299,6 +299,7 @@ public final class ZeebePartition extends Actor
                   logStream.setCommitPosition(deferredCommitPosition);
                   deferredCommitPosition = -1;
                 }
+                criticalComponentsHealthMonitor.registerComponent("logstream", logStream);
                 installStorageServices()
                     .onComplete(
                         (deletionService, errorInstall) -> {
@@ -494,6 +495,7 @@ public final class ZeebePartition extends Actor
       return CompletableActorFuture.completed(null);
     }
 
+    criticalComponentsHealthMonitor.removeComponent("logstream");
     final LogStream logStreamToClose = logStream;
     logStream = null;
     return logStreamToClose.closeAsync();

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -23,14 +23,20 @@ import io.zeebe.logstreams.impl.backpressure.NoopAppendLimiter;
 import io.zeebe.logstreams.spi.LogStorage;
 import io.zeebe.logstreams.spi.LogStorage.AppendListener;
 import io.zeebe.util.Environment;
+import io.zeebe.util.health.FailureListener;
+import io.zeebe.util.health.HealthMonitorable;
+import io.zeebe.util.health.HealthStatus;
 import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 
 /** Consume the write buffer and append the blocks to the distributedlog. */
-public final class LogStorageAppender extends Actor {
+public final class LogStorageAppender extends Actor implements HealthMonitorable {
 
   public static final Logger LOG = Loggers.LOGSTREAMS_LOGGER;
   private static final Map<String, AlgorithmCfg> ALGORITHM_CFG =
@@ -44,6 +50,8 @@ public final class LogStorageAppender extends Actor {
   private final AppendBackpressureMetrics appendBackpressureMetrics;
   private final Environment env;
   private final LoggedEventImpl positionReader = new LoggedEventImpl();
+  private FailureListener failureListener;
+  private final ActorFuture<Void> closeFuture;
 
   public LogStorageAppender(
       final String name,
@@ -62,6 +70,7 @@ public final class LogStorageAppender extends Actor {
         env.getBool(BackpressureConstants.ENV_BP_APPENDER).orElse(true);
     appendEntryLimiter =
         isBackpressureEnabled ? initBackpressure(partitionId) : initNoBackpressure(partitionId);
+    closeFuture = new CompletableActorFuture<>();
   }
 
   private AppendLimiter initBackpressure(final int partitionId) {
@@ -130,6 +139,30 @@ public final class LogStorageAppender extends Actor {
     actor.consume(writeBufferSubscription, this::onWriteBufferAvailable);
   }
 
+  @Override
+  protected void onActorClosed() {
+    closeFuture.complete(null);
+  }
+
+  @Override
+  public ActorFuture<Void> closeAsync() {
+    if (actor.isClosed()) {
+      return closeFuture;
+    }
+    super.closeAsync();
+    return closeFuture;
+  }
+
+  @Override
+  protected void handleFailure(final Exception failure) {
+    onFailure(failure);
+  }
+
+  @Override
+  public void onActorFailed() {
+    closeFuture.complete(null);
+  }
+
   private void onWriteBufferAvailable() {
     final BlockPeek blockPeek = new BlockPeek();
     if (writeBufferSubscription.peekBlock(blockPeek, maxAppendBlockSize, true) > 0) {
@@ -150,6 +183,24 @@ public final class LogStorageAppender extends Actor {
     } while (offset < view.capacity());
 
     return positions;
+  }
+
+  @Override
+  public HealthStatus getHealthStatus() {
+    return actor.isClosed() ? HealthStatus.UNHEALTHY : HealthStatus.HEALTHY;
+  }
+
+  @Override
+  public void addFailureListener(final FailureListener failureListener) {
+    actor.run(() -> this.failureListener = failureListener);
+  }
+
+  private void onFailure(final Throwable error) {
+    LOG.error("Actor {} failed in phase {}.", name, actor.getLifecyclePhase(), error);
+    actor.fail();
+    if (failureListener != null) {
+      failureListener.onFailure();
+    }
   }
 
   private static final class Positions {
@@ -175,6 +226,11 @@ public final class LogStorageAppender extends Actor {
     @Override
     public void onWriteError(final Throwable error) {
       LOG.error("Failed to append block with last event position {}.", positions.highest, error);
+      if (error instanceof NoSuchElementException) {
+        // Not a failure. It is probably during transition to follower.
+        return;
+      }
+      onFailure(error);
     }
 
     @Override
@@ -186,6 +242,7 @@ public final class LogStorageAppender extends Actor {
     public void onCommitError(final long address, final Throwable error) {
       LOG.error("Failed to commit block with last event position {}.", positions.highest, error);
       releaseBackPressure();
+      onFailure(error);
     }
 
     private void releaseBackPressure() {

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStream.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStream.java
@@ -8,6 +8,7 @@
 package io.zeebe.logstreams.log;
 
 import io.zeebe.logstreams.impl.log.LogStreamBuilderImpl;
+import io.zeebe.util.health.HealthMonitorable;
 import io.zeebe.util.sched.ActorCondition;
 import io.zeebe.util.sched.future.ActorFuture;
 
@@ -18,7 +19,7 @@ import io.zeebe.util.sched.future.ActorFuture;
  *
  * <p>To read events, the {@link LogStream#newLogStreamReader()} ()} can be used.
  */
-public interface LogStream extends AutoCloseable {
+public interface LogStream extends AutoCloseable, HealthMonitorable {
 
   /** @return a new default LogStream builder */
   static LogStreamBuilder builder() {

--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.impl.log;
+
+import static io.zeebe.test.util.TestUtil.waitUntil;
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.dispatcher.Dispatcher;
+import io.zeebe.dispatcher.Dispatchers;
+import io.zeebe.logstreams.spi.LogStorage;
+import io.zeebe.logstreams.spi.LogStorageReader;
+import io.zeebe.util.ByteValue;
+import io.zeebe.util.health.HealthStatus;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.BiConsumer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class LogStorageAppenderHealthTest {
+
+  private static final int MAX_FRAGMENT_SIZE = 1024;
+  private static final int PARTITION_ID = 0;
+
+  @Rule public final ActorSchedulerRule schedulerRule = new ActorSchedulerRule();
+
+  private Dispatcher dispatcher;
+  private ControllableLogStorage failingLogStorage;
+  private LogStorageAppender appender;
+  private LogStreamWriterImpl writer;
+
+  @Before
+  public void setUp() {
+    failingLogStorage = new ControllableLogStorage();
+
+    dispatcher =
+        Dispatchers.create("0")
+            .actorScheduler(schedulerRule.get())
+            .bufferSize((int) ByteValue.ofMegabytes(100 * MAX_FRAGMENT_SIZE))
+            .maxFragmentLength(MAX_FRAGMENT_SIZE)
+            .initialPartitionId(0)
+            .build();
+    final var subscription = dispatcher.openSubscription("log");
+
+    appender =
+        new LogStorageAppender(
+            "appender", PARTITION_ID, failingLogStorage, subscription, MAX_FRAGMENT_SIZE);
+    writer = new LogStreamWriterImpl(PARTITION_ID, dispatcher);
+  }
+
+  @After
+  public void tearDown() {
+    appender.close();
+    dispatcher.close();
+  }
+
+  @Test
+  public void shouldFailActorWhenWriteFails() {
+    // given
+    failingLogStorage.onNextAppend(
+        (pos, listener) -> listener.onWriteError(new RuntimeException("foo")));
+
+    // when
+    writer.value(wrapString("value")).tryWrite();
+    schedulerRule.submitActor(appender).join();
+
+    // then
+    waitUntil(() -> appender.getHealthStatus() == HealthStatus.UNHEALTHY);
+  }
+
+  @Test
+  public void shouldFailActorWhenCommitFails() {
+    // given
+    failingLogStorage.onNextAppend(
+        (pos, listener) -> listener.onCommitError(pos, new RuntimeException("foo")));
+
+    // when
+    writer.value(wrapString("value")).tryWrite();
+    schedulerRule.submitActor(appender).join();
+
+    // then
+    waitUntil(() -> appender.getHealthStatus() == HealthStatus.UNHEALTHY);
+  }
+
+  @Test
+  public void shouldBeHealthyWhenNoExceptions() throws InterruptedException {
+    // given
+    final CountDownLatch latch = new CountDownLatch(1);
+    failingLogStorage.onNextAppend(
+        (pos, listener) -> {
+          listener.onWrite(pos);
+          latch.countDown();
+        });
+
+    // when
+    writer.value(wrapString("value")).tryWrite();
+    schedulerRule.submitActor(appender).join();
+
+    // then
+    latch.await();
+    assertThat(latch.getCount()).isEqualTo(0);
+    assertThat(appender.getHealthStatus()).isEqualTo(HealthStatus.HEALTHY);
+  }
+
+  private static class ControllableLogStorage implements LogStorage {
+
+    private BiConsumer<Long, AppendListener> onAppend = (pos, listener) -> listener.onWrite(pos);
+
+    void onNextAppend(final BiConsumer<Long, AppendListener> onAppend) {
+      this.onAppend = onAppend;
+    }
+
+    @Override
+    public LogStorageReader newReader() {
+      return null;
+    }
+
+    @Override
+    public void append(
+        final long lowestPosition,
+        final long highestPosition,
+        final ByteBuffer blockBuffer,
+        final AppendListener listener) {
+      onAppend.accept(highestPosition, listener);
+    }
+
+    @Override
+    public void open() throws IOException {}
+
+    @Override
+    public void close() {}
+
+    @Override
+    public boolean isOpen() {
+      return false;
+    }
+
+    @Override
+    public boolean isClosed() {
+      return false;
+    }
+
+    @Override
+    public void flush() throws Exception {}
+  }
+}

--- a/util/src/main/java/io/zeebe/util/sched/Actor.java
+++ b/util/src/main/java/io/zeebe/util/sched/Actor.java
@@ -8,6 +8,7 @@
 package io.zeebe.util.sched;
 
 import io.zeebe.util.CloseableSilently;
+import io.zeebe.util.Loggers;
 import io.zeebe.util.sched.future.ActorFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -57,7 +58,7 @@ public abstract class Actor implements CloseableSilently {
 
   @Override
   public void close() {
-    actor.close().join(MAX_CLOSE_TIMEOUT, TimeUnit.SECONDS);
+    closeAsync().join(MAX_CLOSE_TIMEOUT, TimeUnit.SECONDS);
   }
 
   public ActorFuture<Void> closeAsync() {
@@ -66,5 +67,22 @@ public abstract class Actor implements CloseableSilently {
 
   public static String buildActorName(final int nodeId, final String name) {
     return String.format("Broker-%d-%s", nodeId, name);
+  }
+
+  /**
+   * Invoked when a task throws an exception when the actor phase is not 'STARTING' and 'CLOSING'.
+   *
+   * @param failure
+   */
+  protected void handleFailure(final Exception failure) {
+    Loggers.ACTOR_LOGGER.error(
+        "Uncaught exception in '{}' in phase '{}'. Continuing with next job.",
+        getName(),
+        actor.getLifecyclePhase(),
+        failure);
+  }
+
+  public void onActorFailed() {
+    // clean ups
   }
 }

--- a/util/src/main/java/io/zeebe/util/sched/ActorControl.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorControl.java
@@ -525,4 +525,10 @@ public class ActorControl {
 
     return thread;
   }
+
+  /** Mark actor as failed. This sets the lifecycle phase to 'FAILED' and discards all jobs. */
+  public void fail() {
+    ensureCalledFromWithinActor("fail()");
+    task.fail();
+  }
 }

--- a/util/src/main/java/io/zeebe/util/sched/ActorJob.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorJob.java
@@ -43,7 +43,7 @@ public final class ActorJob {
         resultFuture = null;
       }
 
-    } catch (final Throwable e) {
+    } catch (final Exception e) {
       task.onFailure(e);
     } finally {
       this.actorThread = null;

--- a/util/src/main/java/io/zeebe/util/sched/ActorTask.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorTask.java
@@ -273,7 +273,7 @@ public class ActorTask {
     }
   }
 
-  public void onFailure(final Throwable failure) {
+  public void onFailure(final Exception failure) {
     switch (lifecyclePhase) {
       case STARTING:
         Loggers.ACTOR_LOGGER.error(
@@ -294,9 +294,7 @@ public class ActorTask {
         break;
 
       default:
-        Loggers.ACTOR_LOGGER.error(
-            "Actor failed in phase '{}'. Continue with next job.", lifecyclePhase, failure);
-
+        actor.handleFailure(failure);
         currentJob.failFuture(failure);
     }
   }
@@ -544,6 +542,12 @@ public class ActorTask {
 
   public void insertJob(final ActorJob job) {
     fastLaneJobs.addFirst(job);
+  }
+
+  public void fail() {
+    lifecyclePhase = ActorLifecyclePhase.FAILED;
+    discardNextJobs();
+    actor.onActorFailed();
   }
 
   /** Describes an actor's scheduling state */

--- a/util/src/test/java/io/zeebe/util/sched/lifecycle/LifecycleRecordingActor.java
+++ b/util/src/test/java/io/zeebe/util/sched/lifecycle/LifecycleRecordingActor.java
@@ -55,6 +55,11 @@ class LifecycleRecordingActor extends Actor {
     phases.add(actor.getLifecyclePhase());
   }
 
+  @Override
+  public void onActorFailed() {
+    phases.add(actor.getLifecyclePhase());
+  }
+
   protected void blockPhase() {
     blockPhase(new CompletableActorFuture<>(), mock(BiConsumer.class));
   }


### PR DESCRIPTION
## Description
- Enable actor specific exception handling instead of logging and continuing with the next job.
- Expose an api to fail an actor. Actors can use this when exceptions occur.
- LogStorage appender fails the actor when unexpected exceptions occur. When the actor is failed or closed it is considered as unhealthy.

## Related issues

closes #4000

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
