### PR TITLE
[BACKPORT] fix(broker): catch error inside multi-instance subprocess

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/MultiInstanceActivityTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/MultiInstanceActivityTransformer.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.processor.workflow.deployment.model.transformer;
 
 import io.zeebe.engine.processor.workflow.deployment.model.BpmnStep;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableActivity;
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableFlowElementContainer;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableLoopCharacteristics;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableMultiInstanceBody;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableWorkflow;
@@ -71,8 +72,13 @@ public final class MultiInstanceActivityTransformer implements ModelElementTrans
 
       // attach boundary events to the multi-instance body
       innerActivity.getBoundaryEvents().forEach(multiInstanceBody::attach);
+      innerActivity.getEventSubprocesses().forEach(multiInstanceBody::attach);
 
       innerActivity.getEvents().removeAll(innerActivity.getBoundaryEvents());
+      innerActivity.getEventSubprocesses().stream()
+          .map(ExecutableFlowElementContainer::getStartEvents)
+          .forEach(innerActivity.getEvents()::remove);
+
       innerActivity.getInterruptingElementIds().clear();
 
       // attach incoming and outgoing sequence flows to the multi-instance body

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/error/ErrorEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/error/ErrorEventTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.zeebe.engine.util.EngineRule;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.builder.EventSubProcessBuilder;
 import io.zeebe.model.bpmn.builder.ServiceTaskBuilder;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.intent.JobIntent;
@@ -20,6 +21,7 @@ import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.test.util.record.RecordingExporter;
 import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
 import java.util.function.Consumer;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -160,5 +162,125 @@ public class ErrorEventTest {
         .extracting(Record::getIntent)
         .containsExactly(
             JobIntent.CREATE, JobIntent.CREATED, JobIntent.THROW_ERROR, JobIntent.ERROR_THROWN);
+  }
+
+  @Test
+  public void shouldCatchErrorFromChildInstance() {
+    // given
+    final var workflowChild =
+        Bpmn.createExecutableProcess("wf-child")
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeTaskType(JOB_TYPE))
+            .endEvent()
+            .done();
+
+    final var workflowParent =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("wf-child"))
+            .boundaryEvent("error", b -> b.error(ERROR_CODE).endEvent())
+            .endEvent()
+            .done();
+
+    ENGINE
+        .deployment()
+        .withXmlResource("wf-child.bpmn", workflowChild)
+        .withXmlResource("wf-parent.bpmn", workflowParent)
+        .deploy();
+
+    final var parentWorkflowInstanceKey =
+        ENGINE.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var childWorkflowInstanceKey =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentWorkflowInstanceKey(parentWorkflowInstanceKey)
+            .getFirst()
+            .getValue()
+            .getWorkflowInstanceKey();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(childWorkflowInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .throwError();
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(childWorkflowInstanceKey)
+                .limitToWorkflowInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.SERVICE_TASK, WorkflowInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, WorkflowInstanceIntent.ELEMENT_TERMINATED));
+
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(parentWorkflowInstanceKey)
+                .limitToWorkflowInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.CALL_ACTIVITY, WorkflowInstanceIntent.EVENT_OCCURRED),
+            tuple(BpmnElementType.CALL_ACTIVITY, WorkflowInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, WorkflowInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.BOUNDARY_EVENT, WorkflowInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, WorkflowInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldCatchErrorInsideMultiInstanceSubprocess() {
+    // given
+    final Consumer<EventSubProcessBuilder> eventSubprocess =
+        s -> s.startEvent("error-start-event").error(ERROR_CODE).endEvent();
+
+    final var workflow =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.multiInstance(m -> m.zeebeInputCollection("items"))
+                        .embeddedSubProcess()
+                        .eventSubProcess("error-subprocess", eventSubprocess)
+                        .startEvent()
+                        .serviceTask("task", t -> t.zeebeTaskType(JOB_TYPE))
+                        .endEvent())
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(workflow).deploy();
+
+    final var workflowInstanceKey =
+        ENGINE
+            .workflowInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("items", List.of(1))
+            .create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(workflowInstanceKey)
+        .withType(JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .throwError();
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .limitToWorkflowInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("error-start-event", WorkflowInstanceIntent.EVENT_OCCURRED),
+            tuple("task", WorkflowInstanceIntent.ELEMENT_TERMINATED),
+            tuple("error-subprocess", WorkflowInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("error-start-event", WorkflowInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("error-start-event", WorkflowInstanceIntent.ELEMENT_COMPLETED),
+            tuple("error-subprocess", WorkflowInstanceIntent.ELEMENT_COMPLETED),
+            tuple("subprocess", WorkflowInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, WorkflowInstanceIntent.ELEMENT_COMPLETED));
   }
 }


### PR DESCRIPTION
## Description

* when an error is thrown inside a multi-instance embedded subprocess then the error is caught by an event subprocess in it
* attaching the event subprocesses to the multi-instance body

## Related issues

related #3671 (backport)
