### PR TITLE
[BACKPORT] Remove onOpen lifecycle method

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/CommandProcessorImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/CommandProcessorImpl.java
@@ -17,7 +17,7 @@ public final class CommandProcessorImpl<T extends UnifiedRecordValue>
 
   private final CommandProcessor<T> wrappedProcessor;
 
-  private KeyGenerator keyGenerator;
+  private final KeyGenerator keyGenerator;
 
   private boolean isAccepted;
   private long entityKey;
@@ -28,13 +28,10 @@ public final class CommandProcessorImpl<T extends UnifiedRecordValue>
   private RejectionType rejectionType;
   private String rejectionReason;
 
-  public CommandProcessorImpl(final CommandProcessor<T> commandProcessor) {
+  public CommandProcessorImpl(
+      final KeyGenerator keyGenerator, final CommandProcessor<T> commandProcessor) {
+    this.keyGenerator = keyGenerator;
     this.wrappedProcessor = commandProcessor;
-  }
-
-  @Override
-  public void onOpen(final ReadonlyProcessingContext context) {
-    this.keyGenerator = context.getZeebeState().getKeyGenerator();
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/NoopTypedStreamWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/NoopTypedStreamWriter.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor;
+
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.RejectionType;
+import io.zeebe.protocol.record.intent.Intent;
+import java.util.function.Consumer;
+
+final class NoopTypedStreamWriter implements TypedStreamWriter {
+
+  @Override
+  public void appendRejection(
+      final TypedRecord<? extends UnpackedObject> command,
+      final RejectionType type,
+      final String reason) {
+    // no op implementation
+  }
+
+  @Override
+  public void appendRejection(
+      final TypedRecord<? extends UnpackedObject> command,
+      final RejectionType type,
+      final String reason,
+      final Consumer<RecordMetadata> metadata) {
+    // no op implementation
+  }
+
+  @Override
+  public void appendNewEvent(final long key, final Intent intent, final UnpackedObject value) {
+    // no op implementation
+  }
+
+  @Override
+  public void appendFollowUpEvent(final long key, final Intent intent, final UnpackedObject value) {
+    // no op implementation
+  }
+
+  @Override
+  public void appendFollowUpEvent(
+      final long key,
+      final Intent intent,
+      final UnpackedObject value,
+      final Consumer<RecordMetadata> metadata) {
+    // no op implementation
+  }
+
+  @Override
+  public void configureSourceContext(final long sourceRecordPosition) {
+    // no op implementation
+  }
+
+  @Override
+  public void appendNewCommand(final Intent intent, final UnpackedObject value) {
+    // no op implementation
+  }
+
+  @Override
+  public void appendFollowUpCommand(
+      final long key, final Intent intent, final UnpackedObject value) {
+    // no op implementation
+  }
+
+  @Override
+  public void appendFollowUpCommand(
+      final long key,
+      final Intent intent,
+      final UnpackedObject value,
+      final Consumer<RecordMetadata> metadata) {
+    // no op implementation
+  }
+
+  @Override
+  public void reset() {
+    // no op implementation
+  }
+
+  @Override
+  public long flush() {
+    return 0;
+  }
+
+  @Override
+  public void close() {
+    // no op implementation
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/ProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ProcessingContext.java
@@ -21,7 +21,7 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
   private EventFilter eventFilter;
   private LogStream logStream;
   private LogStreamReader logStreamReader;
-  private TypedStreamWriter logStreamWriter;
+  private TypedStreamWriter logStreamWriter = new NoopTypedStreamWriter();
   private CommandResponseWriter commandResponseWriter;
 
   private RecordValues recordValues;

--- a/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
@@ -14,13 +14,10 @@ import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.logstreams.impl.Loggers;
 import io.zeebe.logstreams.log.LogStreamReader;
 import io.zeebe.logstreams.log.LoggedEvent;
-import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.impl.record.value.error.ErrorRecord;
-import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.ValueType;
-import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.util.retry.EndlessRetryStrategy;
 import io.zeebe.util.retry.RetryStrategy;
 import io.zeebe.util.sched.ActorControl;
@@ -94,7 +91,7 @@ public final class ReProcessingStateMachine {
 
   private final EventFilter eventFilter;
   private final LogStreamReader logStreamReader;
-  private final TypedStreamWriter noopstreamWriter = new NoopStreamWriter();
+  private final TypedStreamWriter noopstreamWriter = new NoopTypedStreamWriter();
   private final TypedResponseWriter noopResponseWriter = new NoopResponseWriter();
 
   private final DbContext dbContext;
@@ -318,66 +315,5 @@ public final class ReProcessingStateMachine {
   private void onRecovered() {
     recoveryFuture.complete(null);
     failedEventPositions.clear();
-  }
-
-  private static final class NoopStreamWriter implements TypedStreamWriter {
-
-    @Override
-    public void setDisabled(boolean disabled) {}
-
-    @Override
-    public void appendRejection(
-        final TypedRecord<? extends UnpackedObject> command,
-        final RejectionType type,
-        final String reason) {}
-
-    @Override
-    public void appendRejection(
-        final TypedRecord<? extends UnpackedObject> command,
-        final RejectionType type,
-        final String reason,
-        final Consumer<RecordMetadata> metadata) {}
-
-    @Override
-    public void appendNewEvent(final long key, final Intent intent, final UnpackedObject value) {}
-
-    @Override
-    public void appendFollowUpEvent(
-        final long key, final Intent intent, final UnpackedObject value) {}
-
-    @Override
-    public void appendFollowUpEvent(
-        final long key,
-        final Intent intent,
-        final UnpackedObject value,
-        final Consumer<RecordMetadata> metadata) {}
-
-    @Override
-    public void configureSourceContext(final long sourceRecordPosition) {}
-
-    @Override
-    public void appendNewCommand(final Intent intent, final UnpackedObject value) {}
-
-    @Override
-    public void appendFollowUpCommand(
-        final long key, final Intent intent, final UnpackedObject value) {}
-
-    @Override
-    public void appendFollowUpCommand(
-        final long key,
-        final Intent intent,
-        final UnpackedObject value,
-        final Consumer<RecordMetadata> metadata) {}
-
-    @Override
-    public void reset() {}
-
-    @Override
-    public long flush() {
-      return 0;
-    }
-
-    @Override
-    public void close() {}
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
@@ -323,6 +323,9 @@ public final class ReProcessingStateMachine {
   private static final class NoopStreamWriter implements TypedStreamWriter {
 
     @Override
+    public void setDisabled(boolean disabled) {}
+
+    @Override
     public void appendRejection(
         final TypedRecord<? extends UnpackedObject> command,
         final RejectionType type,

--- a/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
@@ -323,9 +323,6 @@ public final class ReProcessingStateMachine {
   private static final class NoopStreamWriter implements TypedStreamWriter {
 
     @Override
-    public void setDisabled(boolean disabled) {}
-
-    @Override
     public void appendRejection(
         final TypedRecord<? extends UnpackedObject> command,
         final RejectionType type,

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -135,6 +135,7 @@ public class StreamProcessor extends Actor {
       final ReProcessingStateMachine reProcessingStateMachine =
           new ReProcessingStateMachine(processingContext);
 
+      processingContext.getLogStreamWriter().setDisabled(true);
       final ActorFuture<Void> recoverFuture =
           reProcessingStateMachine.startRecover(snapshotPosition);
 
@@ -145,6 +146,7 @@ public class StreamProcessor extends Actor {
               LOG.error("Unexpected error on recovery happens.", throwable);
               onFailure(throwable);
             } else {
+              processingContext.getLogStreamWriter().setDisabled(false);
               onRecovered();
             }
           });

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -121,8 +121,6 @@ public class StreamProcessor extends Actor {
       snapshotPosition = recoverFromSnapshot();
 
       initProcessors();
-
-      lifecycleAwareListeners.forEach(l -> l.onOpen(processingContext));
     } catch (final Throwable e) {
       onFailure(e);
       LangUtil.rethrowUnchecked(e);
@@ -135,7 +133,6 @@ public class StreamProcessor extends Actor {
       final ReProcessingStateMachine reProcessingStateMachine =
           new ReProcessingStateMachine(processingContext);
 
-      processingContext.getLogStreamWriter().setDisabled(true);
       final ActorFuture<Void> recoverFuture =
           reProcessingStateMachine.startRecover(snapshotPosition);
 
@@ -146,7 +143,6 @@ public class StreamProcessor extends Actor {
               LOG.error("Unexpected error on recovery happens.", throwable);
               onFailure(throwable);
             } else {
-              processingContext.getLogStreamWriter().setDisabled(false);
               onRecovered();
             }
           });

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -135,7 +135,6 @@ public class StreamProcessor extends Actor {
       final ReProcessingStateMachine reProcessingStateMachine =
           new ReProcessingStateMachine(processingContext);
 
-      processingContext.getLogStreamWriter().setDisabled(true);
       final ActorFuture<Void> recoverFuture =
           reProcessingStateMachine.startRecover(snapshotPosition);
 
@@ -146,7 +145,6 @@ public class StreamProcessor extends Actor {
               LOG.error("Unexpected error on recovery happens.", throwable);
               onFailure(throwable);
             } else {
-              processingContext.getLogStreamWriter().setDisabled(false);
               onRecovered();
             }
           });

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorLifecycleAware.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorLifecycleAware.java
@@ -9,8 +9,6 @@ package io.zeebe.engine.processor;
 
 public interface StreamProcessorLifecycleAware {
 
-  default void onOpen(final ReadonlyProcessingContext context) {}
-
   /** Callback after reprocessing was successful and before regular processing begins */
   default void onRecovered(final ReadonlyProcessingContext context) {}
 

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriter.java
@@ -16,8 +16,6 @@ import java.util.function.Consumer;
 /** Things that any actor can write to a partition. */
 public interface TypedCommandWriter extends CloseableSilently {
 
-  void setDisabled(boolean disabled);
-
   void appendNewCommand(Intent intent, UnpackedObject value);
 
   void appendFollowUpCommand(long key, Intent intent, UnpackedObject value);

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriter.java
@@ -16,6 +16,8 @@ import java.util.function.Consumer;
 /** Things that any actor can write to a partition. */
 public interface TypedCommandWriter extends CloseableSilently {
 
+  void setDisabled(boolean disabled);
+
   void appendNewCommand(Intent intent, UnpackedObject value);
 
   void appendFollowUpCommand(long key, Intent intent, UnpackedObject value);

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
@@ -29,7 +29,6 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
   protected final LogStreamBatchWriter batchWriter;
 
   protected long sourceRecordPosition = -1;
-  private boolean disabled = false;
 
   public TypedCommandWriterImpl(final LogStreamBatchWriter batchWriter) {
     metadata.protocolVersion(Protocol.PROTOCOL_VERSION);
@@ -71,7 +70,6 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
       final String rejectionReason,
       final UnpackedObject value,
       final Consumer<RecordMetadata> additionalMetadata) {
-    assert !disabled : "Command writer called in disabled mode, probably during reprocessing";
 
     final LogEntryBuilder event = batchWriter.event();
 
@@ -91,11 +89,6 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
     }
 
     event.metadataWriter(metadata).valueWriter(value).done();
-  }
-
-  @Override
-  public void setDisabled(boolean disabled) {
-    this.disabled = disabled;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
@@ -29,6 +29,7 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
   protected final LogStreamBatchWriter batchWriter;
 
   protected long sourceRecordPosition = -1;
+  private boolean disabled = false;
 
   public TypedCommandWriterImpl(final LogStreamBatchWriter batchWriter) {
     metadata.protocolVersion(Protocol.PROTOCOL_VERSION);
@@ -70,6 +71,8 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
       final String rejectionReason,
       final UnpackedObject value,
       final Consumer<RecordMetadata> additionalMetadata) {
+    assert !disabled : "Command writer called in disabled mode, probably during reprocessing";
+
     final LogEntryBuilder event = batchWriter.event();
 
     if (sourceRecordPosition >= 0) {
@@ -88,6 +91,11 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
     }
 
     event.metadataWriter(metadata).valueWriter(value).done();
+  }
+
+  @Override
+  public void setDisabled(boolean disabled) {
+    this.disabled = disabled;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
@@ -29,7 +29,6 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
   protected final LogStreamBatchWriter batchWriter;
 
   protected long sourceRecordPosition = -1;
-  private boolean disabled = false;
 
   public TypedCommandWriterImpl(final LogStreamBatchWriter batchWriter) {
     metadata.protocolVersion(Protocol.PROTOCOL_VERSION);
@@ -71,8 +70,6 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
       final String rejectionReason,
       final UnpackedObject value,
       final Consumer<RecordMetadata> additionalMetadata) {
-    assert !disabled : "Command writer called in disabled mode, probably during reprocessing";
-
     final LogEntryBuilder event = batchWriter.event();
 
     if (sourceRecordPosition >= 0) {
@@ -91,11 +88,6 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
     }
 
     event.metadataWriter(metadata).valueWriter(value).done();
-  }
-
-  @Override
-  public void setDisabled(boolean disabled) {
-    this.disabled = disabled;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedRecordProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedRecordProcessors.java
@@ -18,11 +18,14 @@ public final class TypedRecordProcessors {
 
   private final RecordProcessorMap recordProcessorMap = new RecordProcessorMap();
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
+  private final KeyGenerator keyGenerator;
 
-  private TypedRecordProcessors() {}
+  private TypedRecordProcessors(final KeyGenerator keyGenerator) {
+    this.keyGenerator = keyGenerator;
+  }
 
-  public static TypedRecordProcessors processors() {
-    return new TypedRecordProcessors();
+  public static TypedRecordProcessors processors(final KeyGenerator keyGenerator) {
+    return new TypedRecordProcessors(keyGenerator);
   }
 
   // TODO: could remove the ValueType argument as it follows from the intent
@@ -48,7 +51,7 @@ public final class TypedRecordProcessors {
 
   public <T extends UnifiedRecordValue> TypedRecordProcessors onCommand(
       final ValueType valueType, final Intent intent, final CommandProcessor<T> commandProcessor) {
-    return onCommand(valueType, intent, new CommandProcessorImpl<>(commandProcessor));
+    return onCommand(valueType, intent, new CommandProcessorImpl<>(keyGenerator, commandProcessor));
   }
 
   public TypedRecordProcessors withListener(final StreamProcessorLifecycleAware listener) {

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/WorkflowEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/WorkflowEventProcessors.java
@@ -54,7 +54,7 @@ public final class WorkflowEventProcessors {
         zeebeState.getWorkflowInstanceSubscriptionState();
 
     final WorkflowEngineState workflowEngineState =
-        new WorkflowEngineState(zeebeState.getWorkflowState());
+        new WorkflowEngineState(zeebeState.getPartitionId(), zeebeState.getWorkflowState());
     typedRecordProcessors.withListener(workflowEngineState);
 
     addWorkflowInstanceCommandProcessor(typedRecordProcessors, workflowEngineState, zeebeState);

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/distribute/DeploymentDistributeProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/distribute/DeploymentDistributeProcessor.java
@@ -31,6 +31,7 @@ public final class DeploymentDistributeProcessor implements TypedRecordProcessor
   private final DeploymentsState deploymentsState;
   private final DeploymentDistributor deploymentDistributor;
   private ActorControl actor;
+  private TypedStreamWriter logStreamWriter;
 
   public DeploymentDistributeProcessor(
       final DeploymentsState deploymentsState, final DeploymentDistributor deploymentDistributor) {
@@ -41,22 +42,18 @@ public final class DeploymentDistributeProcessor implements TypedRecordProcessor
   @Override
   public void onOpen(final ReadonlyProcessingContext processingContext) {
     actor = processingContext.getActor();
+    logStreamWriter = processingContext.getLogStreamWriter();
+    actor.submit(this::reprocessPendingDeployments);
   }
 
-  @Override
-  public void onRecovered(ReadonlyProcessingContext context) {
-    actor.submit(() -> reprocessPendingDeployments(context.getLogStreamWriter()));
-  }
-
-  private void reprocessPendingDeployments(TypedStreamWriter logStreamWriter) {
+  private void reprocessPendingDeployments() {
     deploymentsState.foreachPending(
         ((pendingDeploymentDistribution, key) -> {
           final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
           final DirectBuffer deployment = pendingDeploymentDistribution.getDeployment();
           buffer.putBytes(0, deployment, 0, deployment.capacity());
 
-          distributeDeployment(
-              key, pendingDeploymentDistribution.getSourcePosition(), buffer, logStreamWriter);
+          distributeDeployment(key, pendingDeploymentDistribution.getSourcePosition(), buffer);
         }));
   }
 
@@ -77,23 +74,19 @@ public final class DeploymentDistributeProcessor implements TypedRecordProcessor
     final DirectBuffer bufferView = new UnsafeBuffer();
     bufferView.wrap(buffer, 0, deploymentEvent.getLength());
 
-    distributeDeployment(key, position, bufferView, streamWriter);
+    distributeDeployment(key, position, bufferView);
   }
 
   private void distributeDeployment(
-      final long key,
-      final long position,
-      final DirectBuffer buffer,
-      TypedStreamWriter logStreamWriter) {
+      final long key, final long position, final DirectBuffer buffer) {
     final ActorFuture<Void> pushDeployment =
         deploymentDistributor.pushDeployment(key, position, buffer);
 
     actor.runOnCompletion(
-        pushDeployment, (aVoid, throwable) -> writeCreatingDeploymentCommand(logStreamWriter, key));
+        pushDeployment, (aVoid, throwable) -> writeCreatingDeploymentCommand(key));
   }
 
-  private void writeCreatingDeploymentCommand(
-      TypedStreamWriter logStreamWriter, final long deploymentKey) {
+  private void writeCreatingDeploymentCommand(final long deploymentKey) {
     final PendingDeploymentDistribution pendingDeploymentDistribution =
         deploymentDistributor.removePendingDeployment(deploymentKey);
     final DirectBuffer buffer = pendingDeploymentDistribution.getDeployment();

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/CorrelateWorkflowInstanceSubscription.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/CorrelateWorkflowInstanceSubscription.java
@@ -71,7 +71,7 @@ public final class CorrelateWorkflowInstanceSubscription
   }
 
   @Override
-  public void onOpen(final ReadonlyProcessingContext processingContext) {
+  public void onRecovered(final ReadonlyProcessingContext processingContext) {
     final ActorControl actor = processingContext.getActor();
 
     final PendingWorkflowInstanceSubscriptionChecker pendingSubscriptionChecker =

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageObserver.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageObserver.java
@@ -36,16 +36,12 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
   }
 
   @Override
-  public void onOpen(final ReadonlyProcessingContext processingContext) {
-
-    final ActorControl actor = processingContext.getActor();
-
+  public void onRecovered(ReadonlyProcessingContext context) {
+    final ActorControl actor = context.getActor();
     // it is safe to reuse the write because we running in the same actor/thread
     final MessageTimeToLiveChecker timeToLiveChecker =
-        new MessageTimeToLiveChecker(processingContext.getLogStreamWriter(), messageState);
-    processingContext
-        .getActor()
-        .runAtFixedRate(MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL, timeToLiveChecker);
+        new MessageTimeToLiveChecker(context.getLogStreamWriter(), messageState);
+    context.getActor().runAtFixedRate(MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL, timeToLiveChecker);
 
     final PendingMessageSubscriptionChecker pendingSubscriptionChecker =
         new PendingMessageSubscriptionChecker(

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/timer/DueDateTimerChecker.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/timer/DueDateTimerChecker.java
@@ -94,13 +94,9 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
   }
 
   @Override
-  public void onOpen(final ReadonlyProcessingContext processingContext) {
+  public void onRecovered(final ReadonlyProcessingContext processingContext) {
     this.actor = processingContext.getActor();
     streamWriter = processingContext.getLogStreamWriter();
-  }
-
-  @Override
-  public void onRecovered(final ReadonlyProcessingContext processingContext) {
     // check if timers are due after restart
     triggerTimers();
   }

--- a/engine/src/main/java/io/zeebe/engine/state/ZeebeState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/ZeebeState.java
@@ -54,6 +54,7 @@ public class ZeebeState {
   private final DbString lastProcessedEventKey;
   private final DbLong lastProcessedEventPosition;
   private final ColumnFamily<DbString, DbLong> lastProcessedRecordPositionColumnFamily;
+  private final int partitionId;
 
   public ZeebeState(final ZeebeDb<ZbColumnFamilies> zeebeDb, final DbContext dbContext) {
     this(Protocol.DEPLOYMENT_PARTITION, zeebeDb, dbContext);
@@ -61,6 +62,7 @@ public class ZeebeState {
 
   public ZeebeState(
       final int partitionId, final ZeebeDb<ZbColumnFamilies> zeebeDb, final DbContext dbContext) {
+    this.partitionId = partitionId;
     keyState = new KeyState(partitionId, zeebeDb, dbContext);
     workflowState = new WorkflowState(zeebeDb, dbContext, keyState);
     deploymentState = new DeploymentsState(zeebeDb, dbContext);
@@ -168,5 +170,9 @@ public class ZeebeState {
   public long getLastSuccessfulProcessedRecordPosition() {
     final DbLong position = lastProcessedRecordPositionColumnFamily.get(lastProcessedEventKey);
     return position != null ? position.getValue() : NO_EVENTS_PROCESSED;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/WorkflowEngineState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/WorkflowEngineState.java
@@ -20,18 +20,13 @@ import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 public final class WorkflowEngineState implements StreamProcessorLifecycleAware {
 
   private final WorkflowState workflowState;
-  private ElementInstanceState elementInstanceState;
-  private WorkflowEngineMetrics metrics;
+  private final ElementInstanceState elementInstanceState;
+  private final WorkflowEngineMetrics metrics;
 
-  public WorkflowEngineState(final WorkflowState workflowState) {
+  public WorkflowEngineState(final int partitionId, final WorkflowState workflowState) {
     this.workflowState = workflowState;
-  }
-
-  @Override
-  public void onOpen(final ReadonlyProcessingContext processingContext) {
     this.elementInstanceState = workflowState.getElementInstanceState();
-
-    this.metrics = new WorkflowEngineMetrics(processingContext.getLogStream().getPartitionId());
+    this.metrics = new WorkflowEngineMetrics(partitionId);
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/state/instance/WorkflowEngineState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/WorkflowEngineState.java
@@ -32,9 +32,12 @@ public final class WorkflowEngineState implements StreamProcessorLifecycleAware 
     this.elementInstanceState = workflowState.getElementInstanceState();
 
     this.metrics = new WorkflowEngineMetrics(processingContext.getLogStream().getPartitionId());
+  }
 
+  @Override
+  public void onRecovered(ReadonlyProcessingContext context) {
     final UpdateVariableStreamWriter updateVariableStreamWriter =
-        new UpdateVariableStreamWriter(processingContext.getLogStreamWriter());
+        new UpdateVariableStreamWriter(context.getLogStreamWriter());
 
     elementInstanceState.getVariablesState().setListener(updateVariableStreamWriter);
   }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/WorkflowEngineState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/WorkflowEngineState.java
@@ -32,12 +32,9 @@ public final class WorkflowEngineState implements StreamProcessorLifecycleAware 
     this.elementInstanceState = workflowState.getElementInstanceState();
 
     this.metrics = new WorkflowEngineMetrics(processingContext.getLogStream().getPartitionId());
-  }
 
-  @Override
-  public void onRecovered(ReadonlyProcessingContext context) {
     final UpdateVariableStreamWriter updateVariableStreamWriter =
-        new UpdateVariableStreamWriter(context.getLogStreamWriter());
+        new UpdateVariableStreamWriter(processingContext.getLogStreamWriter());
 
     elementInstanceState.getVariablesState().setListener(updateVariableStreamWriter);
   }

--- a/engine/src/test/java/io/zeebe/engine/processor/SkipFailingEventsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/SkipFailingEventsTest.java
@@ -99,7 +99,7 @@ public final class SkipFailingEventsTest {
         DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
-          return TypedRecordProcessors.processors()
+          return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE,
                   WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -138,7 +138,7 @@ public final class SkipFailingEventsTest {
         DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
-          return TypedRecordProcessors.processors()
+          return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE,
                   WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -186,7 +186,7 @@ public final class SkipFailingEventsTest {
         DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
-          return TypedRecordProcessors.processors()
+          return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_ACTIVATING, processor)
               .onEvent(
@@ -266,7 +266,7 @@ public final class SkipFailingEventsTest {
         DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
-          return TypedRecordProcessors.processors()
+          return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
               .withListener(
                   new StreamProcessorLifecycleAware() {
                     @Override
@@ -324,7 +324,7 @@ public final class SkipFailingEventsTest {
         DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
-          return TypedRecordProcessors.processors()
+          return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
               .onCommand(ValueType.JOB, JobIntent.COMPLETE, errorProneProcessor)
               .onEvent(ValueType.JOB, JobIntent.ACTIVATED, dumpProcessor);
         });
@@ -398,7 +398,7 @@ public final class SkipFailingEventsTest {
         DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
-          return TypedRecordProcessors.processors()
+          return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
               .onCommand(ValueType.TIMER, TimerIntent.CREATE, errorProneProcessor);
         });
 

--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorReprocessingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorReprocessingTest.java
@@ -58,12 +58,11 @@ public final class StreamProcessorReprocessingTest {
 
     // when
     final TypedRecordProcessor typedRecordProcessor = mock(TypedRecordProcessor.class);
-    final StreamProcessor streamProcessor =
-        streamProcessorRule.startTypedStreamProcessor(
-            (processors, state) ->
-                processors
-                    .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor)
-                    .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATED, typedRecordProcessor));
+    streamProcessorRule.startTypedStreamProcessor(
+        (processors, state) ->
+            processors
+                .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor)
+                .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATED, typedRecordProcessor));
 
     verify(typedRecordProcessor, TIMEOUT.times(1))
         .processRecord(eq(secondPosition), any(), any(), any(), any());
@@ -71,7 +70,6 @@ public final class StreamProcessorReprocessingTest {
 
     // then
     final InOrder inOrder = inOrder(typedRecordProcessor);
-    inOrder.verify(typedRecordProcessor, TIMEOUT.times(2)).onOpen(any());
     // reprocessing
     inOrder
         .verify(typedRecordProcessor, TIMEOUT.times(1))
@@ -118,7 +116,6 @@ public final class StreamProcessorReprocessingTest {
 
     // then
     final InOrder inOrder = inOrder(typedRecordProcessor);
-    inOrder.verify(typedRecordProcessor, TIMEOUT.times(2)).onOpen(any());
     // reprocessing
     inOrder
         .verify(typedRecordProcessor, TIMEOUT.times(1))
@@ -155,12 +152,11 @@ public final class StreamProcessorReprocessingTest {
 
     // when
     final TypedRecordProcessor typedRecordProcessor = mock(TypedRecordProcessor.class);
-    final StreamProcessor streamProcessor =
-        streamProcessorRule.startTypedStreamProcessor(
-            (processors, state) ->
-                processors
-                    .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor)
-                    .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATED, typedRecordProcessor));
+    streamProcessorRule.startTypedStreamProcessor(
+        (processors, state) ->
+            processors
+                .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor)
+                .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATED, typedRecordProcessor));
 
     verify(typedRecordProcessor, TIMEOUT.times(1))
         .processRecord(eq(secondPosition), any(), any(), any(), any());
@@ -168,7 +164,6 @@ public final class StreamProcessorReprocessingTest {
 
     // then
     final InOrder inOrder = inOrder(typedRecordProcessor);
-    inOrder.verify(typedRecordProcessor, TIMEOUT.times(2)).onOpen(any());
     // no reprocessing
     inOrder.verify(typedRecordProcessor, TIMEOUT.times(2)).onRecovered(any());
     // normal processing
@@ -217,7 +212,6 @@ public final class StreamProcessorReprocessingTest {
 
     // then
     final InOrder inOrder = inOrder(typedRecordProcessor);
-    inOrder.verify(typedRecordProcessor, TIMEOUT.times(1)).onOpen(any());
     inOrder
         .verify(typedRecordProcessor, TIMEOUT.times(2))
         .processRecord(eq(firstPosition), any(), any(), any(), any());
@@ -243,7 +237,6 @@ public final class StreamProcessorReprocessingTest {
 
     // then
     final InOrder inOrder = inOrder(typedRecordProcessor);
-    inOrder.verify(typedRecordProcessor, TIMEOUT.times(1)).onOpen(any());
     inOrder
         .verify(typedRecordProcessor, never())
         .processRecord(eq(firstPosition), any(), any(), any(), any());

--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorReprocessingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorReprocessingTest.java
@@ -59,7 +59,7 @@ public final class StreamProcessorReprocessingTest {
     // when
     final TypedRecordProcessor typedRecordProcessor = mock(TypedRecordProcessor.class);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors
                 .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor)
                 .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATED, typedRecordProcessor));
@@ -105,7 +105,7 @@ public final class StreamProcessorReprocessingTest {
     // when
     final TypedRecordProcessor typedRecordProcessor = mock(TypedRecordProcessor.class);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors
                 .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor)
                 .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATED, typedRecordProcessor));
@@ -153,7 +153,7 @@ public final class StreamProcessorReprocessingTest {
     // when
     final TypedRecordProcessor typedRecordProcessor = mock(TypedRecordProcessor.class);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors
                 .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor)
                 .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATED, typedRecordProcessor));
@@ -206,7 +206,7 @@ public final class StreamProcessorReprocessingTest {
         .when(typedRecordProcessor)
         .processRecord(anyLong(), any(), any(), any(), any());
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor));
 
@@ -231,7 +231,7 @@ public final class StreamProcessorReprocessingTest {
     // when
     final TypedRecordProcessor<?> typedRecordProcessor = mock(TypedRecordProcessor.class);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor));
 
@@ -266,7 +266,7 @@ public final class StreamProcessorReprocessingTest {
     // when
     final CountDownLatch processLatch = new CountDownLatch(1);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors
                 .onEvent(
                     ValueType.WORKFLOW_INSTANCE,
@@ -317,7 +317,7 @@ public final class StreamProcessorReprocessingTest {
     // given
     final CountDownLatch processingLatch = new CountDownLatch(2);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 ELEMENT_ACTIVATING,
@@ -342,7 +342,7 @@ public final class StreamProcessorReprocessingTest {
     final List<Long> processedPositions = new ArrayList<>();
     final CountDownLatch newProcessLatch = new CountDownLatch(1);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 ELEMENT_ACTIVATING,
@@ -371,7 +371,7 @@ public final class StreamProcessorReprocessingTest {
     // given
     final CountDownLatch processingLatch = new CountDownLatch(2);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 ELEMENT_ACTIVATING,
@@ -402,7 +402,7 @@ public final class StreamProcessorReprocessingTest {
     final List<Long> processedPositions = new ArrayList<>();
     final CountDownLatch newProcessLatch = new CountDownLatch(2);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 ELEMENT_ACTIVATING,

--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
@@ -80,7 +80,6 @@ public final class StreamProcessorTest {
 
     // then
     final InOrder inOrder = inOrder(lifecycleAware);
-    inOrder.verify(lifecycleAware, times(1)).onOpen(any());
     inOrder.verify(lifecycleAware, times(1)).onRecovered(any());
     inOrder.verify(lifecycleAware, times(1)).onClose();
 
@@ -110,7 +109,6 @@ public final class StreamProcessorTest {
 
     // then
     final InOrder inOrder = inOrder(typedRecordProcessor);
-    inOrder.verify(typedRecordProcessor, times(1)).onOpen(any());
     inOrder.verify(typedRecordProcessor, times(1)).onRecovered(any());
     inOrder.verify(typedRecordProcessor, times(1)).onClose();
 
@@ -134,7 +132,6 @@ public final class StreamProcessorTest {
 
     // then
     final InOrder inOrder = inOrder(typedRecordProcessor);
-    inOrder.verify(typedRecordProcessor, TIMEOUT.times(1)).onOpen(any());
     inOrder.verify(typedRecordProcessor, TIMEOUT.times(1)).onRecovered(any());
     inOrder
         .verify(typedRecordProcessor, TIMEOUT.times(1))
@@ -173,7 +170,6 @@ public final class StreamProcessorTest {
 
     // then
     final InOrder inOrder = inOrder(typedRecordProcessor);
-    inOrder.verify(typedRecordProcessor, TIMEOUT.times(1)).onOpen(any());
     inOrder.verify(typedRecordProcessor, TIMEOUT.times(1)).onRecovered(any());
     inOrder
         .verify(typedRecordProcessor, TIMEOUT.times(2))
@@ -201,7 +197,6 @@ public final class StreamProcessorTest {
 
     // then
     final InOrder inOrder = inOrder(typedRecordProcessor);
-    inOrder.verify(typedRecordProcessor, TIMEOUT.times(1)).onOpen(any());
     inOrder.verify(typedRecordProcessor, TIMEOUT.times(1)).onRecovered(any());
     inOrder
         .verify(typedRecordProcessor, TIMEOUT.times(1))
@@ -366,7 +361,7 @@ public final class StreamProcessorTest {
         (processingContext) -> {
           processingContextActor = processingContext.getActor();
           final ZeebeState state = processingContext.getZeebeState();
-          return processors()
+          return processors(state.getKeyGenerator())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE,
                   WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -425,7 +420,7 @@ public final class StreamProcessorTest {
         (processingContext) -> {
           processingContextActor = processingContext.getActor();
           final ZeebeState state = processingContext.getZeebeState();
-          return processors()
+          return processors(state.getKeyGenerator())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE,
                   WorkflowInstanceIntent.ELEMENT_ACTIVATING,

--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
@@ -474,7 +474,7 @@ public final class StreamProcessorTest {
     final CountDownLatch processingLatch = new CountDownLatch(1);
     final StreamProcessor streamProcessor =
         streamProcessorRule.startTypedStreamProcessor(
-            (processors, state) ->
+            (processors, context) ->
                 processors.onEvent(
                     ValueType.WORKFLOW_INSTANCE,
                     WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -513,7 +513,7 @@ public final class StreamProcessorTest {
     // given
     final CountDownLatch processingLatch = new CountDownLatch(2);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -550,7 +550,7 @@ public final class StreamProcessorTest {
     // given
     final CountDownLatch recoveredLatch = new CountDownLatch(1);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -577,7 +577,7 @@ public final class StreamProcessorTest {
   @Test
   public void shouldNotCreateSnapshotsIfNoProcessorProcessEvent() throws Exception {
     // given
-    streamProcessorRule.startTypedStreamProcessor((processors, state) -> processors);
+    streamProcessorRule.startTypedStreamProcessor((processors, context) -> processors);
 
     // when
     final long position =
@@ -603,7 +603,7 @@ public final class StreamProcessorTest {
     // given
     final TypedRecordProcessor typedRecordProcessor = mock(TypedRecordProcessor.class);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -629,7 +629,7 @@ public final class StreamProcessorTest {
     // given
     final CountDownLatch processLatch = new CountDownLatch(1);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -671,7 +671,7 @@ public final class StreamProcessorTest {
     // given
     final CountDownLatch processLatch = new CountDownLatch(1);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -714,7 +714,7 @@ public final class StreamProcessorTest {
     // given
     final CountDownLatch processLatch = new CountDownLatch(1);
     streamProcessorRule.startTypedStreamProcessor(
-        (processors, state) ->
+        (processors, context) ->
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 WorkflowInstanceIntent.ELEMENT_ACTIVATING,

--- a/engine/src/test/java/io/zeebe/engine/processor/TypedStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/TypedStreamProcessorTest.java
@@ -73,7 +73,7 @@ public final class TypedStreamProcessorTest {
         STREAM_NAME,
         DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
         (processingContext) ->
-            TypedRecordProcessors.processors()
+            TypedRecordProcessors.processors(keyGenerator)
                 .onCommand(ValueType.DEPLOYMENT, DeploymentIntent.CREATE, new BatchProcessor()));
     final long firstEventPosition =
         streams
@@ -106,7 +106,7 @@ public final class TypedStreamProcessorTest {
         STREAM_NAME,
         DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
         (processingContext) ->
-            TypedRecordProcessors.processors()
+            TypedRecordProcessors.processors(keyGenerator)
                 .onCommand(
                     ValueType.DEPLOYMENT, DeploymentIntent.CREATE, new ErrorProneProcessor()));
     final AtomicLong requestId = new AtomicLong(0);

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorRule.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.zeebe.engine.processor.CopiedRecords;
-import io.zeebe.engine.processor.ReadonlyProcessingContext;
 import io.zeebe.engine.processor.StreamProcessorLifecycleAware;
 import io.zeebe.engine.processor.workflow.job.JobEventProcessors;
 import io.zeebe.engine.processor.workflow.message.command.SubscriptionCommandSender;
@@ -98,7 +97,9 @@ public final class WorkflowInstanceStreamProcessorRule extends ExternalResource
         .thenReturn(true);
 
     environmentRule.startTypedStreamProcessor(
-        (typedRecordProcessors, zeebeState) -> {
+        (typedRecordProcessors, processingContext) -> {
+          final var zeebeState = processingContext.getZeebeState();
+          actor = processingContext.getActor();
           workflowState = zeebeState.getWorkflowState();
           WorkflowEventProcessors.addWorkflowProcessors(
               zeebeState,
@@ -288,11 +289,6 @@ public final class WorkflowInstanceStreamProcessorRule extends ExternalResource
 
     waitUntil(() -> lookupStream.get().findFirst().isPresent());
     return lookupStream.get().findFirst().get();
-  }
-
-  @Override
-  public void onRecovered(final ReadonlyProcessingContext processingContext) {
-    actor = processingContext.getActor();
   }
 
   @Override

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorRule.java
@@ -291,13 +291,8 @@ public final class WorkflowInstanceStreamProcessorRule extends ExternalResource
   }
 
   @Override
-  public void onOpen(final ReadonlyProcessingContext processingContext) {
-    actor = processingContext.getActor();
-  }
-
-  @Override
   public void onRecovered(final ReadonlyProcessingContext processingContext) {
-    // recovered
+    actor = processingContext.getActor();
   }
 
   @Override

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorTest.java
@@ -168,7 +168,7 @@ public final class WorkflowInstanceStreamProcessorTest {
   }
 
   @Test
-  public void shouldCancelAndCompleteJobConcurrentlyInSubProcess() {
+  public void shouldCancelAndCompleteJobConcurrentlyIbProcess() {
     // given
     streamProcessorRule.deploy(SUB_PROCESS_WORKFLOW);
     final Record<WorkflowInstanceRecord> createdEvent =

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/DeploymentCreateProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/DeploymentCreateProcessorTest.java
@@ -39,7 +39,8 @@ public final class DeploymentCreateProcessorTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     rule.startTypedStreamProcessor(
-        (typedRecordProcessors, zeebeState) -> {
+        (typedRecordProcessors, processingContext) -> {
+          final var zeebeState = processingContext.getZeebeState();
           workflowState = zeebeState.getWorkflowState();
           DeploymentEventProcessors.addDeploymentCreateProcessor(
               typedRecordProcessors,

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/DeploymentCreatedProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/DeploymentCreatedProcessorTest.java
@@ -42,7 +42,8 @@ public final class DeploymentCreatedProcessorTest {
   @Before
   public void setUp() {
     rule.startTypedStreamProcessor(
-        (typedRecordProcessors, zeebeState) -> {
+        (typedRecordProcessors, processingContext) -> {
+          final var zeebeState = processingContext.getZeebeState();
           workflowState = zeebeState.getWorkflowState();
 
           DeploymentEventProcessors.addDeploymentCreateProcessor(

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/TransformingDeploymentCreateProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/TransformingDeploymentCreateProcessorTest.java
@@ -61,7 +61,8 @@ public final class TransformingDeploymentCreateProcessorTest {
         .thenReturn(true);
 
     rule.startTypedStreamProcessor(
-        (typedRecordProcessors, zeebeState) -> {
+        (typedRecordProcessors, processingContext) -> {
+          final var zeebeState = processingContext.getZeebeState();
           workflowState = zeebeState.getWorkflowState();
           DeploymentEventProcessors.addTransformingDeploymentProcessor(
               typedRecordProcessors,

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/IncidentStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/IncidentStreamProcessorRule.java
@@ -74,8 +74,8 @@ public final class IncidentStreamProcessorRule extends ExternalResource {
         .thenReturn(true);
 
     environmentRule.startTypedStreamProcessor(
-        (typedRecordProcessors, zeebeState) -> {
-          this.zeebeState = zeebeState;
+        (typedRecordProcessors, processingContext) -> {
+          this.zeebeState = processingContext.getZeebeState();
           workflowState = zeebeState.getWorkflowState();
           final BpmnStepProcessor stepProcessor =
               WorkflowEventProcessors.addWorkflowProcessors(

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/message/MessageStreamProcessorTest.java
@@ -61,7 +61,8 @@ public final class MessageStreamProcessorTest {
         .thenReturn(true);
 
     rule.startTypedStreamProcessor(
-        (typedRecordProcessors, zeebeState) -> {
+        (typedRecordProcessors, processingContext) -> {
+          final var zeebeState = processingContext.getZeebeState();
           MessageEventProcessors.addMessageProcessors(
               typedRecordProcessors, zeebeState, mockSubscriptionCommandSender);
           return typedRecordProcessors;

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -185,7 +185,11 @@ public final class EngineRule extends ExternalResource {
     RecordingExporter.reset();
 
     startProcessors();
-    TestUtil.waitUntil(() -> RecordingExporter.getRecords().size() >= lastSize);
+    TestUtil.waitUntil(
+        () -> RecordingExporter.getRecords().size() >= lastSize,
+        "Failed to reprocess all events, only re-exported %d but expected %d",
+        RecordingExporter.getRecords().size(),
+        lastSize);
   }
 
   public List<Integer> getPartitionIds() {

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -185,11 +185,7 @@ public final class EngineRule extends ExternalResource {
     RecordingExporter.reset();
 
     startProcessors();
-    TestUtil.waitUntil(
-        () -> RecordingExporter.getRecords().size() >= lastSize,
-        "Failed to reprocess all events, only re-exported %d but expected %d",
-        RecordingExporter.getRecords().size(),
-        lastSize);
+    TestUtil.waitUntil(() -> RecordingExporter.getRecords().size() >= lastSize);
   }
 
   public List<Integer> getPartitionIds() {

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -270,7 +270,7 @@ public final class EngineRule extends ExternalResource {
     private TypedEventImpl typedEvent;
 
     @Override
-    public void onOpen(final ReadonlyProcessingContext context) {
+    public void onRecovered(final ReadonlyProcessingContext context) {
       final int partitionId = context.getLogStream().getPartitionId();
       typedEvent = new TypedEventImpl(partitionId);
       final ActorControl actor = context.getActor();
@@ -285,6 +285,7 @@ public final class EngineRule extends ExternalResource {
               ((reader, throwable) -> {
                 if (throwable == null) {
                   logStreamReader = reader;
+                  onNewEventCommitted();
                 }
               }));
     }

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -11,6 +11,7 @@ import static io.zeebe.engine.util.Records.workflowInstance;
 
 import io.zeebe.db.ZeebeDbFactory;
 import io.zeebe.engine.processor.CommandResponseWriter;
+import io.zeebe.engine.processor.ReadonlyProcessingContext;
 import io.zeebe.engine.processor.StreamProcessor;
 import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.engine.processor.TypedRecordProcessorFactory;
@@ -103,7 +104,7 @@ public final class StreamProcessorRule implements TestRule {
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
           return factory.build(
-              TypedRecordProcessors.processors(zeebeState.getKeyGenerator()), zeebeState);
+              TypedRecordProcessors.processors(zeebeState.getKeyGenerator()), processingContext);
         });
   }
 
@@ -279,7 +280,8 @@ public final class StreamProcessorRule implements TestRule {
 
   @FunctionalInterface
   public interface StreamProcessorTestFactory {
-    TypedRecordProcessors build(TypedRecordProcessors builder, ZeebeState zeebeState);
+    TypedRecordProcessors build(
+        TypedRecordProcessors builder, ReadonlyProcessingContext processingContext);
   }
 
   private class SetupRule extends ExternalResource {

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -98,16 +98,12 @@ public final class StreamProcessorRule implements TestRule {
     return streams.getLogStreamRecordWriter(logName);
   }
 
-  public LogStreamRecordWriter newLogStreamRecordWriter(final int partitionId) {
-    final String logName = getLogName(partitionId);
-    return streams.newLogStreamRecordWriter(logName);
-  }
-
   public StreamProcessor startTypedStreamProcessor(final StreamProcessorTestFactory factory) {
     return startTypedStreamProcessor(
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
-          return factory.build(TypedRecordProcessors.processors(), zeebeState);
+          return factory.build(
+              TypedRecordProcessors.processors(zeebeState.getKeyGenerator()), zeebeState);
         });
   }
 
@@ -226,20 +222,6 @@ public final class StreamProcessorRule implements TestRule {
       final int partition, final Intent intent, final UnpackedObject value) {
     return streams
         .newRecord(getLogName(partition))
-        .recordType(RecordType.COMMAND)
-        .intent(intent)
-        .event(value)
-        .write();
-  }
-
-  public long writeCommandOnPartition(
-      final LogStreamRecordWriter writer,
-      final long key,
-      final Intent intent,
-      final UnpackedObject value) {
-    return streams
-        .newRecord(writer)
-        .key(key)
         .recordType(RecordType.COMMAND)
         .intent(intent)
         .event(value)

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -20,13 +20,10 @@ import io.zeebe.db.ZeebeDb;
 import io.zeebe.db.ZeebeDbFactory;
 import io.zeebe.engine.processor.AsyncSnapshotDirector;
 import io.zeebe.engine.processor.CommandResponseWriter;
-import io.zeebe.engine.processor.ReadonlyProcessingContext;
 import io.zeebe.engine.processor.StreamProcessor;
-import io.zeebe.engine.processor.StreamProcessorLifecycleAware;
 import io.zeebe.engine.processor.TypedEventRegistry;
 import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.engine.processor.TypedRecordProcessorFactory;
-import io.zeebe.engine.processor.TypedRecordProcessors;
 import io.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.zeebe.logstreams.log.LogStreamReader;
 import io.zeebe.logstreams.log.LogStreamRecordWriter;
@@ -225,21 +222,9 @@ public final class TestStreams {
             .actorScheduler(actorScheduler)
             .commandResponseWriter(mockCommandResponseWriter)
             .onProcessedListener(mockOnProcessedListener)
-            .streamProcessorFactory(
-                (context) -> {
-                  final TypedRecordProcessors processors = factory.createProcessors(context);
-                  processors.withListener(
-                      new StreamProcessorLifecycleAware() {
-                        @Override
-                        public void onOpen(final ReadonlyProcessingContext context) {
-                          openFuture.complete(null);
-                        }
-                      });
-                  return processors;
-                })
+            .streamProcessorFactory(factory)
             .build();
     streamProcessor.openAsync().join();
-    openFuture.join();
 
     final var asyncSnapshotDirector =
         new AsyncSnapshotDirector(

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -47,8 +47,6 @@ import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.test.util.AutoCloseableRule;
 import io.zeebe.util.Loggers;
 import io.zeebe.util.sched.ActorScheduler;
-import io.zeebe.util.sched.future.ActorFuture;
-import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -213,8 +211,6 @@ public final class TestStreams {
     final StateSnapshotController currentSnapshotController =
         spy(new StateSnapshotController(zeebeDbFactory, storage));
     final String logName = stream.getLogName();
-
-    final ActorFuture<Void> openFuture = new CompletableActorFuture<>();
 
     try {
       currentSnapshotController.recover();

--- a/util/src/main/java/io/zeebe/util/retry/EndlessRetryStrategy.java
+++ b/util/src/main/java/io/zeebe/util/retry/EndlessRetryStrategy.java
@@ -11,8 +11,12 @@ import io.zeebe.util.sched.ActorControl;
 import io.zeebe.util.sched.future.ActorFuture;
 import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.function.BooleanSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class EndlessRetryStrategy implements RetryStrategy {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EndlessRetryStrategy.class);
 
   private final ActorControl actor;
   private final ActorRetryMechanism retryMechanism;
@@ -50,6 +54,11 @@ public final class EndlessRetryStrategy implements RetryStrategy {
         actor.done();
       } else {
         actor.yield();
+        LOG.error(
+            "Catched exception {} with message {}, will retry...",
+            exception.getClass(),
+            exception.getMessage(),
+            exception);
       }
     }
   }


### PR DESCRIPTION
## Description

As an alternative to https://github.com/zeebe-io/zeebe/pull/3693 and https://github.com/zeebe-io/zeebe/pull/3690. We remove the possibility to have access to the writer during reprocessing, since the onOpen Lifecycle method no longer exist, we only have access to the writer **AFTER** the reprocessing is done.


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

reverts #3694 (hotfix) and replaces it with our mainline fix

related #3686 (backport)
related #3693 (backport) 
related #3690 (backport)