### PR TITLE
chore(broker): Replace GSON with Jackson in BrokerCfg and GatewayCfg

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -69,11 +69,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-exporter-api</artifactId>
     </dependency>
@@ -201,6 +196,11 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_hotspot</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
     </dependency>
 
     <dependency>

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
@@ -7,9 +7,12 @@
  */
 package io.zeebe.broker.system.configuration;
 
-import com.google.gson.GsonBuilder;
+import static io.zeebe.util.ObjectWriterFactory.getDefaultJsonObjectWriter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.zeebe.broker.exporter.debug.DebugLogExporter;
 import io.zeebe.util.Environment;
+import io.zeebe.util.exception.UncheckedExecutionException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -147,6 +150,10 @@ public final class BrokerCfg {
   }
 
   public String toJson() {
-    return new GsonBuilder().setPrettyPrinting().create().toJson(this);
+    try {
+      return getDefaultJsonObjectWriter().writeValueAsString(this);
+    } catch (JsonProcessingException e) {
+      throw new UncheckedExecutionException("Writing to JSON failed", e);
+    }
   }
 }

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -59,11 +59,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-core</artifactId>
     </dependency>
@@ -101,6 +96,15 @@
     <dependency>
       <groupId>me.dinowernli</groupId>
       <artifactId>java-grpc-prometheus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
 
     <dependency>

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/GatewayCfg.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/GatewayCfg.java
@@ -7,7 +7,10 @@
  */
 package io.zeebe.gateway.impl.configuration;
 
-import com.google.gson.GsonBuilder;
+import static io.zeebe.util.ObjectWriterFactory.getDefaultJsonObjectWriter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.zeebe.util.exception.UncheckedExecutionException;
 import java.util.Objects;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -113,6 +116,10 @@ public class GatewayCfg {
   }
 
   public String toJson() {
-    return new GsonBuilder().setPrettyPrinting().create().toJson(this);
+    try {
+      return getDefaultJsonObjectWriter().writeValueAsString(this);
+    } catch (JsonProcessingException e) {
+      throw new UncheckedExecutionException("Writing to JSON failed", e);
+    }
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -157,6 +157,22 @@
       </dependency>
 
       <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${version.jackson}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${version.jackson}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>${version.jackson}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.msgpack</groupId>
         <artifactId>msgpack-core</artifactId>
         <version>${version.msgpack}</version>
@@ -167,6 +183,8 @@
         <artifactId>jackson-dataformat-msgpack</artifactId>
         <version>${version.msgpack}</version>
       </dependency>
+
+
 
       <dependency>
         <groupId>junit</groupId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -25,6 +25,25 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>provided</scope>

--- a/util/src/main/java/io/zeebe/util/ObjectWriterFactory.java
+++ b/util/src/main/java/io/zeebe/util/ObjectWriterFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.PackageVersion;
+import java.io.IOException;
+import org.springframework.util.unit.DataSize;
+
+public class ObjectWriterFactory {
+
+  private static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectWriter DEFAULT_JSON_OBJECT_WRITER;
+
+  static {
+    DEFAULT_OBJECT_MAPPER.registerModule(new CustomModule());
+    DEFAULT_OBJECT_MAPPER.registerModule(new JavaTimeModule());
+    DEFAULT_OBJECT_MAPPER.disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS);
+    DEFAULT_JSON_OBJECT_WRITER = DEFAULT_OBJECT_MAPPER.writerWithDefaultPrettyPrinter();
+  }
+
+  public static ObjectWriter getDefaultJsonObjectWriter() {
+    return DEFAULT_JSON_OBJECT_WRITER;
+  }
+
+  private static final class CustomModule extends SimpleModule {
+
+    private CustomModule() {
+      super(PackageVersion.VERSION);
+      addSerializer(DataSize.class, new DataSizeSerializer());
+    }
+  }
+
+  private static final class DataSizeSerializer extends StdSerializer<DataSize> {
+
+    private DataSizeSerializer() {
+      super(DataSize.class);
+    }
+
+    @Override
+    public void serialize(
+        final DataSize dataSize,
+        final JsonGenerator jsonGenerator,
+        final SerializerProvider serializerProvider)
+        throws IOException {
+
+      jsonGenerator.writeString(dataSize.toMegabytes() + "MB");
+    }
+  }
+}

--- a/util/src/test/java/io/zeebe/util/ObjectWriterFactoryTest.java
+++ b/util/src/test/java/io/zeebe/util/ObjectWriterFactoryTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util;
+
+import static io.zeebe.util.ObjectWriterFactory.getDefaultJsonObjectWriter;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.springframework.util.unit.DataSize;
+
+public class ObjectWriterFactoryTest {
+
+  @Test
+  public void shouldReturnNonNullDefaultObjectWriter() {
+    // when
+    final ObjectWriter actual = getDefaultJsonObjectWriter();
+
+    // then
+    assertThat(actual).isNotNull();
+  }
+
+  @Test
+  public void shouldReturnObjectWriterWithPrettyPrintingEnabled() {
+    // given
+    final Map<String, String> objectToSerialize = new HashMap<>();
+    objectToSerialize.put("field1", "value1");
+    objectToSerialize.put("field2", "value2");
+
+    String actual;
+    // when
+    try {
+      actual = getDefaultJsonObjectWriter().writeValueAsString(objectToSerialize);
+    } catch (JsonProcessingException e) {
+      fail(e.getMessage());
+      actual = "";
+    }
+
+    // then
+    assertThat(actual)
+        .withFailMessage("Should be pretty printed and therefore contain line breaks")
+        .contains(System.lineSeparator());
+  }
+
+  @Test
+  public void shouldReturnObjectWriterThatWritesDurationAsISO8601() {
+    // given
+    final Duration objectToSerialize = Duration.ofSeconds(30);
+
+    String actual;
+    // when
+    try {
+      actual = getDefaultJsonObjectWriter().writeValueAsString(objectToSerialize);
+    } catch (JsonProcessingException e) {
+      fail(e.getMessage());
+      actual = "";
+    }
+
+    // then
+    assertThat(actual)
+        .describedAs("Serialized form of Duration")
+        .isEqualTo("\"" + Duration.ofSeconds(30).toString() + "\"");
+  }
+
+  @Test
+  public void shouldReturnObjectWriterThatWritesDataSizesInMB() {
+    // given
+    final DataSize objectToSerialize = DataSize.ofMegabytes(512);
+
+    String actual;
+    // when
+    try {
+      actual = getDefaultJsonObjectWriter().writeValueAsString(objectToSerialize);
+    } catch (JsonProcessingException e) {
+      fail(e.getMessage());
+      actual = "";
+    }
+
+    // then
+    assertThat(actual).describedAs("Serialized form of DataSize").isEqualTo("\"512MB\"");
+  }
+}


### PR DESCRIPTION
Background:
The configuration objects are serialized to JSON and written to the log during startup.
Currently the behavior uses GSON. This is one of the few places where GSON is used.
In all other places we use Jackson. There is nothing special about using GSON here,
so it can and should be replaced with Jackson.

Scope
- Replace GSON with Jackson in BrokerCfg and GatewayCfg
- Factory method for JSON object writers with custom serializers for Duration (and other Java time objects)
  and DataSize objects

Out of Scope

Dependency to GSON in ExporterConfiguration - the class had a low test coverage and comparing
the default output of GSON vs. Jackson revealed that they are not identical, so changing the
serializer/deserializer here could alter behavior.

## Related issues

closes #3994

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
