### PR TITLE
chore(benchmarks): fix profile script

### DIFF
--- a/benchmarks/docs/scripts/profile.sh
+++ b/benchmarks/docs/scripts/profile.sh
@@ -2,23 +2,15 @@
 # Usage:
 #   kubectl exec -it zeebe-0 bash -- < profile.sh
 #   kubectl cp zeebe-0:/tmp/profiler/flamegraph-2019-03-27_12-42-33.svg .
-
+set -oxe pipefail
 
 unset JAVA_TOOL_OPTIONS
 
 if hash apk 2> /dev/null; then
     apk add --no-cache openjdk11 openjdk11-dbg
 else
-    # add stretch backports to get java 11
-    echo 'deb http://ftp.debian.org/debian stretch-backports main' | tee /etc/apt/sources.list.d/stretch-backports.list
-
-    # update - to get backports as well
-    echo "update"
     apt-get update
-
-    # install jdk 11 from backport
-    echo "install jdk"
-    apt-get -t stretch-backports install -y openjdk-11-jdk openjdk-11-dbg
+    apt-get install -y openjdk-11-jdk openjdk-11-dbg
 fi
 
 PID=$(jps | grep StandaloneBroker | cut -d " " -f 1)
@@ -26,6 +18,18 @@ PID=$(jps | grep StandaloneBroker | cut -d " " -f 1)
 mkdir -p /tmp/profiler
 cd /tmp/profiler
 
-wget -O - https://github.com/jvm-profiling-tools/async-profiler/releases/download/v1.5/async-profiler-1.5-linux-x64.tar.gz | tar xzvf -
+wget -O - https://github.com/jvm-profiling-tools/async-profiler/releases/download/v1.5/async-profiler-1.5-linux-x64.tar.gz | tar xzvf
 
-./profiler.sh -d 60 -f $PWD/flamegraph-$(date +%Y-%m-%d_%H-%M-%S).svg $PID
+# Running Profiler on k8:
+#
+#  * -e cpu will not work since we need more permissions in the docker image
+#  * echo 1 > /proc/sys/kernel/perf_event_paranoid will not work since read-only file system
+#  * adding sys_admin capalities seem to have no effect - at least with the helm charts
+#
+# Workaround for now is -e itimer, which then doesn't show the kernel calls
+#
+# Resources:
+#
+# https://blog.alicegoldfuss.com/enabling-perf-in-kubernetes/
+# https://wenfeng-gao.github.io/post/how-to-use-async-profiler-to-profile-java-in-contianer/
+./profiler.sh -e itimer -d 60 -f $PWD/flamegraph-$(date +%Y-%m-%d_%H-%M-%S).svg $PID


### PR DESCRIPTION
## Description
It was no longer possible to profile the benchmarks with out Helm setup. This PR fixes this.

### Running Profiler on k8:

  * -e cpu will not work since we need more permissions in the docker image
  * echo 1 > /proc/sys/kernel/perf_event_paranoid will not work since read-only file system
  * adding sys_admin capalities seem to have no effect - at least with the helm charts

Workaround for now is -e itimer, which then doesn't show the kernel calls

#### Resources:

https://blog.alicegoldfuss.com/enabling-perf-in-kubernetes/
https://wenfeng-gao.github.io/post/how-to-use-async-profiler-to-profile-java-in-contianer/
https://github.com/jvm-profiling-tools/async-profiler#troubleshooting
<!-- Please explain the changes you made here. -->

Flamegraph looks like this then:

![76595428-e2a11d80-64fb-11ea-8846-4d2d6a222a55](https://user-images.githubusercontent.com/2758593/76604252-b04ceb80-650e-11ea-9bb8-a5c3583e4e2d.png)


## Related issues

<!-- Which issues are closed by this PR or are related -->
Currently configuring the securityContext seems not to have any effect, see
https://github.com/zeebe-io/zeebe-cluster-helm/issues/17

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
