### PR TITLE
Fixes chaos CI pipeline

### DIFF
--- a/.ci/scripts/chaos-tests/install_deps.sh
+++ b/.ci/scripts/chaos-tests/install_deps.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-apk --no-cache add bash make curl
+apk --no-cache add bash make curl openssl
 
 pip install chaostoolkit
 chaos --version
@@ -11,3 +11,14 @@ kubectl_version=$(curl -s https://storage.googleapis.com/kubernetes-release/rele
 curl -LO https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/linux/amd64/kubectl
 install kubectl /usr/local/bin/
 kubectl version --client
+
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+
+helm version
+helm repo add zeebe https://helm.zeebe.io
+helm repo update
+
+curl -LO https://raw.githubusercontent.com/ahmetb/kubectx/master/kubens
+install kubens /usr/local/bin/

--- a/.ci/scripts/chaos-tests/kustomize/kustomization.yml
+++ b/.ci/scripts/chaos-tests/kustomize/kustomization.yml
@@ -5,9 +5,11 @@ kind: Kustomization
 namespace: zeebe-chaos-test
 
 resources:
-  - zeebe.yaml
-  - starter.yaml
+  - statefulset.yaml
+  - configmap.yaml
+  - service.yaml
   - worker.yaml
+
 
 patchesStrategicMerge:
   - zeebe_statefulset_tolerations.yml

--- a/.ci/scripts/chaos-tests/kustomize/zeebe_statefulset_tolerations.yml
+++ b/.ci/scripts/chaos-tests/kustomize/zeebe_statefulset_tolerations.yml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: zeebe
+  name: zeebe-chaos-test-zeebe
 spec:
   template:
     spec:

--- a/benchmarks/setup/default/Makefile
+++ b/benchmarks/setup/default/Makefile
@@ -3,7 +3,7 @@ all: zeebe starter worker
 
 .PHONY: zeebe
 zeebe:
-	-helm install --name default zeebe/zeebe-cluster -f zeebe-values.yaml
+	-helm install default zeebe/zeebe-cluster -f zeebe-values.yaml --skip-crds
 	-kubectl apply -f curator-cronjob.yaml
 	-kubectl apply -f curator-configmap.yaml
 
@@ -21,7 +21,7 @@ clean: clean-starter clean-worker clean-zeebe
 
 .PHONY: clean-zeebe
 clean-zeebe:
-	-helm delete --purge default
+	-helm uninstall default
 	-kubectl delete -f curator-cronjob.yaml
 	-kubectl delete -f curator-configmap.yaml
 	-kubectl delete pvc -l app=default-zeebe


### PR DESCRIPTION
## Description

Migrated the benchmark setup to helm 3.*.

Fixes chaos CI builds :

 * uses the new benchmark setup, incl. helm templates, namespace folder and makefile
 * uses the new chaos repository and run all the kubernetes experiments

**Bonus** Archives finally the log and journal files, which helps in understanding why a chaos experiment has failed.

Finally green again https://ci.zeebe.camunda.cloud/job/chaos-test/

![chaos-ci](https://user-images.githubusercontent.com/2758593/76725123-88979680-674d-11ea-9731-dc4e726e556f.png)


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/3756

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
