### PR TITLE
chore(deps): update dependency feel-scala to v1.11.0

### DIFF
--- a/expression-language/pom.xml
+++ b/expression-language/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.camunda.bpm.extension.feel.scala</groupId>
+      <groupId>org.camunda.feel</groupId>
       <artifactId>feel-engine</artifactId>
     </dependency>
 

--- a/expression-language/src/main/java/io/zeebe/el/impl/FeelExpression.java
+++ b/expression-language/src/main/java/io/zeebe/el/impl/FeelExpression.java
@@ -8,7 +8,7 @@
 package io.zeebe.el.impl;
 
 import io.zeebe.el.Expression;
-import org.camunda.feel.ParsedExpression;
+import org.camunda.feel.syntaxtree.ParsedExpression;
 
 public final class FeelExpression implements Expression {
 

--- a/expression-language/src/main/java/io/zeebe/el/impl/FeelExpressionLanguage.java
+++ b/expression-language/src/main/java/io/zeebe/el/impl/FeelExpressionLanguage.java
@@ -20,8 +20,8 @@ import io.zeebe.el.impl.feel.MessagePackValueMapper;
 import java.util.regex.Pattern;
 import org.camunda.feel.FeelEngine;
 import org.camunda.feel.FeelEngine.Failure;
-import org.camunda.feel.ParsedExpression;
-import org.camunda.feel.interpreter.Val;
+import org.camunda.feel.syntaxtree.ParsedExpression;
+import org.camunda.feel.syntaxtree.Val;
 import scala.util.Either;
 
 /**

--- a/expression-language/src/main/scala/io/zeebe/el/impl/feel/FeelEvaluationResult.scala
+++ b/expression-language/src/main/scala/io/zeebe/el/impl/feel/FeelEvaluationResult.scala
@@ -11,7 +11,7 @@ import java.lang
 
 import io.zeebe.el.{EvaluationResult, Expression, ResultType}
 import org.agrona.DirectBuffer
-import org.camunda.feel.interpreter.{Val, ValBoolean, ValContext, ValList, ValNull, ValNumber, ValString}
+import org.camunda.feel.syntaxtree.{Val, ValBoolean, ValContext, ValList, ValNull, ValNumber, ValString}
 
 class FeelEvaluationResult(
                             expression: Expression,

--- a/expression-language/src/main/scala/io/zeebe/el/impl/feel/FeelToMessagePackTransformer.scala
+++ b/expression-language/src/main/scala/io/zeebe/el/impl/feel/FeelToMessagePackTransformer.scala
@@ -11,7 +11,7 @@ import io.zeebe.el.impl.Loggers.LOGGER
 import io.zeebe.msgpack.spec.MsgPackWriter
 import org.agrona.concurrent.UnsafeBuffer
 import org.agrona.{DirectBuffer, ExpandableArrayBuffer}
-import org.camunda.feel.interpreter.{Val, _}
+import org.camunda.feel.syntaxtree.{Val, _}
 
 class FeelToMessagePackTransformer {
 

--- a/expression-language/src/main/scala/io/zeebe/el/impl/feel/FeelVariableContext.scala
+++ b/expression-language/src/main/scala/io/zeebe/el/impl/feel/FeelVariableContext.scala
@@ -8,8 +8,7 @@
 package io.zeebe.el.impl.feel
 
 import io.zeebe.el.EvaluationContext
-import org.camunda.feel.interpreter.VariableProvider
-import org.camunda.feel.spi.CustomContext
+import org.camunda.feel.context.{CustomContext, VariableProvider}
 
 class FeelVariableContext(context: EvaluationContext) extends CustomContext {
 

--- a/expression-language/src/main/scala/io/zeebe/el/impl/feel/MessagePackContext.scala
+++ b/expression-language/src/main/scala/io/zeebe/el/impl/feel/MessagePackContext.scala
@@ -11,8 +11,7 @@ import io.zeebe.msgpack.spec.MsgPackReader
 import io.zeebe.util.buffer.BufferUtil.{bufferAsString, cloneBuffer}
 import org.agrona.DirectBuffer
 import org.agrona.concurrent.UnsafeBuffer
-import org.camunda.feel.interpreter.VariableProvider
-import org.camunda.feel.spi.CustomContext
+import org.camunda.feel.context.{CustomContext, VariableProvider}
 
 class MessagePackContext(
                           reader: MsgPackReader,

--- a/expression-language/src/main/scala/io/zeebe/el/impl/feel/MessagePackValueMapper.scala
+++ b/expression-language/src/main/scala/io/zeebe/el/impl/feel/MessagePackValueMapper.scala
@@ -11,8 +11,8 @@ import io.zeebe.el.impl.Loggers.LOGGER
 import io.zeebe.msgpack.spec.{MsgPackReader, MsgPackToken, MsgPackType}
 import io.zeebe.util.buffer.BufferUtil.bufferAsString
 import org.agrona.DirectBuffer
-import org.camunda.feel.interpreter.{Val, _}
-import org.camunda.feel.spi.CustomValueMapper
+import org.camunda.feel.syntaxtree.{Val, _}
+import org.camunda.feel.valuemapper.CustomValueMapper
 
 class MessagePackValueMapper extends CustomValueMapper {
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -78,7 +78,7 @@
     <version.testcontainers>1.13.0</version.testcontainers>
     <version.netflix.concurrency>0.3.6</version.netflix.concurrency>
     <version.zeebe-test-container>0.32.0</version.zeebe-test-container>
-    <version.feel-scala>1.10.1</version.feel-scala>
+    <version.feel-scala>1.11.0</version.feel-scala>
     <version.spring-framework>5.2.4.RELEASE</version.spring-framework>
     <version.spring-boot>2.2.5.RELEASE</version.spring-boot>
 
@@ -537,7 +537,7 @@
       </dependency>
 
       <dependency>
-        <groupId>org.camunda.bpm.extension.feel.scala</groupId>
+        <groupId>org.camunda.feel</groupId>
         <artifactId>feel-engine</artifactId>
         <version>${version.feel-scala}</version>
       </dependency>


### PR DESCRIPTION
## Description

* update dependency of `feel-scala` from version `1.10.1` to `1.11.0` (https://github.com/camunda/feel-scala/releases/tag/1.11.0)
* relevant changes: 
  * external functions are disabled by default

## Related issues

/

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
