### PR TITLE
chore(logstreams): fixes race condition on LogStream#close()

### DIFF
--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertNotNull;
 
 import io.zeebe.logstreams.util.LogStreamRule;
 import io.zeebe.logstreams.util.SynchronousLogStream;
+import io.zeebe.test.util.TestUtil;
 import org.agrona.DirectBuffer;
 import org.junit.Before;
 import org.junit.Rule;
@@ -100,6 +101,7 @@ public final class LogStreamTest {
     writer.value(wrapString("value")).tryWrite();
     writer.value(wrapString("value")).tryWrite();
     final long positionBeforeClose = writer.value(wrapString("value")).tryWrite();
+    TestUtil.waitUntil(() -> logStream.getCommitPosition() >= positionBeforeClose);
 
     // when
     logStream.close();

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamRule.java
@@ -61,18 +61,6 @@ public final class LogStreamRule extends ExternalResource {
     return new LogStreamRule(temporaryFolder, true, b -> {});
   }
 
-  public static LogStreamRule createRuleWithoutStarting(final TemporaryFolder temporaryFolder) {
-    return new LogStreamRule(temporaryFolder, false, b -> {});
-  }
-
-  public SynchronousLogStream startLogStreamWithStorageConfiguration(
-      final UnaryOperator<Builder> builder) {
-    logStorageRule = new AtomixLogStorageRule(temporaryFolder);
-    this.logStorageRule.open(builder);
-    createLogStream();
-    return logStream;
-  }
-
   @Override
   protected void before() {
     actorSchedulerRule = new ActorSchedulerRule(clock);


### PR DESCRIPTION
## Description

- fixes a race condition where the test writes to the dispatcher and closes the LogStream without waiting for the written event to have been persisted on disk
- removes some unused methods

## Related issues

closes #4046 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
