### PR TITLE
Remove maxSnapshotCount config setting

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -24,7 +24,6 @@ public final class DataCfg implements ConfigurationEntry {
 
   private Duration snapshotPeriod = Duration.ofMinutes(15);
 
-  private int maxSnapshots = 3;
   private int logIndexDensity = 100;
 
   @Override
@@ -61,14 +60,6 @@ public final class DataCfg implements ConfigurationEntry {
     this.snapshotPeriod = snapshotPeriod;
   }
 
-  public int getMaxSnapshots() {
-    return maxSnapshots;
-  }
-
-  public void setMaxSnapshots(final int maxSnapshots) {
-    this.maxSnapshots = maxSnapshots;
-  }
-
   public int getLogIndexDensity() {
     return logIndexDensity;
   }
@@ -88,8 +79,6 @@ public final class DataCfg implements ConfigurationEntry {
         + ", snapshotPeriod='"
         + snapshotPeriod
         + '\''
-        + ", maxSnapshots="
-        + maxSnapshots
         + ", logIndexDensity="
         + logIndexDensity
         + '}';

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -364,7 +364,6 @@ public final class ZeebePartition extends Actor
         runtimeDirectory,
         atomixRaftPartition.getServer().getSnapshotStore(),
         new AtomixRecordEntrySupplierImpl(reader),
-        brokerCfg.getData().getMaxSnapshots(),
         new SnapshotMetrics(partitionId));
   }
 

--- a/broker/src/test/java/io/zeebe/broker/logstreams/AtomixLogDeletionServiceTest.java
+++ b/broker/src/test/java/io/zeebe/broker/logstreams/AtomixLogDeletionServiceTest.java
@@ -71,7 +71,6 @@ public final class AtomixLogDeletionServiceTest {
             null,
             logStorageRule.getSnapshotStore(),
             new AtomixRecordEntrySupplierImpl(storageReader),
-            1,
             new SnapshotMetrics(PARTITION_ID));
     compactor = new Compactor();
 

--- a/broker/src/test/resources/system/default.yaml
+++ b/broker/src/test/resources/system/default.yaml
@@ -184,11 +184,6 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_SNAPSHOTPERIOD.
       # snapshotPeriod: 15m
 
-      # The maximum number of snapshots kept (must be a positive integer). When this
-      # limit is passed the oldest snapshot is deleted.
-      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_MAXSNAPSHOTS.
-      # maxSnapshots: 3
-
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/dist/src/main/config/zeebe.cfg.yaml
+++ b/dist/src/main/config/zeebe.cfg.yaml
@@ -184,11 +184,6 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_SNAPSHOTPERIOD.
       # snapshotPeriod: 15m
 
-      # The maximum number of snapshots kept (must be a positive integer). When this
-      # limit is passed the oldest snapshot is deleted.
-      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_MAXSNAPSHOTS.
-      # maxSnapshots: 3
-
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/docs/src/operations/resource-planning.md
+++ b/docs/src/operations/resource-planning.md
@@ -9,45 +9,44 @@ While we cannot tell you exactly what you need - beyond _it depends_ - we can ex
 All Brokers in a partition use disk space to store:
 
 - The event log for each partition they participate in. By default, this is a minimum of 512MB for each partition, incrementing in 512MB segments. The event log is truncated on a given broker when data has been processed and successfully exported by all loaded exporters.
-- One or more periodic snapshots of the running state (inflight data) of each partition (unbounded, based on in-flight work). The number of snapshots to retain, and their frequency is configurable. By default it is set to three snapshots retained, and a snapshot [every 15 minutes](https://github.com/zeebe-io/zeebe/blob/cca5aeda4bd9d7e7e83f68d221bbf1a3e4d0f000/dist/src/main/config/zeebe.cfg.toml#L145).
+- A snapshot of the running state (inflight data) of each partition (unbounded, based on in-flight work). The frequency of snapshots to retain is configurable. By default it is set to a snapshot [every 15 minutes](https://github.com/zeebe-io/zeebe/blob/cca5aeda4bd9d7e7e83f68d221bbf1a3e4d0f000/dist/src/main/config/zeebe.cfg.toml#L145).
 
 Additionally, the leader of a partition also uses disk space to store:
 - A projection of the running state of the partition in RocksDB. (unbounded, based on in-flight work)
 
-By default this data is stored in 
+By default this data is stored in
 
-- `segments` - the data of the log split into segments. The log is only appended - until it is truncated by reaching the max snapshot count.
+- `segments` - the data of the log split into segments. The log is only appended - its data can be deleted when it becomes part of a new snapshot.
 - `state` - the active state. Deployed workflows, active workflow instances, etc. Completed workflow instances or jobs are removed.
-- `snapshot` - the data of a state at a certain point in time
+- `snapshot` - a state at a certain point in time
 
 If you want a recipe to explode your disk space usage, here are a few ways to do it:
 
-- Create a high number of snapshots with a long period between them.
 - Load an exporter, such as the Debug Exporter, that does not advance its record position.
 
 ## Event Log
 
-The event log for each partition is segmented. By default, the segment size is 512MB. This can be changed in the zeebe.cfg.toml file with the setting [logSegmentSize](https://github.com/zeebe-io/zeebe/blob/0.20.0/dist/src/main/config/zeebe.cfg.toml#L148). 
+The event log for each partition is segmented. By default, the segment size is 512MB. This can be changed in the zeebe.cfg.toml file with the setting [logSegmentSize](https://github.com/zeebe-io/zeebe/blob/0.20.0/dist/src/main/config/zeebe.cfg.toml#L148).
 
-An event log segment can be deleted once all the events it contains have been processed by exporters, replicated to other brokers, and processed. Three things can cause the event log to not be truncated:
+An event log segment can be deleted once all the events it contains have been processed by exporters, replicated to other brokers, and processed. Three things can cause the event log to not be deleted:
 
-- A cluster loses its quorum, in which case events are queued but not processed. 
+- A cluster loses its quorum, in which case events are queued but not processed.
 - An exporter does not advance its read position in the event log.
-- The max number of snapshots has not been written.
+- There is no snapshot of it yet.
 
-An event log segment is not deleted until all the events in it have been exported by all configured exporters. This means that exporters that rely on side-effects, perform intensive computation, or experience back pressure from external storage will cause disk usage to grow, as they delay the deletion of event log segments. 
+An event log segment is not deleted until all the events in it have been exported by all configured exporters. This means that exporters that rely on side-effects, perform intensive computation, or experience back pressure from external storage will cause disk usage to grow, as they delay the deletion of event log segments.
 
 Exporting is only performed on the partition leader, but the followers of the partition do not delete segments in their replica of the partition until the leader marks all events in it as unneeded by exporters.
 
-No event log segments are deleted until the maximum number of snapshots has been reached. When the maximum number of snapshots has been reached, the event log is truncated up to the oldest snapshot.
+We make sure that event log segments are not deleted too early. No event log segment is deleted until a snapshot has been taken that includes that segment. When a snapshot has been taken, the event log is only deleted up to that point.
 
 ## Snapshots
 
-The running state of the partition is captured periodically on the leader in a snapshot. By default, this period is [every 15 minutes](https://github.com/zeebe-io/zeebe/blob/0.20.0/dist/src/main/config/zeebe.cfg.toml#L151). This can be changed in the zeebe.cfg.toml file. The number of valid snapshots to retain is configured in zeebe.cfg.toml. By default, the leader and followers retain only the latest valid snapshot.
+The running state of the partition is captured periodically on the leader in a snapshot. By default, this period is [every 15 minutes](https://github.com/zeebe-io/zeebe/blob/0.20.0/dist/src/main/config/zeebe.cfg.toml#L151). This can be changed in the zeebe.cfg.toml file.
 
 A snapshot is a projection of all events that represent the current running state of the workflows running on the partition.  It contains all active data, for example, deployed workflows, active workflow instances, and not yet completed jobs.
 
-When the broker has as many snapshots as configured by the parameter maxSnapshots, it deletes all data on the log which was written before the oldest snapshot.
+When the broker has a (new) snapshot, it tries to deletes all data on the log which was written before the snapshot.
 
 ## RocksDB
 
@@ -55,12 +54,12 @@ On the lead broker of a partition, the current running state is kept in memory, 
 
 ## Effect of exporters and external system failure
 
-If an external system relied on by an exporter fails - for example, if you are exporting data to ElasticSearch and the connection to the ElasticSearch cluster fails - then the exporter will not advance its position in the event log, and brokers cannot truncate their logs. The broker event log will grow until the exporter is able to re-establish the connection and export the data. 
+If an external system relied on by an exporter fails - for example, if you are exporting data to ElasticSearch and the connection to the ElasticSearch cluster fails - then the exporter will not advance its position in the event log, and brokers cannot truncate their logs. The broker event log will grow until the exporter is able to re-establish the connection and export the data.
 To ensure that your brokers are resilient in the event of external system failure, give them sufficient disk space to continue operating without truncating the event log until the connection to the external system is restored.
 
 ## Effect on exporters of node failure
 
-Only the leader of a partition exports events. Only committed events (events that have been replicated) are passed to exporters. The exporter will then update its read position. The exporter read position is only replicated between brokers in the snapshot. It is not itself written to the event log. This means that _an exporter’s current position cannot be reconstructed from the replicated event log, only from a snapshot_. 
+Only the leader of a partition exports events. Only committed events (events that have been replicated) are passed to exporters. The exporter will then update its read position. The exporter read position is only replicated between brokers in the snapshot. It is not itself written to the event log. This means that _an exporter’s current position cannot be reconstructed from the replicated event log, only from a snapshot_.
 
 When a partition fails over to a new leader, the new leader is able to construct the current partition state by projecting the event log from the point of the last snapshot. The position of exporters cannot be reconstructed from the event log, so it is set to the last snapshot. This means that an exporter can see the same events twice in the event of a fail-over.
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
@@ -38,7 +38,6 @@ import org.springframework.util.unit.DataSize;
 @RunWith(Parameterized.class)
 public final class ClusteredDataDeletionTest {
   private static final Duration SNAPSHOT_PERIOD = Duration.ofSeconds(30);
-  private static final int MAX_SNAPSHOTS = 1;
   @Rule public final ClusteringRule clusteringRule;
 
   public ClusteredDataDeletionTest(final Consumer<BrokerCfg> configurator, final String name) {
@@ -60,7 +59,6 @@ public final class ClusteredDataDeletionTest {
 
   private static void configureNoExporters(final BrokerCfg brokerCfg) {
     final DataCfg data = brokerCfg.getData();
-    data.setMaxSnapshots(MAX_SNAPSHOTS);
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
     data.setLogSegmentSize(DataSize.ofKilobytes(8));
     data.setLogIndexDensity(50);
@@ -71,7 +69,6 @@ public final class ClusteredDataDeletionTest {
 
   private static void configureCustomExporter(final BrokerCfg brokerCfg) {
     final DataCfg data = brokerCfg.getData();
-    data.setMaxSnapshots(MAX_SNAPSHOTS);
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
     data.setLogSegmentSize(DataSize.ofKilobytes(8));
     data.setLogIndexDensity(50);
@@ -151,7 +148,7 @@ public final class ClusteredDataDeletionTest {
         });
 
     clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
-    brokers.forEach(clusteringRule::waitForValidSnapshotAtBroker);
+    brokers.forEach(clusteringRule::waitForSnapshotAtBroker);
     return segmentCounts;
   }
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
@@ -37,7 +37,6 @@ public final class RestoreTest {
           3,
           3,
           cfg -> {
-            cfg.getData().setMaxSnapshots(1);
             cfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD);
             cfg.getData().setLogSegmentSize(ATOMIX_SEGMENT_SIZE);
             cfg.getNetwork().setMaxMessageSize(ATOMIX_SEGMENT_SIZE);
@@ -70,23 +69,23 @@ public final class RestoreTest {
     // when
     final long firstWorkflowKey = clientRule.deployWorkflow(firstWorkflow);
     clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
-    clusteringRule.waitForValidSnapshotAtBroker(getLeader());
+    clusteringRule.waitForSnapshotAtBroker(getLeader());
 
     final long secondWorkflowKey = clientRule.deployWorkflow(secondWorkflow);
 
     writeManyEventsUntilAtomixLogIsCompactable();
-    clusteringRule.waitForValidSnapshotAtBroker(
+    clusteringRule.waitForSnapshotAtBroker(
         clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId()));
 
     clusteringRule.restartBroker(2);
-    clusteringRule.waitForValidSnapshotAtBroker(clusteringRule.getBroker(2));
+    clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(2));
 
     clusteringRule.stopBroker(1);
 
     final long thirdWorkflowKey = clientRule.deployWorkflow(thirdWorkflow);
 
     writeManyEventsUntilAtomixLogIsCompactable();
-    clusteringRule.waitForValidSnapshotAtBroker(
+    clusteringRule.waitForSnapshotAtBroker(
         clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId()));
 
     clusteringRule.restartBroker(1);

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/HealthMonitoringTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/HealthMonitoringTest.java
@@ -55,8 +55,8 @@ public class HealthMonitoringTest {
     // do some work to create a snapshot
     clientRule.createSingleJob(JOB_TYPE);
     clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
-    clusteringRule.waitForValidSnapshotAtBroker(leader);
-    followers.forEach(clusteringRule::waitForValidSnapshotAtBroker);
+    clusteringRule.waitForSnapshotAtBroker(leader);
+    followers.forEach(clusteringRule::waitForSnapshotAtBroker);
 
     // when
     // corrupt snapshot on all followers because we cannot control which one will become leader


### PR DESCRIPTION
## Description

This PR removes the maxSnapshotCount configuration setting from the
DataCfg. From now on we can assume there is always only a maximum of 1
snapshot present at any time.

## Related issues

closes #3889 