### PR TITLE
Always create snapshots

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -234,7 +234,7 @@ public final class TestStreams {
             currentSnapshotController,
             stream.getAsyncLogStream(),
             snapshotInterval);
-    actorScheduler.submitActor(asyncSnapshotDirector);
+    actorScheduler.submitActor(asyncSnapshotDirector).join();
 
     final LogContext context = logContextMap.get(logName);
     final ProcessorContext processorContext =

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/FailingSnapshotChunkReplicationTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/FailingSnapshotChunkReplicationTest.java
@@ -97,7 +97,8 @@ public final class FailingSnapshotChunkReplicationTest {
     final List<SnapshotChunk> replicatedChunks = replicator.replicatedChunks;
     assertThat(replicatedChunks.size()).isGreaterThan(0);
 
-    final var snapshotDirectory = receiverStorage.getPendingDirectoryFor("1");
+    final var snapshotDirectory =
+        receiverStorage.getPendingDirectoryFor(replicatedChunks.get(0).getSnapshotId());
     assertThat(snapshotDirectory).exists();
     final var files = Files.list(snapshotDirectory).collect(Collectors.toList());
     assertThat(files)
@@ -106,7 +107,7 @@ public final class FailingSnapshotChunkReplicationTest {
             replicatedChunks.subList(0, 2).stream()
                 .map(SnapshotChunk::getChunkName)
                 .toArray(String[]::new));
-    assertThat(receiverStorage.exists("1")).isFalse();
+    assertThat(receiverStorage.exists(replicatedChunks.get(0).getSnapshotId())).isFalse();
   }
 
   private final class FlakyReplicator implements SnapshotReplication {

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/ReplicateSnapshotControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/ReplicateSnapshotControllerTest.java
@@ -8,7 +8,6 @@
 package io.zeebe.logstreams.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.groups.Tuple.tuple;
 
 import io.zeebe.db.impl.DefaultColumnFamily;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
@@ -82,9 +81,12 @@ public final class ReplicateSnapshotControllerTest {
     final int chunkTotalCount = firstChunk.getTotalCount();
     assertThat(totalCount).isEqualTo(chunkTotalCount);
 
+    assertThat(replicatedChunks).extracting(SnapshotChunk::getTotalCount).containsOnly(totalCount);
+
     assertThat(replicatedChunks)
-        .extracting(SnapshotChunk::getSnapshotId, SnapshotChunk::getTotalCount)
-        .containsOnly(tuple("1", totalCount));
+        .extracting(SnapshotChunk::getSnapshotId)
+        .flatExtracting(chunk -> List.of(chunk.split("_")))
+        .contains("1");
   }
 
   @Test

--- a/util/src/main/java/io/zeebe/util/sched/Actor.java
+++ b/util/src/main/java/io/zeebe/util/sched/Actor.java
@@ -22,6 +22,10 @@ public abstract class Actor implements CloseableSilently {
     return getClass().getName();
   }
 
+  public boolean isActorClosed() {
+    return actor.isClosed();
+  }
+
   protected void onActorStarting() {
     // setup
   }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -129,7 +129,8 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
       try {
         checkpoint.createCheckpoint(snapshotDir.getAbsolutePath());
       } catch (final RocksDBException rocksException) {
-        throw new ZeebeDbException(rocksException);
+        throw new ZeebeDbException(
+            String.format("Failed to take snapshot in path %s.", snapshotDir), rocksException);
       }
     }
   }


### PR DESCRIPTION
## Description
To simplify the snapshot process and also include exporter changes we now take 
Snapshots **always**, there is no comparison of the latest position.

This means we do not check the position of the last snapshot:
  * on normal snapshot taking
  * on enforcing snapshot on close  
  * after restart, snapshot can be taken with the same position

There where tests which tested that this is not happing (which is btw interesting how they can verify that) now we verify that we are able to create a snapshot. The changes simplifies a bit the `AsyncSnapshotDirector`. 

Actually I wanted to remove completely the **StreamProcessor** reference. For that we would need to introduce again some suppliers for example, which provides us the last processed position and written position. We still need these positions to determine whether the snapshot is valid or not.


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4017

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
