### PR TITLE
Snapshots with randomized offset

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -25,6 +25,9 @@ public final class SystemContext {
       "Node id %s needs to be non negative and smaller then cluster size %s.";
   private static final String REPLICATION_FACTOR_ERROR_MSG =
       "Replication factor %s needs to be larger then zero and not larger then cluster size %s.";
+  private static final String SNAPSHOT_PERIOD_ERROR_MSG =
+      "Snapshot period %s needs to be larger then or equals to one minute.";
+  private static final Duration ONE_MINUTE = Duration.ofMinutes(1);
   protected final BrokerCfg brokerCfg;
   private Map<String, String> diagnosticContext;
   private ActorScheduler scheduler;
@@ -70,6 +73,13 @@ public final class SystemContext {
     if (replicationFactor < 1 || replicationFactor > clusterSize) {
       throw new IllegalArgumentException(
           String.format(REPLICATION_FACTOR_ERROR_MSG, replicationFactor, clusterSize));
+    }
+
+    final var dataCfg = brokerCfg.getData();
+
+    final var snapshotPeriod = dataCfg.getSnapshotPeriod();
+    if (snapshotPeriod.isNegative() || snapshotPeriod.minus(ONE_MINUTE).isNegative()) {
+      throw new IllegalArgumentException(String.format(SNAPSHOT_PERIOD_ERROR_MSG, snapshotPeriod));
     }
   }
 

--- a/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -7,6 +7,8 @@
  */
 package io.zeebe.broker.system;
 
+import static io.zeebe.engine.processor.AsyncSnapshotDirector.MINIMUM_SNAPSHOT_PERIOD;
+
 import io.zeebe.broker.Loggers;
 import io.zeebe.broker.system.configuration.BrokerCfg;
 import io.zeebe.broker.system.configuration.ClusterCfg;
@@ -27,7 +29,6 @@ public final class SystemContext {
       "Replication factor %s needs to be larger then zero and not larger then cluster size %s.";
   private static final String SNAPSHOT_PERIOD_ERROR_MSG =
       "Snapshot period %s needs to be larger then or equals to one minute.";
-  private static final Duration ONE_MINUTE = Duration.ofMinutes(1);
   protected final BrokerCfg brokerCfg;
   private Map<String, String> diagnosticContext;
   private ActorScheduler scheduler;
@@ -78,7 +79,7 @@ public final class SystemContext {
     final var dataCfg = brokerCfg.getData();
 
     final var snapshotPeriod = dataCfg.getSnapshotPeriod();
-    if (snapshotPeriod.isNegative() || snapshotPeriod.minus(ONE_MINUTE).isNegative()) {
+    if (snapshotPeriod.isNegative() || snapshotPeriod.minus(MINIMUM_SNAPSHOT_PERIOD).isNegative()) {
       throw new IllegalArgumentException(String.format(SNAPSHOT_PERIOD_ERROR_MSG, snapshotPeriod));
     }
   }

--- a/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
@@ -46,6 +46,20 @@ public final class SimpleBrokerStartTest {
   }
 
   @Test
+  public void shouldFailToCreateBrokerWithSmallSnapshotPeriod() {
+    // given
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getData().setSnapshotPeriod(Duration.ofMillis(1));
+
+    // when
+    final var catchedThrownBy =
+        assertThatThrownBy(() -> new Broker(brokerCfg, newTemporaryFolder.getAbsolutePath(), null));
+
+    // then
+    catchedThrownBy.isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   public void shouldCallPartitionListenerAfterStart() throws Exception {
     // given
     final var brokerCfg = new BrokerCfg();

--- a/engine/src/main/java/io/zeebe/engine/processor/RandomDuration.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/RandomDuration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor;
+
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+
+public final class RandomDuration {
+
+  public static final Duration ONE_MINUTE = Duration.ofMinutes(1);
+
+  private RandomDuration() {}
+
+  /**
+   * Returns a pseudo-random duration between the given minimum and maximum duration.
+   *
+   * <p>If the max duration is smaller or equals to the minimum duration, then the minimum duration
+   * is returned. This ensure to always have a base line or lower limit.
+   *
+   * @param minDuration the minimum duration, inclusive
+   * @param maxDuration the maximum duration, exclusive
+   * @return a pseudo-random duration between the minimum and maximum duration
+   */
+  public static Duration getRandomDuration(Duration minDuration, Duration maxDuration) {
+    if (minDuration.toMillis() >= maxDuration.toMillis()) {
+      return minDuration;
+    }
+
+    final var maxMilliseconds = maxDuration.minus(minDuration).toMillis();
+
+    final ThreadLocalRandom threadLocalRandom = ThreadLocalRandom.current();
+    final var randomMiliseconds = threadLocalRandom.nextLong(0, maxMilliseconds);
+
+    // base min duration
+    return minDuration.plusMillis(randomMiliseconds);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/RandomDuration.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/RandomDuration.java
@@ -12,8 +12,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public final class RandomDuration {
 
-  public static final Duration ONE_MINUTE = Duration.ofMinutes(1);
-
   private RandomDuration() {}
 
   /**
@@ -22,21 +20,25 @@ public final class RandomDuration {
    * <p>If the max duration is smaller or equals to the minimum duration, then the minimum duration
    * is returned. This ensure to always have a base line or lower limit.
    *
+   * <p>The random duration is minute based, so if the given duration differ only in seconds then
+   * the minimum duration is returned
+   *
    * @param minDuration the minimum duration, inclusive
    * @param maxDuration the maximum duration, exclusive
    * @return a pseudo-random duration between the minimum and maximum duration
    */
-  public static Duration getRandomDuration(Duration minDuration, Duration maxDuration) {
-    if (minDuration.toMillis() >= maxDuration.toMillis()) {
+  public static Duration getRandomDurationMinuteBased(
+      final Duration minDuration, final Duration maxDuration) {
+    if (minDuration.toMinutes() >= maxDuration.toMinutes()) {
       return minDuration;
     }
 
-    final var maxMilliseconds = maxDuration.minus(minDuration).toMillis();
+    final var maxMinutes = maxDuration.minus(minDuration).toMinutes();
 
-    final ThreadLocalRandom threadLocalRandom = ThreadLocalRandom.current();
-    final var randomMiliseconds = threadLocalRandom.nextLong(0, maxMilliseconds);
+    final var threadLocalRandom = ThreadLocalRandom.current();
+    final var randomMinutes = threadLocalRandom.nextLong(0, maxMinutes);
 
     // base min duration
-    return minDuration.plusMillis(randomMiliseconds);
+    return minDuration.plusMinutes(randomMinutes);
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processor/RandomDurationTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/RandomDurationTest.java
@@ -21,7 +21,8 @@ public class RandomDurationTest {
     final Duration maxDuration = Duration.ofMinutes(10);
 
     // when
-    final var randomDuration = RandomDuration.getRandomDuration(minDuration, maxDuration);
+    final var randomDuration =
+        RandomDuration.getRandomDurationMinuteBased(minDuration, maxDuration);
 
     // then
     assertThat(randomDuration).isBetween(minDuration, maxDuration);
@@ -34,7 +35,8 @@ public class RandomDurationTest {
     final Duration maxDuration = Duration.ofMinutes(10);
 
     // when
-    final var randomDuration = RandomDuration.getRandomDuration(minDuration, maxDuration);
+    final var randomDuration =
+        RandomDuration.getRandomDurationMinuteBased(minDuration, maxDuration);
 
     // then
     assertThat(randomDuration).isBetween(minDuration, maxDuration);
@@ -47,7 +49,8 @@ public class RandomDurationTest {
     final Duration maxDuration = Duration.ofMinutes(-1);
 
     // when
-    final var randomDuration = RandomDuration.getRandomDuration(minDuration, maxDuration);
+    final var randomDuration =
+        RandomDuration.getRandomDurationMinuteBased(minDuration, maxDuration);
 
     // then
     assertThat(randomDuration).isBetween(minDuration, maxDuration);
@@ -56,11 +59,26 @@ public class RandomDurationTest {
   @Test
   public void shouldGetMinDurationWhenMaxDurationIsSmaller() {
     // given
-    final Duration minDuration = Duration.ofMinutes(1);
-    final Duration maxDuration = Duration.ofSeconds(10);
+    final Duration minDuration = Duration.ofMinutes(10);
+    final Duration maxDuration = Duration.ofMinutes(1);
 
     // when
-    final var randomDuration = RandomDuration.getRandomDuration(minDuration, maxDuration);
+    final var randomDuration =
+        RandomDuration.getRandomDurationMinuteBased(minDuration, maxDuration);
+
+    // then
+    assertThat(randomDuration).isEqualTo(minDuration);
+  }
+
+  @Test
+  public void shouldGetMinDurationWhenDiffIsOnlySeconds() {
+    // given
+    final Duration minDuration = Duration.ofMinutes(1);
+    final Duration maxDuration = Duration.ofSeconds(90);
+
+    // when
+    final var randomDuration =
+        RandomDuration.getRandomDurationMinuteBased(minDuration, maxDuration);
 
     // then
     assertThat(randomDuration).isEqualTo(minDuration);
@@ -72,7 +90,8 @@ public class RandomDurationTest {
     final Duration minDuration = Duration.ofMinutes(1);
 
     // when
-    final var randomDuration = RandomDuration.getRandomDuration(minDuration, minDuration);
+    final var randomDuration =
+        RandomDuration.getRandomDurationMinuteBased(minDuration, minDuration);
 
     // then
     assertThat(randomDuration).isEqualTo(minDuration);

--- a/engine/src/test/java/io/zeebe/engine/processor/RandomDurationTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/RandomDurationTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.Test;
+
+public class RandomDurationTest {
+
+  @Test
+  public void shouldGetRandomDuration() {
+    // given
+    final Duration minDuration = Duration.ofMinutes(1);
+    final Duration maxDuration = Duration.ofMinutes(10);
+
+    // when
+    final var randomDuration = RandomDuration.getRandomDuration(minDuration, maxDuration);
+
+    // then
+    assertThat(randomDuration).isBetween(minDuration, maxDuration);
+  }
+
+  @Test
+  public void shouldGetRandomDurationOnNegativeMin() {
+    // given
+    final Duration minDuration = Duration.ofMinutes(-1);
+    final Duration maxDuration = Duration.ofMinutes(10);
+
+    // when
+    final var randomDuration = RandomDuration.getRandomDuration(minDuration, maxDuration);
+
+    // then
+    assertThat(randomDuration).isBetween(minDuration, maxDuration);
+  }
+
+  @Test
+  public void shouldGetRandomDurationOnNegativeDurations() {
+    // given
+    final Duration minDuration = Duration.ofMinutes(-10);
+    final Duration maxDuration = Duration.ofMinutes(-1);
+
+    // when
+    final var randomDuration = RandomDuration.getRandomDuration(minDuration, maxDuration);
+
+    // then
+    assertThat(randomDuration).isBetween(minDuration, maxDuration);
+  }
+
+  @Test
+  public void shouldGetMinDurationWhenMaxDurationIsSmaller() {
+    // given
+    final Duration minDuration = Duration.ofMinutes(1);
+    final Duration maxDuration = Duration.ofSeconds(10);
+
+    // when
+    final var randomDuration = RandomDuration.getRandomDuration(minDuration, maxDuration);
+
+    // then
+    assertThat(randomDuration).isEqualTo(minDuration);
+  }
+
+  @Test
+  public void shouldGetMinDurationWhenMaxDurationIsEquals() {
+    // given
+    final Duration minDuration = Duration.ofMinutes(1);
+
+    // when
+    final var randomDuration = RandomDuration.getRandomDuration(minDuration, minDuration);
+
+    // then
+    assertThat(randomDuration).isEqualTo(minDuration);
+  }
+}

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
@@ -37,7 +37,7 @@ import org.springframework.util.unit.DataSize;
 
 @RunWith(Parameterized.class)
 public final class ClusteredDataDeletionTest {
-  private static final Duration SNAPSHOT_PERIOD = Duration.ofSeconds(30);
+  private static final Duration SNAPSHOT_PERIOD = Duration.ofMinutes(1);
   @Rule public final ClusteringRule clusteringRule;
 
   public ClusteredDataDeletionTest(final Consumer<BrokerCfg> configurator, final String name) {


### PR DESCRIPTION
## Description

As discussed the first interval is randomized between one minute and snapshot interval. After that is always uses the snapshot interval to schedule the next snapshots.

I added also a check on the Broker start (system context), which disallows snapshot periods smaller then one minutes, since this make no sense actually.

I will run a benchmark after lunch.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3376 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
