### PR TITLE
chore(logstreams): fix append failure listener

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -230,7 +230,7 @@ public final class LogStorageAppender extends Actor implements HealthMonitorable
         // Not a failure. It is probably during transition to follower.
         return;
       }
-      onFailure(error);
+      actor.run(() -> onFailure(error));
     }
 
     @Override
@@ -242,7 +242,7 @@ public final class LogStorageAppender extends Actor implements HealthMonitorable
     public void onCommitError(final long address, final Throwable error) {
       LOG.error("Failed to commit block with last event position {}.", positions.highest, error);
       releaseBackPressure();
-      onFailure(error);
+      actor.run(() -> onFailure(error));
     }
 
     private void releaseBackPressure() {


### PR DESCRIPTION
## Description

Use actor call to execute on failure method

## Related issues

closes #4084

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
