### PR TITLE
fix(broker): fix typo in legacy env var mapping

### DIFF
--- a/legacy/toml-config/src/main/java/io/zeebe/legacy/tomlconfig/LegacyConfigurationSupport.java
+++ b/legacy/toml-config/src/main/java/io/zeebe/legacy/tomlconfig/LegacyConfigurationSupport.java
@@ -49,7 +49,7 @@ public final class LegacyConfigurationSupport {
 
     // zeebe.gateway.monitoring
     MAPPING_GATEWAY.put(
-        "ZEEBE_GATEWAY_MONITORING_ENABLED", new Replacement("zeebe.gateway.monitoring.enadbled"));
+        "ZEEBE_GATEWAY_MONITORING_ENABLED", new Replacement("zeebe.gateway.monitoring.enabled"));
     MAPPING_GATEWAY.put(
         "ZEEBE_GATEWAY_MONITORING_HOST", new Replacement("zeebe.gateway.monitoring.host"));
     MAPPING_GATEWAY.put(


### PR DESCRIPTION
## Description

Fixed typo in legacy env var mapping

## Related issues
closes #4090

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
