### PR TITLE
chore(broker): transition to inactive role

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -159,6 +159,8 @@ public final class ZeebePartition extends Actor
         }
         break;
       case INACTIVE:
+        inactiveTransition();
+        break;
       case PASSIVE:
       case PROMOTABLE:
       case CANDIDATE:
@@ -203,6 +205,17 @@ public final class ZeebePartition extends Actor
                 onFailure();
               }
             });
+  }
+
+  private void inactiveTransition() {
+    closePartition()
+        .onComplete(
+            (v, t) -> {
+              if (t != null) {
+                LOG.error("Failed to close partition when transition to inactive role");
+              }
+            });
+    updateHealthStatus(HealthStatus.UNHEALTHY);
   }
 
   private ActorFuture<Void> onTransitionTo(

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -130,6 +130,17 @@
       <artifactId>spring-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>atomix-primitive</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>atomix-raft</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Description

When unexpected failures happen in raft it transition to inactive role. Instead of transitioning to follower we should close the partition services otherwise it might still be trying to use some of the raft services.

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
