### PR TITLE
chore(engine): add inconsistency check

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotDirector.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotDirector.java
@@ -94,8 +94,11 @@ public final class AsyncSnapshotDirector extends Actor {
 
   @Override
   public ActorFuture<Void> closeAsync() {
-    final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
+    if (actor.isClosed()) {
+      return CompletableActorFuture.completed(null);
+    }
 
+    final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     actor.call(
         () ->
             actor.runOnCompletion(
@@ -119,8 +122,8 @@ public final class AsyncSnapshotDirector extends Actor {
                                       } else {
                                         LOG.error(
                                             "Unexpected error on retrieving commit position", ex2);
-                                        future.completeExceptionally(errorOnRetrieveCommitPos);
                                         super.closeAsync();
+                                        future.completeExceptionally(errorOnRetrieveCommitPos);
                                       }
                                     });
 

--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorInconsistentPositionTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorInconsistentPositionTest.java
@@ -25,6 +25,8 @@ import io.zeebe.protocol.record.ValueType;
 import io.zeebe.test.util.AutoCloseableRule;
 import io.zeebe.util.sched.clock.ControlledActorClock;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
+import org.agrona.CloseHelper;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -67,6 +69,12 @@ public final class StreamProcessorInconsistentPositionTest {
         new StreamProcessingComposite(testStreams, 1, DEFAULT_DB_FACTORY);
     secondStreamProcessorComposite =
         new StreamProcessingComposite(testStreams, 2, DEFAULT_DB_FACTORY);
+  }
+
+  @After
+  public void tearDown() {
+    // we expect that AsyncSnapshotDirector can't be closed without problems
+    CloseHelper.quietClose(() -> testStreams.closeProcessor(getLogName(1)));
   }
 
   @Test

--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorInconsistentPositionTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorInconsistentPositionTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor;
+
+import static io.zeebe.engine.state.DefaultZeebeDbFactory.DEFAULT_DB_FACTORY;
+import static io.zeebe.engine.util.StreamProcessingComposite.getLogName;
+import static io.zeebe.protocol.record.intent.WorkflowInstanceIntent.ELEMENT_ACTIVATED;
+import static io.zeebe.protocol.record.intent.WorkflowInstanceIntent.ELEMENT_ACTIVATING;
+import static io.zeebe.protocol.record.intent.WorkflowInstanceIntent.ELEMENT_COMPLETED;
+import static io.zeebe.protocol.record.intent.WorkflowInstanceIntent.ELEMENT_COMPLETING;
+import static io.zeebe.test.util.TestUtil.waitUntil;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.zeebe.engine.util.RecordStream;
+import io.zeebe.engine.util.StreamProcessingComposite;
+import io.zeebe.engine.util.TestStreams;
+import io.zeebe.logstreams.util.AtomixLogStorageRule;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.test.util.AutoCloseableRule;
+import io.zeebe.util.sched.clock.ControlledActorClock;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+
+public final class StreamProcessorInconsistentPositionTest {
+
+  private final TemporaryFolder tempFolder = new TemporaryFolder();
+  private final AutoCloseableRule closeables = new AutoCloseableRule();
+  private final ControlledActorClock clock = new ControlledActorClock();
+  private final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule(clock);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(tempFolder).around(actorSchedulerRule).around(closeables);
+
+  private StreamProcessingComposite firstStreamProcessorComposite;
+  private StreamProcessingComposite secondStreamProcessorComposite;
+  private TestStreams testStreams;
+
+  @Before
+  public void setup() throws Exception {
+
+    testStreams = new TestStreams(tempFolder, closeables, actorSchedulerRule.get());
+
+    final var dataDirectory = tempFolder.newFolder();
+
+    final AtomixLogStorageRule logStorageRule = new AtomixLogStorageRule(tempFolder, 1);
+    logStorageRule.open(
+        b ->
+            b.withDirectory(dataDirectory)
+                .withMaxEntrySize(4 * 1024 * 1024)
+                .withMaxSegmentSize(128 * 1024 * 1024));
+
+    testStreams.createLogStream(getLogName(1), 1, logStorageRule);
+    testStreams.createLogStream(getLogName(2), 2, logStorageRule);
+
+    firstStreamProcessorComposite =
+        new StreamProcessingComposite(testStreams, 1, DEFAULT_DB_FACTORY);
+    secondStreamProcessorComposite =
+        new StreamProcessingComposite(testStreams, 2, DEFAULT_DB_FACTORY);
+  }
+
+  @Test
+  public void shouldNotStartOnInconsistentLog() {
+    // given
+    final var position =
+        firstStreamProcessorComposite.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING);
+    final var secondPosition =
+        firstStreamProcessorComposite.writeWorkflowInstanceEvent(ELEMENT_ACTIVATED);
+    waitUntil(
+        () ->
+            new RecordStream(testStreams.events(getLogName(1)))
+                .onlyWorkflowInstanceRecords()
+                .withIntent(ELEMENT_ACTIVATED)
+                .exists());
+
+    final var otherPosition =
+        secondStreamProcessorComposite.writeWorkflowInstanceEvent(ELEMENT_COMPLETING);
+    final var otherSecondPosition =
+        secondStreamProcessorComposite.writeWorkflowInstanceEvent(ELEMENT_COMPLETED);
+    waitUntil(
+        () ->
+            new RecordStream(testStreams.events(getLogName(2)))
+                .onlyWorkflowInstanceRecords()
+                .withIntent(ELEMENT_COMPLETED)
+                .exists());
+
+    assertThat(position).isEqualTo(otherPosition);
+    assertThat(secondPosition).isEqualTo(otherSecondPosition);
+
+    // when
+    final TypedRecordProcessor typedRecordProcessor = mock(TypedRecordProcessor.class);
+    final var streamProcessor =
+        firstStreamProcessorComposite.startTypedStreamProcessor(
+            (processors, context) ->
+                processors
+                    .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor)
+                    .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATED, typedRecordProcessor));
+
+    // then
+    waitUntil(streamProcessor::isFailed);
+    assertThat(streamProcessor.isFailed()).isTrue();
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.util;
+
+import static io.zeebe.engine.util.Records.workflowInstance;
+
+import io.zeebe.db.ZeebeDbFactory;
+import io.zeebe.engine.processor.ReadonlyProcessingContext;
+import io.zeebe.engine.processor.StreamProcessor;
+import io.zeebe.engine.processor.TypedRecordProcessorFactory;
+import io.zeebe.engine.processor.TypedRecordProcessors;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.logstreams.log.LogStreamRecordWriter;
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.intent.Intent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+
+public class StreamProcessingComposite {
+
+  private static final String STREAM_NAME = "stream-";
+
+  private final TestStreams streams;
+  private final int partitionId;
+  private final ZeebeDbFactory zeebeDbFactory;
+  private ZeebeState zeebeState;
+
+  public StreamProcessingComposite(
+      final TestStreams streams, final int partitionId, final ZeebeDbFactory zeebeDbFactory) {
+    this.streams = streams;
+    this.partitionId = partitionId;
+    this.zeebeDbFactory = zeebeDbFactory;
+  }
+
+  public LogStreamRecordWriter getLogStreamRecordWriter(final int partitionId) {
+    final String logName = getLogName(partitionId);
+    return streams.getLogStreamRecordWriter(logName);
+  }
+
+  public StreamProcessor startTypedStreamProcessor(final StreamProcessorTestFactory factory) {
+    return startTypedStreamProcessor(
+        (processingContext) -> {
+          zeebeState = processingContext.getZeebeState();
+          return factory.build(
+              TypedRecordProcessors.processors(zeebeState.getKeyGenerator()), processingContext);
+        });
+  }
+
+  public StreamProcessor startTypedStreamProcessor(final TypedRecordProcessorFactory factory) {
+    return startTypedStreamProcessor(partitionId, factory);
+  }
+
+  public StreamProcessor startTypedStreamProcessor(
+      final int partitionId, final TypedRecordProcessorFactory factory) {
+    return streams.startStreamProcessor(
+        getLogName(partitionId),
+        zeebeDbFactory,
+        (processingContext -> {
+          zeebeState = processingContext.getZeebeState();
+          return factory.createProcessors(processingContext);
+        }));
+  }
+
+  public void closeStreamProcessor(final int partitionId) {
+    try {
+      streams.closeProcessor(getLogName(partitionId));
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public ZeebeState getZeebeState() {
+    return zeebeState;
+  }
+
+  public RecordStream events() {
+    return new RecordStream(streams.events(getLogName(partitionId)));
+  }
+
+  public long writeWorkflowInstanceEvent(final WorkflowInstanceIntent intent) {
+    return writeWorkflowInstanceEvent(intent, 1);
+  }
+
+  public long writeWorkflowInstanceEventWithSource(
+      final WorkflowInstanceIntent intent, final int instanceKey, final long sourceEventPosition) {
+    return streams
+        .newRecord(getLogName(partitionId))
+        .event(workflowInstance(instanceKey))
+        .recordType(RecordType.EVENT)
+        .sourceRecordPosition(sourceEventPosition)
+        .intent(intent)
+        .write();
+  }
+
+  public long writeWorkflowInstanceEvent(
+      final WorkflowInstanceIntent intent, final int instanceKey) {
+    return streams
+        .newRecord(getLogName(partitionId))
+        .event(workflowInstance(instanceKey))
+        .recordType(RecordType.EVENT)
+        .intent(intent)
+        .write();
+  }
+
+  public long writeEvent(final long key, final Intent intent, final UnpackedObject value) {
+    return streams
+        .newRecord(getLogName(partitionId))
+        .recordType(RecordType.EVENT)
+        .key(key)
+        .intent(intent)
+        .event(value)
+        .write();
+  }
+
+  public long writeEvent(final Intent intent, final UnpackedObject value) {
+    return streams
+        .newRecord(getLogName(partitionId))
+        .recordType(RecordType.EVENT)
+        .intent(intent)
+        .event(value)
+        .write();
+  }
+
+  public long writeBatch(final RecordToWrite... recordToWrites) {
+    return streams.writeBatch(getLogName(partitionId), recordToWrites);
+  }
+
+  public long writeCommandOnPartition(
+      final int partition, final Intent intent, final UnpackedObject value) {
+    return streams
+        .newRecord(getLogName(partition))
+        .recordType(RecordType.COMMAND)
+        .intent(intent)
+        .event(value)
+        .write();
+  }
+
+  public long writeCommandOnPartition(
+      final int partition, final long key, final Intent intent, final UnpackedObject value) {
+    return streams
+        .newRecord(getLogName(partition))
+        .key(key)
+        .recordType(RecordType.COMMAND)
+        .intent(intent)
+        .event(value)
+        .write();
+  }
+
+  public long writeCommand(final long key, final Intent intent, final UnpackedObject value) {
+    return streams
+        .newRecord(getLogName(partitionId))
+        .recordType(RecordType.COMMAND)
+        .key(key)
+        .intent(intent)
+        .event(value)
+        .write();
+  }
+
+  public long writeCommand(final Intent intent, final UnpackedObject value) {
+    return streams
+        .newRecord(getLogName(partitionId))
+        .recordType(RecordType.COMMAND)
+        .intent(intent)
+        .event(value)
+        .write();
+  }
+
+  public long writeCommand(
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final UnpackedObject value) {
+    return streams
+        .newRecord(getLogName(partitionId))
+        .recordType(RecordType.COMMAND)
+        .requestId(requestId)
+        .requestStreamId(requestStreamId)
+        .intent(intent)
+        .event(value)
+        .write();
+  }
+
+  public static String getLogName(final int partitionId) {
+    return STREAM_NAME + partitionId;
+  }
+
+  @FunctionalInterface
+  public interface StreamProcessorTestFactory {
+    TypedRecordProcessors build(
+        TypedRecordProcessors builder, ReadonlyProcessingContext processingContext);
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -119,13 +119,23 @@ public final class TestStreams {
       throw new UncheckedIOException(e);
     }
 
+    return createLogStream(name, partitionId, segments);
+  }
+
+  public SyncLogStream createLogStream(
+      final String name, final int partitionId, final File segmentsDir) {
     final AtomixLogStorageRule logStorageRule =
         new AtomixLogStorageRule(dataDirectory, partitionId);
     logStorageRule.open(
         b ->
-            b.withDirectory(segments)
+            b.withDirectory(segmentsDir)
                 .withMaxEntrySize(4 * 1024 * 1024)
                 .withMaxSegmentSize(128 * 1024 * 1024));
+    return createLogStream(name, partitionId, logStorageRule);
+  }
+
+  public SyncLogStream createLogStream(
+      final String name, final int partitionId, final AtomixLogStorageRule logStorageRule) {
     final var logStream =
         SyncLogStream.builder()
             .withLogName(name)
@@ -139,7 +149,6 @@ public final class TestStreams {
     logContextMap.put(name, logContext);
     closeables.manage(logContext);
     closeables.manage(() -> logContextMap.remove(name));
-
     return logStream;
   }
 


### PR DESCRIPTION
## Description

I added an position check to the reprocessing. I think based on that we can discuss further. 

It just throws an exception, which causes to fail the StreamProcessor etc. This is the same as we detect a problem in the source positions. Currently there is no recovery or handling. There is already a plan to implement such things, since there several other places where StreamProcessor can go into the failed state, we need to look at this then.

At least with this check we do not start and we detect this quite fast, since also all requests will timeout then etc.

~Test was no really possible without breaking our complete abstraction etc. Writers are created in the LogStream. I think we can this discuss this further. We also plan to write a tool which generates inconsistent logs. It makes sense to see how the processor then reacts on such things.~

**Update:**
 The test creates one log storage and two LogStreams, which use the same
 storage. On both streams events are written, which means events with
 same position end in the same log. The test verifies that
 starting a stream processor will mean that the StreamProcessor ends in
 fail mode.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3936 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
