### PR TITLE
fix(broker): sensible defaults for GatewayCfg

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/GatewayCfg.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/GatewayCfg.java
@@ -26,11 +26,12 @@ public class GatewayCfg {
   private SecurityCfg security = new SecurityCfg();
 
   public void init() {
-    network.init(ConfigurationDefaults.DEFAULT_HOST);
+    init(ConfigurationDefaults.DEFAULT_HOST);
   }
 
   public void init(final String defaultHost) {
     network.init(defaultHost);
+    monitoring.init(defaultHost);
   }
 
   public NetworkCfg getNetwork() {

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/MonitoringCfg.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/MonitoringCfg.java
@@ -10,7 +10,6 @@ package io.zeebe.gateway.impl.configuration;
 import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_MONITORING_ENABLED;
 import static io.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_MONITORING_PORT;
 
-import io.zeebe.util.Environment;
 import java.net.InetSocketAddress;
 import java.util.Objects;
 
@@ -21,7 +20,7 @@ public final class MonitoringCfg {
   private String host;
   private int port = DEFAULT_MONITORING_PORT;
 
-  public void init(final Environment environment, final String defaultHost) {
+  public void init(final String defaultHost) {
     if (host == null) {
       host = defaultHost;
     }

--- a/gateway/src/test/java/io/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -7,6 +7,8 @@
  */
 package io.zeebe.gateway.impl.configuration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.zeebe.test.util.TestConfigurationFactory;
 import io.zeebe.util.Environment;
 import java.io.IOException;
@@ -14,7 +16,6 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public final class GatewayCfgTest {
@@ -54,7 +55,7 @@ public final class GatewayCfgTest {
     final GatewayCfg gatewayCfg = readDefaultConfig();
 
     // then
-    Assertions.assertThat(gatewayCfg).isEqualTo(DEFAULT_CFG);
+    assertThat(gatewayCfg).isEqualTo(DEFAULT_CFG);
   }
 
   @Test
@@ -63,7 +64,7 @@ public final class GatewayCfgTest {
     final GatewayCfg gatewayCfg = readEmptyConfig();
 
     // then
-    Assertions.assertThat(gatewayCfg).isEqualTo(DEFAULT_CFG);
+    assertThat(gatewayCfg).isEqualTo(DEFAULT_CFG);
   }
 
   @Test
@@ -72,7 +73,7 @@ public final class GatewayCfgTest {
     final GatewayCfg gatewayCfg = readCustomConfig();
 
     // then
-    Assertions.assertThat(gatewayCfg).isEqualTo(CUSTOM_CFG);
+    assertThat(gatewayCfg).isEqualTo(CUSTOM_CFG);
   }
 
   @Test
@@ -133,7 +134,23 @@ public final class GatewayCfgTest {
     final GatewayCfg gatewayCfg = readCustomConfig();
 
     // then
-    Assertions.assertThat(gatewayCfg).isEqualTo(expected);
+    assertThat(gatewayCfg).isEqualTo(expected);
+  }
+
+  @Test
+  public void shoudldInitializeMonitoringCfgWhenInitIsCalled() {
+    // given
+    final GatewayCfg sutGatewayConfig = new GatewayCfg();
+
+    // when
+    sutGatewayConfig.init();
+
+    // then
+    final MonitoringCfg monitoringCfg = sutGatewayConfig.getMonitoring();
+
+    assertThat(monitoringCfg.getHost())
+        .describedAs("Default monitoring host")
+        .isEqualTo(ConfigurationDefaults.DEFAULT_HOST);
   }
 
   private void setEnv(final String key, final String value) {


### PR DESCRIPTION
## Description

Call init method of MonitoringCfg from GatewayCfg 

## Related issues

closes #4094

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
