### PR TITLE
Extract spring boot application to inner class

### DIFF
--- a/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
@@ -31,11 +31,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.core.env.Environment;
 
-@SpringBootApplication
-public class StandaloneGateway implements CommandLineRunner {
-
-  @Autowired GatewayCfg configuration;
-  @Autowired Environment springEnvironment;
+public class StandaloneGateway {
 
   private final AtomixCluster atomixCluster;
   private final Gateway gateway;
@@ -114,13 +110,20 @@ public class StandaloneGateway implements CommandLineRunner {
         new LegacyConfigurationSupport(Scope.GATEWAY);
     legacyConfigurationSupport.checkForLegacyTomlConfigurationArgument(args, "broker.cfg.yaml");
 
-    SpringApplication.run(StandaloneGateway.class, args);
+    SpringApplication.run(Launcher.class, args);
   }
 
-  @Override
-  public void run(final String... args) throws Exception {
-    final GatewayCfg gatewayCfg = configuration;
-    gatewayCfg.init();
-    new StandaloneGateway(gatewayCfg).run();
+  @SpringBootApplication
+  public static class Launcher implements CommandLineRunner {
+
+    @Autowired GatewayCfg configuration;
+    @Autowired Environment springEnvironment;
+
+    @Override
+    public void run(final String... args) throws Exception {
+      final GatewayCfg gatewayCfg = configuration;
+      gatewayCfg.init();
+      new StandaloneGateway(gatewayCfg).run();
+    }
   }
 }


### PR DESCRIPTION
## Description

To prevent multiple instantiations of the `StandaloneGateway` class the spring boot command line runner is extracted to an inner class.

## Related issues

closes #4096

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
