### PR TITLE
fix(broker): fix race condition on compaction

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -109,7 +109,9 @@ public final class AtomixFactory {
             .withPartitionSize(clusterCfg.getReplicationFactor())
             .withMembers(getRaftGroupMembers(clusterCfg))
             .withDataDirectory(raftDirectory)
-            .withStateMachineFactory(ZeebeRaftStateMachine::new)
+            .withStateMachineFactory(
+                (raftContext, threadContext, threadContextFactory) ->
+                    new ZeebeRaftStateMachine(raftContext, threadContext))
             .withSnapshotStoreFactory(new DbSnapshotStoreFactory())
             .withFlushOnCommit();
 


### PR DESCRIPTION
## Description

 * Compaction causes reseting readers, which was problematic when happened on other thread then the raft thread, since
   raft thread also uses readers to send append entries to members etc.

~Still we might have the problem that the stream processor uses a reader in a separate thread and this can lead to undefined behavior~ No problem, see here https://github.com/zeebe-io/zeebe/issues/4103

Benchmark with this change looks quite stable now:

![race](https://user-images.githubusercontent.com/2758593/77198219-d7935200-6ae6-11ea-91a0-85a4a676ee08.png)

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->
closes https://github.com/zeebe-io/atomix/issues/186

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
