### PR TITLE
chore(broker): improve fault tolerance on snapshot replication errors

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbPendingSnapshot.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbPendingSnapshot.java
@@ -18,7 +18,6 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import org.agrona.IoUtil;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 
@@ -92,7 +91,12 @@ public final class DbPendingSnapshot implements PendingSnapshot {
     final var filename = getFile(chunkId);
     final var path = directory.resolve(filename);
 
-    IoUtil.ensureDirectoryExists(directory.toFile(), "Pending snapshot directory");
+    try {
+      FileUtil.ensureDirectoryExists(directory);
+    } catch (final IOException e) {
+      LOGGER.error("Failed to ensure pending snapshot directory {} exists", directory, e);
+      throw new UncheckedIOException(e);
+    }
 
     try (final var channel =
         Files.newByteChannel(path, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/FileSnapshotConsumer.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/FileSnapshotConsumer.java
@@ -92,7 +92,7 @@ final class FileSnapshotConsumer implements SnapshotConsumer {
     final var snapshotFile = tmpSnapshotDirectory.resolve(chunkName);
     if (Files.exists(snapshotFile)) {
       logger.debug("Received a snapshot chunk which already exist '{}'.", snapshotFile);
-      return true;
+      return false;
     }
 
     logger.debug("Consume snapshot chunk {} of snapshot {}", chunkName, snapshotId);

--- a/util/src/main/java/io/zeebe/util/FileUtil.java
+++ b/util/src/main/java/io/zeebe/util/FileUtil.java
@@ -20,6 +20,7 @@ import java.nio.file.CopyOption;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
@@ -31,16 +32,28 @@ public final class FileUtil {
 
   public static final Logger LOG = Loggers.FILE_LOGGER;
 
+  private FileUtil() {}
+
   public static void deleteFolder(final String path) throws IOException {
     final Path directory = Paths.get(path);
 
     deleteFolder(directory);
   }
 
+  public static void ensureDirectoryExists(final Path directory) throws IOException {
+    if (Files.exists(directory)) {
+      if (!Files.isDirectory(directory)) {
+        throw new NotDirectoryException(directory.toString());
+      }
+    } else {
+      Files.createDirectories(directory);
+    }
+  }
+
   public static void deleteFolder(final Path directory) throws IOException {
     Files.walkFileTree(
         directory,
-        new SimpleFileVisitor<Path>() {
+        new SimpleFileVisitor<>() {
           @Override
           public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs)
               throws IOException {


### PR DESCRIPTION
## Description

- adds `FileUtil#ensureDirectoryExists`: while Argona already provides something similar, it simply returns a boolean, so we cannot properly say what the error is. In some cases it may be useful to receive the error, hence the addition.
- handles I/O errors when consuming snapshot chunks and invalidating the snapshot

## Related issues

Related to many issues but will not close them - writing in different folders will do this. The motivation here is to make it more fault-tolerant so we don't close the partition, and to help us better diagnose issues.

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
