### PR TITLE
chore(broker): avoid NPE by using Optional

### DIFF
--- a/broker/src/test/java/io/zeebe/broker/clustering/atomix/storage/snapshot/AtomixSnapshotStorageTest.java
+++ b/broker/src/test/java/io/zeebe/broker/clustering/atomix/storage/snapshot/AtomixSnapshotStorageTest.java
@@ -64,8 +64,8 @@ public final class AtomixSnapshotStorageTest {
     when(entrySupplier.getIndexedEntry(2)).thenReturn(Optional.of(newEntry(2)));
 
     // when
-    final var first = storage.getPendingSnapshotFor(1);
-    final var second = storage.getPendingSnapshotFor(2);
+    final var first = storage.getPendingSnapshotFor(1).orElseThrow();
+    final var second = storage.getPendingSnapshotFor(2).orElseThrow();
 
     // then
     assertThat(first.getPath()).doesNotExist();
@@ -85,7 +85,7 @@ public final class AtomixSnapshotStorageTest {
     final var snapshot = storage.getPendingSnapshotFor(1);
 
     // then
-    assertThat(snapshot).isNull();
+    assertThat(snapshot).isEmpty();
   }
 
   @Test
@@ -95,7 +95,7 @@ public final class AtomixSnapshotStorageTest {
     final var storage = newStorage();
 
     // when
-    final var directory = storage.getPendingDirectoryFor(id);
+    final var directory = storage.getPendingDirectoryFor(id).orElseThrow();
 
     // then
     assertThat(directory).doesNotExist();
@@ -104,7 +104,7 @@ public final class AtomixSnapshotStorageTest {
   }
 
   @Test
-  public void shouldReturnNullIfIdIsNotMetadata() {
+  public void shouldReturnEmptyIfIdIsNotMetadata() {
     // given
     final var id = "foo";
     final var storage = newStorage();
@@ -113,7 +113,7 @@ public final class AtomixSnapshotStorageTest {
     final var directory = storage.getPendingDirectoryFor(id);
 
     // then
-    assertThat(directory).isNull();
+    assertThat(directory).isEmpty();
   }
 
   @Test
@@ -168,7 +168,7 @@ public final class AtomixSnapshotStorageTest {
 
   private Snapshot newPendingSnapshot(final long position) {
     when(entrySupplier.getIndexedEntry(position)).thenReturn(Optional.of(newEntry(position)));
-    return snapshotStorage.getPendingSnapshotFor(position);
+    return snapshotStorage.getPendingSnapshotFor(position).orElseThrow();
   }
 
   private Snapshot newCommittedSnapshot(final long position) throws IOException {

--- a/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotDirector.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/AsyncSnapshotDirector.java
@@ -17,7 +17,6 @@ import io.zeebe.util.sched.SchedulingHints;
 import io.zeebe.util.sched.future.ActorFuture;
 import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.time.Duration;
-import java.util.function.Supplier;
 import org.slf4j.Logger;
 
 public final class AsyncSnapshotDirector extends Actor {
@@ -82,11 +81,6 @@ public final class AsyncSnapshotDirector extends Actor {
     logStream.registerOnCommitPositionUpdatedCondition(commitCondition);
   }
 
-  private void scheduleSnapshotOnRate() {
-    actor.runAtFixedRate(snapshotRate, this::prepareTakingSnapshot);
-    prepareTakingSnapshot();
-  }
-
   @Override
   protected void onActorCloseRequested() {
     logStream.removeOnCommitPositionUpdatedCondition(commitCondition);
@@ -141,6 +135,11 @@ public final class AsyncSnapshotDirector extends Actor {
     return future;
   }
 
+  private void scheduleSnapshotOnRate() {
+    actor.runAtFixedRate(snapshotRate, this::prepareTakingSnapshot);
+    prepareTakingSnapshot();
+  }
+
   private String getConditionNameForPosition() {
     return getName() + "-wait-for-endPosition-committed";
   }
@@ -156,6 +155,13 @@ public final class AsyncSnapshotDirector extends Actor {
         futureLastProcessedPosition,
         (lastProcessedPosition, error) -> {
           if (error == null) {
+            if (lastProcessedPosition == StreamProcessor.UNSET_POSITION) {
+              LOG.debug(
+                  "We will skip taking this snapshot, because we haven't processed something yet.");
+              takingSnapshot = false;
+              return;
+            }
+
             this.lowerBoundSnapshotPosition = lastProcessedPosition;
             takeSnapshot();
           } else {
@@ -173,8 +179,18 @@ public final class AsyncSnapshotDirector extends Actor {
         .onComplete(
             (commitPosition, errorOnRetrievingCommitPosition) -> {
               if (errorOnRetrievingCommitPosition == null) {
-                pendingSnapshot =
-                    createSnapshot(() -> snapshotController.takeTempSnapshot(tempSnapshotPosition));
+                final var optionalPendingSnapshot =
+                    snapshotController.takeTempSnapshot(tempSnapshotPosition);
+                if (optionalPendingSnapshot.isEmpty()) {
+                  LOG.warn(
+                      "Failed to obtain a pending snapshot directory for position {}",
+                      tempSnapshotPosition);
+                  takingSnapshot = false;
+                  return;
+                }
+
+                LOG.debug("Created snapshot for {}", processorName);
+                pendingSnapshot = optionalPendingSnapshot.get();
 
                 final ActorFuture<Long> lastWrittenPosition =
                     streamProcessor.getLastWrittenPositionAsync();
@@ -199,12 +215,6 @@ public final class AsyncSnapshotDirector extends Actor {
                     errorOnRetrievingCommitPosition);
               }
             });
-  }
-
-  private Snapshot createSnapshot(final Supplier<Snapshot> snapshotCreation) {
-    final var snapshot = snapshotCreation.get();
-    LOG.debug("Created snapshot for {}", processorName);
-    return snapshot;
   }
 
   private void onCommitCheck() {
@@ -237,7 +247,8 @@ public final class AsyncSnapshotDirector extends Actor {
 
   void enforceSnapshotCreation(
       final long commitPosition, final long lastWrittenPosition, final long lastProcessedPosition) {
-    if (commitPosition >= lastWrittenPosition) {
+    if (lastProcessedPosition > StreamProcessor.UNSET_POSITION
+        && commitPosition >= lastWrittenPosition) {
       LOG.debug(LOG_MSG_ENFORCE_SNAPSHOT, lastProcessedPosition);
       try {
         snapshotController.takeSnapshot(lastProcessedPosition);

--- a/engine/src/main/java/io/zeebe/engine/processor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ProcessingStateMachine.java
@@ -126,11 +126,11 @@ public final class ProcessingStateMachine {
   private LoggedEvent currentEvent;
   private TypedRecordProcessor<?> currentProcessor;
   private ZeebeDbTransaction zeebeDbTransaction;
-  private long writtenEventPosition = -1L;
-  private long lastSuccessfulProcessedEventPosition = -1L;
-  private long lastWrittenEventPosition = -1L;
+  private long writtenEventPosition = StreamProcessor.UNSET_POSITION;
+  private long lastSuccessfulProcessedEventPosition = StreamProcessor.UNSET_POSITION;
+  private long lastWrittenEventPosition = StreamProcessor.UNSET_POSITION;
   private boolean onErrorHandling;
-  private long errorRecordPosition = -1;
+  private long errorRecordPosition = StreamProcessor.UNSET_POSITION;
   private volatile boolean onErrorHandlingLoop;
   private int onErrorRetries;
 

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 
 public class StreamProcessor extends Actor implements HealthMonitorable {
   static final Duration HEALTH_CHECK_TICK_DURATION = Duration.ofSeconds(5);
+  static final long UNSET_POSITION = -1L;
   private static final String ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED =
       "Expected to find event with the snapshot position %s in log stream, but nothing was found. Failed to recover '%s'.";
   private static final Logger LOG = Loggers.LOGSTREAMS_LOGGER;

--- a/logstreams/src/main/java/io/zeebe/logstreams/spi/SnapshotController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/spi/SnapshotController.java
@@ -11,6 +11,8 @@ import io.zeebe.db.ZeebeDb;
 import io.zeebe.logstreams.state.Snapshot;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 public interface SnapshotController extends AutoCloseable {
@@ -18,16 +20,21 @@ public interface SnapshotController extends AutoCloseable {
    * Takes a snapshot based on the given position and immediately commits it.
    *
    * @param lowerBoundSnapshotPosition the lower bound snapshot position
+   * @return a committed snapshot, or nothing if the operation failed
+   * @see io.zeebe.logstreams.state.SnapshotStorage#commitSnapshot(Path)
+   * @see io.zeebe.logstreams.state.SnapshotStorage#getPendingSnapshotFor(long)
    */
-  Snapshot takeSnapshot(long lowerBoundSnapshotPosition);
+  Optional<Snapshot> takeSnapshot(long lowerBoundSnapshotPosition);
 
   /**
    * Takes a snapshot based on the given position. The position is a last processed lower bound
    * event position.
    *
    * @param lowerBoundSnapshotPosition the lower bound snapshot position
+   * @return a pending snapshot, or nothing if the operation fails
+   * @see io.zeebe.logstreams.state.SnapshotStorage#getPendingSnapshotFor(long)
    */
-  Snapshot takeTempSnapshot(long lowerBoundSnapshotPosition);
+  Optional<Snapshot> takeTempSnapshot(long lowerBoundSnapshotPosition);
 
   /**
    * Commits the given temporary snapshot to the underlying storage.

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotStorage.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotStorage.java
@@ -24,18 +24,19 @@ public interface SnapshotStorage extends AutoCloseable {
    * and therefore should be cached if it needs to be reused.
    *
    * @param snapshotPosition the position to use
-   * @return a pending snapshot
+   * @return a pending snapshot, or nothing if no snapshot metadata could be created from the
+   *     position
    */
-  Snapshot getPendingSnapshotFor(long snapshotPosition);
+  Optional<Snapshot> getPendingSnapshotFor(long snapshotPosition);
 
   /**
    * Returns an existing, temporary working directory for a snapshot with the given ID; primarily
    * used during replication of snapshots to preserver the snapshot ID.
    *
    * @param id the snapshot ID
-   * @return an existing path
+   * @return an existing path, or nothing if snapshot metadata cannot be extracted from the given ID
    */
-  Path getPendingDirectoryFor(String id);
+  Optional<Path> getPendingDirectoryFor(String id);
 
   /**
    * Commits to the snapshot to the underlying store, making it permanently accessible. This may

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/FailingSnapshotChunkReplicationTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/FailingSnapshotChunkReplicationTest.java
@@ -76,7 +76,7 @@ public final class FailingSnapshotChunkReplicationTest {
     final List<SnapshotChunk> replicatedChunks = replicator.replicatedChunks;
     assertThat(replicatedChunks.size()).isGreaterThan(0);
 
-    final var snapshotDirectory = receiverStorage.getPendingDirectoryFor("1");
+    final var snapshotDirectory = receiverStorage.getPendingDirectoryFor("1").orElseThrow();
     assertThat(snapshotDirectory).doesNotExist();
     assertThat(receiverStorage.exists("1")).isFalse();
   }
@@ -98,7 +98,9 @@ public final class FailingSnapshotChunkReplicationTest {
     assertThat(replicatedChunks.size()).isGreaterThan(0);
 
     final var snapshotDirectory =
-        receiverStorage.getPendingDirectoryFor(replicatedChunks.get(0).getSnapshotId());
+        receiverStorage
+            .getPendingDirectoryFor(replicatedChunks.get(0).getSnapshotId())
+            .orElseThrow();
     assertThat(snapshotDirectory).exists();
     final var files = Files.list(snapshotDirectory).collect(Collectors.toList());
     assertThat(files)

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/StateSnapshotControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/StateSnapshotControllerTest.java
@@ -46,13 +46,12 @@ public final class StateSnapshotControllerTest {
   }
 
   @Test
-  public void shouldThrowExceptionOnTakeSnapshotIfClosed() {
+  public void shouldNotTakeSnapshotIfDbIsClosed() {
     // given
 
     // then
     assertThat(snapshotController.isDbOpened()).isFalse();
-    assertThatThrownBy(() -> snapshotController.takeSnapshot(1))
-        .isInstanceOf(NullPointerException.class);
+    assertThat(snapshotController.takeSnapshot(1)).isEmpty();
   }
 
   @Test
@@ -194,8 +193,8 @@ public final class StateSnapshotControllerTest {
 
     snapshotController.takeSnapshot(1L);
     snapshotController.takeSnapshot(3L);
-    final var lastValidSnapshot = snapshotController.takeSnapshot(5L);
-    final var lastTempSnapshot = snapshotController.takeTempSnapshot(6L);
+    final var lastValidSnapshot = snapshotController.takeSnapshot(5L).orElseThrow();
+    final var lastTempSnapshot = snapshotController.takeTempSnapshot(6L).orElseThrow();
 
     // when/then
     assertThat(snapshotController.getLastValidSnapshotDirectory().toPath())

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/TestSnapshotStorage.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/TestSnapshotStorage.java
@@ -59,14 +59,15 @@ public final class TestSnapshotStorage implements SnapshotStorage {
   }
 
   @Override
-  public Snapshot getPendingSnapshotFor(final long snapshotPosition) {
-    return new SnapshotImpl(
-        getPendingDirectoryFor(snapshotPosition + "_" + System.currentTimeMillis()));
+  public Optional<Snapshot> getPendingSnapshotFor(final long snapshotPosition) {
+    final var pendingDirectory =
+        getPendingDirectoryFor(snapshotPosition + "_" + System.currentTimeMillis());
+    return pendingDirectory.map(SnapshotImpl::new);
   }
 
   @Override
-  public Path getPendingDirectoryFor(final String id) {
-    return pendingDirectory.resolve(id);
+  public Optional<Path> getPendingDirectoryFor(final String id) {
+    return Optional.of(pendingDirectory.resolve(id));
   }
 
   @Override
@@ -163,15 +164,10 @@ public final class TestSnapshotStorage implements SnapshotStorage {
     }
 
     @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      final SnapshotImpl snapshot = (SnapshotImpl) o;
-      return path.equals(snapshot.path);
+    public int compareTo(final Snapshot other) {
+      return Comparator.comparing(Snapshot::getCompactionBound)
+          .thenComparing(Snapshot::getPath)
+          .compare(this, other);
     }
 
     @Override
@@ -180,10 +176,15 @@ public final class TestSnapshotStorage implements SnapshotStorage {
     }
 
     @Override
-    public int compareTo(Snapshot other) {
-      return Comparator.comparing(Snapshot::getCompactionBound)
-          .thenComparing(Snapshot::getPath)
-          .compare(this, other);
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final SnapshotImpl snapshot = (SnapshotImpl) o;
+      return path.equals(snapshot.path);
     }
 
     @Override


### PR DESCRIPTION
## Description

This PR migrates several SnapshotStorage APIs from returning nullable types to return Optional values, handling potential empty values where it makes sense. This is not a silver bullet for our snapshot replication issues, but it should be much safer than returning nullables.

Additionally skips taking snapshots when we are still on position `-1`.

## Related issues

closes #4085 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
