### PR TITLE
chore(broker): split snapshot replication destination folders

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshotMetadata.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/snapshot/DbSnapshotMetadata.java
@@ -52,6 +52,10 @@ public final class DbSnapshotMetadata implements DbSnapshotId {
     return metadata;
   }
 
+  public String getFileName() {
+    return String.format("%d-%d-%d", getIndex(), getTerm(), getTimestamp().unixTimestamp());
+  }
+
   @Override
   public long getIndex() {
     return index;

--- a/broker/src/test/java/io/zeebe/broker/logstreams/AtomixLogDeletionServiceTest.java
+++ b/broker/src/test/java/io/zeebe/broker/logstreams/AtomixLogDeletionServiceTest.java
@@ -61,14 +61,17 @@ public final class AtomixLogDeletionServiceTest {
   private Compactor compactor;
 
   @Before
-  public void setUp() {
+  public void setUp() throws IOException {
+    final var runtimeDirectory = temporaryFolder.newFolder().toPath();
+    final var pendingDirectory = temporaryFolder.newFolder().toPath();
     storageReader =
         new AtomixLogStorageReader(
             ZeebeIndexAdapter.ofDensity(5),
             logStorageRule.getRaftLog().openReader(-1, Mode.COMMITS));
     snapshotStorage =
         new AtomixSnapshotStorage(
-            null,
+            runtimeDirectory,
+            pendingDirectory,
             logStorageRule.getSnapshotStore(),
             new AtomixRecordEntrySupplierImpl(storageReader),
             new SnapshotMetrics(PARTITION_ID));

--- a/engine/src/test/java/io/zeebe/engine/processor/AsyncSnapshotingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/AsyncSnapshotingTest.java
@@ -15,6 +15,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.zeebe.db.impl.DefaultColumnFamily;
@@ -252,6 +254,7 @@ public final class AsyncSnapshotingTest {
                 new RuntimeException("getLastWrittenPositionAsync fails")));
     setCommitPosition(commitPosition);
     clock.addTime(Duration.ofMinutes(1));
+    verify(mockStreamProcessor, timeout(5000).times(1)).getLastWrittenPositionAsync();
 
     // when
     when(mockStreamProcessor.getLastWrittenPositionAsync())
@@ -301,6 +304,7 @@ public final class AsyncSnapshotingTest {
         .thenReturn(CompletableActorFuture.completed(lastWrittenPosition));
     setCommitPosition(commitPosition);
     clock.addTime(Duration.ofMinutes(1));
+    verify(mockStreamProcessor, timeout(5000).times(1)).getLastProcessedPositionAsync();
 
     // when
     when(mockStreamProcessor.getLastProcessedPositionAsync())
@@ -351,8 +355,10 @@ public final class AsyncSnapshotingTest {
             CompletableActorFuture.completedExceptionally(
                 new RuntimeException("getCommitPositionAsync fails")));
     clock.addTime(Duration.ofMinutes(1));
+    verify(logStream, timeout(5000).times(1)).getCommitPositionAsync();
 
     // when
+
     setCommitPosition(100L);
     clock.addTime(Duration.ofMinutes(1));
 


### PR DESCRIPTION
## Description

- splits destination folders for the different snapshot replications as they run in different thread context and both need to modify the same on-disk state
- Atomix snapshot replication will now write to raft-pending/ folder
- Zeebe snapshot replication will now write to pushed-pending/ folder

## Related issues

closes #3531, #4078, #3887, #3764

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
