### PR TITLE
chore(broker): step down on failures during leader installation

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/PartitionListener.java
+++ b/broker/src/main/java/io/zeebe/broker/PartitionListener.java
@@ -8,10 +8,13 @@
 package io.zeebe.broker;
 
 import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.util.sched.future.ActorFuture;
 
 /**
  * Can be implemented and used to react on partition role changes, like on Leader on Actor should be
- * started and on Follower one should be removed.
+ * started and on Follower one should be removed. If this listener performs actions that are
+ * critical to the progress of a partition, it is expected to complete the future exceptionally on a
+ * failure. Otherwise the future should complete normally.
  */
 public interface PartitionListener {
 
@@ -22,8 +25,9 @@ public interface PartitionListener {
    * @param partitionId the corresponding partition id
    * @param term the current term
    * @param logStream the corresponding log stream
+   * @return future that should be completed by the listener
    */
-  void onBecomingFollower(int partitionId, long term, LogStream logStream);
+  ActorFuture<Void> onBecomingFollower(int partitionId, long term, LogStream logStream);
 
   /**
    * Is called by the {@link io.zeebe.broker.system.partitions.ZeebePartition} on becoming partition
@@ -32,6 +36,7 @@ public interface PartitionListener {
    * @param partitionId the corresponding partition id
    * @param term the current term
    * @param logStream the corresponding log stream
+   * @return future that should be completed by the listener
    */
-  void onBecomingLeader(int partitionId, long term, LogStream logStream);
+  ActorFuture<Void> onBecomingLeader(int partitionId, long term, LogStream logStream);
 }

--- a/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
@@ -20,6 +20,7 @@ import io.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.zeebe.util.LogUtil;
 import io.zeebe.util.VersionUtil;
 import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.future.ActorFuture;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -55,14 +56,15 @@ public final class TopologyManagerImpl extends Actor
   }
 
   @Override
-  public void onBecomingFollower(
+  public ActorFuture<Void> onBecomingFollower(
       final int partitionId, final long term, final LogStream logStream) {
-    setFollower(partitionId);
+    return setFollower(partitionId);
   }
 
   @Override
-  public void onBecomingLeader(final int partitionId, final long term, final LogStream logStream) {
-    setLeader(term, partitionId);
+  public ActorFuture<Void> onBecomingLeader(
+      final int partitionId, final long term, final LogStream logStream) {
+    return setLeader(term, partitionId);
   }
 
   @Override
@@ -81,8 +83,8 @@ public final class TopologyManagerImpl extends Actor
         .forEach(m -> event(new ClusterMembershipEvent(Type.MEMBER_ADDED, m)));
   }
 
-  public void setLeader(final long term, final int partitionId) {
-    actor.call(
+  public ActorFuture<Void> setLeader(final long term, final int partitionId) {
+    return actor.call(
         () -> {
           partitionLeaders.put(partitionId, localBroker);
           localBroker.setLeaderForPartition(partitionId, term);
@@ -91,8 +93,8 @@ public final class TopologyManagerImpl extends Actor
         });
   }
 
-  public void setFollower(final int partitionId) {
-    actor.call(
+  public ActorFuture<Void> setFollower(final int partitionId) {
+    return actor.call(
         () -> {
           removeIfLeader(localBroker, partitionId);
           localBroker.setFollowerForPartition(partitionId);

--- a/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
@@ -15,6 +15,8 @@ import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
 import org.agrona.collections.Int2ObjectHashMap;
 
 public final class SubscriptionApiCommandMessageHandlerService extends Actor
@@ -44,29 +46,36 @@ public final class SubscriptionApiCommandMessageHandlerService extends Actor
   }
 
   @Override
-  public void onBecomingFollower(
+  public ActorFuture<Void> onBecomingFollower(
       final int partitionId, final long term, final LogStream logStream) {
-    actor.submit(() -> leaderPartitions.remove(partitionId));
+    return actor.call(
+        () -> {
+          leaderPartitions.remove(partitionId);
+          return null;
+        });
   }
 
   @Override
-  public void onBecomingLeader(final int partitionId, final long term, final LogStream logStream) {
+  public ActorFuture<Void> onBecomingLeader(
+      final int partitionId, final long term, final LogStream logStream) {
+    final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     actor.submit(
-        () -> {
-          logStream
-              .newLogStreamRecordWriter()
-              .onComplete(
-                  (recordWriter, error) -> {
-                    if (error == null) {
-                      leaderPartitions.put(partitionId, recordWriter);
-                    } else {
-                      // TODO https://github.com/zeebe-io/zeebe/issues/3499
-                      Loggers.SYSTEM_LOGGER.error(
-                          "Unexpected error on retrieving write buffer for partition {}",
-                          partitionId,
-                          error);
-                    }
-                  });
-        });
+        () ->
+            logStream
+                .newLogStreamRecordWriter()
+                .onComplete(
+                    (recordWriter, error) -> {
+                      if (error == null) {
+                        leaderPartitions.put(partitionId, recordWriter);
+                        future.complete(null);
+                      } else {
+                        Loggers.SYSTEM_LOGGER.error(
+                            "Unexpected error on retrieving write buffer for partition {}",
+                            partitionId,
+                            error);
+                        future.completeExceptionally(error);
+                      }
+                    }));
+    return future;
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
@@ -15,6 +15,8 @@ import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
 import org.agrona.collections.Int2ObjectHashMap;
 
 public final class LeaderManagementRequestHandler extends Actor implements PartitionListener {
@@ -31,13 +33,19 @@ public final class LeaderManagementRequestHandler extends Actor implements Parti
   }
 
   @Override
-  public void onBecomingFollower(
+  public ActorFuture<Void> onBecomingFollower(
       final int partitionId, final long term, final LogStream logStream) {
-    actor.submit(() -> leaderForPartitions.remove(partitionId));
+    return actor.call(
+        () -> {
+          leaderForPartitions.remove(partitionId);
+          return null;
+        });
   }
 
   @Override
-  public void onBecomingLeader(final int partitionId, final long term, final LogStream logStream) {
+  public ActorFuture<Void> onBecomingLeader(
+      final int partitionId, final long term, final LogStream logStream) {
+    final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     actor.submit(
         () ->
             logStream
@@ -46,14 +54,16 @@ public final class LeaderManagementRequestHandler extends Actor implements Parti
                     (recordWriter, error) -> {
                       if (error == null) {
                         leaderForPartitions.put(partitionId, recordWriter);
+                        future.complete(null);
                       } else {
                         Loggers.CLUSTERING_LOGGER.error(
                             "Unexpected error on retrieving write buffer for partition {}",
                             partitionId,
                             error);
-                        // TODO https://github.com/zeebe-io/zeebe/issues/3499
+                        future.completeExceptionally(error);
                       }
                     }));
+    return future;
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -21,6 +21,7 @@ import io.zeebe.util.health.HealthMonitor;
 import io.zeebe.util.health.HealthMonitorable;
 import io.zeebe.util.health.HealthStatus;
 import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.future.ActorFuture;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -65,18 +66,19 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
   }
 
   @Override
-  public void onBecomingFollower(
+  public ActorFuture<Void> onBecomingFollower(
       final int partitionId, final long term, final LogStream logStream) {
-    updateBrokerReadyStatus(partitionId);
+    return updateBrokerReadyStatus(partitionId);
   }
 
   @Override
-  public void onBecomingLeader(final int partitionId, final long term, final LogStream logStream) {
-    updateBrokerReadyStatus(partitionId);
+  public ActorFuture<Void> onBecomingLeader(
+      final int partitionId, final long term, final LogStream logStream) {
+    return updateBrokerReadyStatus(partitionId);
   }
 
-  private void updateBrokerReadyStatus(final int partitionId) {
-    actor.call(
+  private ActorFuture<Void> updateBrokerReadyStatus(final int partitionId) {
+    return actor.call(
         () -> {
           if (!brokerStarted) {
             partitionInstallStatus.put(partitionId, true);

--- a/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.zeebe.broker.system.configuration.BrokerCfg;
 import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.io.File;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
@@ -68,13 +70,16 @@ public final class SimpleBrokerStartTest {
     broker.addPartitionListener(
         new PartitionListener() {
           @Override
-          public void onBecomingFollower(
-              final int partitionId, final long term, final LogStream logStream) {}
+          public ActorFuture<Void> onBecomingFollower(
+              final int partitionId, final long term, final LogStream logStream) {
+            return CompletableActorFuture.completed(null);
+          }
 
           @Override
-          public void onBecomingLeader(
+          public ActorFuture<Void> onBecomingLeader(
               final int partitionId, final long term, final LogStream logStream) {
             leaderLatch.countDown();
+            return CompletableActorFuture.completed(null);
           }
         });
 

--- a/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -33,6 +33,8 @@ import io.zeebe.test.util.socket.SocketUtil;
 import io.zeebe.util.FileUtil;
 import io.zeebe.util.allocation.DirectBufferAllocator;
 import io.zeebe.util.sched.clock.ControlledActorClock;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -280,13 +282,16 @@ public final class EmbeddedBrokerRule extends ExternalResource {
     }
 
     @Override
-    public void onBecomingFollower(
-        final int partitionId, final long term, final LogStream logStream) {}
+    public ActorFuture<Void> onBecomingFollower(
+        final int partitionId, final long term, final LogStream logStream) {
+      return CompletableActorFuture.completed(null);
+    }
 
     @Override
-    public void onBecomingLeader(
+    public ActorFuture<Void> onBecomingLeader(
         final int partitionId, final long term, final LogStream logStream) {
       latch.countDown();
+      return CompletableActorFuture.completed(null);
     }
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -46,6 +46,8 @@ import io.zeebe.test.util.socket.SocketUtil;
 import io.zeebe.util.exception.UncheckedExecutionException;
 import io.zeebe.util.sched.ActorScheduler;
 import io.zeebe.util.sched.clock.ControlledActorClock;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -670,14 +672,17 @@ public final class ClusteringRule extends ExternalResource {
     }
 
     @Override
-    public void onBecomingFollower(
-        final int partitionId, final long term, final LogStream logStream) {}
+    public ActorFuture<Void> onBecomingFollower(
+        final int partitionId, final long term, final LogStream logStream) {
+      return CompletableActorFuture.completed(null);
+    }
 
     @Override
-    public void onBecomingLeader(
+    public ActorFuture<Void> onBecomingLeader(
         final int partitionId, final long term, final LogStream logStream) {
       logstreams.put(partitionId, logStream);
       latch.countDown();
+      return CompletableActorFuture.completed(null);
     }
 
     void awaitLeaders() throws InterruptedException {

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRestartTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRestartTest.java
@@ -15,6 +15,8 @@ import io.zeebe.broker.test.EmbeddedBrokerRule;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.response.PublishMessageResponse;
 import io.zeebe.logstreams.log.LogStream;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.time.Duration;
 import org.junit.Rule;
 import org.junit.Test;
@@ -76,15 +78,17 @@ public class BrokerRestartTest {
     }
 
     @Override
-    public void onBecomingFollower(
+    public ActorFuture<Void> onBecomingFollower(
         final int partitionId, final long term, final LogStream logStream) {
       this.logStream = logStream;
+      return CompletableActorFuture.completed(null);
     }
 
     @Override
-    public void onBecomingLeader(
+    public ActorFuture<Void> onBecomingLeader(
         final int partitionId, final long term, final LogStream logStream) {
       this.logStream = logStream;
+      return CompletableActorFuture.completed(null);
     }
   }
 }

--- a/util/src/main/java/io/zeebe/util/health/CriticalComponentsHealthMonitor.java
+++ b/util/src/main/java/io/zeebe/util/health/CriticalComponentsHealthMonitor.java
@@ -89,6 +89,9 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
           break;
         case UNHEALTHY:
           failureListener.onFailure();
+          log.debug(
+              "Detected unhealthy components. The current health status of components: {}",
+              componentHealth);
           break;
         default:
           log.warn("Unknown health status {}", status);


### PR DESCRIPTION
## Description

* Detect failures in CommandApi, SubscriptionApi, LeaderManagementHandler when installing leader services.
* On failures that leads to unhealthy state, ZeebePartition tries to stepdown if it is a leader.
* After stepdown, the partition might be able to successfully install follower services. Hence recover and mark healthy if transition to a new role succeeds.

## Related issues

closes #3499

Related #3835 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
