### PR TITLE
fix flaky MultiInstanceReceiveTaskTest

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/multiinstance/MultiInstanceReceiveTaskTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/multiinstance/MultiInstanceReceiveTaskTest.java
@@ -111,7 +111,7 @@ public final class MultiInstanceReceiveTaskTest {
                 .message()
                 .withName(MESSAGE_NAME)
                 .withCorrelationKey(element)
-                .withTimeToLive(Duration.ofSeconds(1).toMillis())
+                .withTimeToLive(Duration.ofSeconds(3).toMillis())
                 .publish());
 
     // then


### PR DESCRIPTION
## Description

I increased the time to live for the messages.

Brilliant, right? 

Ok, I did a little more. I validated that this is the most likely cause for the flakiness. I did reduce the time on my local machine and with a reduced TTL I did observe the same test failures as occur on Jenkins.

It is not conclusive proof though. I did observe the tests failing. I did not observe the tests being flaky. I guess it can be done by fiddling around with the numbers. 

So let me know if this is good enough for you guys. And yes, it only fixes the symptom, not the cause. But as a low hanging fruit, this is too juicy not to pick.

## Related issues

closes #4131

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
