### PR TITLE
Fixes not overwriting Default Job Timeout property in Java Client with user supplied values

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -142,7 +142,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
               Integer.parseInt(properties.getProperty(ClientProperties.DEFAULT_JOB_TIMEOUT))));
     }
     if (properties.containsKey(ClientProperties.DEFAULT_JOB_POLL_INTERVAL)) {
-      defaultJobTimeout(
+      defaultJobPollInterval(
           Duration.ofMillis(
               Integer.parseInt(
                   properties.getProperty(ClientProperties.DEFAULT_JOB_POLL_INTERVAL))));


### PR DESCRIPTION
## Description

In Zeebe Java Client, when using the `withProperties` method of `ZeebeClientBuilderImpl`, the incorrect setter method was invoked for the property `zeebe.client.job.pollinterval`. This has been corrected to invoke `defaultJobPollInterval` instead of `defaultJobTimeout`

## Related issues


closes #4133 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
