### PR TITLE
OPE-956 Fix index pattern in Operate docs

### DIFF
--- a/docs/src/operate-deployment-guide/schema-and-migration.md
+++ b/docs/src/operate-deployment-guide/schema-and-migration.md
@@ -16,7 +16,7 @@ follow the Elasticsearch REST API format and can be found in `schema/create` fol
 
 Index names follow the defined pattern:
 ```
-operate_{datatype}_{schemaversion}_[{date}]
+operate-{datatype}-{schemaversion}_[{date}]
 
 ```
 , where `datatype` defines which data is stored in the index, e.g. `user`, `variable` etc.,
@@ -28,7 +28,7 @@ E.g. to define desired number of shards and replicas, you can define following t
 ```
 PUT _template/template_operate
 {
-  "index_patterns": ["operate_*"],
+  "index_patterns": ["operate-*"],
   "settings": {
     "number_of_shards": 5,
     "number_of_replicas": 2


### PR DESCRIPTION
## Description

Index pattern was fixed in Operate docs.

## Related issues

closes https://jira.camunda.com/browse/OPE-956

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
