### PR TITLE
Add feel expressions for timer events

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractCatchEventBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractCatchEventBuilder.java
@@ -102,6 +102,10 @@ public abstract class AbstractCatchEventBuilder<
     return myself;
   }
 
+  public B timerWithDateExpression(final String timerDate) {
+    return timerWithDate(asZeebeExpression(timerDate));
+  }
+
   /**
    * Sets an event definition for the timer with a time date.
    *
@@ -123,6 +127,16 @@ public abstract class AbstractCatchEventBuilder<
   /**
    * Sets an event definition for the timer with a time duration.
    *
+   * @param timerDuration the duration of the timer (as feel expression, without the '=' prefix)
+   * @return the builder object
+   */
+  public B timerWithDurationExpression(final String timerDuration) {
+    return timerWithDuration(asZeebeExpression(timerDuration));
+  }
+
+  /**
+   * Sets an event definition for the timer with a time duration.
+   *
    * @param timerDuration the time duration of the timer
    * @return the builder object
    */
@@ -136,6 +150,16 @@ public abstract class AbstractCatchEventBuilder<
     element.getEventDefinitions().add(timerEventDefinition);
 
     return myself;
+  }
+
+  /**
+   * Sets an event definition for the timer with a time cycle.
+   *
+   * @param timerCycle the time cycle of the timer (as feel expression, without the '=' prefix)
+   * @return the builder object
+   */
+  public B timerWithCycleExpression(final String timerCycle) {
+    return timerWithCycle(asZeebeExpression(timerCycle));
   }
 
   /**

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/time/Interval.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/time/Interval.java
@@ -46,6 +46,14 @@ public class Interval implements TemporalAmount {
     this.units.addAll(duration.getUnits());
   }
 
+  public Interval(final Duration duration) {
+    this(Period.ZERO, duration);
+  }
+
+  public Interval(final Period period) {
+    this(period, Duration.ZERO);
+  }
+
   public Period getPeriod() {
     return period;
   }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/time/TimeDateTimer.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/util/time/TimeDateTimer.java
@@ -27,11 +27,12 @@ public class TimeDateTimer implements Timer {
     this.interval = interval;
   }
 
+  public TimeDateTimer(final ZonedDateTime dateTime) {
+    this(new Interval(Period.ZERO, Duration.ofMillis(dateTime.toInstant().toEpochMilli())));
+  }
+
   public static TimeDateTimer parse(final String timeDate) {
-    final ZonedDateTime dateTime = ZonedDateTime.parse(timeDate);
-    final Interval interval =
-        new Interval(Period.ZERO, Duration.ofMillis(dateTime.toInstant().toEpochMilli()));
-    return new TimeDateTimer(interval);
+    return new TimeDateTimer(ZonedDateTime.parse(timeDate));
   }
 
   @Override

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/TimerEventDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/TimerEventDefinitionValidator.java
@@ -19,10 +19,6 @@ import io.zeebe.model.bpmn.instance.TimeCycle;
 import io.zeebe.model.bpmn.instance.TimeDate;
 import io.zeebe.model.bpmn.instance.TimeDuration;
 import io.zeebe.model.bpmn.instance.TimerEventDefinition;
-import io.zeebe.model.bpmn.util.time.Interval;
-import io.zeebe.model.bpmn.util.time.RepeatingInterval;
-import io.zeebe.model.bpmn.util.time.TimeDateTimer;
-import java.time.format.DateTimeParseException;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
@@ -42,51 +38,20 @@ public class TimerEventDefinitionValidator implements ModelElementValidator<Time
     int definitionsCount = 0;
 
     if (timeDate != null) {
-
-      validateTimeDate(element.getTimeDate(), validationResultCollector);
       definitionsCount++;
     }
 
     if (timeDuration != null) {
-      validateTimeDuration(validationResultCollector, timeDuration);
       definitionsCount++;
     }
 
     if (timeCycle != null) {
-      validateTimeCycle(validationResultCollector, timeCycle);
       definitionsCount++;
     }
 
     if (definitionsCount != 1) {
       validationResultCollector.addError(
           0, "Must be exactly one type of timer: timeDuration, timeDate or timeCycle");
-    }
-  }
-
-  private void validateTimeDate(
-      final TimeDate timeDate, final ValidationResultCollector validationResultCollector) {
-    try {
-      TimeDateTimer.parse(timeDate.getTextContent());
-    } catch (final DateTimeParseException e) {
-      validationResultCollector.addError(0, "Time date is invalid");
-    }
-  }
-
-  private void validateTimeCycle(
-      final ValidationResultCollector validationResultCollector, final TimeCycle timeCycle) {
-    try {
-      RepeatingInterval.parse(timeCycle.getTextContent());
-    } catch (final DateTimeParseException e) {
-      validationResultCollector.addError(0, "Time cycle is invalid");
-    }
-  }
-
-  private void validateTimeDuration(
-      final ValidationResultCollector validationResultCollector, final TimeDuration timeDuration) {
-    try {
-      Interval.parse(timeDuration.getTextContent());
-    } catch (final DateTimeParseException e) {
-      validationResultCollector.addError(0, "Time duration is invalid");
     }
   }
 }

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeTimerValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeTimerValidationTest.java
@@ -21,7 +21,6 @@ import static java.util.Collections.singletonList;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.zeebe.model.bpmn.instance.IntermediateCatchEvent;
-import io.zeebe.model.bpmn.instance.TimerEventDefinition;
 import org.junit.runners.Parameterized.Parameters;
 
 public class ZeebeTimerValidationTest extends AbstractZeebeValidationTest {
@@ -29,22 +28,6 @@ public class ZeebeTimerValidationTest extends AbstractZeebeValidationTest {
   @Parameters(name = "{index}: {1}")
   public static Object[][] parameters() {
     return new Object[][] {
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .intermediateCatchEvent("catch", c -> c.timerWithDuration(""))
-            .endEvent()
-            .done(),
-        singletonList(expect(TimerEventDefinition.class, "Time duration is invalid"))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .intermediateCatchEvent("catch", c -> c.timerWithDuration("R/PT01S"))
-            .endEvent()
-            .done(),
-        singletonList(expect(TimerEventDefinition.class, "Time duration is invalid"))
-      },
       {
         Bpmn.createExecutableProcess("process")
             .startEvent()
@@ -66,41 +49,6 @@ public class ZeebeTimerValidationTest extends AbstractZeebeValidationTest {
             .done(),
         singletonList(
             expect(BoundaryEvent.class, "Interrupting timer event with time cycle is not allowed."))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .serviceTask("task", b -> b.zeebeJobType("type"))
-            .boundaryEvent("catch")
-            .cancelActivity(false)
-            .timerWithCycle("R5/")
-            .endEvent()
-            .done(),
-        singletonList(expect(TimerEventDefinition.class, "Time cycle is invalid"))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .intermediateCatchEvent("catch", c -> c.timerWithDuration("foo"))
-            .endEvent()
-            .done(),
-        singletonList(expect(TimerEventDefinition.class, "Time duration is invalid"))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .timerWithDate("03-20")
-            .endEvent()
-            .done(),
-        singletonList(expect(TimerEventDefinition.class, "Time date is invalid"))
-      },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .timerWithCycle("R5/2008-03-01T13:00:00Z/P1Y2M10DT2H30M")
-            .endEvent()
-            .done(),
-        singletonList(expect(TimerEventDefinition.class, "Time cycle is invalid"))
       }
     };
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/EngineProcessors.java
@@ -60,7 +60,12 @@ public final class EngineProcessors {
             zeebeState, expressionProcessor, subscriptionCommandSender, partitionsCount);
 
     addDeploymentRelatedProcessorAndServices(
-        catchEventBehavior, partitionId, zeebeState, typedRecordProcessors, deploymentResponder);
+        catchEventBehavior,
+        partitionId,
+        zeebeState,
+        typedRecordProcessors,
+        deploymentResponder,
+        expressionProcessor);
     addMessageProcessors(subscriptionCommandSender, zeebeState, typedRecordProcessors);
 
     final BpmnStepProcessor stepProcessor =
@@ -116,12 +121,13 @@ public final class EngineProcessors {
       final int partitionId,
       final ZeebeState zeebeState,
       final TypedRecordProcessors typedRecordProcessors,
-      final DeploymentResponder deploymentResponder) {
+      final DeploymentResponder deploymentResponder,
+      final ExpressionProcessor expressionProcessor) {
     final WorkflowState workflowState = zeebeState.getWorkflowState();
     final boolean isDeploymentPartition = partitionId == Protocol.DEPLOYMENT_PARTITION;
     if (isDeploymentPartition) {
       DeploymentEventProcessors.addTransformingDeploymentProcessor(
-          typedRecordProcessors, zeebeState, catchEventBehavior);
+          typedRecordProcessors, zeebeState, catchEventBehavior, expressionProcessor);
     } else {
       DeploymentEventProcessors.addDeploymentCreateProcessor(
           typedRecordProcessors, workflowState, deploymentResponder, partitionId);

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/EngineProcessors.java
@@ -50,10 +50,11 @@ public final class EngineProcessors {
     addDistributeDeploymentProcessors(
         actor, zeebeState, typedRecordProcessors, deploymentDistributor);
 
+    final var variablesState =
+        zeebeState.getWorkflowState().getElementInstanceState().getVariablesState();
     final var expressionProcessor =
         new ExpressionProcessor(
-            ExpressionLanguageFactory.createExpressionLanguage(),
-            zeebeState.getWorkflowState().getElementInstanceState().getVariablesState());
+            ExpressionLanguageFactory.createExpressionLanguage(), variablesState::getVariable);
 
     final CatchEventBehavior catchEventBehavior =
         new CatchEventBehavior(

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/ExpressionProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/ExpressionProcessor.java
@@ -16,7 +16,6 @@ import io.zeebe.el.ExpressionLanguage;
 import io.zeebe.el.ResultType;
 import io.zeebe.engine.processor.workflow.message.MessageCorrelationKeyContext;
 import io.zeebe.engine.processor.workflow.message.MessageCorrelationKeyException;
-import io.zeebe.engine.state.instance.VariablesState;
 import io.zeebe.model.bpmn.util.time.Interval;
 import io.zeebe.protocol.record.value.ErrorType;
 import java.time.ZonedDateTime;
@@ -37,10 +36,10 @@ public final class ExpressionProcessor {
   private final VariableStateEvaluationContext evaluationContext;
 
   public ExpressionProcessor(
-      final ExpressionLanguage expressionLanguage, final VariablesState variablesState) {
+      final ExpressionLanguage expressionLanguage, final VariablesLookup lookup) {
     this.expressionLanguage = expressionLanguage;
 
-    evaluationContext = new VariableStateEvaluationContext(variablesState);
+    evaluationContext = new VariableStateEvaluationContext(lookup);
   }
 
   /**
@@ -370,12 +369,12 @@ public final class ExpressionProcessor {
 
     private final DirectBuffer variableNameBuffer = new UnsafeBuffer();
 
-    private final VariablesState variablesState;
+    private final VariablesLookup lookup;
 
     private long variableScopeKey;
 
-    public VariableStateEvaluationContext(final VariablesState variablesState) {
-      this.variablesState = variablesState;
+    public VariableStateEvaluationContext(final VariablesLookup lookup) {
+      this.lookup = lookup;
     }
 
     @Override
@@ -384,7 +383,13 @@ public final class ExpressionProcessor {
 
       variableNameBuffer.wrap(variableName.getBytes());
 
-      return variablesState.getVariable(variableScopeKey, variableNameBuffer);
+      return lookup.getVariable(variableScopeKey, variableNameBuffer);
     }
+  }
+
+  @FunctionalInterface
+  public interface VariablesLookup {
+
+    DirectBuffer getVariable(final long scopeKey, final DirectBuffer name);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/ExpressionProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/ExpressionProcessor.java
@@ -17,7 +17,10 @@ import io.zeebe.el.ResultType;
 import io.zeebe.engine.processor.workflow.message.MessageCorrelationKeyContext;
 import io.zeebe.engine.processor.workflow.message.MessageCorrelationKeyException;
 import io.zeebe.engine.state.instance.VariablesState;
+import io.zeebe.model.bpmn.util.time.Interval;
 import io.zeebe.protocol.record.value.ErrorType;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -25,6 +28,8 @@ import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public final class ExpressionProcessor {
+
+  private static final EvaluationContext EMPTY_EVALUATION_CONTEXT = x -> null;
 
   private final DirectBuffer resultView = new UnsafeBuffer();
 
@@ -56,6 +61,31 @@ public final class ExpressionProcessor {
             result -> typeCheck(result, ResultType.STRING, ErrorType.EXTRACT_VALUE_ERROR, context))
         .map(EvaluationResult::getString)
         .map(this::wrapResult);
+  }
+
+  /**
+   * Evaluates the given expression and returns the result as string. If the evaluation fails or the
+   * result is not a string then an exception is thrown.
+   *
+   * @param expression the expression to evaluate
+   * @param scopeKey the scope to load the variables from (a negative key is intended to imply an
+   *     empty variable context)
+   * @return the evaluation result as string
+   * @throws EvaluationException if expression evaluation failed
+   */
+  public String evaluateStringExpression(final Expression expression, final long scopeKey) {
+
+    final var evaluationResult = evaluateExpression(expression, scopeKey);
+    if (evaluationResult.isFailure()) {
+      throw new EvaluationException(evaluationResult.getFailureMessage());
+    }
+    if (!evaluationResult.getType().equals(ResultType.STRING)) {
+      throw new EvaluationException(
+          String.format(
+              "Expected result of the expression '%s' to be '%s', but was '%s'.",
+              evaluationResult.getExpression(), ResultType.STRING, evaluationResult.getType()));
+    }
+    return evaluationResult.getString();
   }
 
   /**
@@ -93,6 +123,74 @@ public final class ExpressionProcessor {
         .flatMap(
             result -> typeCheck(result, ResultType.BOOLEAN, ErrorType.EXTRACT_VALUE_ERROR, context))
         .map(EvaluationResult::getBoolean);
+  }
+
+  /**
+   * Evaluates the given expression and returns the result as an Interval. If the evaluation fails
+   * or the result is not an interval then an exception is thrown.
+   *
+   * @param expression the expression to evaluate
+   * @param scopeKey the scope to load the variables from (a negative key is intended to imply an
+   *     empty variable context)
+   * @return the evaluation result as interval
+   * @throws EvaluationException if expression evaluation failed
+   */
+  public Interval evaluateIntervalExpression(final Expression expression, final long scopeKey) {
+    final var result = evaluateExpression(expression, scopeKey);
+    if (result.isFailure()) {
+      throw new EvaluationException(result.getFailureMessage());
+    }
+    switch (result.getType()) {
+      case DURATION:
+        return new Interval(result.getDuration());
+      case PERIOD:
+        return new Interval(result.getPeriod());
+      case STRING:
+        try {
+          return Interval.parse(result.getString());
+        } catch (DateTimeParseException e) {
+          throw new EvaluationException(
+              String.format(
+                  "Expected result of the expression '%s' to be parsed to a duration, but was '%s'",
+                  expression.getExpression(), result.getString()),
+              e);
+        }
+      default:
+        final var expected = List.of(ResultType.DURATION, ResultType.PERIOD, ResultType.STRING);
+        throw new EvaluationException(
+            String.format(
+                "Expected result of the expression '%s' to be one of '%s', but was '%s'",
+                expression.getExpression(), expected, result.getType()));
+    }
+  }
+
+  /**
+   * Evaluates the given expression and returns the result as ZonedDateTime. If the evaluation fails
+   * or the result is not a ZonedDateTime then an exception is thrown.
+   *
+   * @param expression the expression to evaluate
+   * @param scopeKey the scope to load the variables from (a negative key is intended to imply an
+   *     empty variable context)
+   * @return the evaluation result as ZonedDateTime
+   * @throws EvaluationException if expression evaluation failed
+   */
+  public ZonedDateTime evaluateDateTimeExpression(
+      final Expression expression, final Long scopeKey) {
+    final var result = evaluateExpression(expression, scopeKey);
+    if (result.isFailure()) {
+      throw new EvaluationException(result.getFailureMessage());
+    }
+    if (result.getType() == ResultType.DATE_TIME) {
+      return result.getDateTime();
+    }
+    if (result.getType() == ResultType.STRING) {
+      return ZonedDateTime.parse(result.getString());
+    }
+    final var expected = List.of(ResultType.DATE_TIME, ResultType.STRING);
+    throw new EvaluationException(
+        String.format(
+            "Expected result of the expression '%s' to be one of '%s', but was '%s'",
+            expression.getExpression(), expected, result.getType()));
   }
 
   /**
@@ -198,14 +296,43 @@ public final class ExpressionProcessor {
   private EvaluationResult evaluateExpression(
       final Expression expression, final long variableScopeKey) {
 
-    evaluationContext.variableScopeKey = variableScopeKey;
+    final EvaluationContext context;
+    if (variableScopeKey < 0) {
+      context = EMPTY_EVALUATION_CONTEXT;
+    } else {
+      evaluationContext.variableScopeKey = variableScopeKey;
+      context = evaluationContext;
+    }
 
-    return expressionLanguage.evaluateExpression(expression, evaluationContext);
+    return expressionLanguage.evaluateExpression(expression, context);
   }
 
   private DirectBuffer wrapResult(final String result) {
     resultView.wrap(result.getBytes());
     return resultView;
+  }
+
+  public static final class EvaluationException extends RuntimeException {
+
+    public EvaluationException(final String message) {
+      super(message);
+    }
+
+    public EvaluationException(final String message, final Throwable cause) {
+      super(message, cause);
+    }
+
+    public EvaluationException(final Throwable cause) {
+      super(cause);
+    }
+
+    public EvaluationException(
+        final String message,
+        final Throwable cause,
+        final boolean enableSuppression,
+        final boolean writableStackTrace) {
+      super(message, cause, enableSuppression, writableStackTrace);
+    }
   }
 
   protected static final class CorrelationKeyResultHandler

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/WorkflowEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/WorkflowEventProcessors.java
@@ -67,7 +67,8 @@ public final class WorkflowEventProcessors {
 
     addMessageStreamProcessors(
         typedRecordProcessors, subscriptionState, subscriptionCommandSender, zeebeState);
-    addTimerStreamProcessors(typedRecordProcessors, timerChecker, zeebeState, catchEventBehavior);
+    addTimerStreamProcessors(
+        typedRecordProcessors, timerChecker, zeebeState, catchEventBehavior, expressionProcessor);
     addVariableDocumentStreamProcessors(typedRecordProcessors, zeebeState);
     addWorkflowInstanceCreationStreamProcessors(typedRecordProcessors, zeebeState);
 
@@ -124,7 +125,8 @@ public final class WorkflowEventProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final DueDateTimerChecker timerChecker,
       final ZeebeState zeebeState,
-      final CatchEventBehavior catchEventOutput) {
+      final CatchEventBehavior catchEventOutput,
+      final ExpressionProcessor expressionProcessor) {
     final WorkflowState workflowState = zeebeState.getWorkflowState();
 
     typedRecordProcessors
@@ -133,7 +135,7 @@ public final class WorkflowEventProcessors {
         .onCommand(
             ValueType.TIMER,
             TimerIntent.TRIGGER,
-            new TriggerTimerProcessor(zeebeState, catchEventOutput))
+            new TriggerTimerProcessor(zeebeState, catchEventOutput, expressionProcessor))
         .onCommand(ValueType.TIMER, TimerIntent.CANCEL, new CancelTimerProcessor(workflowState))
         .withListener(timerChecker);
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/DeploymentEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/DeploymentEventProcessors.java
@@ -12,6 +12,7 @@ import static io.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 import io.zeebe.engine.processor.TypedRecordProcessors;
 import io.zeebe.engine.processor.workflow.CatchEventBehavior;
 import io.zeebe.engine.processor.workflow.DeploymentResponder;
+import io.zeebe.engine.processor.workflow.ExpressionProcessor;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.deployment.WorkflowState;
 import io.zeebe.protocol.record.ValueType;
@@ -32,10 +33,11 @@ public final class DeploymentEventProcessors {
   public static void addTransformingDeploymentProcessor(
       final TypedRecordProcessors typedRecordProcessors,
       final ZeebeState zeebeState,
-      final CatchEventBehavior catchEventBehavior) {
-    typedRecordProcessors.onCommand(
-        ValueType.DEPLOYMENT,
-        CREATE,
-        new TransformingDeploymentCreateProcessor(zeebeState, catchEventBehavior));
+      final CatchEventBehavior catchEventBehavior,
+      final ExpressionProcessor expressionProcessor) {
+    final var processor =
+        new TransformingDeploymentCreateProcessor(
+            zeebeState, catchEventBehavior, expressionProcessor);
+    typedRecordProcessors.onCommand(ValueType.DEPLOYMENT, CREATE, processor);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/TransformingDeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/TransformingDeploymentCreateProcessor.java
@@ -16,12 +16,14 @@ import io.zeebe.engine.processor.TypedRecordProcessor;
 import io.zeebe.engine.processor.TypedResponseWriter;
 import io.zeebe.engine.processor.TypedStreamWriter;
 import io.zeebe.engine.processor.workflow.CatchEventBehavior;
+import io.zeebe.engine.processor.workflow.ExpressionProcessor;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableCatchEventElement;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableStartEvent;
 import io.zeebe.engine.processor.workflow.deployment.transform.DeploymentTransformer;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.deployment.WorkflowState;
 import io.zeebe.engine.state.instance.TimerInstance;
+import io.zeebe.model.bpmn.util.time.Timer;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.impl.record.value.deployment.Workflow;
 import io.zeebe.protocol.record.RejectionType;
@@ -34,19 +36,25 @@ import org.agrona.DirectBuffer;
 public final class TransformingDeploymentCreateProcessor
     implements TypedRecordProcessor<DeploymentRecord> {
 
-  public static final String DEPLOYMENT_ALREADY_EXISTS_MESSAGE =
+  private static final String DEPLOYMENT_ALREADY_EXISTS_MESSAGE =
       "Expected to create a new deployment with key '%d', but there is already an existing deployment with that key";
+  private static final String COULD_NOT_CREATE_TIMER_MESSAGE =
+      "Expected to create timer for start event, but encountered the following error: %s";
   private final DeploymentTransformer deploymentTransformer;
   private final WorkflowState workflowState;
   private final CatchEventBehavior catchEventBehavior;
   private final KeyGenerator keyGenerator;
+  private final ExpressionProcessor expressionProcessor;
 
   public TransformingDeploymentCreateProcessor(
-      final ZeebeState zeebeState, final CatchEventBehavior catchEventBehavior) {
+      final ZeebeState zeebeState,
+      final CatchEventBehavior catchEventBehavior,
+      final ExpressionProcessor expressionProcessor) {
     this.workflowState = zeebeState.getWorkflowState();
     this.keyGenerator = zeebeState.getKeyGenerator();
     this.deploymentTransformer = new DeploymentTransformer(zeebeState);
     this.catchEventBehavior = catchEventBehavior;
+    this.expressionProcessor = expressionProcessor;
   }
 
   @Override
@@ -61,10 +69,16 @@ public final class TransformingDeploymentCreateProcessor
     if (accepted) {
       final long key = keyGenerator.nextKey();
       if (workflowState.putDeployment(key, deploymentEvent)) {
+        try {
+          createTimerIfTimerStartEvent(command, streamWriter);
+        } catch (RuntimeException e) {
+          final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
+          responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
+          streamWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, reason);
+          return;
+        }
         responseWriter.writeEventOnCommand(key, DeploymentIntent.CREATED, deploymentEvent, command);
         streamWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
-
-        createTimerIfTimerStartEvent(command, streamWriter);
       } else {
         // should not be possible
         final String reason = String.format(DEPLOYMENT_ALREADY_EXISTS_MESSAGE, key);
@@ -96,12 +110,16 @@ public final class TransformingDeploymentCreateProcessor
         if (startEvent.isTimer()) {
           hasAtLeastOneTimer = true;
 
+          // There are no variables when there is no process instance yet,
+          // we use a negative scope key to indicate this
+          final long scopeKey = -1L;
+          final Timer timer = startEvent.getTimerFactory().apply(expressionProcessor, scopeKey);
           catchEventBehavior.subscribeToTimerEvent(
               NO_ELEMENT_INSTANCE,
               NO_ELEMENT_INSTANCE,
               workflow.getKey(),
               startEvent.getId(),
-              startEvent.getTimer(),
+              timer,
               streamWriter);
         }
       }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/TransformingDeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/TransformingDeploymentCreateProcessor.java
@@ -52,7 +52,7 @@ public final class TransformingDeploymentCreateProcessor
       final ExpressionProcessor expressionProcessor) {
     this.workflowState = zeebeState.getWorkflowState();
     this.keyGenerator = zeebeState.getKeyGenerator();
-    this.deploymentTransformer = new DeploymentTransformer(zeebeState);
+    this.deploymentTransformer = new DeploymentTransformer(zeebeState, expressionProcessor);
     this.catchEventBehavior = catchEventBehavior;
     this.expressionProcessor = expressionProcessor;
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/BpmnFactory.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/BpmnFactory.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.processor.workflow.deployment.model;
 
 import io.zeebe.el.ExpressionLanguage;
 import io.zeebe.el.ExpressionLanguageFactory;
+import io.zeebe.engine.processor.workflow.ExpressionProcessor;
 import io.zeebe.engine.processor.workflow.deployment.model.transformation.BpmnTransformer;
 import io.zeebe.engine.processor.workflow.deployment.transform.BpmnValidator;
 
@@ -18,8 +19,8 @@ public final class BpmnFactory {
     return new BpmnTransformer(createExpressionLanguage());
   }
 
-  public static BpmnValidator createValidator() {
-    return new BpmnValidator(createExpressionLanguage());
+  public static BpmnValidator createValidator(final ExpressionProcessor expressionProcessor) {
+    return new BpmnValidator(createExpressionLanguage(), expressionProcessor);
   }
 
   private static ExpressionLanguage createExpressionLanguage() {

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableCatchEvent.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableCatchEvent.java
@@ -7,7 +7,9 @@
  */
 package io.zeebe.engine.processor.workflow.deployment.model.element;
 
+import io.zeebe.engine.processor.workflow.ExpressionProcessor;
 import io.zeebe.model.bpmn.util.time.Timer;
+import java.util.function.BiFunction;
 
 public interface ExecutableCatchEvent extends ExecutableFlowElement {
 
@@ -27,7 +29,7 @@ public interface ExecutableCatchEvent extends ExecutableFlowElement {
     return true;
   }
 
-  Timer getTimer();
+  BiFunction<ExpressionProcessor, Long, Timer> getTimerFactory();
 
   ExecutableError getError();
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableCatchEventElement.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableCatchEventElement.java
@@ -7,10 +7,12 @@
  */
 package io.zeebe.engine.processor.workflow.deployment.model.element;
 
+import io.zeebe.engine.processor.workflow.ExpressionProcessor;
 import io.zeebe.model.bpmn.util.time.Timer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BiFunction;
 import org.agrona.DirectBuffer;
 
 public class ExecutableCatchEventElement extends ExecutableFlowNode
@@ -18,9 +20,9 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
   private final List<ExecutableCatchEvent> events = Collections.singletonList(this);
 
   private ExecutableMessage message;
-  private Timer timer;
   private ExecutableError error;
   private boolean interrupting;
+  private BiFunction<ExpressionProcessor, Long, Timer> timerFactory;
 
   public ExecutableCatchEventElement(final String id) {
     super(id);
@@ -28,7 +30,7 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
 
   @Override
   public boolean isTimer() {
-    return timer != null;
+    return timerFactory != null;
   }
 
   @Override
@@ -51,12 +53,12 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
   }
 
   @Override
-  public Timer getTimer() {
-    return timer;
+  public BiFunction<ExpressionProcessor, Long, Timer> getTimerFactory() {
+    return timerFactory;
   }
 
-  public void setTimer(final Timer timer) {
-    this.timer = timer;
+  public void setTimerFactory(final BiFunction<ExpressionProcessor, Long, Timer> timerFactory) {
+    this.timerFactory = timerFactory;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableReceiveTask.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableReceiveTask.java
@@ -7,7 +7,9 @@
  */
 package io.zeebe.engine.processor.workflow.deployment.model.element;
 
-import io.zeebe.model.bpmn.util.time.RepeatingInterval;
+import io.zeebe.engine.processor.workflow.ExpressionProcessor;
+import io.zeebe.model.bpmn.util.time.Timer;
+import java.util.function.BiFunction;
 
 public class ExecutableReceiveTask extends ExecutableActivity implements ExecutableCatchEvent {
 
@@ -41,8 +43,8 @@ public class ExecutableReceiveTask extends ExecutableActivity implements Executa
   }
 
   @Override
-  public RepeatingInterval getTimer() {
-    return null;
+  public BiFunction<ExpressionProcessor, Long, Timer> getTimerFactory() {
+    return (expressionProcessor, context) -> null;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ProcessTimerStartEventExpressionValidator.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ProcessTimerStartEventExpressionValidator.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.deployment.model.validation;
+
+import io.zeebe.el.Expression;
+import io.zeebe.el.ExpressionLanguage;
+import io.zeebe.engine.processor.workflow.ExpressionProcessor;
+import io.zeebe.model.bpmn.instance.Process;
+import io.zeebe.model.bpmn.instance.StartEvent;
+import io.zeebe.model.bpmn.instance.TimerEventDefinition;
+import io.zeebe.model.bpmn.util.time.RepeatingInterval;
+import io.zeebe.model.bpmn.util.time.TimeDateTimer;
+import io.zeebe.model.bpmn.util.time.Timer;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ProcessTimerStartEventExpressionValidator
+    implements ModelElementValidator<StartEvent> {
+
+  private static final String ERROR_MESSAGE_TEMPLATE =
+      "Expected a valid timer expression for start event, but encountered the following error: %s";
+  private final ExpressionLanguage expressionLanguage;
+  private final ExpressionProcessor expressionProcessor;
+
+  public ProcessTimerStartEventExpressionValidator(
+      final ExpressionLanguage expressionLanguage, final ExpressionProcessor expressionProcessor) {
+    this.expressionLanguage = expressionLanguage;
+    this.expressionProcessor = expressionProcessor;
+  }
+
+  @Override
+  public Class<StartEvent> getElementType() {
+    return StartEvent.class;
+  }
+
+  @Override
+  public void validate(
+      final StartEvent element, final ValidationResultCollector validationResultCollector) {
+    if (!(element.getScope() instanceof Process)) {
+      return;
+    }
+    element.getEventDefinitions().stream()
+        .filter(TimerEventDefinition.class::isInstance)
+        .map(TimerEventDefinition.class::cast)
+        .forEach(definition -> validation(definition, validationResultCollector));
+  }
+
+  private void validation(
+      final TimerEventDefinition timerEventDefinition,
+      final ValidationResultCollector validationResultCollector) {
+    try {
+      final var timer = tryEvaluateTimer(timerEventDefinition);
+    } catch (RuntimeException e) {
+      validationResultCollector.addError(0, String.format(ERROR_MESSAGE_TEMPLATE, e.getMessage()));
+    }
+  }
+
+  /**
+   * Try to create a timer from the timer event definition by evaluating its time expression.
+   *
+   * @param timerEventDefinition The definition specifying the timer expression to evaluate
+   * @throws RuntimeException when the expression could not be evaluated or when the expression
+   *     result could not be used to create a timer.
+   */
+  private Timer tryEvaluateTimer(final TimerEventDefinition timerEventDefinition) {
+    // There are no variables when there is no process instance yet,
+    // we use a negative scope key to indicate this
+    final long scopeKey = -1;
+    final Expression expression;
+    if (timerEventDefinition.getTimeDuration() != null) {
+      final String duration = timerEventDefinition.getTimeDuration().getTextContent();
+      expression = expressionLanguage.parseExpression(duration);
+      return new RepeatingInterval(
+          1, expressionProcessor.evaluateIntervalExpression(expression, scopeKey));
+
+    } else if (timerEventDefinition.getTimeCycle() != null) {
+      final String cycle = timerEventDefinition.getTimeCycle().getTextContent();
+      expression = expressionLanguage.parseExpression(cycle);
+      return RepeatingInterval.parse(
+          expressionProcessor.evaluateStringExpression(expression, scopeKey));
+
+    } else if (timerEventDefinition.getTimeDate() != null) {
+      final String timeDate = timerEventDefinition.getTimeDate().getTextContent();
+      expression = expressionLanguage.parseExpression(timeDate);
+      return new TimeDateTimer(
+          expressionProcessor.evaluateDateTimeExpression(expression, scopeKey));
+    }
+    throw new IllegalStateException(
+        "Expected timer event to have a time duration, time cycle or time date definition, but found none");
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/transform/BpmnValidator.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/transform/BpmnValidator.java
@@ -8,6 +8,7 @@
 package io.zeebe.engine.processor.workflow.deployment.transform;
 
 import io.zeebe.el.ExpressionLanguage;
+import io.zeebe.engine.processor.workflow.ExpressionProcessor;
 import io.zeebe.engine.processor.workflow.deployment.model.validation.ZeebeRuntimeValidators;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.model.bpmn.traversal.ModelWalker;
@@ -23,10 +24,12 @@ public final class BpmnValidator {
 
   private final ValidationErrorFormatter formatter = new ValidationErrorFormatter();
 
-  public BpmnValidator(final ExpressionLanguage expressionLanguage) {
+  public BpmnValidator(
+      final ExpressionLanguage expressionLanguage, final ExpressionProcessor expressionProcessor) {
     designTimeAspectValidator = new ValidationVisitor(ZeebeDesignTimeValidators.VALIDATORS);
     runtimeAspectValidator =
-        new ValidationVisitor(ZeebeRuntimeValidators.getValidators(expressionLanguage));
+        new ValidationVisitor(
+            ZeebeRuntimeValidators.getValidators(expressionLanguage, expressionProcessor));
   }
 
   public String validate(final BpmnModelInstance modelInstance) {

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/transform/DeploymentTransformer.java
@@ -11,6 +11,7 @@ import static io.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.zeebe.engine.Loggers;
 import io.zeebe.engine.processor.KeyGenerator;
+import io.zeebe.engine.processor.workflow.ExpressionProcessor;
 import io.zeebe.engine.processor.workflow.deployment.model.BpmnFactory;
 import io.zeebe.engine.processor.workflow.deployment.model.yaml.BpmnYamlParser;
 import io.zeebe.engine.state.ZeebeState;
@@ -39,7 +40,7 @@ import org.slf4j.Logger;
 public final class DeploymentTransformer {
   private static final Logger LOG = Loggers.WORKFLOW_PROCESSOR_LOGGER;
 
-  private final BpmnValidator validator = BpmnFactory.createValidator();
+  private final BpmnValidator validator;
   private final BpmnYamlParser yamlParser = new BpmnYamlParser();
   private final WorkflowState workflowState;
   private final KeyGenerator keyGenerator;
@@ -50,9 +51,11 @@ public final class DeploymentTransformer {
   private RejectionType rejectionType;
   private String rejectionReason;
 
-  public DeploymentTransformer(final ZeebeState zeebeState) {
+  public DeploymentTransformer(
+      final ZeebeState zeebeState, final ExpressionProcessor expressionProcessor) {
     workflowState = zeebeState.getWorkflowState();
     keyGenerator = zeebeState.getKeyGenerator();
+    validator = BpmnFactory.createValidator(expressionProcessor);
 
     try {
       digestGenerator = MessageDigest.getInstance("MD5");

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/CatchEventSubscriber.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/CatchEventSubscriber.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.processor.workflow.handlers;
 
 import io.zeebe.engine.processor.workflow.BpmnStepContext;
 import io.zeebe.engine.processor.workflow.CatchEventBehavior;
+import io.zeebe.engine.processor.workflow.ExpressionProcessor.EvaluationException;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableCatchEventSupplier;
 import io.zeebe.engine.processor.workflow.message.MessageCorrelationKeyException;
 import io.zeebe.protocol.record.value.ErrorType;
@@ -28,6 +29,8 @@ public final class CatchEventSubscriber {
     } catch (final MessageCorrelationKeyException e) {
       context.raiseIncident(
           ErrorType.EXTRACT_VALUE_ERROR, e.getContext().getVariablesScopeKey(), e.getMessage());
+    } catch (final EvaluationException e) {
+      context.raiseIncident(ErrorType.EXTRACT_VALUE_ERROR, e.getMessage());
     }
 
     return false;

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/timer/TriggerTimerProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/timer/TriggerTimerProcessor.java
@@ -13,11 +13,14 @@ import io.zeebe.engine.processor.TypedResponseWriter;
 import io.zeebe.engine.processor.TypedStreamWriter;
 import io.zeebe.engine.processor.workflow.CatchEventBehavior;
 import io.zeebe.engine.processor.workflow.EventHandle;
+import io.zeebe.engine.processor.workflow.ExpressionProcessor;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableCatchEvent;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.deployment.WorkflowState;
 import io.zeebe.engine.state.instance.TimerInstance;
+import io.zeebe.model.bpmn.util.time.Interval;
 import io.zeebe.model.bpmn.util.time.RepeatingInterval;
+import io.zeebe.model.bpmn.util.time.Timer;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.TimerIntent;
@@ -36,10 +39,14 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
   private final CatchEventBehavior catchEventBehavior;
   private final WorkflowState workflowState;
   private final EventHandle eventHandle;
+  private final ExpressionProcessor expressionProcessor;
 
   public TriggerTimerProcessor(
-      final ZeebeState zeebeState, final CatchEventBehavior catchEventBehavior) {
+      final ZeebeState zeebeState,
+      final CatchEventBehavior catchEventBehavior,
+      final ExpressionProcessor expressionProcessor) {
     this.catchEventBehavior = catchEventBehavior;
+    this.expressionProcessor = expressionProcessor;
     workflowState = zeebeState.getWorkflowState();
 
     eventHandle =
@@ -123,12 +130,16 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
 
   private void rescheduleTimer(
       final TimerRecord record, final TypedStreamWriter writer, final ExecutableCatchEvent event) {
-    if (event.getTimer() == null) {
+    final Timer timer;
+    try {
+      timer = event.getTimerFactory().apply(expressionProcessor, record.getElementInstanceKey());
+    } catch (Exception e) {
       final String message =
           String.format(
-              "Expected to reschedule repeating timer for element with id '%s', but no timer definition was found",
+              "Expected to reschedule repeating timer for element with id '%s', but an exception occurred",
               BufferUtil.bufferAsString(event.getId()));
-      throw new IllegalStateException(message);
+      throw new IllegalStateException(message, e);
+      // todo(#4208): raise incident instead of throwing an exception
     }
 
     int repetitions = record.getRepetitions();
@@ -136,14 +147,14 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
       repetitions--;
     }
 
-    final RepeatingInterval timer =
-        new RepeatingInterval(repetitions, event.getTimer().getInterval());
+    final Interval interval = timer.getInterval();
+    final Timer repeatingInterval = new RepeatingInterval(repetitions, interval);
     catchEventBehavior.subscribeToTimerEvent(
         record.getElementInstanceKey(),
         record.getWorkflowInstanceKey(),
         record.getWorkflowKey(),
         event.getId(),
-        timer,
+        repeatingInterval,
         writer);
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/WorkflowInstanceStreamProcessorRule.java
@@ -103,10 +103,12 @@ public final class WorkflowInstanceStreamProcessorRule extends ExternalResource
           actor = processingContext.getActor();
           workflowState = zeebeState.getWorkflowState();
 
+          final var variablesState =
+              zeebeState.getWorkflowState().getElementInstanceState().getVariablesState();
           final ExpressionProcessor expressionProcessor =
               new ExpressionProcessor(
                   ExpressionLanguageFactory.createExpressionLanguage(),
-                  zeebeState.getWorkflowState().getElementInstanceState().getVariablesState());
+                  variablesState::getVariable);
 
           WorkflowEventProcessors.addWorkflowProcessors(
               zeebeState,

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/boundary/BoundaryEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/boundary/BoundaryEventTest.java
@@ -48,7 +48,7 @@ public final class BoundaryEventTest {
           .serviceTask("task", b -> b.zeebeJobType("type"))
           .boundaryEvent("timer")
           .cancelActivity(true)
-          .timerWithDuration("PT0.1S")
+          .timerWithDurationExpression("duration(\"PT0.1S\")")
           .endEvent("end1")
           .moveToNode("timer")
           .endEvent("end2")
@@ -61,7 +61,7 @@ public final class BoundaryEventTest {
           .serviceTask("task", b -> b.zeebeJobType("type"))
           .boundaryEvent("event")
           .cancelActivity(false)
-          .timerWithCycle("R/PT1S")
+          .timerWithCycleExpression("cycle(duration(\"PT1S\"))")
           .endEvent()
           .done();
 

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/CreateDeploymentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/CreateDeploymentTest.java
@@ -561,6 +561,28 @@ public final class CreateDeploymentTest {
                 + "Duplicated process id in resources 'p2.bpmn' and 'p3.bpmn'");
   }
 
+  @Test
+  public void shouldRejectDeploymentWithInvalidTimerStartEventExpression() {
+    // given
+    final BpmnModelInstance definition =
+        Bpmn.createExecutableProcess("process1")
+            .startEvent()
+            .timerWithCycleExpression("INVALID_CYCLE_EXPRESSION")
+            .done();
+
+    // when
+    final Record<DeploymentRecordValue> deploymentRejection =
+        ENGINE.deployment().withXmlResource("p1.bpmn", definition).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(deploymentRejection)
+        .hasRejectionType(RejectionType.PROCESSING_ERROR)
+        .hasRejectionReason(
+            "Expected to create timer for start event, but encountered the following error: "
+                + "failed to evaluate expression 'INVALID_CYCLE_EXPRESSION': "
+                + "no variable found for name 'INVALID_CYCLE_EXPRESSION'");
+  }
+
   private DeployedWorkflow findWorkflow(
       final List<DeployedWorkflow> workflows, final String processId) {
     return workflows.stream()

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/CreateDeploymentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/CreateDeploymentTest.java
@@ -566,7 +566,7 @@ public final class CreateDeploymentTest {
     // given
     final BpmnModelInstance definition =
         Bpmn.createExecutableProcess("process1")
-            .startEvent()
+            .startEvent("start-event-1")
             .timerWithCycleExpression("INVALID_CYCLE_EXPRESSION")
             .done();
 
@@ -576,11 +576,14 @@ public final class CreateDeploymentTest {
 
     // then
     Assertions.assertThat(deploymentRejection)
-        .hasRejectionType(RejectionType.PROCESSING_ERROR)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
-            "Expected to create timer for start event, but encountered the following error: "
-                + "failed to evaluate expression 'INVALID_CYCLE_EXPRESSION': "
-                + "no variable found for name 'INVALID_CYCLE_EXPRESSION'");
+            "Expected to deploy new resources, but encountered the following errors:\n"
+                + "'p1.bpmn': - Element: start-event-1\n"
+                + "    - ERROR: Expected a valid timer expression for start event, "
+                + "but encountered the following error: failed to evaluate expression "
+                + "'INVALID_CYCLE_EXPRESSION': no variable found for name "
+                + "'INVALID_CYCLE_EXPRESSION'\n");
   }
 
   private DeployedWorkflow findWorkflow(

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/TransformingDeploymentCreateProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/TransformingDeploymentCreateProcessorTest.java
@@ -76,7 +76,8 @@ public final class TransformingDeploymentCreateProcessorTest {
               typedRecordProcessors,
               zeebeState,
               new CatchEventBehavior(
-                  zeebeState, expressionProcessor, mockSubscriptionCommandSender, 1));
+                  zeebeState, expressionProcessor, mockSubscriptionCommandSender, 1),
+              expressionProcessor);
           return typedRecordProcessors;
         });
   }

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/TransformingDeploymentCreateProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/TransformingDeploymentCreateProcessorTest.java
@@ -67,10 +67,11 @@ public final class TransformingDeploymentCreateProcessorTest {
           final var zeebeState = processingContext.getZeebeState();
           workflowState = zeebeState.getWorkflowState();
 
+          final var variablesState = workflowState.getElementInstanceState().getVariablesState();
           final ExpressionProcessor expressionProcessor =
               new ExpressionProcessor(
                   ExpressionLanguageFactory.createExpressionLanguage(),
-                  zeebeState.getWorkflowState().getElementInstanceState().getVariablesState());
+                  variablesState::getVariable);
 
           DeploymentEventProcessors.addTransformingDeploymentProcessor(
               typedRecordProcessors,

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/IncidentStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/IncidentStreamProcessorRule.java
@@ -80,10 +80,11 @@ public final class IncidentStreamProcessorRule extends ExternalResource {
           zeebeState = processingContext.getZeebeState();
           workflowState = zeebeState.getWorkflowState();
 
+          final var variablesState = workflowState.getElementInstanceState().getVariablesState();
           final ExpressionProcessor expressionProcessor =
               new ExpressionProcessor(
                   ExpressionLanguageFactory.createExpressionLanguage(),
-                  zeebeState.getWorkflowState().getElementInstanceState().getVariablesState());
+                  variablesState::getVariable);
 
           final BpmnStepProcessor stepProcessor =
               WorkflowEventProcessors.addWorkflowProcessors(

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/TimerIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/incident/TimerIncidentTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.record.Assertions;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.intent.IncidentIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.ErrorType;
+import io.zeebe.protocol.record.value.IncidentRecordValue;
+import io.zeebe.protocol.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.test.util.BrokerClassRuleHelper;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.Collections;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class TimerIncidentTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String ELEMENT_ID = "timer-1";
+  private static final String DURATION_VARIABLE = "timer_duration";
+  private static final String DURATION_EXPRESSION = "duration(" + DURATION_VARIABLE + ")";
+  private static final String CYCLE_EXPRESSION = "cycle(" + DURATION_EXPRESSION + ")";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  private static BpmnModelInstance createWorkflow(final String expression) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .intermediateCatchEvent(ELEMENT_ID, b -> b.timerWithDurationExpression(expression))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance createWorkflowWithCycle(final String expression) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .serviceTask(
+            ELEMENT_ID,
+            serviceTaskBuilder ->
+                serviceTaskBuilder
+                    .zeebeJobTypeExpression("boundary_timer_test")
+                    .boundaryEvent(
+                        "boundary-event-1",
+                        timerBoundaryEventBuilder ->
+                            timerBoundaryEventBuilder
+                                .cancelActivity(false)
+                                .timerWithCycleExpression(expression)
+                                .endEvent("boundary-timer-end-event")))
+        .endEvent()
+        .done();
+  }
+
+  @Test
+  public void shouldCreateIncidentIfDurationVariableNotFound() {
+    // when
+    ENGINE.deployment().withXmlResource(createWorkflow(DURATION_EXPRESSION)).deploy();
+    final long workflowInstanceKey = ENGINE.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .getFirst();
+
+    final Record<WorkflowInstanceRecordValue> elementInstance =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementId(ELEMENT_ID)
+            .getFirst();
+
+    Assertions.assertThat(incident.getValue())
+        .hasElementInstanceKey(elementInstance.getKey())
+        .hasElementId(elementInstance.getValue().getElementId())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "failed to evaluate expression '"
+                + DURATION_EXPRESSION
+                + "': no variable found for name '"
+                + DURATION_VARIABLE
+                + "'");
+  }
+
+  @Test
+  public void shouldCreateIncidentIfDurationVariableNotADuration() {
+    // when
+    ENGINE.deployment().withXmlResource(createWorkflow(DURATION_VARIABLE)).deploy();
+    final long workflowInstanceKey =
+        ENGINE
+            .workflowInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable(DURATION_VARIABLE, "not_a_duration_expression")
+            .create();
+
+    // then
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .getFirst();
+
+    final Record<WorkflowInstanceRecordValue> elementInstance =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementId(ELEMENT_ID)
+            .getFirst();
+
+    Assertions.assertThat(incident.getValue())
+        .hasElementInstanceKey(elementInstance.getKey())
+        .hasElementId(elementInstance.getValue().getElementId())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "Expected result of the expression '"
+                + DURATION_VARIABLE
+                + "' to be parsed to a duration, but was 'not_a_duration_expression'");
+  }
+
+  @Test
+  public void shouldCreateIncidentIfCycleExpressionCannotBeEvaluated() {
+    // when
+    ENGINE.deployment().withXmlResource(createWorkflowWithCycle(CYCLE_EXPRESSION)).deploy();
+    final long workflowInstanceKey =
+        ENGINE
+            .workflowInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable(DURATION_VARIABLE, "not_a_duration_expression")
+            .create();
+
+    // then
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .getFirst();
+
+    final Record<WorkflowInstanceRecordValue> elementInstance =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementId(ELEMENT_ID)
+            .getFirst();
+
+    Assertions.assertThat(incident.getValue())
+        .hasElementInstanceKey(elementInstance.getKey())
+        .hasElementId(elementInstance.getValue().getElementId())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "failed to evaluate expression '"
+                + CYCLE_EXPRESSION
+                + "': cycle function expected an interval (duration) parameter, but found 'ValNull'");
+  }
+
+  @Test
+  public void shouldResolveIncident() {
+    // given
+    ENGINE.deployment().withXmlResource(createWorkflow(DURATION_EXPRESSION)).deploy();
+    final long workflowInstanceKey = ENGINE.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .getFirst();
+
+    // when
+    ENGINE
+        .variables()
+        .ofScope(incident.getValue().getVariableScopeKey())
+        .withDocument(Collections.singletonMap(DURATION_VARIABLE, Duration.ofSeconds(1).toString()))
+        .update();
+
+    ENGINE.incident().ofInstance(workflowInstanceKey).withKey(incident.getKey()).resolve();
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withRecordKey(incident.getValue().getElementInstanceKey())
+                .limit(2))
+        .extracting(Record::getIntent)
+        .contains(WorkflowInstanceIntent.ELEMENT_ACTIVATED);
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/CreateWorkflowInstanceProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/CreateWorkflowInstanceProcessorTest.java
@@ -13,9 +13,12 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.zeebe.el.ExpressionLanguageFactory;
 import io.zeebe.engine.processor.CommandProcessorTestCase;
 import io.zeebe.engine.processor.KeyGenerator;
 import io.zeebe.engine.processor.TypedRecord;
+import io.zeebe.engine.processor.workflow.ExpressionProcessor;
+import io.zeebe.engine.processor.workflow.ExpressionProcessor.VariablesLookup;
 import io.zeebe.engine.processor.workflow.deployment.transform.DeploymentTransformer;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.deployment.DeployedWorkflow;
@@ -66,8 +69,12 @@ public final class CreateWorkflowInstanceProcessorTest
 
   @BeforeClass
   public static void init() {
+    final VariablesLookup emptyLookup = (variable, scopeKey) -> null;
+    final var expressionProcessor =
+        new ExpressionProcessor(ExpressionLanguageFactory.createExpressionLanguage(), emptyLookup);
     transformer =
-        new DeploymentTransformer(CommandProcessorTestCase.ZEEBE_STATE_RULE.getZeebeState());
+        new DeploymentTransformer(
+            CommandProcessorTestCase.ZEEBE_STATE_RULE.getZeebeState(), expressionProcessor);
   }
 
   @Before

--- a/expression-language/src/main/java/io/zeebe/el/EvaluationResult.java
+++ b/expression-language/src/main/java/io/zeebe/el/EvaluationResult.java
@@ -7,6 +7,9 @@
  */
 package io.zeebe.el;
 
+import java.time.Duration;
+import java.time.Period;
+import java.time.ZonedDateTime;
 import java.util.List;
 import org.agrona.DirectBuffer;
 
@@ -56,6 +59,27 @@ public interface EvaluationResult {
    * @return the evaluation result, or {@code null} if it is not a number
    */
   Number getNumber();
+
+  /**
+   * Use {@link #getType()} to check if the result is of the type {@link ResultType#DURATION}.
+   *
+   * @return the evaluation result, or {@code null} if it is not a duration
+   */
+  Duration getDuration();
+
+  /**
+   * Use {@link #getType()} to check if the result is of the type {@link ResultType#PERIOD}.
+   *
+   * @return the evaluation result, or {@code null} if it is not a period
+   */
+  Period getPeriod();
+
+  /**
+   * Use {@link #getType()} to check if the result is of the type {@link ResultType#DATE_TIME}.
+   *
+   * @return the evaluation result, or {@code null} if it is not a date time
+   */
+  ZonedDateTime getDateTime();
 
   /**
    * Use {@link #getType()} to check if the result is of the type {@link ResultType#ARRAY}.

--- a/expression-language/src/main/java/io/zeebe/el/ResultType.java
+++ b/expression-language/src/main/java/io/zeebe/el/ResultType.java
@@ -13,7 +13,9 @@ public enum ResultType {
   BOOLEAN,
   NUMBER,
   STRING,
-
+  DURATION,
+  PERIOD,
+  DATE_TIME,
   ARRAY,
   OBJECT
 }

--- a/expression-language/src/main/java/io/zeebe/el/impl/EvaluationFailure.java
+++ b/expression-language/src/main/java/io/zeebe/el/impl/EvaluationFailure.java
@@ -10,6 +10,9 @@ package io.zeebe.el.impl;
 import io.zeebe.el.EvaluationResult;
 import io.zeebe.el.Expression;
 import io.zeebe.el.ResultType;
+import java.time.Duration;
+import java.time.Period;
+import java.time.ZonedDateTime;
 import java.util.List;
 import org.agrona.DirectBuffer;
 
@@ -60,6 +63,21 @@ public final class EvaluationFailure implements EvaluationResult {
 
   @Override
   public Number getNumber() {
+    return null;
+  }
+
+  @Override
+  public Duration getDuration() {
+    return null;
+  }
+
+  @Override
+  public Period getPeriod() {
+    return null;
+  }
+
+  @Override
+  public ZonedDateTime getDateTime() {
     return null;
   }
 

--- a/expression-language/src/main/java/io/zeebe/el/impl/StaticExpression.java
+++ b/expression-language/src/main/java/io/zeebe/el/impl/StaticExpression.java
@@ -13,6 +13,9 @@ import io.zeebe.el.EvaluationResult;
 import io.zeebe.el.Expression;
 import io.zeebe.el.ResultType;
 import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Period;
+import java.time.ZonedDateTime;
 import java.util.List;
 import org.agrona.DirectBuffer;
 
@@ -96,6 +99,21 @@ public final class StaticExpression implements Expression, EvaluationResult {
   @Override
   public Number getNumber() {
     return getType() == ResultType.NUMBER ? (Number) result : null;
+  }
+
+  @Override
+  public Duration getDuration() {
+    return null;
+  }
+
+  @Override
+  public Period getPeriod() {
+    return null;
+  }
+
+  @Override
+  public ZonedDateTime getDateTime() {
+    return null;
   }
 
   @Override

--- a/expression-language/src/main/scala/io/zeebe/el/impl/feel/FeelEvaluationResult.scala
+++ b/expression-language/src/main/scala/io/zeebe/el/impl/feel/FeelEvaluationResult.scala
@@ -7,6 +7,7 @@
  */
 package io.zeebe.el.impl.feel
 
+import java.time.{Duration, Period, ZoneId, ZonedDateTime}
 import java.{lang, util}
 
 import io.zeebe.el.{EvaluationResult, Expression, ResultType}
@@ -35,6 +36,10 @@ class FeelEvaluationResult(
     case _: ValString => ResultType.STRING
     case _: ValList => ResultType.ARRAY
     case _: ValContext => ResultType.OBJECT
+    case _: ValDayTimeDuration => ResultType.DURATION
+    case _: ValYearMonthDuration => ResultType.PERIOD
+    case _: ValDateTime => ResultType.DATE_TIME
+    case _: ValLocalDateTime => ResultType.DATE_TIME
     case _ => null
   }
 
@@ -52,6 +57,22 @@ class FeelEvaluationResult(
 
   override def getNumber: Number = result match {
     case ValNumber(number) => number
+    case _ => null
+  }
+
+  override def getDuration: Duration = result match {
+    case ValDayTimeDuration(duration) => duration
+    case _ => null
+  }
+
+  override def getPeriod: Period = result match {
+    case ValYearMonthDuration(period) => period
+    case _ => null
+  }
+
+  override def getDateTime: ZonedDateTime = result match {
+    case ValDateTime(dateTime) => dateTime
+    case ValLocalDateTime(dateTime) => dateTime.atZone(ZoneId.systemDefault())
     case _ => null
   }
 

--- a/expression-language/src/test/java/io/zeebe/el/EvaluationResultTest.java
+++ b/expression-language/src/test/java/io/zeebe/el/EvaluationResultTest.java
@@ -121,6 +121,21 @@ public class EvaluationResultTest {
   }
 
   @Test
+  public void localDateTimeExpression() {
+    final var evaluationResult = evaluateExpression("=date and time(\"2020-04-01T10:31:10\")");
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.DATE_TIME);
+    assertThat(evaluationResult.getDuration()).isNull();
+    assertThat(evaluationResult.getPeriod()).isNull();
+    assertThat(evaluationResult.getDateTime())
+        .isEqualTo(LocalDateTime.of(2020, 4, 1, 10, 31, 10).atZone(ZoneId.systemDefault()));
+    assertThat(evaluationResult.getBoolean()).isNull();
+    assertThat(evaluationResult.getString()).isNull();
+    assertThat(evaluationResult.getNumber()).isNull();
+    assertThat(evaluationResult.getList()).isNull();
+  }
+
+  @Test
   public void nullExpression() {
     final var evaluationResult = evaluateExpression("=null");
 

--- a/expression-language/src/test/java/io/zeebe/el/EvaluationResultTest.java
+++ b/expression-language/src/test/java/io/zeebe/el/EvaluationResultTest.java
@@ -10,6 +10,10 @@ package io.zeebe.el;
 import static io.zeebe.test.util.MsgPackUtil.asMsgPack;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
@@ -27,6 +31,8 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getString()).isEqualTo("x");
     assertThat(evaluationResult.getBoolean()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
+    assertThat(evaluationResult.getPeriod()).isNull();
+    assertThat(evaluationResult.getDuration()).isNull();
     assertThat(evaluationResult.getList()).isNull();
   }
 
@@ -38,6 +44,8 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getString()).isEqualTo("x");
     assertThat(evaluationResult.getBoolean()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
+    assertThat(evaluationResult.getPeriod()).isNull();
+    assertThat(evaluationResult.getDuration()).isNull();
     assertThat(evaluationResult.getList()).isNull();
     assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("\"x\""));
   }
@@ -50,8 +58,10 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getNumber()).isEqualTo(1L);
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getBoolean()).isNull();
-    assertThat(evaluationResult.getList()).isNull();
+    assertThat(evaluationResult.getPeriod()).isNull();
+    assertThat(evaluationResult.getDuration()).isNull();
     assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("1"));
+    assertThat(evaluationResult.getList()).isNull();
   }
 
   @Test
@@ -62,8 +72,52 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getBoolean()).isTrue();
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
+    assertThat(evaluationResult.getPeriod()).isNull();
+    assertThat(evaluationResult.getDuration()).isNull();
     assertThat(evaluationResult.getList()).isNull();
     assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("true"));
+  }
+
+  @Test
+  public void durationExpression() {
+    final var evaluationResult = evaluateExpression("=duration(\"PT2H\")");
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.DURATION);
+    assertThat(evaluationResult.getDuration()).isEqualTo(Duration.ofHours(2));
+    assertThat(evaluationResult.getPeriod()).isNull();
+    assertThat(evaluationResult.getBoolean()).isNull();
+    assertThat(evaluationResult.getString()).isNull();
+    assertThat(evaluationResult.getNumber()).isNull();
+    assertThat(evaluationResult.getList()).isNull();
+  }
+
+  @Test
+  public void periodExpression() {
+    final var evaluationResult = evaluateExpression("=duration(\"P2M\")");
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.PERIOD);
+    assertThat(evaluationResult.getDuration()).isNull();
+    assertThat(evaluationResult.getPeriod()).isEqualTo(Period.ofMonths(2));
+    assertThat(evaluationResult.getBoolean()).isNull();
+    assertThat(evaluationResult.getString()).isNull();
+    assertThat(evaluationResult.getNumber()).isNull();
+    assertThat(evaluationResult.getList()).isNull();
+  }
+
+  @Test
+  public void dateTimeExpression() {
+    final var evaluationResult =
+        evaluateExpression("=date and time(\"2020-04-01T10:31:10@Europe/Berlin\")");
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.DATE_TIME);
+    assertThat(evaluationResult.getDuration()).isNull();
+    assertThat(evaluationResult.getPeriod()).isNull();
+    assertThat(evaluationResult.getDateTime())
+        .isEqualTo(LocalDateTime.of(2020, 4, 1, 10, 31, 10).atZone(ZoneId.of("Europe/Berlin")));
+    assertThat(evaluationResult.getBoolean()).isNull();
+    assertThat(evaluationResult.getString()).isNull();
+    assertThat(evaluationResult.getNumber()).isNull();
+    assertThat(evaluationResult.getList()).isNull();
   }
 
   @Test
@@ -74,8 +128,10 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getBoolean()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
-    assertThat(evaluationResult.getList()).isNull();
+    assertThat(evaluationResult.getPeriod()).isNull();
+    assertThat(evaluationResult.getDuration()).isNull();
     assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("null"));
+    assertThat(evaluationResult.getList()).isNull();
   }
 
   @Test
@@ -86,9 +142,11 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getBoolean()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
+    assertThat(evaluationResult.getPeriod()).isNull();
+    assertThat(evaluationResult.getDuration()).isNull();
+    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("[1,2,3]"));
     assertThat(evaluationResult.getList())
         .isEqualTo(List.of(asMsgPack("1"), asMsgPack("2"), asMsgPack("3")));
-    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("[1,2,3]"));
   }
 
   @Test
@@ -99,8 +157,10 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getBoolean()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
-    assertThat(evaluationResult.getList()).isNull();
+    assertThat(evaluationResult.getPeriod()).isNull();
+    assertThat(evaluationResult.getDuration()).isNull();
     assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack(Map.of("x", 1)));
+    assertThat(evaluationResult.getList()).isNull();
   }
 
   @Test
@@ -118,30 +178,6 @@ public class EvaluationResultTest {
   @Test
   public void timeExpression() {
     final var evaluationResult = evaluateExpression("=time(\"14:00:00\")");
-
-    assertThat(evaluationResult.getType()).isNull();
-    assertThat(evaluationResult.getString()).isNull();
-    assertThat(evaluationResult.getBoolean()).isNull();
-    assertThat(evaluationResult.getNumber()).isNull();
-    assertThat(evaluationResult.getList()).isNull();
-    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("null"));
-  }
-
-  @Test
-  public void dateTimeExpression() {
-    final var evaluationResult = evaluateExpression("=date and time(\"2020-04-02T14:00:00\")");
-
-    assertThat(evaluationResult.getType()).isNull();
-    assertThat(evaluationResult.getString()).isNull();
-    assertThat(evaluationResult.getBoolean()).isNull();
-    assertThat(evaluationResult.getNumber()).isNull();
-    assertThat(evaluationResult.getList()).isNull();
-    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("null"));
-  }
-
-  @Test
-  public void durationExpression() {
-    final var evaluationResult = evaluateExpression("=duration(\"P5D\")");
 
     assertThat(evaluationResult.getType()).isNull();
     assertThat(evaluationResult.getString()).isNull();

--- a/expression-language/src/test/java/io/zeebe/el/FeelAppendFunctionTest.java
+++ b/expression-language/src/test/java/io/zeebe/el/FeelAppendFunctionTest.java
@@ -100,7 +100,7 @@ public class FeelAppendFunctionTest {
     assertThat(evaluationResult.isFailure()).isTrue();
     assertThat(evaluationResult.getFailureMessage())
         .startsWith(
-            "failed to evaluate expression 'appendTo(x,y)': expected two contexts but found");
+            "failed to evaluate expression 'appendTo(x,y)': append function expected two context parameters, but found");
   }
 
   @Test
@@ -111,7 +111,7 @@ public class FeelAppendFunctionTest {
     assertThat(evaluationResult.isFailure()).isTrue();
     assertThat(evaluationResult.getFailureMessage())
         .startsWith(
-            "failed to evaluate expression 'appendTo(x,y)': expected two contexts but found");
+            "failed to evaluate expression 'appendTo(x,y)': append function expected two context parameters, but found");
   }
 
   private EvaluationResult evaluateExpression(

--- a/expression-language/src/test/java/io/zeebe/el/FeelCycleFunctionTest.java
+++ b/expression-language/src/test/java/io/zeebe/el/FeelCycleFunctionTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.el;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.test.util.MsgPackUtil;
+import java.util.Map;
+import org.junit.Test;
+
+public class FeelCycleFunctionTest {
+
+  private static final EvaluationContext EMPTY_CONTEXT = x -> null;
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage();
+
+  @Test
+  public void emptyDuration() {
+    final var evaluationResult = evaluateExpression("cycle(interval)", EMPTY_CONTEXT);
+
+    assertThat(evaluationResult.getType()).isNull();
+  }
+
+  @Test
+  public void infiniteOneHourDuration() {
+    final var evaluationResult = evaluateExpression("cycle(duration(\"PT1H\"))", EMPTY_CONTEXT);
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.STRING);
+    assertThat(evaluationResult.getString()).isEqualTo("R/PT1H");
+  }
+
+  @Test
+  public void infiniteTwoMonthsDuration() {
+    final var evaluationResult = evaluateExpression("cycle(duration(\"P2M\"))", EMPTY_CONTEXT);
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.STRING);
+    assertThat(evaluationResult.getString()).isEqualTo("R/P2M");
+  }
+
+  @Test
+  public void threeTimesOneHourDuration() {
+    final var context = Map.of("repetitions", MsgPackUtil.asMsgPack("3"));
+    final var evaluationResult =
+        evaluateExpression("cycle(repetitions, duration(\"PT1H\"))", context::get);
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.STRING);
+    assertThat(evaluationResult.getString()).isEqualTo("R3/PT1H");
+  }
+
+  @Test
+  public void threeTimesTwoMonthsDuration() {
+    final var context = Map.of("repetitions", MsgPackUtil.asMsgPack("3"));
+    final var evaluationResult =
+        evaluateExpression("cycle(repetitions, duration(\"P2M\"))", context::get);
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.STRING);
+    assertThat(evaluationResult.getString()).isEqualTo("R3/P2M");
+  }
+
+  @Test
+  public void nullTimesOneHourDuration() {
+    final var context = Map.of("repetitions", MsgPackUtil.asMsgPack("null"));
+    final var evaluationResult =
+        evaluateExpression("cycle(repetitions, duration(\"PT1H\"))", context::get);
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.STRING);
+    assertThat(evaluationResult.getString()).isEqualTo("R/PT1H");
+  }
+
+  @Test
+  public void nullTimesTwoMonthsDuration() {
+    final var context = Map.of("repetitions", MsgPackUtil.asMsgPack("null"));
+    final var evaluationResult =
+        evaluateExpression("cycle(repetitions, duration(\"P2M\"))", context::get);
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.STRING);
+    assertThat(evaluationResult.getString()).isEqualTo("R/P2M");
+  }
+
+  private EvaluationResult evaluateExpression(
+      final String expression, final EvaluationContext context) {
+    final var parseExpression = expressionLanguage.parseExpression("=" + expression);
+    return expressionLanguage.evaluateExpression(parseExpression, context);
+  }
+}


### PR DESCRIPTION
## Description

This PR adds feel expression support to all timer events.

Supported timer events:
 - start event
 - intermediate catch event
 - boundary event

This PR also adds a custom feel function for cycle expressions:
- `cycle(interval : duration)` : evaluates to a cycle that repeats according to the specified interval an infinite number of times
- `cycle(repetitions : number, interval : duration)` : evaluates to a cycle that repeats according to the specified interval the number of times specified by 'repetitions'

Example usage:
- `cycle(duration("PT1H"))` : repeats infinitely with a 1 hour interval
- `cycle(24, duration("PT1H"))` : repeats 24 times with a 1 hour interval
- `cycle(x, date and time(y) - date and time(z))` : repeats x times with an interval of the duration between date and time z and date and time y

## Related issues

closes #3799