### PR TITLE
chore(broker): Log configuration before it is being used

### DIFF
--- a/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
@@ -21,10 +21,12 @@ import io.zeebe.gateway.impl.configuration.ClusterCfg;
 import io.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.zeebe.legacy.tomlconfig.LegacyConfigurationSupport;
 import io.zeebe.legacy.tomlconfig.LegacyConfigurationSupport.Scope;
+import io.zeebe.util.VersionUtil;
 import io.zeebe.util.sched.ActorScheduler;
 import java.io.IOException;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -32,7 +34,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.core.env.Environment;
 
 public class StandaloneGateway {
-
+  private static final Logger LOG = Loggers.GATEWAY_LOGGER;
   private final AtomixCluster atomixCluster;
   private final Gateway gateway;
   private final GatewayCfg gatewayCfg;
@@ -123,6 +125,12 @@ public class StandaloneGateway {
     public void run(final String... args) throws Exception {
       final GatewayCfg gatewayCfg = configuration;
       gatewayCfg.init();
+
+      if (LOG.isInfoEnabled()) {
+        LOG.info("Version: {}", VersionUtil.getVersion());
+        LOG.info("Starting standalone gateway with configuration {}", gatewayCfg.toJson());
+      }
+
       new StandaloneGateway(gatewayCfg).run();
     }
   }


### PR DESCRIPTION
## Description

This pull request changes when the configuration is logged. Before that, the configuration was already used before it was logged. This led to situations in which the application failed to launch due to a configuration error - before it could print out the configuration.

This change now moves the logging of configuration to a point in time before the configuration is accessed.

## Related issues
closes #4180

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
