### PR TITLE
feat(distro): add StackdriverJSONLayout appender

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -30,6 +30,12 @@ JavaOpts: |
   -XX:HeapDumpPath=/usr/local/zeebe/data
   -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
 
+# Environment variables
+env:
+  # Enable JSON logging for google cloud stackdriver
+  - name: ZEEBE_LOG_APPENDER
+    value: Stackdriver
+
 # RESOURCES
 resources:
   limits:

--- a/benchmarks/setup/operate/zeebe-values.yaml
+++ b/benchmarks/setup/operate/zeebe-values.yaml
@@ -30,6 +30,12 @@ JavaOpts: |
   -XX:HeapDumpPath=/usr/local/zeebe/data
   -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
 
+# Environment variables
+env:
+  # Enable JSON logging for google cloud stackdriver
+  - name: ZEEBE_LOG_APPENDER
+    value: Stackdriver
+
 # RESOURCES
 resources:
   limits:

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -134,7 +134,7 @@
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <extraJvmArguments>
-            -Xms128m -Dlog4j.configurationFile=../config/log4j2.xml
+            -Xms128m
             --illegal-access=deny
           </extraJvmArguments>
           <repositoryLayout>flat</repositoryLayout>

--- a/dist/src/main/config/log4j2.xml
+++ b/dist/src/main/config/log4j2.xml
@@ -12,6 +12,10 @@
         pattern="${log.pattern}"/>
     </Console>
 
+    <Console name="Stackdriver" target="SYSTEM_OUT">
+      <StackdriverJSONLayout/>
+    </Console>
+
     <RollingFile name="RollingFile" fileName="${log.path}/zeebe.log"
       filePattern="${log.path}/zeebe-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout>
@@ -33,7 +37,7 @@
       <AppenderRef ref="RollingFile"/>
 
       <!-- remove to disable console logging -->
-      <AppenderRef ref="Console"/>
+      <AppenderRef ref="${env:ZEEBE_LOG_APPENDER:-Console}"/>
     </Root>
   </Loggers>
 

--- a/docs/src/appendix/environment-variables.md
+++ b/docs/src/appendix/environment-variables.md
@@ -1,7 +1,7 @@
 # Environment Variables
 
 ## Environment Variables for Configuration
-The configuration can be provided as a file or through environment variables. Mixing both sources is also possible. In that case environment variables have precedence over the configuration settings in the configuration file. 
+The configuration can be provided as a file or through environment variables. Mixing both sources is also possible. In that case environment variables have precedence over the configuration settings in the configuration file.
 
 All available environment variables are documented in the configuration file templates:
 * [Broker Configuration Template](broker-config-template.md)
@@ -10,8 +10,9 @@ All available environment variables are documented in the configuration file tem
 ## Environment Variables for Operators
 The following environment variables are intended for operators:
   - `ZEEBE_LOG_LEVEL`: Sets the log level of the Zeebe Logger (default: `info`).
- 
- ## Environment Variables for Developers 
+  - `ZEEBE_LOG_APPENDER`: Sets the console log appender (default: `Console`). We recommend using `Stackdriver` if Zeebe runs on Google Cloud Platform to output JSON formatted log messages
+
+ ## Environment Variables for Developers
 The following environment variables are intended for developers:
  - `SPRING_PROFILES_ACTIVE=dev`: If this is set, the broker will start in a temporary folder and all data will be cleaned up upon exit
  - `ZEEBE_DEBUG=true/false`: Activates a `DebugLogExporter` with default settings. The value of the environment variable toggles pretty printing

--- a/docs/src/operations/configuration.md
+++ b/docs/src/operations/configuration.md
@@ -55,8 +55,8 @@ export SPRING_CONFIG_LOCATION='file:./[path to config file]'
 *Command line argument*
 ```shell script
 ./bin/broker --spring.config.location=file:./[path to config file]
- 
-or 
+
+or
 
 ./bin/gateway --spring.config.location=file:./[path to config file]
 ```
@@ -66,7 +66,7 @@ or
 Rename the configuration file to `application.yml` and place it in the following location:
 ```shell script
 ./config/application.yml
-``` 
+```
 
 *Misc*
 
@@ -94,7 +94,7 @@ If the configuration could be read, Zeebe will log out the effective configurati
 
 In some cases of invalid configuration Zeebe will fail to start with a warning that explains which configuration setting could not be read.
 ```
-17:17:38.796 [] [main] ERROR org.springframework.boot.diagnostics.LoggingFailureAnalysisReporter - 
+17:17:38.796 [] [main] ERROR org.springframework.boot.diagnostics.LoggingFailureAnalysisReporter -
 
 ***************************
 APPLICATION FAILED TO START
@@ -114,3 +114,18 @@ Action:
 Update your application's configuration
 ```
 
+## Logging
+
+Zeebe uses Log4j2 framework for logging. In the distribution and the docker image you can find the default log configuration file in `config/log4j2.xml`.
+
+### Google Stackdriver (JSON) logging
+
+To enable Google Stackdriver compatible JSON logging you can set the environment variable `ZEEBE_LOG_APPENDER=Stackdriver` before starting Zeebe.
+
+### Default logging configuration
+
+* `config/log4j2.xml` (applied by default)
+
+```
+{{#include ../../../dist/src/main/config/log4j2.xml}}
+```

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -25,6 +25,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/util/src/main/java/io/zeebe/util/StackdriverJSONLayout.java
+++ b/util/src/main/java/io/zeebe/util/StackdriverJSONLayout.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.impl.ThrowableProxy;
+import org.apache.logging.log4j.core.layout.AbstractStringLayout;
+import org.apache.logging.log4j.core.util.StringBuilderWriter;
+
+/**
+ * Idea and code (slightly changed) from
+ * <li><a href=
+ *     "https://k11i.biz/blog/2018/10/03/stackdriver-logging-friendly-layout-java/">https://k11i.biz/blog/2018/10/03/stackdriver-logging-friendly-layout-java/</a>
+ */
+@Plugin(name = "StackdriverJSONLayout", category = Node.CATEGORY, elementType = Layout.ELEMENT_TYPE)
+public class StackdriverJSONLayout extends AbstractStringLayout {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  public StackdriverJSONLayout() {
+    this(StandardCharsets.UTF_8);
+  }
+
+  protected StackdriverJSONLayout(Charset charset) {
+    super(charset);
+  }
+
+  @PluginFactory
+  public static StackdriverJSONLayout create() {
+    return new StackdriverJSONLayout();
+  }
+
+  @Override
+  public String toSerializable(LogEvent event) {
+    try (StringBuilderWriter writer = new StringBuilderWriter()) {
+      try {
+        OBJECT_MAPPER.writeValue(writer, logEventToMap(event));
+        writer.append('\n');
+        return writer.toString();
+      } catch (IOException e) {
+        return null;
+      }
+    }
+  }
+
+  protected Map<String, Object> logEventToMap(LogEvent event) {
+    final Map<String, Object> map = new LinkedHashMap<>();
+
+    map.put("timestampSeconds", event.getTimeMillis() / 1000);
+    map.put("timestampNanos", (event.getTimeMillis() % 1000) * 1_000_000);
+    // 'Level' is equal to 'severity' in gcloud/stackdriver
+    putIfNotNull("severity", event.getLevel().toString(), map);
+    putIfNotNull("thread", event.getThreadName(), map);
+    putIfNotNull("logger", event.getLoggerName(), map);
+    putIfNotNull("message", event.getMessage().getFormattedMessage(), map);
+    putIfNotNull("exception", getThrowableAsString(event.getThrownProxy()), map);
+    return map;
+  }
+
+  private String getThrowableAsString(ThrowableProxy thrownProxy) {
+    if (thrownProxy != null) {
+      return thrownProxy.getExtendedStackTraceAsString();
+    }
+    return null;
+  }
+
+  private void putIfNotNull(String key, String value, Map<String, Object> map) {
+    if (value != null) {
+      map.put(key, value);
+    }
+  }
+}

--- a/util/src/test/java/io/zeebe/util/StackdriverJSONLayoutTest.java
+++ b/util/src/test/java/io/zeebe/util/StackdriverJSONLayoutTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.StringLayout;
+import org.apache.logging.log4j.core.appender.WriterAppender;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StackdriverJSONLayoutTest {
+
+  private static final ObjectReader OBJECT_READER = new ObjectMapper().reader();
+
+  private Logger logger;
+  private Writer logTarget;
+  private WriterAppender appender;
+
+  @Before
+  public void before() {
+    logger = (Logger) LogManager.getLogger();
+    logTarget = new StringWriter();
+    appender = createAndStartAppender(new StackdriverJSONLayout(), logTarget);
+    logger.addAppender(appender);
+  }
+
+  @After
+  public void tearDown() {
+    logger.removeAppender(appender);
+  }
+
+  @Test
+  public void testJSONOutput() throws IOException {
+    // when
+    logger.error("Should appear as JSON formatted output");
+
+    // then
+    final Map<String, String> jsonMap = writerToMap(logTarget);
+
+    SoftAssertions.assertSoftly(
+        softly ->
+            softly
+                .assertThat(jsonMap)
+                .containsKeys(
+                    "logger", "message", "severity", "thread", "timestampNanos", "timestampSeconds")
+                .containsEntry("message", "Should appear as JSON formatted output")
+                .containsEntry("severity", "ERROR")
+                .containsEntry("logger", logger.getName()));
+  }
+
+  private Map<String, String> writerToMap(Writer logTarget) throws JsonProcessingException {
+    return OBJECT_READER
+        .withValueToUpdate(new HashMap<String, String>())
+        .readValue(logTarget.toString());
+  }
+
+  private WriterAppender createAndStartAppender(StringLayout layout, Writer logTarget) {
+    final WriterAppender appender =
+        WriterAppender.createAppender(layout, null, logTarget, "test", false, false);
+    appender.start();
+    return appender;
+  }
+}


### PR DESCRIPTION
## Description

To enable stackdriver compatible JSON logging set env variable `ZEEBE_LOG_APPENDER` to `Stackdriver`.

Remove log4j2 configuration location from startup parameters to allow overriding with custom file locations.

Enable stackdriver logging in benchmarks per default to improve log discovery.

Add documentation how to enable stackdriver logging.

## Related issues

closes #4190 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
