### PR TITLE
feat(broker): FEEL expressions for message names

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/zeebe/MessageBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/zeebe/MessageBuilder.java
@@ -31,7 +31,11 @@ public class MessageBuilder extends AbstractBaseElementBuilder<MessageBuilder, M
     return this;
   }
 
-  public MessageBuilder zeebeCorrelationKey(final String correlationKey) {
+  public MessageBuilder nameExpression(final String nameExpression) {
+    return name(asZeebeExpression(nameExpression));
+  }
+
+  public MessageBuilder zeebeCorrelationKey(String correlationKey) {
     final ZeebeSubscription subscription = getCreateSingleExtensionElement(ZeebeSubscription.class);
     subscription.setCorrelationKey(correlationKey);
     return this;

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableMessage.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableMessage.java
@@ -8,12 +8,13 @@
 package io.zeebe.engine.processor.workflow.deployment.model.element;
 
 import io.zeebe.el.Expression;
-import org.agrona.DirectBuffer;
+import java.util.Optional;
 
 public class ExecutableMessage extends AbstractFlowElement {
 
   private Expression correlationKeyExpression;
-  private DirectBuffer messageName;
+  private Expression messageNameExpression;
+  private String messageName;
 
   public ExecutableMessage(final String id) {
     super(id);
@@ -27,11 +28,27 @@ public class ExecutableMessage extends AbstractFlowElement {
     this.correlationKeyExpression = correlationKey;
   }
 
-  public DirectBuffer getMessageName() {
-    return messageName;
+  public Expression getMessageNameExpression() {
+    return messageNameExpression;
   }
 
-  public void setMessageName(final DirectBuffer messageName) {
+  public void setMessageNameExpression(final Expression messageName) {
+    this.messageNameExpression = messageName;
+  }
+
+  /**
+   * Returns the message name, if it has been resolved previously (and is independent of the
+   * variable context). If this returns an empty {@code Optional} then the message name must be
+   * resolved by evaluating {@code getMessageNameExpression()}
+   *
+   * @return the message name, if it has been resolved previously (and is independent of the *
+   *     variable context)
+   */
+  public Optional<String> getMessageName() {
+    return Optional.ofNullable(messageName);
+  }
+
+  public void setMessageName(String messageName) {
     this.messageName = messageName;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/MessageTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/MessageTransformer.java
@@ -7,14 +7,16 @@
  */
 package io.zeebe.engine.processor.workflow.deployment.model.transformer;
 
+import io.zeebe.el.EvaluationResult;
 import io.zeebe.el.Expression;
+import io.zeebe.el.ExpressionLanguage;
+import io.zeebe.el.ResultType;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableMessage;
 import io.zeebe.engine.processor.workflow.deployment.model.transformation.ModelElementTransformer;
 import io.zeebe.engine.processor.workflow.deployment.model.transformation.TransformContext;
 import io.zeebe.model.bpmn.instance.ExtensionElements;
 import io.zeebe.model.bpmn.instance.Message;
 import io.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription;
-import io.zeebe.util.buffer.BufferUtil;
 
 public final class MessageTransformer implements ModelElementTransformer<Message> {
 
@@ -27,21 +29,36 @@ public final class MessageTransformer implements ModelElementTransformer<Message
   public void transform(final Message element, final TransformContext context) {
 
     final String id = element.getId();
-    final ExecutableMessage executableElement = new ExecutableMessage(id);
+    final ExpressionLanguage expressionLanguage = context.getExpressionLanguage();
 
+    final ExecutableMessage executableElement = new ExecutableMessage(id);
     final ExtensionElements extensionElements = element.getExtensionElements();
 
     if (extensionElements != null) {
       final ZeebeSubscription subscription =
           extensionElements.getElementsQuery().filterByType(ZeebeSubscription.class).singleResult();
       final Expression correlationKeyExpression =
-          context.getExpressionLanguage().parseExpression(subscription.getCorrelationKey());
+          expressionLanguage.parseExpression(subscription.getCorrelationKey());
 
       executableElement.setCorrelationKeyExpression(correlationKeyExpression);
     }
 
     if (element.getName() != null) {
-      executableElement.setMessageName(BufferUtil.wrapString(element.getName()));
+      final Expression messageNameExpression =
+          expressionLanguage.parseExpression(element.getName());
+
+      executableElement.setMessageNameExpression(messageNameExpression);
+
+      if (messageNameExpression.isStatic()) {
+        final EvaluationResult messageNameResult =
+            expressionLanguage.evaluateExpression(messageNameExpression, variable -> null);
+
+        if (messageNameResult.getType() == ResultType.STRING) {
+          final String messageName = messageNameResult.getString();
+          executableElement.setMessageName(messageName);
+        }
+      }
+
       context.addMessage(executableElement);
     }
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/StartEventTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/StartEventTransformer.java
@@ -7,14 +7,19 @@
  */
 package io.zeebe.engine.processor.workflow.deployment.model.transformer;
 
+import io.zeebe.el.EvaluationResult;
+import io.zeebe.el.ExpressionLanguage;
+import io.zeebe.el.ResultType;
 import io.zeebe.engine.processor.workflow.deployment.model.BpmnStep;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableCatchEventElement;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableFlowElementContainer;
+import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableMessage;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableStartEvent;
 import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableWorkflow;
 import io.zeebe.engine.processor.workflow.deployment.model.transformation.ModelElementTransformer;
 import io.zeebe.engine.processor.workflow.deployment.model.transformation.TransformContext;
 import io.zeebe.model.bpmn.instance.FlowNode;
+import io.zeebe.model.bpmn.instance.Process;
 import io.zeebe.model.bpmn.instance.StartEvent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 
@@ -44,11 +49,52 @@ public final class StartEventTransformer implements ModelElementTransformer<Star
       workflow.addStartEvent(startEvent);
     }
 
+    if (startEvent.isMessage() && element.getScope() instanceof Process) {
+      evaluateMessageNameExpression(startEvent, context);
+    }
+
     bindLifecycle(startEvent);
   }
 
   private void bindLifecycle(final ExecutableCatchEventElement startEvent) {
     startEvent.bindLifecycleState(
         WorkflowInstanceIntent.EVENT_OCCURRED, BpmnStep.START_EVENT_EVENT_OCCURRED);
+  }
+
+  /**
+   * Evaluates the message name expression of the message. For start events, there are no variables
+   * available, so only static expressions or expressions based on literals are valid
+   *
+   * @param startEvent the start event; must not be {@code null}
+   * @param context the transformation context; must not be {@code null}
+   * @throws IllegalStateException thrown if either the evaluation failed or the result of the
+   *     evaluation was not a String
+   */
+  private void evaluateMessageNameExpression(
+      ExecutableStartEvent startEvent, TransformContext context) {
+    final ExecutableMessage message = startEvent.getMessage();
+
+    if (message.getMessageName().isEmpty()) {
+      final ExpressionLanguage expressionLanguage = context.getExpressionLanguage();
+
+      final EvaluationResult messageNameResult =
+          expressionLanguage.evaluateExpression(
+              message.getMessageNameExpression(), variable -> null);
+
+      if (messageNameResult.isFailure()) {
+        throw new IllegalStateException(
+            String.format(
+                "Error while evaluating '%s': %s",
+                message.getMessageNameExpression(), messageNameResult.getFailureMessage()));
+      } else if (messageNameResult.getType() == ResultType.STRING) {
+        final String messageName = messageNameResult.getString();
+        message.setMessageName(messageName);
+      } else {
+        throw new IllegalStateException(
+            String.format(
+                "Expected FEEL expression or static value of '%s' of type STRING, but was: %s",
+                messageNameResult.getExpression(), messageNameResult.getType().name()));
+      }
+    }
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ProcessMessageStartEventMessageNameValidator.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ProcessMessageStartEventMessageNameValidator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.deployment.model.validation;
+
+import io.zeebe.el.EvaluationResult;
+import io.zeebe.el.Expression;
+import io.zeebe.el.ExpressionLanguage;
+import io.zeebe.el.ResultType;
+import io.zeebe.model.bpmn.instance.MessageEventDefinition;
+import io.zeebe.model.bpmn.instance.Process;
+import io.zeebe.model.bpmn.instance.StartEvent;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+/**
+ * This class validates that the message names of messages associated with a start event can be
+ * evaluated without a context (that is, the expressions do not refer to variables) and evaluate to
+ * a string
+ */
+final class ProcessMessageStartEventMessageNameValidator
+    implements ModelElementValidator<StartEvent> {
+
+  private final ExpressionLanguage expressionLanguage;
+
+  ProcessMessageStartEventMessageNameValidator(final ExpressionLanguage expressionLanguage) {
+    this.expressionLanguage = expressionLanguage;
+  }
+
+  @Override
+  public Class<StartEvent> getElementType() {
+    return StartEvent.class;
+  }
+
+  @Override
+  public void validate(
+      final StartEvent element, final ValidationResultCollector validationResultCollector) {
+    if (element.getScope() instanceof Process) {
+      element.getEventDefinitions().stream()
+          .filter(MessageEventDefinition.class::isInstance)
+          .map(MessageEventDefinition.class::cast)
+          .forEach(definition -> validateMessageName(definition, validationResultCollector));
+    }
+  }
+
+  private void validateMessageName(
+      final MessageEventDefinition messageEventDefinition,
+      final ValidationResultCollector resultCollector) {
+    final String nameExpression = messageEventDefinition.getMessage().getName();
+    final Expression parseResult = expressionLanguage.parseExpression(nameExpression);
+
+    final EvaluationResult evaluationResult =
+        expressionLanguage.evaluateExpression(parseResult, var -> null);
+
+    if (evaluationResult.isFailure()) {
+      resultCollector.addError(
+          0,
+          String.format(
+              "Expected constant expression but found '%s', which could not be evaluated without context: %s",
+              nameExpression, evaluationResult.getFailureMessage()));
+    } else if (evaluationResult.getType() != ResultType.STRING) {
+      resultCollector.addError(
+          0,
+          String.format(
+              "Expected constant expression of type String for message name '%s', but was %s",
+              nameExpression, evaluationResult.getType()));
+    }
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ZeebeExpressionValidator.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ZeebeExpressionValidator.java
@@ -43,7 +43,6 @@ public final class ZeebeExpressionValidator<T extends ModelElementInstance>
 
   @Override
   public void validate(final T element, final ValidationResultCollector validationResultCollector) {
-
     verifications.forEach(
         verification -> {
           final String expression = verification.expressionSupplier.apply(element);
@@ -104,7 +103,6 @@ public final class ZeebeExpressionValidator<T extends ModelElementInstance>
     }
 
     public ZeebeExpressionValidator<T> build(final ExpressionLanguage expressionLanguage) {
-
       return new ZeebeExpressionValidator<>(expressionLanguage, elementType, verifications);
     }
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -11,6 +11,7 @@ import io.zeebe.el.ExpressionLanguage;
 import io.zeebe.engine.processor.workflow.ExpressionProcessor;
 import io.zeebe.engine.processor.workflow.deployment.model.validation.ZeebeExpressionValidator.ExpressionVerification;
 import io.zeebe.model.bpmn.instance.ConditionExpression;
+import io.zeebe.model.bpmn.instance.Message;
 import io.zeebe.model.bpmn.instance.TimerEventDefinition;
 import io.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
@@ -39,6 +40,11 @@ public final class ZeebeRuntimeValidators {
                 ZeebeOutput::getSource, expression -> expression.isNonStatic().isMandatory())
             .hasValidPath(ZeebeOutput::getTarget)
             .build(expressionLanguage),
+        ZeebeExpressionValidator.verifyThat(Message.class)
+            .hasValidExpression(Message::getName, expression -> expression.isOptional())
+            .build(expressionLanguage),
+        // Checks message name expressions of start event messages
+        new ProcessMessageStartEventMessageNameValidator(expressionLanguage),
         // ----------------------------------------
         ZeebeExpressionValidator.verifyThat(ZeebeSubscription.class)
             .hasValidExpression(

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/BufferedMessageToStartEventCorrelator.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/BufferedMessageToStartEventCorrelator.java
@@ -17,6 +17,7 @@ import io.zeebe.engine.state.deployment.DeployedWorkflow;
 import io.zeebe.engine.state.instance.EventScopeInstanceState;
 import io.zeebe.engine.state.message.Message;
 import io.zeebe.engine.state.message.MessageState;
+import io.zeebe.util.buffer.BufferUtil;
 import io.zeebe.util.sched.clock.ActorClock;
 import org.agrona.DirectBuffer;
 
@@ -83,10 +84,11 @@ public final class BufferedMessageToStartEventCorrelator implements WorkflowPost
     for (final ExecutableStartEvent startEvent : workflow.getWorkflow().getStartEvents()) {
       if (startEvent.isMessage()) {
 
-        final var messageName = startEvent.getMessage().getMessageName();
+        final DirectBuffer messageNameBuffer =
+            startEvent.getMessage().getMessageName().map(BufferUtil::wrapString).orElseThrow();
 
         messageState.visitMessages(
-            messageName,
+            messageNameBuffer,
             correlationKey,
             message -> {
               // correlate the first message with same correlation key that was not correlated yet

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageNameException.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageNameException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.message;
+
+import static java.util.stream.Collectors.joining;
+
+import io.zeebe.engine.processor.workflow.BpmnStepContext;
+import io.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import org.agrona.DirectBuffer;
+
+public final class MessageNameException extends RuntimeException {
+
+  private final BpmnStepContext context;
+
+  public MessageNameException(
+      final BpmnStepContext context, final List<DirectBuffer> failedEventIds) {
+    super(generateMessage(failedEventIds));
+    this.context = context;
+  }
+
+  private static String generateMessage(final List<DirectBuffer> failedEventIds) {
+    return failedEventIds.stream()
+        .map(BufferUtil::bufferAsString)
+        .collect(joining(", ", "Message name could not be resolved for: EventIDs [", "]"));
+  }
+
+  public BpmnStepContext getContext() {
+    return context;
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ProcessMessageStartEventMessageNameValidatorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ProcessMessageStartEventMessageNameValidatorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor.workflow.deployment.model.validation;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.zeebe.el.EvaluationResult;
+import io.zeebe.el.Expression;
+import io.zeebe.el.ExpressionLanguage;
+import io.zeebe.el.ResultType;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.instance.StartEvent;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProcessMessageStartEventMessageNameValidatorTest {
+
+  private static final String TEST_EXPRESSION = "expression";
+
+  private static final BpmnModelInstance MODEL =
+      Bpmn.createProcess().startEvent().message(TEST_EXPRESSION).endEvent().done();
+
+  private static final StartEvent START_EVENT =
+      MODEL.getModelElementsByType(StartEvent.class).iterator().next();
+
+  @Mock ExpressionLanguage mockExpressionLanguage;
+
+  @Mock Expression mockExpression;
+
+  @Mock EvaluationResult mockResult;
+
+  @Mock ValidationResultCollector mockResultCollector;
+
+  ProcessMessageStartEventMessageNameValidator sutValidator;
+
+  @Before
+  public void setUp() {
+    when(mockExpressionLanguage.parseExpression(TEST_EXPRESSION)).thenReturn(mockExpression);
+
+    when(mockExpressionLanguage.evaluateExpression(Mockito.eq(mockExpression), Mockito.any()))
+        .thenReturn(mockResult);
+
+    sutValidator = new ProcessMessageStartEventMessageNameValidator(mockExpressionLanguage);
+  }
+
+  @Test
+  public void shouldLetValidMessageNameExpressionsPass() {
+    // given
+    when(mockResult.isFailure()).thenReturn(false);
+    when(mockResult.getType()).thenReturn(ResultType.STRING);
+
+    // when
+    sutValidator.validate(START_EVENT, mockResultCollector);
+
+    // then
+    verifyNoInteractions(mockResultCollector);
+  }
+
+  @Test
+  public void shoulAddErrorIfEvaluationFailed() {
+    // given
+    when(mockResult.isFailure()).thenReturn(true);
+    when(mockResult.getFailureMessage()).thenReturn("Test failure message");
+
+    // when
+    sutValidator.validate(START_EVENT, mockResultCollector);
+
+    // then
+    verify(mockResultCollector)
+        .addError(
+            0,
+            "Expected constant expression but found 'expression', which could not be evaluated without context: Test failure message");
+  }
+
+  @Test
+  public void shoulAddErrorIfEvaluationDoesNotReturnString() {
+    // given
+    when(mockResult.isFailure()).thenReturn(false);
+    when(mockResult.getType()).thenReturn(ResultType.NUMBER);
+
+    // when
+    sutValidator.validate(START_EVENT, mockResultCollector);
+
+    // then
+    verify(mockResultCollector)
+        .addError(
+            0,
+            "Expected constant expression of type String for message name 'expression', but was NUMBER");
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -186,7 +186,7 @@ public final class ZeebeRuntimeValidationTest {
         Arrays.asList(expect(ZeebeOutput.class, MISSING_PATH_EXPRESSION_MESSAGE))
       },
       {
-        // correlation key expression is not supported
+        // name expression is invalid
         Bpmn.createExecutableProcess("process")
             .startEvent()
             .intermediateCatchEvent("catch")
@@ -206,7 +206,6 @@ public final class ZeebeRuntimeValidationTest {
         Arrays.asList(expect(ZeebeSubscription.class, STATIC_EXPRESSION_MESSAGE))
       },
       {
-        // correlation key expression is not supported
         Bpmn.createExecutableProcess("process")
             .startEvent()
             .receiveTask("catch")
@@ -335,6 +334,34 @@ public final class ZeebeRuntimeValidationTest {
                 StartEvent.class,
                 INVALID_TIMER_START_EVENT_EXPRESSION_MESSAGE + "Repetition spec must start with R"))
       },
+      {
+        /* message on start event has expression that contains a variable reference
+         * This must fail validation, because at the time the expression is evaluated,
+         * there are no variables defined
+         */
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .message(messageBuilder -> messageBuilder.nameExpression("variableReference"))
+            .done(),
+        Arrays.asList(
+            expect(
+                StartEvent.class,
+                "Expected constant expression but found '=variableReference', which could not be evaluated without context: "
+                    + "failed to evaluate expression 'variableReference': no variable found for name 'variableReference'"))
+      },
+      {
+        /* message on start event has expression that evaluates to something other than string
+         * This must fail validation, because the message name must be a string
+         */
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .message(messageBuilder -> messageBuilder.nameExpression("false"))
+            .done(),
+        Arrays.asList(
+            expect(
+                StartEvent.class,
+                "Expected constant expression of type String for message name '=false', but was BOOLEAN"))
+      }
     };
   }
 

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/gateway/EventbasedGatewayTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/gateway/EventbasedGatewayTest.java
@@ -438,6 +438,8 @@ public final class EventbasedGatewayTest {
             .map(r -> r.getValue().getMessageName())
             .collect(Collectors.toList());
 
+    assertThat(messageNames).hasSize(2);
+
     assertThat(
             RecordingExporter.workflowInstanceSubscriptionRecords(
                     WorkflowInstanceSubscriptionIntent.CORRELATED)


### PR DESCRIPTION
## Description

Added expressions for message names.

For start events the expressions must be constant expressions, because at this point in time no variables are available.

TODO:
* extend tests
* add validator that rejects start event messages with a message name that cannot be evaluated without variables

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3800

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
