### PR TITLE
fix(clients/go): return empty map on nil/invalid type

### DIFF
--- a/clients/go/internal/utils/structmap.go
+++ b/clients/go/internal/utils/structmap.go
@@ -38,6 +38,11 @@ func MapMarshal(iface interface{}, tag string, omitempty, omitminus bool) map[st
 
 func MapStructMarshal(value reflect.Value, tag string, omitempty, omitminus bool) map[string]interface{} {
 	m := make(map[string]interface{})
+
+	if !value.IsValid() {
+		return m
+	}
+
 	typeof := value.Type()
 	for i := 0; i < typeof.NumField(); i++ {
 		fieldType := typeof.Field(i)

--- a/clients/go/internal/utils/structmap_test.go
+++ b/clients/go/internal/utils/structmap_test.go
@@ -294,6 +294,27 @@ func TestMapStructMarshal(t *testing.T) {
 	if res["C"].(map[string]interface{})["Foo"].(string) != "bar" {
 		t.Fatal("map nested map string fail")
 	}
+
+}
+
+func TestMapStructMarshalWithNil(t *testing.T) {
+	res := MapStructMarshal(reflect.ValueOf(struct {
+		A *struct{}
+	}{}), "json", true, true)
+
+	if m := res["A"].(map[string]interface{}); len(m) != 0 {
+		t.Fatal("unexpected value instead of empty map")
+	}
+}
+
+func TestMapMapMarshalWithNil(t *testing.T) {
+	res := MapStructMarshal(reflect.ValueOf(struct {
+		A map[string]interface{}
+	}{}), "json", true, true)
+
+	if m := res["A"].(map[string]interface{}); len(m) != 0 {
+		t.Fatal("unexpected value instead of empty map")
+	}
 }
 
 func TestMapStructMarshal_Tagged(t *testing.T) {


### PR DESCRIPTION
## Description

Returns an empty map when the value nil or an invalid type
## Related issues

closes #4144 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
