### PR TITLE
chore(broker): use raft thread context in state machine

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -111,7 +111,7 @@ public final class AtomixFactory {
             .withDataDirectory(raftDirectory)
             .withStateMachineFactory(
                 (raftContext, threadContext, threadContextFactory) ->
-                    new ZeebeRaftStateMachine(raftContext, threadContext))
+                    new ZeebeRaftStateMachine(raftContext))
             .withSnapshotStoreFactory(new DbSnapshotStoreFactory())
             .withFlushOnCommit();
 

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/ZeebeRaftStateMachine.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/ZeebeRaftStateMachine.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
 
 public final class ZeebeRaftStateMachine implements RaftStateMachine {
   private final RaftContext raft;
-  private final ThreadContext threadContext;
 
   // hard coupled state
   private final RaftLogReader reader;
@@ -34,10 +33,8 @@ public final class ZeebeRaftStateMachine implements RaftStateMachine {
   // represents the last enqueued index
   private long lastEnqueued;
 
-  public ZeebeRaftStateMachine(final RaftContext raft, final ThreadContext threadContext) {
+  public ZeebeRaftStateMachine(final RaftContext raft) {
     this.raft = raft;
-    this.threadContext = threadContext;
-
     this.reader = raft.getLog().openReader(1, RaftLogReader.Mode.COMMITS);
 
     this.lastEnqueued = reader.getFirstIndex() - 1;
@@ -47,7 +44,7 @@ public final class ZeebeRaftStateMachine implements RaftStateMachine {
 
   @Override
   public ThreadContext executor() {
-    return threadContext;
+    return raft.getThreadContext();
   }
 
   /**
@@ -58,13 +55,14 @@ public final class ZeebeRaftStateMachine implements RaftStateMachine {
    */
   @Override
   public CompletableFuture<Void> compact() {
+    raft.checkThread();
     final var log = raft.getLog();
     if (log.isCompactable(compactableIndex)) {
       final var index = log.getCompactableIndex(compactableIndex);
       if (index > reader.getFirstIndex()) {
         final var future = new CompletableFuture<Void>();
         logger.debug("Compacting log up from {} up to {}", reader.getFirstIndex(), index);
-        raft.getThreadContext().execute(() -> safeCompact(index, future));
+        compact(index, future);
         return future;
       }
     }
@@ -74,31 +72,34 @@ public final class ZeebeRaftStateMachine implements RaftStateMachine {
 
   @Override
   public void applyAll(final long index) {
-    threadContext.execute(() -> safeApplyAll(index, null));
+    raft.checkThread();
+    applyAll(index, null);
   }
 
   @Override
   public <T> CompletableFuture<T> apply(final long index) {
+    raft.checkThread();
     final var future = new CompletableFuture<T>();
-    threadContext.execute(() -> safeApplyAll(index, future));
+    applyAll(index, future);
     return future;
   }
 
   @Override
   public <T> CompletableFuture<T> apply(final Indexed<? extends RaftLogEntry> entry) {
+    raft.checkThread();
     final CompletableFuture<T> future = new CompletableFuture<>();
-    threadContext.execute(() -> safeApplyIndexed(entry, future));
+    applyIndexed(entry, future);
     return future;
   }
 
   @Override
   public void close() {
+    raft.checkThread();
     logger.debug("Closing state machine {}", raft.getName());
     reader.close();
   }
 
-  private void safeCompact(final long index, final CompletableFuture<Void> future) {
-    raft.checkThread();
+  private void compact(final long index, final CompletableFuture<Void> future) {
     logger.debug("Compacting up to index {}", index);
 
     try {
@@ -112,23 +113,15 @@ public final class ZeebeRaftStateMachine implements RaftStateMachine {
     }
   }
 
-  private void safeApplyAll(final long index, final CompletableFuture<?> future) {
-    threadContext.checkThread();
-
+  private void applyAll(final long index, final CompletableFuture<?> future) {
     lastEnqueued = Math.max(lastEnqueued, raft.getSnapshotStore().getCurrentSnapshotIndex());
     while (lastEnqueued < index) {
       final long nextIndex = ++lastEnqueued;
-      threadContext.execute(() -> safeApplyIndex(nextIndex, future));
+      applyIndex(nextIndex, future);
     }
   }
 
-  @Override
-  public void setCompactableIndex(final long index) {
-    this.compactableIndex = index;
-  }
-
-  private void safeApplyIndex(final long index, final CompletableFuture<?> future) {
-    threadContext.checkThread();
+  private void applyIndex(final long index, final CompletableFuture<?> future) {
     final var optionalFuture = Optional.ofNullable(future);
 
     // skip if we have a newer snapshot
@@ -145,7 +138,7 @@ public final class ZeebeRaftStateMachine implements RaftStateMachine {
     // Apply entries prior to this entry.
     if (reader.hasNext() && reader.getNextIndex() == index) {
       try {
-        safeApplyIndexed(reader.next(), future);
+        applyIndexed(reader.next(), future);
       } catch (final Exception e) {
         logger.error("Failed to apply entry at index {}", index, e);
         optionalFuture.ifPresent(f -> f.completeExceptionally(e));
@@ -166,9 +159,8 @@ public final class ZeebeRaftStateMachine implements RaftStateMachine {
     }
   }
 
-  private <T> void safeApplyIndexed(
+  private <T> void applyIndexed(
       final Indexed<? extends RaftLogEntry> indexed, final CompletableFuture<T> future) {
-    threadContext.checkThread();
     final var optionalFuture = Optional.ofNullable(future);
     logger.trace("Applying {}", indexed);
 
@@ -177,6 +169,11 @@ public final class ZeebeRaftStateMachine implements RaftStateMachine {
 
     // mark as applied regardless of result
     raft.setLastApplied(indexed.index(), indexed.entry().term());
+  }
+
+  @Override
+  public void setCompactableIndex(final long index) {
+    this.compactableIndex = index;
   }
 
   @Override


### PR DESCRIPTION
## Description

When a writer truncates, it should also reset the readers (#4197). However this operation is not thread safe. Since writers are always running on the raft thread context, it  is safer to use the readers in the state machine also in the raft thread context until we fix #4198. Note that readers in Zeebe stream processor are safe because a leader never truncates.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4199 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
