### PR TITLE
chore(atomix): reset readers when writer truncates

### DIFF
--- a/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
@@ -602,6 +602,9 @@ public class SegmentedJournal<E> implements Journal<E> {
     for (final SegmentedJournalReader reader : readers) {
       if (reader.getNextIndex() >= index) {
         reader.reset(index);
+      } else {
+        // This is not thread safe https://github.com/zeebe-io/zeebe/issues/4198
+        reader.reset(reader.getNextIndex());
       }
     }
   }

--- a/atomix/storage/src/test/java/io/atomix/storage/journal/TestEntry.java
+++ b/atomix/storage/src/test/java/io/atomix/storage/journal/TestEntry.java
@@ -19,6 +19,7 @@ package io.atomix.storage.journal;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 import io.atomix.utils.misc.ArraySizeHashPrinter;
+import java.util.Arrays;
 
 /**
  * Test entry.
@@ -38,6 +39,23 @@ public class TestEntry {
 
   public byte[] bytes() {
     return bytes;
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(bytes);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TestEntry testEntry = (TestEntry) o;
+    return Arrays.equals(bytes, testEntry.bytes);
   }
 
   @Override


### PR DESCRIPTION
## Description

When a writer truncates, reset the reader to its current index to clear prefetched bytes from memory.

## Related issues

closes #4197, #3687

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
