### PR TITLE
Introduce List storage for engine tests

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -140,13 +140,6 @@
       <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>atomix-cluster</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorInconsistentPositionTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorInconsistentPositionTest.java
@@ -17,10 +17,10 @@ import static io.zeebe.test.util.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import io.zeebe.engine.util.ListLogStorage;
 import io.zeebe.engine.util.RecordStream;
 import io.zeebe.engine.util.StreamProcessingComposite;
 import io.zeebe.engine.util.TestStreams;
-import io.zeebe.logstreams.util.AtomixLogStorageRule;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.test.util.AutoCloseableRule;
 import io.zeebe.util.sched.clock.ControlledActorClock;
@@ -49,21 +49,13 @@ public final class StreamProcessorInconsistentPositionTest {
   private TestStreams testStreams;
 
   @Before
-  public void setup() throws Exception {
+  public void setup() {
 
     testStreams = new TestStreams(tempFolder, closeables, actorSchedulerRule.get());
 
-    final var dataDirectory = tempFolder.newFolder();
-
-    final AtomixLogStorageRule logStorageRule = new AtomixLogStorageRule(tempFolder, 1);
-    logStorageRule.open(
-        b ->
-            b.withDirectory(dataDirectory)
-                .withMaxEntrySize(4 * 1024 * 1024)
-                .withMaxSegmentSize(128 * 1024 * 1024));
-
-    testStreams.createLogStream(getLogName(1), 1, logStorageRule);
-    testStreams.createLogStream(getLogName(2), 2, logStorageRule);
+    final var listLogStorage = new ListLogStorage();
+    testStreams.createLogStream(getLogName(1), 1, listLogStorage);
+    testStreams.createLogStream(getLogName(2), 2, listLogStorage);
 
     firstStreamProcessorComposite =
         new StreamProcessingComposite(testStreams, 1, DEFAULT_DB_FACTORY);

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -125,6 +125,7 @@ public final class EngineRule extends ExternalResource {
   protected void after() {
     subscriptionHandlerExecutor.shutdown();
     environmentRule = null;
+    subscriptionHandlers.clear();
   }
 
   public void start() {

--- a/engine/src/test/java/io/zeebe/engine/util/ListLogStorage.java
+++ b/engine/src/test/java/io/zeebe/engine/util/ListLogStorage.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.util;
+
+import io.atomix.raft.zeebe.ZeebeEntry;
+import io.zeebe.logstreams.spi.LogStorage;
+import io.zeebe.logstreams.spi.LogStorageReader;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.LongConsumer;
+import org.agrona.DirectBuffer;
+
+public class ListLogStorage implements LogStorage {
+
+  private final ConcurrentNavigableMap<Long, Integer> positionIndexMapping;
+  private final List<ZeebeEntry> entries;
+  private LongConsumer positionListener;
+
+  public ListLogStorage() {
+    this.entries = new CopyOnWriteArrayList<>();
+    this.positionIndexMapping = new ConcurrentSkipListMap<>();
+  }
+
+  public void setPositionListener(final LongConsumer positionListener) {
+    this.positionListener = positionListener;
+  }
+
+  @Override
+  public LogStorageReader newReader() {
+    return new LogStorageReader() {
+      @Override
+      public boolean isEmpty() {
+        return entries.isEmpty();
+      }
+
+      @Override
+      public long read(final DirectBuffer readBuffer, final long address) {
+        final var index = (int) (address - 1);
+
+        if (index < 0 || index >= entries.size()) {
+          return OP_RESULT_NO_DATA;
+        }
+
+        final var zeebeEntry = entries.get(index);
+        final var data = zeebeEntry.data();
+        readBuffer.wrap(data, data.position(), data.remaining());
+
+        return address + 1;
+      }
+
+      @Override
+      public long readLastBlock(final DirectBuffer readBuffer) {
+        return read(readBuffer, entries.size());
+      }
+
+      @Override
+      public long lookUpApproximateAddress(final long position) {
+
+        if (position == Long.MIN_VALUE) {
+          return entries.isEmpty() ? OP_RESULT_INVALID_ADDR : 1;
+        }
+
+        final var lowerIndex = positionIndexMapping.lowerEntry(position);
+        if (lowerIndex != null) {
+          return lowerIndex.getValue();
+        }
+
+        return 1;
+      }
+
+      @Override
+      public void close() {}
+    };
+  }
+
+  @Override
+  public void append(
+      final long lowestPosition,
+      final long highestPosition,
+      final ByteBuffer blockBuffer,
+      final AppendListener listener) {
+    try {
+      final var zeebeEntry =
+          new ZeebeEntry(
+              0, System.currentTimeMillis(), lowestPosition, highestPosition, blockBuffer);
+      entries.add(zeebeEntry);
+      final var index = entries.size();
+      positionIndexMapping.put(lowestPosition, index);
+      listener.onWrite(index);
+
+      if (positionListener != null) {
+        positionListener.accept(zeebeEntry.highestPosition());
+      }
+      listener.onCommit(index);
+    } catch (final Exception e) {
+      listener.onWriteError(e);
+    }
+  }
+
+  @Override
+  public void open() throws IOException {}
+
+  @Override
+  public void close() {
+    entries.clear();
+  }
+
+  @Override
+  public boolean isOpen() {
+    return true;
+  }
+
+  @Override
+  public boolean isClosed() {
+    return false;
+  }
+
+  @Override
+  public void flush() throws Exception {}
+}

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -103,6 +103,10 @@ public final class StreamProcessorRule implements TestRule {
             .around(new FailedTestRecordPrinter());
   }
 
+  public ActorSchedulerRule getActorSchedulerRule() {
+    return actorSchedulerRule;
+  }
+
   @Override
   public Statement apply(final Statement base, final Description description) {
     return chain.apply(base, description);

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -52,6 +52,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -232,7 +233,7 @@ public final class TestStreams {
             .onProcessedListener(mockOnProcessedListener)
             .streamProcessorFactory(factory)
             .build();
-    streamProcessor.openAsync().join();
+    streamProcessor.openAsync().join(15, TimeUnit.SECONDS);
 
     final var asyncSnapshotDirector =
         new AsyncSnapshotDirector(
@@ -241,7 +242,7 @@ public final class TestStreams {
             currentSnapshotController,
             stream.getAsyncLogStream(),
             snapshotInterval);
-    actorScheduler.submitActor(asyncSnapshotDirector).join();
+    actorScheduler.submitActor(asyncSnapshotDirector).join(15, TimeUnit.SECONDS);
 
     final LogContext context = logContextMap.get(logName);
     final ProcessorContext processorContext =

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -28,9 +28,9 @@ import io.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.zeebe.logstreams.log.LogStreamReader;
 import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.logstreams.spi.LogStorage;
 import io.zeebe.logstreams.state.SnapshotStorage;
 import io.zeebe.logstreams.state.StateSnapshotController;
-import io.zeebe.logstreams.util.AtomixLogStorageRule;
 import io.zeebe.logstreams.util.SyncLogStream;
 import io.zeebe.logstreams.util.SynchronousLogStream;
 import io.zeebe.logstreams.util.TestSnapshotStorage;
@@ -44,7 +44,6 @@ import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.test.util.AutoCloseableRule;
 import io.zeebe.util.Loggers;
 import io.zeebe.util.sched.ActorScheduler;
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileAlreadyExistsException;
@@ -112,40 +111,39 @@ public final class TestStreams {
   }
 
   public SynchronousLogStream createLogStream(final String name, final int partitionId) {
-    final File segments;
-    try {
-      segments = dataDirectory.newFolder(name, "segments");
-    } catch (final IOException e) {
-      throw new UncheckedIOException(e);
-    }
-
-    return createLogStream(name, partitionId, segments);
+    final var listLogStorage = new ListLogStorage();
+    return createLogStream(
+        name,
+        partitionId,
+        listLogStorage,
+        logStream -> listLogStorage.setPositionListener(logStream::setCommitPosition));
   }
 
-  public SyncLogStream createLogStream(
-      final String name, final int partitionId, final File segmentsDir) {
-    final AtomixLogStorageRule logStorageRule =
-        new AtomixLogStorageRule(dataDirectory, partitionId);
-    logStorageRule.open(
-        b ->
-            b.withDirectory(segmentsDir)
-                .withMaxEntrySize(4 * 1024 * 1024)
-                .withMaxSegmentSize(128 * 1024 * 1024));
-    return createLogStream(name, partitionId, logStorageRule);
+  public SynchronousLogStream createLogStream(
+      final String name, final int partitionId, final ListLogStorage listLogStorage) {
+    return createLogStream(
+        name,
+        partitionId,
+        listLogStorage,
+        logStream -> listLogStorage.setPositionListener(logStream::setCommitPosition));
   }
 
-  public SyncLogStream createLogStream(
-      final String name, final int partitionId, final AtomixLogStorageRule logStorageRule) {
+  public SynchronousLogStream createLogStream(
+      final String name,
+      final int partitionId,
+      final LogStorage logStorage,
+      final Consumer<SyncLogStream> logStreamConsumer) {
     final var logStream =
         SyncLogStream.builder()
             .withLogName(name)
-            .withLogStorage(logStorageRule.getStorage())
+            .withLogStorage(logStorage)
             .withPartitionId(partitionId)
             .withActorScheduler(actorScheduler)
             .build();
-    logStorageRule.setPositionListener(logStream::setCommitPosition);
 
-    final LogContext logContext = LogContext.createLogContext(logStream, logStorageRule);
+    logStreamConsumer.accept(logStream);
+
+    final LogContext logContext = LogContext.createLogContext(logStream, logStorage);
     logContextMap.put(name, logContext);
     closeables.manage(logContext);
     closeables.manage(() -> logContextMap.remove(name));
@@ -357,31 +355,30 @@ public final class TestStreams {
       writer.metadataWriter(metadata);
       writer.valueWriter(value);
 
-      return doRepeatedly(() -> writer.tryWrite()).until(p -> p >= 0);
+      return doRepeatedly(writer::tryWrite).until(p -> p >= 0);
     }
   }
 
   private static final class LogContext implements AutoCloseable {
     private final SynchronousLogStream logStream;
-    private final AtomixLogStorageRule logStorageRule;
+    private final LogStorage logStorage;
     private final LogStreamRecordWriter logStreamWriter;
 
-    private LogContext(
-        final SynchronousLogStream logStream, final AtomixLogStorageRule logStorageRule) {
+    private LogContext(final SynchronousLogStream logStream, final LogStorage logStorage) {
       this.logStream = logStream;
       logStreamWriter = logStream.newLogStreamRecordWriter();
-      this.logStorageRule = logStorageRule;
+      this.logStorage = logStorage;
     }
 
     public static LogContext createLogContext(
-        final SyncLogStream logStream, final AtomixLogStorageRule logStorageRule) {
-      return new LogContext(logStream, logStorageRule);
+        final SyncLogStream logStream, final LogStorage logStorage) {
+      return new LogContext(logStream, logStorage);
     }
 
     @Override
     public void close() {
       logStream.close();
-      logStorageRule.close();
+      logStorage.close();
     }
 
     public LogStreamRecordWriter getLogStreamWriter() {


### PR DESCRIPTION
## Description

Replaces the AtomixLogStorage with an on heap ListStorage.
Most of the tests are by factor 2 faster then before.

For example variable.mappings tests before:

![old](https://user-images.githubusercontent.com/2758593/78557599-5db2d680-7811-11ea-9223-47d1de6e66f5.png)

now:

![improve](https://user-images.githubusercontent.com/2758593/78557612-61465d80-7811-11ea-869e-1c314ff6bec3.png)



The engine test suite now runs on jenkins with around 1:50 min, before 02:39 min.

## Related issues

closes #4240 
closes #4242 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
