### PR TITLE
chore(raft): add test to simulate network partition

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -18,14 +18,18 @@ package io.atomix.raft;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.PrimitiveInfo;
@@ -53,6 +57,7 @@ import io.atomix.raft.primitive.TestPrimitiveImpl;
 import io.atomix.raft.primitive.TestPrimitiveService;
 import io.atomix.raft.primitive.TestPrimitiveType;
 import io.atomix.raft.protocol.TestRaftProtocolFactory;
+import io.atomix.raft.protocol.TestRaftServerProtocol;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.storage.log.entry.CloseSessionEntry;
@@ -71,6 +76,7 @@ import io.atomix.raft.storage.snapshot.SnapshotStore;
 import io.atomix.raft.storage.system.Configuration;
 import io.atomix.raft.utils.LoadMonitor;
 import io.atomix.storage.StorageLevel;
+import io.atomix.storage.journal.Indexed;
 import io.atomix.storage.journal.JournalReader.Mode;
 import io.atomix.storage.statistics.StorageStatistics;
 import io.atomix.utils.concurrent.Futures;
@@ -88,6 +94,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -96,6 +103,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -108,6 +116,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 
 /** Raft test. */
@@ -148,6 +157,7 @@ public class RaftTest extends ConcurrentTestCase {
   protected volatile TestRaftProtocolFactory protocolFactory;
   protected volatile ThreadContext context;
   private Path directory;
+  private final Map<MemberId, TestRaftServerProtocol> serverProtocols = Maps.newConcurrentMap();
 
   @Before
   @After
@@ -262,12 +272,14 @@ public class RaftTest extends ConcurrentTestCase {
   private RaftServer createServer(
       final MemberId memberId,
       final Function<RaftServer.Builder, RaftServer.Builder> configurator) {
+    final TestRaftServerProtocol protocol = protocolFactory.newServerProtocol(memberId);
     final RaftServer.Builder defaults =
         RaftServer.builder(memberId)
             .withMembershipService(mock(ClusterMembershipService.class))
-            .withProtocol(protocolFactory.newServerProtocol(memberId));
+            .withProtocol(protocol);
     final RaftServer server = configurator.apply(defaults).build();
 
+    serverProtocols.put(memberId, protocol);
     servers.add(server);
     return server;
   }
@@ -464,8 +476,7 @@ public class RaftTest extends ConcurrentTestCase {
   @Test
   public void testLeaderLeave() throws Throwable {
     final List<RaftServer> servers = createServers(3);
-    final RaftServer server =
-        servers.stream().filter(s -> s.getRole() == RaftServer.Role.LEADER).findFirst().get();
+    final RaftServer server = getLeader(servers).get();
     server.leave().thenRun(this::resume);
     await(30000);
   }
@@ -1101,8 +1112,7 @@ public class RaftTest extends ConcurrentTestCase {
       await(30000, 2);
     }
 
-    final RaftServer leader =
-        servers.stream().filter(s -> s.getRole() == RaftServer.Role.LEADER).findFirst().get();
+    final RaftServer leader = getLeader(servers).get();
     leader.shutdown().get(10, TimeUnit.SECONDS);
 
     for (int i = 0; i < 10; i++) {
@@ -1160,8 +1170,7 @@ public class RaftTest extends ConcurrentTestCase {
           resume();
         });
 
-    final RaftServer leader =
-        servers.stream().filter(s -> s.getRole() == Role.LEADER).findFirst().get();
+    final RaftServer leader = getLeader(servers).get();
     final MemberId memberId = new MemberId(leader.name());
     leader.shutdown().get(10, TimeUnit.SECONDS);
 
@@ -1275,8 +1284,7 @@ public class RaftTest extends ConcurrentTestCase {
 
     primitive.sendEvent(true).thenRun(this::resume);
 
-    final RaftServer leader =
-        servers.stream().filter(s -> s.getRole() == RaftServer.Role.LEADER).findFirst().get();
+    final RaftServer leader = getLeader(servers).get();
     leader.shutdown().get(10, TimeUnit.SECONDS);
 
     await(30000);
@@ -1657,8 +1665,7 @@ public class RaftTest extends ConcurrentTestCase {
   public void testRoleChangeNotificationAfterInitialEntryOnLeader() throws Throwable {
     // given
     final List<RaftServer> servers = createServers(3);
-    final RaftServer leader =
-        servers.stream().filter(s -> s.getRole() == RaftServer.Role.LEADER).findFirst().get();
+    final RaftServer leader = getLeader(servers).get();
     final CountDownLatch transitionCompleted = new CountDownLatch(1);
     servers.stream()
         .forEach(
@@ -1672,6 +1679,14 @@ public class RaftTest extends ConcurrentTestCase {
     // then
     transitionCompleted.await(10, TimeUnit.SECONDS);
     assertEquals(0, transitionCompleted.getCount());
+  }
+
+  private Optional<RaftServer> getLeader(final List<RaftServer> servers) {
+    return servers.stream().filter(s -> s.getRole() == Role.LEADER).findFirst();
+  }
+
+  private List<RaftServer> getFollowers(final List<RaftServer> servers) {
+    return servers.stream().filter(s -> s.getRole() == Role.FOLLOWER).collect(Collectors.toList());
   }
 
   private void assertLastReadInitialEntry(
@@ -1717,6 +1732,129 @@ public class RaftTest extends ConcurrentTestCase {
     assertEquals(0, secondListener.getCount());
 
     assertEquals(server.getRole(), Role.INACTIVE);
+  }
+
+  @Test
+  public void shouldLeaderStepDownOnDisconnect() throws Throwable {
+    final List<RaftServer> servers = createServers(3);
+    final RaftServer leader = getLeader(servers).get();
+    final MemberId leaderId = leader.getContext().getCluster().getMember().memberId();
+
+    final CountDownLatch stepDownListener = new CountDownLatch(1);
+    leader.addRoleChangeListener(
+        (role, term) -> {
+          if (role == Role.FOLLOWER) {
+            stepDownListener.countDown();
+          }
+        });
+
+    // when
+    protocolFactory.partition(leaderId);
+
+    // then
+    assertTrue(stepDownListener.await(30, TimeUnit.SECONDS));
+    assertFalse(leader.isLeader());
+  }
+
+  @Test
+  public void shouldReconnect() throws Throwable {
+    final List<RaftServer> servers = createServers(3);
+    final RaftServer leader = getLeader(servers).get();
+    final MemberId leaderId = leader.getContext().getCluster().getMember().memberId();
+    final AtomicLong commitIndex = new AtomicLong();
+    leader
+        .getContext()
+        .addCommitListener(
+            new RaftCommitListener() {
+              @Override
+              public <T extends RaftLogEntry> void onCommit(final Indexed<T> entry) {
+                commitIndex.set(entry.index());
+              }
+            });
+    final RaftClient client = createClient();
+    final TestPrimitive primitive = createPrimitive(client);
+    primitive.onEvent(
+        event -> {
+          threadAssertNotNull(event);
+          resume();
+        });
+
+    for (int i = 0; i < 1_000; i++) {
+      primitive.sendEvent(true);
+    }
+    await(30000, 500);
+
+    // when
+    protocolFactory.partition(leaderId);
+    waitUntil(() -> !leader.isLeader(), 100);
+    for (int i = 0; i < 2_000; i++) {
+      primitive.sendEvent(true);
+    }
+    final long lastCommitIndex = primitive.sendEvent(true).get();
+    protocolFactory.heal(leaderId);
+
+    // then
+    waitUntil(() -> commitIndex.get() >= lastCommitIndex, 200);
+  }
+
+  @Test
+  public void shouldFailOverOnLeaderDisconnect() throws Throwable {
+    final List<RaftServer> servers = createServers(3);
+
+    final RaftServer leader = getLeader(servers).get();
+    final MemberId leaderId = leader.getContext().getCluster().getMember().memberId();
+
+    final CountDownLatch newLeaderElected = new CountDownLatch(1);
+    final AtomicReference<MemberId> newLeaderId = new AtomicReference<>();
+    servers.forEach(
+        s ->
+            s.addRoleChangeListener(
+                (role, term) -> {
+                  if (role == Role.LEADER) {
+                    newLeaderElected.countDown();
+                    newLeaderId.set(s.getContext().getCluster().getMember().memberId());
+                  }
+                }));
+    // when
+    protocolFactory.partition(leaderId);
+
+    // then
+    assertTrue(newLeaderElected.await(30, TimeUnit.SECONDS));
+    assertTrue(!newLeaderId.get().equals(leaderId));
+  }
+
+  @Test
+  public void shouldTriggerHeartbeatTimeouts() throws Throwable {
+    final List<RaftServer> servers = createServers(3);
+    final List<RaftServer> followers = getFollowers(servers);
+    final MemberId followerId = followers.get(0).getContext().getCluster().getMember().memberId();
+
+    // when
+    final TestRaftServerProtocol followerServer = serverProtocols.get(followerId);
+    Mockito.clearInvocations(followerServer);
+    protocolFactory.partition(followerId);
+
+    // then
+    // should send poll requests to 2 nodes
+    verify(followerServer, timeout(5000).atLeast(2)).poll(any(), any());
+  }
+
+  @Test
+  public void shouldReSendPollRequestOnTimeouts() throws Throwable {
+    final List<RaftServer> servers = createServers(3);
+    final List<RaftServer> followers = getFollowers(servers);
+    final MemberId followerId = followers.get(0).getContext().getCluster().getMember().memberId();
+
+    // when
+    final TestRaftServerProtocol followerServer = serverProtocols.get(followerId);
+    Mockito.clearInvocations(followerServer);
+    protocolFactory.partition(followerId);
+    verify(followerServer, timeout(5000).atLeast(2)).poll(any(), any());
+    Mockito.clearInvocations(followerServer);
+
+    // then
+    // no response for previous poll requests, so send them again
+    verify(followerServer, timeout(5000).atLeast(2)).poll(any(), any());
   }
 
   private static final class FakeStatistics extends StorageStatistics {

--- a/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftProtocolFactory.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftProtocolFactory.java
@@ -16,6 +16,8 @@
  */
 package io.atomix.raft.protocol;
 
+import static org.mockito.Mockito.spy;
+
 import com.google.common.collect.Maps;
 import io.atomix.cluster.MemberId;
 import io.atomix.utils.concurrent.ThreadContext;
@@ -38,7 +40,7 @@ public class TestRaftProtocolFactory {
    * @param memberId the client member identifier
    * @return a new test client protocol
    */
-  public RaftClientProtocol newClientProtocol(final MemberId memberId) {
+  public TestRaftClientProtocol newClientProtocol(final MemberId memberId) {
     return new TestRaftClientProtocol(memberId, servers, clients, context);
   }
 
@@ -48,7 +50,32 @@ public class TestRaftProtocolFactory {
    * @param memberId the server member identifier
    * @return a new test server protocol
    */
-  public RaftServerProtocol newServerProtocol(final MemberId memberId) {
-    return new TestRaftServerProtocol(memberId, servers, clients, context);
+  public TestRaftServerProtocol newServerProtocol(final MemberId memberId) {
+    final TestRaftServerProtocol spyProtocol =
+        spy(new TestRaftServerProtocol(memberId, servers, clients, context));
+    servers.put(memberId, spyProtocol);
+    return spyProtocol;
+  }
+
+  /** Disconnect server from rest of the servers */
+  public void partition(final MemberId target) {
+    servers.keySet().forEach(other -> partition(target, other));
+  }
+
+  /** Disconnect two members */
+  private void partition(final MemberId first, final MemberId second) {
+    servers.get(first).disconnect(second);
+    servers.get(second).disconnect(first);
+  }
+
+  /** Heal network partition between target and rest of the cluster */
+  public void heal(final MemberId target) {
+    servers.keySet().forEach(other -> heal(target, other));
+  }
+
+  /** Heal network partition between two members */
+  private void heal(final MemberId first, final MemberId second) {
+    servers.get(first).reconnect(second);
+    servers.get(second).reconnect(first);
   }
 }


### PR DESCRIPTION
## Description

- Enable RaftTest to simulate network partition
- Add tests for leader and follower disconnect

## Related issues

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
