### PR TITLE
chore(test): expose broker clock in zeebe test

### DIFF
--- a/test/src/main/java/io/zeebe/test/ZeebeTestRule.java
+++ b/test/src/main/java/io/zeebe/test/ZeebeTestRule.java
@@ -14,6 +14,7 @@ import io.zeebe.client.api.response.WorkflowInstanceEvent;
 import io.zeebe.test.util.record.RecordingExporter;
 import io.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.zeebe.util.SocketUtil;
+import io.zeebe.util.sched.clock.ControlledActorClock;
 import java.util.Properties;
 import java.util.function.Supplier;
 import org.junit.rules.ExternalResource;
@@ -52,6 +53,10 @@ public class ZeebeTestRule extends ExternalResource {
 
   public BrokerCfg getBrokerCfg() {
     return brokerRule.getBrokerCfg();
+  }
+
+  public ControlledActorClock getBrokerClock() {
+    return brokerRule.getClock();
   }
 
   @Override


### PR DESCRIPTION
## Description

Exposes broker clock in `ZeebeTestRule`.

## Related issues

closes #3751 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
