### PR TITLE
Handle exceptions thrown by continuation job in actor

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -715,6 +715,14 @@ public final class ZeebePartition extends Actor
     super.close();
   }
 
+  @Override
+  protected void handleFailure(final Exception failure) {
+    LOG.warn("Uncaught exception in {}.", actorName, failure);
+    // Most probably exception happened in the middle of installing leader or follower services
+    // because this actor is not doing anything else
+    onInstallFailure();
+  }
+
   private ActorFuture<LogStream> openLogStream() {
     return LogStream.builder()
         .withLogStorage(atomixLogStorage)

--- a/util/src/main/java/io/zeebe/util/sched/future/FutureContinuationRunnable.java
+++ b/util/src/main/java/io/zeebe/util/sched/future/FutureContinuationRunnable.java
@@ -7,7 +7,7 @@
  */
 package io.zeebe.util.sched.future;
 
-import io.zeebe.util.Loggers;
+import io.zeebe.util.LangUtil;
 import java.util.function.BiConsumer;
 
 public final class FutureContinuationRunnable<T> implements Runnable {
@@ -26,8 +26,8 @@ public final class FutureContinuationRunnable<T> implements Runnable {
       try {
         final T res = future.get();
         consumer.accept(res, null);
-      } catch (final Throwable e) {
-        Loggers.ACTOR_LOGGER.debug("Continuing on future completion failed", e);
+      } catch (final Exception e) {
+        LangUtil.rethrowUnchecked(e);
       }
     } else {
       consumer.accept(null, future.getException());


### PR DESCRIPTION
## Description

- Do not catch exceptions thrown by a continuation job. Instead it will be handled the same way as other unhandled exceptions in an actor task.
- Mark unhealthy on unhandled exceptions in ZeebePartition actor.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4062 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
