### PR TITLE
Only init variable names to nil for output element variable

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/multiinstance/AbstractMultiInstanceBodyHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/multiinstance/AbstractMultiInstanceBodyHandler.java
@@ -135,21 +135,17 @@ public abstract class AbstractMultiInstanceBodyHandler
                 variablesState.setVariableLocal(
                     elementInstanceKey, workflowKey, variableName, item));
 
-    // Output element expressions that are just a variable or nested variable need to be initialised
-    // with a nil-value. This makes sure that they are not written at a non-local scope.
+    // Output element expressions that are just a variable or nested property of a variable need to
+    // be initialised with a nil-value. This makes sure that they are not written at a non-local
+    // scope.
     loopCharacteristics
         .getOutputElement()
-        .map(Expression::getExpression)
-        .map(expression -> expression.split("\\.")[0]) // only take the main variable name
-        // TODO #4100 (@korthout/@saig0)
-        // Filter out all non-variable expressions without this ugly regex :)
+        .flatMap(Expression::getVariableName)
+        .map(BufferUtil::wrapString)
         .ifPresent(
             variableName ->
                 variablesState.setVariableLocal(
-                    elementInstanceKey,
-                    workflowKey,
-                    BufferUtil.wrapString(variableName),
-                    NIL_VALUE));
+                    elementInstanceKey, workflowKey, variableName, NIL_VALUE));
 
     variablesState.setVariableLocal(
         elementInstanceKey,

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/multiinstance/MultiInstanceActivityTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/multiinstance/MultiInstanceActivityTest.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.engine.processor.workflow.multiinstance;
 
+import static io.zeebe.protocol.record.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -16,7 +17,6 @@ import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.model.bpmn.builder.MultiInstanceLoopCharacteristicsBuilder;
 import io.zeebe.model.bpmn.builder.zeebe.MessageBuilder;
 import io.zeebe.model.bpmn.instance.ServiceTask;
-import io.zeebe.protocol.record.Assertions;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.intent.JobBatchIntent;
 import io.zeebe.protocol.record.intent.JobIntent;
@@ -25,6 +25,7 @@ import io.zeebe.protocol.record.intent.VariableIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.protocol.record.value.JobRecordValue;
+import io.zeebe.protocol.record.value.VariableRecordValue;
 import io.zeebe.test.util.JsonUtil;
 import io.zeebe.test.util.record.RecordingExporter;
 import io.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -33,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.assertj.core.groups.Tuple;
@@ -51,11 +53,11 @@ public final class MultiInstanceActivityTest {
   private static final String ELEMENT_ID = "task";
   private static final String JOB_TYPE = "test";
 
-  private static final String INPUT_COLLECTION_VARIABLE = "items";
+  private static final String INPUT_COLLECTION_EXPRESSION = "items";
   private static final String INPUT_ELEMENT_VARIABLE = "item";
   private static final List<Integer> INPUT_COLLECTION = List.of(10, 20, 30);
   private static final String OUTPUT_COLLECTION_VARIABLE = "results";
-  private static final String OUTPUT_ELEMENT_VARIABLE = "result";
+  private static final String OUTPUT_ELEMENT_EXPRESSION = "result";
   private static final List<Integer> OUTPUT_COLLECTION = List.of(11, 22, 33);
 
   private static final String MESSAGE_CORRELATION_KEY_VARIABLE = "correlationKey";
@@ -65,10 +67,10 @@ public final class MultiInstanceActivityTest {
   private static final Consumer<MultiInstanceLoopCharacteristicsBuilder> INPUT_VARIABLE_BUILDER =
       multiInstance(
           m ->
-              m.zeebeInputCollectionExpression(INPUT_COLLECTION_VARIABLE)
+              m.zeebeInputCollectionExpression(INPUT_COLLECTION_EXPRESSION)
                   .zeebeInputElement(INPUT_ELEMENT_VARIABLE)
-                  .zeebeOutputCollection(OUTPUT_COLLECTION_VARIABLE)
-                  .zeebeOutputElementExpression(OUTPUT_ELEMENT_VARIABLE));
+                  .zeebeOutputElementExpression(OUTPUT_ELEMENT_EXPRESSION)
+                  .zeebeOutputCollection(OUTPUT_COLLECTION_VARIABLE));
 
   private static final Consumer<MessageBuilder> MESSAGE_BUILDER =
       m -> m.name(MESSAGE_NAME).zeebeCorrelationKeyExpression(MESSAGE_CORRELATION_KEY_VARIABLE);
@@ -152,7 +154,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -177,7 +179,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -206,7 +208,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -232,7 +234,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -262,7 +264,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -295,7 +297,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -328,7 +330,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -353,7 +355,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, 1);
@@ -386,7 +388,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     final int completedJobs = INPUT_COLLECTION.size() - 1;
@@ -425,7 +427,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, Collections.emptyList())
+            .withVariable(INPUT_COLLECTION_EXPRESSION, Collections.emptyList())
             .create();
 
     // then
@@ -458,7 +460,7 @@ public final class MultiInstanceActivityTest {
             workflow(
                 miBuilder.andThen(
                     m ->
-                        m.zeebeInputCollectionExpression(INPUT_COLLECTION_VARIABLE)
+                        m.zeebeInputCollectionExpression(INPUT_COLLECTION_EXPRESSION)
                             .zeebeInputElement(null))))
         .deploy();
 
@@ -467,7 +469,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -490,7 +492,8 @@ public final class MultiInstanceActivityTest {
         .withXmlResource(
             workflow(
                 miBuilder.andThen(
-                    m -> m.zeebeInputCollectionExpression("nested." + INPUT_COLLECTION_VARIABLE))))
+                    m ->
+                        m.zeebeInputCollectionExpression("nested." + INPUT_COLLECTION_EXPRESSION))))
         .deploy();
 
     final long workflowInstanceKey =
@@ -498,7 +501,7 @@ public final class MultiInstanceActivityTest {
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
             .withVariable(
-                "nested", Collections.singletonMap(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION))
+                "nested", Collections.singletonMap(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION))
             .create();
 
     RecordingExporter.jobRecords(JobIntent.CREATED)
@@ -519,6 +522,88 @@ public final class MultiInstanceActivityTest {
   }
 
   @Test
+  public void shouldCollectNestedOutputElements() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            workflow(
+                miBuilder.andThen(
+                    m -> m.zeebeOutputElementExpression(OUTPUT_ELEMENT_EXPRESSION + ".nested"))))
+        .deploy();
+
+    final long workflowInstanceKey =
+        ENGINE
+            .workflowInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
+            .create();
+
+    // complete jobs
+    completeJobs(
+        workflowInstanceKey,
+        INPUT_COLLECTION.size(),
+        i -> Map.of("nested", OUTPUT_COLLECTION.get(i)));
+
+    // then
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withName(OUTPUT_ELEMENT_EXPRESSION) // without '.nested'
+                .withValue("null")
+                .limit(INPUT_COLLECTION.size()))
+        .hasSize(INPUT_COLLECTION.size());
+
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withName(OUTPUT_COLLECTION_VARIABLE)
+                .withScopeKey(workflowInstanceKey)
+                .getFirst()
+                .getValue())
+        .hasValue(JsonUtil.toJson(OUTPUT_COLLECTION));
+  }
+
+  @Test
+  public void shouldCollectOutputElementsFromExpression() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            workflow(
+                miBuilder.andThen(
+                    m ->
+                        m.zeebeOutputElementExpression(
+                            "number(string(loopCounter) + string(loopCounter))"))))
+        .deploy();
+
+    final long workflowInstanceKey =
+        ENGINE
+            .workflowInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
+            .create();
+
+    // complete jobs
+    completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limitToWorkflowInstance(workflowInstanceKey)
+                .variableRecords()
+                .map(Record::getValue)
+                .map(VariableRecordValue::getName))
+        .noneMatch("number(string(loopCounter) + string(loopCounter))"::equals);
+
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withName(OUTPUT_COLLECTION_VARIABLE)
+                .withScopeKey(workflowInstanceKey)
+                .getFirst()
+                .getValue())
+        .hasValue(JsonUtil.toJson(OUTPUT_COLLECTION));
+  }
+
+  @Test
   public void shouldSetOutputCollectionVariable() {
     // given
     ENGINE.deployment().withXmlResource(workflow(miBuilder)).deploy();
@@ -528,7 +613,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -540,7 +625,7 @@ public final class MultiInstanceActivityTest {
             .withScopeKey(workflowInstanceKey)
             .getFirst();
 
-    Assertions.assertThat(variableRecord.getValue()).hasValue(JsonUtil.toJson(OUTPUT_COLLECTION));
+    assertThat(variableRecord.getValue()).hasValue(JsonUtil.toJson(OUTPUT_COLLECTION));
   }
 
   @Test
@@ -553,7 +638,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -584,7 +669,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -592,14 +677,14 @@ public final class MultiInstanceActivityTest {
     // then
     assertThat(
             RecordingExporter.variableRecords(VariableIntent.CREATED)
-                .withName(OUTPUT_ELEMENT_VARIABLE)
+                .withName(OUTPUT_ELEMENT_EXPRESSION)
                 .limit(INPUT_COLLECTION.size()))
         .extracting(r -> r.getValue().getValue())
         .containsOnly("null");
 
     assertThat(
             RecordingExporter.variableRecords(VariableIntent.UPDATED)
-                .withName(OUTPUT_ELEMENT_VARIABLE)
+                .withName(OUTPUT_ELEMENT_EXPRESSION)
                 .limit(INPUT_COLLECTION.size()))
         .extracting(r -> r.getValue().getValue())
         .containsExactlyElementsOf(
@@ -616,7 +701,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, List.of())
+            .withVariable(INPUT_COLLECTION_EXPRESSION, List.of())
             .create();
 
     // then
@@ -626,7 +711,7 @@ public final class MultiInstanceActivityTest {
             .withWorkflowInstanceKey(workflowInstanceKey)
             .getFirst();
 
-    Assertions.assertThat(variableRecord.getValue()).hasValue("[]");
+    assertThat(variableRecord.getValue()).hasValue("[]");
   }
 
   @Test
@@ -645,7 +730,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -670,7 +755,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -683,7 +768,7 @@ public final class MultiInstanceActivityTest {
                 .withWorkflowInstanceKey(workflowInstanceKey)
                 .withScopeKey(workflowInstanceKey))
         .extracting(r -> r.getValue().getName())
-        .doesNotContain(OUTPUT_ELEMENT_VARIABLE);
+        .doesNotContain(OUTPUT_ELEMENT_EXPRESSION);
   }
 
   @Test
@@ -696,7 +781,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -742,7 +827,7 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
@@ -779,7 +864,8 @@ public final class MultiInstanceActivityTest {
     final ServiceTask task = workflow(miBuilder).getModelElementById(ELEMENT_ID);
     final var workflow =
         task.builder()
-            .zeebeOutputExpression("loopCounter", OUTPUT_ELEMENT_VARIABLE) // overrides the variable
+            .zeebeOutputExpression(
+                "loopCounter", OUTPUT_ELEMENT_EXPRESSION) // overrides the variable
             .zeebeOutputExpression("loopCounter", "global") // propagates to root scope
             .done();
 
@@ -790,13 +876,13 @@ public final class MultiInstanceActivityTest {
         ENGINE
             .workflowInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariable(INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION)
+            .withVariable(INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION)
             .create();
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size());
 
     // then
-    Assertions.assertThat(
+    assertThat(
             RecordingExporter.variableRecords()
                 .withScopeKey(workflowInstanceKey)
                 .withName(OUTPUT_COLLECTION_VARIABLE)
@@ -837,7 +923,7 @@ public final class MultiInstanceActivityTest {
             .ofBpmnProcessId(PROCESS_ID)
             .withVariables(
                 Map.of(
-                    INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION,
+                    INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION,
                     MESSAGE_CORRELATION_KEY_VARIABLE, MESSAGE_CORRELATION_KEY))
             .create();
 
@@ -927,7 +1013,7 @@ public final class MultiInstanceActivityTest {
             .ofBpmnProcessId(PROCESS_ID)
             .withVariables(
                 Map.of(
-                    INPUT_COLLECTION_VARIABLE, INPUT_COLLECTION,
+                    INPUT_COLLECTION_EXPRESSION, INPUT_COLLECTION,
                     MESSAGE_CORRELATION_KEY_VARIABLE, MESSAGE_CORRELATION_KEY))
             .create();
 
@@ -998,6 +1084,14 @@ public final class MultiInstanceActivityTest {
   }
 
   private void completeJobs(final long workflowInstanceKey, final int count) {
+    final Function<Integer, Object> defaultResultProvider = OUTPUT_COLLECTION::get;
+    completeJobs(workflowInstanceKey, count, defaultResultProvider);
+  }
+
+  private void completeJobs(
+      final long workflowInstanceKey,
+      final int count,
+      final Function<Integer, Object> resultProvider) {
     IntStream.range(0, count)
         .forEach(
             i -> {
@@ -1019,7 +1113,7 @@ public final class MultiInstanceActivityTest {
                           ENGINE
                               .job()
                               .withKey(jobKey)
-                              .withVariable(OUTPUT_ELEMENT_VARIABLE, OUTPUT_COLLECTION.get(i))
+                              .withVariable(OUTPUT_ELEMENT_EXPRESSION, resultProvider.apply(i))
                               .complete());
             });
   }

--- a/expression-language/src/main/java/io/zeebe/el/Expression.java
+++ b/expression-language/src/main/java/io/zeebe/el/Expression.java
@@ -7,11 +7,19 @@
  */
 package io.zeebe.el;
 
+import java.util.Optional;
+
 /** A parsed expression. */
 public interface Expression {
 
   /** @return the (raw) expression as string */
   String getExpression();
+
+  /**
+   * @return optional of the name of the variable if expression is a single variable or a property
+   *     of a single variable, otherwise empty
+   */
+  Optional<String> getVariableName();
 
   /**
    * @return {@code true} if it is an static expression that does not require additional context

--- a/expression-language/src/main/java/io/zeebe/el/impl/FeelExpression.java
+++ b/expression-language/src/main/java/io/zeebe/el/impl/FeelExpression.java
@@ -8,7 +8,11 @@
 package io.zeebe.el.impl;
 
 import io.zeebe.el.Expression;
+import java.util.Optional;
+import org.camunda.feel.syntaxtree.Exp;
 import org.camunda.feel.syntaxtree.ParsedExpression;
+import org.camunda.feel.syntaxtree.PathExpression;
+import org.camunda.feel.syntaxtree.Ref;
 
 public final class FeelExpression implements Expression {
 
@@ -24,6 +28,11 @@ public final class FeelExpression implements Expression {
   }
 
   @Override
+  public Optional<String> getVariableName() {
+    return extractVariableName(expression.expression());
+  }
+
+  @Override
   public boolean isStatic() {
     return false;
   }
@@ -36,6 +45,18 @@ public final class FeelExpression implements Expression {
   @Override
   public String getFailureMessage() {
     return null;
+  }
+
+  private static Optional<String> extractVariableName(final Exp expression) {
+    if (expression instanceof PathExpression) {
+      final var path = (PathExpression) expression;
+      return extractVariableName(path.path());
+    }
+    if (expression instanceof Ref) {
+      final var ref = (Ref) expression;
+      return Optional.of(ref.names().head());
+    }
+    return Optional.empty();
   }
 
   public ParsedExpression getParsedExpression() {

--- a/expression-language/src/main/java/io/zeebe/el/impl/InvalidExpression.java
+++ b/expression-language/src/main/java/io/zeebe/el/impl/InvalidExpression.java
@@ -8,6 +8,7 @@
 package io.zeebe.el.impl;
 
 import io.zeebe.el.Expression;
+import java.util.Optional;
 
 public final class InvalidExpression implements Expression {
 
@@ -22,6 +23,11 @@ public final class InvalidExpression implements Expression {
   @Override
   public String getExpression() {
     return expression;
+  }
+
+  @Override
+  public Optional<String> getVariableName() {
+    return Optional.empty();
   }
 
   @Override

--- a/expression-language/src/main/java/io/zeebe/el/impl/StaticExpression.java
+++ b/expression-language/src/main/java/io/zeebe/el/impl/StaticExpression.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.time.Period;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.agrona.DirectBuffer;
 
 /**
@@ -52,6 +53,11 @@ public final class StaticExpression implements Expression, EvaluationResult {
   @Override
   public String getExpression() {
     return expression;
+  }
+
+  @Override
+  public Optional<String> getVariableName() {
+    return Optional.empty();
   }
 
   @Override

--- a/expression-language/src/test/java/io/zeebe/el/ExpressionLanguageTest.java
+++ b/expression-language/src/test/java/io/zeebe/el/ExpressionLanguageTest.java
@@ -29,6 +29,7 @@ public class ExpressionLanguageTest {
     assertThat(expression.isStatic()).isTrue();
     assertThat(expression.isValid()).isTrue();
     assertThat(expression.getExpression()).isEqualTo("x");
+    assertThat(expression.getVariableName()).isEmpty();
     assertThat(expression.getFailureMessage()).isNull();
   }
 
@@ -41,6 +42,7 @@ public class ExpressionLanguageTest {
     assertThat(expression.isStatic()).isTrue();
     assertThat(expression.isValid()).isTrue();
     assertThat(expression.getExpression()).isEqualTo("3");
+    assertThat(expression.getVariableName()).isEmpty();
     assertThat(expression.getFailureMessage()).isNull();
   }
 
@@ -53,6 +55,7 @@ public class ExpressionLanguageTest {
     assertThat(expression.isStatic()).isTrue();
     assertThat(expression.isValid()).isTrue();
     assertThat(expression.getExpression()).isEqualTo("3.141");
+    assertThat(expression.getVariableName()).isEmpty();
     assertThat(expression.getFailureMessage()).isNull();
   }
 
@@ -64,6 +67,7 @@ public class ExpressionLanguageTest {
     assertThat(expression.isStatic()).isFalse();
     assertThat(expression.isValid()).isTrue();
     assertThat(expression.getExpression()).isEqualTo("x.y");
+    assertThat(expression.getVariableName()).contains("x");
     assertThat(expression.getFailureMessage()).isNull();
   }
 
@@ -75,6 +79,7 @@ public class ExpressionLanguageTest {
     assertThat(expression.isStatic()).isFalse();
     assertThat(expression.isValid()).isTrue();
     assertThat(expression.getExpression()).isEqualTo("{\nx:1\n}");
+    assertThat(expression.getVariableName()).isEmpty();
     assertThat(expression.getFailureMessage()).isNull();
   }
 
@@ -85,6 +90,7 @@ public class ExpressionLanguageTest {
     assertThat(expression).isNotNull();
     assertThat(expression.isValid()).isFalse();
     assertThat(expression.getExpression()).isEqualTo("x ?! 5");
+    assertThat(expression.getVariableName()).isEmpty();
     assertThat(expression.getFailureMessage())
         .startsWith("failed to parse expression 'x ?! 5': [1.3] failure:");
   }
@@ -99,6 +105,7 @@ public class ExpressionLanguageTest {
     assertThat(evaluationResult.getType()).isEqualTo(ResultType.STRING);
     assertThat(evaluationResult.getString()).isEqualTo("x");
     assertThat(evaluationResult.getExpression()).isEqualTo("x");
+    assertThat(expression.getVariableName()).isEmpty();
     assertThat(evaluationResult.getFailureMessage()).isNull();
   }
 
@@ -112,6 +119,7 @@ public class ExpressionLanguageTest {
     assertThat(evaluationResult.getType()).isEqualTo(ResultType.NUMBER);
     assertThat(evaluationResult.getNumber().longValue()).isEqualTo(3);
     assertThat(evaluationResult.getExpression()).isEqualTo("3");
+    assertThat(expression.getVariableName()).isEmpty();
     assertThat(evaluationResult.getFailureMessage()).isNull();
   }
 
@@ -125,6 +133,7 @@ public class ExpressionLanguageTest {
     assertThat(evaluationResult.getType()).isEqualTo(ResultType.NUMBER);
     assertThat(evaluationResult.getNumber().doubleValue()).isEqualTo(3.141);
     assertThat(evaluationResult.getExpression()).isEqualTo("3.141");
+    assertThat(expression.getVariableName()).isEmpty();
     assertThat(evaluationResult.getFailureMessage()).isNull();
     // given
     final StaticExpression sutStaticExpression = new StaticExpression("3.141");
@@ -155,6 +164,7 @@ public class ExpressionLanguageTest {
     assertThat(evaluationResult.getType()).isEqualTo(ResultType.STRING);
     assertThat(evaluationResult.getString()).isEqualTo("x");
     assertThat(evaluationResult.getExpression()).isEqualTo("x");
+    assertThat(expression.getVariableName()).contains("x");
     assertThat(evaluationResult.getFailureMessage()).isNull();
   }
 
@@ -168,6 +178,7 @@ public class ExpressionLanguageTest {
     assertThat(evaluationResult.getFailureMessage())
         .startsWith("failed to evaluate expression 'x': no variable found for name 'x'");
     assertThat(evaluationResult.getExpression()).isEqualTo("x");
+    assertThat(expression.getVariableName()).contains("x");
     assertThat(evaluationResult.getType()).isNull();
     assertThat(evaluationResult.getString()).isNull();
   }


### PR DESCRIPTION
## Description

Introduced a `Optional<String> getVariableName()` method to `Expression` that provides a name of the top most variable in the expression if it is a single variable or a nested property of a variable.

This method is in turn used to init the output element variable to nil at the local scope of a multi instance body, to make sure such a body can set a variable with that name at its own scope.

## Related issues

closes #4100 