### PR TITLE
chore(logstreams): add snapshot checksum verification

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/engine/impl/SnapshotChunkImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/SnapshotChunkImpl.java
@@ -27,6 +27,7 @@ public final class SnapshotChunkImpl
   private int totalCount;
   private String chunkName;
   private long checksum;
+  private long snapshotChecksum;
 
   public SnapshotChunkImpl() {}
 
@@ -35,6 +36,7 @@ public final class SnapshotChunkImpl
     totalCount = chunk.getTotalCount();
     chunkName = chunk.getChunkName();
     checksum = chunk.getChecksum();
+    snapshotChecksum = chunk.getSnapshotChecksum();
     content.wrap(chunk.getContent());
   }
 
@@ -54,6 +56,7 @@ public final class SnapshotChunkImpl
 
     totalCount = SnapshotChunkDecoder.totalCountNullValue();
     checksum = SnapshotChunkDecoder.checksumNullValue();
+    snapshotChecksum = SnapshotChunkDecoder.snapshotChecksumNullValue();
 
     snapshotId = "";
     chunkName = "";
@@ -80,6 +83,7 @@ public final class SnapshotChunkImpl
         .snapshotId(snapshotId)
         .chunkName(chunkName)
         .checksum(checksum)
+        .snapshotChecksum(snapshotChecksum)
         .putContent(content, 0, content.capacity());
   }
 
@@ -91,6 +95,7 @@ public final class SnapshotChunkImpl
     snapshotId = decoder.snapshotId();
     chunkName = decoder.chunkName();
     checksum = decoder.checksum();
+    snapshotChecksum = decoder.snapshotChecksum();
 
     if (decoder.contentLength() > 0) {
       decoder.wrapContent(content);
@@ -123,6 +128,11 @@ public final class SnapshotChunkImpl
   }
 
   @Override
+  public long getSnapshotChecksum() {
+    return snapshotChecksum;
+  }
+
+  @Override
   public String toString() {
     return "SnapshotChunkImpl{"
         + "snapshotId="
@@ -134,6 +144,8 @@ public final class SnapshotChunkImpl
         + '\''
         + ", checksum="
         + checksum
+        + ", snapshotChecksum="
+        + snapshotChecksum
         + "} "
         + super.toString();
   }

--- a/broker/src/main/resources/management-schema.xml
+++ b/broker/src/main/resources/management-schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude"
-  package="io.zeebe.clustering.management" id="5" version="1"
+  package="io.zeebe.clustering.management" id="5" version="2"
   semanticVersion="0.1.0" description="Zeebe Cluster Management Protocol" byteOrder="littleEndian">
 
   <xi:include href="../../../../protocol/src/main/resources/common-types.xml"/>
@@ -41,7 +41,8 @@
   <sbe:message name="SnapshotChunk" id="4">
     <field name="totalCount" id="0" type="int32"/>
     <field name="checksum" id="1" type="uint64"/>
-    <data name="snapshotId" id="2" type="varDataEncoding" />
+    <field name="snapshotChecksum" id="5" type="uint64" sinceVersion="2"/>
+    <data name="snapshotId" id="2" type="varDataEncoding"/>
     <data name="chunkName" id="3" type="varDataEncoding"/>
     <data name="content" id="4" type="blob"/>
   </sbe:message>

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/ReplicationController.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/ReplicationController.java
@@ -32,10 +32,15 @@ final class ReplicationController {
     this.metrics.setCount(0);
   }
 
-  void replicate(final String snapshotId, final int totalCount, final File snapshotChunkFile) {
+  void replicate(
+      final String snapshotId,
+      final int totalCount,
+      final File snapshotChunkFile,
+      long snapshotChecksum) {
     try {
       final SnapshotChunk chunkToReplicate =
-          SnapshotChunkUtil.createSnapshotChunkFromFile(snapshotChunkFile, snapshotId, totalCount);
+          SnapshotChunkUtil.createSnapshotChunkFromFile(
+              snapshotChunkFile, snapshotId, totalCount, snapshotChecksum);
       replication.replicate(chunkToReplicate);
     } catch (final IOException ioe) {
       LOG.error(
@@ -103,7 +108,8 @@ final class ReplicationController {
 
   private boolean tryToMarkSnapshotAsValid(
       final SnapshotChunk snapshotChunk, final ReplicationContext context) {
-    if (snapshotConsumer.completeSnapshot(snapshotChunk.getSnapshotId())) {
+    if (snapshotConsumer.completeSnapshot(
+        snapshotChunk.getSnapshotId(), snapshotChunk.getSnapshotChecksum())) {
       final var elapsed = System.currentTimeMillis() - context.startTimestamp;
       receivedSnapshots.remove(snapshotChunk.getSnapshotId());
       metrics.decrementCount();

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotChunk.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotChunk.java
@@ -22,4 +22,7 @@ public interface SnapshotChunk {
 
   /** @return the content of the current chunk */
   byte[] getContent();
+
+  /** @return the checksum of the entire snapshot */
+  long getSnapshotChecksum();
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotChunkUtil.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotChunkUtil.java
@@ -21,13 +21,16 @@ public final class SnapshotChunkUtil {
   }
 
   public static SnapshotChunk createSnapshotChunkFromFile(
-      final File snapshotChunkFile, final String snapshotId, final int totalCount)
+      final File snapshotChunkFile,
+      final String snapshotId,
+      final int totalCount,
+      long snapshotChecksum)
       throws IOException {
     final byte[] content;
     content = Files.readAllBytes(snapshotChunkFile.toPath());
     final long checksum = createChecksum(content);
     return new SnapshotChunkImpl(
-        snapshotId, totalCount, snapshotChunkFile.getName(), checksum, content);
+        snapshotId, totalCount, snapshotChunkFile.getName(), checksum, content, snapshotChecksum);
   }
 
   private static final class SnapshotChunkImpl implements SnapshotChunk {
@@ -35,6 +38,7 @@ public final class SnapshotChunkUtil {
     private final int totalCount;
     private final String chunkName;
     private final byte[] content;
+    private final long snapshotChecksum;
     private final long checksum;
 
     SnapshotChunkImpl(
@@ -42,12 +46,14 @@ public final class SnapshotChunkUtil {
         final int totalCount,
         final String chunkName,
         final long checksum,
-        final byte[] content) {
+        final byte[] content,
+        long snapshotChecksum) {
       this.snapshotId = snapshotId;
       this.totalCount = totalCount;
       this.chunkName = chunkName;
       this.checksum = checksum;
       this.content = content;
+      this.snapshotChecksum = snapshotChecksum;
     }
 
     @Override
@@ -73,6 +79,11 @@ public final class SnapshotChunkUtil {
     @Override
     public byte[] getContent() {
       return content;
+    }
+
+    @Override
+    public long getSnapshotChecksum() {
+      return snapshotChecksum;
     }
   }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotConsumer.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/state/SnapshotConsumer.java
@@ -10,7 +10,7 @@ package io.zeebe.logstreams.state;
 public interface SnapshotConsumer {
   boolean consumeSnapshotChunk(SnapshotChunk chunk);
 
-  boolean completeSnapshot(String snapshotId);
+  boolean completeSnapshot(String snapshotId, long snapshotChecksum);
 
   void invalidateSnapshot(String snapshotId);
 }


### PR DESCRIPTION
## Description

Introduces a checksum for the entire snapshot that is checked before marking a snapshot as valid. This means that invalid or incomplete snapshots won't be committed.

## Related issues

closes #4123

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
