### PR TITLE
chore(engine): add onFailed stream processor lifecycle

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -172,6 +172,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
     phase = Phase.FAILED;
     closeFuture = CompletableActorFuture.completed(null);
     isOpened.set(false);
+    lifecycleAwareListeners.forEach(StreamProcessorLifecycleAware::onFailed);
     tearDown();
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorLifecycleAware.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorLifecycleAware.java
@@ -13,4 +13,6 @@ public interface StreamProcessorLifecycleAware {
   default void onRecovered(final ReadonlyProcessingContext context) {}
 
   default void onClose() {}
+
+  default void onFailed() {}
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/BpmnStepProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/BpmnStepProcessor.java
@@ -50,6 +50,11 @@ public final class BpmnStepProcessor implements TypedRecordProcessor<WorkflowIns
   }
 
   @Override
+  public void onFailed() {
+    state.onClose();
+  }
+
+  @Override
   public void processRecord(
       final TypedRecord<WorkflowInstanceRecord> record,
       final TypedResponseWriter responseWriter,

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobTimeoutTrigger.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobTimeoutTrigger.java
@@ -46,6 +46,14 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
     }
   }
 
+  @Override
+  public void onFailed() {
+    if (timer != null) {
+      timer.cancel();
+      timer = null;
+    }
+  }
+
   void deactivateTimedOutJobs() {
     final long now = currentTimeMillis();
     state.forEachTimedOutEntry(


### PR DESCRIPTION
## Description

Enable stream processor lifecycle listeners to react when StreamProcessor fails.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4081

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
