### PR TITLE
chore(benchmarks): add more starters per default

### DIFF
--- a/benchmarks/project/src/main/resources/bpmn/simpleProcess.bpmn
+++ b/benchmarks/project/src/main/resources/bpmn/simpleProcess.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_03xfdqi" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.7.0">
+  <bpmn:process id="simpleProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0n8pemi</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_0ir1yv6">
+      <bpmn:incoming>SequenceFlow_0n8pemi</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0n8pemi" sourceRef="StartEvent_1" targetRef="EndEvent_0ir1yv6" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="simpleProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0ir1yv6_di" bpmnElement="EndEvent_0ir1yv6">
+        <dc:Bounds x="272" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0n8pemi_di" bpmnElement="SequenceFlow_0n8pemi">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="272" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/benchmarks/project/src/main/resources/bpmn/timerProcess.bpmn
+++ b/benchmarks/project/src/main/resources/bpmn/timerProcess.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1iivtrg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.7.0">
+  <bpmn:process id="timerProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_04u8lgc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_0vwombs">
+      <bpmn:incoming>SequenceFlow_04u8lgc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1kgia40</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_04u8lgc" sourceRef="StartEvent_1" targetRef="IntermediateCatchEvent_0vwombs" />
+    <bpmn:endEvent id="EndEvent_1khq409">
+      <bpmn:incoming>SequenceFlow_1kgia40</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1kgia40" sourceRef="IntermediateCatchEvent_0vwombs" targetRef="EndEvent_1khq409" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="timerProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_0vwombs_di" bpmnElement="IntermediateCatchEvent_0vwombs">
+        <dc:Bounds x="272" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_04u8lgc_di" bpmnElement="SequenceFlow_04u8lgc">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="272" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1khq409_di" bpmnElement="EndEvent_1khq409">
+        <dc:Bounds x="372" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1kgia40_di" bpmnElement="SequenceFlow_1kgia40">
+        <di:waypoint x="308" y="97" />
+        <di:waypoint x="372" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/benchmarks/setup/default/Makefile
+++ b/benchmarks/setup/default/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: zeebe starter worker
+all: zeebe starter timer simpleStarter worker
 
 .PHONY: zeebe
 zeebe:
@@ -11,13 +11,21 @@ zeebe:
 starter:
 	kubectl apply -f starter.yaml
 
+.PHONY: timer
+timer:
+	kubectl apply -f timer.yaml
+
+.PHONY: simpleStarter
+simpleStarter:
+	kubectl apply -f simpleStarter.yaml
+
 .PHONY: worker
 worker:
 	kubectl apply -f worker.yaml
 
 
 .PHONY: clean
-clean: clean-starter clean-worker clean-zeebe
+clean: clean-starter clean-timer clean-simpleStarter clean-worker clean-zeebe
 
 .PHONY: clean-zeebe
 clean-zeebe:
@@ -30,6 +38,14 @@ clean-zeebe:
 .PHONY: clean-starter
 clean-starter:
 	-kubectl delete -f starter.yaml
+
+.PHONY: clean-timer
+clean-timer:
+	-kubectl delete -f timer.yaml
+
+.PHONY: clean-simpleStarter
+clean-simpleStarter:
+	-kubectl delete -f simpleStarter.yaml
 
 .PHONY: clean-worker
 clean-worker:

--- a/benchmarks/setup/default/simpleStarter.yaml
+++ b/benchmarks/setup/default/simpleStarter.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple
+  labels:
+    app: simple
+spec:
+  selector:
+    matchLabels:
+      app: simple
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: simple
+    spec:
+      containers:
+      - name: simple
+        image: gcr.io/zeebe-io/starter:zeebe
+        imagePullPolicy: Always
+        env:
+          - name: JAVA_OPTIONS
+            value: "-Dapp.brokerUrl=default-zeebe:26500 -Dapp.starter.rate=300 -Dzeebe.client.requestTimeout=62000 -XX:+HeapDumpOnOutOfMemoryError -Dapp.starter.bpmnXmlPath=bpmn/simpleProcess.bpmn -Dapp.starter.processId=simpleProcess"
+          - name: LOG_LEVEL
+            value: "warn"
+        resources:
+          limits:
+            cpu: 2
+            memory: 2Gi
+          requests:
+            cpu: 2
+            memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: zeebe
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/name: zeebe-cluster
+  name: simple
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 9600
+    protocol: TCP
+    targetPort: 9600
+  publishNotReadyAddresses: true
+  selector:
+    app: simple
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/benchmarks/setup/default/timer.yaml
+++ b/benchmarks/setup/default/timer.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: timer
+  labels:
+    app: timer
+spec:
+  selector:
+    matchLabels:
+      app: timer
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: timer
+    spec:
+      containers:
+      - name: timer
+        image: gcr.io/zeebe-io/starter:zeebe
+        imagePullPolicy: Always
+        env:
+          - name: JAVA_OPTIONS
+            value: "-Dapp.brokerUrl=default-zeebe:26500 -Dapp.starter.rate=300 -Dzeebe.client.requestTimeout=62000 -XX:+HeapDumpOnOutOfMemoryError -Dapp.starter.bpmnXmlPath=bpmn/timerProcess.bpmn -Dapp.starter.processId=timerProcess"
+          - name: LOG_LEVEL
+            value: "warn"
+        resources:
+          limits:
+            cpu: 2
+            memory: 2Gi
+          requests:
+            cpu: 2
+            memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: zeebe
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/name: zeebe-cluster
+  name: timer
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 9600
+    protocol: TCP
+    targetPort: 9600
+  publishNotReadyAddresses: true
+  selector:
+    app: timer
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/benchmarks/setup/newBenchmark.sh
+++ b/benchmarks/setup/newBenchmark.sh
@@ -19,6 +19,4 @@ kubens $namespace
 cp -rv default/ $namespace
 cd $namespace
 
-sed -i "s/default/$namespace/g" Makefile
-sed -i "s/default/$namespace/g" worker.yaml
-sed -i "s/default/$namespace/g" starter.yaml
+sed -i "s/default/$namespace/g" Makefile starter.yaml timer.yaml simpleStarter.yaml worker.yaml


### PR DESCRIPTION
## Description

To improve our test coverage I added a simple starter and a timer starter. The simple one contains just start event and end event. It is quite interesting to see how the latency behaves on these instances and to just introduce some more load to the broker.
The timer starter contains a workflow with a timer set to PT1S. Per default we will start all of them
to have high load and test that this can be handled by the brokers without any problems.


![metrics](https://user-images.githubusercontent.com/2758593/78907407-f1d6a500-7a80-11ea-82c7-8a5a5a3a1cab.png)


## Further

I want to add later also workflow with contain message catch events and a pod which just publishes messages.
<!-- Please explain the changes you made here. -->

<!-- Which issues are closed by this PR or are related -->


## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
