### PR TITLE
Remove bootstrapping raft cluster logic

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/RaftMember.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/RaftMember.java
@@ -188,8 +188,5 @@ public interface RaftMember {
      * be elected leaders.
      */
     ACTIVE,
-
-    /** Bootstraps the partition cluster, which means it tries directly to become candidate. */
-    BOOTSTRAP,
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -138,14 +138,7 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     }
 
     if (configuration == null) {
-
-      final MemberId firstMemberId = new ArrayList<>(cluster).get(0);
-      if (cluster.size() == 1 || (cluster.size() > 1 && firstMemberId.equals(member.memberId()))) {
-        // try to bootstrap partition as leader
-        member.setType(Type.BOOTSTRAP);
-      } else {
-        member.setType(Type.ACTIVE);
-      }
+      member.setType(Type.ACTIVE);
 
       // Create a set of active members.
       final Set<RaftMember> activeMembers =
@@ -388,9 +381,6 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
             () -> {
               // Transition the server to the appropriate state for the local member type.
               raft.transition(member.getType());
-              if (member.getType() == Type.BOOTSTRAP) {
-                member.setType(Type.ACTIVE);
-              }
 
               // Attempt to join the cluster. If the local member is ACTIVE then failing to join the
               // cluster

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -626,11 +626,6 @@ public class RaftContext implements AutoCloseable {
           transition(RaftServer.Role.FOLLOWER);
         }
         break;
-      case BOOTSTRAP:
-        if (!(role instanceof ActiveRole)) {
-          transition(Role.CANDIDATE);
-        }
-        break;
       case PROMOTABLE:
         if (this.role.role() != RaftServer.Role.PROMOTABLE) {
           transition(RaftServer.Role.PROMOTABLE);

--- a/atomix/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/atomix/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -47,6 +47,7 @@ import org.junit.Test;
 /** Atomix test. */
 public class AtomixTest extends AbstractAtomixTest {
 
+  private static final int TIMEOUT_IN_S = 90;
   private List<Atomix> instances;
 
   @Before
@@ -61,7 +62,7 @@ public class AtomixTest extends AbstractAtomixTest {
         instances.stream().map(Atomix::stop).collect(Collectors.toList());
     try {
       CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]))
-          .get(30, TimeUnit.SECONDS);
+          .get(TIMEOUT_IN_S, TimeUnit.SECONDS);
     } catch (final Exception e) {
       // Do nothing
     }
@@ -106,11 +107,12 @@ public class AtomixTest extends AbstractAtomixTest {
                     .withMembers("1")
                     .withDataPath(new File(getDataDir(), "scale-up"))
                     .build())
-            .get(30, TimeUnit.SECONDS);
+            .get(TIMEOUT_IN_S, TimeUnit.SECONDS);
     final Atomix atomix2 =
-        startAtomix(2, Arrays.asList(1, 2), Profile.client()).get(30, TimeUnit.SECONDS);
+        startAtomix(2, Arrays.asList(1, 2), Profile.client()).get(TIMEOUT_IN_S, TimeUnit.SECONDS);
     final Atomix atomix3 =
-        startAtomix(3, Arrays.asList(1, 2, 3), Profile.client()).get(30, TimeUnit.SECONDS);
+        startAtomix(3, Arrays.asList(1, 2, 3), Profile.client())
+            .get(TIMEOUT_IN_S, TimeUnit.SECONDS);
   }
 
   @Test
@@ -123,10 +125,10 @@ public class AtomixTest extends AbstractAtomixTest {
                     .withMembers("1")
                     .withDataPath(new File(getDataDir(), "start-stop-consensus"))
                     .build())
-            .get(30, TimeUnit.SECONDS);
-    atomix1.stop().get(30, TimeUnit.SECONDS);
+            .get(TIMEOUT_IN_S, TimeUnit.SECONDS);
+    atomix1.stop().get(TIMEOUT_IN_S, TimeUnit.SECONDS);
     try {
-      atomix1.start().get(30, TimeUnit.SECONDS);
+      atomix1.start().get(TIMEOUT_IN_S, TimeUnit.SECONDS);
       fail("Expected ExecutionException");
     } catch (final ExecutionException ex) {
       assertTrue(ex.getCause() instanceof IllegalStateException);
@@ -157,14 +159,15 @@ public class AtomixTest extends AbstractAtomixTest {
     futures.add(startAtomix(1, Arrays.asList(1, 2, 3), profiles[0]));
     futures.add(startAtomix(2, Arrays.asList(1, 2, 3), profiles[1]));
     futures.add(startAtomix(3, Arrays.asList(1, 2, 3), profiles[2]));
-    Futures.allOf(futures).get(30, TimeUnit.SECONDS);
+    Futures.allOf(futures).get(TIMEOUT_IN_S, TimeUnit.SECONDS);
 
     final TestClusterMembershipEventListener dataListener =
         new TestClusterMembershipEventListener();
     instances.get(0).getMembershipService().addListener(dataListener);
 
     final Atomix client1 =
-        startAtomix(4, Arrays.asList(1, 2, 3), Profile.client()).get(30, TimeUnit.SECONDS);
+        startAtomix(4, Arrays.asList(1, 2, 3), Profile.client())
+            .get(TIMEOUT_IN_S, TimeUnit.SECONDS);
     assertEquals(1, client1.getPartitionService().getPartitionGroups().size());
 
     // client1 added to data node
@@ -178,7 +181,8 @@ public class AtomixTest extends AbstractAtomixTest {
     client1.getMembershipService().addListener(clientListener);
 
     final Atomix client2 =
-        startAtomix(5, Arrays.asList(1, 2, 3), Profile.client()).get(30, TimeUnit.SECONDS);
+        startAtomix(5, Arrays.asList(1, 2, 3), Profile.client())
+            .get(TIMEOUT_IN_S, TimeUnit.SECONDS);
     assertEquals(1, client2.getPartitionService().getPartitionGroups().size());
 
     // client2 added to data node
@@ -187,7 +191,7 @@ public class AtomixTest extends AbstractAtomixTest {
     // client2 added to client node
     assertEquals(ClusterMembershipEvent.Type.MEMBER_ADDED, clientListener.event().type());
 
-    client2.stop().get(30, TimeUnit.SECONDS);
+    client2.stop().get(TIMEOUT_IN_S, TimeUnit.SECONDS);
 
     // client2 removed from data node
     assertEquals(ClusterMembershipEvent.Type.REACHABILITY_CHANGED, dataListener.event().type());
@@ -226,7 +230,7 @@ public class AtomixTest extends AbstractAtomixTest {
                 .withMembers("1", "2", "3")
                 .withDataPath(new File(new File(getDataDir(), "client-properties"), "3"))
                 .build()));
-    Futures.allOf(futures).get(30, TimeUnit.SECONDS);
+    Futures.allOf(futures).get(TIMEOUT_IN_S, TimeUnit.SECONDS);
 
     final TestClusterMembershipEventListener dataListener =
         new TestClusterMembershipEventListener();
@@ -236,7 +240,7 @@ public class AtomixTest extends AbstractAtomixTest {
     properties.setProperty("a-key", "a-value");
     final Atomix client1 =
         startAtomix(4, Arrays.asList(1, 2, 3), properties, Profile.client())
-            .get(30, TimeUnit.SECONDS);
+            .get(TIMEOUT_IN_S, TimeUnit.SECONDS);
     assertEquals(1, client1.getPartitionService().getPartitionGroups().size());
 
     // client1 added to data node


### PR DESCRIPTION
## Description

 Remove bootstrap cluster logic, which was based on zeebe-io/atomix@8e03d0e#diff-2b7ee5642689e551130f883959f7174e
 to avoid disrubtion of cluster on bootstrap and race conditions.

 This feature made lot of tests flaky, since the ordering was not 100% guaranteed. It happens that node become later available, but were in charge to bootstrap partition.
 This means cluster was already formed and leader choosen, when the node which should bootstrap partition
 becomes available it tried to become leader (it directly transition to candidate).

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/zeebe-io/zeebe/issues/4260
related https://github.com/zeebe-io/zeebe/issues/4258
closes https://github.com/zeebe-io/zeebe/issues/4147

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
