### PR TITLE
Replace array with list

### DIFF
--- a/util/src/main/java/io/zeebe/util/sched/ActorControl.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorControl.java
@@ -7,6 +7,8 @@
  */
 package io.zeebe.util.sched;
 
+import static io.zeebe.util.sched.ActorThread.ensureCalledFromActorThread;
+
 import io.zeebe.util.sched.ActorTask.ActorLifecyclePhase;
 import io.zeebe.util.sched.channel.ChannelConsumerCondition;
 import io.zeebe.util.sched.channel.ChannelSubscription;
@@ -38,8 +40,7 @@ public class ActorControl {
   }
 
   public static ActorControl current() {
-    final ActorThread actorThread =
-        ActorControl.ensureCalledFromActorThread("ActorControl#current");
+    final ActorThread actorThread = ensureCalledFromActorThread("ActorControl#current");
 
     return new ActorControl(actorThread.currentTask);
   }
@@ -513,17 +514,6 @@ public class ActorControl {
     }
 
     return currentJob;
-  }
-
-  private static ActorThread ensureCalledFromActorThread(final String methodName) {
-    final ActorThread thread = ActorThread.current();
-
-    if (thread == null) {
-      throw new UnsupportedOperationException(
-          "Incorrect usage of actor. " + methodName + ": must be called from actor thread");
-    }
-
-    return thread;
   }
 
   /** Mark actor as failed. This sets the lifecycle phase to 'FAILED' and discards all jobs. */

--- a/util/src/main/java/io/zeebe/util/sched/ActorThread.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorThread.java
@@ -157,6 +157,17 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
     }
   }
 
+  public static ActorThread ensureCalledFromActorThread(final String methodName) {
+    final ActorThread thread = ActorThread.current();
+
+    if (thread == null) {
+      throw new UnsupportedOperationException(
+          "Incorrect usage of actor. " + methodName + ": must be called from actor thread");
+    }
+
+    return thread;
+  }
+
   public ActorJob newJob() {
     ActorJob job = jobs.poll();
 


### PR DESCRIPTION
## Description

Replaces inefficient usage of subscription array with an array list. Previous the subscription array was always copied and replaced by a smaller or larger array, when subscriptions where added or removed. With the usage of an array list the resizing is now a bit more efficient. For further information check #4285 


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4285

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
