### PR TITLE
fix(protocol): map msg value type to correct intent

### DIFF
--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/Intent.java
@@ -107,7 +107,7 @@ public interface Intent {
       case WORKFLOW_INSTANCE:
         return WorkflowInstanceIntent.valueOf(intent);
       case MESSAGE:
-        return WorkflowInstanceIntent.valueOf(intent);
+        return MessageIntent.valueOf(intent);
       case MESSAGE_SUBSCRIPTION:
         return MessageSubscriptionIntent.valueOf(intent);
       case MESSAGE_START_EVENT_SUBSCRIPTION:


### PR DESCRIPTION
## Description

Map Message ValueType to the correct MessageIntent.

## Related issues

closes #4289

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
