### PR TITLE
Fix RaftMember.Type backwards compatibility 

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/RaftMember.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/RaftMember.java
@@ -188,5 +188,15 @@ public interface RaftMember {
      * be elected leaders.
      */
     ACTIVE,
+
+    /**
+     * <b>DEPRECATED</b>
+     *
+     * <p>We need to keep this type to be backwards compatible
+     *
+     * <p>Bootstraps the partition cluster, which means it tries directly to become candidate.
+     */
+    @Deprecated
+    BOOTSTRAP,
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/DefaultRaftMember.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/DefaultRaftMember.java
@@ -48,7 +48,7 @@ public final class DefaultRaftMember implements RaftMember, AutoCloseable {
   public DefaultRaftMember(final MemberId id, final Type type, final Instant updated) {
     this.id = checkNotNull(id, "id cannot be null");
     this.hash = Hashing.murmur3_32().hashUnencodedChars(id.id()).asInt();
-    this.type = checkNotNull(type, "type cannot be null");
+    setTypeInternal(checkNotNull(type, "type cannot be null"));
     this.updated = checkNotNull(updated, "updated cannot be null");
   }
 
@@ -119,9 +119,13 @@ public final class DefaultRaftMember implements RaftMember, AutoCloseable {
    * @param type the member type
    */
   void setType(final Type type) {
-    this.type = type;
+    setTypeInternal(type);
   }
 
+  /** Internal set type method to ensure that we not set deprecated BOOTSTRAP type. */
+  private void setTypeInternal(final Type type) {
+    this.type = Type.BOOTSTRAP == type ? Type.ACTIVE : type;
+  }
   /**
    * Updates the member type.
    *
@@ -130,7 +134,7 @@ public final class DefaultRaftMember implements RaftMember, AutoCloseable {
    */
   public DefaultRaftMember update(final RaftMember.Type type, final Instant time) {
     if (this.type != type) {
-      this.type = checkNotNull(type, "type cannot be null");
+      setTypeInternal(checkNotNull(type, "type cannot be null"));
       if (time.isAfter(updated)) {
         this.updated = checkNotNull(time, "time cannot be null");
       }

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -622,6 +622,7 @@ public class RaftContext implements AutoCloseable {
   public void transition(final RaftMember.Type type) {
     switch (type) {
       case ACTIVE:
+      case BOOTSTRAP:
         if (!(role instanceof ActiveRole)) {
           transition(RaftServer.Role.FOLLOWER);
         }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Parent</name>
@@ -118,7 +120,7 @@
     <extension.version.os-maven-plugin>1.6.2</extension.version.os-maven-plugin>
 
     <!-- version against which backwards compatibility is checked -->
-    <backwards.compat.version>0.22.1</backwards.compat.version>
+    <backwards.compat.version>0.23.0</backwards.compat.version>
     <ignored.changes.file>ignored-changes.xml</ignored.changes.file>
   </properties>
 
@@ -189,7 +191,6 @@
         <artifactId>jackson-dataformat-msgpack</artifactId>
         <version>${version.msgpack}</version>
       </dependency>
-
 
 
       <dependency>
@@ -887,7 +888,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -980,7 +981,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <dependencyConvergence />
+                  <dependencyConvergence/>
                 </rules>
               </configuration>
             </execution>

--- a/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
@@ -38,7 +38,6 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-@Ignore
 @RunWith(Parameterized.class)
 public class UpgradeTest {
 
@@ -172,6 +171,7 @@ public class UpgradeTest {
   }
 
   @Test
+  @Ignore
   public void oldGatewayWithNewBroker() {
     // given
     state

--- a/upgrade-tests/src/test/resources/log4j2-test.xml
+++ b/upgrade-tests/src/test/resources/log4j2-test.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright © 2020  camunda services GmbH (info@camunda.com)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<Configuration status="WARN">
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout
+        pattern="%d{HH:mm:ss.SSS} [%t] [%X{actor-name}] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.zeebe" level="debug"/>
+
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+
+</Configuration>


### PR DESCRIPTION
## Description

 * Brings back the `RaftMember.Type.BOOTSTRAP` to ensure backwards compatibility. (@deepthidevaki your part)
 * enable upgrade tests and add logging for tests (@MiguelPires your part to review)

I assigned you both since it is a broader scope. I still need to fix the upgrade test for the gw.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4309

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
