### PR TITLE
chore(monitor): use zeebe_health to extract variable values

### DIFF
--- a/monitor/README.md
+++ b/monitor/README.md
@@ -7,6 +7,23 @@ Currently, metrics are exported using Prometheus. You can find
 documentation about the different metrics 
 [here](https://docs.zeebe.io/operations/metrics.html).
 
+### Testing
+
+You can easily test metrics locally by using the standard provided [docker compose
+file](../docker/compose/docker-compose.yaml) in combination with the one [here](docker-compose.yml), e.g.:
+
+```sh
+docker-compose --project-directory ./ -f docker-compose.yml -f ../docker/compose/docker-compose.yaml up -d
+```
+
+This will start the usual 3 brokers cluster, as well as a Grafana instance (on port 3000) and a Prometheus instance on
+port 9090. The Prometheus instance is configured to scrape the brokers every 5 seconds, and pre-assigns them the
+namespace and pod label as `local` and `broker-*`.
+
+> Remember that docker-compose does not remove volumes on the down command, so if you are completely done with it you
+> will need to run either `docker-compose --project-directory ./ -f docker-compose.yml -f ../docker/compose/docker-compose.yaml down -v` 
+> or `docker volume prune`
+
 ### Grafana
 
 You can find [here](grafana/zeebe.json) a pre-built Grafana dashboard to
@@ -36,3 +53,4 @@ checking `Export for sharing externally` as you do.
 #### Preview
 
 ![Zeebe Grafana Dashboard Preview](grafana/preview.png)
+

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3'
+
+volumes:
+    grafana: {}
+    prometheus: {}
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus/:/etc/prometheus/
+      - prometheus:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    ports:
+      - 9090:9090
+
+  grafana:
+    image: grafana/grafana:latest
+    depends_on:
+      - prometheus
+    ports:
+      - 3000:3000
+    volumes:
+      - grafana:/var/lib/grafana
+      - ./grafana/zeebe.json:/var/lib/grafana/dashboards/zeebe.json
+      - ./grafana/provisioning/:/etc/grafana/provisioning/
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=camunda
+      - GF_USERS_ALLOW_SIGN_UP=false
+
+

--- a/monitor/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitor/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+- name: 'Prometheus'
+  orgId: 1
+  folder: ''
+  type: file
+  options:
+    path: /var/lib/grafana/dashboards

--- a/monitor/grafana/provisioning/datasources/datasources.yml
+++ b/monitor/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,20 @@
+apiVersion: 1
+
+deleteDatasources:
+  - name: Prometheus
+    orgId: 1
+
+datasources:
+- name: Prometheus
+  type: prometheus
+  access: proxy
+  orgId: 1
+  url: http://prometheus:9090
+  basicAuth: false
+  isDefault: true
+  jsonData:
+     graphiteVersion: "1.1"
+     tlsAuth: false
+     tlsAuthWithCACert: false
+  version: 1
+  editable: true

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -64,11 +64,12 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1586154330555,
+  "iteration": 1587026668314,
   "links": [],
   "panels": [
     {
       "collapsed": true,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -105,6 +106,7 @@
           "styles": [
             {
               "alias": "Time",
+              "align": "auto",
               "dateFormat": "YYYY-MM-DD HH:mm:ss",
               "link": false,
               "pattern": "Time",
@@ -112,6 +114,7 @@
             },
             {
               "alias": "Broker - Partition",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -131,6 +134,7 @@
             },
             {
               "alias": "Role",
+              "align": "auto",
               "colorMode": "value",
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -164,6 +168,7 @@
             },
             {
               "alias": "test",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -328,12 +333,14 @@
           "styles": [
             {
               "alias": "Time",
+              "align": "auto",
               "dateFormat": "YYYY-MM-DD HH:mm:ss",
               "pattern": "Time",
               "type": "date"
             },
             {
               "alias": "",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -350,6 +357,7 @@
             },
             {
               "alias": "Broker Partition",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -364,6 +372,7 @@
             },
             {
               "alias": "Status",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -431,12 +440,14 @@
           "styles": [
             {
               "alias": "Time",
+              "align": "auto",
               "dateFormat": "YYYY-MM-DD HH:mm:ss",
               "pattern": "Time",
               "type": "date"
             },
             {
               "alias": "Pod",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -451,6 +462,7 @@
             },
             {
               "alias": "Status",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -1269,6 +1281,7 @@
     },
     {
       "collapsed": true,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1301,12 +1314,14 @@
           "styles": [
             {
               "alias": "Time",
+              "align": "auto",
               "dateFormat": "YYYY-MM-DD HH:mm:ss",
               "pattern": "Time",
               "type": "date"
             },
             {
               "alias": "",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -1358,12 +1373,14 @@
           "styles": [
             {
               "alias": "Time",
+              "align": "auto",
               "dateFormat": "YYYY-MM-DD HH:mm:ss",
               "pattern": "Time",
               "type": "date"
             },
             {
               "alias": "",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -1974,6 +1991,7 @@
     },
     {
       "collapsed": true,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2490,6 +2508,7 @@
     },
     {
       "collapsed": true,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3180,6 +3199,7 @@
     },
     {
       "collapsed": true,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3542,6 +3562,7 @@
     },
     {
       "collapsed": true,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3881,6 +3902,7 @@
     },
     {
       "collapsed": true,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4272,6 +4294,7 @@
     },
     {
       "collapsed": true,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -4984,6 +5007,7 @@
     },
     {
       "collapsed": true,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -5239,13 +5263,14 @@
     }
   ],
   "refresh": "10s",
-  "schemaVersion": 19,
+  "schemaVersion": 22,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
+          "selected": false,
           "text": "Prometheus",
           "value": "Prometheus"
         },
@@ -5265,40 +5290,19 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "",
+        "definition": "label_values(zeebe_health, namespace)",
         "hide": 0,
         "includeAll": true,
+        "index": -1,
         "label": null,
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(jvm_info, namespace)",
+        "query": "label_values(zeebe_health, namespace)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": "(.*-zeebe-[0-9]+$)",
-        "current": {},
-        "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(jvm_info{namespace=~\"$namespace\"}, pod)",
-        "hide": 0,
-        "includeAll": true,
-        "label": null,
-        "multi": false,
-        "name": "pod",
-        "options": [],
-        "query": "label_values(jvm_info{namespace=~\"$namespace\"}, pod)",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -5309,18 +5313,42 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "",
+        "definition": "label_values(zeebe_health{namespace=~\"$namespace\"}, pod)",
         "hide": 0,
         "includeAll": true,
+        "index": -1,
         "label": null,
-        "multi": false,
-        "name": "partition",
+        "multi": true,
+        "name": "pod",
         "options": [],
-        "query": "label_values(zeebe_stream_processor_events_total{namespace=~\"$namespace\", pod=~\"$pod\"}, partition)",
+        "query": "label_values(zeebe_health{namespace=~\"$namespace\"}, pod)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
+        "definition": "label_values(zeebe_health{namespace=~\"$namespace\", pod=~\"$pod\"}, partition)",
+        "hide": 0,
+        "includeAll": true,
+        "index": -1,
+        "label": null,
+        "multi": true,
+        "name": "partition",
+        "options": [],
+        "query": "label_values(zeebe_health{namespace=~\"$namespace\", pod=~\"$pod\"}, partition)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -5361,5 +5389,8 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "I4lo7_EZk",
+  "variables": {
+    "list": []
+  },
   "version": 2
 }

--- a/monitor/prometheus/prometheus.yml
+++ b/monitor/prometheus/prometheus.yml
@@ -1,0 +1,29 @@
+global:
+  scrape_interval:     5s
+  evaluation_interval: 5s 
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+         - targets: ['localhost:9090']
+
+  - job_name: 'broker-1'
+    static_configs:
+      - targets: ['broker-1:9600']
+        labels:
+          namespace: 'local'
+          pod: 'broker-1'
+
+  - job_name: 'broker-2'
+    static_configs:
+      - targets: ['broker-2:9600']
+        labels:
+          namespace: 'local'
+          pod: 'broker-2'
+
+  - job_name: 'broker-3'
+    static_configs:
+      - targets: ['broker-3:9600']
+        labels:
+          namespace: 'local'
+          pod: 'broker-3'


### PR DESCRIPTION
## Description

- uses zeebe_health metric for all variables to extract variable values over jvm_info or zeebe_stream_*
- adds a test docker-compose environment to view dashboard and test local metrics
- switches `pod` and `partition` variables to multi-selection to allow viewing multiple pods/partitions at once

## Related issues

closes #4308 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
