### PR TITLE
chore(ci): keep develop builds for 7 days

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,10 @@
 
 def buildName = "${env.JOB_BASE_NAME.replaceAll("%2F", "-").replaceAll("\\.", "-").take(20)}-${env.BUILD_ID}"
 
+//for develop branch keep builds for 7 days to be able to analyse build errors, for all other branches, keep the last 10 builds
+def daysToKeep = (env.BRANCH_NAME=='develop') ? '7' : '-1'
+def numToKeep = (env.BRANCH_NAME=='develop') ? '-1' : '10'
+
 pipeline {
     agent {
       kubernetes {
@@ -19,7 +23,7 @@ pipeline {
     }
 
     options {
-        buildDiscarder(logRotator(daysToKeepStr: '-1', numToKeepStr: '10'))
+        buildDiscarder(logRotator(daysToKeepStr: daysToKeep, numToKeepStr: numToKeep))
         timestamps()
         timeout(time: 45, unit: 'MINUTES')
     }


### PR DESCRIPTION
## Description

This changes the jenkins file such that builds for the develop branch are kept for 7 days. For all other branches only the last 10 builds are kept, as usual.

Maybe not the most elegant solution, but it should help in analyzing build errors. Will help me greatly in updating the build statistics. We can roll this back, if we find a better solution or when it is no longer necessary.

## Related issues
closes #4320

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
