### PR TITLE
chore(ci): collect test results immediately

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,6 +104,10 @@ pipeline {
                 }
 
                 stage('Unit (Java)') {
+                    environment {
+                      SUREFIRE_REPORT_NAME_SUFFIX = 'java'
+                    }
+
                     steps {
                         container('maven') {
                             configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
@@ -111,8 +115,18 @@ pipeline {
                             }
                         }
                     }
+
+                    post {
+                        always {
+                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}.xml", keepLongStdio: true
+                        }
+                    }
                 }
                 stage('Unit 8 (Java 8)') {
+                    environment {
+                      SUREFIRE_REPORT_NAME_SUFFIX = 'java8'
+                    }
+
                     steps {
                         container('maven-jdk8') {
                             configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
@@ -120,14 +134,30 @@ pipeline {
                             }
                         }
                     }
+
+                    post {
+                        always {
+                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}.xml", keepLongStdio: true
+                        }
+                    }
                 }
 
                 stage('IT (Java)') {
+                    environment {
+                      SUREFIRE_REPORT_NAME_SUFFIX = 'it'
+                    }
+
                     steps {
                         container('maven') {
                             configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
                                 sh '.ci/scripts/distribution/it-java.sh'
                             }
+                        }
+                    }
+
+                    post {
+                        always {
+                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}.xml", keepLongStdio: true
                         }
                     }
                 }
@@ -143,10 +173,6 @@ pipeline {
             }
 
             post {
-                always {
-                    junit testResults: "**/*/TEST-*.xml", keepLongStdio: true
-                }
-
                 failure {
                     archive "**/*/surefire-reports/*-output.txt"
                 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -758,6 +758,7 @@
                 <value>io.zeebe.ZeebeTestListener</value>
               </property>
             </properties>
+            <reportNameSuffix>${env.SUREFIRE_REPORT_NAME_SUFFIX}</reportNameSuffix>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
## Description

Currently test results are only collected after all test stages completed. The one exception to this is the Go tests which are collected immediately. This should be expanded to the other test stages as well.

## Related issues

closes #4348

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
