### PR TITLE
fix(atomix): consume read buffer correctly

### DIFF
--- a/atomix/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentReader.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentReader.java
@@ -168,7 +168,6 @@ class FileChannelJournalSegmentReader<E> implements JournalReader<E> {
   /** Reads the next entry in the segment. */
   @SuppressWarnings("unchecked")
   private void readNext() {
-    // Compute the index of the next entry in the segment.
     final long index = getNextIndex();
 
     try {
@@ -186,7 +185,9 @@ class FileChannelJournalSegmentReader<E> implements JournalReader<E> {
         return;
       }
 
-      final var cantReadEntry = memory.remaining() < length;
+      // we using a CRC32 - which is 32 byte checksum
+      // remaining bytes need to be larger or equals to entry length + checksum length
+      final var cantReadEntry = memory.remaining() < (length + Integer.BYTES);
       if (cantReadEntry) {
         readBytesIntoBuffer();
         memory.mark();

--- a/atomix/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentReader.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentReader.java
@@ -172,54 +172,82 @@ class FileChannelJournalSegmentReader<E> implements JournalReader<E> {
     final long index = getNextIndex();
 
     try {
-      // Read more bytes from the segment if necessary.
-      if (memory.remaining() < maxEntrySize) {
-        final long position = channel.position() + memory.position();
-        channel.position(position);
-        memory.clear();
-        channel.read(memory);
-        channel.position(position);
-        memory.flip();
-      }
-
       // Mark the buffer so it can be reset if necessary.
       memory.mark();
 
-      try {
-        // Read the length of the entry.
-        final int length = memory.getInt();
-
-        // If the buffer length is zero then return.
-        if (length <= 0 || length > maxEntrySize) {
-          memory.reset().limit(memory.position());
-          nextEntry = null;
-          return;
-        }
-
-        // Read the checksum of the entry.
-        final long checksum = memory.getInt() & 0xFFFFFFFFL;
-
-        // Compute the checksum for the entry bytes.
-        final Checksum crc32 = new CRC32();
-        crc32.update(memory.array(), memory.position(), length);
-
-        // If the stored checksum equals the computed checksum, return the entry.
-        if (checksum == crc32.getValue()) {
-          final int limit = memory.limit();
-          memory.limit(memory.position() + length);
-          final E entry = namespace.deserialize(memory);
-          memory.limit(limit);
-          nextEntry = new Indexed<>(index, entry, length);
-        } else {
-          memory.reset().limit(memory.position());
-          nextEntry = null;
-        }
-      } catch (final BufferUnderflowException e) {
-        memory.reset().limit(memory.position());
-        nextEntry = null;
+      final var cantReadLength = memory.remaining() < Integer.BYTES;
+      if (cantReadLength) {
+        readBytesIntoBuffer();
+        memory.mark();
       }
+
+      final int length = memory.getInt();
+      if (isLengthInvalid(length)) {
+        return;
+      }
+
+      final var cantReadEntry = memory.remaining() < length;
+      if (cantReadEntry) {
+        readBytesIntoBuffer();
+        memory.mark();
+        // we don't need to read the length again
+      }
+
+      readNextEntry(index, length);
+
+    } catch (final BufferUnderflowException e) {
+      resetReading();
     } catch (final IOException e) {
       throw new StorageException(e);
     }
+  }
+
+  private void readNextEntry(final long index, final int length) {
+    if (isChecksumInvalid(length)) {
+      resetReading();
+      return;
+    }
+
+    // If the stored checksum equals the computed checksum, set the next entry.
+    final int limit = memory.limit();
+    memory.limit(memory.position() + length);
+    final E entry = namespace.deserialize(memory);
+    memory.limit(limit);
+    nextEntry = new Indexed<>(index, entry, length);
+  }
+
+  private void resetReading() {
+    memory.reset().limit(memory.position());
+    nextEntry = null;
+  }
+
+  private boolean isChecksumInvalid(final int length) {
+    // Read the checksum of the entry.
+    final long checksum = memory.getInt() & 0xFFFFFFFFL;
+
+    // Compute the checksum for the entry bytes.
+    final Checksum crc32 = new CRC32();
+    crc32.update(memory.array(), memory.position(), length);
+
+    return checksum != crc32.getValue();
+  }
+
+  private boolean isLengthInvalid(final int length) {
+    // If the buffer length is zero then return.
+    if (length <= 0 || length > maxEntrySize) {
+      memory.reset().limit(memory.position());
+      nextEntry = null;
+      return true;
+    }
+    return false;
+  }
+
+  private void readBytesIntoBuffer() throws IOException {
+    final long position = channel.position() + memory.position();
+    channel.position(position);
+    memory.clear();
+    channel.read(memory);
+    channel.position(position);
+    memory.flip();
   }
 }

--- a/atomix/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
+++ b/atomix/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
@@ -91,7 +91,7 @@ public abstract class AbstractJournalTest {
         .withNamespace(NAMESPACE)
         .withStorageLevel(storageLevel())
         .withMaxSegmentSize(maxSegmentSize)
-        .withMaxEntrySize(64)
+        .withMaxEntrySize(48)
         .withJournalIndexFactory(() -> index)
         .build();
   }

--- a/atomix/storage/src/test/java/io/atomix/storage/journal/FileChannelJournalSegmentReaderTest.java
+++ b/atomix/storage/src/test/java/io/atomix/storage/journal/FileChannelJournalSegmentReaderTest.java
@@ -24,6 +24,9 @@ import io.atomix.storage.journal.index.SparseJournalIndex;
 import io.atomix.utils.serializer.Namespace;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,7 +36,7 @@ public class FileChannelJournalSegmentReaderTest {
   private static final Namespace NAMESPACE = Namespace.builder().register(Integer.class).build();
   private static final Integer ENTRY = 1;
   private static final int ENTRY_SIZE =
-      NAMESPACE.serialize(ENTRY).length + Long.BYTES; // padding for checksum;
+      NAMESPACE.serialize(ENTRY).length + Integer.BYTES; // padding for checksum;
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -42,6 +45,33 @@ public class FileChannelJournalSegmentReaderTest {
   @Before
   public void setUp() throws IOException {
     directory = temporaryFolder.newFolder();
+  }
+
+  @Test
+  public void shouldReadEventsOnAllSegments() {
+    // given
+    final int entriesPerSegment = 7;
+    final SparseJournalIndex journalIndex = new SparseJournalIndex(5);
+    try (final SegmentedJournal<Integer> journal = createJournal(entriesPerSegment, journalIndex)) {
+      final SegmentedJournalWriter<Integer> writer = journal.writer();
+      final SegmentedJournalReader<Integer> reader = journal.openReader(1, Mode.ALL);
+
+      final var expectedEntryCount = entriesPerSegment * 3;
+      for (int i = 0; i < expectedEntryCount; i++) {
+        writer.append(i);
+      }
+
+      // when
+      final var entries = new ArrayList<Integer>();
+      while (reader.hasNext()) {
+        entries.add(reader.next().entry());
+      }
+
+      // then
+      assertEquals(expectedEntryCount, entries.size());
+      assertEquals(
+          IntStream.range(0, expectedEntryCount).boxed().collect(Collectors.toList()), entries);
+    }
   }
 
   @Test
@@ -79,6 +109,7 @@ public class FileChannelJournalSegmentReaderTest {
         .withDirectory(directory)
         .withNamespace(NAMESPACE)
         .withStorageLevel(StorageLevel.DISK)
+        .withMaxEntrySize(ENTRY_SIZE)
         .withMaxSegmentSize(maxSegmentSize)
         .withJournalIndexFactory(() -> journalIndex)
         .build();


### PR DESCRIPTION
## Description

Fix issue where the read buffer was consumed only half and the rest was
 thrown away.

Refactor `FileChannelJournalSegmentReader#readNext` to improve readability and hopefully maintainability.
<!-- Please explain the changes you made here. -->

I run also a benchmark with these changes (https://github.com/zeebe-io/zeebe/pull/4358 was also part of the branch I run a benchmark with)

![metrics](https://user-images.githubusercontent.com/2758593/80199113-45202a00-8621-11ea-9595-e8c65130ec97.png)


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4248 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
