### PR TITLE
fix(broker): use exporter positions to calculate compactable index in snapshots

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/AtomixRecordEntrySupplier.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/storage/AtomixRecordEntrySupplier.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.broker.clustering.atomix.storage;
 
+import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.zeebe.ZeebeEntry;
 import io.atomix.storage.journal.Indexed;
 import io.zeebe.protocol.record.Record;
@@ -18,7 +19,7 @@ import java.util.Optional;
  */
 @FunctionalInterface
 public interface AtomixRecordEntrySupplier extends AutoCloseable {
-  Optional<Indexed<ZeebeEntry>> getIndexedEntry(long position);
+  Optional<Indexed<? extends RaftLogEntry>> getIndexedEntry(long position);
 
   @Override
   default void close() {}

--- a/broker/src/main/java/io/zeebe/broker/logstreams/state/StatePositionSupplier.java
+++ b/broker/src/main/java/io/zeebe/broker/logstreams/state/StatePositionSupplier.java
@@ -9,77 +9,14 @@ package io.zeebe.broker.logstreams.state;
 
 import io.zeebe.broker.exporter.stream.ExportersState;
 import io.zeebe.db.ZeebeDb;
-import io.zeebe.engine.state.DefaultZeebeDbFactory;
-import io.zeebe.engine.state.LastProcessedPositionState;
-import io.zeebe.engine.state.ZbColumnFamilies;
-import java.nio.file.Path;
-import org.slf4j.Logger;
 
 public class StatePositionSupplier {
-
-  private final Logger logger;
-
-  public StatePositionSupplier(final Logger log) {
-    this.logger = log;
-  }
-
-  public long getLowestPosition(final Path directory) {
-    long processedPosition = -1;
-    long exportedPosition = -1;
-
-    try (final var db = open(directory)) {
-      processedPosition = getLastProcessedPosition(directory, db);
-      exportedPosition = getMinimumExportedPosition(directory, db);
-    } catch (final Exception e) {
-      logger.error(
-          "Unexpected error occurred while obtaining the processed and exported position from the snapshot {}",
-          directory,
-          e);
-    }
-
-    return Math.min(processedPosition, exportedPosition);
-  }
-
-  public long getLastProcessedPosition(final Path directory) {
-    long processedPosition = -1;
-
-    try (final var db = open(directory)) {
-      processedPosition = getLastProcessedPosition(directory, db);
-    } catch (final Exception e) {
-      logger.error(
-          "Unexpected error occurred while obtaining the processed position from the given snapshot {}",
-          directory,
-          e);
-    }
-
-    return processedPosition;
-  }
-
-  private long getMinimumExportedPosition(
-      final Path directory, final ZeebeDb<ZbColumnFamilies> zeebeDb) {
+  public static long getHighestExportedPosition(final ZeebeDb zeebeDb) {
     final ExportersState exporterState = new ExportersState(zeebeDb, zeebeDb.createContext());
-
     if (exporterState.hasExporters()) {
-      final long lowestPosition = exporterState.getLowestPosition();
-      logger.debug("The lowest exported position for snapshot {} is {}", directory, lowestPosition);
-
-      return lowestPosition;
+      return exporterState.getLowestPosition();
     } else {
-      logger.debug("No exporters present in snapshot {}", directory);
       return Long.MAX_VALUE;
     }
-  }
-
-  private long getLastProcessedPosition(
-      final Path directory, final ZeebeDb<ZbColumnFamilies> zeebeDb) {
-    final var lastProcessedState = new LastProcessedPositionState(zeebeDb, zeebeDb.createContext());
-    final long lowestPosition = lastProcessedState.getPosition();
-    logger.debug("The last processed position for snapshot {} is {}", directory, lowestPosition);
-    return lowestPosition;
-  }
-
-  private ZeebeDb<ZbColumnFamilies> open(final Path directory) {
-    return DefaultZeebeDbFactory.defaultFactory(ZbColumnFamilies.class)
-        .createDb(directory.toFile());
   }
 }

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/FailingSnapshotChunkReplicationTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/FailingSnapshotChunkReplicationTest.java
@@ -49,10 +49,14 @@ public final class FailingSnapshotChunkReplicationTest {
         new StateSnapshotController(
             ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class),
             replicatorStorage,
-            replicator);
+            replicator,
+            zeebeDb -> Long.MAX_VALUE);
     receiverSnapshotController =
         new StateSnapshotController(
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class), receiverStorage, replicator);
+            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class),
+            receiverStorage,
+            replicator,
+            zeebeDb -> Long.MAX_VALUE);
 
     autoCloseableRule.manage(replicatorSnapshotController);
     autoCloseableRule.manage(replicatorStorage);

--- a/logstreams/src/test/java/io/zeebe/logstreams/state/ReplicateSnapshotControllerTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/state/ReplicateSnapshotControllerTest.java
@@ -48,11 +48,17 @@ public final class ReplicateSnapshotControllerTest {
     replicator = new Replicator();
     replicatorSnapshotController =
         new StateSnapshotController(
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class), storage, replicator);
+            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class),
+            storage,
+            replicator,
+            db -> Long.MAX_VALUE);
 
     receiverSnapshotController =
         new StateSnapshotController(
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class), receiverStorage, replicator);
+            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class),
+            receiverStorage,
+            replicator,
+            db -> Long.MAX_VALUE);
 
     autoCloseableRule.manage(replicatorSnapshotController);
     autoCloseableRule.manage(receiverSnapshotController);

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
@@ -39,6 +39,7 @@ public final class RestoreTest {
           cfg -> {
             cfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD);
             cfg.getData().setLogSegmentSize(ATOMIX_SEGMENT_SIZE);
+            cfg.getData().setLogIndexDensity(1);
             cfg.getNetwork().setMaxMessageSize(ATOMIX_SEGMENT_SIZE);
           });
   private final GrpcClientRule clientRule =

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -251,5 +251,6 @@ public final class SnapshotReplicationTest {
 
   private static void configureBroker(final BrokerCfg brokerCfg) {
     brokerCfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD);
+    brokerCfg.getData().setLogIndexDensity(1);
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/HealthMonitoringTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/HealthMonitoringTest.java
@@ -43,7 +43,14 @@ public class HealthMonitoringTest {
   private static final Duration SNAPSHOT_PERIOD = Duration.ofMinutes(5);
   private final Timeout testTimeout = Timeout.seconds(120);
   private final ClusteringRule clusteringRule =
-      new ClusteringRule(1, 3, 3, cfg -> cfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD));
+      new ClusteringRule(
+          1,
+          3,
+          3,
+          cfg -> {
+            cfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD);
+            cfg.getData().setLogIndexDensity(1);
+          });
   private final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 
   @Rule

--- a/util/src/main/java/io/zeebe/util/StackdriverJSONLayout.java
+++ b/util/src/main/java/io/zeebe/util/StackdriverJSONLayout.java
@@ -69,6 +69,8 @@ public class StackdriverJSONLayout extends AbstractStringLayout {
     putIfNotNull("logger", event.getLoggerName(), map);
     putIfNotNull("message", event.getMessage().getFormattedMessage(), map);
     putIfNotNull("exception", getThrowableAsString(event.getThrownProxy()), map);
+    map.put("context", event.getContextData().toMap());
+
     return map;
   }
 


### PR DESCRIPTION
## Description

- use concrete entry supplier in AtomixSnapshotStorageTest instead of mocks
- use ZeebeIndexMapping and RaftLogReader directly to supply the correct Atomix entry for snapshot metadata
- do not create a snapshot if a snapshot with that index already exists
- add context map to stackdriver logs
- update exported position in RecordingExporter
- ensure log density is 1 in QA tests that require snapshotting with low synthetic loads
- include partition in ZeebeRaftStateMachine log context

## Related issues

closes #4350 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
