### PR TITLE
chore(ci): abort build on connection errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -200,6 +200,9 @@ pipeline {
             // Retrigger the build if there were connection issues
             script {
                 if (connectionProblem()) {
+                    currentBuild.result = 'ABORTED'
+                    currentBuild.description = "Aborted due to connection error"
+
                     build job: currentBuild.projectName, propagate: false, quietPeriod: 60, wait: false
                 }
             }


### PR DESCRIPTION
## Description

If a connection issue is detected:
- the build will be set to aborted
- the description will state the reason for the abort

## Related issues

closes #4383

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
