### PR TITLE
docs(bpmn-workflows): message name as expression

### DIFF
--- a/docs/src/bpmn-workflows/message-events/message-events.md
+++ b/docs/src/bpmn-workflows/message-events/message-events.md
@@ -36,6 +36,8 @@ When the activity is entered then it creates a corresponding message subscriptio
 
 A message can be referenced by one or more message events. It **must** define the name of the message (e.g. `Money collected`) and the `correlationKey` expression (e.g. `= orderId`). If the message is only referenced by message start events then the `correlationKey` is not required.
 
+Usually, the name of the message is defined as a static value (e.g. `order canceled`), but it can also be defined as [expression](/reference/expressions.html) (e.g. `= "order " + awaitingAction`). If the expression belongs to a message start event of the workflow, then it is evaluated on deploying the workflow. Otherwise, it is evaluated on activating the message event. The evaluation must result in a `string`.
+
 The `correlationKey` is an expression that usually [accesses a variable](/reference/expressions.html#access-variables) of the workflow instance that holds the correlation key of the message. The expression is evaluated on activating the message event and must result either in a `string` or in a `number`.
 
 In order to correlate a message to the message event, the message is published with the defined name (e.g. `Money collected`) and the **value** of the `correlationKey` expression. For example, if the workflow instance has a variable `orderId` with value `"order-123"` then the message must be published with the correlation key `"order-123"`.

--- a/docs/src/bpmn-workflows/receive-tasks/receive-tasks.md
+++ b/docs/src/bpmn-workflows/receive-tasks/receive-tasks.md
@@ -14,6 +14,8 @@ A message can published using one of the Zeebe clients. When the message is corr
 
 A message can be referenced by one or more receive tasks. It **must** define the name of the message (e.g. `Money collected`) and the `correlationKey` expression (e.g. `= orderId`).
 
+Usually, the name of the message is defined as a static value (e.g. `order canceled`), but it can also be defined as [expression](/reference/expressions.html) (e.g. `= "order " + awaitingAction`). The expression is evaluated on activating the receive task and must result in a `string`.
+
 The `correlationKey` is an expression that usually [accesses a variable](/reference/expressions.html#access-variables) of the workflow instance that holds the correlation key of the message. The expression is evaluated on activating the receive task and must result either in a `string` or in a `number`.
 
 In order to correlate a message to the receive task, the message is published with the defined name (e.g. `Money collected`) and the **value** of the `correlationKey` expression. For example, if the workflow instance has a variable `orderId` with value `"order-123"` then the message must be published with the correlation key `"order-123"`.

--- a/docs/src/reference/expressions.md
+++ b/docs/src/reference/expressions.md
@@ -10,6 +10,7 @@ The following attributes of BPMN elements **require** an expression:
 
 Additionally, the following attributes of BPMN elements can define an expression **optionally** instead of a static value:
 * Timer Catch Event: [timer definition](/bpmn-workflows/timer-events/timer-events.html#timers)
+* Message Catch Event / Receive Task: [message name](/bpmn-workflows/message-events/message-events.html#messages)
 * Service Task: [job type](/bpmn-workflows/service-tasks/service-tasks.html#task-definition), [job retries](/bpmn-workflows/service-tasks/service-tasks.html#task-definition)
 * Call Activity: [process id](/bpmn-workflows/call-activities/call-activities.html#defining-the-called-workflow)
 

--- a/docs/src/reference/message-correlation/message-correlation.md
+++ b/docs/src/reference/message-correlation/message-correlation.md
@@ -14,7 +14,7 @@ A message is not sent to a workflow instance directly. Instead, the message corr
 
 ![Message Correlation](/reference/message-correlation/message-correlation.png)
 
-A subscription is opened when a workflow instance awaits a message, for example, when entering a message catch event. The message name is defined statically in the workflow (e.g. `Money collected`). The correlation key is defined dynamically as an expression (e.g. `= orderId`) that is evaluated on activating the message catch event. The result of the evaluation is used as correlation key of the subscription (e.g. `"order-123"`).
+A subscription is opened when a workflow instance awaits a message, for example, when entering a message catch event. The message name is defined either statically in the workflow (e.g. `Money collected`) or dynamically as an expression. The correlation key is defined dynamically as an expression (e.g. `= orderId`). The expressions are evaluated on activating the message catch event. The results of the evaluations are used as message name and as correlation key of the subscription (e.g. `"order-123"`).
 
  When a message is published and the message name and the correlation key matches to a subscription then the message is correlated to the corresponding workflow instance. If no proper subscription is opened then the message is discarded.
 


### PR DESCRIPTION
## Description

* add the message name to the list of attributes with optional expression support
* mention that a message name can be an expression in the BPMN workflow sections 

## Related issues

related #4204 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
