### PR TITLE
chore(benchmarks): update benchmark setup

### DIFF
--- a/benchmarks/setup/default/Makefile
+++ b/benchmarks/setup/default/Makefile
@@ -7,6 +7,10 @@ zeebe:
 	-kubectl apply -f curator-cronjob.yaml
 	-kubectl apply -f curator-configmap.yaml
 
+.PHONY: update
+update:
+	-helm upgrade default zeebe/zeebe-cluster -f zeebe-values.yaml
+
 .PHONY: starter
 starter:
 	kubectl apply -f starter.yaml

--- a/benchmarks/setup/default/simpleStarter.yaml
+++ b/benchmarks/setup/default/simpleStarter.yaml
@@ -20,7 +20,7 @@ spec:
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS
-            value: "-Dapp.brokerUrl=default-zeebe:26500 -Dapp.starter.rate=300 -Dzeebe.client.requestTimeout=62000 -XX:+HeapDumpOnOutOfMemoryError -Dapp.starter.bpmnXmlPath=bpmn/simpleProcess.bpmn -Dapp.starter.processId=simpleProcess"
+            value: "-Dapp.brokerUrl=default-zeebe-gateway:26500 -Dapp.starter.rate=300 -Dzeebe.client.requestTimeout=62000 -XX:+HeapDumpOnOutOfMemoryError -Dapp.starter.bpmnXmlPath=bpmn/simpleProcess.bpmn -Dapp.starter.processId=simpleProcess"
           - name: LOG_LEVEL
             value: "warn"
         resources:

--- a/benchmarks/setup/default/starter.yaml
+++ b/benchmarks/setup/default/starter.yaml
@@ -20,7 +20,7 @@ spec:
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS
-            value: "-Dapp.brokerUrl=default-zeebe:26500 -Dapp.starter.rate=300 -Dzeebe.client.requestTimeout=62000 -XX:+HeapDumpOnOutOfMemoryError"
+            value: "-Dapp.brokerUrl=default-zeebe-gateway:26500 -Dapp.starter.rate=300 -Dzeebe.client.requestTimeout=62000 -XX:+HeapDumpOnOutOfMemoryError"
           - name: LOG_LEVEL
             value: "warn"
         resources:

--- a/benchmarks/setup/default/timer.yaml
+++ b/benchmarks/setup/default/timer.yaml
@@ -20,7 +20,7 @@ spec:
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS
-            value: "-Dapp.brokerUrl=default-zeebe:26500 -Dapp.starter.rate=300 -Dzeebe.client.requestTimeout=62000 -XX:+HeapDumpOnOutOfMemoryError -Dapp.starter.bpmnXmlPath=bpmn/timerProcess.bpmn -Dapp.starter.processId=timerProcess"
+            value: "-Dapp.brokerUrl=default-zeebe-gateway:26500 -Dapp.starter.rate=300 -Dzeebe.client.requestTimeout=62000 -XX:+HeapDumpOnOutOfMemoryError -Dapp.starter.bpmnXmlPath=bpmn/timerProcess.bpmn -Dapp.starter.processId=timerProcess"
           - name: LOG_LEVEL
             value: "warn"
         resources:

--- a/benchmarks/setup/default/worker.yaml
+++ b/benchmarks/setup/default/worker.yaml
@@ -20,7 +20,7 @@ spec:
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS
-            value: "-Dapp.brokerUrl=default-zeebe:26500 -Dzeebe.client.requestTimeout=62000 -Dapp.worker.capacity=120 -XX:+HeapDumpOnOutOfMemoryError"
+            value: "-Dapp.brokerUrl=default-zeebe-gateway:26500 -Dzeebe.client.requestTimeout=62000 -Dapp.worker.capacity=120 -XX:+HeapDumpOnOutOfMemoryError"
           - name: LOG_LEVEL
             value: "warn"
         resources:

--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -11,12 +11,17 @@ cpuThreadCount: 4
 ioThreadCount: 4
 gatewayMetrics: true
 
-zeebeCfg: |
-  # custom TOML configuration
+gateway:
+  replicas: 1
+  logLevel: debug
+
+# Uncomment to add custom YAML configuration
+# This will overwrite anything at the application.yml location
+# zeebeCfg: {}
 
 # JavaOpts:
 # DEFAULTS
-JavaOpts: |
+JavaOpts: >
   -XX:+UseParallelGC 
   -XX:MinHeapFreeRatio=5
   -XX:MaxHeapFreeRatio=10
@@ -26,6 +31,7 @@ JavaOpts: |
   -XX:+PrintFlagsFinal
   -Xmx4g
   -Xms4g
+  -XX:+ExitOnOutOfMemoryError
   -XX:+HeapDumpOnOutOfMemoryError
   -XX:HeapDumpPath=/usr/local/zeebe/data
   -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log


### PR DESCRIPTION
## Description

Updates the benchmark setup to the latest Helm setup:

- Workers and starters point to the right service (the gateway service)
- Default configuration is updated
- Adds `-XX:ExitOnOutOfMemoryError` by default: see https://github.com/zeebe-io/zeebe/issues/4178
- Switches `JAVA_TOOL_OPTIONS` to use folded multiline instead of simple multiline: see https://helm.sh/docs/chart_template_guide/yaml_techniques/#folded-multi-line-strings

## Related issues

closes #4178

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
