### PR TITLE
chore(ci): add commit summary to build info

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,17 @@ pipeline {
     stages {
         stage('Prepare') {
             steps {
+                script {
+                    commit_summary = sh([returnStdout: true, script: 'git show -s --format=%s']).trim()
+                    displayNameFull = "#" + BUILD_NUMBER + ': ' + commit_summary
+
+                    if (displayNameFull.length() <= 45) {
+                      currentBuild.displayName = displayNameFull
+                    } else {
+                      displayStringHardTruncate = displayNameFull.take(45)
+                      currentBuild.displayName = displayStringHardTruncate.take(displayStringHardTruncate.lastIndexOf(" "))
+                    }
+                }
                 container('maven') {
                     sh '.ci/scripts/distribution/prepare.sh'
                 }
@@ -40,6 +51,7 @@ pipeline {
                 container('golang') {
                     sh '.ci/scripts/distribution/prepare-go.sh'
                 }
+
             }
         }
 


### PR DESCRIPTION
## Description

This change adds the commit summary to the build info. See attached issue for screenshots of what it looks like

## Related issues

closes #4408

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
