### PR TITLE
docs(reference): describe restrictions of a variable name

### DIFF
--- a/docs/src/reference/variables.md
+++ b/docs/src/reference/variables.md
@@ -2,6 +2,18 @@
 
 Variables are part of a workflow instance and represent the data of the instance. A variable has a name and a JSON value. The visibility of a variable is defined by its variable scope.
 
+## Variable Names
+
+The name of a variable can be any alphanumeric string including the `_` symbol. For a combination of words, it is recommended to use the `camelCase` or the `snake_case` format. The `kebab-case` format is not allowed because it contains the operator `-`.
+
+When accessing a variable in an expression, keep in mind that the variable name is case-sensitive.
+
+Restrictions of a variable name:
+* it may not start with a number
+* it may not contain whitespaces
+* it may not contain an operator (e.g. `+`, `-`, `*`, `/`, `=`, `>`, `?`, `.`)
+* it may not be a literal (e.g. `null`, `true`, `false`) or a keyword (e.g. `function`, `if`, `then`, `else`, `for`, `between`, `instance`, `of`, `not`)
+
 ## Variable Values
 
 The value of a variable is stored as a **JSON** value. It must have one of the following types:


### PR DESCRIPTION
## Description

* avoid that users use an invalid name for a variable by describing how a variable name should look like

## Related issues

none

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
