### PR TITLE
chore(ci): Fix pipelineJob triggers to new definition

### DIFF
--- a/.ci/jobs/chaos_test_zeebe.dsl
+++ b/.ci/jobs/chaos_test_zeebe.dsl
@@ -9,14 +9,20 @@ pipelineJob('chaos-test') {
         }
     }
 
-    triggers {
-        cron('H 1 * * *')
-    }
+    properties {
+        logRotator {
+            numToKeep(10)
+            daysToKeep(-1)
+            artifactDaysToKeep(-1)
+            artifactNumToKeep(10)
+        }
 
-    logRotator {
-        numToKeep(10)
-        daysToKeep(-1)
-        artifactDaysToKeep(-1)
-        artifactNumToKeep(10)
+        pipelineTriggers {
+            triggers {
+                cron {
+                    spec('H 1 * * *')
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Required after upgrading Jenkins job-dsl to 1.77

Related: INFRA-1343

## Description

Pipeline jobs having a `triggers` section need it to be moved to `properties` section if Jenkins is using `job-dsl>=1.77`
<!-- Please explain the changes you made here. -->

## Related issues

https://jira.camunda.com/browse/INFRA-1343

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
