### PR TITLE
[BACKPORT]  Fixes detection of empty log on seekToEnd

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
@@ -24,7 +24,18 @@ public final class AtomixLogStorageReader implements LogStorageReader {
 
   @Override
   public boolean isEmpty() {
-    return reader.isEmpty();
+    if (!reader.isEmpty()) {
+      // although seemingly inefficient, the log will contain mostly ZeebeEntry entries and a few
+      // InitialEntry, so this should be rather fast in practice
+      reader.reset();
+      while (reader.hasNext()) {
+        if (reader.next().type() == ZeebeEntry.class) {
+          return false;
+        }
+      }
+    }
+
+    return true;
   }
 
   @Override


### PR DESCRIPTION
## Description

- adds `LogStorageReader#isEmpty` as interface method
- fixes detection of empty log on `seekToEnd`
- removes `LogStorageReader#getFirstBlockAddress`, which was only used to detect an empty log

## Related issues

related to #3543
