### PR TITLE
[BACKPORT] Add memory mapped file configuration

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -111,6 +111,7 @@ public final class AtomixFactory {
             .withDataDirectory(raftDirectory)
             .withStateMachineFactory(ZeebeRaftStateMachine::new)
             .withSnapshotStoreFactory(new DbSnapshotStoreFactory())
+            .withStorageLevel(dataCfg.getAtomixStorageLevel())
             .withFlushOnCommit();
 
     // by default, the Atomix max entry size is 1 MB

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.broker.system.configuration;
 
+import io.atomix.storage.StorageLevel;
 import io.zeebe.util.Environment;
 import java.util.Arrays;
 import java.util.List;
@@ -26,6 +27,9 @@ public final class DataCfg implements ConfigurationEntry {
 
   private int maxSnapshots = 3;
 
+  // useMmap is not explicitly exposed to the user
+  private boolean useMmap = true;
+
   @Override
   public void init(
       final BrokerCfg globalConfig, final String brokerBase, final Environment environment) {
@@ -37,6 +41,7 @@ public final class DataCfg implements ConfigurationEntry {
 
   private void applyEnvironment(final Environment environment) {
     environment.getList(EnvironmentConstants.ENV_DIRECTORIES).ifPresent(v -> directories = v);
+    environment.getBool(EnvironmentConstants.ENV_USE_MMAP).ifPresent(this::setUseMmap);
   }
 
   public List<String> getDirectories() {
@@ -77,6 +82,18 @@ public final class DataCfg implements ConfigurationEntry {
 
   public void setRaftSegmentSize(final String raftSegmentSize) {
     this.raftSegmentSize = raftSegmentSize;
+  }
+
+  public boolean useMmap() {
+    return useMmap;
+  }
+
+  public void setUseMmap(final boolean useMmap) {
+    this.useMmap = useMmap;
+  }
+
+  public StorageLevel getAtomixStorageLevel() {
+    return useMmap() ? StorageLevel.MAPPED : StorageLevel.DISK;
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
@@ -22,4 +22,5 @@ public final class EnvironmentConstants {
   public static final String ENV_EMBED_GATEWAY = "ZEEBE_EMBED_GATEWAY";
   public static final String ENV_DEBUG_EXPORTER = "ZEEBE_DEBUG";
   public static final String ENV_STEP_TIMEOUT = "ZEEBE_STEP_TIMEOUT";
+  public static final String ENV_USE_MMAP = "ZEEBE_BROKER_DATA_USEMMAP";
 }


### PR DESCRIPTION
## Description

Add configuration option `ZEEBE_BROKER_DATA_USEMMAP` to enable use of memory mapped file for the log storage. In combination with replication this setting will lead the broker to fail starting as this is not supported yet.

## Related issues

related to #4413

