### PR TITLE
fix(ci): Fix call to cleanBeforeCheckoutTrait

### DIFF
--- a/.ci/jobs/github_zeebe_io.dsl
+++ b/.ci/jobs/github_zeebe_io.dsl
@@ -11,12 +11,16 @@ organizationFolder('zeebe-io') {
             credentialsId('camunda-jenkins-github')
 
             traits {
-                 cleanBeforeCheckoutTrait()
-                 gitHubBranchDiscovery {
+                cleanBeforeCheckoutTrait {
+                    extension {
+                        deleteUntrackedNestedRepositories(false)
+                    }
+                }
+                gitHubBranchDiscovery {
                     strategyId(3)
-                 }
-                 pruneStaleBranchTrait()
-                 localBranchTrait()
+                }
+                pruneStaleBranchTrait()
+                localBranchTrait()
             }
         }
     }


### PR DESCRIPTION
Broken after Jenkins Git plugin updated to v.4

Related: INFRA-1305

## Description

Fix a broken seed job:
https://ci.zeebe.camunda.cloud/job/seed-job-zeebe/765/console

Solution: https://issues.jenkins-ci.org/browse/JENKINS-26660?focusedCommentId=383868&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-383868
<!-- Please explain the changes you made here. -->

## Related issues

INFRA-1305

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
