### PR TITLE
chore(qa): remove wrong test that leads to flakyness

### DIFF
--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -74,32 +74,6 @@ public final class SnapshotReplicationTest {
   }
 
   @Test
-  public void shouldReceiveLatestSnapshotOnRejoin() {
-    // given
-    final var leaderNodeId = clusteringRule.getLeaderForPartition(1).getNodeId();
-    final var followers =
-        clusteringRule.getOtherBrokerObjects(leaderNodeId).stream()
-            .map(b -> b.getConfig().getCluster().getNodeId())
-            .collect(Collectors.toList());
-
-    final var firstFollowerId = followers.get(0);
-    final var secondFollowerId = followers.get(1);
-
-    // when - snapshot
-    clusteringRule.stopBroker(firstFollowerId);
-    triggerSnapshotCreation();
-    clusteringRule.restartBroker(firstFollowerId);
-    clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(secondFollowerId));
-    clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(firstFollowerId));
-
-    // then - replicated
-    final Map<Integer, Map<String, Long>> brokerSnapshotChecksums = getBrokerSnapshotChecksums();
-    final var leaderChecksums = Objects.requireNonNull(brokerSnapshotChecksums.get(leaderNodeId));
-    assertThat(brokerSnapshotChecksums.get(firstFollowerId)).containsAllEntriesOf(leaderChecksums);
-    assertThat(brokerSnapshotChecksums.get(secondFollowerId)).containsAllEntriesOf(leaderChecksums);
-  }
-
-  @Test
   public void shouldReceiveNewSnapshotsOnRejoin() {
     // given
     final var leaderNodeId = clusteringRule.getLeaderForPartition(1).getNodeId();


### PR DESCRIPTION
## Description

Remove  `shouldReceiveLatestSnapshotOnRejoin` that test for non-existing behavior. Snapshot replication is not reliable. We currently do not guarantee that a broker will receive a snapshot that was replicated when it was down.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4354

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
