### PR TITLE
feat(broker): add configuration option for mmap

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -9,9 +9,11 @@ package io.zeebe.broker.system;
 
 import static io.zeebe.engine.processor.AsyncSnapshotDirector.MINIMUM_SNAPSHOT_PERIOD;
 
+import io.atomix.storage.StorageLevel;
 import io.zeebe.broker.Loggers;
 import io.zeebe.broker.system.configuration.BrokerCfg;
 import io.zeebe.broker.system.configuration.ClusterCfg;
+import io.zeebe.broker.system.configuration.DataCfg;
 import io.zeebe.broker.system.configuration.ThreadsCfg;
 import io.zeebe.util.sched.ActorScheduler;
 import io.zeebe.util.sched.clock.ActorClock;
@@ -29,6 +31,8 @@ public final class SystemContext {
       "Replication factor %s needs to be larger then zero and not larger then cluster size %s.";
   private static final String SNAPSHOT_PERIOD_ERROR_MSG =
       "Snapshot period %s needs to be larger then or equals to one minute.";
+  private static final String MMAP_REPLICATION_ERROR_MSG =
+      "Using memory mapped storage level is currently unsafe with replication enabled; if you wish to use replication, set useMmap flag to false (e.g. ZEEBE_BROKER_DATA_USEMMAP=false)";
   protected final BrokerCfg brokerCfg;
   private Map<String, String> diagnosticContext;
   private ActorScheduler scheduler;
@@ -58,6 +62,7 @@ public final class SystemContext {
 
   private void validateConfiguration() {
     final ClusterCfg cluster = brokerCfg.getCluster();
+    final DataCfg data = brokerCfg.getData();
 
     final int partitionCount = cluster.getPartitionsCount();
     if (partitionCount < 1) {
@@ -70,7 +75,13 @@ public final class SystemContext {
       throw new IllegalArgumentException(String.format(NODE_ID_ERROR_MSG, nodeId, clusterSize));
     }
 
+    final StorageLevel storageLevel = data.getAtomixStorageLevel();
     final int replicationFactor = cluster.getReplicationFactor();
+
+    if (storageLevel == StorageLevel.MAPPED && replicationFactor > 1) {
+      throw new IllegalStateException(MMAP_REPLICATION_ERROR_MSG);
+    }
+
     if (replicationFactor < 1 || replicationFactor > clusterSize) {
       throw new IllegalArgumentException(
           String.format(REPLICATION_FACTOR_ERROR_MSG, replicationFactor, clusterSize));

--- a/broker/src/test/java/io/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
+++ b/broker/src/test/java/io/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.clustering.atomix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.core.Atomix;
+import io.atomix.raft.partition.RaftPartitionGroup;
+import io.atomix.raft.partition.RaftPartitionGroupConfig;
+import io.atomix.storage.StorageLevel;
+import io.zeebe.broker.system.configuration.BrokerCfg;
+import io.zeebe.util.Environment;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public final class AtomixFactoryTest {
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private Environment environment;
+
+  @Before
+  public void setUp() {
+    environment = new Environment();
+  }
+
+  @Test
+  public void shouldUseMappedStorageLevel() {
+    // given
+    final var brokerConfig = newConfig();
+    brokerConfig.getData().setUseMmap(true);
+
+    // when
+    final var atomix = AtomixFactory.fromConfiguration(brokerConfig);
+
+    // then
+    final var config = getPartitionGroupConfig(atomix);
+    assertThat(config.getStorageConfig().getLevel()).isEqualTo(StorageLevel.MAPPED);
+  }
+
+  @Test
+  public void shouldUseDiskStorageLevel() {
+    // given
+    final var brokerConfig = newConfig();
+    brokerConfig.getData().setUseMmap(false);
+
+    // when
+    final var atomix = AtomixFactory.fromConfiguration(brokerConfig);
+
+    // then
+    final var config = getPartitionGroupConfig(atomix);
+    assertThat(config.getStorageConfig().getLevel()).isEqualTo(StorageLevel.DISK);
+  }
+
+  private RaftPartitionGroup getPartitionGroup(final Atomix atomix) {
+    return (RaftPartitionGroup)
+        atomix.getPartitionService().getPartitionGroup(AtomixFactory.GROUP_NAME);
+  }
+
+  private RaftPartitionGroupConfig getPartitionGroupConfig(final Atomix atomix) {
+    return (RaftPartitionGroupConfig) getPartitionGroup(atomix).config();
+  }
+
+  private BrokerCfg newConfig() {
+    final var config = new BrokerCfg();
+    config.init(temporaryFolder.getRoot().getAbsolutePath(), environment);
+
+    return config;
+  }
+}

--- a/broker/src/test/java/io/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/SystemContextTest.java
@@ -131,6 +131,20 @@ public final class SystemContextTest {
         .isEqualTo(Duration.ofMinutes(1));
   }
 
+  @Test
+  public void shouldInvalidateConfigIfUseMmapTrueWithReplication() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getData().setUseMmap(true);
+    brokerCfg.getCluster().setClusterSize(2);
+    brokerCfg.getCluster().setReplicationFactor(2);
+
+    // then
+    expectedException.expect(IllegalStateException.class);
+    expectedException.expectMessage("memory mapped");
+    initSystemContext(brokerCfg);
+  }
+
   private SystemContext initSystemContext(final BrokerCfg brokerCfg) {
     return new SystemContext(brokerCfg, "test", new ControlledActorClock());
   }

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -524,6 +524,15 @@ public final class BrokerCfgTest {
     assertThat(actual.getExporters().get("elasticsearch")).isEqualTo(expected);
   }
 
+  @Test
+  public void shouldUseMmap() {
+    // given
+    environment.put("zeebe.broker.data.useMmap", "true");
+
+    // then
+    assertUseMmap(true);
+  }
+
   private BrokerCfg readConfig(final String name) {
     final String configPath = "/system/" + name + ".yaml";
 
@@ -585,6 +594,17 @@ public final class BrokerCfgTest {
   private void assertDefaultHost(final String host) {
     assertHost("default", host);
     assertHost("empty", host);
+  }
+
+  private void assertUseMmap(final boolean useMmap) {
+    assertUseMmap("default", useMmap);
+    assertUseMmap("empty", useMmap);
+  }
+
+  private void assertUseMmap(final String configFileName, final boolean useMmap) {
+    final var config = readConfig(configFileName);
+    final var data = config.getData();
+    assertThat(data.useMmap()).isEqualTo(useMmap);
   }
 
   private void assertHost(final String configFileName, final String host) {

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
@@ -9,6 +9,7 @@ package io.zeebe.broker.system.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.atomix.storage.StorageLevel;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
@@ -29,5 +30,41 @@ public class DataCfgTest {
     final List<String> actual = sutDataCfg.getDirectories();
 
     assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void shouldGetMappedAtomixStorageLevel() {
+    // given
+    final var sutDataCfg = new DataCfg();
+
+    // when
+    sutDataCfg.setUseMmap(true);
+
+    // then
+    final var actual = sutDataCfg.getAtomixStorageLevel();
+    assertThat(actual).isEqualTo(StorageLevel.MAPPED);
+  }
+
+  @Test
+  public void shouldGetDiskAtomixStorageLevel() {
+    // given
+    final var sutDataCfg = new DataCfg();
+
+    // when
+    sutDataCfg.setUseMmap(false);
+
+    // then
+    final var actual = sutDataCfg.getAtomixStorageLevel();
+    assertThat(actual).isEqualTo(StorageLevel.DISK);
+  }
+
+  @Test
+  public void shouldGetDiskAtomixStorageLevelAsDefault() {
+    // given
+    final var sutDataCfg = new DataCfg();
+
+    // then
+    final var actual = sutDataCfg.getAtomixStorageLevel();
+    assertThat(actual).isEqualTo(StorageLevel.DISK);
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/BrokerLeaderChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/BrokerLeaderChangeTest.java
@@ -34,7 +34,8 @@ public final class BrokerLeaderChangeTest {
       Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
 
   public final Timeout testTimeout = Timeout.seconds(120);
-  public final ClusteringRule clusteringRule = new ClusteringRule(1, 3, 3);
+  public final ClusteringRule clusteringRule =
+      new ClusteringRule(1, 3, 3, cfg -> cfg.getData().setUseMmap(false));
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 
   @Rule

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
@@ -62,6 +62,7 @@ public final class ClusteredDataDeletionTest {
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
     data.setLogSegmentSize(DataSize.ofKilobytes(8));
     data.setLogIndexDensity(50);
+    data.setUseMmap(false);
     brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(8));
 
     brokerCfg.setExporters(Collections.emptyMap());
@@ -72,6 +73,7 @@ public final class ClusteredDataDeletionTest {
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
     data.setLogSegmentSize(DataSize.ofKilobytes(8));
     data.setLogIndexDensity(50);
+    data.setUseMmap(false);
     brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(8));
 
     final ExporterCfg exporterCfg = new ExporterCfg();

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/DeploymentClusteredTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/DeploymentClusteredTest.java
@@ -27,7 +27,8 @@ public final class DeploymentClusteredTest {
       Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
 
   public final Timeout testTimeout = Timeout.seconds(120);
-  public final ClusteringRule clusteringRule = new ClusteringRule(3, 3, 3);
+  public final ClusteringRule clusteringRule =
+      new ClusteringRule(3, 3, 3, cfg -> cfg.getData().setUseMmap(false));
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 
   @Rule

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/GossipClusteringTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/GossipClusteringTest.java
@@ -21,7 +21,8 @@ import org.junit.rules.Timeout;
 public final class GossipClusteringTest {
 
   public final Timeout testTimeout = Timeout.seconds(120);
-  public final ClusteringRule clusteringRule = new ClusteringRule(1, 3, 3);
+  public final ClusteringRule clusteringRule =
+      new ClusteringRule(1, 3, 3, cfg -> cfg.getData().setUseMmap(false));
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 
   @Rule

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
@@ -41,6 +41,7 @@ public final class RestoreTest {
             cfg.getData().setLogSegmentSize(ATOMIX_SEGMENT_SIZE);
             cfg.getData().setLogIndexDensity(1);
             cfg.getNetwork().setMaxMessageSize(ATOMIX_SEGMENT_SIZE);
+            cfg.getData().setUseMmap(false);
           });
   private final GrpcClientRule clientRule =
       new GrpcClientRule(

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -226,5 +226,6 @@ public final class SnapshotReplicationTest {
   private static void configureBroker(final BrokerCfg brokerCfg) {
     brokerCfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD);
     brokerCfg.getData().setLogIndexDensity(1);
+    brokerCfg.getData().setUseMmap(false);
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/topology/TopologyClusterSmallerReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/topology/TopologyClusterSmallerReplicationTest.java
@@ -25,7 +25,8 @@ import org.junit.rules.Timeout;
 public final class TopologyClusterSmallerReplicationTest {
 
   private static final Timeout TEST_TIMEOUT = Timeout.seconds(120);
-  private static final ClusteringRule CLUSTERING_RULE = new ClusteringRule(3, 2, 3);
+  private static final ClusteringRule CLUSTERING_RULE =
+      new ClusteringRule(3, 2, 3, cfg -> cfg.getData().setUseMmap(false));
   private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(CLUSTERING_RULE);
 
   @ClassRule

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/topology/TopologyClusterTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/topology/TopologyClusterTest.java
@@ -27,7 +27,8 @@ import org.junit.rules.Timeout;
 public final class TopologyClusterTest {
 
   private static final Timeout TEST_TIMEOUT = Timeout.seconds(120);
-  private static final ClusteringRule CLUSTERING_RULE = new ClusteringRule();
+  private static final ClusteringRule CLUSTERING_RULE =
+      new ClusteringRule(3, 3, 3, cfg -> cfg.getData().setUseMmap(false));
   private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(CLUSTERING_RULE);
 
   @ClassRule


### PR DESCRIPTION
## Description

- adds a `useMmap` flag under the broker config data section, by default false
- Atomix uses `StorageLevel.MAPPED` if `useMmap` is true, `StorageLevel.DISK` otherwise
- Broker fails to start if `useMmap` is true and `replicationFactor` is greater than 1, as it is currently unsafe to use memory mapped files with replication enabled
- QA tests with replication explicitly set it to false even if it is the default to be safe
- Introduces `AtomixFactoryTest` to make sure we configure Atomix properly from the broker configuration
- Setting is omitted from the configuration templates for now, as it is a "use at your own risk" flag

## Related issues

closes #4413

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
