### PR TITLE
docs(getting-started): fix tutorial BPMN workflow

### DIFF
--- a/docs/src/getting-started/img/order-process.bpmn
+++ b/docs/src/getting-started/img/order-process.bpmn
@@ -40,7 +40,7 @@
       <bpmn:outgoing>SequenceFlow_08vb0ur</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_1girnrf" name="&#62;=$100" sourceRef="ExclusiveGateway_05lcnr8" targetRef="ServiceTask_1a7kbmc">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">orderValue&gt;=100</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=orderValue&gt;=100</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_05ptfs8">
       <bpmn:incoming>SequenceFlow_1rl28fn</bpmn:incoming>
@@ -56,7 +56,7 @@
   </bpmn:process>
   <bpmn:message id="Message_155nrcd" name="payment-received">
     <bpmn:extensionElements>
-      <zeebe:subscription correlationKey="orderId" />
+      <zeebe:subscription correlationKey="=orderId" />
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">


### PR DESCRIPTION
## Description

Per error received when deploying the example workflow, expressions must start with '=':
```
Error: rpc error: code = InvalidArgument desc = Command rejected with code 'CREATE': Expected to deploy new resources, but encountered the following errors:
'order-process.bpmn': - Element: Message_155nrcd > extensionElements > subscription
    - ERROR: Expected expression but found static value 'orderId'. An expression must start with '=' (e.g. '=orderId').
- Element: SequenceFlow_1girnrf > conditionExpression
    - ERROR: Expected expression but found static value 'orderValue>=100'. An expression must start with '=' (e.g. '=orderValue>=100').
```

## Related issues

Closes #4421

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
