### PR TITLE
chore(deps): don't update docker deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "config:base"
   ],
 
-  "ignoreDeps": ["docker/engine", "docker/docker", "docker/distribution", "docker/go-connections", "docker/go-units"],
+  "ignoreDeps": ["github.com/docker/engine", "github.com/docker/docker", "github.com/docker/distribution", "github.com/docker/go-connections", "github.com/docker/go-units"],
 
   "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
## Description

Since the Docker dependencies don't follow semver, they cause issues when the renovate bot tries to bump the version (e.g.., it "updates" to an old version). The presented error is not very obvious and usually requires a bit of googling to understand, so I'd prefer if this dependency was manually updated instead of having to deal with these PRs.
Hopefully, this PR makes the renovate bot ignore the Docker dependencies.

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
