### PR TITLE
Delete log on newer snapshot than log

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -39,7 +39,6 @@ import io.atomix.utils.logging.LoggerContext;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -351,7 +350,7 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
    */
   public List<RaftMemberContext> getRemoteMemberStates(final RaftMember.Type type) {
     final List<RaftMemberContext> members = memberTypes.get(type);
-    return members != null ? members : Collections.EMPTY_LIST;
+    return members != null ? members : List.of();
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -45,6 +45,7 @@ import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.log.entry.InitializeEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.storage.snapshot.SnapshotListener;
 import io.atomix.raft.storage.system.Configuration;
 import io.atomix.raft.zeebe.ZeebeEntry;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
@@ -86,6 +87,11 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     commitInitialEntriesFuture = commitInitialEntries();
 
     return super.start().thenRun(this::startTimers).thenApply(v -> this);
+  }
+
+  @Override
+  protected SnapshotListener createSnapshotListener() {
+    return null;
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/PartitionListener.java
+++ b/broker/src/main/java/io/zeebe/broker/PartitionListener.java
@@ -24,10 +24,9 @@ public interface PartitionListener {
    *
    * @param partitionId the corresponding partition id
    * @param term the current term
-   * @param logStream the corresponding log stream
    * @return future that should be completed by the listener
    */
-  ActorFuture<Void> onBecomingFollower(int partitionId, long term, LogStream logStream);
+  ActorFuture<Void> onBecomingFollower(int partitionId, long term);
 
   /**
    * Is called by the {@link io.zeebe.broker.system.partitions.ZeebePartition} on becoming partition

--- a/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
@@ -56,8 +56,7 @@ public final class TopologyManagerImpl extends Actor
   }
 
   @Override
-  public ActorFuture<Void> onBecomingFollower(
-      final int partitionId, final long term, final LogStream logStream) {
+  public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
     return setFollower(partitionId);
   }
 

--- a/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
@@ -46,8 +46,7 @@ public final class SubscriptionApiCommandMessageHandlerService extends Actor
   }
 
   @Override
-  public ActorFuture<Void> onBecomingFollower(
-      final int partitionId, final long term, final LogStream logStream) {
+  public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
     return actor.call(
         () -> {
           leaderPartitions.remove(partitionId);

--- a/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
@@ -33,8 +33,7 @@ public final class LeaderManagementRequestHandler extends Actor implements Parti
   }
 
   @Override
-  public ActorFuture<Void> onBecomingFollower(
-      final int partitionId, final long term, final LogStream logStream) {
+  public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
     return actor.call(
         () -> {
           leaderForPartitions.remove(partitionId);

--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -66,8 +66,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
   }
 
   @Override
-  public ActorFuture<Void> onBecomingFollower(
-      final int partitionId, final long term, final LogStream logStream) {
+  public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
     return updateBrokerReadyStatus(partitionId);
   }
 

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -303,7 +303,8 @@ public final class ZeebePartition extends Actor
     LOG.debug("Installing follower partition service for partition {}", atomixRaftPartition.id());
 
     final CompletableActorFuture<Void> installFuture = new CompletableActorFuture<>();
-    basePartitionInstallation()
+
+    installStorageServices()
         .onComplete(
             (deletionService, errorOnInstallation) -> {
               if (errorOnInstallation == null) {

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -217,7 +217,7 @@ public final class ZeebePartition extends Actor
               if (error == null) {
                 final List<ActorFuture<Void>> listenerFutures =
                     partitionListeners.stream()
-                        .map(l -> l.onBecomingFollower(partitionId, newTerm, logStream))
+                        .map(l -> l.onBecomingFollower(partitionId, newTerm))
                         .collect(Collectors.toList());
                 actor.runOnCompletion(
                     listenerFutures,

--- a/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -10,7 +10,6 @@ package io.zeebe.broker.transport.commandapi;
 import io.zeebe.broker.Loggers;
 import io.zeebe.broker.transport.backpressure.BackpressureMetrics;
 import io.zeebe.broker.transport.backpressure.RequestLimiter;
-import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.Protocol;
@@ -194,11 +193,11 @@ final class CommandApiRequestHandler implements RequestHandler {
         });
   }
 
-  void removePartition(final LogStream logStream) {
+  void removePartition(final int partitionId) {
     cmdQueue.add(
         () -> {
-          leadingStreams.remove(logStream.getPartitionId());
-          partitionLimiters.remove(logStream.getPartitionId());
+          leadingStreams.remove(partitionId);
+          partitionLimiters.remove(partitionId);
         });
   }
 

--- a/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiService.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiService.java
@@ -56,11 +56,10 @@ public final class CommandApiService extends Actor implements PartitionListener 
   }
 
   @Override
-  public ActorFuture<Void> onBecomingFollower(
-      final int partitionId, final long term, final LogStream logStream) {
+  public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
     return actor.call(
         () -> {
-          requestHandler.removePartition(logStream);
+          requestHandler.removePartition(partitionId);
           cleanLeadingPartition(partitionId);
         });
   }

--- a/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
@@ -70,8 +70,7 @@ public final class SimpleBrokerStartTest {
     broker.addPartitionListener(
         new PartitionListener() {
           @Override
-          public ActorFuture<Void> onBecomingFollower(
-              final int partitionId, final long term, final LogStream logStream) {
+          public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
             return CompletableActorFuture.completed(null);
           }
 

--- a/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -282,8 +282,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
     }
 
     @Override
-    public ActorFuture<Void> onBecomingFollower(
-        final int partitionId, final long term, final LogStream logStream) {
+    public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
       return CompletableActorFuture.completed(null);
     }
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -673,8 +673,7 @@ public final class ClusteringRule extends ExternalResource {
     }
 
     @Override
-    public ActorFuture<Void> onBecomingFollower(
-        final int partitionId, final long term, final LogStream logStream) {
+    public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
       return CompletableActorFuture.completed(null);
     }
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/HealthMonitoringTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/HealthMonitoringTest.java
@@ -147,8 +147,7 @@ public class HealthMonitoringTest {
     }
 
     @Override
-    public ActorFuture<Void> onBecomingFollower(
-        final int partitionId, final long term, final LogStream logStream) {
+    public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
       followerInstall.countDown();
       return CompletableActorFuture.completedExceptionally(
           new RuntimeException("fail follower installation"));

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRestartTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRestartTest.java
@@ -78,9 +78,7 @@ public class BrokerRestartTest {
     }
 
     @Override
-    public ActorFuture<Void> onBecomingFollower(
-        final int partitionId, final long term, final LogStream logStream) {
-      this.logStream = logStream;
+    public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
       return CompletableActorFuture.completed(null);
     }
 


### PR DESCRIPTION
## Description

We had the problem that we distributed our snapshot via our snapshot replication, but on a slow follower we might be not able to use this snapshot.

**Scenario:**

  * Three nodes one partition.
  * **Leader** and **Follower A** have the same state (`Log [0 - 100]`)
  * **Follower B** is behind (`Log [0 - 50]`)

If a snapshot (e.g. index `65`) is taken on **Leader** it is distributed to all followers. **Follower A** can use it to compact his log. **Follower B** can't use it since he can't find the corresponding index in his log, which means he can't compact. He is also not allowed to delete the complete log on compaction.

Logs look now like this:

 * **Leader** and **Follower A** `Log [65-100]`.
 * **Follower B** `Log [0-50]`


When the **Leader** goes down, for what ever reason. The **Follower A** was not able to become leader, since the **Follower B** didn't accepted the initial entry. The initial entry has the index `101`, but the **Follower B** needed an entry for index `51`, which **Follower A** don't had. It ended in a endless loop where **Follower A** send last entry he knows (`65`) and Follower B said he had an older one (`50`).
This problem existed until the old leader comes back and had no data loss otherwise the cluster can be seen as death.

The problem was that either the **Follower A** need to send the latest snapshot to the **Follower B** _or_ the **Follower B** need to reset his log on receiving the snapshot the first time when he detects a gap.

_We chosed the second option, since on the raft install request we already did this._

This means **now** when the **Follower B** receives a snapshot with index index `65`, he deletes his log and resets his index to `65`. His log looks then like this `Log [65]`. This makes it possible to form a healthy cluster quite quick and accept the initial entries even if the old leader dies and never comes back.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4439

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
