### PR TITLE
fix(clients/java): parse USE_PLAINTEXT_CONNECTION as boolean

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -156,7 +156,17 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
           Duration.ofMillis(Long.parseLong(properties.getProperty(DEFAULT_REQUEST_TIMEOUT))));
     }
     if (properties.containsKey(USE_PLAINTEXT_CONNECTION)) {
-      usePlaintext();
+      /**
+       * The following condition is phrased in this particular way in order to be backwards
+       * compatible with older versions of the software. In older versions the content of the
+       * property was not interpreted. It was assumed to be true, whenever it was set. Because of
+       * that, code examples in this code base set the flag to an empty string. By phrasing the
+       * condition this way, the old code will still work with this new implementation. Only if
+       * somebody deliberately sets the flag to false, the behavior will change
+       */
+      if (!"false".equalsIgnoreCase(properties.getProperty(USE_PLAINTEXT_CONNECTION))) {
+        usePlaintext();
+      }
     }
     if (properties.containsKey(CA_CERTIFICATE_PATH)) {
       caCertificatePath(properties.getProperty(CA_CERTIFICATE_PATH));

--- a/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
@@ -98,7 +98,7 @@ public final class ZeebeClientTest extends ClientTest {
     // given
     Environment.system().put(PLAINTEXT_CONNECTION_VAR, "false");
     final Properties properties = new Properties();
-    properties.putIfAbsent(USE_PLAINTEXT_CONNECTION, "");
+    properties.putIfAbsent(USE_PLAINTEXT_CONNECTION, "true");
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
     builder.withProperties(properties);
 

--- a/test/src/main/java/io/zeebe/test/ZeebeTestRule.java
+++ b/test/src/main/java/io/zeebe/test/ZeebeTestRule.java
@@ -41,7 +41,7 @@ public class ZeebeTestRule extends ExternalResource {
               properties.setProperty(
                   ClientProperties.BROKER_CONTACTPOINT,
                   SocketUtil.toHostAndPortString(brokerRule.getGatewayAddress()));
-              properties.putIfAbsent(ClientProperties.USE_PLAINTEXT_CONNECTION, "");
+              properties.putIfAbsent(ClientProperties.USE_PLAINTEXT_CONNECTION, "true");
 
               return properties;
             });

--- a/test/src/main/java/io/zeebe/test/exporter/ExporterIntegrationRule.java
+++ b/test/src/main/java/io/zeebe/test/exporter/ExporterIntegrationRule.java
@@ -385,7 +385,7 @@ public class ExporterIntegrationRule extends ExternalResource {
         ClientProperties.BROKER_CONTACTPOINT,
         SocketUtil.toHostAndPortString(
             getBrokerConfig().getGateway().getNetwork().toSocketAddress()));
-    properties.put(ClientProperties.USE_PLAINTEXT_CONNECTION, "");
+    properties.put(ClientProperties.USE_PLAINTEXT_CONNECTION, "true");
 
     return properties;
   }


### PR DESCRIPTION
## Description

Changes behavior of `USE_PLAINTEXT_CONNECTION` flag; If it is explicitly set to `false`, it won't be applied.

## Related issues

closes #4245

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
