### PR TITLE
fix(broker): prevent auto config of elasticsearch client

### DIFF
--- a/dist/src/main/java/io/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/zeebe/broker/StandaloneBroker.java
@@ -23,9 +23,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientAutoConfiguration;
 import org.springframework.core.env.Environment;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = RestClientAutoConfiguration.class)
 public class StandaloneBroker implements CommandLineRunner {
 
   @Autowired BrokerCfg configuration;

--- a/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientAutoConfiguration;
 import org.springframework.core.env.Environment;
 
 public class StandaloneGateway {
@@ -116,7 +117,7 @@ public class StandaloneGateway {
     SpringApplication.run(Launcher.class, args);
   }
 
-  @SpringBootApplication
+  @SpringBootApplication(exclude = RestClientAutoConfiguration.class)
   public static class Launcher implements CommandLineRunner {
 
     @Autowired GatewayCfg configuration;


### PR DESCRIPTION
## Description

Prevent ElasticSearch auto configuration.

## Related issues

closes #4403

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
