### PR TITLE
chore(gateway): retry when partitions not available

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClient.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClient.java
@@ -10,8 +10,10 @@ package io.zeebe.gateway.impl.broker;
 import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.zeebe.transport.impl.IncomingResponse;
 import io.zeebe.util.sched.future.ActorFuture;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 public interface BrokerClient extends AutoCloseable {
 
@@ -23,6 +25,12 @@ public interface BrokerClient extends AutoCloseable {
       BrokerRequest<T> request,
       BrokerResponseConsumer<T> responseConsumer,
       Consumer<Throwable> throwableConsumer);
+
+  <T> void sendRequest(
+      BrokerRequest<T> request,
+      BrokerResponseConsumer<T> responseConsumer,
+      Consumer<Throwable> throwableConsumer,
+      Predicate<IncomingResponse> shouldRetryPredicate);
 
   BrokerTopologyManager getTopologyManager();
 }

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClientImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClientImpl.java
@@ -24,6 +24,7 @@ import io.zeebe.transport.ClientTransportBuilder;
 import io.zeebe.transport.RemoteAddress;
 import io.zeebe.transport.SocketAddress;
 import io.zeebe.transport.Transports;
+import io.zeebe.transport.impl.IncomingResponse;
 import io.zeebe.transport.impl.memory.NonBlockingMemoryPool;
 import io.zeebe.transport.impl.memory.UnboundedMemoryPool;
 import io.zeebe.util.ByteValue;
@@ -34,6 +35,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import org.slf4j.Logger;
 
 public class BrokerClientImpl implements BrokerClient {
@@ -171,16 +173,25 @@ public class BrokerClientImpl implements BrokerClient {
    * @see io.zeebe.gateway.impl.broker.BrokerClient#sendRequest(io.zeebe.gateway.impl.broker.request.BrokerRequest)
    */
   @Override
-  public <T> ActorFuture<BrokerResponse<T>> sendRequest(BrokerRequest<T> request) {
+  public <T> ActorFuture<BrokerResponse<T>> sendRequest(final BrokerRequest<T> request) {
     return requestManager.sendRequest(request);
   }
 
   @Override
   public <T> void sendRequest(
-      BrokerRequest<T> request,
-      BrokerResponseConsumer<T> responseConsumer,
-      Consumer<Throwable> throwableConsumer) {
+      final BrokerRequest<T> request,
+      final BrokerResponseConsumer<T> responseConsumer,
+      final Consumer<Throwable> throwableConsumer) {
     requestManager.sendRequest(request, responseConsumer, throwableConsumer);
+  }
+
+  @Override
+  public <T> void sendRequest(
+      final BrokerRequest<T> request,
+      final BrokerResponseConsumer<T> responseConsumer,
+      final Consumer<Throwable> throwableConsumer,
+      final Predicate<IncomingResponse> shouldRetryPredicate) {
+    requestManager.sendRequest(request, responseConsumer, throwableConsumer, shouldRetryPredicate);
   }
 
   @Override

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/RoundRobinDispatchStrategy.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/RoundRobinDispatchStrategy.java
@@ -8,15 +8,19 @@
 package io.zeebe.gateway.impl.broker;
 
 import io.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
-import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManagerImpl;
+import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Return the next partition using a round robin strategy, but skips the partitions where there is
+ * no leader at the moment.
+ */
 public class RoundRobinDispatchStrategy implements RequestDispatchStrategy {
 
-  protected final BrokerTopologyManagerImpl topologyManager;
+  protected final BrokerTopologyManager topologyManager;
   protected final AtomicInteger partitions = new AtomicInteger(0);
 
-  public RoundRobinDispatchStrategy(final BrokerTopologyManagerImpl topologyManager) {
+  public RoundRobinDispatchStrategy(final BrokerTopologyManager topologyManager) {
     this.topologyManager = topologyManager;
   }
 
@@ -25,10 +29,15 @@ public class RoundRobinDispatchStrategy implements RequestDispatchStrategy {
     final BrokerClusterState topology = topologyManager.getTopology();
 
     if (topology != null) {
-      final int offset = partitions.getAndIncrement();
-      return topology.getPartition(offset);
-    } else {
-      return BrokerClusterState.PARTITION_ID_NULL;
+      for (int i = 0; i < topology.getPartitionsCount(); i++) {
+        final int offset = partitions.getAndIncrement();
+        final int partition = topology.getPartition(offset);
+        if (topology.getLeaderForPartition(partition) != BrokerClusterState.NODE_ID_NULL) {
+          return partition;
+        }
+      }
     }
+
+    return BrokerClusterState.PARTITION_ID_NULL;
   }
 }

--- a/gateway/src/main/java/io/zeebe/gateway/impl/job/CreateWorkflowHandler.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/job/CreateWorkflowHandler.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.impl.job;
+
+import io.zeebe.gateway.Loggers;
+import io.zeebe.gateway.cmd.BrokerErrorException;
+import io.zeebe.gateway.impl.broker.BrokerClient;
+import io.zeebe.gateway.impl.broker.BrokerResponseConsumer;
+import io.zeebe.gateway.impl.broker.RoundRobinDispatchStrategy;
+import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
+import io.zeebe.gateway.impl.broker.request.BrokerCreateWorkflowInstanceRequest;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
+import io.zeebe.protocol.record.ErrorCode;
+import io.zeebe.transport.impl.sender.NoRemoteAddressFoundException;
+import java.util.function.Consumer;
+
+public class CreateWorkflowHandler {
+
+  private final BrokerClient brokerClient;
+  private final RoundRobinDispatchStrategy roundRobinDispatchStrategy;
+
+  public CreateWorkflowHandler(
+      final BrokerClient brokerClient, final BrokerTopologyManager topologyManager) {
+    this.brokerClient = brokerClient;
+    roundRobinDispatchStrategy = new RoundRobinDispatchStrategy(topologyManager);
+  }
+
+  public void createWorkflow(
+      final int partitionsCount,
+      final BrokerCreateWorkflowInstanceRequest request,
+      final BrokerResponseConsumer<WorkflowInstanceCreationRecord> responseConsumer,
+      final Consumer<Throwable> throwableConsumer) {
+    createWorkflow(
+        request,
+        partitionIdIteratorForType(partitionsCount),
+        responseConsumer,
+        throwableConsumer,
+        null);
+  }
+
+  private void createWorkflow(
+      final BrokerCreateWorkflowInstanceRequest request,
+      final PartitionIdIterator partitionIdIterator,
+      final BrokerResponseConsumer<WorkflowInstanceCreationRecord> responseConsumer,
+      final Consumer<Throwable> throwableConsumer,
+      final Throwable lastError) {
+
+    if (partitionIdIterator.hasNext()) {
+      final int partitionId = partitionIdIterator.next();
+
+      // partitions to check
+      request.setPartitionId(partitionId);
+      brokerClient.sendRequest(
+          request,
+          responseConsumer,
+          error -> {
+            if (shouldRetryWithNextPartition(error)) {
+              Loggers.GATEWAY_LOGGER.trace(
+                  "Failed to create workflow on partition {}",
+                  partitionIdIterator.getCurrentPartitionId(),
+                  error);
+              createWorkflow(
+                  request, partitionIdIterator, responseConsumer, throwableConsumer, error);
+            } else {
+              throwableConsumer.accept(error);
+            }
+          },
+          response -> false);
+    } else {
+      // no partition left to check
+      throwableConsumer.accept(lastError);
+    }
+  }
+
+  private boolean shouldRetryWithNextPartition(final Throwable error) {
+    if (error instanceof NoRemoteAddressFoundException) {
+      return true;
+    } else if (error instanceof BrokerErrorException) {
+      return ((BrokerErrorException) error).getError().getCode()
+          == ErrorCode.PARTITION_LEADER_MISMATCH;
+    }
+    // TODO: Add ResourceExhausted
+    return false;
+  }
+
+  private PartitionIdIterator partitionIdIteratorForType(final int partitionsCount) {
+    final int nextPartitionId = roundRobinDispatchStrategy.determinePartition();
+    return new PartitionIdIterator(nextPartitionId, partitionsCount);
+  }
+}

--- a/gateway/src/main/java/io/zeebe/gateway/impl/job/PartitionIdIterator.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/job/PartitionIdIterator.java
@@ -18,7 +18,7 @@ public class PartitionIdIterator implements Iterator<Integer> {
   private final OfInt iterator;
   private int currentPartitionId;
 
-  public PartitionIdIterator(int startPartitionId, int partitionsCount) {
+  public PartitionIdIterator(final int startPartitionId, final int partitionsCount) {
     iterator =
         IntStream.range(0, partitionsCount)
             .map(index -> ((index + startPartitionId) % partitionsCount) + START_PARTITION_ID)

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/GrpcClientRule.java
@@ -89,16 +89,16 @@ public class GrpcClientRule extends ExternalResource {
         .collect(Collectors.toList());
   }
 
-  public long createSingleJob(String type) {
+  public long createSingleJob(final String type) {
     return createSingleJob(type, b -> {}, "{}");
   }
 
-  public long createSingleJob(String type, Consumer<ServiceTaskBuilder> consumer) {
+  public long createSingleJob(final String type, final Consumer<ServiceTaskBuilder> consumer) {
     return createSingleJob(type, consumer, "{}");
   }
 
   public long createSingleJob(
-      String type, Consumer<ServiceTaskBuilder> consumer, String variables) {
+      final String type, final Consumer<ServiceTaskBuilder> consumer, final String variables) {
     final BpmnModelInstance modelInstance = createSingleJobModelInstance(type, consumer);
     final long workflowKey = deployWorkflow(modelInstance);
     final long workflowInstanceKey = createWorkflowInstance(workflowKey, variables);
@@ -111,7 +111,7 @@ public class GrpcClientRule extends ExternalResource {
   }
 
   public BpmnModelInstance createSingleJobModelInstance(
-      String jobType, Consumer<ServiceTaskBuilder> taskBuilderConsumer) {
+      final String jobType, final Consumer<ServiceTaskBuilder> taskBuilderConsumer) {
     return Bpmn.createExecutableProcess("process")
         .startEvent("start")
         .serviceTask(
@@ -124,7 +124,7 @@ public class GrpcClientRule extends ExternalResource {
         .done();
   }
 
-  public long deployWorkflow(BpmnModelInstance modelInstance) {
+  public long deployWorkflow(final BpmnModelInstance modelInstance) {
     final DeploymentEvent deploymentEvent =
         getClient()
             .newDeployCommand()
@@ -135,7 +135,7 @@ public class GrpcClientRule extends ExternalResource {
     return deploymentEvent.getWorkflows().get(0).getWorkflowKey();
   }
 
-  public long createWorkflowInstance(long workflowKey, String variables) {
+  public long createWorkflowInstance(final long workflowKey, final String variables) {
     return getClient()
         .newCreateInstanceCommand()
         .workflowKey(workflowKey)
@@ -145,7 +145,7 @@ public class GrpcClientRule extends ExternalResource {
         .getWorkflowInstanceKey();
   }
 
-  public long createWorkflowInstance(long workflowKey) {
+  public long createWorkflowInstance(final long workflowKey) {
     return getClient()
         .newCreateInstanceCommand()
         .workflowKey(workflowKey)

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/AvailabilityTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/AvailabilityTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.it.GrpcClientRule;
+import io.zeebe.client.api.response.ActivatedJob;
+import io.zeebe.client.api.response.BrokerInfo;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.intent.WorkflowInstanceCreationIntent;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+
+public class AvailabilityTest {
+
+  private static final String JOBTYPE = "availability-test";
+  private static final BpmnModelInstance WORKFLOW =
+      Bpmn.createExecutableProcess("process")
+          .startEvent()
+          .serviceTask(
+              "task",
+              t -> {
+                t.zeebeTaskType(JOBTYPE);
+              })
+          .endEvent()
+          .done();
+  private final int partitionCount = 3;
+  private final Timeout testTimeout = Timeout.seconds(120);
+  private final ClusteringRule clusteringRule = new ClusteringRule(partitionCount, 1, 3);
+  private final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(testTimeout).around(clusteringRule).around(clientRule);
+
+  private long workflowKey;
+
+  @Before
+  public void setup() {
+    workflowKey = clientRule.deployWorkflow(WORKFLOW);
+  }
+
+  @Test
+  public void shouldCreateWorkflowWhenOnePartitionDown() {
+    final BrokerInfo leaderForPartition = clusteringRule.getLeaderForPartition(partitionCount);
+
+    // when
+    clusteringRule.stopBroker(leaderForPartition.getNodeId(), false);
+
+    for (int i = 0; i < 2 * partitionCount; i++) {
+      clientRule.createWorkflowInstance(workflowKey);
+    }
+
+    // then
+    // all create instance requests should complete successfully
+    assertThat(
+            RecordingExporter.workflowInstanceCreationRecords()
+                .withIntent(WorkflowInstanceCreationIntent.CREATED)
+                .map(Record::getPartitionId)
+                .limit(2 * partitionCount)
+                .count())
+        .isEqualTo(2 * partitionCount);
+  }
+
+  @Test
+  public void shouldCreateWorkflowWhenPartitionRecovers() {
+    // given
+    final int failingPartition = partitionCount;
+    final BrokerInfo leaderForPartition = clusteringRule.getLeaderForPartition(failingPartition);
+    clusteringRule.stopBroker(leaderForPartition.getNodeId(), false);
+
+    for (int i = 0; i < partitionCount; i++) {
+      clientRule.createWorkflowInstance(workflowKey);
+    }
+
+    // when
+    clusteringRule.restartBroker(leaderForPartition.getNodeId());
+
+    for (int i = 0; i < partitionCount; i++) {
+      clientRule.createWorkflowInstance(workflowKey);
+    }
+
+    // then
+    // all create instance requests should complete successfully
+    assertThat(
+            RecordingExporter.workflowInstanceCreationRecords()
+                .withIntent(WorkflowInstanceCreationIntent.CREATED)
+                .filter(r -> r.getPartitionId() == failingPartition))
+        .hasSizeGreaterThanOrEqualTo(1);
+  }
+
+  @Test
+  public void shouldActivateJobsWhenOnePartitionDown() {
+    // given
+    final int numInstances = 2 * partitionCount;
+    final BrokerInfo leaderForPartition = clusteringRule.getLeaderForPartition(partitionCount);
+    clusteringRule.stopBroker(leaderForPartition.getNodeId(), false);
+
+    for (int i = 0; i < numInstances; i++) {
+      clientRule.createWorkflowInstance(workflowKey);
+    }
+
+    // when
+
+    final Set<Long> activatedJobsKey = new HashSet<>();
+    for (int i = 0; i < numInstances; i++) {
+      final List<ActivatedJob> jobs =
+          clientRule
+              .getClient()
+              .newActivateJobsCommand()
+              .jobType(JOBTYPE)
+              .maxJobsToActivate(1)
+              .timeout(Duration.ofMinutes(5))
+              .requestTimeout(Duration.ofSeconds(5)) // put a lower timeout than gateway timeout
+              .send()
+              .join()
+              .getJobs();
+      jobs.forEach(job -> activatedJobsKey.add(job.getKey()));
+    }
+
+    // then
+    assertThat(activatedJobsKey).hasSize(numInstances);
+  }
+}

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Transport</name>

--- a/transport/src/main/java/io/zeebe/transport/ClientOutput.java
+++ b/transport/src/main/java/io/zeebe/transport/ClientOutput.java
@@ -7,12 +7,12 @@
  */
 package io.zeebe.transport;
 
+import io.zeebe.transport.impl.IncomingResponse;
 import io.zeebe.util.buffer.BufferWriter;
 import io.zeebe.util.sched.future.ActorFuture;
 import java.time.Duration;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import org.agrona.DirectBuffer;
 
 public interface ClientOutput {
 
@@ -43,6 +43,9 @@ public interface ClientOutput {
    */
   ActorFuture<ClientResponse> sendRequest(Integer nodeId, BufferWriter writer, Duration timeout);
 
+  ActorFuture<ClientResponse> sendRequestWithRetry(
+      Supplier<Integer> nodeIdSupplier, BufferWriter writer, Duration timeout);
+
   /**
    * Send a request to a node with retries if there is no current connection or the node is not
    * resolvable. Makes this method more robust in the presence of short intermittent disconnects.
@@ -70,7 +73,7 @@ public interface ClientOutput {
    */
   ActorFuture<ClientResponse> sendRequestWithRetry(
       Supplier<Integer> nodeIdSupplier,
-      Predicate<DirectBuffer> responseInspector,
+      Predicate<IncomingResponse> responseInspector,
       BufferWriter writer,
       Duration timeout);
 }

--- a/transport/src/main/java/io/zeebe/transport/impl/ClientReceiveHandler.java
+++ b/transport/src/main/java/io/zeebe/transport/impl/ClientReceiveHandler.java
@@ -26,7 +26,9 @@ public class ClientReceiveHandler implements FragmentHandler {
   protected final List<ClientInputListener> listeners;
 
   public ClientReceiveHandler(
-      Sender requestPool, Dispatcher receiveBuffer, List<ClientInputListener> listeners) {
+      final Sender requestPool,
+      final Dispatcher receiveBuffer,
+      final List<ClientInputListener> listeners) {
     this.requestPool = requestPool;
     this.receiveBuffer = receiveBuffer;
     this.listeners = listeners;
@@ -34,7 +36,11 @@ public class ClientReceiveHandler implements FragmentHandler {
 
   @Override
   public int onFragment(
-      DirectBuffer buffer, int readOffset, int length, int streamId, boolean isMarkedFailed) {
+      final DirectBuffer buffer,
+      int readOffset,
+      int length,
+      final int streamId,
+      final boolean isMarkedFailed) {
     transportHeaderDescriptor.wrap(buffer, readOffset);
     readOffset += TransportHeaderDescriptor.headerLength();
     length -= TransportHeaderDescriptor.headerLength();
@@ -53,7 +59,7 @@ public class ClientReceiveHandler implements FragmentHandler {
         buffer.getBytes(readOffset, responseBuffer, 0, length);
 
         invokeResponseListeners(streamId, requestId, buffer, readOffset, length);
-        requestPool.submitResponse(new IncomingResponse(requestId, responseBuffer));
+        requestPool.submitResponse(new IncomingResponse(requestId, responseBuffer, null));
 
         return CONSUME_FRAGMENT_RESULT;
 
@@ -76,7 +82,8 @@ public class ClientReceiveHandler implements FragmentHandler {
     return CONSUME_FRAGMENT_RESULT;
   }
 
-  protected int onMessage(DirectBuffer buffer, int offset, int length, int streamId) {
+  protected int onMessage(
+      final DirectBuffer buffer, final int offset, final int length, final int streamId) {
     if (receiveBuffer == null) {
       return CONSUME_FRAGMENT_RESULT;
     }
@@ -89,7 +96,8 @@ public class ClientReceiveHandler implements FragmentHandler {
     }
   }
 
-  protected void invokeMessageListeners(int streamId, DirectBuffer buf, int offset, int length) {
+  protected void invokeMessageListeners(
+      final int streamId, final DirectBuffer buf, final int offset, final int length) {
     if (listeners != null) {
       for (int i = 0; i < listeners.size(); i++) {
         listeners.get(i).onMessage(streamId, buf, offset, length);
@@ -98,7 +106,11 @@ public class ClientReceiveHandler implements FragmentHandler {
   }
 
   protected void invokeResponseListeners(
-      int streamId, long requestId, DirectBuffer buf, int offset, int length) {
+      final int streamId,
+      final long requestId,
+      final DirectBuffer buf,
+      final int offset,
+      final int length) {
     if (listeners != null) {
       for (int i = 0; i < listeners.size(); i++) {
         listeners.get(i).onResponse(streamId, requestId, buf, offset, length);

--- a/transport/src/main/java/io/zeebe/transport/impl/IncomingResponse.java
+++ b/transport/src/main/java/io/zeebe/transport/impl/IncomingResponse.java
@@ -12,10 +12,13 @@ import org.agrona.DirectBuffer;
 public class IncomingResponse {
   private final long requestId;
   private final DirectBuffer responseBuffer;
+  private final Exception exception;
 
-  public IncomingResponse(long requestId, DirectBuffer responseBuffer) {
+  public IncomingResponse(
+      final long requestId, final DirectBuffer responseBuffer, final Exception exception) {
     this.requestId = requestId;
     this.responseBuffer = responseBuffer;
+    this.exception = exception;
   }
 
   public long getRequestId() {
@@ -24,5 +27,9 @@ public class IncomingResponse {
 
   public DirectBuffer getResponseBuffer() {
     return responseBuffer;
+  }
+
+  public Exception getException() {
+    return exception;
   }
 }

--- a/transport/src/main/java/io/zeebe/transport/impl/sender/NoRemoteAddressFoundException.java
+++ b/transport/src/main/java/io/zeebe/transport/impl/sender/NoRemoteAddressFoundException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.transport.impl.sender;
+
+public final class NoRemoteAddressFoundException extends Exception {
+  public static final NoRemoteAddressFoundException INSTANCE = new NoRemoteAddressFoundException();
+
+  private NoRemoteAddressFoundException() {
+    super("No remote address found");
+  }
+}

--- a/transport/src/main/java/io/zeebe/transport/impl/sender/Sender.java
+++ b/transport/src/main/java/io/zeebe/transport/impl/sender/Sender.java
@@ -44,39 +44,30 @@ public class Sender extends Actor implements TimerHandler {
   private static final int DEFAULT_BATCH_SIZE = (int) ByteValue.ofKilobytes(128).toBytes();
 
   private static final Logger LOG = Loggers.TRANSPORT_LOGGER;
-
+  protected final Duration keepAlivePeriod;
   private long nextRequestId = 0;
-
   private final ConcurrentQueueChannel<IncomingResponse> submittedResponses =
       new ConcurrentQueueChannel<>(new ManyToOneConcurrentLinkedQueue<>());
   private final ConcurrentQueueChannel<OutgoingRequest> submittedRequests =
       new ConcurrentQueueChannel<>(new ManyToOneConcurrentLinkedQueue<>());
   private final ConcurrentQueueChannel<OutgoingMessage> submittedMessages =
       new ConcurrentQueueChannel<>(new ManyToOneConcurrentLinkedQueue<>());
-
   private final Long2ObjectHashMap<OutgoingRequest> inFlightRequests = new Long2ObjectHashMap<>();
   private final Long2ObjectHashMap<OutgoingRequest> requestsByTimeoutIds =
       new Long2ObjectHashMap<>();
-
   private final Int2ObjectHashMap<ChannelWriteQueue> channelMap = new Int2ObjectHashMap<>();
   private final List<ChannelWriteQueue> channelList = new ArrayList<>();
-
   private final Deque<Batch> recycledBuffers = new LinkedList<>();
-
   private DeadlineTimerWheel requestTimeouts;
-
   private final Runnable sendNext = this::sendNext;
-
-  protected final Duration keepAlivePeriod;
-
   private final TransportMemoryPool messageMemoryPool;
   private final TransportMemoryPool requestMemoryPool;
 
   public Sender(
-      ActorContext actorContext,
-      TransportMemoryPool messageMemoryPool,
-      TransportMemoryPool requestMemoryPool,
-      Duration keepalivePeriod) {
+      final ActorContext actorContext,
+      final TransportMemoryPool messageMemoryPool,
+      final TransportMemoryPool requestMemoryPool,
+      final Duration keepalivePeriod) {
     this.messageMemoryPool = messageMemoryPool;
     this.requestMemoryPool = requestMemoryPool;
     this.keepAlivePeriod = keepalivePeriod;
@@ -113,7 +104,8 @@ public class Sender extends Actor implements TimerHandler {
       final IncomingResponse response = submittedResponses.poll();
 
       if (response != null) {
-        onResponseReceived(response);
+        final OutgoingRequest request = inFlightRequests.remove(response.getRequestId());
+        onResponseReceived(request, response);
       }
     }
 
@@ -146,15 +138,13 @@ public class Sender extends Actor implements TimerHandler {
     sendNext();
   }
 
-  private void onResponseReceived(final IncomingResponse response) {
-    final OutgoingRequest request = inFlightRequests.remove(response.getRequestId());
-
+  private void onResponseReceived(final OutgoingRequest request, final IncomingResponse response) {
     if (request != null) {
       boolean shouldRetry = false;
 
       try {
         shouldRetry = !request.tryComplete(response);
-      } catch (Exception e) {
+      } catch (final Exception e) {
         request.fail(e);
         reclaimRequestBuffer(request.getRequestBuffer().byteBuffer());
         return;
@@ -198,8 +188,14 @@ public class Sender extends Actor implements TimerHandler {
           actor.runDelayed(Duration.ofMillis(10), () -> submittedRequests.offer(request));
         }
       } else {
-        // no remote address available, retry
-        actor.runDelayed(Duration.ofMillis(10), () -> submittedRequests.offer(request));
+        final IncomingResponse failedResponseNoRemote =
+            new IncomingResponse(
+                request.getLastRequestId(), null, NoRemoteAddressFoundException.INSTANCE);
+        if (request.shouldRetry(failedResponseNoRemote)) {
+          actor.runDelayed(Duration.ofMillis(10), () -> submittedRequests.offer(request));
+        } else {
+          request.fail(NoRemoteAddressFoundException.INSTANCE);
+        }
       }
     }
   }
@@ -239,7 +235,7 @@ public class Sender extends Actor implements TimerHandler {
   }
 
   private void sendKeepalives() {
-    for (ChannelWriteQueue channelWriteQueue : channelList) {
+    for (final ChannelWriteQueue channelWriteQueue : channelList) {
       if (!channelWriteQueue.hasPending()) {
         channelWriteQueue
             .getPendingWrites()
@@ -250,6 +246,76 @@ public class Sender extends Actor implements TimerHandler {
     sendNext();
   }
 
+  public ActorFuture<ClientResponse> submitRequest(final OutgoingRequest request) {
+    submittedRequests.add(request);
+    return request.getResponseFuture();
+  }
+
+  public void submitMessage(final OutgoingMessage outgoingMessage) {
+    submittedMessages.add(outgoingMessage);
+  }
+
+  public void submitResponse(final IncomingResponse incomingClientResponse) {
+    submittedResponses.add(incomingClientResponse);
+  }
+
+  public ActorFuture<Void> close() {
+    return actor.close();
+  }
+
+  public ActorFuture<Void> onChannelConnected(final TransportChannel ch) {
+    return actor.call(
+        () -> {
+          final ChannelWriteQueue sendQueue = new ChannelWriteQueue(ch);
+          channelMap.put(ch.getStreamId(), sendQueue);
+          channelList.add(sendQueue);
+        });
+  }
+
+  public ActorFuture<Void> onChannelClosed(final TransportChannel channel) {
+    return actor.call(
+        () -> {
+          final ChannelWriteQueue sendQueue = channelMap.remove(channel.getStreamId());
+          if (sendQueue != null) {
+            channelList.remove(sendQueue);
+            // re-submit pending requests so that they can be retried
+            sendQueue.pendingWrites.forEach(Batch::onChannelClosed);
+          }
+        });
+  }
+
+  @Override
+  public boolean onTimerExpiry(final TimeUnit timeUnit, final long now, final long timerId) {
+    final OutgoingRequest request = requestsByTimeoutIds.get(timerId);
+
+    if (request != null) {
+      reclaimRequestBuffer(request.getRequestBuffer().byteBuffer());
+      request.timeout();
+      inFlightRequests.remove(request.getLastRequestId());
+    }
+
+    return true;
+  }
+
+  public ByteBuffer allocateMessageBuffer(final int length) {
+    return messageMemoryPool.allocate(length);
+  }
+
+  public void reclaimMessageBuffer(final ByteBuffer allocatedBuffer) {
+    messageMemoryPool.reclaim(allocatedBuffer);
+  }
+
+  public ByteBuffer allocateRequestBuffer(final int requestedCapacity) {
+    return requestMemoryPool.allocate(requestedCapacity);
+  }
+
+  public void reclaimRequestBuffer(final ByteBuffer allocatedBuffer) {
+    requestMemoryPool.reclaim(allocatedBuffer);
+  }
+
+  public void failPendingRequestsToRemote(
+      final RemoteAddressImpl remoteAddress, final String reason) {}
+
   public class ChannelWriteQueue {
     private final Deque<Batch> pendingWrites = new LinkedList<>();
 
@@ -257,7 +323,7 @@ public class Sender extends Actor implements TimerHandler {
 
     private Batch currentWrite;
 
-    public ChannelWriteQueue(TransportChannel channel) {
+    public ChannelWriteQueue(final TransportChannel channel) {
       this.channel = channel;
     }
 
@@ -281,7 +347,7 @@ public class Sender extends Actor implements TimerHandler {
       }
     }
 
-    public void offer(OutgoingRequest request) {
+    public void offer(final OutgoingRequest request) {
       // try to fit into last pending batch
       final Batch existingBatch = pendingWrites.peekLast();
 
@@ -306,7 +372,7 @@ public class Sender extends Actor implements TimerHandler {
       }
     }
 
-    public void offer(OutgoingMessage message) {
+    public void offer(final OutgoingMessage message) {
       // try to fit into last pending batch
       Batch batch = pendingWrites.peekLast();
 
@@ -340,6 +406,19 @@ public class Sender extends Actor implements TimerHandler {
     }
   }
 
+  class ControlMessage extends Batch {
+    ControlMessage(final DirectBuffer controlMessageTemplate) {
+      super(controlMessageTemplate.capacity());
+      view.putBytes(0, controlMessageTemplate, 0, controlMessageTemplate.capacity());
+      this.writeOffset = controlMessageTemplate.capacity();
+    }
+
+    @Override
+    public void recycle() {
+      // don't do it
+    }
+  }
+
   private class Batch {
     final List<OutgoingRequest> requestsInBatch = new ArrayList<>();
 
@@ -347,12 +426,12 @@ public class Sender extends Actor implements TimerHandler {
     final ByteBuffer batchBuffer;
     int writeOffset = 0;
 
-    Batch(int size) {
+    Batch(final int size) {
       batchBuffer = ByteBuffer.allocateDirect(size);
       view.wrap(batchBuffer);
     }
 
-    public boolean addToBatch(OutgoingRequest request, TransportChannel channel) {
+    public boolean addToBatch(final OutgoingRequest request, final TransportChannel channel) {
       final DirectBuffer requestBuffer = request.getRequestBuffer();
       final int requestLength = requestBuffer.capacity();
 
@@ -375,7 +454,7 @@ public class Sender extends Actor implements TimerHandler {
       }
     }
 
-    public boolean addToBatch(OutgoingMessage message) {
+    public boolean addToBatch(final OutgoingMessage message) {
       final DirectBuffer buffer = message.getBuffer();
       final int requiredLength = buffer.capacity();
 
@@ -389,7 +468,7 @@ public class Sender extends Actor implements TimerHandler {
       }
     }
 
-    public boolean writeTo(TransportChannel channel) {
+    public boolean writeTo(final TransportChannel channel) {
       return channel.write(batchBuffer) > 0;
     }
 
@@ -414,86 +493,4 @@ public class Sender extends Actor implements TimerHandler {
       recycle();
     }
   }
-
-  class ControlMessage extends Batch {
-    ControlMessage(DirectBuffer controlMessageTemplate) {
-      super(controlMessageTemplate.capacity());
-      view.putBytes(0, controlMessageTemplate, 0, controlMessageTemplate.capacity());
-      this.writeOffset = controlMessageTemplate.capacity();
-    }
-
-    @Override
-    public void recycle() {
-      // don't do it
-    }
-  }
-
-  public ActorFuture<ClientResponse> submitRequest(OutgoingRequest request) {
-    submittedRequests.add(request);
-    return request.getResponseFuture();
-  }
-
-  public void submitMessage(OutgoingMessage outgoingMessage) {
-    submittedMessages.add(outgoingMessage);
-  }
-
-  public void submitResponse(IncomingResponse incomingClientResponse) {
-    submittedResponses.add(incomingClientResponse);
-  }
-
-  public ActorFuture<Void> close() {
-    return actor.close();
-  }
-
-  public ActorFuture<Void> onChannelConnected(TransportChannel ch) {
-    return actor.call(
-        () -> {
-          final ChannelWriteQueue sendQueue = new ChannelWriteQueue(ch);
-          channelMap.put(ch.getStreamId(), sendQueue);
-          channelList.add(sendQueue);
-        });
-  }
-
-  public ActorFuture<Void> onChannelClosed(TransportChannel channel) {
-    return actor.call(
-        () -> {
-          final ChannelWriteQueue sendQueue = channelMap.remove(channel.getStreamId());
-          if (sendQueue != null) {
-            channelList.remove(sendQueue);
-            // re-submit pending requests so that they can be retried
-            sendQueue.pendingWrites.forEach(Batch::onChannelClosed);
-          }
-        });
-  }
-
-  @Override
-  public boolean onTimerExpiry(TimeUnit timeUnit, long now, long timerId) {
-    final OutgoingRequest request = requestsByTimeoutIds.get(timerId);
-
-    if (request != null) {
-      reclaimRequestBuffer(request.getRequestBuffer().byteBuffer());
-      request.timeout();
-      inFlightRequests.remove(request.getLastRequestId());
-    }
-
-    return true;
-  }
-
-  public ByteBuffer allocateMessageBuffer(int length) {
-    return messageMemoryPool.allocate(length);
-  }
-
-  public void reclaimMessageBuffer(ByteBuffer allocatedBuffer) {
-    messageMemoryPool.reclaim(allocatedBuffer);
-  }
-
-  public ByteBuffer allocateRequestBuffer(int requestedCapacity) {
-    return requestMemoryPool.allocate(requestedCapacity);
-  }
-
-  public void reclaimRequestBuffer(ByteBuffer allocatedBuffer) {
-    requestMemoryPool.reclaim(allocatedBuffer);
-  }
-
-  public void failPendingRequestsToRemote(RemoteAddressImpl remoteAddress, String reason) {}
 }


### PR DESCRIPTION
## Description

For requests that can be send to any partition retry with different partition when leader not available.

* Refactor automatic retry in `io.zeebe.transport.impl.sender` so that create workflow and activate job requests are not retried with the same partition when leader not available.
* Add 'CreateWorkflowHandler' to retry requests with different partition
* Refactor RoundRobinStrategy to include only partitions where leader is available

## Related issues

Related to #4496 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
