### PR TITLE
[BACKPORT] chore(broker): expose workflow and job processing latency metrics

### DIFF
--- a/broker-core/src/main/java/io/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.exporter.metrics;
+
+import io.prometheus.client.Histogram;
+
+public class ExecutionLatencyMetrics {
+
+  private static final Histogram WORKFLOW_INSTANCE_EXECUTION =
+      Histogram.build()
+          .namespace("zeebe")
+          .name("workflow_instance_execution_time")
+          .help("The execution time of processing a complete workflow instance")
+          .labelNames("partition")
+          .register();
+
+  private static final Histogram JOB_LIFE_TIME =
+      Histogram.build()
+          .namespace("zeebe")
+          .name("job_life_time")
+          .help("The life time of an job")
+          .labelNames("partition")
+          .register();
+
+  private static final Histogram JOB_ACTIVATION_TIME =
+      Histogram.build()
+          .namespace("zeebe")
+          .name("job_activation_time")
+          .help("The time until an job was activated")
+          .labelNames("partition")
+          .register();
+
+  public void observeWorkflowInstanceExecutionTime(
+      final int partitionId, final long creationTimeMs, final long completionTimeMs) {
+    WORKFLOW_INSTANCE_EXECUTION
+        .labels(Integer.toString(partitionId))
+        .observe(latencyInSeconds(creationTimeMs, completionTimeMs));
+  }
+
+  public void observeJobLifeTime(
+      final int partitionId, final long creationTimeMs, final long completionTimeMs) {
+    JOB_LIFE_TIME
+        .labels(Integer.toString(partitionId))
+        .observe(latencyInSeconds(creationTimeMs, completionTimeMs));
+  }
+
+  public void observeJobActivationTime(
+      final int partitionId, final long creationTimeMs, final long activationTimeMs) {
+    JOB_ACTIVATION_TIME
+        .labels(Integer.toString(partitionId))
+        .observe(latencyInSeconds(creationTimeMs, activationTimeMs));
+  }
+
+  /**
+   * Takes start and end time in milliseconds and calculates the difference (latency) in seconds.
+   *
+   * @param startTimeMs the start time in milliseconds
+   * @param endTimeMs the end time in milliseconds
+   * @return the latency in seconds
+   */
+  private static double latencyInSeconds(final long startTimeMs, final long endTimeMs) {
+    return ((endTimeMs - startTimeMs) / 1000f);
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/broker-core/src/main/java/io/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.exporter.metrics;
+
+import io.zeebe.broker.system.configuration.ExporterCfg;
+import io.zeebe.exporter.api.Exporter;
+import io.zeebe.exporter.api.context.Controller;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.intent.Intent;
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.protocol.record.value.WorkflowInstanceRecordValue;
+import java.time.Duration;
+import java.util.NavigableMap;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.agrona.collections.Long2LongHashMap;
+
+public class MetricsExporter implements Exporter {
+
+  public static final Duration TIME_TO_LIVE = Duration.ofSeconds(10);
+  private final ExecutionLatencyMetrics executionLatencyMetrics;
+  private final Long2LongHashMap jobKeyToCreationTimeMap;
+  private final Long2LongHashMap workflowInstanceKeyToCreationTimeMap;
+
+  private final NavigableMap<Long, Long> creationTimeToJobKeyNavigableMap;
+  private final NavigableMap<Long, Long> creationTimeToWorkflowInstanceKeyNavigableMap;
+
+  private Controller controller;
+
+  public MetricsExporter() {
+    this.executionLatencyMetrics = new ExecutionLatencyMetrics();
+    this.jobKeyToCreationTimeMap = new Long2LongHashMap(-1);
+    this.workflowInstanceKeyToCreationTimeMap = new Long2LongHashMap(-1);
+    this.creationTimeToJobKeyNavigableMap = new TreeMap<>();
+    this.creationTimeToWorkflowInstanceKeyNavigableMap = new TreeMap<>();
+  }
+
+  @Override
+  public void open(final Controller controller) {
+    this.controller = controller;
+
+    controller.scheduleTask(TIME_TO_LIVE, this::cleanUp);
+  }
+
+  @Override
+  public void close() {
+    jobKeyToCreationTimeMap.clear();
+    workflowInstanceKeyToCreationTimeMap.clear();
+  }
+
+  @Override
+  public void export(final Record record) {
+    if (record.getRecordType() != RecordType.EVENT) {
+      controller.updateLastExportedRecordPosition(record.getPosition());
+      return;
+    }
+
+    final int partitionId = record.getPartitionId();
+    final long recordKey = record.getKey();
+
+    final ValueType currentValueType = record.getValueType();
+    if (currentValueType == ValueType.JOB) {
+      handleJobRecord(record, partitionId, recordKey);
+    } else if (currentValueType == ValueType.WORKFLOW_INSTANCE) {
+      handleWorkflowInstanceRecord(record, partitionId, recordKey);
+    }
+
+    controller.updateLastExportedRecordPosition(record.getPosition());
+  }
+
+  private void handleWorkflowInstanceRecord(
+      final Record<?> record, final int partitionId, final long recordKey) {
+    final Intent currentIntent = record.getIntent();
+
+    if (currentIntent == WorkflowInstanceIntent.ELEMENT_ACTIVATING
+        && isWorkflowInstanceRecord(record)) {
+      storeWorkflowInstanceCreation(record.getTimestamp(), recordKey);
+    } else if (currentIntent == WorkflowInstanceIntent.ELEMENT_COMPLETED
+        && isWorkflowInstanceRecord(record)) {
+      final long creationTime = workflowInstanceKeyToCreationTimeMap.remove(recordKey);
+      executionLatencyMetrics.observeWorkflowInstanceExecutionTime(
+          partitionId, creationTime, record.getTimestamp());
+    }
+  }
+
+  private void storeWorkflowInstanceCreation(final long creationTime, final long recordKey) {
+    workflowInstanceKeyToCreationTimeMap.put(recordKey, creationTime);
+    creationTimeToWorkflowInstanceKeyNavigableMap.put(creationTime, recordKey);
+  }
+
+  private void handleJobRecord(
+      final Record<?> record, final int partitionId, final long recordKey) {
+    final Intent currentIntent = record.getIntent();
+
+    if (currentIntent == JobIntent.CREATED) {
+      storeJobCreation(record.getTimestamp(), recordKey);
+    } else if (currentIntent == JobIntent.ACTIVATED) {
+      final long creationTime = jobKeyToCreationTimeMap.get(recordKey);
+      executionLatencyMetrics.observeJobActivationTime(
+          partitionId, creationTime, record.getTimestamp());
+    } else if (currentIntent == JobIntent.COMPLETED) {
+      final long creationTime = jobKeyToCreationTimeMap.remove(recordKey);
+      executionLatencyMetrics.observeJobLifeTime(partitionId, creationTime, record.getTimestamp());
+    }
+  }
+
+  private void storeJobCreation(final long creationTime, final long recordKey) {
+    jobKeyToCreationTimeMap.put(recordKey, creationTime);
+    creationTimeToJobKeyNavigableMap.put(creationTime, recordKey);
+  }
+
+  private void cleanUp() {
+    final long currentTimeMillis = System.currentTimeMillis();
+
+    final long deadTime = currentTimeMillis - TIME_TO_LIVE.toMillis();
+    clearMaps(deadTime, creationTimeToJobKeyNavigableMap, jobKeyToCreationTimeMap);
+    clearMaps(
+        deadTime,
+        creationTimeToWorkflowInstanceKeyNavigableMap,
+        workflowInstanceKeyToCreationTimeMap);
+  }
+
+  private void clearMaps(
+      final long deadTime,
+      final NavigableMap<Long, Long> timeToKeyMap,
+      final Long2LongHashMap keyToTimestampMap) {
+    final SortedMap<Long, Long> outOfScopeInstances = timeToKeyMap.headMap(deadTime);
+
+    for (final Long key : outOfScopeInstances.values()) {
+      keyToTimestampMap.remove(key);
+    }
+    outOfScopeInstances.clear();
+  }
+
+  public static ExporterCfg defaultConfig() {
+    final ExporterCfg exporterCfg = new ExporterCfg();
+    exporterCfg.setId(defaultExporterId());
+    exporterCfg.setClassName(MetricsExporter.class.getName());
+    return exporterCfg;
+  }
+
+  public static String defaultExporterId() {
+    return MetricsExporter.class.getSimpleName();
+  }
+
+  private static boolean isWorkflowInstanceRecord(final Record<?> record) {
+    final WorkflowInstanceRecordValue recordValue = (WorkflowInstanceRecordValue) record.getValue();
+    return BpmnElementType.PROCESS == recordValue.getBpmnElementType();
+  }
+}

--- a/broker-core/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
+++ b/broker-core/src/main/java/io/zeebe/broker/system/configuration/EnvironmentConstants.java
@@ -20,7 +20,6 @@ public class EnvironmentConstants {
   public static final String ENV_CLUSTER_NAME = "ZEEBE_CLUSTER_NAME";
   public static final String ENV_EMBED_GATEWAY = "ZEEBE_EMBED_GATEWAY";
   public static final String ENV_DEBUG_EXPORTER = "ZEEBE_DEBUG";
-
   public static final String ENV_GOSSIP_BROADCAST_UPDATES =
       "ZEEBE_BROKER_CLUSTER_GOSSIPBROADCASTUPDATES";
   public static final String ENV_GOSSIP_BROADCAST_DISPUTES =
@@ -32,4 +31,6 @@ public class EnvironmentConstants {
   public static final String ENV_GOSSIP_SUSPECT_PROBES = "ZEEBE_BROKER_CLUSTER_SUSPECTEDPROBES";
   public static final String ENV_GOSSIP_FAILURE_TIMEOUT =
       "ZEEBE_BROKER_CLUSTER_GOSSIPFAILURETIMEOUT";
+  public static final String ENV_EXECUTION_METRICS_EXPORTER_ENABLED =
+      "ZEEBE_BROKER_EXECUTIONMETRICSEXPORTERENABLED";
 }

--- a/broker-core/src/test/java/io/zeebe/broker/system/ConfigurationTest.java
+++ b/broker-core/src/test/java/io/zeebe/broker/system/ConfigurationTest.java
@@ -18,6 +18,7 @@ import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_CLUS
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_DEBUG_EXPORTER;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_DIRECTORIES;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_EMBED_GATEWAY;
+import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_EXECUTION_METRICS_EXPORTER_ENABLED;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_HOST;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_INITIAL_CONTACT_POINTS;
 import static io.zeebe.broker.system.configuration.EnvironmentConstants.ENV_NODE_ID;
@@ -32,6 +33,7 @@ import static io.zeebe.protocol.Protocol.START_PARTITION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.zeebe.broker.exporter.debug.DebugLogExporter;
+import io.zeebe.broker.exporter.metrics.MetricsExporter;
 import io.zeebe.broker.system.configuration.BrokerCfg;
 import io.zeebe.broker.system.configuration.ClusterCfg;
 import io.zeebe.broker.system.configuration.DataCfg;
@@ -432,6 +434,15 @@ public class ConfigurationTest {
     assertEmbeddedGatewayEnabled("disabled-gateway", true);
   }
 
+  @Test
+  public void shouldEnableMetricsExporter() {
+    // given
+    environment.put(ENV_EXECUTION_METRICS_EXPORTER_ENABLED, "true");
+
+    // then
+    assertMetricsExporter();
+  }
+
   private BrokerCfg readConfig(final String name) {
     final String configPath = "/system/" + name + ".toml";
     final InputStream resourceAsStream = ConfigurationTest.class.getResourceAsStream(configPath);
@@ -590,5 +601,19 @@ public class ConfigurationTest {
     assertThat(cfgCluster.getReplicationFactor()).isEqualTo(replicationFactor);
     assertThat(cfgCluster.getClusterSize()).isEqualTo(clusterSize);
     assertThat(cfgCluster.getInitialContactPoints()).isEqualTo(initialContactPoints);
+  }
+
+  private void assertMetricsExporter() {
+    assertMetricsExporter("default");
+    assertMetricsExporter("empty");
+  }
+
+  private void assertMetricsExporter(final String configFileName) {
+    final ExporterCfg exporterCfg = MetricsExporter.defaultConfig();
+    final BrokerCfg brokerCfg = readConfig(configFileName);
+
+    assertThat(brokerCfg.getExporters())
+        .usingRecursiveFieldByFieldElementComparator()
+        .contains(exporterCfg);
   }
 }

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -64,7 +64,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1589278533477,
+  "iteration": 1589286022855,
   "links": [],
   "panels": [
     {
@@ -2658,6 +2658,198 @@
           "yBucketBound": "auto",
           "yBucketNumber": null,
           "yBucketSize": null
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#ef843c",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "$DS_PROMETHEUS",
+          "description": "Shows the execution time of a process instance. This means the time (latency) between creating the instance and completing it.",
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 12
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 129,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "sum(increase(zeebe_workflow_instance_execution_time_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[30s])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Processing Execution Time",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "dtdurations",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#ef843c",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "$DS_PROMETHEUS",
+          "description": "Shows the time (latency) between creating the job and activating it.",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 131,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "sum(increase(zeebe_job_activation_time_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[30s])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Job Activation Time",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "dtdurations",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#ef843c",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "$DS_PROMETHEUS",
+          "description": "Shows the complete lifetime of an job. This means the time (latency) between creating the job and completing it.",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 133,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "sum(increase(zeebe_job_life_time_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[30s])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Job Life Time",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "dtdurations",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
         }
       ],
       "title": "Processing Latency",
@@ -3185,5 +3377,5 @@
   "variables": {
     "list": []
   },
-  "version": 5
+  "version": 7
 }


### PR DESCRIPTION
## Description

- backports the `MetricsExporter` to expose job creation, activation, and completion latencies, as well as workflow completion latencies
- adds the relevant graphs to the Grafana dashboard

## Related issues

closes #4504 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
