### PR TITLE
chore(ci): send slack notifications on failed release job builds

### DIFF
--- a/.ci/pipelines/release_zeebe.groovy
+++ b/.ci/pipelines/release_zeebe.groovy
@@ -149,4 +149,12 @@ spec:
             }
         }
     }
+
+    post {
+        failure {
+            slackSend(
+              channel: "#zeebe-ci${jenkins.model.JenkinsLocationConfiguration.get()?.getUrl()?.contains('stage') ? '-stage' : ''}",
+              message: "Release job build ${currentBuild.absoluteUrl} failed!")
+        }
+    }
 }

--- a/.ci/pipelines/release_zeebe_java8.groovy
+++ b/.ci/pipelines/release_zeebe_java8.groovy
@@ -149,4 +149,12 @@ spec:
             }
         }
     }
+
+    post {
+        failure {
+            slackSend(
+              channel: "#zeebe-ci${jenkins.model.JenkinsLocationConfiguration.get()?.getUrl()?.contains('stage') ? '-stage' : ''}",
+              message: "Release job build ${currentBuild.absoluteUrl} failed!")
+        }
+    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -252,6 +252,15 @@ pipeline {
                 }
             }
         }
+        changed {
+            script {
+                if (env.BRANCH_NAME == 'develop') {
+                    slackSend(
+                        channel: "#zeebe-ci${jenkins.model.JenkinsLocationConfiguration.get()?.getUrl()?.contains('stage') ? '-stage' : ''}",
+                        message: "Zeebe ${env.BRANCH_NAME} build ${currentBuild.absoluteUrl} changed status to ${currentBuild.currentResult}")
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
- for testing purposes this logic will automatically choose the #zeebe-ci-stage channel on Zeebe Stage CI

See working example here: https://stage.ci.zeebe.camunda.cloud/job/cn-release-test/
and here: https://ci.zeebe.camunda.cloud/job/zeebe-io/job/zeebe/job/INFRA-1168-develop/4/console

Related to INFRA-1168