### PR TITLE
Add tests for snapshotting and compaction

### DIFF
--- a/atomix/cluster/src/test/resources/log4j2-test.xml
+++ b/atomix/cluster/src/test/resources/log4j2-test.xml
@@ -9,7 +9,7 @@
 
   <Loggers>
     <Logger name="io.zeebe" level="debug"/>
-    <Logger name="io.atomix" level="info"/>
+    <Logger name="io.atomix" level="debug"/>
 
     <Root level="info">
       <AppenderRef ref="Console"/>


### PR DESCRIPTION
## Description

Improved further the `RaftRule` such that we are able to trigger snapshotting, which will create snapshots on all nodes. After the snapshot is taken the snapshot listeners are called, which trigger compaction. This setup reflects now how our system works, but it is much easier to test I think.

Normally we do a snapshot on the Leader and replicate that. The snapshot replication call at the end also `SnapshotStore#newSnapshot`. With the current test approach we were able to simplify that approach and test the same behavior. 

I added a test for:

 * normal snapshot taking and verify that all nodes have this snapshot
 * snapshotting triggers compaction verify log is compacted
 * snapshot is send on rejoin cluster

I plan to add further tests, more complex ones probably.

I checked #4467 and the problem was that the node was not able to truncate his log because it was at zero index and the leader was not able to send a snapshot, because it had none. The test was wrongly written I would say.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4467

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
