### PR TITLE
chore(atomix): fix log output in state machine

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/zeebe/ZeebeRaftStateMachine.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/zeebe/ZeebeRaftStateMachine.java
@@ -41,7 +41,7 @@ public final class ZeebeRaftStateMachine implements RaftStateMachine {
     this.lastEnqueued = reader.getFirstIndex() - 1;
     this.logger =
         ContextualLoggerFactory.getLogger(
-            getClass(), LoggerContext.builder(getClass()).add("partition", raft.getName()).build());
+            getClass(), LoggerContext.builder(getClass()).addValue(raft.getName()).build());
     this.metrics = new RaftServiceMetrics(raft.getName());
   }
 


### PR DESCRIPTION
## Description

Log looks now like this:

```
14:10:33.466 [] DEBUG io.atomix.raft.impl.zeebe.ZeebeRaftStateMachine - ZeebeRaftStateMachine{raft-partition-partition-3} - Skipping compaction of non-compactable index 300 (first log index: 301)
```

Instead of:

```
ZeebeRaftStateMachine5947999{partition=raft-partition-partition-3} - Skipping compaction of non-compactable index 5802441 (first log index: {})
```

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/4414

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
