### PR TITLE
[BACKPORT] chore(project): update vulnerable netty version

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -25,7 +25,7 @@
     <nexus.release.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io/
     </nexus.release.repository>
 
-    <version.netty>4.1.48.Final</version.netty>
+    <version.netty>4.1.50.Final</version.netty>
 
     <version.java>11</version.java>
     <plugin.version.javadoc>3.2.0</plugin.version.javadoc>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -60,7 +60,6 @@
     <version.mockito>3.3.3</version.mockito>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.8.20</version.msgpack>
-    <version.netty>4.1.39.Final</version.netty>
     <version.netty-tcnative>2.0.30.Final</version.netty-tcnative>
     <version.objenesis>3.1</version.objenesis>
     <version.prometheus>0.8.1</version.prometheus>


### PR DESCRIPTION
## Description

This PR backports upgrading the Netty version to fix CVE-2020-11612 and SNYK-JAVA-IONETTY-564897 in versions prior to 4.1.46.Final. It seems the distribution was built with 4.1.39.Final (confirmed by downloading it and checking), even though the BOM was using version 4.1.48.Final.

## Related issues

closes #4533 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
