### PR TITLE
chore(docker): minor improvements

### DIFF
--- a/.ci/scripts/docker/build.sh
+++ b/.ci/scripts/docker/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -eux
 
 echo "Building Zeebe Docker image ${IMAGE}:${TAG}"
-docker build --no-cache --build-arg DISTBALL=zeebe-distribution.tar.gz -t ${IMAGE}:${TAG} .
+docker build --no-cache --build-arg DISTBALL=zeebe-distribution.tar.gz -t ${IMAGE}:${TAG} --target app .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,22 @@
-FROM openjdk:11-jre
-
+FROM alpine:latest as builder
 ARG DISTBALL
+
+ENV TMP_ARCHIVE=/tmp/zeebe.tar.gz \
+    TMP_DIR=/tmp/zeebe \
+    TINI_VERSION=v0.19.0
+
+COPY ${DISTBALL} ${TMP_ARCHIVE}
+
+RUN mkdir -p ${TMP_DIR} && \
+    tar xfvz ${TMP_ARCHIVE} --strip 1 -C ${TMP_DIR} && \
+    # already create volume dir to later have correct rights
+    mkdir ${TMP_DIR}/data
+
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini ${TMP_DIR}/bin/tini
+COPY docker/utils/startup.sh ${TMP_DIR}/bin/startup.sh
+RUN chmod +x -R ${TMP_DIR}/bin/
+
+FROM openjdk:11-jre-slim as app
 
 ENV ZB_HOME=/usr/local/zeebe \
     ZEEBE_LOG_LEVEL=info \
@@ -8,23 +24,15 @@ ENV ZB_HOME=/usr/local/zeebe \
     ZEEBE_STANDALONE_GATEWAY=false
 ENV PATH "${ZB_HOME}/bin:${PATH}"
 
-ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini /bin/tini
-RUN chmod +x /bin/tini
-
-COPY ${DISTBALL} ${ZB_HOME}/
-
-RUN tar xfvz ${ZB_HOME}/*.tar.gz --strip 1 -C ${ZB_HOME}/ && rm ${ZB_HOME}/*.tar.gz
-
 WORKDIR ${ZB_HOME}
 EXPOSE 26500 26501 26502
 VOLUME ${ZB_HOME}/data
 
 COPY docker/utils/startup.sh /usr/local/bin
+ENTRYPOINT ["tini", "--", "/usr/local/bin/startup.sh"]
+COPY --from=builder /tmp/zeebe ${ZB_HOME}
 
-### Set execution flag (otherwise, if image is built in a Windows environment, the start scripts won't be executable)
+# Set execution flag (otherwise, if image is built in a Windows environment, the start scripts
+# won't be executable)
 RUN chmod +x ${ZB_HOME}/bin/broker
 RUN chmod +x ${ZB_HOME}/bin/gateway
-
-RUN apt-get --purge remove -y --auto-remove curl
-
-ENTRYPOINT ["tini", "--", "/usr/local/bin/startup.sh"]

--- a/benchmarks/setup/README.md
+++ b/benchmarks/setup/README.md
@@ -38,7 +38,7 @@ If you want to use your own or a different Zeebe snapshot then you could do the 
 # builds the dist with zbctl packed
 clients/go/cmd/zbctl/build.sh && mvn clean install -T1C -DskipTests -pl dist -am
 # builds the a new zeebe docker image
-docker build --build-arg DISTBALL=dist/target/zeebe-distribution-*.tar.gz -t gcr.io/zeebe-io/zeebe:SNAPSHOT-$(date +%Y-%m-%d)-$(git rev-parse --short=8 HEAD) .
+docker build --build-arg DISTBALL=dist/target/zeebe-distribution-*.tar.gz -t gcr.io/zeebe-io/zeebe:SNAPSHOT-$(date +%Y-%m-%d)-$(git rev-parse --short=8 HEAD) --target app .
 # pushes the image to our docker registry
 docker push gcr.io/zeebe-io/zeebe:SNAPSHOT-$(date +%Y-%m-%d)-$(git rev-parse --short=8 HEAD)
 ```

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -16,12 +16,12 @@ GO111MODULE=off mockgen github.com/zeebe-io/zeebe/clients/go/pkg/pb GatewayClien
 To run the integration tests, a Docker image for Zeebe must be built with the tag 'current-test'. To do that you can run (in the zeebe-io/zeebe dir):
 
 ```
-docker build --build-arg DISTBALL=dist/target/zeebe-distribution*.tar.gz -t camunda/zeebe:current-test .
+docker build --build-arg DISTBALL=dist/target/zeebe-distribution*.tar.gz -t camunda/zeebe:current-test --target app .
 ```
 
 To add new zbctl tests, you must generate a golden file with the expected output of the command you are testing. The tests ignore numbers so you can leave any keys or timestamps in your golden file, even though these will most likely be different from test command's output. However, non-numeric variables are not ignored. For instance, the help menu contains:
 
-``` 
+```
 --clientCache string    Specify the path to use for the OAuth credentials cache. If omitted, will read from the environment variable 'ZEEBE_CLIENT_CONFIG_PATH' (default "YOUR_HOME/.camunda/credentials")
 ```
 

--- a/upgrade-tests/README.md
+++ b/upgrade-tests/README.md
@@ -1,6 +1,6 @@
 To run the upgradability tests, a Docker image for Zeebe must be built with the tag 'current-test'. To do that you can run (in the zeebe-io/zeebe dir):
 
 ```
-docker build --build-arg DISTBALL=dist/target/zeebe-distribution*.tar.gz -t camunda/zeebe:current-test .
+docker build --build-arg DISTBALL=dist/target/zeebe-distribution*.tar.gz -t camunda/zeebe:current-test --target app .
 ```
 


### PR DESCRIPTION
## Description

- switches base image from openjdk:jre-11 to openjdk:jre-11-slim for a slightly smaller image
- introduces multi stage build to avoid having the distball copy layer

The goal of the PR is to reduce the amount of data one has to push when pushing the image. Previously, we were pushing two layers: the distball copy, and the distball untarring. This is now squashed into a single layer thanks to the multi-stage build. Using the `slim` variant of the original image also allows us to eschew some typical actions like removing the apt cache, or removing curl, etc., as this is already done for us.

Note that omitting the target flag will still result in a valid image, but in the case where we one day have multiple images, it's better to get in the habit.

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
