### PR TITLE
fix(docs): fix links to config files in docs

### DIFF
--- a/docs/src/appendix/broker-config-template.md
+++ b/docs/src/appendix/broker-config-template.md
@@ -2,9 +2,9 @@
 
 This section references the default Zeebe standalone broker configuration templates, which are shipped with the distribution. They can be found inside the `config` folder and can be used to adjust Zeebe to your needs.
 
-* [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/zeebe-io/zeebe/tree/{{commit}}/dist/src/main/config/config/application.yaml`) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development
-* [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/zeebe-io/zeebe/tree/{{commit}}/dist/src/main/config/broker.standalone.yaml.template`) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development
-* [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/zeebe-io/zeebe/tree/{{commit}}/dist/src/main/config/broker.yaml.template`) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster
+* [`config/application.yaml` Standalone Broker (with embedded gateway)](https://github.com/zeebe-io/zeebe/tree/{{commit}}/dist/src/main/config/application.yaml) - Default configuration containing only the most common configuration settings. Use this as the basis for a single broker deployment for test or development
+* [`config/broker.standalone.yaml.template` Standalone Broker (with embedded gateway)](https://github.com/zeebe-io/zeebe/tree/{{commit}}/dist/src/main/config/broker.standalone.yaml.template) - Complete configuration template for a standalone broker with embedded gateway. Use this as the basis for a single broker deployment for test or development
+* [`config/broker.yaml.template` Broker Node (without embedded gateway)](https://github.com/zeebe-io/zeebe/tree/{{commit}}/dist/src/main/config/broker.yaml.template) - Complete configuration template for a broker node without embedded gateway. Use this as the basis for deploying multiple broker nodes as part of a cluster
 
 ## Default Standalone Broker Configuration
 The default configuration contains the most common configuration options.


### PR DESCRIPTION
## Description

FIxed errors in links:
* There was a trailing `'` character in the links
* the first link had two levels of `/config/`

## Related issues

closes #4393

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ X ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ X ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
