### PR TITLE
chore(exporters/elasticsearch-exporter): remove high level rest client

### DIFF
--- a/exporters/elasticsearch-exporter/pom.xml
+++ b/exporters/elasticsearch-exporter/pom.xml
@@ -30,16 +30,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-high-level-client</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-client</artifactId>
     </dependency>
@@ -62,11 +52,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore-nio</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.carrotsearch</groupId>
-      <artifactId>hppc</artifactId>
     </dependency>
 
     <dependency>
@@ -104,7 +89,16 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
     </dependency>
 
     <dependency>

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
@@ -7,7 +7,10 @@
  */
 package io.zeebe.exporter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.prometheus.client.Histogram;
+import io.zeebe.exporter.dto.BulkResponse;
+import io.zeebe.exporter.dto.PutIndexTemplateResponse;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.value.VariableRecordValue;
@@ -19,25 +22,27 @@ import java.net.URISyntaxException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
-import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
-import org.elasticsearch.action.bulk.BulkItemResponse;
-import org.elasticsearch.action.bulk.BulkRequest;
-import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.client.RequestOptions;
+import org.apache.http.nio.entity.NStringEntity;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContent;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.slf4j.Logger;
 
@@ -46,11 +51,14 @@ public class ElasticsearchClient {
   public static final String INDEX_TEMPLATE_FILENAME_PATTERN = "/zeebe-record-%s-template.json";
   public static final String INDEX_DELIMITER = "_";
   public static final String ALIAS_DELIMITER = "-";
-  protected final RestHighLevelClient client;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ContentType CONTENT_TYPE_NDJSON = ContentType.create("application/x-ndjson");
+
+  protected final RestClient client;
   private final ElasticsearchExporterConfiguration configuration;
   private final Logger log;
   private final DateTimeFormatter formatter;
-  private BulkRequest bulkRequest;
+  private List<String> bulkRequest;
   private ElasticsearchMetrics metrics;
 
   public ElasticsearchClient(
@@ -58,7 +66,7 @@ public class ElasticsearchClient {
     this.configuration = configuration;
     this.log = log;
     this.client = createClient();
-    this.bulkRequest = new BulkRequest();
+    this.bulkRequest = new ArrayList<>();
     this.formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
   }
 
@@ -72,12 +80,7 @@ public class ElasticsearchClient {
     }
 
     checkRecord(record);
-
-    final IndexRequest request =
-        new IndexRequest(indexFor(record), typeFor(record), idFor(record))
-            .source(record.toJson(), XContentType.JSON)
-            .routing(String.valueOf(record.getPartitionId()));
-    bulk(request);
+    bulk(newIndexCommand(record), record);
   }
 
   @SuppressWarnings("unchecked")
@@ -103,51 +106,56 @@ public class ElasticsearchClient {
     }
   }
 
-  public void bulk(final IndexRequest indexRequest) {
-    bulkRequest.add(indexRequest);
+  public void bulk(final Map<String, Object> command, final Record<?> record) {
+    final String serializedCommand;
+
+    try {
+      serializedCommand = MAPPER.writeValueAsString(command);
+    } catch (final IOException e) {
+      throw new ElasticsearchExporterException(
+          "Failed to serialize bulk request command to JSON", e);
+    }
+
+    bulkRequest.add(serializedCommand + "\n" + record.toJson());
   }
 
   /** @return true if all bulk records where flushed successfully */
   public boolean flush() {
     boolean success = true;
-    final int bulkSize = bulkRequest.numberOfActions();
+    final int bulkSize = bulkRequest.size();
     if (bulkSize > 0) {
       try {
         metrics.recordBulkSize(bulkSize);
-        final BulkResponse responses = exportBulk();
-        success = checkBulkResponses(responses);
+        success = exportBulk();
       } catch (final IOException e) {
         throw new ElasticsearchExporterException("Failed to flush bulk", e);
       }
 
       if (success) {
         // all records where flushed, create new bulk request, otherwise retry next time
-        bulkRequest = new BulkRequest();
+        bulkRequest = new ArrayList<>();
       }
     }
 
     return success;
   }
 
-  private BulkResponse exportBulk() throws IOException {
+  private boolean exportBulk() throws IOException {
     try (final Histogram.Timer timer = metrics.measureFlushDuration()) {
-      return client.bulk(bulkRequest, RequestOptions.DEFAULT);
-    }
-  }
+      final var request = new Request("POST", "/_bulk");
+      final var body =
+          new NStringEntity(String.join("\n", bulkRequest) + "\n", CONTENT_TYPE_NDJSON);
+      request.setEntity(body);
 
-  private boolean checkBulkResponses(final BulkResponse responses) {
-    for (final BulkItemResponse response : responses) {
-      if (response.isFailed()) {
-        log.warn("Failed to flush at least one bulk request {}", response.getFailureMessage());
-        return false;
-      }
+      final var response = client.performRequest(request);
+      final var bulkResponse =
+          MAPPER.readValue(response.getEntity().getContent(), BulkResponse.class);
+      return !bulkResponse.hasErrors();
     }
-
-    return true;
   }
 
   public boolean shouldFlush() {
-    return bulkRequest.numberOfActions() >= configuration.bulk.size;
+    return bulkRequest.size() >= configuration.bulk.size;
   }
 
   /** @return true if request was acknowledged */
@@ -165,7 +173,7 @@ public class ElasticsearchClient {
     try (final InputStream inputStream =
         ElasticsearchExporter.class.getResourceAsStream(filename)) {
       if (inputStream != null) {
-        template = XContentHelper.convertToMap(XContentType.JSON.xContent(), inputStream, true);
+        template = convertToMap(XContentType.JSON.xContent(), inputStream);
       } else {
         throw new ElasticsearchExporterException(
             "Failed to find index template in classpath " + filename);
@@ -179,37 +187,37 @@ public class ElasticsearchClient {
     template.put("index_patterns", Collections.singletonList(templateName + INDEX_DELIMITER + "*"));
 
     // update alias in template in case it was changed in configuration
-    template.put("aliases", Collections.singletonMap(aliasName, Collections.EMPTY_MAP));
+    template.put("aliases", Collections.singletonMap(aliasName, Collections.emptyMap()));
 
-    final PutIndexTemplateRequest request =
-        new PutIndexTemplateRequest(templateName).source(template);
-
-    return putIndexTemplate(request);
+    return putIndexTemplate(templateName, template);
   }
 
   /** @return true if request was acknowledged */
-  private boolean putIndexTemplate(final PutIndexTemplateRequest putIndexTemplateRequest) {
+  private boolean putIndexTemplate(final String templateName, final Object body) {
     try {
-      return client
-          .indices()
-          .putTemplate(putIndexTemplateRequest, RequestOptions.DEFAULT)
-          .isAcknowledged();
+      final var request = new Request("PUT", "/_template/" + templateName);
+      request.addParameter("include_type_name", "true");
+      request.setJsonEntity(MAPPER.writeValueAsString(body));
+
+      final var response = client.performRequest(request);
+      final var putIndexTemplateResponse =
+          MAPPER.readValue(response.getEntity().getContent(), PutIndexTemplateResponse.class);
+      return putIndexTemplateResponse.isAcknowledged();
     } catch (final IOException e) {
       throw new ElasticsearchExporterException("Failed to put index template", e);
     }
   }
 
-  private RestHighLevelClient createClient() {
+  private RestClient createClient() {
     final HttpHost httpHost = urlToHttpHost(configuration.url);
-
-    // use single thread for rest client
     final RestClientBuilder builder =
         RestClient.builder(httpHost).setHttpClientConfigCallback(this::setHttpClientConfigCallback);
 
-    return new RestHighLevelClient(builder);
+    return builder.build();
   }
 
   private HttpAsyncClientBuilder setHttpClientConfigCallback(final HttpAsyncClientBuilder builder) {
+    // use single thread for rest client
     builder.setDefaultIOReactorConfig(IOReactorConfig.custom().setIoThreadCount(1).build());
 
     if (configuration.hasAuthenticationPresent()) {
@@ -278,5 +286,27 @@ public class ElasticsearchClient {
 
   private static String indexTemplateForValueType(final ValueType valueType) {
     return String.format(INDEX_TEMPLATE_FILENAME_PATTERN, valueTypeToString(valueType));
+  }
+
+  private Map<String, Object> convertToMap(final XContent content, final InputStream input) {
+    try (XContentParser parser =
+        content.createParser(
+            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, input)) {
+      return parser.mapOrdered();
+    } catch (final IOException e) {
+      throw new ElasticsearchExporterException("Failed to parse content to map", e);
+    }
+  }
+
+  private Map<String, Object> newIndexCommand(final Record<?> record) {
+    final Map<String, Object> command = new HashMap<>();
+    final Map<String, Object> contents = new HashMap<>();
+    contents.put("_index", indexFor(record));
+    contents.put("_type", typeFor(record));
+    contents.put("_id", idFor(record));
+    contents.put("routing", String.valueOf(record.getPartitionId()));
+
+    command.put("index", contents);
+    return command;
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/BulkResponse.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/BulkResponse.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.exporter.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class BulkResponse {
+  private boolean errors;
+
+  public boolean hasErrors() {
+    return errors;
+  }
+}

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/PutIndexTemplateResponse.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/PutIndexTemplateResponse.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.exporter.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class PutIndexTemplateResponse {
+  private boolean acknowledged;
+
+  public boolean isAcknowledged() {
+    return acknowledged;
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterFaultToleranceIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterFaultToleranceIT.java
@@ -11,7 +11,6 @@ import io.zeebe.protocol.record.Record;
 import io.zeebe.test.util.TestUtil;
 import io.zeebe.test.util.record.RecordingExporter;
 import io.zeebe.test.util.socket.SocketUtil;
-import org.elasticsearch.ElasticsearchStatusException;
 import org.junit.Test;
 
 public class ElasticsearchExporterFaultToleranceIT
@@ -41,8 +40,8 @@ public class ElasticsearchExporterFaultToleranceIT
 
   private boolean wasExported(final Record<?> record) {
     try {
-      return esClient.get(record) != null;
-    } catch (final ElasticsearchStatusException e) {
+      return esClient.getDocument(record) != null;
+    } catch (final Exception e) {
       // suppress exception in order to retry and see if it was exported yet or not
       // the exception can occur since elastic may not be ready yet, or maybe the index hasn't been
       // created yet, etc.

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/dto/GetDocumentResponse.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/dto/GetDocumentResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.exporter.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class GetDocumentResponse {
+  @JsonProperty("found")
+  private boolean found;
+
+  @JsonProperty("_source")
+  private Map<String, Object> source;
+
+  public boolean isFound() {
+    return found;
+  }
+
+  public Map<String, Object> getSource() {
+    return source;
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/dto/GetSettingsForIndicesResponse.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/dto/GetSettingsForIndicesResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.exporter.dto;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class GetSettingsForIndicesResponse {
+  @JsonUnwrapped private Map<String, IndexSettings> indices;
+
+  public GetSettingsForIndicesResponse() {
+    this.indices = new HashMap<>();
+  }
+
+  @JsonAnySetter
+  public void put(final String index, final SettingsWrapper settingsWrapper) {
+    indices.put(index, settingsWrapper.getIndex());
+  }
+
+  public Map<String, IndexSettings> getIndices() {
+    return indices;
+  }
+
+  @SuppressWarnings("FieldCanBeLocal")
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class IndexSettings {
+    @JsonProperty("number_of_shards")
+    private int numberOfShards = -1;
+
+    @JsonProperty("number_of_replicas")
+    private int numberOfReplicas = -1;
+
+    public int getNumberOfShards() {
+      return numberOfShards;
+    }
+
+    public int getNumberOfReplicas() {
+      return numberOfReplicas;
+    }
+  }
+
+  private static final class SettingsWrapper {
+    @JsonProperty("settings")
+    private IndexSettingsWrapper wrapper;
+
+    public IndexSettings getIndex() {
+      return wrapper.indexSettings;
+    }
+
+    private static final class IndexSettingsWrapper {
+      @JsonProperty("index")
+      private IndexSettings indexSettings;
+    }
+  }
+}

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/util/ElasticsearchContainer.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/util/ElasticsearchContainer.java
@@ -10,20 +10,15 @@ package io.zeebe.exporter.util;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Map;
 import org.apache.http.HttpHost;
-import org.elasticsearch.client.ElasticsearchClient;
-import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.security.PutRoleRequest;
-import org.elasticsearch.client.security.PutUserRequest;
-import org.elasticsearch.client.security.RefreshPolicy;
-import org.elasticsearch.client.security.user.User;
-import org.elasticsearch.client.security.user.privileges.Role;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
@@ -31,6 +26,7 @@ import org.testcontainers.utility.Base58;
 
 public class ElasticsearchContainer extends GenericContainer<ElasticsearchContainer>
     implements ElasticsearchNode<ElasticsearchContainer> {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final int DEFAULT_HTTP_PORT = 9200;
   private static final int DEFAULT_TCP_PORT = 9300;
   private static final String DEFAULT_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch";
@@ -39,11 +35,11 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
   private boolean isAuthEnabled;
   private String username;
   private String password;
-  private RestHighLevelClient client;
+  private RestClient client;
   private int port;
 
   public ElasticsearchContainer() {
-    this(ElasticsearchClient.class.getPackage().getImplementationVersion());
+    this(RestClient.class.getPackage().getImplementationVersion());
   }
 
   public ElasticsearchContainer(final String version) {
@@ -105,7 +101,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     super.doStart();
 
     if (isAuthEnabled) {
-      client = new RestHighLevelClient(RestClient.builder(getRestHttpHost()));
+      client = RestClient.builder(getRestHttpHost()).build();
       setupUser();
     }
   }
@@ -152,27 +148,24 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
   }
 
   private void setupUser() {
-    final User user = new User(username, Collections.singleton("zeebe-exporter"));
+    final var request = new Request("POST", "/_xpack/security/user/" + username);
+    final var body =
+        Map.of(
+            "roles", Collections.singleton("zeebe-exporter"), "password", password.toCharArray());
 
     try {
+      request.setJsonEntity(MAPPER.writeValueAsString(body));
       createRole(client);
-      client
-          .security()
-          .putUser(
-              PutUserRequest.withPassword(
-                  user, password.toCharArray(), true, RefreshPolicy.IMMEDIATE),
-              RequestOptions.DEFAULT);
+      client.performRequest(request);
     } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
 
   // note: caveat, do not use custom index prefixes!
-  private void createRole(final RestHighLevelClient client) throws IOException {
-    final Role role = Role.builder().name("zeebe-exporter").build();
-
-    client
-        .security()
-        .putRole(new PutRoleRequest(role, RefreshPolicy.IMMEDIATE), RequestOptions.DEFAULT);
+  private void createRole(final RestClient client) throws IOException {
+    final var request = new Request("PUT", "/_xpack/security/role/zeebe-exporter");
+    request.setJsonEntity("{}");
+    client.performRequest(request);
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -336,19 +336,7 @@
 
       <dependency>
         <groupId>org.elasticsearch</groupId>
-        <artifactId>elasticsearch</artifactId>
-        <version>${version.elasticsearch}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.elasticsearch</groupId>
         <artifactId>elasticsearch-x-content</artifactId>
-        <version>${version.elasticsearch}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.elasticsearch.client</groupId>
-        <artifactId>elasticsearch-rest-high-level-client</artifactId>
         <version>${version.elasticsearch}</version>
       </dependency>
 
@@ -446,12 +434,6 @@
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>${version.commons-codec}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.carrotsearch</groupId>
-        <artifactId>hppc</artifactId>
-        <version>${version.hppc}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

This PR removes Elasticsearch's high level REST client and replaces it with the low level REST client, primarily to remove many heavy dependencies (such as embedding the Elasticsearch server itself) from the project. Out of scope was refactoring the exporter in general, though it could benefit from it. The scope here was strictly replacing the clients, which means most requests are simply maps, with a few DTOs to more easily handle responses.

## Related issues

closes #1343 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
