### PR TITLE
[BACKPORT] v022 4557

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerClusterStateImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerClusterStateImpl.java
@@ -55,7 +55,7 @@ public final class BrokerClusterStateImpl implements BrokerClusterState {
   }
 
   public void setPartitionLeader(final int partitionId, final int leaderId, final long term) {
-    if (partitionLeaderTerms.getOrDefault(partitionId, -1L) < term) {
+    if (partitionLeaderTerms.getOrDefault(partitionId, -1L) <= term) {
       partitionLeaders.put(partitionId, leaderId);
       partitionLeaderTerms.put(partitionId, Long.valueOf(term));
       final List<Integer> followers = partitionFollowers.get(partitionId);

--- a/gateway/src/test/java/io/zeebe/gateway/topology/TopologyUpdateTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/topology/TopologyUpdateTest.java
@@ -154,6 +154,25 @@ public final class TopologyUpdateTest {
     assertThat(topologyManager.getTopology().getLeaderForPartition(1)).isEqualTo(newLeaderId);
   }
 
+  @Test
+  public void shouldUpdateTopologyOnBrokerRemoveAndDirectlyRejoin() {
+    // given
+    final int leaderId = 1;
+    final BrokerInfo leader = createBroker(leaderId);
+    leader.setLeaderForPartition(1, 1);
+    topologyManager.event(createMemberAddedEvent(leader));
+    waitUntil(() -> topologyManager.getTopology() != null);
+
+    // when
+    topologyManager.event(createMemberRemoveEvent(leader));
+    waitUntil(() -> topologyManager.getTopology().getBrokers().isEmpty());
+    topologyManager.event(createMemberAddedEvent(leader));
+
+    // then
+    waitUntil(() -> topologyManager.getTopology().getBrokers().contains(leaderId));
+    assertThat(topologyManager.getTopology().getLeaderForPartition(1)).isEqualTo(leaderId);
+  }
+
   private BrokerInfo createBroker(final int brokerId) {
     final BrokerInfo broker =
         new BrokerInfo()


### PR DESCRIPTION
## Description

Backports #4557 to 0.22.x

> 
>  Previous we had the problem that if a Leader was marked as DEAD via swim it was removed from the topology.
>  Since we don't want to delete the term to check whether we receive an old or new topology, we haven't updated
>  the topology when the same leader came back again. This fix solves this.

<!-- Please explain the changes you made here. -->
