### PR TITLE
3404 address timeouts in docu link checker

### DIFF
--- a/.ci/scripts/docs/build.sh
+++ b/.ci/scripts/docs/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -eux
 
 # enable external link checker
-#export MDBOOK_OUTPUT__LINKCHECK__FOLLOW_WEB_LINKS='true'
+export MDBOOK_OUTPUT__LINKCHECK__FOLLOW_WEB_LINKS='true'
 
 cd docs/
 mdbook build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,10 +176,12 @@ pipeline {
 
                 stage('Build Docs') {
                     steps {
+                      retry(3) {
                         container('maven') {
                             sh '.ci/scripts/docs/prepare.sh'
                             sh '.ci/scripts/docs/build.sh'
                         }
+                      }
                     }
                 }
             }


### PR DESCRIPTION
## Description

- re-enabled link checker
- added retry to docu build step (in case a website is down just when we build the docs)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3404

## Pull Request Checklist

- [ X ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
