### PR TITLE
chore(atomix): fix flaky test

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftFailOverTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftFailOverTest.java
@@ -133,6 +133,7 @@ public class RaftFailOverTest {
   public void shouldCompactLogOnSnapshot() throws Exception {
     // given
     raftRule.appendEntries(128);
+    raftRule.awaitSameLogSizeOnAllNodes();
     final var memberLogs = raftRule.getMemberLogs();
 
     // when


### PR DESCRIPTION
# Description

 We need to wait until all entries are replicated to all nodes to make the test reliable.
Tried it locally after 26 runs the test failed, after fixing it I run it 100 times without any failures.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/4588

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
