### PR TITLE
chore(engine): migrate sub-process processor

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/nwe/BpmnElementProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/nwe/BpmnElementProcessors.java
@@ -43,8 +43,7 @@ public final class BpmnElementProcessors {
 
   public <T extends ExecutableFlowElement> BpmnElementProcessor<T> getProcessor(
       final BpmnElementType bpmnElementType) {
-    if (bpmnElementType == BpmnElementType.SUB_PROCESS
-        || bpmnElementType == BpmnElementType.PROCESS) {
+    if (bpmnElementType == BpmnElementType.PROCESS) {
       return null;
     }
 

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/SubProcessTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/transformer/SubProcessTransformer.java
@@ -32,14 +32,23 @@ public final class SubProcessTransformer implements ModelElementTransformer<SubP
 
     if (element.triggeredByEvent()) {
       transformEventSubprocess(element, currentWorkflow, subprocess);
-    }
 
-    subprocess.bindLifecycleState(
-        WorkflowInstanceIntent.ELEMENT_ACTIVATED, BpmnStep.CONTAINER_ELEMENT_ACTIVATED);
-    subprocess.bindLifecycleState(
-        WorkflowInstanceIntent.ELEMENT_COMPLETED, BpmnStep.FLOWOUT_ELEMENT_COMPLETED);
-    subprocess.bindLifecycleState(
-        WorkflowInstanceIntent.ELEMENT_TERMINATING, BpmnStep.CONTAINER_ELEMENT_TERMINATING);
+    } else {
+      subprocess.bindLifecycleState(
+          WorkflowInstanceIntent.ELEMENT_ACTIVATING, BpmnStep.BPMN_ELEMENT_PROCESSOR);
+      subprocess.bindLifecycleState(
+          WorkflowInstanceIntent.ELEMENT_ACTIVATED, BpmnStep.BPMN_ELEMENT_PROCESSOR);
+      subprocess.bindLifecycleState(
+          WorkflowInstanceIntent.ELEMENT_COMPLETING, BpmnStep.BPMN_ELEMENT_PROCESSOR);
+      subprocess.bindLifecycleState(
+          WorkflowInstanceIntent.ELEMENT_COMPLETED, BpmnStep.BPMN_ELEMENT_PROCESSOR);
+      subprocess.bindLifecycleState(
+          WorkflowInstanceIntent.ELEMENT_TERMINATING, BpmnStep.BPMN_ELEMENT_PROCESSOR);
+      subprocess.bindLifecycleState(
+          WorkflowInstanceIntent.ELEMENT_TERMINATED, BpmnStep.BPMN_ELEMENT_PROCESSOR);
+      subprocess.bindLifecycleState(
+          WorkflowInstanceIntent.EVENT_OCCURRED, BpmnStep.BPMN_ELEMENT_PROCESSOR);
+    }
   }
 
   private void transformEventSubprocess(
@@ -61,6 +70,12 @@ public final class SubProcessTransformer implements ModelElementTransformer<SubP
     final ExecutableStartEvent startEvent = subprocess.getStartEvents().iterator().next();
 
     startEvent.setEventSubProcess(subprocess.getId());
+    subprocess.bindLifecycleState(
+        WorkflowInstanceIntent.ELEMENT_ACTIVATED, BpmnStep.CONTAINER_ELEMENT_ACTIVATED);
+    subprocess.bindLifecycleState(
+        WorkflowInstanceIntent.ELEMENT_COMPLETED, BpmnStep.FLOWOUT_ELEMENT_COMPLETED);
+    subprocess.bindLifecycleState(
+        WorkflowInstanceIntent.ELEMENT_TERMINATING, BpmnStep.CONTAINER_ELEMENT_TERMINATING);
     startEvent.bindLifecycleState(
         WorkflowInstanceIntent.EVENT_OCCURRED, BpmnStep.EVENT_SUBPROC_EVENT_OCCURRED);
   }


### PR DESCRIPTION
# Description

* migrate sub-process processor
* fix termination of an embedded sub-process with a waiting token on a joining parallel gateway
* clean up tests for embedded sub-process

## Related issues

closes #4474 
closes #4400 
closes #4352

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
