### PR TITLE
[Backport] Interrupt Sub-Process with parallel gateway

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/activity/ActivityElementTerminatedHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/activity/ActivityElementTerminatedHandler.java
@@ -12,6 +12,7 @@ import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableAct
 import io.zeebe.engine.processor.workflow.handlers.IncidentResolver;
 import io.zeebe.engine.processor.workflow.handlers.element.ElementTerminatedHandler;
 import io.zeebe.engine.state.instance.ElementInstance;
+import io.zeebe.protocol.record.value.BpmnElementType;
 
 /**
  * Performs usual ElementTerminated logic and publishes any deferred record. At the moment, it will
@@ -29,7 +30,9 @@ public class ActivityElementTerminatedHandler<T extends ExecutableActivity>
 
   @Override
   protected boolean handleState(final BpmnStepContext<T> context) {
-    publishDeferredRecords(context);
+    publishDeferredRecords(
+        context,
+        record -> record.getValue().getBpmnElementType() == BpmnElementType.BOUNDARY_EVENT);
     return super.handleState(context);
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/subprocess/EmbeddedSubProcessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/subprocess/EmbeddedSubProcessTest.java
@@ -19,6 +19,7 @@ import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceSubscriptionIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.protocol.record.value.JobRecordValue;
 import io.zeebe.protocol.record.value.WorkflowInstanceRecordValue;
 import io.zeebe.test.util.MsgPackUtil;
@@ -357,5 +358,59 @@ public final class EmbeddedSubProcessTest {
             tuple(WorkflowInstanceIntent.ELEMENT_ACTIVATED, "event"),
             tuple(WorkflowInstanceIntent.ELEMENT_COMPLETING, "event"),
             tuple(WorkflowInstanceIntent.ELEMENT_COMPLETED, "event"));
+  }
+
+  @Test
+  public void shouldTerminateSubProcessWithParallelFlow() {
+    // given
+    final var workflow =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .subProcess(
+                "sub-process",
+                subProcess ->
+                    subProcess
+                        .embeddedSubProcess()
+                        .startEvent()
+                        .parallelGateway("fork")
+                        .serviceTask("task-1", b -> b.zeebeJobType("task-1"))
+                        .sequenceFlowId("join-1")
+                        .parallelGateway("join")
+                        .moveToNode("fork")
+                        .serviceTask("task-2", b -> b.zeebeJobType("task-2"))
+                        .sequenceFlowId("join-2")
+                        .connectTo("join")
+                        .endEvent())
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(workflow).deploy();
+
+    final long workflowInstanceKey = ENGINE.workflowInstance().ofBpmnProcessId("process").create();
+
+    ENGINE.job().ofInstance(workflowInstanceKey).withType("task-1").complete();
+
+    RecordingExporter.workflowInstanceRecords()
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementId("join-1")
+        .withIntent(WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN)
+        .await();
+
+    // when
+    ENGINE.workflowInstance().withInstanceKey(workflowInstanceKey).cancel();
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .limitToWorkflowInstanceTerminated())
+        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
+        .containsSequence(
+            tuple(BpmnElementType.PROCESS, WorkflowInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SUB_PROCESS, WorkflowInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SERVICE_TASK, WorkflowInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.SERVICE_TASK, WorkflowInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.SUB_PROCESS, WorkflowInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, WorkflowInstanceIntent.ELEMENT_TERMINATED));
   }
 }


### PR DESCRIPTION
## Description

* publish only deferred boundary events when the sub-process is terminated to avoid that other events are published (e.g. a taken sequence flow on a joining parallel gateway)

## Related issues

Backport of #4590

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
