### PR TITLE
[Backport] Interrupt Sub-Process with parallel gateway

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/activity/ActivityElementTerminatedHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/activity/ActivityElementTerminatedHandler.java
@@ -12,6 +12,7 @@ import io.zeebe.engine.processor.workflow.deployment.model.element.ExecutableAct
 import io.zeebe.engine.processor.workflow.handlers.IncidentResolver;
 import io.zeebe.engine.processor.workflow.handlers.element.ElementTerminatedHandler;
 import io.zeebe.engine.state.instance.ElementInstance;
+import io.zeebe.protocol.record.value.BpmnElementType;
 
 /**
  * Performs usual ElementTerminated logic and publishes any deferred record. At the moment, it will
@@ -29,7 +30,9 @@ public class ActivityElementTerminatedHandler<T extends ExecutableActivity>
 
   @Override
   protected boolean handleState(final BpmnStepContext<T> context) {
-    publishDeferredRecords(context);
+    publishDeferredRecords(
+        context,
+        record -> record.getValue().getBpmnElementType() == BpmnElementType.BOUNDARY_EVENT);
     return super.handleState(context);
   }
 }


### PR DESCRIPTION
## Description

* publish only deferred boundary events when the sub-process is terminated to avoid that other events are published (e.g. a taken sequence flow on a joining parallel gateway)

## Related issues

Backport of #4590

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
