### PR TITLE
4581 run all tests

### DIFF
--- a/.ci/scripts/distribution/it-java.sh
+++ b/.ci/scripts/distribution/it-java.sh
@@ -1,6 +1,18 @@
-#!/bin/sh -eux
+#!/bin/bash -eux
 
 
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
-mvn -o -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl qa/integration-tests -pl upgrade-tests -DtestMavenId=2
+tmpfile=$(mktemp)
+
+mvn -o -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl qa/integration-tests -pl upgrade-tests -DtestMavenId=2 | tee ${tmpfile}
+
+status=${PIPESTATUS[0]}
+
+if [[ $status != 0 ]]; then
+  exit $status;
+fi
+
+if grep -q "\[INFO\] Build failures were ignored\." ${tmpfile}; then
+  exit 1
+fi

--- a/.ci/scripts/distribution/test-java.sh
+++ b/.ci/scripts/distribution/test-java.sh
@@ -1,6 +1,17 @@
-#!/bin/sh -eux
-
+#!/bin/bash -eux
 
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
-mvn -o -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -Dzeebe.it.skip -DtestMavenId=1
+tmpfile=$(mktemp)
+
+mvn -o -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -Dzeebe.it.skip -DtestMavenId=1 | tee ${tmpfile}
+
+status=${PIPESTATUS[0]}
+
+if [[ $status != 0 ]]; then
+  exit $status;
+fi
+
+if grep -q "\[INFO\] Build failures were ignored\." ${tmpfile}; then
+  exit 1
+fi

--- a/.ci/scripts/distribution/test-java8.sh
+++ b/.ci/scripts/distribution/test-java8.sh
@@ -1,8 +1,20 @@
-#!/bin/sh -eux
+#!/bin/bash -eux
 
 
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
 mvn -v
 
-mvn -o -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -pl clients/java -DtestMavenId=3
+tmpfile=$(mktemp)
+
+mvn -o -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -pl clients/java -DtestMavenId=3 | tee ${tmpfile}
+
+status=${PIPESTATUS[0]}
+
+if [[ $status != 0 ]]; then
+  exit $status;
+fi
+
+if grep -q "\[INFO\] Build failures were ignored\." ${tmpfile}; then
+  exit 1
+fi


### PR DESCRIPTION
## Description

This runs all tests even if there are failures in the first modules. After running the tests, the log is parsed to fail the build stage automatically in case of failures. 

## Related issues

closes #4581

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing

commit messages will be cleaned up after review