### PR TITLE
chore(atomix): fix flaky Swim test

### DIFF
--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -14,7 +14,9 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <artifactId>atomix-cluster</artifactId>
 
   <dependencies>
@@ -115,6 +117,13 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.0.3</version>
       <scope>test</scope>
     </dependency>
 

--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -123,7 +123,6 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>4.0.3</version>
       <scope>test</scope>
     </dependency>
 

--- a/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
@@ -209,13 +209,6 @@ public class SwimProtocolTest extends ConcurrentTestCase {
     // Partition node 1 from node 2.
     partition(member1, member2);
 
-    // Verify that neither node is ever removed from the cluster since node 3 can still ping nodes 1
-    // and 2.
-    Thread.sleep(500);
-    checkMembers(member1, member1, member2, member3);
-    checkMembers(member2, member1, member2, member3);
-    checkMembers(member3, member1, member2, member3);
-
     // Heal the partition.
     heal(member1, member2);
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -41,6 +41,7 @@
     <version.animal-sniffer>1.18</version.animal-sniffer>
     <version.assertj>3.16.1</version.assertj>
     <version.camunda>7.13.0</version.camunda>
+    <version.awaitility>4.0.3</version.awaitility>
     <version.commons-lang>3.10</version.commons-lang>
     <version.commons-logging>1.2</version.commons-logging>
     <version.commons-math>3.6.1</version.commons-math>
@@ -214,6 +215,12 @@
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
         <version>${version.restassert}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>${version.awaitility}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description
Fixes and improves flaky SwimProtocolTest. Introduces Awaitility lib to await certain events.
Reduces the execution time from ~15 seconds to 6 seconds.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4382 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
