### PR TITLE
chore(atomix): initialize event subscriptions after listener is added

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterEventService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterEventService.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.atomix.cluster.ClusterMembershipEvent;
+import io.atomix.cluster.ClusterMembershipEvent.Type;
 import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
@@ -189,6 +190,10 @@ public class DefaultClusterEventService
           Executors.newSingleThreadScheduledExecutor(
               namedThreads("atomix-cluster-event-executor-%d", LOGGER));
       membershipService.addListener(this);
+      // Listener doesn't receive notification about the Members added before the listener is added.
+      membershipService
+          .getMembers()
+          .forEach(m -> event(new ClusterMembershipEvent(Type.MEMBER_ADDED, m)));
       LOGGER.info("Started");
     }
     return CompletableFuture.completedFuture(this);

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventServiceTest.java
@@ -53,6 +53,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.junit.After;
 import org.junit.Test;
 
 /** Cluster event service test. */
@@ -116,7 +117,8 @@ public class DefaultClusterEventServiceTest {
     return clusterEventingService1.start().join();
   }
 
-  private void tearDown() {
+  @After
+  public void tearDown() {
     CompletableFuture.allOf(
             managedMemberShipServices.values().stream()
                 .map(Managed::stop)
@@ -191,8 +193,6 @@ public class DefaultClusterEventServiceTest {
     // then
     assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
     assertEquals(3, events.size());
-
-    tearDown();
   }
 
   @Test
@@ -242,8 +242,6 @@ public class DefaultClusterEventServiceTest {
     // then
     assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
     assertEquals(2, events.size());
-
-    tearDown();
   }
 
   @Test
@@ -290,8 +288,6 @@ public class DefaultClusterEventServiceTest {
     assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
     assertEquals(2, events.size());
     assertThat(events).containsExactlyInAnyOrder(1, 2);
-
-    tearDown();
   }
 
   @Test
@@ -331,8 +327,6 @@ public class DefaultClusterEventServiceTest {
     // then
     assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
     assertEquals(1, events.size());
-
-    tearDown();
   }
 
   @Test
@@ -374,8 +368,6 @@ public class DefaultClusterEventServiceTest {
 
     assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
     assertEquals(1, events.size());
-
-    tearDown();
   }
 
   @Test
@@ -405,7 +397,5 @@ public class DefaultClusterEventServiceTest {
     eventService1.broadcast("test", "bar");
     awaitCompletion.await(10, TimeUnit.SECONDS);
     assertEquals("bar", received.get());
-
-    tearDown();
   }
 }

--- a/atomix/cluster/src/test/resources/log4j2-test.xml
+++ b/atomix/cluster/src/test/resources/log4j2-test.xml
@@ -9,7 +9,7 @@
 
   <Loggers>
     <Logger name="io.zeebe" level="debug"/>
-    <Logger name="io.atomix" level="debug"/>
+    <Logger name="io.atomix" level="trace"/>
 
     <Root level="info">
       <AppenderRef ref="Console"/>


### PR DESCRIPTION
## Description

When membership service adds the members before the cluster event registers the listener, the listener is not notified. In this case the event service cannot know about the subscriptions of that member. The test was flaky because of this bug. 

## Related issues

closes #4436 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
