### PR TITLE
chore(ci): centralize image pulls

### DIFF
--- a/.ci/scripts/docker/pull.sh
+++ b/.ci/scripts/docker/pull.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -eux
+
+echo "Pulling base images for testcontainers"
+docker pull alpine:3.5
+docker pull quay.io/testcontainers/ryuk:0.2.3
+
+echo "Pulling images required for upgrade tests"
+docker pull camunda/zeebe:0.23.0


### PR DESCRIPTION
## Description

So this is an idea, but I am not sure it's a good one. Feel free to refuse this PR if you think it's not a good idea.

The problem it aims to solve is that sometimes our builds fail due to:
- connection errors with Docker Hub Registry
- connection errors with other Docker registries (such as quay.io for several hours today)

The causes manifest then as tests failing with stack traces that point back to the Docker timeouts.

The change is to centralize image pulls in the preparation phase. There is a retry and a clean abort if the image pulls fail.

The downside is that we now have another place to maintain dependencies and version numbers. 

I guess my ideal setup long term would be a pass-through Docker registry maintained by infra. But this could serve as a workaround for now.

## Related issues

No issue created

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [n/a] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [n/a] If submitting code, please run `mvn clean install -DskipTests` locally before committing
