### PR TITLE
Gateway do not send requests to non-available partitions

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -152,12 +152,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
     </dependency>

--- a/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
@@ -19,6 +19,7 @@ import io.zeebe.gateway.cmd.GrpcStatusException;
 import io.zeebe.gateway.cmd.GrpcStatusExceptionImpl;
 import io.zeebe.gateway.cmd.PartitionNotFoundException;
 import io.zeebe.gateway.impl.broker.BrokerClient;
+import io.zeebe.gateway.impl.broker.RequestRetryHandler;
 import io.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.zeebe.gateway.impl.broker.request.BrokerRequest;
@@ -70,12 +71,14 @@ public final class EndpointManager extends GatewayGrpc.GatewayImplBase {
   private final BrokerClient brokerClient;
   private final BrokerTopologyManager topologyManager;
   private final LongPollingActivateJobsHandler activateJobsHandler;
+  private final RequestRetryHandler requestRetryHandler;
 
   public EndpointManager(
       final BrokerClient brokerClient, final LongPollingActivateJobsHandler longPollingHandler) {
     this.brokerClient = brokerClient;
     topologyManager = brokerClient.getTopologyManager();
     activateJobsHandler = longPollingHandler;
+    requestRetryHandler = new RequestRetryHandler(brokerClient, topologyManager);
   }
 
   private void addBrokerInfo(
@@ -147,7 +150,7 @@ public final class EndpointManager extends GatewayGrpc.GatewayImplBase {
   public void createWorkflowInstance(
       final CreateWorkflowInstanceRequest request,
       final StreamObserver<CreateWorkflowInstanceResponse> responseObserver) {
-    sendRequest(
+    sendRequestWithRetryPartitions(
         request,
         RequestMapper::toCreateWorkflowInstanceRequest,
         ResponseMapper::toCreateWorkflowInstanceResponse,
@@ -159,14 +162,14 @@ public final class EndpointManager extends GatewayGrpc.GatewayImplBase {
       final CreateWorkflowInstanceWithResultRequest request,
       final StreamObserver<CreateWorkflowInstanceWithResultResponse> responseObserver) {
     if (request.getRequestTimeout() > 0) {
-      sendRequest(
+      sendRequestWithRetryPartitions(
           request,
           RequestMapper::toCreateWorkflowInstanceWithResultRequest,
           ResponseMapper::toCreateWorkflowInstanceWithResultResponse,
           responseObserver,
           Duration.ofMillis(request.getRequestTimeout()));
     } else {
-      sendRequest(
+      sendRequestWithRetryPartitions(
           request,
           RequestMapper::toCreateWorkflowInstanceWithResultRequest,
           ResponseMapper::toCreateWorkflowInstanceWithResultResponse,
@@ -305,13 +308,32 @@ public final class EndpointManager extends GatewayGrpc.GatewayImplBase {
     }
 
     suppressCancelledException(grpcRequest, streamObserver);
-    brokerClient.sendRequest(
+    brokerClient.sendRequestWithRetry(
         brokerRequest,
         (key, response) -> consumeResponse(responseMapper, streamObserver, key, response),
         error -> streamObserver.onError(convertThrowable(error)));
   }
 
-  private <GrpcRequestT, BrokerResponseT, GrpcResponseT> void sendRequest(
+  private <GrpcRequestT, BrokerResponseT, GrpcResponseT> void sendRequestWithRetryPartitions(
+      final GrpcRequestT grpcRequest,
+      final Function<GrpcRequestT, BrokerRequest<BrokerResponseT>> requestMapper,
+      final BrokerResponseMapper<BrokerResponseT, GrpcResponseT> responseMapper,
+      final StreamObserver<GrpcResponseT> streamObserver) {
+
+    final BrokerRequest<BrokerResponseT> brokerRequest =
+        mapRequest(grpcRequest, requestMapper, streamObserver);
+    if (brokerRequest == null) {
+      return;
+    }
+
+    suppressCancelledException(grpcRequest, streamObserver);
+    requestRetryHandler.sendRequest(
+        brokerRequest,
+        (key, response) -> consumeResponse(responseMapper, streamObserver, key, response),
+        error -> streamObserver.onError(convertThrowable(error)));
+  }
+
+  private <GrpcRequestT, BrokerResponseT, GrpcResponseT> void sendRequestWithRetryPartitions(
       final GrpcRequestT grpcRequest,
       final Function<GrpcRequestT, BrokerRequest<BrokerResponseT>> requestMapper,
       final BrokerResponseMapper<BrokerResponseT, GrpcResponseT> responseMapper,
@@ -325,7 +347,7 @@ public final class EndpointManager extends GatewayGrpc.GatewayImplBase {
     }
 
     suppressCancelledException(grpcRequest, streamObserver);
-    brokerClient.sendRequest(
+    requestRetryHandler.sendRequest(
         brokerRequest,
         (key, response) -> consumeResponse(responseMapper, streamObserver, key, response),
         error -> streamObserver.onError(convertThrowable(error)),

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClient.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerClient.java
@@ -10,28 +10,75 @@ package io.zeebe.gateway.impl.broker;
 import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
-import io.zeebe.util.sched.future.ActorFuture;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 public interface BrokerClient extends AutoCloseable {
 
   void close();
 
-  <T> ActorFuture<BrokerResponse<T>> sendRequest(BrokerRequest<T> request);
+  /**
+   * Sends a request to the partition if request specifies a partition, otherwise assign a partition
+   * send it to it.
+   *
+   * @param request request to send
+   * @return future which will be completed when a successful response from the broker is received.
+   *     The future will be completed exceptionally on error or on receiving BrokerRejection.
+   */
+  <T> CompletableFuture<BrokerResponse<T>> sendRequest(BrokerRequest<T> request);
 
-  <T> void sendRequest(
+  /**
+   * Sends a request to the partition if request specifies a partition, otherwise assign a partition
+   * send it to it. The request times out after the specified requestTimeout.
+   *
+   * @param request request to send
+   * @param requestTimeout timeout for the request
+   * @return future which will be completed when a successful response from the broker is received.
+   *     The future will be completed exceptionally on error or on receiving BrokerRejection.
+   */
+  <T> CompletableFuture<BrokerResponse<T>> sendRequest(
+      BrokerRequest<T> request, Duration requestTimeout);
+
+  /**
+   * Sends a request to the partition if request specifies a partition, otherwise assign a partition
+   * send it to it. If leader for that partition is not reachable the request will be resend until a
+   * timeout.
+   *
+   * @param request request to send
+   * @return future which will be completed when a successful response from the broker is
+   *     received.The future will be completed exceptionally on error or on receiving
+   *     BrokerRejection.
+   */
+  <T> CompletableFuture<BrokerResponse<T>> sendRequestWithRetry(BrokerRequest<T> request);
+
+  /**
+   * Sends a request to the partition if request specifies a partition, otherwise assign a partition
+   * send it to it. If leader for that partition is not reachable the request will be resend until
+   * the given requestTimeout.
+   *
+   * @param request request to send
+   * @param requestTimeout timeout for the request
+   * @return future which will be completed when a successful response from the broker is
+   *     received.The future will be completed exceptionally on error or on receiving
+   *     BrokerRejection.
+   */
+  <T> CompletableFuture<BrokerResponse<T>> sendRequestWithRetry(
+      BrokerRequest<T> request, Duration requestTimeout);
+
+  /**
+   * Sends a request to the partition if request specifies a partition, otherwise assign a partition
+   * send it to it. If leader for that partition is not reachable the request will be resend until a
+   * timeout.
+   *
+   * @param request
+   * @param responseConsumer consumer that will be invoked when a successful response is received
+   * @param throwableConsumer consumer that will be invoked on errors
+   */
+  <T> void sendRequestWithRetry(
       BrokerRequest<T> request,
       BrokerResponseConsumer<T> responseConsumer,
       Consumer<Throwable> throwableConsumer);
-
-  <T> ActorFuture<BrokerResponse<T>> sendRequest(BrokerRequest<T> request, Duration requestTimeout);
-
-  <T> void sendRequest(
-      BrokerRequest<T> request,
-      BrokerResponseConsumer<T> responseConsumer,
-      Consumer<Throwable> throwableConsumer,
-      Duration requestTimeout);
 
   BrokerTopologyManager getTopologyManager();
 

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerRequestManager.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerRequestManager.java
@@ -20,32 +20,32 @@ import io.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManagerImpl;
 import io.zeebe.gateway.impl.broker.request.BrokerPublishMessageRequest;
 import io.zeebe.gateway.impl.broker.request.BrokerRequest;
-import io.zeebe.gateway.impl.broker.response.BrokerError;
-import io.zeebe.gateway.impl.broker.response.BrokerRejection;
 import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.impl.SubscriptionUtil;
 import io.zeebe.protocol.record.ErrorCode;
 import io.zeebe.protocol.record.MessageHeaderDecoder;
+import io.zeebe.transport.ClientRequest;
 import io.zeebe.transport.ClientTransport;
 import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.future.ActorFuture;
-import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.time.Duration;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 import org.agrona.DirectBuffer;
 
-public final class BrokerRequestManager extends Actor {
+final class BrokerRequestManager extends Actor {
 
+  private static final TransportRequestSender SENDER_WITH_RETRY =
+      (c, s, r, t) -> c.sendRequestWithRetry(s, BrokerRequestManager::responseValidation, r, t);
+  private static final TransportRequestSender SENDER_WITHOUT_RETRY = ClientTransport::sendRequest;
   private final ClientTransport clientTransport;
   private final RequestDispatchStrategy dispatchStrategy;
   private final BrokerTopologyManagerImpl topologyManager;
   private final Duration requestTimeout;
 
-  public BrokerRequestManager(
+  BrokerRequestManager(
       final ClientTransport clientTransport,
       final BrokerTopologyManagerImpl topologyManager,
       final RequestDispatchStrategy dispatchStrategy,
@@ -77,107 +77,50 @@ public final class BrokerRequestManager extends Actor {
     }
   }
 
-  public <T> ActorFuture<BrokerResponse<T>> sendRequest(final BrokerRequest<T> request) {
+  <T> CompletableFuture<BrokerResponse<T>> sendRequestWithRetry(final BrokerRequest<T> request) {
+    return sendRequestWithRetry(request, this.requestTimeout);
+  }
+
+  <T> CompletableFuture<BrokerResponse<T>> sendRequest(final BrokerRequest<T> request) {
     return sendRequest(request, this.requestTimeout);
   }
 
-  public <T> ActorFuture<BrokerResponse<T>> sendRequest(
+  <T> CompletableFuture<BrokerResponse<T>> sendRequest(
+      final BrokerRequest<T> request, final Duration timeout) {
+    return sendRequestInternal(request, SENDER_WITHOUT_RETRY, timeout);
+  }
+
+  <T> CompletableFuture<BrokerResponse<T>> sendRequestWithRetry(
       final BrokerRequest<T> request, final Duration requestTimeout) {
-    final ActorFuture<BrokerResponse<T>> responseFuture = new CompletableActorFuture<>();
-
-    sendRequest(
-        request,
-        (response, error) -> {
-          if (error == null) {
-            responseFuture.complete(response);
-          } else {
-            responseFuture.completeExceptionally(error);
-          }
-        },
-        requestTimeout);
-
-    return responseFuture;
+    return sendRequestInternal(request, SENDER_WITH_RETRY, requestTimeout);
   }
 
-  public <T> void sendRequest(
+  private <T> CompletableFuture<BrokerResponse<T>> sendRequestInternal(
       final BrokerRequest<T> request,
-      final BrokerResponseConsumer<T> responseConsumer,
-      final Consumer<Throwable> throwableConsumer) {
-    sendRequest(request, responseConsumer, throwableConsumer, this.requestTimeout);
-  }
-
-  public <T> void sendRequest(
-      final BrokerRequest<T> request,
-      final BrokerResponseConsumer<T> responseConsumer,
-      final Consumer<Throwable> throwableConsumer,
+      final TransportRequestSender sender,
       final Duration requestTimeout) {
-    sendRequest(
-        request,
-        responseConsumer,
-        rejection -> throwableConsumer.accept(new BrokerRejectionException(rejection)),
-        error -> throwableConsumer.accept(new BrokerErrorException(error)),
-        throwableConsumer,
-        requestTimeout);
-  }
-
-  private <T> void sendRequest(
-      final BrokerRequest<T> request,
-      final BrokerResponseConsumer<T> responseConsumer,
-      final Consumer<BrokerRejection> rejectionConsumer,
-      final Consumer<BrokerError> errorConsumer,
-      final Consumer<Throwable> throwableConsumer,
-      final Duration requestTimeout) {
-
-    sendRequest(
-        request,
-        (response, error) -> {
-          try {
-            if (error == null) {
-              if (response.isResponse()) {
-                responseConsumer.accept(response.getKey(), response.getResponse());
-              } else if (response.isRejection()) {
-                rejectionConsumer.accept(response.getRejection());
-              } else if (response.isError()) {
-                errorConsumer.accept(response.getError());
-              } else {
-                throwableConsumer.accept(
-                    new IllegalBrokerResponseException(
-                        "Expected broker response to be either response, rejection, or error, but is neither of them"));
-              }
-            } else {
-              throwableConsumer.accept(error);
-            }
-          } catch (final RuntimeException e) {
-            throwableConsumer.accept(new BrokerResponseException(e));
-          }
-        },
-        requestTimeout);
-  }
-
-  private <T> void sendRequest(
-      final BrokerRequest<T> request,
-      final BiConsumer<BrokerResponse<T>, Throwable> responseConsumer,
-      final Duration requestTimeout) {
+    final CompletableFuture<BrokerResponse<T>> responseFuture = new CompletableFuture<>();
     request.serializeValue();
-    actor.run(() -> sendRequestInternal(request, responseConsumer, requestTimeout));
+    actor.run(() -> sendRequestInternal(request, responseFuture, sender, requestTimeout));
+    return responseFuture;
   }
 
   private <T> void sendRequestInternal(
       final BrokerRequest<T> request,
-      final BiConsumer<BrokerResponse<T>, Throwable> responseConsumer,
+      final CompletableFuture<BrokerResponse<T>> returnFuture,
+      final TransportRequestSender sender,
       final Duration requestTimeout) {
 
     final BrokerAddressProvider nodeIdProvider;
     try {
       nodeIdProvider = determineBrokerNodeIdProvider(request);
-    } catch (PartitionNotFoundException e) {
-      responseConsumer.accept(null, e);
+    } catch (final PartitionNotFoundException e) {
+      returnFuture.completeExceptionally(e);
       return;
     }
 
     final ActorFuture<DirectBuffer> responseFuture =
-        clientTransport.sendRequestWithRetry(
-            nodeIdProvider, BrokerRequestManager::responseValidation, request, requestTimeout);
+        sender.send(clientTransport, nodeIdProvider, request, requestTimeout);
 
     if (responseFuture != null) {
       actor.runOnCompletion(
@@ -186,16 +129,35 @@ public final class BrokerRequestManager extends Actor {
             try {
               if (error == null) {
                 final BrokerResponse<T> response = request.getResponse(clientResponse);
-                responseConsumer.accept(response, null);
+                handleResponse(response, returnFuture);
               } else {
-                responseConsumer.accept(null, error);
+                returnFuture.completeExceptionally(error);
               }
             } catch (final RuntimeException e) {
-              responseConsumer.accept(null, new ClientResponseException(e));
+              returnFuture.completeExceptionally(new ClientResponseException(e));
             }
           });
     } else {
-      responseConsumer.accept(null, new ClientOutOfMemoryException());
+      returnFuture.completeExceptionally(new ClientOutOfMemoryException());
+    }
+  }
+
+  private <T> void handleResponse(
+      final BrokerResponse<T> response, final CompletableFuture<BrokerResponse<T>> responseFuture) {
+    try {
+      if (response.isResponse()) {
+        responseFuture.complete(response);
+      } else if (response.isRejection()) {
+        responseFuture.completeExceptionally(new BrokerRejectionException(response.getRejection()));
+      } else if (response.isError()) {
+        responseFuture.completeExceptionally(new BrokerErrorException(response.getError()));
+      } else {
+        responseFuture.completeExceptionally(
+            new IllegalBrokerResponseException(
+                "Expected broker response to be either response, rejection, or error, but is neither of them"));
+      }
+    } catch (final RuntimeException e) {
+      responseFuture.completeExceptionally(new BrokerResponseException(e));
     }
   }
 
@@ -248,8 +210,16 @@ public final class BrokerRequestManager extends Actor {
     }
   }
 
+  private interface TransportRequestSender {
+    ActorFuture<DirectBuffer> send(
+        ClientTransport transport,
+        Supplier<String> nodeAddressSupplier,
+        ClientRequest clientRequest,
+        Duration timeout);
+  }
+
   private class BrokerAddressProvider implements Supplier<String> {
-    private final Function<BrokerClusterState, Integer> nodeIdSelector;
+    private final ToIntFunction<BrokerClusterState> nodeIdSelector;
 
     BrokerAddressProvider() {
       this(BrokerClusterState::getRandomBroker);
@@ -259,7 +229,7 @@ public final class BrokerRequestManager extends Actor {
       this(state -> state.getLeaderForPartition(partitionId));
     }
 
-    BrokerAddressProvider(final Function<BrokerClusterState, Integer> nodeIdSelector) {
+    BrokerAddressProvider(final ToIntFunction<BrokerClusterState> nodeIdSelector) {
       this.nodeIdSelector = nodeIdSelector;
     }
 
@@ -267,7 +237,7 @@ public final class BrokerRequestManager extends Actor {
     public String get() {
       final BrokerClusterState topology = topologyManager.getTopology();
       if (topology != null) {
-        return topology.getBrokerAddress(nodeIdSelector.apply(topology));
+        return topology.getBrokerAddress(nodeIdSelector.applyAsInt(topology));
       } else {
         return null;
       }

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/RequestRetriesExhaustedException.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/RequestRetriesExhaustedException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.impl.broker;
+
+import io.zeebe.gateway.cmd.ClientException;
+
+class RequestRetriesExhaustedException extends ClientException {
+
+  RequestRetriesExhaustedException() {
+    super(
+        "Expected to execute the command on one of the partitions, but all failed; there are no more partitions available to retry. "
+            + "Please try again. If the error persists contact your zeebe operator");
+  }
+}

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/RequestRetryHandler.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/RequestRetryHandler.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.impl.broker;
+
+import io.zeebe.gateway.Loggers;
+import io.zeebe.gateway.cmd.BrokerErrorException;
+import io.zeebe.gateway.cmd.NoTopologyAvailableException;
+import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
+import io.zeebe.gateway.impl.broker.request.BrokerRequest;
+import io.zeebe.gateway.impl.broker.response.BrokerResponse;
+import io.zeebe.protocol.record.ErrorCode;
+import java.net.ConnectException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * When a requests to a partition fails, request will be retried with a different partition until
+ * all partitions are tried. The request is retried only for specific errors such as connection
+ * errors or resource exhausted errors. The request is not retried for time outs.
+ */
+public final class RequestRetryHandler {
+
+  private final BrokerClient brokerClient;
+  private final RequestDispatchStrategy roundRobinDispatchStrategy;
+  private final BrokerTopologyManager topologyManager;
+
+  public RequestRetryHandler(
+      final BrokerClient brokerClient, final BrokerTopologyManager topologyManager) {
+    this.brokerClient = brokerClient;
+    roundRobinDispatchStrategy = new RoundRobinDispatchStrategy(topologyManager);
+    this.topologyManager = topologyManager;
+  }
+
+  public <BrokerResponseT> void sendRequest(
+      final BrokerRequest<BrokerResponseT> request,
+      final BrokerResponseConsumer<BrokerResponseT> responseConsumer,
+      final Consumer<Throwable> throwableConsumer) {
+    final Function<
+            BrokerRequest<BrokerResponseT>, CompletableFuture<BrokerResponse<BrokerResponseT>>>
+        requestSender = brokerClient::sendRequest;
+    sendRequestInternal(request, requestSender, responseConsumer, throwableConsumer);
+  }
+
+  public <BrokerResponseT> void sendRequest(
+      final BrokerRequest<BrokerResponseT> request,
+      final BrokerResponseConsumer<BrokerResponseT> responseConsumer,
+      final Consumer<Throwable> throwableConsumer,
+      final Duration requestTimeout) {
+    final Function<
+            BrokerRequest<BrokerResponseT>, CompletableFuture<BrokerResponse<BrokerResponseT>>>
+        requestSender = r -> brokerClient.sendRequest(r, requestTimeout);
+    sendRequestInternal(request, requestSender, responseConsumer, throwableConsumer);
+  }
+
+  private <BrokerResponseT> void sendRequestInternal(
+      final BrokerRequest<BrokerResponseT> request,
+      final Function<
+              BrokerRequest<BrokerResponseT>, CompletableFuture<BrokerResponse<BrokerResponseT>>>
+          requestSender,
+      final BrokerResponseConsumer<BrokerResponseT> responseConsumer,
+      final Consumer<Throwable> throwableConsumer) {
+    final var topology = topologyManager.getTopology();
+    if (topology != null) {
+      sendRequestWithRetry(
+          request,
+          requestSender,
+          partitionIdIteratorForType(topology.getPartitionsCount()),
+          responseConsumer,
+          throwableConsumer,
+          new ArrayList<>());
+    } else {
+      throwableConsumer.accept(
+          new NoTopologyAvailableException(
+              "Expected to send the request to a partition in the topology, but gateway does not know broker topology."
+                  + " Please try again later. If the error persists contact your zeebe operator."));
+    }
+  }
+
+  private <BrokerResponseT> void sendRequestWithRetry(
+      final BrokerRequest<BrokerResponseT> request,
+      final Function<
+              BrokerRequest<BrokerResponseT>, CompletableFuture<BrokerResponse<BrokerResponseT>>>
+          requestSender,
+      final PartitionIdIterator partitionIdIterator,
+      final BrokerResponseConsumer<BrokerResponseT> responseConsumer,
+      final Consumer<Throwable> throwableConsumer,
+      final Collection<Throwable> errors) {
+
+    if (partitionIdIterator.hasNext()) {
+      final int partitionId = partitionIdIterator.next();
+
+      // partitions to check
+      request.setPartitionId(partitionId);
+      requestSender
+          .apply(request)
+          .whenComplete(
+              (response, error) -> {
+                if (error == null) {
+                  responseConsumer.accept(response.getKey(), response.getResponse());
+                } else if (shouldRetryWithNextPartition(error)) {
+                  Loggers.GATEWAY_LOGGER.trace(
+                      "Failed to create workflow on partition {}",
+                      partitionIdIterator.getCurrentPartitionId(),
+                      error);
+                  errors.add(error);
+                  sendRequestWithRetry(
+                      request,
+                      requestSender,
+                      partitionIdIterator,
+                      responseConsumer,
+                      throwableConsumer,
+                      errors);
+                } else {
+                  throwableConsumer.accept(error);
+                }
+              });
+    } else {
+      // no partition left to check
+      final var exception = new RequestRetriesExhaustedException();
+      errors.forEach(exception::addSuppressed);
+      throwableConsumer.accept(exception);
+    }
+  }
+
+  private boolean shouldRetryWithNextPartition(final Throwable error) {
+    if (error instanceof ConnectException) {
+      return true;
+    } else if (error instanceof BrokerErrorException) {
+      final ErrorCode code = ((BrokerErrorException) error).getError().getCode();
+      return code == ErrorCode.PARTITION_LEADER_MISMATCH || code == ErrorCode.RESOURCE_EXHAUSTED;
+    }
+    return false;
+  }
+
+  private PartitionIdIterator partitionIdIteratorForType(final int partitionsCount) {
+    final int nextPartitionId = roundRobinDispatchStrategy.determinePartition();
+    return new PartitionIdIterator(nextPartitionId, partitionsCount, topologyManager);
+  }
+}

--- a/gateway/src/main/java/io/zeebe/gateway/impl/job/ActivateJobsHandler.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/job/ActivateJobsHandler.java
@@ -13,22 +13,29 @@ import io.zeebe.gateway.EndpointManager;
 import io.zeebe.gateway.Loggers;
 import io.zeebe.gateway.ResponseMapper;
 import io.zeebe.gateway.impl.broker.BrokerClient;
+import io.zeebe.gateway.impl.broker.PartitionIdIterator;
+import io.zeebe.gateway.impl.broker.RequestDispatchStrategy;
+import io.zeebe.gateway.impl.broker.RoundRobinDispatchStrategy;
+import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
-public final class ActivateJobsHandler {
+final class ActivateJobsHandler {
 
-  private final Map<String, Integer> jobTypeToNextPartitionId = new HashMap<>();
+  private final Map<String, RequestDispatchStrategy> jobTypeToNextPartitionId =
+      new ConcurrentHashMap<>();
   private final BrokerClient brokerClient;
+  private final BrokerTopologyManager topologyManager;
 
-  public ActivateJobsHandler(final BrokerClient brokerClient) {
+  ActivateJobsHandler(final BrokerClient brokerClient) {
     this.brokerClient = brokerClient;
+    this.topologyManager = brokerClient.getTopologyManager();
   }
 
-  public void activateJobs(
+  void activateJobs(
       final int partitionsCount,
       final BrokerActivateJobsRequest request,
       final int maxJobsToActivate,
@@ -73,33 +80,40 @@ public final class ActivateJobsHandler {
       // partitions to check and jobs to activate left
       request.setPartitionId(partitionId);
       request.setMaxJobsToActivate(remainingAmount);
-      brokerClient.sendRequest(
-          request,
-          (key, response) -> {
-            final ActivateJobsResponse grpcResponse =
-                ResponseMapper.toActivateJobsResponse(key, response);
-            final int jobsCount = grpcResponse.getJobsCount();
-            if (jobsCount > 0) {
-              onResponse.accept(grpcResponse);
-            }
+      brokerClient
+          .sendRequest(request)
+          .whenComplete(
+              (response, error) -> {
+                if (error == null) {
+                  final ActivateJobsResponse grpcResponse =
+                      ResponseMapper.toActivateJobsResponse(
+                          response.getKey(), response.getResponse());
+                  final int jobsCount = grpcResponse.getJobsCount();
+                  if (jobsCount > 0) {
+                    onResponse.accept(grpcResponse);
+                  }
 
-            activateJobs(
-                request,
-                partitionIdIterator,
-                remainingAmount - jobsCount,
-                jobType,
-                onResponse,
-                onCompleted,
-                response.getTruncated());
-          },
-          error -> {
-            logErrorResponse(partitionIdIterator, jobType, error);
-            activateJobs(
-                request, partitionIdIterator, remainingAmount, jobType, onResponse, onCompleted);
-          });
+                  activateJobs(
+                      request,
+                      partitionIdIterator,
+                      remainingAmount - jobsCount,
+                      jobType,
+                      onResponse,
+                      onCompleted,
+                      response.getResponse().getTruncated());
+                } else {
+                  logErrorResponse(partitionIdIterator, jobType, error);
+                  activateJobs(
+                      request,
+                      partitionIdIterator,
+                      remainingAmount,
+                      jobType,
+                      onResponse,
+                      onCompleted);
+                }
+              });
     } else {
       // enough jobs activated or no more partitions left to check
-      jobTypeToNextPartitionId.put(jobType, partitionIdIterator.getCurrentPartitionId());
       onCompleted.accept(remainingAmount);
     }
   }
@@ -118,7 +132,10 @@ public final class ActivateJobsHandler {
 
   private PartitionIdIterator partitionIdIteratorForType(
       final String jobType, final int partitionsCount) {
-    final Integer nextPartitionId = jobTypeToNextPartitionId.computeIfAbsent(jobType, t -> 0);
-    return new PartitionIdIterator(nextPartitionId, partitionsCount);
+    final RequestDispatchStrategy nextPartitionSupplier =
+        jobTypeToNextPartitionId.computeIfAbsent(
+            jobType, t -> new RoundRobinDispatchStrategy(topologyManager));
+    return new PartitionIdIterator(
+        nextPartitionSupplier.determinePartition(), partitionsCount, topologyManager);
   }
 }

--- a/gateway/src/test/java/io/zeebe/gateway/broker/BrokerClientTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/broker/BrokerClientTest.java
@@ -11,12 +11,15 @@ import static io.zeebe.protocol.Protocol.START_PARTITION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
-import static org.hamcrest.CoreMatchers.containsString;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.utils.net.Address;
+import io.zeebe.gateway.cmd.BrokerErrorException;
+import io.zeebe.gateway.cmd.BrokerRejectionException;
+import io.zeebe.gateway.cmd.ClientResponseException;
+import io.zeebe.gateway.cmd.PartitionNotFoundException;
 import io.zeebe.gateway.impl.broker.BrokerClient;
 import io.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.zeebe.gateway.impl.broker.cluster.BrokerClusterStateImpl;
@@ -26,11 +29,9 @@ import io.zeebe.gateway.impl.broker.request.BrokerCreateWorkflowInstanceRequest;
 import io.zeebe.gateway.impl.broker.request.BrokerSetVariablesRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerError;
 import io.zeebe.gateway.impl.broker.response.BrokerRejection;
-import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.zeebe.msgpack.value.DocumentValue;
 import io.zeebe.protocol.Protocol;
-import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
 import io.zeebe.protocol.record.ErrorCode;
 import io.zeebe.protocol.record.RejectionType;
@@ -46,7 +47,6 @@ import io.zeebe.test.util.socket.SocketUtil;
 import io.zeebe.util.sched.clock.ControlledActorClock;
 import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -120,13 +120,10 @@ public final class BrokerClientTest {
         .errorData("test")
         .register();
 
-    final BrokerResponse<WorkflowInstanceCreationRecord> response =
-        client.sendRequest(new BrokerCreateWorkflowInstanceRequest()).join();
-
-    assertThat(response.isError()).isTrue();
-    final BrokerError error = response.getError();
-    assertThat(error.getCode()).isEqualTo(ErrorCode.INTERNAL_ERROR);
-    assertThat(error.getMessage()).isEqualTo("test");
+    assertThatThrownBy(
+            () -> client.sendRequestWithRetry(new BrokerCreateWorkflowInstanceRequest()).join())
+        .hasCauseInstanceOf(BrokerErrorException.class)
+        .hasCause(new BrokerErrorException(new BrokerError(ErrorCode.INTERNAL_ERROR, "test")));
 
     // then
     final List<ExecuteCommandRequest> receivedCommandRequests = broker.getReceivedCommandRequests();
@@ -153,15 +150,13 @@ public final class BrokerClientTest {
         };
 
     // then
-    exception.expect(ExecutionException.class);
-    exception.expectMessage("Catch Me");
-
-    // when
-    client.sendRequest(request).join();
+    assertThatThrownBy(() -> client.sendRequestWithRetry(request).join())
+        .hasCauseInstanceOf(ClientResponseException.class)
+        .hasMessageContaining("Catch Me");
   }
 
   @Test
-  public void shouldThrowExceptionIfPartitionNotFoundResponse() {
+  public void shouldTimeoutIfPartitionLeaderMismatchResponse() {
     // given
     broker
         .onExecuteCommandRequest(
@@ -171,18 +166,37 @@ public final class BrokerClientTest {
         .errorData("")
         .register();
 
+    // when
+    final var future = client.sendRequestWithRetry(new BrokerCreateWorkflowInstanceRequest());
+
     // then
-    exception.expect(ExecutionException.class);
-    exception.expectMessage(containsString("timed out"));
     // when the partition is repeatedly not found, the client loops
     // over refreshing the topology and making a request that fails and so on. The timeout
     // kicks in at any point in that loop, so we cannot assert the exact error message any more
     // specifically. It is also possible that Atomix times out before hand if we calculated a very
     // small time out for the request, e.g. < 50ms, so we also cannot assert the value of the
     // timeout
+    assertThatThrownBy(future::join).hasCauseInstanceOf(TimeoutException.class);
+  }
+
+  @Test
+  public void shouldNotTimeoutIfPartitionLeaderMismatchResponseWhenRetryDisabled() {
+    // given
+    broker
+        .onExecuteCommandRequest(
+            ValueType.WORKFLOW_INSTANCE_CREATION, WorkflowInstanceCreationIntent.CREATE)
+        .respondWithError()
+        .errorCode(ErrorCode.PARTITION_LEADER_MISMATCH)
+        .errorData("")
+        .register();
 
     // when
-    client.sendRequest(new BrokerCreateWorkflowInstanceRequest()).join();
+    final var future = client.sendRequest(new BrokerCreateWorkflowInstanceRequest());
+
+    // then
+    assertThatThrownBy(future::join)
+        .hasCause(
+            new BrokerErrorException(new BrokerError(ErrorCode.PARTITION_LEADER_MISMATCH, "")));
   }
 
   @Test
@@ -207,7 +221,7 @@ public final class BrokerClientTest {
     final long key = Protocol.encodePartitionId(1, 123);
     final var request = new BrokerCompleteJobRequest(key, DocumentValue.EMPTY_DOCUMENT);
     request.setPartitionId(1);
-    final var async = client.sendRequest(request, Duration.ofMillis(100));
+    final var async = client.sendRequestWithRetry(request, Duration.ofMillis(100));
 
     // then
     assertThatThrownBy(async::join).hasRootCauseInstanceOf(TimeoutException.class);
@@ -222,13 +236,13 @@ public final class BrokerClientTest {
     request.setLocal(false);
 
     // when
-    final var async = client.sendRequest(request);
+    final var async = client.sendRequestWithRetry(request);
 
     // then
     final String expected =
         "Expected to execute command, but this command refers to an element that doesn't exist.";
     assertThatThrownBy(async::join)
-        .isInstanceOf(ExecutionException.class)
+        .hasCauseInstanceOf(PartitionNotFoundException.class)
         .hasMessageContaining(expected);
   }
 
@@ -239,7 +253,9 @@ public final class BrokerClientTest {
 
     // when
     try {
-      client.sendRequest(new BrokerCompleteJobRequest(1, new UnsafeBuffer(new byte[0]))).join();
+      client
+          .sendRequestWithRetry(new BrokerCompleteJobRequest(1, new UnsafeBuffer(new byte[0])))
+          .join();
 
       fail("should throw exception");
     } catch (final Exception e) {
@@ -259,19 +275,22 @@ public final class BrokerClientTest {
     broker.jobs().registerCompleteCommand(b -> b.rejection(RejectionType.INVALID_ARGUMENT, "foo"));
 
     // when
-    final BrokerResponse<JobRecord> response =
-        client
-            .sendRequest(
-                new BrokerCompleteJobRequest(
-                    Protocol.encodePartitionId(Protocol.DEPLOYMENT_PARTITION, 79),
-                    DocumentValue.EMPTY_DOCUMENT))
-            .join();
+    final var responseFuture =
+        client.sendRequestWithRetry(
+            new BrokerCompleteJobRequest(
+                Protocol.encodePartitionId(Protocol.DEPLOYMENT_PARTITION, 79),
+                DocumentValue.EMPTY_DOCUMENT));
 
     // then
-    assertThat(response.isRejection()).isTrue();
-    final BrokerRejection rejection = response.getRejection();
-    assertThat(rejection.getType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(rejection.getReason()).isEqualTo("foo");
+    assertThatThrownBy(responseFuture::join)
+        .hasCauseInstanceOf(BrokerRejectionException.class)
+        .hasCause(
+            new BrokerRejectionException(
+                new BrokerRejection(
+                    JobIntent.COMPLETE,
+                    Protocol.encodePartitionId(Protocol.DEPLOYMENT_PARTITION, 79),
+                    RejectionType.INVALID_ARGUMENT,
+                    "foo")));
   }
 
   private void registerCreateWfCommand() {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -86,6 +86,7 @@
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.config>1.4.0</version.config>
     <version.kryo>4.0.2</version.kryo>
+    <version.awaitility>4.0.3</version.awaitility>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.0.0</plugin.version.antrun>
@@ -196,6 +197,12 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${version.junit}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>${version.awaitility}</version>
       </dependency>
 
       <dependency>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -177,6 +177,12 @@
       <artifactId>rest-assured</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/AvailabilityTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/AvailabilityTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.it.util.GrpcClientRule;
+import io.zeebe.client.api.response.ActivatedJob;
+import io.zeebe.client.api.response.BrokerInfo;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceCreationIntent;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+
+public class AvailabilityTest {
+
+  private static final String JOBTYPE = "availability-test";
+  private static final BpmnModelInstance WORKFLOW =
+      Bpmn.createExecutableProcess("process")
+          .startEvent()
+          .serviceTask(
+              "task",
+              t -> {
+                t.zeebeJobType(JOBTYPE);
+              })
+          .endEvent()
+          .done();
+  private final int partitionCount = 3;
+  private final Timeout testTimeout = Timeout.seconds(120);
+  private final ClusteringRule clusteringRule = new ClusteringRule(partitionCount, 1, 3);
+  private final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(testTimeout).around(clusteringRule).around(clientRule);
+
+  private long workflowKey;
+
+  @Before
+  public void setup() {
+    workflowKey = clientRule.deployWorkflow(WORKFLOW);
+  }
+
+  @Test
+  public void shouldCreateWorkflowWhenOnePartitionDown() {
+    final BrokerInfo leaderForPartition = clusteringRule.getLeaderForPartition(partitionCount);
+
+    // when
+    clusteringRule.stopBroker(leaderForPartition.getNodeId());
+
+    for (int i = 0; i < 2 * partitionCount; i++) {
+      clientRule.createWorkflowInstance(workflowKey);
+    }
+
+    // then
+    final List<Integer> partitionIds =
+        RecordingExporter.workflowInstanceCreationRecords()
+            .withIntent(WorkflowInstanceCreationIntent.CREATED)
+            .map(Record::getPartitionId)
+            .limit(2 * partitionCount)
+            .collect(Collectors.toList());
+
+    assertThat(partitionIds).hasSize(2 * partitionCount);
+    assertThat(partitionIds).containsExactlyInAnyOrder(1, 1, 1, 2, 2, 2);
+  }
+
+  @Test
+  public void shouldCreateWorkflowWhenPartitionRecovers() {
+    // given
+    final int failingPartition = partitionCount;
+    final BrokerInfo leaderForPartition = clusteringRule.getLeaderForPartition(failingPartition);
+    clusteringRule.stopBroker(leaderForPartition.getNodeId());
+
+    for (int i = 0; i < partitionCount; i++) {
+      clientRule.createWorkflowInstance(workflowKey);
+    }
+
+    // when
+    clusteringRule.restartBroker(leaderForPartition.getNodeId());
+
+    for (int i = 0; i < partitionCount; i++) {
+      clientRule.createWorkflowInstance(workflowKey);
+    }
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceCreationRecords()
+                .withIntent(WorkflowInstanceCreationIntent.CREATED)
+                .filter(r -> r.getPartitionId() == failingPartition))
+        .hasSizeGreaterThanOrEqualTo(1);
+  }
+
+  @Test
+  public void shouldActivateJobsWhenOnePartitionDown() {
+    // given
+    final int numInstances = 2 * partitionCount;
+    final BrokerInfo leaderForPartition = clusteringRule.getLeaderForPartition(partitionCount);
+    clusteringRule.stopBroker(leaderForPartition.getNodeId());
+
+    for (int i = 0; i < numInstances; i++) {
+      clientRule.createWorkflowInstance(workflowKey);
+    }
+
+    // when
+
+    final Set<Long> activatedJobsKey = new HashSet<>();
+    for (int i = 0; i < numInstances; i++) {
+      final List<ActivatedJob> jobs =
+          clientRule
+              .getClient()
+              .newActivateJobsCommand()
+              .jobType(JOBTYPE)
+              .maxJobsToActivate(1)
+              .timeout(Duration.ofMinutes(5))
+              .requestTimeout(
+                  Duration.ofSeconds(
+                      5)) // put a lower timeout than gateway timeout to ensure that the test fails
+              // if gateway waits on unavailable broker
+              .send()
+              .join()
+              .getJobs();
+      jobs.forEach(job -> activatedJobsKey.add(job.getKey()));
+    }
+
+    // then
+    assertThat(activatedJobsKey).hasSize(numInstances);
+  }
+
+  @Test
+  public void shouldActivateJobsRoundRobinWhenOnePartitionDown() {
+    // given
+    final int numInstances = 2 * partitionCount;
+    final BrokerInfo leaderForPartition = clusteringRule.getLeaderForPartition(partitionCount);
+    clusteringRule.stopBroker(leaderForPartition.getNodeId());
+
+    for (int i = 0; i < numInstances; i++) {
+      clientRule.createWorkflowInstance(workflowKey);
+    }
+
+    // when
+    Awaitility.await()
+        .until(
+            () ->
+                RecordingExporter.jobRecords(JobIntent.CREATED).limit(numInstances).count()
+                    == numInstances);
+
+    final Set<Long> activatedJobsKey = new HashSet<>();
+    final List<ActivatedJob> jobs =
+        clientRule
+            .getClient()
+            .newActivateJobsCommand()
+            .jobType(JOBTYPE)
+            .maxJobsToActivate(2 * numInstances)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs();
+    jobs.forEach(job -> activatedJobsKey.add(job.getKey()));
+
+    // then
+    assertThat(activatedJobsKey).hasSize(numInstances);
+  }
+}

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/BrokerLeaderChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/BrokerLeaderChangeTest.java
@@ -48,7 +48,7 @@ public final class BrokerLeaderChangeTest {
     final int partition = Protocol.START_PARTITION_ID;
     final int oldLeader = clusteringRule.getLeaderForPartition(partition).getNodeId();
 
-    clusteringRule.stopBroker(oldLeader);
+    clusteringRule.stopBrokerAndAwaitNewLeader(oldLeader);
 
     waitUntil(() -> clusteringRule.getLeaderForPartition(partition).getNodeId() != oldLeader);
 
@@ -73,7 +73,7 @@ public final class BrokerLeaderChangeTest {
     final long jobKey = clientRule.createSingleJob(JOB_TYPE);
 
     // when
-    clusteringRule.stopBroker(leaderForPartition.getNodeId());
+    clusteringRule.stopBrokerAndAwaitNewLeader(leaderForPartition.getNodeId());
     final JobCompleter jobCompleter = new JobCompleter(jobKey);
 
     // then

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -563,7 +563,7 @@ public final class ClusteringRule extends ExternalResource {
     request.setPartitionId(partitionId);
 
     final BrokerResponse<WorkflowInstanceCreationRecord> response =
-        gateway.getBrokerClient().sendRequest(request).join();
+        gateway.getBrokerClient().sendRequestWithRetry(request).join();
 
     if (response.isResponse()) {
       return response.getResponse().getWorkflowInstanceKey();

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/GossipClusteringTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/GossipClusteringTest.java
@@ -53,7 +53,7 @@ public final class GossipClusteringTest {
     final InetSocketAddress[] otherBrokers = clusteringRule.getOtherBrokers(2);
 
     // when
-    clusteringRule.stopBroker(2);
+    clusteringRule.stopBrokerAndAwaitNewLeader(2);
 
     // then
     final List<InetSocketAddress> topologyBrokers = clusteringRule.getBrokersInCluster();
@@ -69,7 +69,7 @@ public final class GossipClusteringTest {
         clusteringRule.getOtherBrokers(leaderForPartition.getNodeId());
 
     // when
-    clusteringRule.stopBroker(leaderForPartition.getNodeId());
+    clusteringRule.stopBrokerAndAwaitNewLeader(leaderForPartition.getNodeId());
 
     // then
     final List<InetSocketAddress> topologyBrokers = clusteringRule.getBrokersInCluster();

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
@@ -57,7 +57,7 @@ public final class RestoreTest {
   @Test
   public void shouldReplicateLogEvents() {
     // given
-    clusteringRule.stopBroker(2);
+    clusteringRule.stopBrokerAndAwaitNewLeader(2);
 
     final BpmnModelInstance firstWorkflow =
         Bpmn.createExecutableProcess("process-test1").startEvent().endEvent().done();
@@ -82,7 +82,7 @@ public final class RestoreTest {
     clusteringRule.restartBroker(2);
     clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(2));
 
-    clusteringRule.stopBroker(1);
+    clusteringRule.stopBrokerAndAwaitNewLeader(1);
 
     final long thirdWorkflowKey = clientRule.deployWorkflow(thirdWorkflow);
 
@@ -91,7 +91,7 @@ public final class RestoreTest {
         clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId()));
 
     clusteringRule.restartBroker(1);
-    clusteringRule.stopBroker(0);
+    clusteringRule.stopBrokerAndAwaitNewLeader(0);
 
     // then
     // If restore did not happen, following workflows won't be deployed

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -86,7 +86,7 @@ public final class SnapshotReplicationTest {
     final var secondFollowerId = followers.get(1);
 
     // when - snapshot
-    clusteringRule.stopBroker(firstFollowerId);
+    clusteringRule.stopBrokerAndAwaitNewLeader(firstFollowerId);
     triggerSnapshotCreation();
     final var snapshotAtSecondFollower =
         clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(secondFollowerId));

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/gateway/GatewayIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/gateway/GatewayIntegrationTest.java
@@ -11,16 +11,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.AtomixCluster;
 import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.gateway.cmd.BrokerRejectionException;
 import io.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.zeebe.gateway.impl.broker.request.BrokerCreateWorkflowInstanceRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerRejection;
-import io.zeebe.gateway.impl.broker.response.BrokerResponse;
 import io.zeebe.gateway.impl.configuration.GatewayCfg;
-import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceCreationRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.test.util.socket.SocketUtil;
 import io.zeebe.util.sched.clock.ControlledActorClock;
 import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -61,18 +62,27 @@ public final class GatewayIntegrationTest {
   }
 
   @Test
-  public void shouldReturnRejectionWithCorrectTypeAndReason() {
+  public void shouldReturnRejectionWithCorrectTypeAndReason() throws InterruptedException {
     // given
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<Throwable> errorResponse = new AtomicReference<>();
 
     // when
-    final BrokerResponse<WorkflowInstanceCreationRecord> response =
-        client.sendRequest(new BrokerCreateWorkflowInstanceRequest()).join();
+    client.sendRequestWithRetry(
+        new BrokerCreateWorkflowInstanceRequest(),
+        (k, r) -> {},
+        error -> {
+          errorResponse.set(error);
+          latch.countDown();
+        });
 
     // then
-    assertThat(response.isRejection()).isTrue();
-    final BrokerRejection error = response.getRejection();
-    assertThat(error.getType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
-    assertThat(error.getReason())
+    latch.await();
+    final var error = errorResponse.get();
+    assertThat(error).isInstanceOf(BrokerRejectionException.class);
+    final BrokerRejection rejection = ((BrokerRejectionException) error).getRejection();
+    assertThat(rejection.getType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection.getReason())
         .isEqualTo("Expected at least a bpmnProcessId or a key greater than -1, but none given");
   }
 }

--- a/transport/src/main/java/io/zeebe/transport/ClientTransport.java
+++ b/transport/src/main/java/io/zeebe/transport/ClientTransport.java
@@ -39,7 +39,7 @@ public interface ClientTransport extends AutoCloseable {
    *     timeout.
    */
   default ActorFuture<DirectBuffer> sendRequestWithRetry(
-      Supplier<String> nodeAddressSupplier,
+      final Supplier<String> nodeAddressSupplier,
       final ClientRequest clientRequest,
       final Duration timeout) {
     return sendRequestWithRetry(nodeAddressSupplier, response -> true, clientRequest, timeout);
@@ -76,4 +76,26 @@ public interface ClientTransport extends AutoCloseable {
       Predicate<DirectBuffer> responseValidator,
       ClientRequest clientRequest,
       Duration timeout);
+
+  /**
+   * Send a request to a node with out any retries.
+   *
+   * <p>Guarantees:
+   *
+   * <ul>
+   *   <li>Not garbage-free
+   *   <li>1 intermediary copies of the request
+   *
+   * @param nodeAddressSupplier supplier for the node address the retries are executed against
+   *     (retries may be executed against different nodes). The supplier may resolve to <code>null
+   *     </code> to signal that a node address can not be determined. In that case, the request will
+   *     be completed with a NoRemoteAddressFoundException.
+   * @param clientRequest the request which should be send
+   * @param timeout The timeout until the returned future fails if no response is received.
+   * @return a future carrying the response that was accepted or null in case no memory is currently
+   *     available to allocate the request. Can complete exceptionally in failure cases such as
+   *     timeout.
+   */
+  ActorFuture<DirectBuffer> sendRequest(
+      Supplier<String> nodeAddressSupplier, ClientRequest clientRequest, Duration timeout);
 }

--- a/transport/src/main/java/io/zeebe/transport/impl/RequestContext.java
+++ b/transport/src/main/java/io/zeebe/transport/impl/RequestContext.java
@@ -25,6 +25,7 @@ final class RequestContext {
   private final Supplier<String> nodeAddressSupplier;
   private final int partitionId;
   private final byte[] requestBytes;
+  private final boolean shouldRetry;
   private final long startTime;
   private final Duration timeout;
   private final Predicate<DirectBuffer> responseValidator;
@@ -37,11 +38,13 @@ final class RequestContext {
       final int partitionId,
       final byte[] requestBytes,
       final Predicate<DirectBuffer> responseValidator,
+      final boolean shouldRetry,
       final Duration timeout) {
     this.currentFuture = currentFuture;
     this.nodeAddressSupplier = nodeAddressSupplier;
     this.partitionId = partitionId;
     this.requestBytes = requestBytes;
+    this.shouldRetry = shouldRetry;
     this.startTime = ActorClock.currentTimeMillis();
     this.responseValidator = responseValidator;
     this.timeout = timeout;
@@ -84,12 +87,12 @@ final class RequestContext {
     return responseValidator.test(response);
   }
 
-  public void complete(DirectBuffer buffer) {
+  public void complete(final DirectBuffer buffer) {
     currentFuture.complete(buffer);
     cancelTimer();
   }
 
-  public void completeExceptionally(Throwable throwable) {
+  public void completeExceptionally(final Throwable throwable) {
     currentFuture.completeExceptionally(throwable);
     cancelTimer();
   }
@@ -100,12 +103,16 @@ final class RequestContext {
     }
   }
 
-  public void setScheduledTimer(ScheduledTimer scheduledTimer) {
+  public void setScheduledTimer(final ScheduledTimer scheduledTimer) {
     this.scheduledTimer = scheduledTimer;
   }
 
   public void timeout() {
     currentFuture.completeExceptionally(
         new TimeoutException("Request timed out after " + timeout.toString()));
+  }
+
+  public boolean shouldRetry() {
+    return shouldRetry;
   }
 }

--- a/transport/src/test/java/io/zeebe/transport/impl/AtomixTransportTest.java
+++ b/transport/src/test/java/io/zeebe/transport/impl/AtomixTransportTest.java
@@ -23,6 +23,7 @@ import io.zeebe.transport.ServerOutput;
 import io.zeebe.transport.ServerTransport;
 import io.zeebe.transport.TransportFactory;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
+import java.net.ConnectException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
@@ -237,6 +238,20 @@ public class AtomixTransportTest {
 
     // then
     assertThatThrownBy(requestFuture::join).hasCauseInstanceOf(TimeoutException.class);
+  }
+
+  @Test
+  public void shouldNotRetryWhenNoRemoteFoundWhenSpecified() {
+    // given
+
+    // when
+    final var requestFuture =
+        clientTransport.sendRequest(() -> null, new Request("messageABC"), Duration.ofMillis(300));
+
+    // then
+    assertThatThrownBy(requestFuture::join)
+        .hasCauseInstanceOf(ConnectException.class)
+        .hasMessageContaining("no remote address found");
   }
 
   @Test


### PR DESCRIPTION
## Description

* Enable transport to send request without retries when remote node is not available
* Do not retry ActivateJobs and CreateWorkflowInstance requests at the transport level when remote node is not available
* Do not send ActivateJobs and CreateWorkflowInstance requests to a partition when the leader is not known
* Retry CreateWorkflowInstance request with a different partition if the leader for the partition is not available, or the request rejected due to RESOURCE_EXHAUSTED or PARTITION_LEADER_MISMATCH. 
* Refactor BrokerClient interface and BrokerRequestManager

## Related issues

closes #4593

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
