### PR TITLE
chore(gateway): add flag to enable/disable long polling

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -92,6 +92,11 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_SECURITY_PRIVATEKEYPATH.
         # privateKeyPath:
 
+      # longPolling:
+        # Enables long polling for available jobs
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_LONGPOLLING_ENABLED.
+        # enabled: true
+
     # network:
       # This section contains the network configuration. Particularly, it allows to
       # configure the hosts and ports the broker should bind to. The broker exposes three sockets:

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -106,3 +106,8 @@
       # Sets the path to the private key file location
       # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_SECURITY_PRIVATEKEYPATH.
       # privateKeyPath:
+
+    # longPolling:
+      # Enables long polling for available jobs
+      # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_LONGPOLLING_ENABLED.
+      # enabled: true

--- a/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/zeebe/gateway/EndpointManager.java
@@ -25,7 +25,7 @@ import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.zeebe.gateway.impl.broker.response.BrokerError;
 import io.zeebe.gateway.impl.broker.response.BrokerRejection;
-import io.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
+import io.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.zeebe.gateway.protocol.GatewayGrpc;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
@@ -70,14 +70,14 @@ public final class EndpointManager extends GatewayGrpc.GatewayImplBase {
 
   private final BrokerClient brokerClient;
   private final BrokerTopologyManager topologyManager;
-  private final LongPollingActivateJobsHandler activateJobsHandler;
+  private final ActivateJobsHandler activateJobsHandler;
   private final RequestRetryHandler requestRetryHandler;
 
   public EndpointManager(
-      final BrokerClient brokerClient, final LongPollingActivateJobsHandler longPollingHandler) {
+      final BrokerClient brokerClient, final ActivateJobsHandler activateJobsHandler) {
     this.brokerClient = brokerClient;
     topologyManager = brokerClient.getTopologyManager();
-    activateJobsHandler = longPollingHandler;
+    this.activateJobsHandler = activateJobsHandler;
     requestRetryHandler = new RequestRetryHandler(brokerClient, topologyManager);
   }
 

--- a/gateway/src/main/java/io/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/zeebe/gateway/Gateway.java
@@ -17,7 +17,9 @@ import io.zeebe.gateway.impl.broker.BrokerClientImpl;
 import io.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.zeebe.gateway.impl.configuration.NetworkCfg;
 import io.zeebe.gateway.impl.configuration.SecurityCfg;
+import io.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
+import io.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
 import io.zeebe.util.VersionUtil;
 import io.zeebe.util.sched.ActorScheduler;
 import java.io.File;
@@ -96,10 +98,16 @@ public final class Gateway {
 
     brokerClient = buildBrokerClient();
 
-    final LongPollingActivateJobsHandler longPollingHandler = buildLongPollingHandler(brokerClient);
-    actorScheduler.submitActor(longPollingHandler);
-
-    final EndpointManager endpointManager = new EndpointManager(brokerClient, longPollingHandler);
+    final ActivateJobsHandler activateJobsHandler;
+    if (gatewayCfg.getLongPolling().isEnabled()) {
+      final LongPollingActivateJobsHandler longPollingHandler =
+          buildLongPollingHandler(brokerClient);
+      actorScheduler.submitActor(longPollingHandler);
+      activateJobsHandler = longPollingHandler;
+    } else {
+      activateJobsHandler = new RoundRobinActivateJobsHandler(brokerClient);
+    }
+    final EndpointManager endpointManager = new EndpointManager(brokerClient, activateJobsHandler);
 
     final ServerBuilder serverBuilder = serverBuilderFactory.apply(gatewayCfg);
 

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -111,7 +111,6 @@ public final class ClusterCfg {
         + '\''
         + ", requestTimeout='"
         + requestTimeout
-        + '\''
         + ", clusterName='"
         + clusterName
         + '\''

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ConfigurationDefaults.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/ConfigurationDefaults.java
@@ -20,6 +20,7 @@ public final class ConfigurationDefaults {
   public static final String DEFAULT_MAX_MESSAGE_SIZE = "4M";
   public static final int DEFAULT_MAX_MESSAGE_COUNT = 16;
   public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(15);
+  public static final boolean DEFAULT_LONG_POLLING_ENABLED = true;
   public static final boolean DEFAULT_TLS_ENABLED = false;
 
   public static final String DEFAULT_CLUSTER_NAME = "zeebe-cluster";

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/GatewayCfg.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/GatewayCfg.java
@@ -24,6 +24,7 @@ public class GatewayCfg {
   private ThreadsCfg threads = new ThreadsCfg();
   private MonitoringCfg monitoring = new MonitoringCfg();
   private SecurityCfg security = new SecurityCfg();
+  private LongPollingCfg longPolling = new LongPollingCfg();
   private boolean initialized = false;
 
   public void init() {
@@ -85,9 +86,18 @@ public class GatewayCfg {
     return this;
   }
 
+  public LongPollingCfg getLongPolling() {
+    return longPolling;
+  }
+
+  public GatewayCfg setLongPolling(final LongPollingCfg longPolling) {
+    this.longPolling = longPolling;
+    return this;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(network, cluster, threads, monitoring, security);
+    return Objects.hash(network, cluster, threads, monitoring, security, longPolling);
   }
 
   @Override
@@ -103,7 +113,8 @@ public class GatewayCfg {
         && Objects.equals(cluster, that.cluster)
         && Objects.equals(threads, that.threads)
         && Objects.equals(monitoring, that.monitoring)
-        && Objects.equals(security, that.security);
+        && Objects.equals(security, that.security)
+        && Objects.equals(longPolling, that.longPolling);
   }
 
   @Override
@@ -119,6 +130,8 @@ public class GatewayCfg {
         + monitoring
         + ", securityCfg="
         + security
+        + ", longPollingCfg="
+        + longPolling
         + '}';
   }
 

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/LongPollingCfg.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/LongPollingCfg.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.impl.configuration;
+
+import java.util.Objects;
+
+public final class LongPollingCfg {
+
+  private boolean enabled = ConfigurationDefaults.DEFAULT_LONG_POLLING_ENABLED;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public LongPollingCfg setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(enabled);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final LongPollingCfg that = (LongPollingCfg) o;
+    return enabled == that.enabled;
+  }
+
+  @Override
+  public String toString() {
+    return "LongPollingCfg{" + "enabled=" + enabled + '}';
+  }
+}

--- a/gateway/src/main/java/io/zeebe/gateway/impl/job/ActivateJobsHandler.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/job/ActivateJobsHandler.java
@@ -7,135 +7,19 @@
  */
 package io.zeebe.gateway.impl.job;
 
-import io.grpc.Status.Code;
-import io.grpc.StatusRuntimeException;
-import io.zeebe.gateway.EndpointManager;
-import io.zeebe.gateway.Loggers;
-import io.zeebe.gateway.ResponseMapper;
-import io.zeebe.gateway.impl.broker.BrokerClient;
-import io.zeebe.gateway.impl.broker.PartitionIdIterator;
-import io.zeebe.gateway.impl.broker.RequestDispatchStrategy;
-import io.zeebe.gateway.impl.broker.RoundRobinDispatchStrategy;
-import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
-import io.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.grpc.stub.StreamObserver;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Consumer;
 
-final class ActivateJobsHandler {
+/** Can handle an 'activate jobs' request from a client. */
+public interface ActivateJobsHandler {
 
-  private final Map<String, RequestDispatchStrategy> jobTypeToNextPartitionId =
-      new ConcurrentHashMap<>();
-  private final BrokerClient brokerClient;
-  private final BrokerTopologyManager topologyManager;
-
-  ActivateJobsHandler(final BrokerClient brokerClient) {
-    this.brokerClient = brokerClient;
-    this.topologyManager = brokerClient.getTopologyManager();
-  }
-
+  /**
+   * Handle activate jobs request from a client
+   *
+   * @param request The request to handle
+   * @param responseObserver The stream to write the responses to
+   */
   void activateJobs(
-      final int partitionsCount,
-      final BrokerActivateJobsRequest request,
-      final int maxJobsToActivate,
-      final String type,
-      final Consumer<ActivateJobsResponse> onResponse,
-      final Consumer<Integer> onCompleted) {
-    activateJobs(
-        request,
-        partitionIdIteratorForType(type, partitionsCount),
-        maxJobsToActivate,
-        type,
-        onResponse,
-        onCompleted);
-  }
-
-  private void activateJobs(
-      final BrokerActivateJobsRequest request,
-      final PartitionIdIterator partitionIdIterator,
-      final int remainingAmount,
-      final String jobType,
-      final Consumer<ActivateJobsResponse> onResponse,
-      final Consumer<Integer> onCompleted) {
-    activateJobs(
-        request, partitionIdIterator, remainingAmount, jobType, onResponse, onCompleted, false);
-  }
-
-  private void activateJobs(
-      final BrokerActivateJobsRequest request,
-      final PartitionIdIterator partitionIdIterator,
-      final int remainingAmount,
-      final String jobType,
-      final Consumer<ActivateJobsResponse> onResponse,
-      final Consumer<Integer> onCompleted,
-      final boolean pollPrevPartition) {
-
-    if (remainingAmount > 0 && (pollPrevPartition || partitionIdIterator.hasNext())) {
-      final int partitionId =
-          pollPrevPartition
-              ? partitionIdIterator.getCurrentPartitionId()
-              : partitionIdIterator.next();
-
-      // partitions to check and jobs to activate left
-      request.setPartitionId(partitionId);
-      request.setMaxJobsToActivate(remainingAmount);
-      brokerClient
-          .sendRequest(request)
-          .whenComplete(
-              (response, error) -> {
-                if (error == null) {
-                  final ActivateJobsResponse grpcResponse =
-                      ResponseMapper.toActivateJobsResponse(
-                          response.getKey(), response.getResponse());
-                  final int jobsCount = grpcResponse.getJobsCount();
-                  if (jobsCount > 0) {
-                    onResponse.accept(grpcResponse);
-                  }
-
-                  activateJobs(
-                      request,
-                      partitionIdIterator,
-                      remainingAmount - jobsCount,
-                      jobType,
-                      onResponse,
-                      onCompleted,
-                      response.getResponse().getTruncated());
-                } else {
-                  logErrorResponse(partitionIdIterator, jobType, error);
-                  activateJobs(
-                      request,
-                      partitionIdIterator,
-                      remainingAmount,
-                      jobType,
-                      onResponse,
-                      onCompleted);
-                }
-              });
-    } else {
-      // enough jobs activated or no more partitions left to check
-      onCompleted.accept(remainingAmount);
-    }
-  }
-
-  private void logErrorResponse(
-      final PartitionIdIterator partitionIdIterator, final String jobType, final Throwable error) {
-    final StatusRuntimeException statusRuntimeException = EndpointManager.convertThrowable(error);
-    if (statusRuntimeException.getStatus().getCode() != Code.RESOURCE_EXHAUSTED) {
-      Loggers.GATEWAY_LOGGER.warn(
-          "Failed to activate jobs for type {} from partition {}",
-          jobType,
-          partitionIdIterator.getCurrentPartitionId(),
-          error);
-    }
-  }
-
-  private PartitionIdIterator partitionIdIteratorForType(
-      final String jobType, final int partitionsCount) {
-    final RequestDispatchStrategy nextPartitionSupplier =
-        jobTypeToNextPartitionId.computeIfAbsent(
-            jobType, t -> new RoundRobinDispatchStrategy(topologyManager));
-    return new PartitionIdIterator(
-        nextPartitionSupplier.determinePartition(), partitionsCount, topologyManager);
-  }
+      ActivateJobsRequest request, StreamObserver<ActivateJobsResponse> responseObserver);
 }

--- a/gateway/src/main/java/io/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.impl.job;
+
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import io.zeebe.gateway.EndpointManager;
+import io.zeebe.gateway.Loggers;
+import io.zeebe.gateway.RequestMapper;
+import io.zeebe.gateway.ResponseMapper;
+import io.zeebe.gateway.impl.broker.BrokerClient;
+import io.zeebe.gateway.impl.broker.PartitionIdIterator;
+import io.zeebe.gateway.impl.broker.RequestDispatchStrategy;
+import io.zeebe.gateway.impl.broker.RoundRobinDispatchStrategy;
+import io.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
+import io.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
+import io.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * Iterates in round-robin fashion over partitions to activate jobs. Uses a map from job type to
+ * partition-IDs to determine the next partition to use.
+ */
+public final class RoundRobinActivateJobsHandler implements ActivateJobsHandler {
+
+  private final Map<String, RequestDispatchStrategy> jobTypeToNextPartitionId =
+      new ConcurrentHashMap<>();
+  private final BrokerClient brokerClient;
+  private final BrokerTopologyManager topologyManager;
+
+  public RoundRobinActivateJobsHandler(final BrokerClient brokerClient) {
+    this.brokerClient = brokerClient;
+    this.topologyManager = brokerClient.getTopologyManager();
+  }
+
+  @Override
+  public void activateJobs(
+      final ActivateJobsRequest request,
+      final StreamObserver<ActivateJobsResponse> responseObserver) {
+    final BrokerClusterState topology = brokerClient.getTopologyManager().getTopology();
+    if (topology != null) {
+      final int partitionsCount = topology.getPartitionsCount();
+      activateJobs(
+          partitionsCount,
+          RequestMapper.toActivateJobsRequest(request),
+          request.getMaxJobsToActivate(),
+          request.getType(),
+          responseObserver::onNext,
+          remainingAmount -> responseObserver.onCompleted());
+    }
+  }
+
+  public void activateJobs(
+      final int partitionsCount,
+      final BrokerActivateJobsRequest request,
+      final int maxJobsToActivate,
+      final String type,
+      final Consumer<ActivateJobsResponse> onResponse,
+      final Consumer<Integer> onCompleted) {
+    activateJobs(
+        request,
+        partitionIdIteratorForType(type, partitionsCount),
+        maxJobsToActivate,
+        type,
+        onResponse,
+        onCompleted);
+  }
+
+  private void activateJobs(
+      final BrokerActivateJobsRequest request,
+      final PartitionIdIterator partitionIdIterator,
+      final int remainingAmount,
+      final String jobType,
+      final Consumer<ActivateJobsResponse> onResponse,
+      final Consumer<Integer> onCompleted) {
+    activateJobs(
+        request, partitionIdIterator, remainingAmount, jobType, onResponse, onCompleted, false);
+  }
+
+  private void activateJobs(
+      final BrokerActivateJobsRequest request,
+      final PartitionIdIterator partitionIdIterator,
+      final int remainingAmount,
+      final String jobType,
+      final Consumer<ActivateJobsResponse> onResponse,
+      final Consumer<Integer> onCompleted,
+      final boolean pollPrevPartition) {
+
+    if (remainingAmount > 0 && (pollPrevPartition || partitionIdIterator.hasNext())) {
+      final int partitionId =
+          pollPrevPartition
+              ? partitionIdIterator.getCurrentPartitionId()
+              : partitionIdIterator.next();
+
+      // partitions to check and jobs to activate left
+      request.setPartitionId(partitionId);
+      request.setMaxJobsToActivate(remainingAmount);
+      brokerClient
+          .sendRequest(request)
+          .whenComplete(
+              (response, error) -> {
+                if (error == null) {
+                  final ActivateJobsResponse grpcResponse =
+                      ResponseMapper.toActivateJobsResponse(
+                          response.getKey(), response.getResponse());
+                  final int jobsCount = grpcResponse.getJobsCount();
+                  if (jobsCount > 0) {
+                    onResponse.accept(grpcResponse);
+                  }
+
+                  activateJobs(
+                      request,
+                      partitionIdIterator,
+                      remainingAmount - jobsCount,
+                      jobType,
+                      onResponse,
+                      onCompleted,
+                      response.getResponse().getTruncated());
+                } else {
+                  logErrorResponse(partitionIdIterator, jobType, error);
+                  activateJobs(
+                      request,
+                      partitionIdIterator,
+                      remainingAmount,
+                      jobType,
+                      onResponse,
+                      onCompleted);
+                }
+              });
+    } else {
+      // enough jobs activated or no more partitions left to check
+      onCompleted.accept(remainingAmount);
+    }
+  }
+
+  private void logErrorResponse(
+      final PartitionIdIterator partitionIdIterator, final String jobType, final Throwable error) {
+    final StatusRuntimeException statusRuntimeException = EndpointManager.convertThrowable(error);
+    if (statusRuntimeException.getStatus().getCode() != Code.RESOURCE_EXHAUSTED) {
+      Loggers.GATEWAY_LOGGER.warn(
+          "Failed to activate jobs for type {} from partition {}",
+          jobType,
+          partitionIdIterator.getCurrentPartitionId(),
+          error);
+    }
+  }
+
+  private PartitionIdIterator partitionIdIteratorForType(
+      final String jobType, final int partitionsCount) {
+    final RequestDispatchStrategy nextPartitionSupplier =
+        jobTypeToNextPartitionId.computeIfAbsent(
+            jobType, t -> new RoundRobinDispatchStrategy(topologyManager));
+    return new PartitionIdIterator(
+        nextPartitionSupplier.determinePartition(), partitionsCount, topologyManager);
+  }
+}

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/ActivateJobsTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/ActivateJobsTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.zeebe.gateway.api.util.GatewayTest;
 import io.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
@@ -24,8 +25,27 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public final class ActivateJobsTest extends GatewayTest {
+
+  public ActivateJobsTest(final boolean isLongPollingEnabled) {
+    super(getConfig(isLongPollingEnabled));
+  }
+
+  @Parameters(name = "{index}: longPolling.enabled[{0}]")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][] {{true}, {false}});
+  }
+
+  private static GatewayCfg getConfig(final boolean isLongPollingEnabled) {
+    final var config = new GatewayCfg();
+    config.getLongPolling().setEnabled(isLongPollingEnabled);
+    return config;
+  }
 
   @Test
   public void shouldMapRequestAndResponse() {

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/NonLongPollingActivateJobsTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/NonLongPollingActivateJobsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.api.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.gateway.api.util.GatewayTest;
+import io.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.Test;
+
+public final class NonLongPollingActivateJobsTest extends GatewayTest {
+
+  public NonLongPollingActivateJobsTest() {
+    super(getConfig());
+  }
+
+  private static GatewayCfg getConfig() {
+    final var config = new GatewayCfg();
+    config.getLongPolling().setEnabled(false);
+    return config;
+  }
+
+  @Test
+  public void shouldActivateNoJobsWhenNonAvailable() {
+    // given
+    final String jobType = "testJob";
+    final String worker = "testWorker";
+    final int maxJobsToActivate = 13;
+    final Duration timeout = Duration.ofMinutes(12);
+    final List<String> fetchVariables = Arrays.asList("foo", "bar", "baz");
+
+    // no jobs available
+    final ActivateJobsStub stub = new ActivateJobsStub();
+    stub.registerWith(brokerClient);
+    stub.addAvailableJobs(jobType, 0);
+
+    final ActivateJobsRequest request =
+        ActivateJobsRequest.newBuilder()
+            .setType(jobType)
+            .setWorker(worker)
+            .setMaxJobsToActivate(maxJobsToActivate)
+            .setTimeout(timeout.toMillis())
+            .addAllFetchVariable(fetchVariables)
+            .build();
+
+    // when
+    final Iterator<ActivateJobsResponse> responses = client.activateJobs(request);
+
+    // then no jobs activated
+    assertThat(responses.hasNext()).isFalse();
+  }
+}

--- a/gateway/src/test/java/io/zeebe/gateway/api/util/GatewayTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/util/GatewayTest.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.gateway.api.util;
 
+import io.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
 import io.zeebe.util.sched.clock.ControlledActorClock;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
@@ -14,15 +15,26 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
 
-public class GatewayTest {
+public abstract class GatewayTest {
 
-  protected final ControlledActorClock actorClock = new ControlledActorClock();
-  public final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule(actorClock);
-  public final StubbedGatewayRule gatewayRule = new StubbedGatewayRule(actorSchedulerRule);
-  @Rule public RuleChain ruleChain = RuleChain.outerRule(actorSchedulerRule).around(gatewayRule);
+  public final ControlledActorClock actorClock;
+  public final ActorSchedulerRule actorSchedulerRule;
+  public final StubbedGatewayRule gatewayRule;
+  @Rule public RuleChain ruleChain;
   protected StubbedGateway gateway;
   protected GatewayBlockingStub client;
   protected StubbedBrokerClient brokerClient;
+
+  public GatewayTest() {
+    this(new GatewayCfg());
+  }
+
+  public GatewayTest(final GatewayCfg config) {
+    actorClock = new ControlledActorClock();
+    actorSchedulerRule = new ActorSchedulerRule(actorClock);
+    gatewayRule = new StubbedGatewayRule(actorSchedulerRule, config);
+    ruleChain = RuleChain.outerRule(actorSchedulerRule).around(gatewayRule);
+  }
 
   @Before
   public void setUp() {

--- a/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedGateway.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedGateway.java
@@ -12,6 +12,7 @@ import io.grpc.Server;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.zeebe.gateway.EndpointManager;
+import io.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.zeebe.gateway.protocol.GatewayGrpc;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
@@ -24,22 +25,24 @@ public final class StubbedGateway {
   private static final String SERVER_NAME = "server";
 
   private final StubbedBrokerClient brokerClient;
-  private final LongPollingActivateJobsHandler longPollingHandler;
+  private final ActivateJobsHandler activateJobsHandler;
   private final ActorScheduler actorScheduler;
   private Server server;
 
   public StubbedGateway(
       final ActorScheduler actorScheduler,
       final StubbedBrokerClient brokerClient,
-      final LongPollingActivateJobsHandler longPollingHandler) {
+      final ActivateJobsHandler activateJobsHandler) {
     this.actorScheduler = actorScheduler;
     this.brokerClient = brokerClient;
-    this.longPollingHandler = longPollingHandler;
+    this.activateJobsHandler = activateJobsHandler;
   }
 
   public void start() throws IOException {
-    actorScheduler.submitActor(longPollingHandler);
-    final EndpointManager endpointManager = new EndpointManager(brokerClient, longPollingHandler);
+    if (activateJobsHandler instanceof LongPollingActivateJobsHandler) {
+      actorScheduler.submitActor((LongPollingActivateJobsHandler) activateJobsHandler);
+    }
+    final EndpointManager endpointManager = new EndpointManager(brokerClient, activateJobsHandler);
     final InProcessServerBuilder serverBuilder =
         InProcessServerBuilder.forName(SERVER_NAME).addService(endpointManager);
     server = serverBuilder.build();

--- a/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedGatewayRule.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/util/StubbedGatewayRule.java
@@ -7,7 +7,10 @@
  */
 package io.zeebe.gateway.api.util;
 
+import io.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
+import io.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import org.junit.rules.ExternalResource;
@@ -18,18 +21,25 @@ public final class StubbedGatewayRule extends ExternalResource {
   protected GatewayBlockingStub client;
   private final ActorSchedulerRule actorSchedulerRule;
   private final StubbedBrokerClient brokerClient;
-  private final LongPollingActivateJobsHandler longPollingHandler;
+  private final ActivateJobsHandler activateJobsHandler;
 
-  public StubbedGatewayRule(final ActorSchedulerRule actorSchedulerRule) {
+  public StubbedGatewayRule(final ActorSchedulerRule actorSchedulerRule, final GatewayCfg config) {
     this.actorSchedulerRule = actorSchedulerRule;
     this.brokerClient = new StubbedBrokerClient();
-    this.longPollingHandler =
-        LongPollingActivateJobsHandler.newBuilder().setBrokerClient(brokerClient).build();
+    this.activateJobsHandler = getActivateJobsHandler(config, brokerClient);
+  }
+
+  private static ActivateJobsHandler getActivateJobsHandler(
+      final GatewayCfg config, final StubbedBrokerClient brokerClient) {
+    if (config.getLongPolling().isEnabled()) {
+      return LongPollingActivateJobsHandler.newBuilder().setBrokerClient(brokerClient).build();
+    }
+    return new RoundRobinActivateJobsHandler(brokerClient);
   }
 
   @Override
   protected void before() throws Throwable {
-    gateway = new StubbedGateway(actorSchedulerRule.get(), brokerClient, longPollingHandler);
+    gateway = new StubbedGateway(actorSchedulerRule.get(), brokerClient, activateJobsHandler);
     gateway.start();
     client = gateway.buildClient();
   }

--- a/gateway/src/test/java/io/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -45,6 +45,7 @@ public final class GatewayCfgTest {
         .setPrivateKeyPath("privateKeyPath");
     CUSTOM_CFG.getMonitoring().setEnabled(true).setHost("monitoringHost").setPort(1234);
     CUSTOM_CFG.getThreads().setManagementThreads(100);
+    CUSTOM_CFG.getLongPolling().setEnabled(false);
   }
 
   private final Map<String, String> environment = new HashMap<>();
@@ -122,6 +123,7 @@ public final class GatewayCfgTest {
     setEnv("zeebe.gateway.cluster.contactPoint", "broker:432");
     setEnv("zeebe.gateway.threads.managementThreads", "32");
     setEnv("zeebe.gateway.cluster.requestTimeout", Duration.ofMinutes(43).toString());
+    setEnv("zeebe.gateway.cluster.longPollingEnabled", "false");
     setEnv("zeebe.gateway.cluster.clusterName", "envCluster");
     setEnv("zeebe.gateway.cluster.memberId", "envMember");
     setEnv("zeebe.gateway.cluster.host", "envHost");
@@ -167,6 +169,7 @@ public final class GatewayCfgTest {
             getClass().getClassLoader().getResource("security/test-server.key.pem").getPath())
         .setCertificateChainPath(
             getClass().getClassLoader().getResource("security/test-chain.cert.pem").getPath());
+    expected.getLongPolling().setEnabled(false);
 
     // when
     final GatewayCfg gatewayCfg = readCustomConfig();

--- a/gateway/src/test/resources/configuration/gateway.custom.yaml
+++ b/gateway/src/test/resources/configuration/gateway.custom.yaml
@@ -25,3 +25,6 @@ zeebe:
       enabled: true
       privateKeyPath: privateKeyPath
       certificateChainPath: certificateChainPath
+
+    longPolling:
+      enabled: false

--- a/gateway/src/test/resources/configuration/gateway.default.yaml
+++ b/gateway/src/test/resources/configuration/gateway.default.yaml
@@ -106,3 +106,8 @@
 # Sets the path to the private key file location
 # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_SECURITY_PRIVATEKEYPATH.
 # privateKeyPath:
+
+# longPolling:
+# Enables long polling for available jobs
+# This setting can also be overridden using the environment variable ZEEBE_GATEWAY_LONGPOLLING_ENABLED.
+# enabled: true

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/LongPollingActivateJobsTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/command/LongPollingActivateJobsTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.it.util.GrpcClientRule;
+import io.zeebe.broker.system.configuration.BrokerCfg;
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.api.ZeebeFuture;
+import io.zeebe.client.api.response.ActivateJobsResponse;
+import io.zeebe.client.api.response.ActivatedJob;
+import io.zeebe.test.util.BrokerClassRuleHelper;
+import io.zeebe.util.SocketUtil;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class LongPollingActivateJobsTest {
+
+  private static final EmbeddedBrokerRule BROKER_RULE =
+      new EmbeddedBrokerRule(LongPollingActivateJobsTest::enableLongPolling);
+  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+
+  @ClassRule
+  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  private String jobType;
+
+  private static void enableLongPolling(final BrokerCfg config) {
+    config.getGateway().getLongPolling().setEnabled(true);
+  }
+
+  @Before
+  public void init() {
+    jobType = helper.getJobType();
+  }
+
+  @Test
+  public void shouldActivateJobsRespectingAmountLimit() {
+    // given
+    final int availableJobs = 3;
+    final int activateJobs = 2;
+
+    CLIENT_RULE.createJobs(jobType, availableJobs);
+
+    // when
+    final ActivateJobsResponse response =
+        CLIENT_RULE
+            .getClient()
+            .newActivateJobsCommand()
+            .jobType(jobType)
+            .maxJobsToActivate(activateJobs)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getJobs()).hasSize(activateJobs);
+  }
+
+  @Test
+  public void shouldActivateJobsIfBatchIsTruncated() {
+    // given
+    final int availableJobs = 10;
+
+    final int maxMessageSize =
+        (int) BROKER_RULE.getBrokerCfg().getNetwork().getMaxMessageSizeInBytes();
+    final var largeVariableValue = "x".repeat(maxMessageSize / 4);
+    final String variablesJson = String.format("{\"variablesJson\":\"%s\"}", largeVariableValue);
+
+    CLIENT_RULE.createJobs(jobType, b -> {}, variablesJson, availableJobs);
+
+    // when
+    final var response =
+        CLIENT_RULE
+            .getClient()
+            .newActivateJobsCommand()
+            .jobType(jobType)
+            .maxJobsToActivate(availableJobs)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getJobs()).hasSize(availableJobs);
+  }
+
+  @Test
+  public void shouldWaitUntilJobsAvailable() {
+    // given
+    final int expectedJobsCount = 1;
+
+    final ZeebeFuture<ActivateJobsResponse> responseFuture =
+        CLIENT_RULE
+            .getClient()
+            .newActivateJobsCommand()
+            .jobType(jobType)
+            .maxJobsToActivate(expectedJobsCount)
+            .send();
+
+    // when
+    CLIENT_RULE.createSingleJob(jobType);
+
+    // then
+    final ActivateJobsResponse response = responseFuture.join();
+    assertThat(response.getJobs()).hasSize(expectedJobsCount);
+  }
+
+  @Test
+  public void shouldActivatedJobForOpenRequest() throws InterruptedException {
+    // given
+    sendActivateRequestsAndClose(jobType, 3);
+
+    final var activateJobsResponse =
+        CLIENT_RULE
+            .getClient()
+            .newActivateJobsCommand()
+            .jobType(jobType)
+            .maxJobsToActivate(5)
+            .workerName("open")
+            .send();
+
+    sendActivateRequestsAndClose(jobType, 3);
+
+    // when
+    CLIENT_RULE.createSingleJob(jobType);
+
+    // then
+    final var jobs = activateJobsResponse.join().getJobs();
+
+    assertThat(jobs).hasSize(1).extracting(ActivatedJob::getWorker).contains("open");
+  }
+
+  private void sendActivateRequestsAndClose(final String jobType, final int count)
+      throws InterruptedException {
+    for (int i = 0; i < count; i++) {
+      final ZeebeClient client =
+          ZeebeClient.newClientBuilder()
+              .brokerContactPoint(SocketUtil.toHostAndPortString(BROKER_RULE.getGatewayAddress()))
+              .usePlaintext()
+              .build();
+
+      client
+          .newActivateJobsCommand()
+          .jobType(jobType)
+          .maxJobsToActivate(5)
+          .workerName("closed-" + i)
+          .send();
+
+      Thread.sleep(100);
+      client.close();
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds a config flag `gateway.longPolling.enabled` (or environment variable `ZEEBE_GATEWAY_LONGPOLLING_ENABLED `) to switch on/off long polling for available jobs.

## Related issues

closes #4415

## Checklist

- [x] add config flag
- [x] test config flag
- [x] use config to enable/disable long polling
- [x] test that: given long polling disabled, when requesting to activate jobs and no jobs available, then response is instantly closed; i.e. requests are not blocked (this test assumes long polling is already sufficiently tested)
- [x] test that: given long polling disabled, when requesting to activate jobs and jobs available, then jobs are provided in response.