### PR TITLE
fix(exporters/elasticsearch-exporter): custom headers

### DIFF
--- a/exporters/elasticsearch-exporter/pom.xml
+++ b/exporters/elasticsearch-exporter/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Elasticsearch Exporter</name>
@@ -78,6 +80,18 @@
     <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -53,8 +53,7 @@
                   "type": "long"
                 },
                 "customHeaders": {
-                  "dynamic": true,
-                  "type": "object"
+                  "enabled": false
                 },
                 "worker": {
                   "type": "keyword"

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -37,8 +37,7 @@
               "type": "long"
             },
             "customHeaders": {
-              "dynamic": true,
-              "type": "object"
+              "enabled": false
             },
             "worker": {
               "type": "keyword"

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterAuthenticationIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterAuthenticationIT.java
@@ -16,7 +16,8 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
-public class ElasticsearchExporterIT extends AbstractElasticsearchExporterIntegrationTestCase {
+public class ElasticsearchExporterAuthenticationIT
+    extends AbstractElasticsearchExporterIntegrationTestCase {
   @Parameter(0)
   public String name;
 

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterJobRecordIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterJobRecordIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.client.api.worker.JobWorker;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.protocol.record.intent.JobBatchIntent;
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ElasticsearchExporterJobRecordIT
+    extends AbstractElasticsearchExporterIntegrationTestCase {
+
+  private JobWorker jobWorker;
+
+  @Before
+  public void init() {
+    elastic.start();
+
+    configuration = getDefaultConfiguration();
+    esClient = createElasticsearchClient(configuration);
+
+    exporterBrokerRule.configure("es", ElasticsearchExporter.class, configuration);
+    exporterBrokerRule.start();
+  }
+
+  @After
+  public void cleanUp() {
+    if (jobWorker != null) {
+      jobWorker.close();
+    }
+  }
+
+  @Test
+  public void shouldExportJobRecordWithCustomHeaders() {
+    // when
+    exporterBrokerRule.deployWorkflow(
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t -> t.zeebeJobType("test").zeebeTaskHeader("x", "1").zeebeTaskHeader("y", "2"))
+            .endEvent()
+            .done(),
+        "process.bpmn");
+
+    final var workflowInstanceKey = exporterBrokerRule.createWorkflowInstance("process", Map.of());
+
+    // then
+    final var jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .getFirst();
+
+    assertRecordExported(jobCreated);
+  }
+
+  @Test
+  public void shouldExportJobRecordWithOverlappingCustomHeaders() {
+    // when
+    exporterBrokerRule.deployWorkflow(
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t -> t.zeebeJobType("test").zeebeTaskHeader("x", "1").zeebeTaskHeader("x.y", "2"))
+            .endEvent()
+            .done(),
+        "process.bpmn");
+
+    final var workflowInstanceKey = exporterBrokerRule.createWorkflowInstance("process", Map.of());
+
+    // then
+    final var jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .getFirst();
+
+    assertRecordExported(jobCreated);
+  }
+
+  @Test
+  public void shouldExportJobBatchRecordWithOverlappingCustomHeaders() {
+    // when
+    exporterBrokerRule.deployWorkflow(
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t -> t.zeebeJobType("test").zeebeTaskHeader("x", "1").zeebeTaskHeader("x.y", "2"))
+            .endEvent()
+            .done(),
+        "process.bpmn");
+
+    final var workflowInstanceKey = exporterBrokerRule.createWorkflowInstance("process", Map.of());
+
+    final var jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .getFirst();
+
+    jobWorker =
+        exporterBrokerRule.createJobWorker(
+            "test", ((client, job) -> client.newCompleteCommand(job.getKey()).send()));
+
+    // then
+    final var jobBatchActivated =
+        RecordingExporter.jobBatchRecords(JobBatchIntent.ACTIVATED).withType("test").getFirst();
+
+    assertThat(jobBatchActivated.getValue().getJobKeys()).contains(jobCreated.getKey());
+    assertRecordExported(jobBatchActivated);
+  }
+}


### PR DESCRIPTION
## Description

* service tasks with custom headers that contain a dot can lead to mapping failures in ES
* avoid mapping failures by disabling the index of custom headers for job and job batch records

## Related issues

closes #4640 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
