### PR TITLE
fix(exporters/elasticsearch-exporter): report ES errors on flush

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
@@ -44,15 +44,6 @@ public class ElasticsearchExporter implements Exporter {
     context.setFilter(new ElasticsearchRecordFilter(configuration));
   }
 
-  private void validate(final ElasticsearchExporterConfiguration configuration) {
-    if (configuration.index.prefix != null && configuration.index.prefix.contains("_")) {
-      throw new ExporterException(
-          String.format(
-              "Elasticsearch prefix must not contain underscore. Current value: %s",
-              configuration.index.prefix));
-    }
-  }
-
   @Override
   public void open(final Controller controller) {
     this.controller = controller;
@@ -91,6 +82,15 @@ public class ElasticsearchExporter implements Exporter {
 
     if (client.shouldFlush()) {
       flush();
+    }
+  }
+
+  private void validate(final ElasticsearchExporterConfiguration configuration) {
+    if (configuration.index.prefix != null && configuration.index.prefix.contains("_")) {
+      throw new ExporterException(
+          String.format(
+              "Elasticsearch prefix must not contain underscore. Current value: %s",
+              configuration.index.prefix));
     }
   }
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/BulkItem.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/BulkItem.java
@@ -8,27 +8,17 @@
 package io.zeebe.exporter.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class BulkResponse {
+public final class BulkItem {
 
-  private boolean errors;
-  private List<BulkItem> items;
+  private BulkItemIndex index;
 
-  public List<BulkItem> getItems() {
-    return items;
+  public BulkItemIndex getIndex() {
+    return index;
   }
 
-  public void setItems(final List<BulkItem> items) {
-    this.items = items;
-  }
-
-  public void setErrors(final boolean errors) {
-    this.errors = errors;
-  }
-
-  public boolean hasErrors() {
-    return errors;
+  public void setIndex(final BulkItemIndex index) {
+    this.index = index;
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/BulkItemError.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/BulkItemError.java
@@ -8,27 +8,26 @@
 package io.zeebe.exporter.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class BulkResponse {
+public final class BulkItemError {
 
-  private boolean errors;
-  private List<BulkItem> items;
+  private String type;
+  private String reason;
 
-  public List<BulkItem> getItems() {
-    return items;
+  public String getType() {
+    return type;
   }
 
-  public void setItems(final List<BulkItem> items) {
-    this.items = items;
+  public void setType(final String type) {
+    this.type = type;
   }
 
-  public void setErrors(final boolean errors) {
-    this.errors = errors;
+  public String getReason() {
+    return reason;
   }
 
-  public boolean hasErrors() {
-    return errors;
+  public void setReason(final String reason) {
+    this.reason = reason;
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/BulkItemIndex.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/BulkItemIndex.java
@@ -8,27 +8,26 @@
 package io.zeebe.exporter.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class BulkResponse {
+public final class BulkItemIndex {
 
-  private boolean errors;
-  private List<BulkItem> items;
+  private int status;
+  private BulkItemError error;
 
-  public List<BulkItem> getItems() {
-    return items;
+  public int getStatus() {
+    return status;
   }
 
-  public void setItems(final List<BulkItem> items) {
-    this.items = items;
+  public void setStatus(final int status) {
+    this.status = status;
   }
 
-  public void setErrors(final boolean errors) {
-    this.errors = errors;
+  public BulkItemError getError() {
+    return error;
   }
 
-  public boolean hasErrors() {
-    return errors;
+  public void setError(final BulkItemError error) {
+    this.error = error;
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/PutIndexTemplateResponse.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/PutIndexTemplateResponse.java
@@ -11,9 +11,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class PutIndexTemplateResponse {
+
   private boolean acknowledged;
 
   public boolean isAcknowledged() {
     return acknowledged;
+  }
+
+  public void setAcknowledged(final boolean acknowledged) {
+    this.acknowledged = acknowledged;
   }
 }


### PR DESCRIPTION
## Description

* fix deserialization of bulk response
* log errors from bulk response
* mark flush as not successful to try it again

## Related issues

closes #4667 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
