### PR TITLE
test(qa/integration-tests): improve test stability

### DIFF
--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SingleBrokerDataDeletionTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SingleBrokerDataDeletionTest.java
@@ -55,6 +55,9 @@ public class SingleBrokerDataDeletionTest {
     // given
     final Broker broker = clusteringRule.getBroker(0);
 
+    final var logstream = clusteringRule.getLogStream(1);
+    final var reader = logstream.newLogStreamReader().join();
+
     while (getSegmentsCount(broker) <= 2) {
       writeToLog();
     }
@@ -74,10 +77,9 @@ public class SingleBrokerDataDeletionTest {
     final var firstSnapshot = clusteringRule.waitForSnapshotAtBroker(broker);
 
     // then
-    final var logstream = clusteringRule.getLogStream(1);
-    final var reader = logstream.newLogStreamReader().join();
     final var firstNonExportedPosition =
         ControllableExporter.NOT_EXPORTED_RECORDS.get(0).getPosition();
+
     reader.seek(firstNonExportedPosition);
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().getPosition()).isEqualTo(firstNonExportedPosition);


### PR DESCRIPTION
## Description

* open the log reader first to avoid concurrent access to the log (e.g. during log compaction)

## Related issues

closes #4430

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
