### PR TITLE
[BACKPORT] chore(broker): close and recreate logstream on role transition

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
@@ -33,14 +33,7 @@ public final class LeaderManagementRequestHandler extends Actor implements Parti
   @Override
   public void onBecomingFollower(
       final int partitionId, final long term, final LogStream logStream) {
-    actor.submit(
-        () -> {
-          final var recordWriter = leaderForPartitions.remove(partitionId);
-
-          if (recordWriter != null) {
-            recordWriter.close();
-          }
-        });
+    actor.submit(() -> leaderForPartitions.remove(partitionId));
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -197,11 +197,7 @@ final class CommandApiRequestHandler implements RequestHandler {
   void removePartition(final LogStream logStream) {
     cmdQueue.add(
         () -> {
-          final var recordWriter = leadingStreams.remove(logStream.getPartitionId());
-          if (recordWriter != null) {
-            recordWriter.close();
-          }
-
+          leadingStreams.remove(logStream.getPartitionId());
           partitionLimiters.remove(logStream.getPartitionId());
         });
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/NoopTypedStreamWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/NoopTypedStreamWriter.java
@@ -85,9 +85,4 @@ final class NoopTypedStreamWriter implements TypedStreamWriter {
   public long flush() {
     return 0;
   }
-
-  @Override
-  public void close() {
-    // no op implementation
-  }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -155,7 +155,6 @@ public class StreamProcessor extends Actor {
   @Override
   protected void onActorClosing() {
     processingContext.getLogStreamReader().close();
-    processingContext.getLogStreamWriter().close();
 
     if (onCommitPositionUpdatedCondition != null) {
       logStream.removeOnCommitPositionUpdatedCondition(onCommitPositionUpdatedCondition);

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriter.java
@@ -10,11 +10,10 @@ package io.zeebe.engine.processor;
 import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.intent.Intent;
-import io.zeebe.util.CloseableSilently;
 import java.util.function.Consumer;
 
 /** Things that any actor can write to a partition. */
-public interface TypedCommandWriter extends CloseableSilently {
+public interface TypedCommandWriter {
 
   void appendNewCommand(Intent intent, UnpackedObject value);
 

--- a/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/TypedCommandWriterImpl.java
@@ -120,9 +120,4 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
   public long flush() {
     return batchWriter.tryWrite();
   }
-
-  @Override
-  public void close() {
-    batchWriter.close();
-  }
 }

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -370,7 +370,6 @@ public final class TestStreams {
 
     @Override
     public void close() {
-      logStreamWriter.close();
       logStream.close();
       logStorageRule.close();
     }

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamBatchWriterImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamBatchWriterImpl.java
@@ -60,13 +60,10 @@ public final class LogStreamBatchWriterImpl implements LogStreamBatchWriter, Log
 
   private BufferWriter metadataWriter;
   private BufferWriter valueWriter;
-  private final Runnable closeCallback;
 
-  LogStreamBatchWriterImpl(
-      final int partitionId, final Dispatcher dispatcher, final Runnable closeCallback) {
+  LogStreamBatchWriterImpl(final int partitionId, final Dispatcher dispatcher) {
     this.logWriteBuffer = dispatcher;
     this.logId = partitionId;
-    this.closeCallback = closeCallback;
 
     reset();
   }
@@ -293,10 +290,5 @@ public final class LogStreamBatchWriterImpl implements LogStreamBatchWriter, Log
 
     bufferWriterInstance.reset();
     metadataWriterInstance.reset();
-  }
-
-  @Override
-  public void close() {
-    closeCallback.run();
   }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamWriterImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamWriterImpl.java
@@ -39,13 +39,10 @@ public final class LogStreamWriterImpl implements LogStreamRecordWriter {
   private long sourceRecordPosition = -1L;
   private BufferWriter metadataWriter;
   private BufferWriter valueWriter;
-  private final Runnable closeCallback;
 
-  LogStreamWriterImpl(
-      final int partitionId, final Dispatcher logWriteBuffer, final Runnable closeCallback) {
+  LogStreamWriterImpl(final int partitionId, final Dispatcher logWriteBuffer) {
     this.logWriteBuffer = logWriteBuffer;
     this.partitionId = partitionId;
-    this.closeCallback = closeCallback;
 
     reset();
   }
@@ -170,10 +167,5 @@ public final class LogStreamWriterImpl implements LogStreamRecordWriter {
     } while (claimedPosition == RESULT_PADDING_AT_END_OF_PARTITION);
 
     return claimedPosition - DataFrameDescriptor.alignedFramedLength(framedLength);
-  }
-
-  @Override
-  public void close() {
-    closeCallback.run();
   }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamWriter.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/log/LogStreamWriter.java
@@ -7,9 +7,7 @@
  */
 package io.zeebe.logstreams.log;
 
-import io.zeebe.util.CloseableSilently;
-
-public interface LogStreamWriter extends CloseableSilently {
+public interface LogStreamWriter {
 
   /**
    * Attempts to write the event to the underlying stream.

--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -71,7 +71,7 @@ public final class LogStorageAppenderTest {
     appender =
         new LogStorageAppender(
             "appender", PARTITION_ID, logStorage, subscription, MAX_FRAGMENT_SIZE);
-    writer = new LogStreamWriterImpl(PARTITION_ID, dispatcher, () -> {});
+    writer = new LogStreamWriterImpl(PARTITION_ID, dispatcher);
     reader = new LogStreamReaderImpl(logStorage);
   }
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamBatchWriterTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamBatchWriterTest.java
@@ -414,4 +414,16 @@ public final class LogStreamBatchWriterTest {
     // then
     assertThat(pos).isEqualTo(0);
   }
+
+  @Test
+  public void shouldFailToWriteOnClosedLogStream() {
+    // given
+    logStreamRule.getLogStream().close();
+
+    // when
+    final long pos = writer.event().key(1).value(EVENT_VALUE_1).done().tryWrite();
+
+    // then
+    assertThat(pos).isEqualTo(-1);
+  }
 }

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamTest.java
@@ -92,6 +92,25 @@ public final class LogStreamTest {
     assertThatThrownBy(() -> logStream.newLogStreamBatchWriter()).hasMessage("Actor is closed");
   }
 
+  @Test
+  public void shouldIncreasePositionOnRestart() {
+    // given
+    final LogStreamRecordWriter writer = logStream.newLogStreamRecordWriter();
+    writer.value(wrapString("value")).tryWrite();
+    writer.value(wrapString("value")).tryWrite();
+    writer.value(wrapString("value")).tryWrite();
+    final long positionBeforeClose = writer.value(wrapString("value")).tryWrite();
+
+    // when
+    logStream.close();
+    logStreamRule.createLogStream();
+    final LogStreamRecordWriter newWriter = logStreamRule.getLogStream().newLogStreamRecordWriter();
+    final long positionAfterReOpen = newWriter.value(wrapString("value")).tryWrite();
+
+    // then
+    assertThat(positionAfterReOpen).isGreaterThan(positionBeforeClose);
+  }
+
   static long writeEvent(final SynchronousLogStream logStream) {
     return writeEvent(logStream, wrapString("event"));
   }

--- a/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamWriterTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/log/LogStreamWriterTest.java
@@ -62,7 +62,6 @@ public final class LogStreamWriterTest {
 
   @After
   public void tearDown() {
-    writer.close();
     writer = null;
   }
 
@@ -195,8 +194,6 @@ public final class LogStreamWriterTest {
     final long firstPosition = writer.key(123L).value(EVENT_VALUE).tryWrite();
 
     // when
-    writer.close();
-
     final SynchronousLogStream logStream = logStreamRule.getLogStream();
     writer = logStream.newLogStreamRecordWriter();
     final long secondPosition = writer.key(124L).value(EVENT_VALUE).tryWrite();
@@ -214,7 +211,6 @@ public final class LogStreamWriterTest {
     writerRule.waitForPositionToBeAppended(firstPosition);
 
     // when
-    writer.close();
     writerRule.closeWriter();
 
     final SynchronousLogStream logStream = logStreamRule.getLogStream();

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamRule.java
@@ -69,7 +69,7 @@ public final class LogStreamRule extends ExternalResource {
       final UnaryOperator<Builder> builder) {
     logStorageRule = new AtomixLogStorageRule(temporaryFolder);
     this.logStorageRule.open(builder);
-    startLogStream();
+    createLogStream();
     return logStream;
   }
 
@@ -79,7 +79,7 @@ public final class LogStreamRule extends ExternalResource {
     actorSchedulerRule.before();
 
     if (shouldStartByDefault) {
-      startLogStream();
+      createLogStream();
     }
   }
 
@@ -90,7 +90,7 @@ public final class LogStreamRule extends ExternalResource {
     actorSchedulerRule.after();
   }
 
-  private void startLogStream() {
+  public void createLogStream() {
     final ActorScheduler actorScheduler = actorSchedulerRule.get();
 
     if (logStorageRule == null) {

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamWriterRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/LogStreamWriterRule.java
@@ -36,10 +36,7 @@ public final class LogStreamWriterRule extends ExternalResource {
   }
 
   public void closeWriter() {
-    if (logStreamWriter != null) {
-      logStreamWriter.close();
-      logStreamWriter = null;
-    }
+    logStreamWriter = null;
   }
 
   public long writeEvents(final int count, final DirectBuffer event) {


### PR DESCRIPTION
chore(logstream): remove reference counting on logstream writers
## Description

Backport #3995

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4698 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
