### PR TITLE
chore(benchmark): enable starters to create workflow with results

### DIFF
--- a/benchmarks/project/src/main/java/io/zeebe/Starter.java
+++ b/benchmarks/project/src/main/java/io/zeebe/Starter.java
@@ -68,13 +68,25 @@ public class Starter extends App {
     executorService.scheduleAtFixedRate(
         () -> {
           try {
-            requestFutures.put(
-                client
-                    .newCreateInstanceCommand()
-                    .bpmnProcessId(processId)
-                    .latestVersion()
-                    .variables(variables)
-                    .send());
+            if (starterCfg.isWithResults()) {
+              requestFutures.put(
+                  client
+                      .newCreateInstanceCommand()
+                      .bpmnProcessId(processId)
+                      .latestVersion()
+                      .variables(variables)
+                      .withResult()
+                      .requestTimeout(starterCfg.getWithResultsTimeout())
+                      .send());
+            } else {
+              requestFutures.put(
+                  client
+                      .newCreateInstanceCommand()
+                      .bpmnProcessId(processId)
+                      .latestVersion()
+                      .variables(variables)
+                      .send());
+            }
           } catch (Exception e) {
             LOG.error("Error on creating new workflow instance", e);
           }

--- a/benchmarks/project/src/main/java/io/zeebe/config/StarterCfg.java
+++ b/benchmarks/project/src/main/java/io/zeebe/config/StarterCfg.java
@@ -15,6 +15,8 @@
  */
 package io.zeebe.config;
 
+import java.time.Duration;
+
 public class StarterCfg {
 
   private String processId;
@@ -25,6 +27,8 @@ public class StarterCfg {
   private String bpmnXmlPath;
 
   private String payloadPath;
+  private boolean withResults;
+  private Duration withResultsTimeout;
 
   public String getProcessId() {
     return processId;
@@ -64,5 +68,21 @@ public class StarterCfg {
 
   public void setPayloadPath(String payloadPath) {
     this.payloadPath = payloadPath;
+  }
+
+  public boolean isWithResults() {
+    return this.withResults;
+  }
+
+  public void setWithResults(boolean withResults) {
+    this.withResults = withResults;
+  }
+
+  public Duration getWithResultsTimeout() {
+    return withResultsTimeout;
+  }
+
+  public void setWithResultsTimeout(Duration withResultsTimeout) {
+    this.withResultsTimeout = withResultsTimeout;
   }
 }

--- a/benchmarks/project/src/main/resources/application.conf
+++ b/benchmarks/project/src/main/resources/application.conf
@@ -10,6 +10,8 @@ app {
     threads = 2
     bpmnXmlPath = "bpmn/one_task.bpmn"
     payloadPath = "bpmn/big_payload.json"
+    withResults = false
+    withResultsTimeout = 60s
   }
 
   worker {


### PR DESCRIPTION
## Description

Enable benchmark starters to create workflow with await results. This would enable us to better monitor overall workflow latency as observed by a client. 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
