### PR TITLE
Whether the client 'RequestTimeout' configuration should be set to seconds

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -153,7 +153,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     }
     if (properties.containsKey(DEFAULT_REQUEST_TIMEOUT)) {
       defaultRequestTimeout(
-          Duration.ofMillis(Long.parseLong(properties.getProperty(DEFAULT_REQUEST_TIMEOUT))));
+          Duration.ofSeconds(Long.parseLong(properties.getProperty(DEFAULT_REQUEST_TIMEOUT))));
     }
     if (properties.containsKey(USE_PLAINTEXT_CONNECTION)) {
       /**


### PR DESCRIPTION
descriptionWhether the client RequestTimeout configuration should be set to seconds. The configuration in milliseconds is very easy to cause misunderstanding, which leads to timeout exception