### PR TITLE
Whether the client 'RequestTimeout' configuration should be set to seconds

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -153,7 +153,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     }
     if (properties.containsKey(DEFAULT_REQUEST_TIMEOUT)) {
       defaultRequestTimeout(
-          Duration.ofMillis(Long.parseLong(properties.getProperty(DEFAULT_REQUEST_TIMEOUT))));
+          Duration.ofSeconds(Long.parseLong(properties.getProperty(DEFAULT_REQUEST_TIMEOUT))));
     }
     if (properties.containsKey(USE_PLAINTEXT_CONNECTION)) {
       /**

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -153,7 +153,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     }
     if (properties.containsKey(DEFAULT_REQUEST_TIMEOUT)) {
       defaultRequestTimeout(
-          Duration.ofSeconds(Long.parseLong(properties.getProperty(DEFAULT_REQUEST_TIMEOUT))));
+          Duration.ofMillis(Long.parseLong(properties.getProperty(DEFAULT_REQUEST_TIMEOUT))));
     }
     if (properties.containsKey(USE_PLAINTEXT_CONNECTION)) {
       /**


### PR DESCRIPTION
## Description
Whether the client 'RequestTimeout' configuration should be set to seconds.
So as not to cause misunderstandings and cause timeout exceptions.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
