### PR TITLE
chore(benchmarks): update benchmark defaults

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -27,6 +27,8 @@ gateway:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
 
 # Uncomment to add custom YAML configuration
 # This will overwrite anything at the application.yml location
@@ -66,6 +68,8 @@ env:
       -Dzeebe.broker.exporters.elasticsearch.args.index.ignoreVariablesAbove=32767
   - name: ZEEBE_BROKER_EXECUTION_METRICS_EXPORTER_ENABLED
     value: "true"
+  - name: ATOMIX_LOG_LEVEL
+    value: INFO
 
 # RESOURCES
 resources:

--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -29,6 +29,8 @@ gateway:
           fieldPath: metadata.namespace
     - name: ATOMIX_LOG_LEVEL
       value: INFO
+    - name: ZEEBE_GATEWAY_MONITORING_ENABLED
+      value: "true"
 
 # Uncomment to add custom YAML configuration
 # This will overwrite anything at the application.yml location

--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -18,6 +18,15 @@ podSecurityContext:
 gateway:
   replicas: 1
   logLevel: debug
+  env:
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe-gateway
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
 
 # Uncomment to add custom YAML configuration
 # This will overwrite anything at the application.yml location
@@ -45,6 +54,16 @@ env:
   # Enable JSON logging for google cloud stackdriver
   - name: ZEEBE_LOG_APPENDER
     value: Stackdriver
+  - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+    value: zeebe-broker
+  - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  # Avoid tons of noise when exporting larger payloads
+  - name: JAVA_OPTS
+    value: >-
+      -Dzeebe.broker.exporters.elasticsearch.args.index.ignoreVariablesAbove=32767
   - name: ZEEBE_BROKER_EXECUTION_METRICS_EXPORTER_ENABLED
     value: "true"
 

--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -31,6 +31,8 @@ gateway:
       value: INFO
     - name: ZEEBE_GATEWAY_MONITORING_ENABLED
       value: "true"
+    - name: ZEEBE_GATEWAY_THREADS_MANAGEMENTTHREADS
+      value: "4"
 
 # Uncomment to add custom YAML configuration
 # This will overwrite anything at the application.yml location


### PR DESCRIPTION
## Description

This PR updates the bench mark defaults to set the correct log service name and version for the new Stackdriver layout, as well as increasing the default ES ignoreVariablesAbove to avoid hundreds of thousands of warnings.

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
