### PR TITLE
test(qa/integration-tests): increase test stability

### DIFF
--- a/.ci/scripts/distribution/it-java.sh
+++ b/.ci/scripts/distribution/it-java.sh
@@ -18,7 +18,7 @@ if grep -q "\[WARNING\] Flakes:" ${tmpfile}; then
   grep "\[ERROR\]   Run 1: " ${tmpfile} | awk '{print $4}' >> ./target/FlakyTests.txt
 
   echo ERROR: Flaky Tests detected>&2
-  
+
   exit 1
 fi
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -154,7 +154,7 @@ public final class ClusteringRule extends ExternalResource {
 
     brokers = new HashMap<>();
     brokerCfgs = new HashMap<>();
-    this.partitionIds =
+    partitionIds =
         IntStream.range(START_PARTITION_ID, START_PARTITION_ID + partitionCount)
             .boxed()
             .collect(Collectors.toList());
@@ -369,7 +369,7 @@ public final class ClusteringRule extends ExternalResource {
             () -> {
               try {
                 return client.newTopologyRequest().send().join();
-              } catch (Exception e) {
+              } catch (final Exception e) {
                 LOG.trace("Topology request failed: ", e);
                 return null;
               }
@@ -681,7 +681,7 @@ public final class ClusteringRule extends ExternalResource {
     private final CountDownLatch latch;
 
     LeaderListener(final int partitionCount) {
-      this.latch = new CountDownLatch(partitionCount);
+      latch = new CountDownLatch(partitionCount);
     }
 
     @Override


### PR DESCRIPTION
## Description

* write more segments to ensure that the log can be compacted
* favor `waitUntil()` instead of `assertThat()` because the log is compacted asynchronously

## Related issues

closes #4519 
closes #4430

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
