### PR TITLE
fix(exporters/elasticsearch-exporter): reduce log messages if flush fails

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
@@ -113,11 +113,8 @@ public class ElasticsearchExporter implements Exporter {
   }
 
   private void flush() {
-    if (client.flush()) {
-      controller.updateLastExportedRecordPosition(lastPosition);
-    } else {
-      log.warn("Failed to flush bulk completely");
-    }
+    client.flush();
+    controller.updateLastExportedRecordPosition(lastPosition);
   }
 
   private void createIndexTemplates() {

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/BulkItemError.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/BulkItemError.java
@@ -12,8 +12,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class BulkItemError {
 
-  private String type;
-  private String reason;
+  private String type = "";
+  private String reason = "";
 
   public String getType() {
     return type;

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/BulkResponse.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/dto/BulkResponse.java
@@ -8,13 +8,14 @@
 package io.zeebe.exporter.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Collections;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class BulkResponse {
 
   private boolean errors;
-  private List<BulkItem> items;
+  private List<BulkItem> items = Collections.emptyList();
 
   public List<BulkItem> getItems() {
     return items;

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -301,7 +302,7 @@ public class ElasticsearchExporterTest {
   public void shouldNotHandleFlushException() {
     // given
     when(esClient.shouldFlush()).thenReturn(true);
-    when(esClient.flush()).thenThrow(new ElasticsearchExporterException("expected"));
+    doThrow(new ElasticsearchExporterException("expected")).when(esClient).flush();
 
     createAndOpenExporter();
 
@@ -366,7 +367,6 @@ public class ElasticsearchExporterTest {
 
   private ElasticsearchClient mockElasticsearchClient() {
     final ElasticsearchClient client = mock(ElasticsearchClient.class);
-    when(client.flush()).thenReturn(true);
     when(client.putIndexTemplate(any(ValueType.class))).thenReturn(true);
     when(client.putIndexTemplate(anyString(), anyString(), anyString())).thenReturn(true);
     return client;


### PR DESCRIPTION
## Description

* log an error on flush only once per error type
* throw an exception if the flush operation fails
* the operation is retried using the backoff strategy
* avoid NPE on collecting errors

## Related issues

closes #4722 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
