### PR TITLE
fix(project): fixes Tomcat to 9.0.35 due to CVE-2020-9484

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -85,6 +85,7 @@
     <version.restassert>4.3.0</version.restassert>
     <version.spring-framework>5.2.7.RELEASE</version.spring-framework>
     <version.spring-boot>2.3.1.RELEASE</version.spring-boot>
+    <version.tomcat>9.0.35</version.tomcat>
     <version.classgraph>4.8.86</version.classgraph>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.config>1.4.0</version.config>
@@ -629,6 +630,16 @@
             <artifactId>log4j-to-slf4j</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

This PR fixes the previously not fixed Tomcat version to 9.0.35 (was previous resolved to 9.0.30), due to a security vulnerability in 9.0.30. This does not affect any production versions at the moment.

## Related issues

closes #4733 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
