### PR TITLE
[BACKPORT] fix(util): handle large messages in StackdriverLayout

### DIFF
--- a/util/src/main/java/io/zeebe/util/logging/ByteBufferDestinationOutputStream.java
+++ b/util/src/main/java/io/zeebe/util/logging/ByteBufferDestinationOutputStream.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util.logging;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import org.apache.logging.log4j.core.layout.ByteBufferDestination;
+
+public final class ByteBufferDestinationOutputStream extends OutputStream {
+  private final ByteBufferDestination destination;
+
+  public ByteBufferDestinationOutputStream(final ByteBufferDestination destination) {
+    this.destination = destination;
+  }
+
+  @Override
+  public void write(final int b) throws IOException {
+    final var bytes = new byte[] {(byte) b};
+    write(bytes);
+  }
+
+  @Override
+  public void write(final byte[] bytes) throws IOException {
+    write(bytes, 0, bytes.length);
+  }
+
+  @Override
+  public void write(final byte[] bytes, final int off, final int len) throws IOException {
+    destination.writeBytes(bytes, off, len);
+  }
+}

--- a/util/src/main/java/io/zeebe/util/logging/StackdriverLayout.java
+++ b/util/src/main/java/io/zeebe/util/logging/StackdriverLayout.java
@@ -9,7 +9,6 @@ package io.zeebe.util.logging;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.util.ByteBufferBackedOutputStream;
 import io.zeebe.util.logging.stackdriver.StackdriverLogEntry;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -105,7 +104,7 @@ public final class StackdriverLayout extends AbstractLayout<byte[]> implements L
   public void encode(final LogEvent event, final ByteBufferDestination destination) {
     final var entry = buildLogEntry(event);
 
-    try (final var output = new ByteBufferBackedOutputStream(destination.getByteBuffer())) {
+    try (final var output = new ByteBufferDestinationOutputStream(destination)) {
       WRITER.writeValue(output, entry);
       output.write(LINE_SEPARATOR);
     } catch (final IOException e) {

--- a/util/src/test/java/io/zeebe/util/logging/StackdriverLayoutTest.java
+++ b/util/src/test/java/io/zeebe/util/logging/StackdriverLayoutTest.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.appender.OutputStreamAppender;
 import org.apache.logging.log4j.core.impl.ThrowableProxy;
+import org.apache.logging.log4j.core.util.Constants;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.junit.After;
@@ -368,6 +369,20 @@ public final class StackdriverLayoutTest {
         .containsEntry("message", "Should appear as JSON formatted output")
         .containsEntry("severity", Severity.ERROR.name())
         .containsEntry("logger", logger.getName());
+  }
+
+  @Test
+  public void shouldWriteLargeMessageWithoutOverflow() throws IOException {
+    // given
+    final var largeMessageSize = Constants.ENCODER_BYTE_BUFFER_SIZE * 2;
+    final var largeMessage = "a".repeat(largeMessageSize);
+
+    // when
+    logger.info(largeMessage);
+
+    // then
+    final var jsonMap = readLoggedEvent();
+    softly.assertThat(jsonMap).containsEntry("message", largeMessage);
   }
 
   private Map<String, Object> readLoggedEvent() throws IOException {


### PR DESCRIPTION
## Description

Back ports a fix for the Stackdriver layout to handle messages bigger than its pre-allocated buffer size.

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
