### PR TITLE
chore(bpmn-model): enforce ABI compatibility

### DIFF
--- a/.ci/scripts/release/compat-update.sh
+++ b/.ci/scripts/release/compat-update.sh
@@ -4,7 +4,7 @@ if [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 
   FILE=$(mvn help:evaluate -Dexpression=ignored.changes.file -q -DforceStdout)
 
-  rm -f clients/java/$FILE test/$FILE exporter-api/$FILE protocol/$FILE
+  rm -f clients/java/$FILE test/$FILE exporter-api/$FILE protocol/$FILE bpmn-model/$FILE
 
   git commit -am "chore(project): update backwards compatibility version"
 else

--- a/bpmn-model/pom.xml
+++ b/bpmn-model/pom.xml
@@ -51,4 +51,13 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
## Description

This PR enforces ABI compatibility via clirr.

## Related issues

closes #4222 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
