### PR TITLE
chore(upgrade-tests): reenable oldGatewayWithNewBroker

### DIFF
--- a/upgrade-tests/src/test/java/io/zeebe/test/ContainerStateRule.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/ContainerStateRule.java
@@ -41,7 +41,7 @@ class ContainerStateRule extends TestWatcher {
   }
 
   @Override
-  protected void failed(Throwable e, Description description) {
+  protected void failed(final Throwable e, final Description description) {
     super.failed(e, description);
     if (broker != null) {
       log("Broker", broker.getLogs());
@@ -53,7 +53,7 @@ class ContainerStateRule extends TestWatcher {
   }
 
   @Override
-  protected void finished(Description description) {
+  protected void finished(final Description description) {
     close();
   }
 
@@ -73,6 +73,7 @@ class ContainerStateRule extends TestWatcher {
     broker =
         new ZeebeBrokerContainer(brokerVersion)
             .withFileSystemBind(volumePath, "/usr/local/zeebe/data")
+            .withEnv("ZEEBE_BROKER_CLUSTER_CLUSTERNAME", "zeebe-cluster")
             .withNetwork(network)
             .withEmbeddedGateway(gatewayVersion == null)
             .withLogLevel(Level.DEBUG);
@@ -83,7 +84,8 @@ class ContainerStateRule extends TestWatcher {
     if (gatewayVersion != null) {
       gateway =
           new ZeebeStandaloneGatewayContainer(gatewayVersion)
-              .withContactPoint(broker.getContactPoint())
+              .withEnv("ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT", broker.getContactPoint())
+              .withEnv("ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME", "zeebe-cluster")
               .withNetwork(network)
               .withLogLevel(Level.DEBUG);
       gateway.start();

--- a/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.agrona.IoUtil;
 import org.assertj.core.util.Files;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -171,7 +170,6 @@ public class UpgradeTest {
   }
 
   @Test
-  @Ignore
   public void oldGatewayWithNewBroker() {
     // given
     state


### PR DESCRIPTION
## Description

This PR re-enables the `UpgradeTests#oldGatewayWithNewBroker` test by properly configuring the standalone gateway to connect to the broker.

## Related issues

closes #4314 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
