### PR TITLE
fix(engine): catch error event on multi-instance activity

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/nwe/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/nwe/behavior/BpmnStateTransitionBehavior.java
@@ -259,10 +259,14 @@ public final class BpmnStateTransitionBehavior {
       final BpmnElementContext callActivityContext, final BpmnElementContext childContext) {
     final var workflowKey = callActivityContext.getWorkflowKey();
     final var elementId = callActivityContext.getElementId();
+
     return stateBehavior
         .getWorkflow(workflowKey)
         .map(DeployedWorkflow::getWorkflow)
-        .map(workflow -> workflow.getElementById(elementId, ExecutableCallActivity.class))
+        .map(
+            workflow ->
+                workflow.getElementById(
+                    elementId, BpmnElementType.CALL_ACTIVITY, ExecutableCallActivity.class))
         .orElseThrow(
             () ->
                 new BpmnProcessingException(

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/endevent/ErrorEventHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/endevent/ErrorEventHandler.java
@@ -107,10 +107,13 @@ public final class ErrorEventHandler {
       final ExecutableWorkflow workflow,
       final ElementInstance instance) {
 
-    final var elementId = instance.getValue().getElementIdBuffer();
-    final var activity = workflow.getElementById(elementId, ExecutableActivity.class);
+    final var workflowInstanceRecord = instance.getValue();
+    final var elementId = workflowInstanceRecord.getElementIdBuffer();
+    final var elementType = workflowInstanceRecord.getBpmnElementType();
 
-    for (final ExecutableCatchEvent catchEvent : activity.getEvents()) {
+    final var element = workflow.getElementById(elementId, elementType, ExecutableActivity.class);
+
+    for (final ExecutableCatchEvent catchEvent : element.getEvents()) {
       if (hasErrorCode(catchEvent, errorCode)) {
 
         catchEventTuple.instance = instance;

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/error/ErrorCatchEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/error/ErrorCatchEventTest.java
@@ -83,6 +83,39 @@ public final class ErrorCatchEventTest {
         "error-boundary-event"
       },
       {
+        "boundary event on multi-instance subprocess",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.multiInstance(m -> m.zeebeInputCollectionExpression("[1]"))
+                        .embeddedSubProcess()
+                        .startEvent()
+                        .serviceTask(TASK_ELEMENT_ID, t -> t.zeebeJobType(JOB_TYPE))
+                        .endEvent())
+            .boundaryEvent("error-boundary-event", b -> b.error(ERROR_CODE))
+            .endEvent()
+            .done(),
+        "subprocess",
+        "error-boundary-event"
+      },
+      {
+        "boundary event on multi-instance service task",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                TASK_ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .multiInstance(m -> m.zeebeInputCollectionExpression("[1]")))
+            .boundaryEvent("error-boundary-event", b -> b.error(ERROR_CODE))
+            .endEvent()
+            .done(),
+        TASK_ELEMENT_ID,
+        "error-boundary-event"
+      },
+      {
         "error event subprocess",
         Bpmn.createExecutableProcess(PROCESS_ID)
             .eventSubProcess(


### PR DESCRIPTION
## Description

* be aware of multi-instance activities when looking for an error catch event
* add new helper method to resolve the element based on a given BPMN element type to handle multi-instance activities

## Related issues

closes #4601 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
