### PR TITLE
[Backport] fix(engine): catch error event on multi-instance activity

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableWorkflow.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableWorkflow.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.processor.workflow.deployment.model.element;
 import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
 import static io.zeebe.util.buffer.BufferUtil.wrapString;
 
+import io.zeebe.protocol.record.value.BpmnElementType;
 import java.util.HashMap;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -39,20 +40,46 @@ public class ExecutableWorkflow extends ExecutableFlowElementContainer {
   }
 
   public <T extends ExecutableFlowElement> T getElementById(
-      final DirectBuffer id, final Class<T> expectedType) {
-    final ExecutableFlowElement element = flowElements.get(id);
+      final DirectBuffer id, final Class<T> expectedClass) {
+
+    final var elementType =
+        ExecutableMultiInstanceBody.class.isAssignableFrom(expectedClass)
+            ? BpmnElementType.MULTI_INSTANCE_BODY
+            : BpmnElementType.UNSPECIFIED;
+
+    return getElementById(id, elementType, expectedClass);
+  }
+
+  public <T extends ExecutableFlowElement> T getElementById(
+      final DirectBuffer id, final BpmnElementType elementType, final Class<T> expectedClass) {
+
+    var element = flowElements.get(id);
     if (element == null) {
       return null;
     }
 
-    if (expectedType.isAssignableFrom(element.getClass())) {
+    if (element instanceof ExecutableMultiInstanceBody
+        && elementType != BpmnElementType.MULTI_INSTANCE_BODY) {
+      // the multi-instance body and the inner activity have the same element id
+      final var multiInstanceBody = (ExecutableMultiInstanceBody) element;
+      element = multiInstanceBody.getInnerActivity();
+    }
+
+    if (element.getElementType() != elementType && elementType != BpmnElementType.UNSPECIFIED) {
+      throw new RuntimeException(
+          String.format(
+              "Expected element with id '%s' to be of type '%s', but it is of type '%s'",
+              bufferAsString(id), elementType, element.getElementType()));
+    }
+
+    if (expectedClass.isAssignableFrom(element.getClass())) {
       return (T) element;
     } else {
       throw new RuntimeException(
           String.format(
               "Expected element with id '%s' to be instance of class '%s', but it is an instance of '%s'",
               bufferAsString(id),
-              expectedType.getSimpleName(),
+              expectedClass.getSimpleName(),
               element.getClass().getSimpleName()));
     }
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/endevent/ErrorEventHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/endevent/ErrorEventHandler.java
@@ -107,10 +107,13 @@ public final class ErrorEventHandler {
       final ExecutableWorkflow workflow,
       final ElementInstance instance) {
 
-    final var elementId = instance.getValue().getElementIdBuffer();
-    final var activity = workflow.getElementById(elementId, ExecutableActivity.class);
+    final var workflowInstanceRecord = instance.getValue();
+    final var elementId = workflowInstanceRecord.getElementIdBuffer();
+    final var elementType = workflowInstanceRecord.getBpmnElementType();
 
-    for (final ExecutableCatchEvent catchEvent : activity.getEvents()) {
+    final var element = workflow.getElementById(elementId, elementType, ExecutableActivity.class);
+
+    for (final ExecutableCatchEvent catchEvent : element.getEvents()) {
       if (hasErrorCode(catchEvent, errorCode)) {
 
         catchEventTuple.instance = instance;

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/error/ErrorCatchEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/error/ErrorCatchEventTest.java
@@ -83,6 +83,39 @@ public final class ErrorCatchEventTest {
         "error-boundary-event"
       },
       {
+        "boundary event on multi-instance subprocess",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess(
+                "subprocess",
+                s ->
+                    s.multiInstance(m -> m.zeebeInputCollectionExpression("[1]"))
+                        .embeddedSubProcess()
+                        .startEvent()
+                        .serviceTask(TASK_ELEMENT_ID, t -> t.zeebeJobType(JOB_TYPE))
+                        .endEvent())
+            .boundaryEvent("error-boundary-event", b -> b.error(ERROR_CODE))
+            .endEvent()
+            .done(),
+        "subprocess",
+        "error-boundary-event"
+      },
+      {
+        "boundary event on multi-instance service task",
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                TASK_ELEMENT_ID,
+                t ->
+                    t.zeebeJobType(JOB_TYPE)
+                        .multiInstance(m -> m.zeebeInputCollectionExpression("[1]")))
+            .boundaryEvent("error-boundary-event", b -> b.error(ERROR_CODE))
+            .endEvent()
+            .done(),
+        TASK_ELEMENT_ID,
+        "error-boundary-event"
+      },
+      {
         "error event subprocess",
         Bpmn.createExecutableProcess(PROCESS_ID)
             .eventSubProcess(


### PR DESCRIPTION
## Description

* be aware of multi-instance activities when looking for an error catch event
* add new helper method to resolve the element based on a given BPMN element type to handle multi-instance activities

## Related issues

closes #4601 

Backport of #4751 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
