### PR TITLE
[Backport] fix(engine): catch error event on multi-instance activity

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableWorkflow.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/deployment/model/element/ExecutableWorkflow.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.processor.workflow.deployment.model.element;
 import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
 import static io.zeebe.util.buffer.BufferUtil.wrapString;
 
+import io.zeebe.protocol.record.value.BpmnElementType;
 import java.util.HashMap;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -39,20 +40,46 @@ public class ExecutableWorkflow extends ExecutableFlowElementContainer {
   }
 
   public <T extends ExecutableFlowElement> T getElementById(
-      final DirectBuffer id, final Class<T> expectedType) {
-    final ExecutableFlowElement element = flowElements.get(id);
+      final DirectBuffer id, final Class<T> expectedClass) {
+
+    final var elementType =
+        ExecutableMultiInstanceBody.class.isAssignableFrom(expectedClass)
+            ? BpmnElementType.MULTI_INSTANCE_BODY
+            : BpmnElementType.UNSPECIFIED;
+
+    return getElementById(id, elementType, expectedClass);
+  }
+
+  public <T extends ExecutableFlowElement> T getElementById(
+      final DirectBuffer id, final BpmnElementType elementType, final Class<T> expectedClass) {
+
+    var element = flowElements.get(id);
     if (element == null) {
       return null;
     }
 
-    if (expectedType.isAssignableFrom(element.getClass())) {
+    if (element instanceof ExecutableMultiInstanceBody
+        && elementType != BpmnElementType.MULTI_INSTANCE_BODY) {
+      // the multi-instance body and the inner activity have the same element id
+      final var multiInstanceBody = (ExecutableMultiInstanceBody) element;
+      element = multiInstanceBody.getInnerActivity();
+    }
+
+    if (element.getElementType() != elementType && elementType != BpmnElementType.UNSPECIFIED) {
+      throw new RuntimeException(
+          String.format(
+              "Expected element with id '%s' to be of type '%s', but it is of type '%s'",
+              bufferAsString(id), elementType, element.getElementType()));
+    }
+
+    if (expectedClass.isAssignableFrom(element.getClass())) {
       return (T) element;
     } else {
       throw new RuntimeException(
           String.format(
               "Expected element with id '%s' to be instance of class '%s', but it is an instance of '%s'",
               bufferAsString(id),
-              expectedType.getSimpleName(),
+              expectedClass.getSimpleName(),
               element.getClass().getSimpleName()));
     }
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobErrorThrownProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/job/JobErrorThrownProcessor.java
@@ -112,7 +112,9 @@ public class JobErrorThrownProcessor implements TypedRecordProcessor<JobRecord> 
     // assuming that error events are used rarely
     // - just walk through the scope hierarchy and look for a matching boundary event
     final var elementId = instance.getValue().getElementIdBuffer();
-    final var activity = workflow.getElementById(elementId, ExecutableActivity.class);
+    final var elementType = instance.getValue().getBpmnElementType();
+
+    final var activity = workflow.getElementById(elementId, elementType, ExecutableActivity.class);
 
     for (final ExecutableCatchEvent catchEvent : activity.getEvents()) {
       if (hasErrorCode(catchEvent, errorCode)) {


### PR DESCRIPTION
## Description

* be aware of multi-instance activities when looking for an error catch event
* add new helper method to resolve the element based on a given BPMN element type to handle multi-instance activities

## Related issues

closes #4601 

Backport of #4751 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
