### PR TITLE
chore(dist): gateway does not look for system partition

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -42,11 +42,6 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>atomix</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.zeebe</groupId>
       <artifactId>atomix-cluster</artifactId>
     </dependency>
 

--- a/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/zeebe/gateway/StandaloneGateway.java
@@ -11,7 +11,6 @@ import static java.lang.Runtime.getRuntime;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
-import io.atomix.core.Atomix;
 import io.atomix.utils.net.Address;
 import io.zeebe.gateway.impl.SpringGatewayBridge;
 import io.zeebe.gateway.impl.broker.BrokerClient;
@@ -54,7 +53,7 @@ public class StandaloneGateway {
 
   private AtomixCluster createAtomixCluster(final ClusterCfg clusterCfg) {
     final var atomix =
-        Atomix.builder()
+        AtomixCluster.builder()
             .withMemberId(clusterCfg.getMemberId())
             .withAddress(Address.from(clusterCfg.getHost(), clusterCfg.getPort()))
             .withClusterId(clusterCfg.getClusterName())


### PR DESCRIPTION
## Description

This PR changes the way the standalone gateway connects to the cluster. Previously, it would join the cluster membership service as well as the partition group membership service; now, it only joins the cluster membership service. As the gateway will not host any partitions, it isn't necessary for it to join any group.

## Related issues

closes #4539 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
