### PR TITLE
Probe components health when partition is probed

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -27,6 +27,61 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
+/*
+ * There's 2 ways BrokerHealthCheckService can monitor its current healthstatus:
+ *
+ *  - listening for failures: in which a subcomponent tells its parent component that a failure
+ *   occurred, so that the healthstatus can be updated for all ancestor components. All of the
+ *   subcomponents in the diagram below do this.
+ *  - probing for healthstatus, in which the BrokerHealthCheckService just checks the healthstatus
+ *   of its CriticalComponentsHealthMonitor.
+ *
+ * In turn, the CriticalComponentsHealthMonitors periodically probe their subcomponents for their
+ *  healthstatus and update their own healthstatus when one of their subcomponents has become
+ *  unhealthy.
+ *
+ * The ZeebePartition only probes its CriticalComponentsHealthMonitor when its healthstatus is
+ *  probed by the CriticalComponentsHealthMonitor that monitors the ZeebePartition.
+ *
+ *       +--------------+
+ *       | BrokerHealth |-----healthstatus
+ *       | CheckService |
+ *       +--------------+
+ *    probes    |
+ *    downwards |informs
+ *              |upwards
+ *    +--------------------+
+ *    | CriticalComponents |----healthstatus
+ *    | HealthMonitor      |
+ *    +--------------------+
+ * periodically |
+ * monitors     |informs
+ * downwards    |upwards   +----------------+
+ *              |----------| ZeebePartition |----healthstatus
+ *                   probes ----------------+
+ *                   downwards     |
+ *                   when probed   |informs
+ *                                 |upwards
+ *                       +--------------------+
+ *                       | CriticalComponents |-----healthstatus
+ *                       | HealthMonitor      |
+ *                       +--------------------+
+ *                    periodically |
+ *                    monitors     |informs
+ *                    downwards    |upwards   +------+
+ *                                 |----------| Raft |
+ *                                 |          +------+
+ *                                 |informs
+ *                                 |upwards   +-----------------+
+ *                                 |----------| StreamProcessor |
+ *                                 |          +-----------------+
+ *                                 |informs
+ *                                 |upwards   +-----+
+ *                                 |----------| Log |
+ *                                            +-----+
+ *
+ * https://textik.com/#cb084adedb02d970
+ */
 public final class BrokerHealthCheckService extends Actor implements PartitionListener {
 
   private static final String PARTITION_COMPONENT_NAME_FORMAT = "Partition-%d";

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -770,7 +770,14 @@ public final class ZeebePartition extends Actor
 
   @Override
   public HealthStatus getHealthStatus() {
-    return healthStatus;
+    if (healthStatus == HealthStatus.UNHEALTHY) {
+      return HealthStatus.UNHEALTHY;
+    }
+    final var componentsHealthStatus = criticalComponentsHealthMonitor.getHealthStatus();
+    if (componentsHealthStatus == HealthStatus.UNHEALTHY) {
+      updateHealthStatus(HealthStatus.UNHEALTHY);
+    }
+    return componentsHealthStatus;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -14,7 +14,6 @@ import io.zeebe.logstreams.impl.Loggers;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.zeebe.logstreams.log.LogStreamReader;
-import io.zeebe.util.LangUtil;
 import io.zeebe.util.health.FailureListener;
 import io.zeebe.util.health.HealthMonitorable;
 import io.zeebe.util.health.HealthStatus;
@@ -99,19 +98,15 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
       snapshotPosition = recoverFromSnapshot();
 
       initProcessors();
-    } catch (final Throwable e) {
-      onFailure(e);
-      LangUtil.rethrowUnchecked(e);
-    }
 
-    try {
       processingStateMachine = new ProcessingStateMachine(processingContext, this::isOpened);
+
+      healthCheckTick();
       openFuture.complete(null);
 
       final ReProcessingStateMachine reProcessingStateMachine =
           new ReProcessingStateMachine(processingContext);
 
-      healthCheckTick();
       final ActorFuture<Void> recoverFuture =
           reProcessingStateMachine.startRecover(snapshotPosition);
 
@@ -127,7 +122,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
           });
     } catch (final RuntimeException e) {
       onFailure(e);
-      throw e;
     }
   }
 
@@ -160,11 +154,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
 
   @Override
   protected void handleFailure(final Exception failure) {
-    LOG.error("Actor {} failed in phase {}.", actorName, actor.getLifecyclePhase(), failure);
-    if (this.failureListener != null) {
-      this.failureListener.onFailure();
-    }
-    actor.fail();
+    onFailure(failure);
   }
 
   @Override
@@ -277,6 +267,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
   }
 
   private void onFailure(final Throwable throwable) {
+    LOG.error("Actor {} failed in phase {}.", actorName, actor.getLifecyclePhase(), throwable);
     actor.fail();
     if (!openFuture.isDone()) {
       openFuture.completeExceptionally(throwable);


### PR DESCRIPTION
## Description

When the BrokerHealthCheckService probes the ZeebePartitions for their
health, the ZeebePartition only reported its own health-status. However,
we cannot be sure that this status is updated when one of the components
fails. To make sure that the health check is correct, it is setup to be
bi-directional, so when probing, the partition should also probe its own
critical components.

Lastly, when this results in an UNHEALTHY state, the metrics should be
updated. So we call updateHealthStatus when the partitions own state is
HEALTHY, but its critical components are not.

## Related issues

closes #4723