### PR TITLE
chore(dockerfile): add arg for jdk tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+
+ARG APP_ENV=prod
+
+# Building builder image
 FROM alpine:latest as builder
 ARG DISTBALL
 
@@ -16,7 +20,18 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini ${TMP
 COPY docker/utils/startup.sh ${TMP_DIR}/bin/startup.sh
 RUN chmod +x -R ${TMP_DIR}/bin/
 
-FROM openjdk:11-jre-slim as app
+# Building prod image
+FROM openjdk:11-jre-slim as prod
+RUN echo "running PROD pre-install commands"
+
+# Building dev image
+FROM openjdk:11 as dev
+RUN echo "running DEV pre-install commands"
+RUN apt-get update
+RUN wget -O - https://github.com/jvm-profiling-tools/async-profiler/releases/download/v1.7.1/async-profiler-1.7.1-linux-x64.tar.gz | tar xzv
+
+# Building application image
+FROM ${APP_ENV} as app
 
 ENV ZB_HOME=/usr/local/zeebe \
     ZEEBE_LOG_LEVEL=info \


### PR DESCRIPTION
## Description

I was quite annoyed on debugging that I have to reinstall all the time the jdk and dbg symbols. This solves quite easy via an dockerfile arg.

Example to get JDK image:
```
docker build --build-arg DISTBALL=dist/target/zeebe-distribution-*.tar.gz --build-arg JDK_TAG=11 -t gcr.io/zeebe-io/zeebe:zell-docker-jdk .
```

Example default:

```
docker build --build-arg DISTBALL=dist/target/zeebe-distribution-*.tar.gz -t gcr.io/zeebe-io/zeebe:zell-docker-jre .
```

<!-- Please explain the changes you made here. -->

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
