### PR TITLE
chore(util): compare logged event nano seconds accurately

### DIFF
--- a/util/src/test/java/io/zeebe/util/logging/RecordingAppender.java
+++ b/util/src/test/java/io/zeebe/util/logging/RecordingAppender.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.util.logging;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.ErrorHandler;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+
+/**
+ * An {@link Appender} decorator which delegates all method to the underlying appender while
+ * recording all events it receives through {@link #append(LogEvent)}. These are accessible
+ * afterwards through {@link #getAppendedEvents()}, in the order in which they were appended.
+ */
+final class RecordingAppender implements Appender {
+  private final Appender delegate;
+  private final List<LogEvent> appendedEvents;
+
+  public RecordingAppender(final Appender delegate) {
+    this.delegate = delegate;
+    this.appendedEvents = new ArrayList<>();
+  }
+
+  @Override
+  public void append(final LogEvent event) {
+    appendedEvents.add(event);
+    delegate.append(event);
+  }
+
+  @Override
+  public String getName() {
+    return delegate.getName();
+  }
+
+  @Override
+  public Layout<? extends Serializable> getLayout() {
+    return delegate.getLayout();
+  }
+
+  @Override
+  public boolean ignoreExceptions() {
+    return delegate.ignoreExceptions();
+  }
+
+  @Override
+  public ErrorHandler getHandler() {
+    return delegate.getHandler();
+  }
+
+  @Override
+  public void setHandler(final ErrorHandler handler) {
+    delegate.setHandler(handler);
+  }
+
+  public List<LogEvent> getAppendedEvents() {
+    return appendedEvents;
+  }
+
+  @Override
+  public State getState() {
+    return delegate.getState();
+  }
+
+  @Override
+  public void initialize() {
+    delegate.initialize();
+  }
+
+  @Override
+  public void start() {
+    delegate.start();
+  }
+
+  @Override
+  public void stop() {
+    delegate.stop();
+  }
+
+  @Override
+  public boolean isStarted() {
+    return delegate.isStarted();
+  }
+
+  @Override
+  public boolean isStopped() {
+    return delegate.isStopped();
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes a flaky test which compared the nano adjustment of seconds by grabbing the nano of second before the log, and after, and checking that the logged one was within those bounds. This was wrong since, as specified, it is the nano adjustment of the second, so if the second change it will go out of bounds.

The PR fixes this by introducing a `RecordingAppender` which wraps any appender and records the given logged event, letting us use the exact generated value to accurately check the times.

## Related issues

closes #4770 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
