### PR TITLE
chore(benchmark): remove GC settings

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -41,19 +41,13 @@ gateway:
 # JavaOpts:
 # DEFAULTS
 JavaOpts: >
-  -XX:+UseParallelGC 
-  -XX:MinHeapFreeRatio=5
-  -XX:MaxHeapFreeRatio=10
-  -XX:MaxRAMPercentage=25.0 
-  -XX:GCTimeRatio=4 
-  -XX:AdaptiveSizePolicyWeight=90
-  -XX:+PrintFlagsFinal
   -Xmx4g
   -Xms4g
   -XX:+ExitOnOutOfMemoryError
   -XX:+HeapDumpOnOutOfMemoryError
   -XX:HeapDumpPath=/usr/local/zeebe/data
   -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
+  -Xlog:gc*:file=/usr/local/zeebe/data/gc.log:time:filecount=7,filesize=8M
 
 # Environment variables
 env:


### PR DESCRIPTION
## Description

Removes the GC settings as described here https://github.com/zeebe-io/zeebe/issues/4664#issuecomment-646529238

It also removes the `PrintFinalFlags`, since I see no value in them. It just more annoying then useful, especially if you use jps, jcmd or any other java  tool. If you want to see the flag you can run on the pod `jcmd <pid> VM.flags -all`

I added the gc logging since it might be useful, but we can also drop it for now.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4664 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
