### PR TITLE
Multiple Swim improvements

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -166,6 +166,8 @@ public class SwimMembershipProtocol
       members.put(localMember.id(), localMember);
       post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, localMember));
 
+      LOGGER.debug("Nodes from discovery service {}", discoveryService.getNodes());
+
       registerHandlers();
       gossipFuture =
           swimScheduler.scheduleAtFixedRate(
@@ -177,7 +179,7 @@ public class SwimMembershipProtocol
       syncFuture =
           swimScheduler.scheduleAtFixedRate(
               this::sync, 0, config.getSyncInterval().toMillis(), TimeUnit.MILLISECONDS);
-      LOGGER.info("Started");
+      LOGGER.info("Started {}", this.getClass());
     }
     return CompletableFuture.completedFuture(null);
   }
@@ -313,11 +315,7 @@ public class SwimMembershipProtocol
       // MEMBER_REMOVED
       // event and record an update.
       else if (member.state() == State.DEAD) {
-        members.remove(swimMember.id());
-        randomMembers.remove(swimMember);
-        Collections.shuffle(randomMembers);
-        LOGGER.debug("{} - Member removed {}", this.localMember.id(), swimMember);
-        post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, swimMember.copy()));
+        tryRemoveMember(swimMember);
       }
       recordUpdate(swimMember.copy());
       return true;
@@ -334,11 +332,7 @@ public class SwimMembershipProtocol
               GroupMembershipEvent.Type.REACHABILITY_CHANGED, swimMember.copy()));
     }
     swimMember.setState(State.DEAD);
-    members.remove(swimMember.id());
-    randomMembers.remove(swimMember);
-    Collections.shuffle(randomMembers);
-    LOGGER.debug("{} - Member removed {}", this.localMember.id(), swimMember);
-    post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, swimMember.copy()));
+    tryRemoveMember(swimMember);
   }
 
   private void triggerReachibilityEventOnSuspect(
@@ -388,13 +382,20 @@ public class SwimMembershipProtocol
           && System.currentTimeMillis() - member.getUpdated()
               > config.getFailureTimeout().toMillis()) {
         member.setState(State.DEAD);
-        members.remove(member.id());
-        randomMembers.remove(member);
-        Collections.shuffle(randomMembers);
-        LOGGER.debug("{} - Member removed {}", this.localMember.id(), member);
-        post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, member.copy()));
+
+        tryRemoveMember(member);
         recordUpdate(member.copy());
       }
+    }
+  }
+
+  private void tryRemoveMember(final SwimMember member) {
+    final var deadMember = members.remove(member.id());
+    if (deadMember != null) {
+      randomMembers.remove(member);
+      Collections.shuffle(randomMembers);
+      LOGGER.debug("{} - Member removed {}", this.localMember.id(), member);
+      post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, member.copy()));
     }
   }
 
@@ -416,7 +417,7 @@ public class SwimMembershipProtocol
    * @param member the peer with which to synchronize the node state
    */
   private void sync(final ImmutableMember member) {
-    LOGGER.debug("{} - Synchronizing membership with {}", localMember.id(), member);
+    LOGGER.debug("{} - Start synchronizing membership with {}", localMember.id(), member);
     bootstrapService
         .getMessagingService()
         .sendAndReceive(
@@ -430,14 +431,17 @@ public class SwimMembershipProtocol
               if (error == null) {
                 final Collection<ImmutableMember> members = SERIALIZER.decode(response);
                 LOGGER.debug(
-                    "{} - Synchronized membership with {}, received: {}",
+                    "{} - Finished synchronizing membership with {}, received: '{}'",
                     localMember.id(),
                     member,
                     members);
                 members.forEach(this::updateState);
               } else {
                 LOGGER.debug(
-                    "{} - Failed to synchronize membership with {}", localMember.id(), member);
+                    "{} - Failed to synchronize membership with {}",
+                    localMember.id(),
+                    member,
+                    error);
               }
             },
             swimScheduler);

--- a/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -170,17 +170,12 @@ public class SwimMembershipProtocol
       LOGGER.debug("Nodes from discovery service {}", discoveryService.getNodes());
 
       registerHandlers();
-      gossipFuture =
-          swimScheduler.scheduleAtFixedRate(
-              this::gossip, 0, config.getGossipInterval().toMillis(), TimeUnit.MILLISECONDS);
-      probeFuture =
-          swimScheduler.scheduleAtFixedRate(
-              this::probe, 0, config.getProbeInterval().toMillis(), TimeUnit.MILLISECONDS);
-      swimScheduler.execute(this::syncAll);
-      syncFuture =
-          swimScheduler.scheduleAtFixedRate(
-              this::sync, 0, config.getSyncInterval().toMillis(), TimeUnit.MILLISECONDS);
-      LOGGER.info("Started {}", this.getClass());
+
+      scheduleGossip();
+      scheduleProbe();
+      scheduleSync();
+
+      LOGGER.info("Started");
     }
     return CompletableFuture.completedFuture(null);
   }
@@ -401,19 +396,6 @@ public class SwimMembershipProtocol
     }
   }
 
-  /** Synchronizes the node state with peers. */
-  private void syncAll() {
-    final List<SwimMember> syncMembers =
-        discoveryService.getNodes().stream()
-            .map(node -> new SwimMember(MemberId.from(node.id().id()), node.address()))
-            .filter(member -> !member.id().equals(localMember.id()))
-            .filter(member -> !member.address().equals(localMember.address()))
-            .collect(Collectors.toList());
-    for (final SwimMember member : syncMembers) {
-      sync(member.copy());
-    }
-  }
-
   /**
    * Synchronizes the node state with the given peer.
    *
@@ -446,6 +428,8 @@ public class SwimMembershipProtocol
                     member,
                     error);
               }
+
+              scheduleSync();
             },
             swimScheduler);
   }
@@ -462,6 +446,8 @@ public class SwimMembershipProtocol
       if (member != null) {
         sync(member.copy());
       }
+    } else {
+      scheduleSync();
     }
   }
 
@@ -472,8 +458,7 @@ public class SwimMembershipProtocol
    */
   private Collection<ImmutableMember> handleSync(final ImmutableMember member) {
     updateState(member);
-    return new ArrayList<>(
-        members.values().stream().map(SwimMember::copy).collect(Collectors.toList()));
+    return members.values().stream().map(SwimMember::copy).collect(Collectors.toList());
   }
 
   /** Sends probes to all members or to the next member in round robin fashion. */
@@ -482,14 +467,13 @@ public class SwimMembershipProtocol
     // This is necessary to ensure we attempt to probe all nodes that are provided by the discovery
     // provider.
     final List<SwimMember> probeMembers =
-        Lists.newArrayList(
-            discoveryService.getNodes().stream()
-                .map(node -> new SwimMember(MemberId.from(node.id().id()), node.address()))
-                .filter(member -> !members.containsKey(member.id()))
-                .filter(member -> !member.id().equals(localMember.id()))
-                .filter(member -> !member.address().equals(localMember.address()))
-                .sorted(Comparator.comparing(Member::id))
-                .collect(Collectors.toList()));
+        discoveryService.getNodes().stream()
+            .map(node -> new SwimMember(MemberId.from(node.id().id()), node.address()))
+            .filter(member -> !members.containsKey(member.id()))
+            .filter(member -> !member.id().equals(localMember.id()))
+            .filter(member -> !member.address().equals(localMember.address()))
+            .sorted(Comparator.comparing(Member::id))
+            .collect(Collectors.toList());
 
     // Then add the randomly sorted list of SWIM members.
     probeMembers.addAll(randomMembers);
@@ -501,6 +485,8 @@ public class SwimMembershipProtocol
       final SwimMember probeMember =
           probeMembers.get(Math.abs(probeCounter.incrementAndGet() % probeMembers.size()));
       probe(probeMember.copy());
+    } else {
+      scheduleProbe();
     }
   }
 
@@ -532,6 +518,8 @@ public class SwimMembershipProtocol
                   requestProbes(swimMember.copy());
                 }
               }
+
+              scheduleProbe();
             },
             swimScheduler);
   }
@@ -732,6 +720,8 @@ public class SwimMembershipProtocol
       // Gossip the pending updates to peers.
       gossip(updates);
     }
+
+    scheduleGossip();
   }
 
   /**
@@ -834,6 +824,24 @@ public class SwimMembershipProtocol
 
     // Unregister UDP message listeners.
     bootstrapService.getUnicastService().removeListener(MEMBERSHIP_GOSSIP, gossipListener);
+  }
+
+  private void scheduleGossip() {
+    gossipFuture =
+        swimScheduler.schedule(
+            (Runnable) this::gossip, config.getGossipInterval().toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  private void scheduleSync() {
+    syncFuture =
+        swimScheduler.schedule(
+            (Runnable) this::sync, config.getSyncInterval().toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  private void scheduleProbe() {
+    probeFuture =
+        swimScheduler.schedule(
+            (Runnable) this::probe, config.getProbeInterval().toMillis(), TimeUnit.MILLISECONDS);
   }
 
   /** Bootstrap member location provider type. */


### PR DESCRIPTION
## Description

This PR fixes several issues:
 * we no longer send requests to local nodes.
 * we not trigger mutliple MEMBER_REMOVE events for the SWIM listeners
 * we send requests no longer on a fixed rate

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/4780
closes https://github.com/zeebe-io/zeebe/issues/4779
closes https://github.com/zeebe-io/zeebe/issues/4778

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
