### PR TITLE
chore(broker): handle out of disk space in broker

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -442,6 +442,17 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
     }
 
     /**
+     * Set the minimum free disk space (in bytes) to leave when allocating a new segment
+     *
+     * @param freeDiskSpace free disk space in bytes
+     * @return the Raft partition group builder
+     */
+    public Builder withFreeDiskSpace(final long freeDiskSpace) {
+      config.getStorageConfig().setFreeDiskSpace(freeDiskSpace);
+      return this;
+    }
+
+    /**
      * Enables flush on commit.
      *
      * @return the Raft partition group builder

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
@@ -34,12 +34,14 @@ public class RaftStorageConfig {
   private static final boolean DEFAULT_FLUSH_ON_COMMIT = false;
   private static final PersistedSnapshotStoreFactory DEFAULT_SNAPSHOT_STORE_FACTORY =
       new FileBasedSnapshotStoreFactory();
+  private static final long DEFAULT_FREE_DISK_SPACE = 1024L * 1024 * 1024 * 1; // 1GB
 
   private String directory;
   private StorageLevel level = DEFAULT_STORAGE_LEVEL;
   private int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
   private long segmentSize = DEFAULT_MAX_SEGMENT_SIZE;
   private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
+  private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
 
   @Optional("SnapshotStoreFactory")
   private PersistedSnapshotStoreFactory persistedSnapshotStoreFactory =
@@ -166,6 +168,26 @@ public class RaftStorageConfig {
   public RaftStorageConfig setPersistedSnapshotStoreFactory(
       final PersistedSnapshotStoreFactory persistedSnapshotStoreFactory) {
     this.persistedSnapshotStoreFactory = persistedSnapshotStoreFactory;
+    return this;
+  }
+
+  /**
+   * Returns the minimum free disk space buffer to leave when allocating a new segment
+   *
+   * @return free disk buffer
+   */
+  public long getFreeDiskSpace() {
+    return this.freeDiskSpace;
+  }
+
+  /**
+   * Sets the minimum free disk space buffer
+   *
+   * @param freeDiskSpace
+   * @return
+   */
+  public RaftStorageConfig setFreeDiskSpace(final long freeDiskSpace) {
+    this.freeDiskSpace = freeDiskSpace;
     return this;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -302,7 +302,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
         .withMaxEntrySize((int) storageConfig.getMaxEntrySize().bytes())
         .withFlushOnCommit(storageConfig.isFlushOnCommit())
         .withDynamicCompaction(compactionConfig.isDynamic())
-        .withFreeDiskBuffer(compactionConfig.getFreeDiskBuffer())
+        .withFreeDiskSpace(storageConfig.getFreeDiskSpace())
         .withFreeMemoryBuffer(compactionConfig.getFreeMemoryBuffer())
         .withNamespace(RaftNamespaces.RAFT_STORAGE)
         .withSnapshotStore(persistedSnapshotStore)

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -68,7 +68,7 @@ public final class RaftStorage {
   private final int maxEntrySize;
   private final int maxEntriesPerSegment;
   private final boolean dynamicCompaction;
-  private final double freeDiskBuffer;
+  private final long freeDiskSpace;
   private final double freeMemoryBuffer;
   private final boolean flushOnCommit;
   private final boolean retainStaleSnapshots;
@@ -85,7 +85,7 @@ public final class RaftStorage {
       final int maxEntrySize,
       final int maxEntriesPerSegment,
       final boolean dynamicCompaction,
-      final double freeDiskBuffer,
+      final long freeDiskSpace,
       final double freeMemoryBuffer,
       final boolean flushOnCommit,
       final boolean retainStaleSnapshots,
@@ -100,7 +100,7 @@ public final class RaftStorage {
     this.maxEntrySize = maxEntrySize;
     this.maxEntriesPerSegment = maxEntriesPerSegment;
     this.dynamicCompaction = dynamicCompaction;
-    this.freeDiskBuffer = freeDiskBuffer;
+    this.freeDiskSpace = freeDiskSpace;
     this.freeMemoryBuffer = freeMemoryBuffer;
     this.flushOnCommit = flushOnCommit;
     this.retainStaleSnapshots = retainStaleSnapshots;
@@ -185,12 +185,12 @@ public final class RaftStorage {
   }
 
   /**
-   * Returns the percentage of disk space that must be available before log compaction is forced.
+   * Returns the amount of disk space that must be available before log compaction is forced.
    *
-   * @return the percentage of disk space that must be available before log compaction is forced
+   * @return the amount of disk space that must be available before log compaction is forced
    */
-  public double freeDiskBuffer() {
-    return freeDiskBuffer;
+  public long freeDiskSpace() {
+    return freeDiskSpace;
   }
 
   /**
@@ -317,6 +317,7 @@ public final class RaftStorage {
         .withNamespace(namespace)
         .withMaxSegmentSize(maxSegmentSize)
         .withMaxEntrySize(maxEntrySize)
+        .withFreeDiskSpace(freeDiskSpace)
         .withMaxEntriesPerSegment(maxEntriesPerSegment)
         .withFlushOnCommit(flushOnCommit)
         .withJournalIndexFactory(journalIndexFactory)
@@ -399,7 +400,7 @@ public final class RaftStorage {
     private static final int DEFAULT_MAX_ENTRY_SIZE = 1024 * 1024; // 1MB
     private static final int DEFAULT_MAX_ENTRIES_PER_SEGMENT = 1024 * 1024;
     private static final boolean DEFAULT_DYNAMIC_COMPACTION = true;
-    private static final double DEFAULT_FREE_DISK_BUFFER = .2;
+    private static final long DEFAULT_FREE_DISK_SPACE = 1024L * 1024 * 1024; // 1GB
     private static final double DEFAULT_FREE_MEMORY_BUFFER = .2;
     private static final boolean DEFAULT_FLUSH_ON_COMMIT = true;
     private static final boolean DEFAULT_RETAIN_STALE_SNAPSHOTS = false;
@@ -412,7 +413,7 @@ public final class RaftStorage {
     private int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
     private int maxEntriesPerSegment = DEFAULT_MAX_ENTRIES_PER_SEGMENT;
     private boolean dynamicCompaction = DEFAULT_DYNAMIC_COMPACTION;
-    private double freeDiskBuffer = DEFAULT_FREE_DISK_BUFFER;
+    private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
     private double freeMemoryBuffer = DEFAULT_FREE_MEMORY_BUFFER;
     private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
     private boolean retainStaleSnapshots = DEFAULT_RETAIN_STALE_SNAPSHOTS;
@@ -582,13 +583,12 @@ public final class RaftStorage {
      * Sets the percentage of free disk space that must be preserved before log compaction is
      * forced.
      *
-     * @param freeDiskBuffer the free disk percentage
+     * @param freeDiskSpace the free disk percentage
      * @return the Raft log builder
      */
-    public Builder withFreeDiskBuffer(final double freeDiskBuffer) {
-      checkArgument(freeDiskBuffer > 0, "freeDiskBuffer must be positive");
-      checkArgument(freeDiskBuffer < 1, "freeDiskBuffer must be less than 1");
-      this.freeDiskBuffer = freeDiskBuffer;
+    public Builder withFreeDiskSpace(final long freeDiskSpace) {
+      checkArgument(freeDiskSpace > 0, "freeDiskSpace must be positive");
+      this.freeDiskSpace = freeDiskSpace;
       return this;
     }
 
@@ -711,7 +711,7 @@ public final class RaftStorage {
           maxEntrySize,
           maxEntriesPerSegment,
           dynamicCompaction,
-          freeDiskBuffer,
+          freeDiskSpace,
           freeMemoryBuffer,
           flushOnCommit,
           retainStaleSnapshots,

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -216,6 +216,18 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
     }
 
     /**
+     * Sets the minimum free disk space to leave when allocating a new segment
+     *
+     * @param freeDiskSpace free disk space in bytes
+     * @return the storage builder
+     * @throws IllegalArgumentException if the {@code freeDiskSpace} is not positive
+     */
+    public Builder withFreeDiskSpace(final long freeDiskSpace) {
+      journalBuilder.withFreeDiskSpace(freeDiskSpace);
+      return this;
+    }
+
+    /**
      * Sets the maximum number of allows entries per segment, returning the builder for method
      * chaining.
      *

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -771,13 +771,13 @@ public class RaftTest extends ConcurrentTestCase {
     }
 
     @Override
-    public void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {
-      fail("Unexpected write error: " + error.getMessage());
+    public void onCommit(final Indexed<ZeebeEntry> indexed) {
+      commitFuture.complete(indexed.index());
     }
 
     @Override
-    public void onCommit(final Indexed<ZeebeEntry> indexed) {
-      commitFuture.complete(indexed.index());
+    public void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {
+      fail("Unexpected write error: " + error.getMessage());
     }
 
     public long awaitCommit() throws Exception {

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/RaftStorageTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/RaftStorageTest.java
@@ -45,7 +45,7 @@ public class RaftStorageTest {
     assertEquals(1024 * 1024 * 32, storage.maxLogSegmentSize());
     assertEquals(1024 * 1024, storage.maxLogEntriesPerSegment());
     assertTrue(storage.dynamicCompaction());
-    assertEquals(.2, storage.freeDiskBuffer(), .01);
+    assertEquals(1024L * 1024 * 1024, storage.freeDiskSpace());
     assertTrue(storage.isFlushOnCommit());
     assertFalse(storage.isRetainStaleSnapshots());
     assertTrue(storage.statistics().getFreeMemory() > 0);
@@ -60,7 +60,7 @@ public class RaftStorageTest {
             .withMaxSegmentSize(1024 * 1024)
             .withMaxEntriesPerSegment(1024)
             .withDynamicCompaction(false)
-            .withFreeDiskBuffer(.5)
+            .withFreeDiskSpace(100)
             .withFlushOnCommit(false)
             .withRetainStaleSnapshots()
             .build();
@@ -69,7 +69,7 @@ public class RaftStorageTest {
     assertEquals(1024 * 1024, storage.maxLogSegmentSize());
     assertEquals(1024, storage.maxLogEntriesPerSegment());
     assertFalse(storage.dynamicCompaction());
-    assertEquals(.5, storage.freeDiskBuffer(), .01);
+    assertEquals(100, storage.freeDiskSpace());
     assertFalse(storage.isFlushOnCommit());
     assertTrue(storage.isRetainStaleSnapshots());
   }

--- a/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
@@ -65,6 +65,7 @@ public class SegmentedJournal<E> implements Journal<E> {
   private final Collection<SegmentedJournalReader> readers = Sets.newConcurrentHashSet();
   private volatile JournalSegment<E> currentSegment;
   private volatile boolean open = true;
+  private final long minFreeDiskSpace;
 
   public SegmentedJournal(
       final String name,
@@ -75,7 +76,8 @@ public class SegmentedJournal<E> implements Journal<E> {
       final int maxEntrySize,
       final int maxEntriesPerSegment,
       final boolean flushOnCommit,
-      final Supplier<JournalIndex> journalIndexFactory) {
+      final Supplier<JournalIndex> journalIndexFactory,
+      final long minFreeSpace) {
     this.name = checkNotNull(name, "name cannot be null");
     this.storageLevel = checkNotNull(storageLevel, "storageLevel cannot be null");
     this.directory = checkNotNull(directory, "directory cannot be null");
@@ -89,6 +91,7 @@ public class SegmentedJournal<E> implements Journal<E> {
         journalIndexFactory == null
             ? () -> new SparseJournalIndex(DEFAULT_INDEX_DENSITY)
             : journalIndexFactory;
+    this.minFreeDiskSpace = minFreeSpace;
     open();
     this.writer = openWriter();
   }
@@ -293,7 +296,8 @@ public class SegmentedJournal<E> implements Journal<E> {
 
   /** Asserts that enough disk space is available to allocate a new segment. */
   private void assertDiskSpace() {
-    if (directory().getUsableSpace() < maxSegmentSize() * SEGMENT_BUFFER_FACTOR) {
+    if (directory().getUsableSpace()
+        < Math.max((long) maxSegmentSize() * SEGMENT_BUFFER_FACTOR, minFreeDiskSpace)) {
       throw new StorageException.OutOfDiskSpace(
           "Not enough space to allocate a new journal segment");
     }
@@ -698,7 +702,7 @@ public class SegmentedJournal<E> implements Journal<E> {
     private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
     private static final int DEFAULT_MAX_ENTRY_SIZE = 1024 * 1024;
     private static final int DEFAULT_MAX_ENTRIES_PER_SEGMENT = 1024 * 1024;
-
+    private static final long DEFAULT_MIN_FREE_DISK_SPACE = 1024L * 1024 * 1024 * 1;
     protected String name = DEFAULT_NAME;
     protected StorageLevel storageLevel = StorageLevel.DISK;
     protected File directory = new File(DEFAULT_DIRECTORY);
@@ -709,6 +713,7 @@ public class SegmentedJournal<E> implements Journal<E> {
 
     private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
     private Supplier<JournalIndex> journalIndexFactory;
+    private long freeDiskSpace = DEFAULT_MIN_FREE_DISK_SPACE;
 
     protected Builder() {}
 
@@ -810,6 +815,19 @@ public class SegmentedJournal<E> implements Journal<E> {
     }
 
     /**
+     * Sets the minimum free disk space to leave when allocating a new segment
+     *
+     * @param freeDiskSpace free disk space in bytes
+     * @return the storage builder
+     * @throws IllegalArgumentException if the {@code freeDiskSpace} is not positive
+     */
+    public Builder<E> withFreeDiskSpace(final long freeDiskSpace) {
+      checkArgument(freeDiskSpace > 0, "minFreeDiskSpace must be positive");
+      this.freeDiskSpace = freeDiskSpace;
+      return this;
+    }
+
+    /**
      * Sets the maximum number of allows entries per segment, returning the builder for method
      * chaining.
      *
@@ -881,7 +899,8 @@ public class SegmentedJournal<E> implements Journal<E> {
           maxEntrySize,
           maxEntriesPerSegment,
           flushOnCommit,
-          journalIndexFactory);
+          journalIndexFactory,
+          freeDiskSpace);
     }
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -104,7 +104,8 @@ public final class AtomixFactory {
             .withSnapshotStoreFactory(new FileBasedSnapshotStoreFactory())
             .withStorageLevel(dataCfg.getAtomixStorageLevel())
             .withEntryValidator(new ZeebeEntryValidator())
-            .withFlushOnCommit();
+            .withFlushOnCommit()
+            .withFreeDiskSpace(dataCfg.getFreeDiskSpaceReplicationWatermark());
 
     // by default, the Atomix max entry size is 1 MB
     final int maxMessageSize = (int) networkCfg.getMaxMessageSizeInBytes();

--- a/broker/src/main/java/io/zeebe/broker/engine/impl/DeploymentDistributorImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/DeploymentDistributorImpl.java
@@ -209,6 +209,12 @@ public final class DeploymentDistributorImpl implements DeploymentDistributor {
                             partition,
                             pushRequest.deploymentKey());
 
+                      } else if (errorResponse.getErrorCode() == ErrorCode.RESOURCE_EXHAUSTED) {
+                        LOG.warn(
+                            "Received rejected deployment push due to error of type {}: '{}'. Will be retried after a delay",
+                            errorResponse.getErrorCode().name(),
+                            BufferUtil.bufferAsString(errorResponse.getErrorData()));
+                        return;
                       } else {
                         LOG.warn(
                             "Received rejected deployment push due to error of type {}: '{}'",

--- a/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
@@ -10,6 +10,7 @@ package io.zeebe.broker.engine.impl;
 import io.atomix.core.Atomix;
 import io.zeebe.broker.Loggers;
 import io.zeebe.broker.PartitionListener;
+import io.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.zeebe.engine.processor.workflow.message.command.SubscriptionCommandMessageHandler;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamRecordWriter;
@@ -17,15 +18,20 @@ import io.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.future.ActorFuture;
 import io.zeebe.util.sched.future.CompletableActorFuture;
+import java.util.concurrent.CompletableFuture;
 import org.agrona.collections.Int2ObjectHashMap;
+import org.slf4j.Logger;
 
 public final class SubscriptionApiCommandMessageHandlerService extends Actor
-    implements PartitionListener {
+    implements PartitionListener, DiskSpaceUsageListener {
 
+  private static final String SUBSCRIPTION_TOPIC = "subscription";
+  private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private final Int2ObjectHashMap<LogStreamRecordWriter> leaderPartitions =
       new Int2ObjectHashMap<>();
   private final Atomix atomix;
   private final String actorName;
+  private SubscriptionCommandMessageHandler messageHandler;
 
   public SubscriptionApiCommandMessageHandlerService(
       final BrokerInfo localBroker, final Atomix atomix) {
@@ -40,9 +46,8 @@ public final class SubscriptionApiCommandMessageHandlerService extends Actor
 
   @Override
   protected void onActorStarting() {
-    final SubscriptionCommandMessageHandler messageHandler =
-        new SubscriptionCommandMessageHandler(actor::call, leaderPartitions::get);
-    atomix.getCommunicationService().subscribe("subscription", messageHandler);
+    messageHandler = new SubscriptionCommandMessageHandler(actor::call, leaderPartitions::get);
+    atomix.getCommunicationService().subscribe(SUBSCRIPTION_TOPIC, messageHandler);
   }
 
   @Override
@@ -68,7 +73,7 @@ public final class SubscriptionApiCommandMessageHandlerService extends Actor
                         leaderPartitions.put(partitionId, recordWriter);
                         future.complete(null);
                       } else {
-                        Loggers.SYSTEM_LOGGER.error(
+                        LOG.error(
                             "Unexpected error on retrieving write buffer for partition {}",
                             partitionId,
                             error);
@@ -76,5 +81,32 @@ public final class SubscriptionApiCommandMessageHandlerService extends Actor
                       }
                     }));
     return future;
+  }
+
+  @Override
+  public void onDiskSpaceNotAvailable() {
+    actor.call(
+        () -> {
+          LOG.debug(
+              "Broker is out of disk space. All requests with topic {} will be rejected.",
+              SUBSCRIPTION_TOPIC);
+          atomix.getCommunicationService().unsubscribe(SUBSCRIPTION_TOPIC);
+          atomix
+              .getCommunicationService()
+              // SubscriptionMessageHandler does not send any response
+              .subscribe(SUBSCRIPTION_TOPIC, b -> CompletableFuture.completedFuture(null));
+        });
+  }
+
+  @Override
+  public void onDiskSpaceAvailable() {
+    actor.call(
+        () -> {
+          LOG.debug(
+              "Broker has disk space available again. All requests with topic {} will be accepted.",
+              SUBSCRIPTION_TOPIC);
+          atomix.getCommunicationService().unsubscribe(SUBSCRIPTION_TOPIC);
+          atomix.getCommunicationService().subscribe(SUBSCRIPTION_TOPIC, messageHandler);
+        });
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -93,6 +93,29 @@ public final class SystemContext {
     if (snapshotPeriod.isNegative() || snapshotPeriod.minus(MINIMUM_SNAPSHOT_PERIOD).isNegative()) {
       throw new IllegalArgumentException(String.format(SNAPSHOT_PERIOD_ERROR_MSG, snapshotPeriod));
     }
+
+    final var diskUsageCommandWatermark = dataCfg.getDiskUsageCommandWatermark();
+    if (!(diskUsageCommandWatermark > 0 && diskUsageCommandWatermark < 1)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected diskUsageCommandWatermark to be in the range (0,1), but found %f",
+              diskUsageCommandWatermark));
+    }
+
+    final var diskUsageReplicationWatermark = dataCfg.getDiskUsageReplicationWatermark();
+    if (!(diskUsageReplicationWatermark > 0 && diskUsageReplicationWatermark < 1)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected diskUsageReplicationWatermark to be in the range (0,1), but found %f",
+              diskUsageReplicationWatermark));
+    }
+
+    if (diskUsageCommandWatermark >= diskUsageReplicationWatermark) {
+      throw new IllegalArgumentException(
+          String.format(
+              "diskUsageCommandWatermark (%f) must be less than diskUsageReplicationWatermark (%f)",
+              diskUsageCommandWatermark, diskUsageReplicationWatermark));
+    }
   }
 
   private ActorScheduler initScheduler(final ActorClock clock, final String brokerId) {

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -10,6 +10,7 @@ package io.zeebe.broker.system.configuration;
 import static io.zeebe.util.StringUtil.LIST_SANITIZER;
 
 import io.atomix.storage.StorageLevel;
+import java.io.File;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -19,6 +20,9 @@ import org.springframework.util.unit.DataSize;
 public final class DataCfg implements ConfigurationEntry {
   public static final String DEFAULT_DIRECTORY = "data";
   private static final DataSize DEFAULT_DATA_SIZE = DataSize.ofMegabytes(512);
+  private static final double DEFAULT_DISK_USAGE_REPLICATION_WATERMARK = 0.9;
+  private static final double DEFAULT_DISK_USAGE_COMMAND_WATERMARK = 0.8;
+  private static final Duration DEFAULT_DISK_USAGE_MONITORING_DELAY = Duration.ofSeconds(1);
 
   // Hint: do not use Collections.singletonList as this does not support replaceAll
   private List<String> directories = Arrays.asList(DEFAULT_DIRECTORY);
@@ -30,10 +34,12 @@ public final class DataCfg implements ConfigurationEntry {
   private int logIndexDensity = 100;
 
   private boolean useMmap = false;
+  private double diskUsageReplicationWatermark = DEFAULT_DISK_USAGE_REPLICATION_WATERMARK;
+  private double diskUsageCommandWatermark = DEFAULT_DISK_USAGE_COMMAND_WATERMARK;
+  private Duration diskUsageMonitoringInterval = DEFAULT_DISK_USAGE_MONITORING_DELAY;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
-
     directories.replaceAll(d -> ConfigurationUtil.toAbsolutePath(d, brokerBase));
   }
 
@@ -85,21 +91,59 @@ public final class DataCfg implements ConfigurationEntry {
     return useMmap() ? StorageLevel.MAPPED : StorageLevel.DISK;
   }
 
+  public double getDiskUsageCommandWatermark() {
+    return diskUsageCommandWatermark;
+  }
+
+  public void setDiskUsageCommandWatermark(final double diskUsageCommandWatermark) {
+    this.diskUsageCommandWatermark = diskUsageCommandWatermark;
+  }
+
+  public long getFreeDiskSpaceCommandWatermark() {
+    final var directory = new File(getDirectories().get(0));
+    return Math.round(directory.getTotalSpace() * (1 - diskUsageCommandWatermark));
+  }
+
+  public double getDiskUsageReplicationWatermark() {
+    return this.diskUsageReplicationWatermark;
+  }
+
+  public void setDiskUsageReplicationWatermark(final double diskUsageReplicationWatermark) {
+    this.diskUsageReplicationWatermark = diskUsageReplicationWatermark;
+  }
+
+  public long getFreeDiskSpaceReplicationWatermark() {
+    final var directory = new File(getDirectories().get(0));
+    return Math.round(directory.getTotalSpace() * (1 - diskUsageReplicationWatermark));
+  }
+
+  public Duration getDiskUsageMonitoringInterval() {
+    return diskUsageMonitoringInterval;
+  }
+
+  public void setDiskUsageMonitoringInterval(final Duration diskUsageMonitoringInterval) {
+    this.diskUsageMonitoringInterval = diskUsageMonitoringInterval;
+  }
+
   @Override
   public String toString() {
     return "DataCfg{"
         + "directories="
         + directories
-        + ", logSegmentSize='"
+        + ", logSegmentSize="
         + logSegmentSize
-        + '\''
-        + ", snapshotPeriod='"
+        + ", snapshotPeriod="
         + snapshotPeriod
-        + '\''
         + ", logIndexDensity="
         + logIndexDensity
         + ", useMmap="
         + useMmap
+        + ", diskUsageReplicationWatermark="
+        + diskUsageReplicationWatermark
+        + ", diskUsageCommandWatermark="
+        + diskUsageCommandWatermark
+        + ", diskUsageMonitoringInterval="
+        + diskUsageMonitoringInterval
         + '}';
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
@@ -11,25 +11,43 @@ import io.atomix.core.Atomix;
 import io.zeebe.broker.Loggers;
 import io.zeebe.broker.PartitionListener;
 import io.zeebe.broker.system.management.deployment.PushDeploymentRequestHandler;
+import io.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.zeebe.protocol.impl.encoding.ErrorResponse;
+import io.zeebe.protocol.record.ErrorCode;
+import io.zeebe.util.buffer.BufferUtil;
 import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.future.ActorFuture;
 import io.zeebe.util.sched.future.CompletableActorFuture;
+import java.util.concurrent.CompletableFuture;
 import org.agrona.collections.Int2ObjectHashMap;
+import org.slf4j.Logger;
 
-public final class LeaderManagementRequestHandler extends Actor implements PartitionListener {
+public final class LeaderManagementRequestHandler extends Actor
+    implements PartitionListener, DiskSpaceUsageListener {
 
+  private static final String DEPLOYMENT_TOPIC = "deployment";
+  private static final Logger LOG = Loggers.CLUSTERING_LOGGER;
   private final Int2ObjectHashMap<LogStreamRecordWriter> leaderForPartitions =
       new Int2ObjectHashMap<>();
   private final String actorName;
   private PushDeploymentRequestHandler pushDeploymentRequestHandler;
   private final Atomix atomix;
+  private final ErrorResponse outOfDiskSpaceError;
 
   public LeaderManagementRequestHandler(final BrokerInfo localBroker, final Atomix atomix) {
     this.atomix = atomix;
     this.actorName = buildActorName(localBroker.getNodeId(), "ManagementRequestHandler");
+    this.outOfDiskSpaceError = new ErrorResponse();
+    outOfDiskSpaceError
+        .setErrorCode(ErrorCode.RESOURCE_EXHAUSTED)
+        .setErrorData(
+            BufferUtil.wrapString(
+                String.format(
+                    "Broker %d is out of disk space. Rejecting deployment request.",
+                    localBroker.getNodeId())));
   }
 
   @Override
@@ -55,7 +73,7 @@ public final class LeaderManagementRequestHandler extends Actor implements Parti
                         leaderForPartitions.put(partitionId, recordWriter);
                         future.complete(null);
                       } else {
-                        Loggers.CLUSTERING_LOGGER.error(
+                        LOG.error(
                             "Unexpected error on retrieving write buffer for partition {}",
                             partitionId,
                             error);
@@ -74,10 +92,40 @@ public final class LeaderManagementRequestHandler extends Actor implements Parti
   protected void onActorStarting() {
     pushDeploymentRequestHandler =
         new PushDeploymentRequestHandler(leaderForPartitions, actor, atomix);
-    atomix.getCommunicationService().subscribe("deployment", pushDeploymentRequestHandler);
+    atomix.getCommunicationService().subscribe(DEPLOYMENT_TOPIC, pushDeploymentRequestHandler);
   }
 
   public PushDeploymentRequestHandler getPushDeploymentRequestHandler() {
     return pushDeploymentRequestHandler;
+  }
+
+  @Override
+  public void onDiskSpaceNotAvailable() {
+    actor.call(
+        () -> {
+          LOG.debug(
+              "Broker is out of disk space. All requests with topic {} will be rejected.",
+              DEPLOYMENT_TOPIC);
+          atomix.getCommunicationService().unsubscribe(DEPLOYMENT_TOPIC);
+          atomix
+              .getCommunicationService()
+              .subscribe(
+                  DEPLOYMENT_TOPIC,
+                  b -> CompletableFuture.completedFuture(outOfDiskSpaceError.toBytes()));
+        });
+  }
+
+  @Override
+  public void onDiskSpaceAvailable() {
+    actor.call(
+        () -> {
+          LOG.debug(
+              "Broker has disk space available again. All requests with topic {} will be accepted.",
+              DEPLOYMENT_TOPIC);
+          atomix.getCommunicationService().unsubscribe(DEPLOYMENT_TOPIC);
+          atomix
+              .getCommunicationService()
+              .subscribe(DEPLOYMENT_TOPIC, pushDeploymentRequestHandler);
+        });
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/DiskSpaceUsageListener.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/DiskSpaceUsageListener.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.monitoring;
+
+/**
+ * Used by DiskSpaceUsageMonitor to notify listeners when disk space usage grows above (and below)
+ * the configured threshold
+ */
+public interface DiskSpaceUsageListener {
+
+  /** Will be called when disk space usage grows above the threshold */
+  default void onDiskSpaceNotAvailable() {}
+
+  /** Will be called when disk space usage goes below the threshold after it was above it. */
+  default void onDiskSpaceAvailable() {}
+}

--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/DiskSpaceUsageMonitor.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/DiskSpaceUsageMonitor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.monitoring;
+
+import static io.zeebe.broker.Broker.LOG;
+
+import io.zeebe.broker.system.configuration.DataCfg;
+import io.zeebe.util.sched.Actor;
+import java.io.File;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.LongSupplier;
+
+public class DiskSpaceUsageMonitor extends Actor {
+
+  private final List<DiskSpaceUsageListener> diskSpaceUsageListeners = new ArrayList<>();
+  private boolean currentDiskAvailableStatus = true;
+  private LongSupplier freeDiskSpaceSupplier;
+  private final Duration monitoringDelay;
+  private final long minFreeDiskSpaceRequired;
+
+  public DiskSpaceUsageMonitor(final DataCfg dataCfg) {
+    this.monitoringDelay = dataCfg.getDiskUsageMonitoringInterval();
+    this.minFreeDiskSpaceRequired = dataCfg.getFreeDiskSpaceCommandWatermark();
+    final var directory = new File(dataCfg.getDirectories().get(0));
+    freeDiskSpaceSupplier = directory::getUsableSpace;
+  }
+
+  @Override
+  protected void onActorStarted() {
+    actor.runAtFixedRate(monitoringDelay, this::checkDiskUsageAndNotifyListeners);
+  }
+
+  private void checkDiskUsageAndNotifyListeners() {
+    final long freeDiskSpaceAvailable = freeDiskSpaceSupplier.getAsLong();
+    final boolean previousStatus = currentDiskAvailableStatus;
+    currentDiskAvailableStatus = freeDiskSpaceAvailable >= minFreeDiskSpaceRequired;
+    if (currentDiskAvailableStatus != previousStatus) {
+      if (!currentDiskAvailableStatus) {
+        LOG.warn(
+            "Out of disk space. Current available {} bytes. Minimum needed {} bytes.",
+            freeDiskSpaceAvailable,
+            minFreeDiskSpaceRequired);
+        diskSpaceUsageListeners.forEach(DiskSpaceUsageListener::onDiskSpaceNotAvailable);
+      } else {
+        LOG.info("Disk space available again. Current available {} bytes", freeDiskSpaceAvailable);
+        diskSpaceUsageListeners.forEach(DiskSpaceUsageListener::onDiskSpaceAvailable);
+      }
+    }
+  }
+
+  public void addDiskUsageListener(final DiskSpaceUsageListener listener) {
+    diskSpaceUsageListeners.add(listener);
+  }
+
+  public void removeDiskUsageListener(final DiskSpaceUsageListener listener) {
+    diskSpaceUsageListeners.remove(listener);
+  }
+
+  // Used only for testing
+  public void setFreeDiskSpaceSupplier(final LongSupplier freeDiskSpaceSupplier) {
+    this.freeDiskSpaceSupplier = freeDiskSpaceSupplier;
+  }
+}

--- a/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiService.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiService.java
@@ -9,6 +9,7 @@ package io.zeebe.broker.transport.commandapi;
 
 import io.zeebe.broker.Loggers;
 import io.zeebe.broker.PartitionListener;
+import io.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.zeebe.broker.transport.backpressure.PartitionAwareRequestLimiter;
 import io.zeebe.broker.transport.backpressure.RequestLimiter;
 import io.zeebe.engine.processor.CommandResponseWriter;
@@ -24,7 +25,8 @@ import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.function.Consumer;
 import org.agrona.collections.IntHashSet;
 
-public final class CommandApiService extends Actor implements PartitionListener {
+public final class CommandApiService extends Actor
+    implements PartitionListener, DiskSpaceUsageListener {
 
   private final PartitionAwareRequestLimiter limiter;
   private final ServerTransport serverTransport;
@@ -116,5 +118,15 @@ public final class CommandApiService extends Actor implements PartitionListener 
         partitionLimiter.onResponse(typedRecord.getRequestStreamId(), typedRecord.getRequestId());
       }
     };
+  }
+
+  @Override
+  public void onDiskSpaceNotAvailable() {
+    actor.run(requestHandler::onDiskSpaceNotAvailable);
+  }
+
+  @Override
+  public void onDiskSpaceAvailable() {
+    actor.run(requestHandler::onDiskSpaceAvailable);
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/transport/commandapi/ErrorResponseWriter.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/commandapi/ErrorResponseWriter.java
@@ -82,6 +82,10 @@ public final class ErrorResponseWriter implements BufferWriter {
     return errorCode(ErrorCode.RESOURCE_EXHAUSTED).errorMessage(RESOURCE_EXHAUSTED);
   }
 
+  public ErrorResponseWriter resourceExhausted(final String message) {
+    return errorCode(ErrorCode.RESOURCE_EXHAUSTED).errorMessage(message);
+  }
+
   public ErrorResponseWriter malformedRequest(Throwable e) {
     final StringBuilder builder = new StringBuilder();
 

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -187,6 +187,23 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_SNAPSHOTPERIOD.
       # snapshotPeriod: 15m
 
+      # When the disk usage is above this value all client commands will be rejected.
+      # The value is specified as a percentage of the total disk space.
+      # The value should be in the range (0, 1).
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK
+      # diskUsageCommandWatermark = 0.8
+
+      # When the disk usage is above this value, this broker will stop writing replicated events it receives from other brokers.
+      # The value is specified as a percentage of the total disk space.
+      # The value should be in the range (0, 1).
+      # It is recommended that diskUsageReplicationWatermark > diskUsageCommandWatermark
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
+      # diskUsageReplicationWatermark = 0.9
+
+      # Sets the interval at which the disk usage is monitored
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGINTERVAL
+      # diskUsageMonitoringInterval = 1s
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -139,6 +139,23 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_SNAPSHOTPERIOD.
       # snapshotPeriod: 15m
 
+      # When the disk usage is above this value all client commands will be rejected.
+      # The value is specified as a percentage of the total disk space.
+      # The value should be in the range (0, 1).
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK
+      # diskUsageCommandWatermark = 0.8
+
+      # When the disk usage is above this value, this broker will stop writing replicated events it receives from other brokers.
+      # The value is specified as a percentage of the total disk space.
+      # The value should be in the range (0, 1).
+      # It is recommended that diskUsageReplicationWatermark > diskUsageCommandWatermark
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
+      # diskUsageReplicationWatermark = 0.9
+
+      # Sets the interval at which the disk usage is monitored
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGINTERVAL
+      # diskUsageMonitoringInterval = 1s
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorLifecycleAware.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorLifecycleAware.java
@@ -15,4 +15,8 @@ public interface StreamProcessorLifecycleAware {
   default void onClose() {}
 
   default void onFailed() {}
+
+  default void onPaused() {}
+
+  default void onResumed() {}
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/timer/DueDateTimerChecker.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/timer/DueDateTimerChecker.java
@@ -100,4 +100,19 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
     // check if timers are due after restart
     triggerTimers();
   }
+
+  @Override
+  public void onPaused() {
+    if (scheduledTimer != null) {
+      scheduledTimer.cancel();
+      scheduledTimer = null;
+    }
+  }
+
+  @Override
+  public void onResumed() {
+    if (scheduledTimer == null) {
+      triggerTimers();
+    }
+  }
 }

--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
@@ -588,6 +588,87 @@ public final class StreamProcessorTest {
     assertThat(onProcessedListener.lastProcessedRecord.getPosition()).isEqualTo(position);
   }
 
+  @Test
+  public void shouldNotifyLifecycleListenersOnPauseAndResume() throws InterruptedException {
+    // given
+    final CountDownLatch pauseLatch = new CountDownLatch(1);
+    final CountDownLatch resumeLatch = new CountDownLatch(1);
+    final StreamProcessor streamProcessor =
+        streamProcessorRule.startTypedStreamProcessor(
+            (processors, state) ->
+                processors.withListener(
+                    new StreamProcessorLifecycleAware() {
+                      @Override
+                      public void onPaused() {
+                        pauseLatch.countDown();
+                      }
+
+                      @Override
+                      public void onResumed() {
+                        resumeLatch.countDown();
+                      }
+                    }));
+
+    // when
+    streamProcessor.pauseProcessing();
+    streamProcessor.resumeProcessing();
+
+    // then
+    pauseLatch.await();
+    resumeLatch.await();
+
+    assertThat(pauseLatch.getCount()).isEqualTo(0);
+    assertThat(resumeLatch.getCount()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldResumeProcessMoreRecordsAfterPause() throws InterruptedException {
+    // given
+    final var onProcessedListener = new AwaitableProcessedListener();
+    final CountDownLatch pauseLatch = new CountDownLatch(1);
+    final CountDownLatch resumeLatch = new CountDownLatch(1);
+    final TypedRecordProcessor<?> typedRecordProcessor = mock(TypedRecordProcessor.class);
+    final StreamProcessor streamProcessor =
+        streamProcessorRule.startTypedStreamProcessor(
+            (processors, state) ->
+                processors
+                    .onEvent(
+                        ValueType.WORKFLOW_INSTANCE,
+                        WorkflowInstanceIntent.ELEMENT_ACTIVATING,
+                        typedRecordProcessor)
+                    .withListener(
+                        new StreamProcessorLifecycleAware() {
+                          @Override
+                          public void onPaused() {
+                            pauseLatch.countDown();
+                          }
+
+                          @Override
+                          public void onResumed() {
+                            resumeLatch.countDown();
+                          }
+                        }),
+            onProcessedListener.expect(2));
+
+    streamProcessorRule.writeWorkflowInstanceEvent(WorkflowInstanceIntent.ELEMENT_ACTIVATING);
+
+    // when
+    streamProcessor.pauseProcessing();
+    pauseLatch.await();
+
+    final long positionProcessedAfterResume =
+        streamProcessorRule.writeWorkflowInstanceEvent(WorkflowInstanceIntent.ELEMENT_ACTIVATING);
+
+    streamProcessor.resumeProcessing();
+    resumeLatch.await();
+
+    // then
+    assertThat(onProcessedListener.await()).isTrue();
+    Assertions.assertThat(
+            streamProcessorRule.getZeebeState().getLastSuccessfulProcessedRecordPosition())
+        .isEqualTo(positionProcessedAfterResume);
+  }
+
   /**
    * A simple listener which allows you to wait for specific amount of records to be processed.
    *

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -182,9 +182,16 @@
       <scope>test</scope>
     </dependency>
 
+     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <version>1.14.3</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceRecoveryClusteredTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceRecoveryClusteredTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.health;
+
+import static io.zeebe.broker.it.util.ZeebeAssertHelper.assertWorkflowInstanceCompleted;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.Broker;
+import io.zeebe.broker.it.clustering.ClusteringRule;
+import io.zeebe.broker.it.util.GrpcClientRule;
+import io.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
+import io.zeebe.client.api.response.DeploymentEvent;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.record.intent.DeploymentIntent;
+import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceSubscriptionIntent;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+import org.springframework.util.unit.DataSize;
+
+public class DiskSpaceRecoveryClusteredTest {
+  private static final String CORRELATION_KEY = "item-2";
+  private final String messageName = "test";
+  private final Timeout testTimeout = Timeout.seconds(120);
+  private final ClusteringRule clusteringRule =
+      new ClusteringRule(
+          3,
+          1,
+          3,
+          cfg -> {
+            cfg.getData().setDiskUsageMonitoringInterval(Duration.ofSeconds(1));
+          });
+  private final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(testTimeout).around(clusteringRule).around(clientRule);
+
+  @Test
+  public void shouldDistributeDeploymentAfterDiskSpaceAvailableAgain() throws InterruptedException {
+    // given
+    final var failingBroker =
+        clusteringRule.getBroker(clusteringRule.getLeaderForPartition(3).getNodeId());
+    waitUntilDiskSpaceNotAvailable(failingBroker);
+
+    final long deploymentKey =
+        deployWorkflow(Bpmn.createExecutableProcess("test").startEvent().endEvent().done());
+
+    // when
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(60))
+        .until(
+            () ->
+                RecordingExporter.deploymentRecords(DeploymentIntent.DISTRIBUTE).limit(1).exists());
+
+    waitUntilDiskSpaceAvailable(failingBroker);
+
+    // then
+    clientRule.waitUntilDeploymentIsDone(deploymentKey);
+  }
+
+  @Ignore("https://github.com/zeebe-io/zeebe/issues/4786")
+  @Test
+  public void shouldCorrelateMessageAfterDiskSpaceAvailableAgain() throws InterruptedException {
+    // given
+    final var failingBroker =
+        clusteringRule.getBroker(clusteringRule.getLeaderForPartition(3).getNodeId());
+    final long workflowKey = deployWorkflowWithMessage("process1");
+
+    final long workflowInstanceKey1 =
+        createWorkflowInstance(Map.of("key", CORRELATION_KEY), workflowKey);
+    final long workflowInstanceKey2 =
+        createWorkflowInstance(Map.of("key", CORRELATION_KEY), workflowKey);
+    final long workflowInstanceKey3 =
+        createWorkflowInstance(Map.of("key", CORRELATION_KEY), workflowKey);
+
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(60))
+        .until(
+            () ->
+                RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+                        .limit(3)
+                        .count()
+                    == 3);
+    waitUntilDiskSpaceNotAvailable(failingBroker);
+
+    // when
+    publishMessage(CORRELATION_KEY, "1");
+    publishMessage(CORRELATION_KEY, "2");
+    publishMessage(CORRELATION_KEY, "3");
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(60))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        RecordingExporter.workflowInstanceSubscriptionRecords(
+                                WorkflowInstanceSubscriptionIntent.CORRELATED)
+                            .limit(2)
+                            .count())
+                    .isEqualTo(2));
+
+    waitUntilDiskSpaceAvailable(failingBroker);
+
+    // then
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(60))
+        .untilAsserted(() -> assertWorkflowInstanceCompleted(workflowInstanceKey1));
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(60))
+        .untilAsserted(() -> assertWorkflowInstanceCompleted(workflowInstanceKey2));
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(60))
+        .untilAsserted(() -> assertWorkflowInstanceCompleted(workflowInstanceKey3));
+  }
+
+  private void publishMessage(final String correlationKey, final String messageId) {
+    clientRule
+        .getClient()
+        .newPublishMessageCommand()
+        .messageName(messageName)
+        .correlationKey(correlationKey)
+        .messageId(messageId)
+        .timeToLive(Duration.ofMinutes(1))
+        .send()
+        .join();
+  }
+
+  private long deployWorkflow(final BpmnModelInstance modelInstance) {
+    final DeploymentEvent deploymentEvent =
+        clientRule
+            .getClient()
+            .newDeployCommand()
+            .addWorkflowModel(modelInstance, "workflow.bpmn")
+            .send()
+            .join();
+    return deploymentEvent.getKey();
+  }
+
+  private long deployWorkflowWithMessage(final String processId) {
+    final BpmnModelInstance workflow =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .intermediateCatchEvent()
+            .message(m -> m.name(messageName).zeebeCorrelationKeyExpression("key"))
+            .endEvent("end")
+            .done();
+    return clientRule.deployWorkflow(workflow);
+  }
+
+  private void waitUntilDiskSpaceNotAvailable(final Broker broker) throws InterruptedException {
+    final var diskSpaceMonitor = broker.getDiskSpaceUsageMonitor();
+
+    final CountDownLatch diskSpaceNotAvailable = new CountDownLatch(1);
+    diskSpaceMonitor.addDiskUsageListener(
+        new DiskSpaceUsageListener() {
+          @Override
+          public void onDiskSpaceNotAvailable() {
+            diskSpaceNotAvailable.countDown();
+          }
+
+          @Override
+          public void onDiskSpaceAvailable() {}
+        });
+
+    diskSpaceMonitor.setFreeDiskSpaceSupplier(() -> DataSize.ofGigabytes(0).toBytes());
+
+    clusteringRule.getClock().addTime(Duration.ofSeconds(1));
+
+    // when
+    assertThat(diskSpaceNotAvailable.await(2, TimeUnit.SECONDS)).isTrue();
+  }
+
+  private void waitUntilDiskSpaceAvailable(final Broker broker) throws InterruptedException {
+    final var diskSpaceMonitor = broker.getDiskSpaceUsageMonitor();
+    final CountDownLatch diskSpaceAvailableAgain = new CountDownLatch(1);
+    diskSpaceMonitor.addDiskUsageListener(
+        new DiskSpaceUsageListener() {
+          @Override
+          public void onDiskSpaceAvailable() {
+            diskSpaceAvailableAgain.countDown();
+          }
+        });
+
+    diskSpaceMonitor.setFreeDiskSpaceSupplier(() -> DataSize.ofGigabytes(100).toBytes());
+    clusteringRule.getClock().addTime(Duration.ofSeconds(1));
+    assertThat(diskSpaceAvailableAgain.await(2, TimeUnit.SECONDS)).isTrue();
+  }
+
+  private long createWorkflowInstance(final Object variables, final long workflowKey) {
+    return clientRule
+        .getClient()
+        .newCreateInstanceCommand()
+        .workflowKey(workflowKey)
+        .variables(variables)
+        .send()
+        .join()
+        .getWorkflowInstanceKey();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceRecoveryITTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceRecoveryITTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.health;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Volume;
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.containers.ZeebeBrokerContainer;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.elasticsearch.client.RestClient;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+public class DiskSpaceRecoveryITTest {
+  static ZeebeBrokerContainer zeebeBroker;
+  private static final Logger LOG = LoggerFactory.getLogger(DiskSpaceRecoveryITTest.class);
+  private static final String VOLUME_NAME = "data-DiskSpaceRecoveryITTest";
+  private static String containerIPAddress;
+  private static Integer apiPort;
+  private static ElasticsearchContainer elastic;
+  private ZeebeClient client;
+
+  @BeforeClass
+  public static void setUpClass() {
+    final var elasticHostInternal = "http://elastic:9200";
+    zeebeBroker = createZeebe(elasticHostInternal);
+    final var network = zeebeBroker.getNetwork();
+    elastic = createElastic(network);
+    zeebeBroker.start();
+
+    apiPort = zeebeBroker.getMappedPort(26500);
+    containerIPAddress = zeebeBroker.getContainerIpAddress();
+  }
+
+  private static ZeebeBrokerContainer createZeebe(final String elasticHost) {
+    zeebeBroker =
+        new ZeebeBrokerContainer("current-test")
+            .withEnv(
+                "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME",
+                "io.zeebe.exporter.ElasticsearchExporter")
+            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL", elasticHost)
+            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_DELAY", "1")
+            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE", "1")
+            .withEnv("ZEEBE_BROKER_DATA_SNAPSHOTPERIOD", "1m")
+            .withEnv("ZEEBE_BROKER_DATA_LOGSEGMENTSIZE", "1MB")
+            .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "1MB")
+            .withEnv("ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK", "0.5")
+            .withEnv("ZEEBE_BROKER_DATA_LOGINDEXDENSITY", "1")
+            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_MESSAGE", "true");
+
+    zeebeBroker
+        .getDockerClient()
+        .createVolumeCmd()
+        .withDriver("local")
+        .withDriverOpts(Map.of("type", "tmpfs", "device", "tmpfs", "o", "size=16m"))
+        .withName(VOLUME_NAME)
+        .exec();
+    final Volume newVolume = new Volume("/usr/local/zeebe/data");
+    zeebeBroker.withCreateContainerCmdModifier(
+        cmd ->
+            cmd.withHostConfig(cmd.getHostConfig().withBinds(new Bind(VOLUME_NAME, newVolume)))
+                .withName("zeebe-test"));
+
+    return zeebeBroker;
+  }
+
+  private static ElasticsearchContainer createElastic(final Network network) {
+    final ElasticsearchContainer container =
+        new ElasticsearchContainer(
+            "docker.elastic.co/elasticsearch/elasticsearch:"
+                + RestClient.class.getPackage().getImplementationVersion());
+
+    container.withNetwork(network).withEnv("discovery.type", "single-node");
+    container.withCreateContainerCmdModifier(cmd -> cmd.withName("elastic"));
+    return container;
+  }
+
+  @AfterClass
+  public static void tearDownClass() {
+    zeebeBroker.stop();
+    zeebeBroker.getDockerClient().removeVolumeCmd(VOLUME_NAME).exec();
+    elastic.stop();
+  }
+
+  @Test
+  public void shouldRecoverAfterOutOfDiskSpaceWhenExporterStarts() {
+    // given
+    client =
+        ZeebeClient.newClientBuilder()
+            .brokerContactPoint(containerIPAddress + ":" + apiPort)
+            .usePlaintext()
+            .build();
+
+    // when
+    LOG.info("Wait until broker is out of disk space");
+    await()
+        .timeout(Duration.ofMinutes(3))
+        .pollInterval(1, TimeUnit.MICROSECONDS)
+        .untilAsserted(
+            () ->
+                assertThatThrownBy(this::publishMessage)
+                    .hasRootCauseMessage(
+                        "RESOURCE_EXHAUSTED: Cannot accept requests for partition 1. Broker is out of disk space"));
+
+    elastic.start();
+
+    // then
+    await()
+        .pollInterval(Duration.ofSeconds(10))
+        .timeout(Duration.ofMinutes(3))
+        .untilAsserted(() -> assertThatCode(this::publishMessage).doesNotThrowAnyException());
+  }
+
+  private void publishMessage() {
+    client
+        .newPublishMessageCommand()
+        .messageName("test")
+        .correlationKey(String.valueOf(1))
+        .send()
+        .join();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceRecoveryTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceRecoveryTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.zeebe.broker.it.util.GrpcClientRule;
+import io.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.TimerIntent;
+import io.zeebe.protocol.record.value.JobRecordValueAssert;
+import io.zeebe.protocol.record.value.TimerRecordValueAssert;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+import org.springframework.util.unit.DataSize;
+
+public class DiskSpaceRecoveryTest {
+  private final Timeout testTimeout = Timeout.seconds(120);
+  private final EmbeddedBrokerRule embeddedBrokerRule =
+      new EmbeddedBrokerRule(
+          cfg -> {
+            cfg.getData().setDiskUsageMonitoringInterval(Duration.ofSeconds(1));
+          });
+  private final GrpcClientRule clientRule = new GrpcClientRule(embeddedBrokerRule);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(testTimeout).around(embeddedBrokerRule).around(clientRule);
+
+  @Test
+  public void shouldStopAcceptingRequestWhenDiskSpaceFull() throws InterruptedException {
+    // given
+    waitUntilDiskSpaceNotAvailable();
+
+    // when
+    final var resultFuture =
+        clientRule
+            .getClient()
+            .newPublishMessageCommand()
+            .messageName("test")
+            .correlationKey("test")
+            .send();
+
+    // then
+    Assertions.assertThatThrownBy(resultFuture::join)
+        .hasRootCauseMessage(
+            "RESOURCE_EXHAUSTED: Cannot accept requests for partition 1. Broker is out of disk space");
+  }
+
+  @Test
+  public void shouldRestartAcceptingRequestWhenDiskSpaceAvailableAgain()
+      throws InterruptedException {
+    // given
+    waitUntilDiskSpaceNotAvailable();
+
+    // when
+    waitUntilDiskSpaceAvailable();
+    final var resultFuture =
+        clientRule
+            .getClient()
+            .newPublishMessageCommand()
+            .messageName("test")
+            .correlationKey("Test")
+            .send();
+
+    // then
+    assertThatCode(resultFuture::join).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void shouldProcessTimersWhenDiskSpaceAvailableAgain() throws InterruptedException {
+    // given
+    final BpmnModelInstance timerWorkflow =
+        Bpmn.createExecutableProcess("TimerProcess")
+            .startEvent("start")
+            .intermediateCatchEvent("timer", c -> c.timerWithDuration("PT100S"))
+            .endEvent("end")
+            .done();
+    final long workflowKey = clientRule.deployWorkflow(timerWorkflow);
+    final long workflowInstanceKey = clientRule.createWorkflowInstance(workflowKey);
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(60))
+        .until(
+            () ->
+                RecordingExporter.timerRecords(TimerIntent.CREATED)
+                    .withWorkflowInstanceKey(workflowInstanceKey)
+                    .limit(1)
+                    .exists());
+
+    final var timerKey =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .getFirst()
+            .getValue()
+            .getElementInstanceKey();
+
+    // when
+    waitUntilDiskSpaceNotAvailable();
+    embeddedBrokerRule.getClock().addTime(Duration.ofSeconds(100));
+
+    waitUntilDiskSpaceAvailable();
+
+    // then
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(60))
+        .until(
+            () ->
+                RecordingExporter.timerRecords(TimerIntent.TRIGGER)
+                    .withElementInstanceKey(timerKey)
+                    .limit(1)
+                    .exists());
+
+    TimerRecordValueAssert.assertThat(
+            RecordingExporter.timerRecords(TimerIntent.TRIGGER).getFirst().getValue())
+        .hasWorkflowInstanceKey(workflowInstanceKey);
+  }
+
+  @Test
+  public void shouldTimeoutActivatedJobsWhenDiskSpaceAvailableAgain() throws InterruptedException {
+    // given
+    final BpmnModelInstance timerWorkflow =
+        Bpmn.createExecutableProcess("TimerProcess")
+            .startEvent("start")
+            .serviceTask("test", s -> s.zeebeJobType("timeout"))
+            .endEvent("end")
+            .done();
+    final long workflowKey = clientRule.deployWorkflow(timerWorkflow);
+    final long workflowInstanceKey = clientRule.createWorkflowInstance(workflowKey);
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(60))
+        .until(
+            () ->
+                RecordingExporter.jobRecords(JobIntent.CREATED)
+                    .withWorkflowInstanceKey(workflowInstanceKey)
+                    .limit(1)
+                    .exists());
+
+    final var jobs =
+        clientRule
+            .getClient()
+            .newActivateJobsCommand()
+            .jobType("timeout")
+            .maxJobsToActivate(1)
+            .timeout(Duration.ofSeconds(60))
+            .workerName("test")
+            .send()
+            .join()
+            .getJobs();
+
+    assertThat(jobs).isNotEmpty();
+
+    final var jobKey = jobs.get(0).getElementInstanceKey();
+
+    // when
+    waitUntilDiskSpaceNotAvailable();
+    embeddedBrokerRule.getClock().addTime(Duration.ofSeconds(100));
+
+    waitUntilDiskSpaceAvailable();
+
+    // then
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(60))
+        .until(
+            () ->
+                RecordingExporter.jobRecords(JobIntent.TIME_OUT)
+                    .withWorkflowInstanceKey(workflowInstanceKey)
+                    .limit(1)
+                    .exists());
+
+    JobRecordValueAssert.assertThat(
+            RecordingExporter.jobRecords(JobIntent.TIME_OUT).getFirst().getValue())
+        .hasElementInstanceKey(jobKey);
+  }
+
+  private void waitUntilDiskSpaceNotAvailable() throws InterruptedException {
+    final var diskSpaceMonitor = embeddedBrokerRule.getBroker().getDiskSpaceUsageMonitor();
+
+    final CountDownLatch diskSpaceNotAvailable = new CountDownLatch(1);
+    diskSpaceMonitor.addDiskUsageListener(
+        new DiskSpaceUsageListener() {
+          @Override
+          public void onDiskSpaceNotAvailable() {
+            diskSpaceNotAvailable.countDown();
+          }
+
+          @Override
+          public void onDiskSpaceAvailable() {}
+        });
+
+    diskSpaceMonitor.setFreeDiskSpaceSupplier(() -> DataSize.ofGigabytes(0).toBytes());
+
+    embeddedBrokerRule.getClock().addTime(Duration.ofSeconds(1));
+
+    // when
+    assertThat(diskSpaceNotAvailable.await(2, TimeUnit.SECONDS)).isTrue();
+  }
+
+  private void waitUntilDiskSpaceAvailable() throws InterruptedException {
+    final var diskSpaceMonitor = embeddedBrokerRule.getBroker().getDiskSpaceUsageMonitor();
+    final CountDownLatch diskSpaceAvailableAgain = new CountDownLatch(1);
+    diskSpaceMonitor.addDiskUsageListener(
+        new DiskSpaceUsageListener() {
+          @Override
+          public void onDiskSpaceAvailable() {
+            diskSpaceAvailableAgain.countDown();
+          }
+        });
+
+    diskSpaceMonitor.setFreeDiskSpaceSupplier(() -> DataSize.ofGigabytes(100).toBytes());
+    embeddedBrokerRule.getClock().addTime(Duration.ofSeconds(1));
+    assertThat(diskSpaceAvailableAgain.await(2, TimeUnit.SECONDS)).isTrue();
+  }
+}


### PR DESCRIPTION
## Description

* expose configuration parameters for minimum free disk space
* When broker free disk space available is less than configured min free disk,
  - reject client requests
  - reject commands from other partitions
  - pause stream processor

## Related issues

closes #4441 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
