### PR TITLE
fix(exporters/elasticsearch-exporter): avoid OOM when retrying

### DIFF
--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchExporterTest.java
@@ -23,9 +23,7 @@ import io.zeebe.exporter.api.context.Context;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.ValueType;
-import io.zeebe.protocol.record.value.ErrorRecordValue;
 import io.zeebe.test.exporter.ExporterTestHarness;
-import io.zeebe.test.exporter.record.MockRecordValue;
 import io.zeebe.util.ZbLogger;
 import java.time.Duration;
 import java.util.Arrays;
@@ -370,33 +368,5 @@ public class ElasticsearchExporterTest {
     when(client.putIndexTemplate(any(ValueType.class))).thenReturn(true);
     when(client.putIndexTemplate(anyString(), anyString(), anyString())).thenReturn(true);
     return client;
-  }
-
-  static class ErrorMockRecord extends MockRecordValue implements ErrorRecordValue {
-
-    static final String EXCEPTION_MESSAGE = "Expected Exception Message";
-    static final String STACKTRACE = "Expected Stacktrace";
-    static final long ERROR_EVENT_POSITION = 123;
-    static final long WORKFLOW_INSTANCE_KEY = 456;
-
-    @Override
-    public String getExceptionMessage() {
-      return EXCEPTION_MESSAGE;
-    }
-
-    @Override
-    public String getStacktrace() {
-      return STACKTRACE;
-    }
-
-    @Override
-    public long getErrorEventPosition() {
-      return ERROR_EVENT_POSITION;
-    }
-
-    @Override
-    public long getWorkflowInstanceKey() {
-      return WORKFLOW_INSTANCE_KEY;
-    }
   }
 }


### PR DESCRIPTION
## Description

Don't append record again when retrying to export, in order to avoid OOM exception.

## Related issues

closes #4668 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
