### PR TITLE
[BACKPORT] Probe components health when partition is probed

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -27,6 +27,61 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
+/*
+ * There's 2 ways BrokerHealthCheckService can monitor its current healthstatus:
+ *
+ *  - listening for failures: in which a subcomponent tells its parent component that a failure
+ *   occurred, so that the healthstatus can be updated for all ancestor components. All of the
+ *   subcomponents in the diagram below do this.
+ *  - probing for healthstatus, in which the BrokerHealthCheckService just checks the healthstatus
+ *   of its CriticalComponentsHealthMonitor.
+ *
+ * In turn, the CriticalComponentsHealthMonitors periodically probe their subcomponents for their
+ *  healthstatus and update their own healthstatus when one of their subcomponents has become
+ *  unhealthy.
+ *
+ * The ZeebePartition only probes its CriticalComponentsHealthMonitor when its healthstatus is
+ *  probed by the CriticalComponentsHealthMonitor that monitors the ZeebePartition.
+ *
+ *       +--------------+
+ *       | BrokerHealth |-----healthstatus
+ *       | CheckService |
+ *       +--------------+
+ *    probes    |
+ *    downwards |informs
+ *              |upwards
+ *    +--------------------+
+ *    | CriticalComponents |----healthstatus
+ *    | HealthMonitor      |
+ *    +--------------------+
+ * periodically |
+ * monitors     |informs
+ * downwards    |upwards   +----------------+
+ *              |----------| ZeebePartition |----healthstatus
+ *                   probes ----------------+
+ *                   downwards     |
+ *                   when probed   |informs
+ *                                 |upwards
+ *                       +--------------------+
+ *                       | CriticalComponents |-----healthstatus
+ *                       | HealthMonitor      |
+ *                       +--------------------+
+ *                    periodically |
+ *                    monitors     |informs
+ *                    downwards    |upwards   +------+
+ *                                 |----------| Raft |
+ *                                 |          +------+
+ *                                 |informs
+ *                                 |upwards   +-----------------+
+ *                                 |----------| StreamProcessor |
+ *                                 |          +-----------------+
+ *                                 |informs
+ *                                 |upwards   +-----+
+ *                                 |----------| Log |
+ *                                            +-----+
+ *
+ * https://textik.com/#cb084adedb02d970
+ */
 public final class BrokerHealthCheckService extends Actor implements PartitionListener {
 
   private static final String PARTITION_COMPONENT_NAME_FORMAT = "Partition-%d";

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -774,7 +774,14 @@ public final class ZeebePartition extends Actor
 
   @Override
   public HealthStatus getHealthStatus() {
-    return healthStatus;
+    if (healthStatus == HealthStatus.UNHEALTHY) {
+      return HealthStatus.UNHEALTHY;
+    }
+    final var componentsHealthStatus = criticalComponentsHealthMonitor.getHealthStatus();
+    if (componentsHealthStatus == HealthStatus.UNHEALTHY) {
+      updateHealthStatus(HealthStatus.UNHEALTHY);
+    }
+    return componentsHealthStatus;
   }
 
   @Override


### PR DESCRIPTION
## Description

When the BrokerHealthCheckService probes the ZeebePartitions for their
health, the ZeebePartition only reported its own health-status. However,
we cannot be sure that this status is updated when one of the components
fails. To make sure that the health check is correct, it is setup to be
bi-directional, so when probing, the partition should also probe its own
critical components.

Lastly, when this results in an UNHEALTHY state, the metrics should be
updated. So we call updateHealthStatus when the partitions own state is
HEALTHY, but its critical components are not.

## Related issues

closes #4723 

backport of #4764