### PR TITLE
fix(broker): use logstream name for health monitoring

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -378,7 +378,8 @@ public final class ZeebePartition extends Actor
                   logStream.setCommitPosition(deferredCommitPosition);
                   deferredCommitPosition = -1;
                 }
-                criticalComponentsHealthMonitor.registerComponent("logStream", logStream);
+                criticalComponentsHealthMonitor.registerComponent(
+                    logStream.getLogName(), logStream);
                 installStorageServices()
                     .onComplete(
                         (deletionService, errorInstall) -> {
@@ -579,7 +580,7 @@ public final class ZeebePartition extends Actor
       return CompletableActorFuture.completed(null);
     }
 
-    criticalComponentsHealthMonitor.removeComponent("logstream");
+    criticalComponentsHealthMonitor.removeComponent(logStream.getLogName());
     final LogStream logStreamToClose = logStream;
     logStream = null;
     return logStreamToClose.closeAsync();
@@ -732,7 +733,7 @@ public final class ZeebePartition extends Actor
   private ActorFuture<LogStream> openLogStream() {
     return LogStream.builder()
         .withLogStorage(atomixLogStorage)
-        .withLogName(atomixRaftPartition.name())
+        .withLogName("logstream-" + atomixRaftPartition.name())
         .withNodeId(localBroker.getNodeId())
         .withPartitionId(atomixRaftPartition.id().id())
         .withMaxFragmentSize(maxFragmentSize)


### PR DESCRIPTION
## Description

* Use name of logstream for consistency. Other components use actor name as the component name. But LogStream is not an actor only its implementation is an actor. 

## Related issues

closes #4618 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
