### PR TITLE
chore(atomix): add missing test for multiple data loss

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -238,10 +238,13 @@ public final class RaftRule extends ExternalResource {
   }
 
   public void shutdownServer(final RaftServer raftServer) throws Exception {
-    raftServer.shutdown().get(30, TimeUnit.SECONDS);
-    servers.remove(raftServer.name());
-    compactAwaiters.remove(raftServer.name());
-    memberLog.remove(raftServer.name());
+    shutdownServer(raftServer.name());
+  }
+
+  public void shutdownServer(final String nodeName) throws Exception {
+    servers.remove(nodeName).shutdown().get(30, TimeUnit.SECONDS);
+    compactAwaiters.remove(nodeName);
+    memberLog.remove(nodeName);
   }
 
   private RaftMember getRaftMember(final String memberId) {


### PR DESCRIPTION
## Description

Added a new test to test snapshot replication on multiple data loss an same node.

[See comment](https://github.com/zeebe-io/zeebe/issues/4468#issuecomment-633415646) from @deepthidevaki 

> Thanks.
> 
> The bug that we had before was if the leader replicated the snapshot to the follower once, it won't replicate it again if the follower restarts with data loss. The test we had before was covering this scenario. It would be good to test it so that we don't introduce that bug again. The previous test was as follows:
> 
> Ensure snapshot is replicated by the leader to the follower :
> Append some entries and take snapshot
> Follower restart with data loss
> Assert follower received snapshot
> Verify snapshot is replicated again :
> The same follower restart with data loss
> Assert follower received snapshot


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4468

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing