### PR TITLE
[BACKPORT] fix(broker): use logstream name for health monitoring

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -377,7 +377,8 @@ public final class ZeebePartition extends Actor
                   logStream.setCommitPosition(deferredCommitPosition);
                   deferredCommitPosition = -1;
                 }
-                criticalComponentsHealthMonitor.registerComponent("logStream", logStream);
+                criticalComponentsHealthMonitor.registerComponent(
+                    logStream.getLogName(), logStream);
                 installStorageServices()
                     .onComplete(
                         (deletionService, errorInstall) -> {
@@ -574,7 +575,7 @@ public final class ZeebePartition extends Actor
       return CompletableActorFuture.completed(null);
     }
 
-    criticalComponentsHealthMonitor.removeComponent("logstream");
+    criticalComponentsHealthMonitor.removeComponent(logStream.getLogName());
     final LogStream logStreamToClose = logStream;
     logStream = null;
     return logStreamToClose.closeAsync();
@@ -719,7 +720,7 @@ public final class ZeebePartition extends Actor
   private ActorFuture<LogStream> openLogStream() {
     return LogStream.builder()
         .withLogStorage(atomixLogStorage)
-        .withLogName(atomixRaftPartition.name())
+        .withLogName("logstream-" + atomixRaftPartition.name())
         .withNodeId(localBroker.getNodeId())
         .withPartitionId(atomixRaftPartition.id().id())
         .withMaxFragmentSize(maxFragmentSize)


### PR DESCRIPTION
## Description

* Use consistent name for logstream component

## Related issues

closes #4840 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
