### PR TITLE
chore(ci): zip test results, keep reports for flaky tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -189,7 +189,8 @@ pipeline {
 
             post {
                 failure {
-                    archive "**/*/surefire-reports/*-output.txt"
+                    zip zipFile: 'test-reports.zip', archive: true, glob: "**/*/surefire-reports/**"
+
                     script {
                       if (fileExists('./target/FlakyTests.txt')) {
                           currentBuild.description = "Flaky Tests: <br>" + readFile('./target/FlakyTests.txt').split('\n').join('<br>')


### PR DESCRIPTION
## Description

* zip test results to save storage on Jenkins servers
* also include the XML files in the zip file; this allows us to get more information about flaky tests

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [n/a] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [n/a] If submitting code, please run `mvn clean install -DskipTests` locally before committing
