### PR TITLE
chore(logstreams): fix flaky inconsistent entry test

### DIFF
--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -155,29 +156,38 @@ public final class LogStorageAppenderTest {
     final AtomicReference<Throwable> err = new AtomicReference<>();
 
     logStorageRule.setPositionListener(i -> committed.countDown());
-    final long firstPosition = writer.valueWriter(value).tryWrite();
-    schedulerRule.submitActor(appender).join();
-
-    // when
     logStorageRule.setWriteErrorListener(
         throwable -> {
           err.set(throwable);
           failed.countDown();
         });
+
+    final AtomicLong expectedPos = new AtomicLong(INITIAL_POSITION);
     when(subscription.peekBlock(any(), anyInt(), anyBoolean()))
         .then(
             a -> {
-              // change the entry's position
               final Object result = a.callRealMethod();
               final BlockPeek block = a.getArgument(0);
               assertThat(LogEntryDescriptor.getPosition(block.getBuffer(), 0))
-                  .isEqualTo(INITIAL_POSITION + 1);
-              LogEntryDescriptor.setPosition(
-                  block.getBuffer(), DataFrameDescriptor.messageOffset(0), WRONG_POSITION);
+                  .isEqualTo(expectedPos.get());
+
+              // corrupt second entry
+              if (expectedPos.get() != INITIAL_POSITION) {
+                LogEntryDescriptor.setPosition(
+                    block.getBuffer(), DataFrameDescriptor.messageOffset(0), WRONG_POSITION);
+              } else {
+                expectedPos.incrementAndGet();
+              }
+
               return result;
             });
+
+    // when
+    final long firstPosition = writer.valueWriter(value).tryWrite();
+    schedulerRule.submitActor(appender).join();
     assertThat(committed.await(5, TimeUnit.SECONDS)).isTrue();
-    final var position = writer.valueWriter(value).tryWrite();
+
+    final var secondPosition = writer.valueWriter(value).tryWrite();
 
     // then
     assertThat(failed.await(5, TimeUnit.SECONDS)).isTrue();
@@ -186,7 +196,7 @@ public final class LogStorageAppenderTest {
             String.format(
                 "Unexpected position %d was encountered after position %d when appending positions <%d, %d>.",
                 WRONG_POSITION, firstPosition, WRONG_POSITION, WRONG_POSITION));
-    assertThat(reader.seek(position)).isFalse();
+    assertThat(reader.seek(secondPosition)).isFalse();
     assertThat(reader.hasNext()).isFalse();
   }
 


### PR DESCRIPTION
## Description

Fixes race condition in test that was causing a flaky test.

## Related issues

closes #4849 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
