### PR TITLE
fix(dispatcher): don't allow claiming more than maximumFragmentSize

### DIFF
--- a/dispatcher/src/main/java/io/zeebe/dispatcher/Dispatcher.java
+++ b/dispatcher/src/main/java/io/zeebe/dispatcher/Dispatcher.java
@@ -28,7 +28,7 @@ public class Dispatcher extends Actor {
 
   private static final Logger LOG = Loggers.DISPATCHER_LOGGER;
   private static final String ERROR_MESSAGE_CLAIM_FAILED =
-      "Expected to claim segment of size %d, but can't claim more then %d bytes.";
+      "Expected to claim segment of size %d, but can't claim more than %d bytes.";
 
   private final LogBuffer logBuffer;
   private final LogBufferAppender logAppender;
@@ -145,7 +145,7 @@ public class Dispatcher extends Actor {
             logAppender.claim(
                 partition, activePartitionId, claim, length, streamId, onClaimComplete),
         1,
-        length);
+        LogBufferAppender.claimedFragmentLength(length));
   }
 
   /**
@@ -166,7 +166,7 @@ public class Dispatcher extends Actor {
             logAppender.claim(
                 partition, activePartitionId, batch, fragmentCount, batchLength, onClaimComplete),
         fragmentCount,
-        batchLength);
+        LogBufferAppender.claimedBatchLength(fragmentCount, batchLength));
   }
 
   private synchronized long offer(

--- a/dispatcher/src/test/java/io/zeebe/dispatcher/integration/DispatcherIntegrationTest.java
+++ b/dispatcher/src/test/java/io/zeebe/dispatcher/integration/DispatcherIntegrationTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.zeebe.dispatcher.BlockPeek;
 import io.zeebe.dispatcher.ClaimedFragment;
+import io.zeebe.dispatcher.ClaimedFragmentBatch;
 import io.zeebe.dispatcher.Dispatcher;
 import io.zeebe.dispatcher.Dispatchers;
 import io.zeebe.dispatcher.FragmentHandler;
@@ -173,7 +174,7 @@ public final class DispatcherIntegrationTest {
             .maxFragmentLength(frameLength)
             .bufferSize(frameLength);
 
-    assertThatThrownBy(() -> builder.build())
+    assertThatThrownBy(builder::build)
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Expected the buffer size to be greater than %s, but was %s. The max fragment length is set to %s.",
@@ -195,6 +196,23 @@ public final class DispatcherIntegrationTest {
     assertThat(dispatcher.getLogBuffer().getPartitionSize()).isEqualTo(expectedPartitionSize);
   }
 
+  @Test
+  public void shouldRejectIfFullFrameLengthIsLargerThanMax() {
+    // given
+    final ClaimedFragmentBatch batch = new ClaimedFragmentBatch();
+    final int maxFragmentLength = (int) ByteValue.ofKilobytes(1);
+    final Dispatcher dispatcher =
+        Dispatchers.create("default")
+            .actorScheduler(actorSchedulerRule.get())
+            .maxFragmentLength(maxFragmentLength)
+            .build();
+
+    // when/then
+    assertThatThrownBy(() -> dispatcher.claimFragmentBatch(batch, 2, maxFragmentLength - 1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("can't claim more than");
+  }
+
   protected void claimFragment(
       final Dispatcher dispatcher, final ClaimedFragment claimedFragment, final int totalWork) {
     for (int i = 1; i <= totalWork; i++) {
@@ -210,22 +228,21 @@ public final class DispatcherIntegrationTest {
   protected void claimFragmentOnDifferentThreads(final Dispatcher dispatcher, final int totalWork) {
     for (int i = 1; i <= totalWork; i++) {
       final int runCount = i;
-      new Thread() {
-        @Override
-        public void run() {
-          final ClaimedFragment claimedFragment = new ClaimedFragment();
-          while (dispatcher.claimSingleFragment(claimedFragment, 59) <= 0) {
-            // spin
-          }
-          final MutableDirectBuffer buffer = claimedFragment.getBuffer();
-          buffer.putInt(claimedFragment.getOffset(), runCount);
-          claimedFragment.commit();
-        }
-      }.start();
+      new Thread(
+              () -> {
+                final ClaimedFragment claimedFragment = new ClaimedFragment();
+                while (dispatcher.claimSingleFragment(claimedFragment, 59) <= 0) {
+                  // spin
+                }
+                final MutableDirectBuffer buffer = claimedFragment.getBuffer();
+                buffer.putInt(claimedFragment.getOffset(), runCount);
+                claimedFragment.commit();
+              })
+          .start();
     }
   }
 
-  class Consumer implements FragmentHandler {
+  static class Consumer implements FragmentHandler {
     final ArrayList<Integer> counters = new ArrayList<>();
     final AtomicInteger counter = new AtomicInteger(0);
 


### PR DESCRIPTION
## Description

Take frame headers and alignment into account when checking if the claimed space is larger than the maximum size. This prevents the situation where a batch is successfully claimed but cannot be read into a block because it exceeds the max size (the claimed memory is never released and the writers stop being able to write).

## Related issues

closes #4851 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
