### PR TITLE
[BACKPORT] fix(dispatcher): don't allow claiming more than max size

### DIFF
--- a/dispatcher/src/main/java/io/zeebe/dispatcher/Dispatcher.java
+++ b/dispatcher/src/main/java/io/zeebe/dispatcher/Dispatcher.java
@@ -28,7 +28,7 @@ public class Dispatcher extends Actor {
 
   private static final Logger LOG = Loggers.DISPATCHER_LOGGER;
   private static final String ERROR_MESSAGE_CLAIM_FAILED =
-      "Expected to claim segment of size %d, but can't claim more then %d bytes.";
+      "Expected to claim segment of size %d, but can't claim more than %d bytes.";
 
   private final LogBuffer logBuffer;
   private final LogBufferAppender logAppender;
@@ -142,7 +142,7 @@ public class Dispatcher extends Actor {
         (partition, activePartitionId) ->
             logAppender.claim(
                 partition, activePartitionId, claim, length, streamId, onClaimComplete),
-        length);
+        LogBufferAppender.claimedFragmentLength(length));
   }
 
   /**
@@ -163,7 +163,7 @@ public class Dispatcher extends Actor {
         (partition, activePartitionId) ->
             logAppender.claim(
                 partition, activePartitionId, batch, fragmentCount, batchLength, onClaimComplete),
-        batchLength);
+        LogBufferAppender.claimedBatchLength(fragmentCount, batchLength));
   }
 
   private long offer(


### PR DESCRIPTION
## Description

Take frame headers and alignment into account when checking if the claimed space is larger than the maximum size. This prevents the situation where a batch is successfully claimed but cannot be read into a block because it exceeds the max size (the claimed memory is never released and the writers stop being able to write).

## Related issues

closes #4851 

related to #4859 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
