### PR TITLE
chore(benchmarks): update defaults

### DIFF
--- a/benchmarks/setup/default/simpleStarter.yaml
+++ b/benchmarks/setup/default/simpleStarter.yaml
@@ -20,7 +20,13 @@ spec:
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS
-            value: "-Dapp.brokerUrl=default-zeebe-gateway:26500 -Dapp.starter.rate=300 -Dzeebe.client.requestTimeout=62000 -XX:+HeapDumpOnOutOfMemoryError -Dapp.starter.bpmnXmlPath=bpmn/simpleProcess.bpmn -Dapp.starter.processId=simpleProcess"
+            value: >-
+              -Dapp.brokerUrl=default-zeebe-gateway:26500
+              -Dapp.starter.rate=300
+              -Dzeebe.client.requestTimeout=62000
+              -XX:+HeapDumpOnOutOfMemoryError
+              -Dapp.starter.bpmnXmlPath=bpmn/simpleProcess.bpmn
+              -Dapp.starter.processId=simpleProcess
           - name: LOG_LEVEL
             value: "warn"
         resources:

--- a/benchmarks/setup/default/starter.yaml
+++ b/benchmarks/setup/default/starter.yaml
@@ -20,7 +20,11 @@ spec:
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS
-            value: "-Dapp.brokerUrl=default-zeebe-gateway:26500 -Dapp.starter.rate=300 -Dzeebe.client.requestTimeout=62000 -XX:+HeapDumpOnOutOfMemoryError"
+            value: >-
+              -Dapp.brokerUrl=default-zeebe-gateway:26500
+              -Dapp.starter.rate=300
+              -Dzeebe.client.requestTimeout=62000
+              -XX:+HeapDumpOnOutOfMemoryError
           - name: LOG_LEVEL
             value: "warn"
         resources:

--- a/benchmarks/setup/default/timer.yaml
+++ b/benchmarks/setup/default/timer.yaml
@@ -20,7 +20,13 @@ spec:
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS
-            value: "-Dapp.brokerUrl=default-zeebe-gateway:26500 -Dapp.starter.rate=300 -Dzeebe.client.requestTimeout=62000 -XX:+HeapDumpOnOutOfMemoryError -Dapp.starter.bpmnXmlPath=bpmn/timerProcess.bpmn -Dapp.starter.processId=timerProcess"
+            value: >-
+              -Dapp.brokerUrl=default-zeebe-gateway:26500
+              -Dapp.starter.rate=300
+              -Dzeebe.client.requestTimeout=62000
+              -XX:+HeapDumpOnOutOfMemoryError
+              -Dapp.starter.bpmnXmlPath=bpmn/timerProcess.bpmn
+              -Dapp.starter.processId=timerProcess
           - name: LOG_LEVEL
             value: "warn"
         resources:

--- a/benchmarks/setup/default/worker.yaml
+++ b/benchmarks/setup/default/worker.yaml
@@ -20,12 +20,18 @@ spec:
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS
-            value: "-Dapp.brokerUrl=default-zeebe-gateway:26500 -Dzeebe.client.requestTimeout=62000 -Dapp.worker.capacity=120 -XX:+HeapDumpOnOutOfMemoryError"
+            value: >-
+              -Dapp.brokerUrl=default-zeebe-gateway:26500
+              -Dzeebe.client.requestTimeout=62000
+              -Dapp.worker.capacity=120
+              -Dapp.worker.pollingDelay=1ms
+              -Dapp.worker.completionDelay=50ms
+              -XX:+HeapDumpOnOutOfMemoryError
           - name: LOG_LEVEL
             value: "warn"
         resources:
           limits:
-            cpu: 1
+            cpu: 4
             memory: 2Gi
           requests:
             cpu: 1

--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -40,9 +40,8 @@ gateway:
 
 # JavaOpts:
 # DEFAULTS
-JavaOpts: >
-  -Xmx4g
-  -Xms4g
+JavaOpts: >-
+  -XX:MaxRAMPercentage=25.0
   -XX:+ExitOnOutOfMemoryError
   -XX:+HeapDumpOnOutOfMemoryError
   -XX:HeapDumpPath=/usr/local/zeebe/data
@@ -97,7 +96,7 @@ elasticsearch:
     storageClassName: "ssd"
     resources:
       requests:
-        storage: 300Gi
+        storage: 600Gi
 
   esJavaOpts: "-Xmx4g -Xms4g"
 


### PR DESCRIPTION
## Description

This PRs updates the benchmark defaults. It doubles the ES disk size as we now export more, and it lowers polling and completion delay as most of our benchmarks are essentially stress testing the system.

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
