### PR TITLE
Trigger build every hour for develop

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,9 +4,17 @@
 
 def buildName = "${env.JOB_BASE_NAME.replaceAll("%2F", "-").replaceAll("\\.", "-").take(20)}-${env.BUILD_ID}"
 
+def masterBranchName = 'master'
+def isMasterBranch = env.BRANCH_NAME == masterBranchName
+def developBranchName = 'develop'
+def isDevelopBranch = env.BRANCH_NAME == developBranchName
+
 //for develop branch keep builds for 7 days to be able to analyse build errors, for all other branches, keep the last 10 builds
-def daysToKeep = (env.BRANCH_NAME=='develop') ? '7' : '-1'
-def numToKeep = (env.BRANCH_NAME=='develop') ? '-1' : '10'
+def daysToKeep = isDevelopBranch ? '7' : '-1'
+def numToKeep = isDevelopBranch ? '-1' : '10'
+
+//the develop branch should be run hourly to detect flaky tests and instability, other branches only on commit
+def cronTrigger = isDevelopBranch ? '@hourly' : ''
 
 pipeline {
     agent {
@@ -21,6 +29,10 @@ pipeline {
     environment {
       NEXUS = credentials("camunda-nexus")
       SONARCLOUD_TOKEN = credentials('zeebe-sonarcloud-token')
+    }
+
+    triggers {
+      cron(cronTrigger)
     }
 
     options {
@@ -201,7 +213,7 @@ pipeline {
         }
 
         stage('Upload') {
-            when { branch 'develop' }
+            when { allOf { branch developBranchName ; not {  triggeredBy 'TimerTrigger' } } }
             steps {
                 retry(3) {
                     container('maven') {
@@ -214,9 +226,11 @@ pipeline {
         }
 
         stage('Post') {
+            when { not { triggeredBy 'TimerTrigger' } }
+
             parallel {
                 stage('Docker') {
-                    when { branch 'develop' }
+                    when { branch developBranchName }
 
                     environment {
                         VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
@@ -227,20 +241,20 @@ pipeline {
                             build job: 'zeebe-docker', parameters: [
                                 string(name: 'BRANCH', value: env.BRANCH_NAME),
                                 string(name: 'VERSION', value: env.VERSION),
-                                booleanParam(name: 'IS_LATEST', value: env.BRANCH_NAME == 'master'),
-                                booleanParam(name: 'PUSH', value: env.BRANCH_NAME == 'develop')
+                                booleanParam(name: 'IS_LATEST', value: isMasterBranch),
+                                booleanParam(name: 'PUSH', value: isDevelopBranch)
                             ]
                         }
                     }
                 }
 
                 stage('Docs') {
-                    when { anyOf { branch 'master'; branch 'develop' } }
+                    when { anyOf { branch masterBranchName; branch developBranchName } }
                     steps {
                         retry(3) {
                             build job: 'zeebe-docs', parameters: [
                                 string(name: 'BRANCH', value: env.BRANCH_NAME),
-                                booleanParam(name: 'LIVE', value: env.BRANCH_NAME == 'master')
+                                booleanParam(name: 'LIVE', value: isMasterBranch)
                             ]
                         }
                     }


### PR DESCRIPTION
## Description

To better track stability of the develop branch the build should be triggered on commit and every hour. Other branches should not be effected.

- add cron trigger to develop branch
- extract variables to identify stable and develop branch

After this we can get rid of the branch https://github.com/zeebe-io/zeebe/tree/4340-do-not-merge-monitor-build-health-branch
