### PR TITLE
chore(engine): process workflow events in a batch

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/nwe/behavior/ProcessingRecordWrapper.java
+++ b/engine/src/main/java/io/zeebe/engine/nwe/behavior/ProcessingRecordWrapper.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.nwe.behavior;
+
+import io.zeebe.engine.processor.TypedRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.RejectionType;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.intent.Intent;
+
+public class ProcessingRecordWrapper implements TypedRecord<WorkflowInstanceRecord> {
+
+  private final long key;
+  private final WorkflowInstanceRecord recordValue;
+  private final Intent intent;
+
+  public ProcessingRecordWrapper(
+      final long key, final WorkflowInstanceRecord recordValue, final Intent intent) {
+    this.key = key;
+    this.recordValue = recordValue;
+    this.intent = intent;
+  }
+
+  @Override
+  public long getKey() {
+    return key;
+  }
+
+  @Override
+  public WorkflowInstanceRecord getValue() {
+
+    return recordValue;
+  }
+
+  @Override
+  public int getRequestStreamId() {
+    return 0;
+  }
+
+  @Override
+  public long getRequestId() {
+    return 0;
+  }
+
+  @Override
+  public long getLength() {
+    return 0;
+  }
+
+  @Override
+  public long getPosition() {
+    return 0;
+  }
+
+  @Override
+  public long getSourceRecordPosition() {
+    return 0;
+  }
+
+  @Override
+  public long getTimestamp() {
+    return 0;
+  }
+
+  @Override
+  public Intent getIntent() {
+    return intent;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return 0;
+  }
+
+  @Override
+  public RecordType getRecordType() {
+    return null;
+  }
+
+  @Override
+  public RejectionType getRejectionType() {
+    return null;
+  }
+
+  @Override
+  public String getRejectionReason() {
+    return null;
+  }
+
+  @Override
+  public ValueType getValueType() {
+    return ValueType.WORKFLOW_INSTANCE;
+  }
+
+  @Override
+  public Record<WorkflowInstanceRecord> clone() {
+    return this;
+  }
+
+  @Override
+  public String toJson() {
+    return null;
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorBuilder.java
@@ -42,7 +42,7 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
-  public StreamProcessorBuilder nodeId(int nodeId) {
+  public StreamProcessorBuilder nodeId(final int nodeId) {
     this.nodeId = nodeId;
     return this;
   }
@@ -95,8 +95,9 @@ public final class StreamProcessorBuilder {
   public StreamProcessor build() {
     validate();
 
-    final MetadataFilter metadataFilter = new VersionFilter();
-    final EventFilter eventFilter = new MetadataEventFilter(metadataFilter);
+    final MetadataFilter versionFilter = new VersionFilter();
+    final MetadataFilter isProcessedFilter = metadata -> !metadata.isProcessed();
+    final EventFilter eventFilter = new MetadataEventFilter(versionFilter.and(isProcessedFilter));
     processingContext.eventFilter(eventFilter);
 
     return new StreamProcessor(this);

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/RecordMetadata.java
@@ -41,6 +41,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private int requestStreamId;
   private int protocolVersion = Protocol.PROTOCOL_VERSION; // always the current version by default
   private RejectionType rejectionType;
+  private boolean isProcessed;
 
   public RecordMetadata() {
     reset();
@@ -72,6 +73,10 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
       rejectionReason.wrap(buffer, offset, rejectionReasonLength);
     }
+
+    if (decoder.isProcessed() > 0) {
+      isProcessed = true;
+    }
   }
 
   @Override
@@ -102,6 +107,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         .protocolVersion(protocolVersion)
         .valueType(valueType)
         .intent(intentValue)
+        .isProcessed((short) (isProcessed ? 1 : 0))
         .rejectionType(rejectionType);
 
     offset += RecordMetadataEncoder.BLOCK_LENGTH;
@@ -145,13 +151,13 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public RecordMetadata valueType(final ValueType eventType) {
-    this.valueType = eventType;
+    valueType = eventType;
     return this;
   }
 
   public RecordMetadata intent(final Intent intent) {
     this.intent = intent;
-    this.intentValue = intent.value();
+    intentValue = intent.value();
     return this;
   }
 
@@ -184,12 +190,20 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   }
 
   public RecordMetadata rejectionReason(final DirectBuffer buffer) {
-    this.rejectionReason.wrap(buffer);
+    rejectionReason.wrap(buffer);
     return this;
   }
 
   public String getRejectionReason() {
     return BufferUtil.bufferAsString(rejectionReason);
+  }
+
+  public boolean isProcessed() {
+    return isProcessed;
+  }
+
+  public void setProcessed(final boolean processed) {
+    isProcessed = processed;
   }
 
   public RecordMetadata reset() {
@@ -202,6 +216,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     intent = null;
     rejectionType = RejectionType.NULL_VAL;
     rejectionReason.wrap(0, 0);
+    isProcessed = false;
     return this;
   }
 

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -95,6 +95,7 @@
     <field name="protocolVersion" id="4" type="uint16"/>
     <field name="valueType" id="5" type="ValueType"/>
     <field name="intent" id="6" type="uint8"/>
+    <field name="isProcessed" id="9" type="uint8" presence="optional"/>
     <!-- populated when RecordType is COMMAND_REJECTION -->
     <field name="rejectionType" id="7" type="RejectionType"/>
     <!-- populated when RecordType is COMMAND_REJECTION, UTF-8-encoded String -->


### PR DESCRIPTION
## Description

* add new optional field in record metadata to mark a record as processed
* skip records that are already processed
* process workflow instance events until reaching a wait state

## Related issues

closes #4879 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
