### PR TITLE
chore(atomix): fix possible race conditions on closing messaging service

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyUnicastServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyUnicastServiceTest.java
@@ -16,6 +16,7 @@
  */
 package io.atomix.cluster.messaging.impl;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -53,6 +54,16 @@ public class NettyUnicastServiceTest extends ConcurrentTestCase {
 
     service2.unicast(address1, "test", "Hello world!".getBytes());
     await(5000);
+  }
+
+  @Test
+  public void shouldNotThrowExceptionWhenServiceStopped() throws Exception {
+    // given
+    service2.stop();
+
+    // when - then
+    assertThatCode(() -> service2.unicast(address1, "test", "Hello world!".getBytes()))
+        .doesNotThrowAnyException();
   }
 
   @Before

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -19,7 +19,9 @@ import static io.zeebe.protocol.Protocol.START_PARTITION_ID;
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
+import io.atomix.cluster.messaging.impl.NettyBroadcastService;
 import io.atomix.cluster.messaging.impl.NettyMessagingService;
+import io.atomix.cluster.messaging.impl.NettyUnicastService;
 import io.atomix.cluster.protocol.SwimMembershipProtocol;
 import io.atomix.core.Atomix;
 import io.atomix.raft.partition.RaftPartition;
@@ -538,15 +540,17 @@ public final class ClusteringRule extends ExternalResource {
   public void disconnect(final Broker broker) {
     final var atomix = broker.getAtomix();
 
-    final var messagingService = (NettyMessagingService) atomix.getMessagingService();
-    messagingService.stop().join();
+    ((NettyUnicastService) atomix.getUnicastService()).stop().join();
+    ((NettyMessagingService) atomix.getMessagingService()).stop().join();
+    ((NettyBroadcastService) atomix.getBroadcastService()).stop().join();
   }
 
   public void connect(final Broker broker) {
     final var atomix = broker.getAtomix();
 
-    final var messagingService = (NettyMessagingService) atomix.getMessagingService();
-    messagingService.start().join();
+    ((NettyUnicastService) atomix.getUnicastService()).start().join();
+    ((NettyMessagingService) atomix.getMessagingService()).start().join();
+    ((NettyBroadcastService) atomix.getBroadcastService()).start().join();
   }
 
   public void stopBrokerAndAwaitNewLeader(final int nodeId) {


### PR DESCRIPTION
## Description

 Requests which have been submitted in between might be not completed exceptionally when the service has stopped.
 Sending a message when the service is stopped will not thrown an exception anymore.

I run the test several times locally and also in the CI without failing. Before it was quite easy to reproduce.

![screenshot2020-07-0821:05:55](https://user-images.githubusercontent.com/2758593/86963141-567acc00-c164-11ea-8dfd-d3d271c09f0e.png)

See also https://ci.zeebe.camunda.cloud/job/zeebe-io/job/zeebe/job/4909-fix-msg-service/
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4910 
closes #4909 
closes #4907  

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
