### PR TITLE
chore(qa): evaluate exceptions as false when waiting to get topology

### DIFF
--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -384,6 +384,7 @@ public final class ClusteringRule extends ExternalResource {
     return Awaitility.await()
         .pollInterval(Duration.ofMillis(100))
         .atMost(Duration.ofSeconds(10))
+        .ignoreExceptions()
         .until(() -> client.newTopologyRequest().send().join(), Objects::nonNull);
   }
 
@@ -600,6 +601,7 @@ public final class ClusteringRule extends ExternalResource {
     Awaitility.await()
         .pollInterval(Duration.ofMillis(100))
         .atMost(Duration.ofSeconds(10))
+        .ignoreExceptions()
         .until(() -> getTopologyFromClient().getBrokers(), topologyPredicate);
   }
 


### PR DESCRIPTION
## Description

If the topology query fails with an exception then `waitForTopology` does not retry. Instead `ignoreException` and treat them as failed predicates so that it will be retried until specified timeout. 

closes #4912 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
