### PR TITLE
Propagate message variables from event subprocess

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/nwe/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/nwe/behavior/BpmnStateBehavior.java
@@ -225,4 +225,16 @@ public final class BpmnStateBehavior {
         variablesState.getVariablesAsDocument(sourceContext.getElementInstanceKey());
     variablesState.setTemporaryVariables(targetContext.getElementInstanceKey(), variables);
   }
+
+  public void transferTemporaryVariables(
+      final BpmnElementContext sourceContext, final long targetElementInstanceKey) {
+
+    final var variables =
+        variablesState.getTemporaryVariables(sourceContext.getElementInstanceKey());
+
+    if (variables != null) {
+      variablesState.setTemporaryVariables(targetElementInstanceKey, variables);
+      variablesState.removeTemporaryVariables(sourceContext.getElementInstanceKey());
+    }
+  }
 }

--- a/engine/src/main/java/io/zeebe/engine/nwe/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/nwe/container/SubProcessProcessor.java
@@ -64,7 +64,11 @@ public final class SubProcessProcessor
     } else {
       // event sub-process is activated
       final var startEvent = element.getStartEvents().get(0);
-      stateTransitionBehavior.activateChildInstance(context, startEvent);
+      final var childInstance = stateTransitionBehavior.activateChildInstance(context, startEvent);
+
+      // the event variables are stored as temporary variables in the scope of the subprocess
+      // - move them to the scope of the start event to apply the output variable mappings
+      stateBehavior.transferTemporaryVariables(context, childInstance.getKey());
     }
   }
 


### PR DESCRIPTION
## Description

* the message variables were not propagated because they were stored as temporary variables of the scope of the event subprocess instead of its start event
* copy the temporary variable to the start event scope to apply them with the output mapping
* fix the existing message mapping test to verify the correct behavior

## Related issues

closes #4884 
closes #3930

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release annoncement 
