### PR TITLE
chore(ci): Do not notify slack if build is rescheduled

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -277,7 +277,7 @@ pipeline {
         }
         changed {
             script {
-                if (env.BRANCH_NAME == 'develop') {
+                if (env.BRANCH_NAME == 'develop' && !agentDisconnected()) {
                     slackSend(
                         channel: "#zeebe-ci${jenkins.model.JenkinsLocationConfiguration.get()?.getUrl()?.contains('stage') ? '-stage' : ''}",
                         message: "Zeebe ${env.BRANCH_NAME} build ${currentBuild.absoluteUrl} changed status to ${currentBuild.currentResult}")


### PR DESCRIPTION
## Description

* Stops notifying Slack when build is aborted due to Kubernetes connection error and rescheduled
* If it is aborted for any other reason (e.g. checkout failed), it will still report this to Slack


## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release annoncement 
