### PR TITLE
[Backport 0.23] Remove workflow related data from state when it is not used

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -139,6 +139,7 @@
       <scope>test</scope>
     </dependency>
 
+
     <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>atomix-cluster</artifactId>
@@ -148,6 +149,12 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/element/EventOccurredHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/handlers/element/EventOccurredHandler.java
@@ -115,10 +115,13 @@ public class EventOccurredHandler<T extends ExecutableFlowElement> extends Abstr
       final long eventScopeKey,
       final long variableScopeKey,
       final EventTrigger event) {
-    context
-        .getElementInstanceState()
-        .getVariablesState()
-        .setTemporaryVariables(variableScopeKey, event.getVariables());
+
+    final var variablesState = context.getElementInstanceState().getVariablesState();
+    final var eventVariables = event.getVariables();
+
+    if (eventVariables != null && eventVariables.capacity() > 0) {
+      variablesState.setTemporaryVariables(variableScopeKey, eventVariables);
+    }
 
     context
         .getStateDb()

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/CloseMessageStartEventSubscriptionProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/CloseMessageStartEventSubscriptionProcessor.java
@@ -11,6 +11,7 @@ import io.zeebe.engine.processor.TypedRecord;
 import io.zeebe.engine.processor.TypedRecordProcessor;
 import io.zeebe.engine.processor.TypedResponseWriter;
 import io.zeebe.engine.processor.TypedStreamWriter;
+import io.zeebe.engine.state.instance.EventScopeInstanceState;
 import io.zeebe.engine.state.message.MessageStartEventSubscriptionState;
 import io.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
@@ -19,10 +20,13 @@ public final class CloseMessageStartEventSubscriptionProcessor
     implements TypedRecordProcessor<MessageStartEventSubscriptionRecord> {
 
   private final MessageStartEventSubscriptionState subscriptionState;
+  private final EventScopeInstanceState eventScopeInstanceState;
 
   public CloseMessageStartEventSubscriptionProcessor(
-      final MessageStartEventSubscriptionState subscriptionState) {
+      final MessageStartEventSubscriptionState subscriptionState,
+      final EventScopeInstanceState eventScopeInstanceState) {
     this.subscriptionState = subscriptionState;
+    this.eventScopeInstanceState = eventScopeInstanceState;
   }
 
   @Override
@@ -34,6 +38,8 @@ public final class CloseMessageStartEventSubscriptionProcessor
     final long workflowKey = subscriptionRecord.getWorkflowKey();
 
     subscriptionState.removeSubscriptionsOfWorkflow(workflowKey);
+
+    eventScopeInstanceState.deleteInstance(workflowKey);
 
     streamWriter.appendFollowUpEvent(
         record.getKey(), MessageStartEventSubscriptionIntent.CLOSED, subscriptionRecord);

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/message/MessageEventProcessors.java
@@ -75,7 +75,8 @@ public final class MessageEventProcessors {
         .onCommand(
             ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
             MessageStartEventSubscriptionIntent.CLOSE,
-            new CloseMessageStartEventSubscriptionProcessor(startEventSubscriptionState))
+            new CloseMessageStartEventSubscriptionProcessor(
+                startEventSubscriptionState, eventScopeInstanceState))
         .withListener(
             new MessageObserver(messageState, subscriptionState, subscriptionCommandSender));
   }

--- a/engine/src/main/java/io/zeebe/engine/state/ZeebeState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/ZeebeState.java
@@ -35,6 +35,7 @@ public class ZeebeState {
 
   private static final Logger LOG = Loggers.STREAM_PROCESSING;
 
+  private final ZeebeDb<ZbColumnFamilies> zeebeDb;
   private final KeyState keyState;
   private final WorkflowState workflowState;
   private final DeploymentsState deploymentState;
@@ -56,6 +57,7 @@ public class ZeebeState {
   public ZeebeState(
       final int partitionId, final ZeebeDb<ZbColumnFamilies> zeebeDb, final DbContext dbContext) {
     this.partitionId = partitionId;
+    this.zeebeDb = zeebeDb;
     keyState = new KeyState(partitionId, zeebeDb, dbContext);
     workflowState = new WorkflowState(zeebeDb, dbContext, keyState);
     deploymentState = new DeploymentsState(zeebeDb, dbContext);
@@ -159,5 +161,10 @@ public class ZeebeState {
 
   public int getPartitionId() {
     return partitionId;
+  }
+
+  public boolean isEmpty(final ZbColumnFamilies column) {
+    final var newContext = zeebeDb.createContext();
+    return zeebeDb.isEmpty(column, newContext);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstanceState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstanceState.java
@@ -280,15 +280,6 @@ public final class ElementInstanceState {
     return records;
   }
 
-  public boolean isEmpty() {
-    return elementInstanceColumnFamily.isEmpty()
-        && parentChildColumnFamily.isEmpty()
-        && recordColumnFamily.isEmpty()
-        && recordParentChildColumnFamily.isEmpty()
-        && variablesState.isEmpty()
-        && awaitWorkflowInstanceResultMetadataColumnFamily.isEmpty();
-  }
-
   private void visitRecords(
       final long scopeKey, final Purpose purpose, final RecordVisitor visitor) {
     recordParentKey.wrapLong(scopeKey);

--- a/engine/src/main/java/io/zeebe/engine/state/instance/IncidentState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/IncidentState.java
@@ -66,8 +66,8 @@ public final class IncidentState {
 
   public void createIncident(final long incidentKey, final IncidentRecord incident) {
     this.incidentKey.wrapLong(incidentKey);
-    this.incidentWrite.setRecord(incident);
-    incidentColumnFamily.put(this.incidentKey, this.incidentWrite);
+    incidentWrite.setRecord(incident);
+    incidentColumnFamily.put(this.incidentKey, incidentWrite);
 
     incidentKeyValue.set(incidentKey);
     if (isJobIncident(incident)) {

--- a/engine/src/test/java/io/zeebe/engine/state/WorkflowExecutionCleanStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/WorkflowExecutionCleanStateTest.java
@@ -1,0 +1,612 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state;
+
+import static java.util.function.Predicate.not;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.engine.processor.workflow.message.MessageObserver;
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.protocol.record.intent.IncidentIntent;
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class WorkflowExecutionCleanStateTest {
+
+  private static final String PROCESS_ID = "workflow";
+
+  private static final List<ZbColumnFamilies> IGNORE_NON_EMPTY_COLUMNS =
+      List.of(
+          ZbColumnFamilies.DEFAULT,
+          ZbColumnFamilies.KEY,
+          ZbColumnFamilies.WORKFLOW_VERSION,
+          ZbColumnFamilies.WORKFLOW_CACHE,
+          ZbColumnFamilies.WORKFLOW_CACHE_BY_ID_AND_VERSION,
+          ZbColumnFamilies.WORKFLOW_CACHE_LATEST_KEY,
+          ZbColumnFamilies.WORKFLOW_CACHE_DIGEST_BY_ID);
+
+  @Rule public EngineRule engineRule = EngineRule.singlePartition();
+
+  private ZeebeState zeebeState;
+
+  @Before
+  public void init() {
+    zeebeState = engineRule.getZeebeState();
+
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowWithServiceTask() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final var workflowInstanceKey =
+        engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).withVariable("x", 1).create();
+
+    engineRule
+        .job()
+        .ofInstance(workflowInstanceKey)
+        .withType("test")
+        .withVariable("y", 2)
+        .complete();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowWithSubprocess() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    subProcess ->
+                        subProcess
+                            .zeebeInputExpression("x", "y")
+                            .zeebeOutputExpression("y", "z")
+                            .embeddedSubProcess()
+                            .startEvent()
+                            .endEvent())
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final var workflowInstanceKey =
+        engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).withVariable("x", 1).create();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowWithMultiInstance() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(
+                    "task",
+                    t ->
+                        t.zeebeJobType("test")
+                            .multiInstance(
+                                m ->
+                                    m.zeebeInputCollectionExpression("items")
+                                        .zeebeInputElement("item")
+                                        .zeebeOutputCollection("results")
+                                        .zeebeOutputElementExpression("result")))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final var workflowInstanceKey =
+        engineRule
+            .workflowInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("items", List.of(1))
+            .create();
+
+    engineRule
+        .job()
+        .ofInstance(workflowInstanceKey)
+        .withType("test")
+        .withVariable("result", 2)
+        .complete();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowWithTimerEvent() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .intermediateCatchEvent("timer", e -> e.timerWithDuration("PT0S"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final var workflowInstanceKey =
+        engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowWithMessageEvent() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .intermediateCatchEvent(
+                    "message",
+                    e ->
+                        e.message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+                            .zeebeOutputExpression("x", "y"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var workflowInstanceKey =
+        engineRule
+            .workflowInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("key", "key-1")
+            .create();
+
+    // when
+    final var timeToLive = Duration.ofSeconds(10);
+    engineRule
+        .message()
+        .withName("message")
+        .withCorrelationKey("key-1")
+        .withTimeToLive(timeToLive)
+        .withVariables(Map.of("x", 1))
+        .publish();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    engineRule.increaseTime(timeToLive.plus(MessageObserver.MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL));
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowWithMessageStartEvent() {
+    // given
+    final var deployment =
+        engineRule
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(PROCESS_ID)
+                    .startEvent()
+                    .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+                    .zeebeOutputExpression("x", "y")
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final var workflowKey = deployment.getValue().getDeployedWorkflows().get(0).getWorkflowKey();
+
+    // when
+    final var timeToLive = Duration.ofSeconds(10);
+    final var messagePublished =
+        engineRule
+            .message()
+            .withName("message")
+            .withCorrelationKey("key-1")
+            .withTimeToLive(timeToLive)
+            .withVariables(Map.of("x", 1))
+            .publish();
+
+    final var workflowInstanceKey =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATING)
+            .withWorkflowKey(workflowKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst()
+            .getKey();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    engineRule.increaseTime(timeToLive.plus(MessageObserver.MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL));
+
+    // deploy new workflow without message start event to close the open subscription
+    engineRule
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done())
+        .deploy();
+
+    RecordingExporter.messageStartEventSubscriptionRecords(
+            MessageStartEventSubscriptionIntent.CLOSED)
+        .withWorkfloKey(workflowKey)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowWithErrorEvent() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .boundaryEvent("error", b -> b.error("ERROR"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var workflowInstanceKey =
+        engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).withVariable("x", 1).create();
+
+    // when
+    engineRule
+        .job()
+        .ofInstance(workflowInstanceKey)
+        .withType("test")
+        .withErrorCode("ERROR")
+        .throwError();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowWithIncident() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var workflowInstanceKey =
+        engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).withVariable("x", 1).create();
+
+    // when
+    engineRule.job().ofInstance(workflowInstanceKey).withType("test").withRetries(0).fail();
+
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withWorkflowInstanceKey(workflowInstanceKey)
+            .getFirst();
+
+    engineRule.job().withKey(incidentCreated.getValue().getJobKey()).withRetries(1).updateRetries();
+
+    engineRule
+        .incident()
+        .ofInstance(workflowInstanceKey)
+        .withKey(incidentCreated.getKey())
+        .resolve();
+
+    engineRule
+        .job()
+        .ofInstance(workflowInstanceKey)
+        .withType("test")
+        .withVariable("y", 2)
+        .complete();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowWithExclusiveGateway() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .exclusiveGateway()
+                .sequenceFlowId("s1")
+                .conditionExpression("x > 10")
+                .endEvent()
+                .moveToLastGateway()
+                .sequenceFlowId("s2")
+                .conditionExpression("x <= 10")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final var workflowInstanceKey =
+        engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).withVariable("x", 1).create();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowWithParallelGateway() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .parallelGateway("fork")
+                .endEvent()
+                .moveToNode("fork")
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final var workflowInstanceKey =
+        engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowWithEventBasedGateway() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .eventBasedGateway()
+                .intermediateCatchEvent("timer", e -> e.timerWithDuration("PT0S"))
+                .endEvent()
+                .moveToLastGateway()
+                .intermediateCatchEvent(
+                    "message",
+                    e -> e.message(m -> m.name("message").zeebeCorrelationKeyExpression("key")))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final var workflowInstanceKey =
+        engineRule
+            .workflowInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("key", "key-1")
+            .create();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowWithEventSubprocess() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .eventSubProcess(
+                    "event-subprocess",
+                    subprocess ->
+                        subprocess
+                            .startEvent()
+                            .interrupting(true)
+                            .timerWithDuration("PT0.1S")
+                            .endEvent())
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final var workflowInstanceKey =
+        engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowWithCallActivity() {
+    // given
+    final var childWorkflow = Bpmn.createExecutableProcess("child").startEvent().endEvent().done();
+    final var parentWorkflow =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .callActivity("call", c -> c.zeebeProcessId("child"))
+            .endEvent()
+            .done();
+
+    engineRule
+        .deployment()
+        .withXmlResource("child.bpmn", childWorkflow)
+        .withXmlResource("parent.bpmn", parentWorkflow)
+        .deploy();
+
+    // when
+    final var workflowInstanceKey =
+        engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowCreatedWithResult() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done())
+        .deploy();
+
+    // when
+    final var workflowInstanceKey =
+        engineRule
+            .workflowInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("x", 1)
+            .withResult()
+            .create();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  @Test
+  public void testWorkflowCanceled() {
+    // given
+    engineRule
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var workflowInstanceKey =
+        engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).withVariable("x", 1).create();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .await();
+
+    // when
+    engineRule.workflowInstance().withInstanceKey(workflowInstanceKey).cancel();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_TERMINATED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // then
+    assertThatStateIsEmpty();
+  }
+
+  private void assertThatStateIsEmpty() {
+    // sometimes the state takes few moments until is is empty
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final var nonEmptyColumns =
+                  Arrays.stream(ZbColumnFamilies.values())
+                      .filter(not(IGNORE_NON_EMPTY_COLUMNS::contains))
+                      .filter(not(zeebeState::isEmpty))
+                      .collect(Collectors.toList());
+
+              assertThat(nonEmptyColumns).describedAs("Expected all columns to be empty").isEmpty();
+            });
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -23,6 +23,7 @@ import io.zeebe.engine.processor.workflow.message.command.PartitionCommandSender
 import io.zeebe.engine.processor.workflow.message.command.SubscriptionCommandMessageHandler;
 import io.zeebe.engine.processor.workflow.message.command.SubscriptionCommandSender;
 import io.zeebe.engine.state.DefaultZeebeDbFactory;
+import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.util.client.DeploymentClient;
 import io.zeebe.engine.util.client.IncidentClient;
 import io.zeebe.engine.util.client.JobActivationClient;
@@ -222,6 +223,10 @@ public final class EngineRule extends ExternalResource {
 
   public ControlledActorClock getClock() {
     return environmentRule.getClock();
+  }
+
+  public ZeebeState getZeebeState() {
+    return environmentRule.getZeebeState();
   }
 
   public DeploymentClient deployment() {

--- a/zb-db/src/main/java/io/zeebe/db/ZeebeDb.java
+++ b/zb-db/src/main/java/io/zeebe/db/ZeebeDb.java
@@ -52,4 +52,13 @@ public interface ZeebeDb<ColumnFamilyType extends Enum<ColumnFamilyType>> extend
   void createSnapshot(File snapshotDir);
 
   DbContext createContext();
+
+  /**
+   * Checks the database if the given column is empty.
+   *
+   * @param column the enum of the column to check
+   * @param context the context that is used to access the database
+   * @return {@code true} if the column is empty, otherwise {@code false}
+   */
+  boolean isEmpty(ColumnFamilyType column, DbContext context);
 }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -403,6 +403,12 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
   }
 
   @Override
+  public boolean isEmpty(final ColumnFamilyNames columnFamilyName, final DbContext context) {
+    final var columnFamilyHandle = columnFamilyMap.get(columnFamilyName);
+    return isEmpty(columnFamilyHandle, context);
+  }
+
+  @Override
   public void close() {
     // Correct order of closing
     // 1. transaction


### PR DESCRIPTION
## Description

* backport of #4963 to `0.23` 

## Related issues

closes #4957
closes #4959

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release annoncement 
