### PR TITLE
Introduces a basic rolling upgrade integration test

### DIFF
--- a/test-util/src/main/java/io/zeebe/test/util/asserts/TopologyAssert.java
+++ b/test-util/src/main/java/io/zeebe/test/util/asserts/TopologyAssert.java
@@ -10,6 +10,7 @@ package io.zeebe.test.util.asserts;
 import io.zeebe.client.api.response.BrokerInfo;
 import io.zeebe.client.api.response.Topology;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 
@@ -19,7 +20,7 @@ public class TopologyAssert extends AbstractAssert<TopologyAssert, Topology> {
     super(topology, TopologyAssert.class);
   }
 
-  public static TopologyAssert assertThat(Topology actual) {
+  public static TopologyAssert assertThat(final Topology actual) {
     return new TopologyAssert(actual);
   }
 
@@ -42,6 +43,29 @@ public class TopologyAssert extends AbstractAssert<TopologyAssert, Topology> {
           "Expected <%s> partitions at each broker, but found brokers with different partition count <%s>",
           partitionCount, brokersWithUnexpectedPartitionCount);
     }
+
+    return this;
+  }
+
+  public final TopologyAssert doesNotContainBroker(final int nodeId) {
+    isNotNull();
+
+    final List<Integer> brokers =
+        actual.getBrokers().stream().map(BrokerInfo::getNodeId).collect(Collectors.toList());
+    if (brokers.contains(nodeId)) {
+      failWithMessage(
+          "Expected topology not to contain broker with ID %d, but found the following: [%s]",
+          nodeId, brokers);
+    }
+
+    return this;
+  }
+
+  public final TopologyAssert hasBrokerSatisfying(final Consumer<BrokerInfo> condition) {
+    isNotNull();
+
+    final List<BrokerInfo> brokers = actual.getBrokers();
+    newListAssertInstance(brokers).anySatisfy(condition);
 
     return this;
   }

--- a/upgrade-tests/pom.xml
+++ b/upgrade-tests/pom.xml
@@ -55,6 +55,11 @@
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
@@ -7,30 +7,48 @@
  */
 package io.zeebe.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.api.response.WorkflowInstanceEvent;
+import io.zeebe.client.api.worker.JobHandler;
 import io.zeebe.containers.ZeebeBrokerContainer;
 import io.zeebe.containers.ZeebePort;
-import io.zeebe.test.util.AutoCloseableRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.test.util.asserts.TopologyAssert;
 import io.zeebe.util.VersionUtil;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.lifecycle.Startables;
 
 public class RollingUpdateTest {
-  private static final Logger LOG = LoggerFactory.getLogger(ContainerStateRule.class);
   private static final String OLD_VERSION = VersionUtil.getPreviousVersion();
-  private static final String CURRENT_VERSION = "current-test";
-
-  @Rule public AutoCloseableRule autoCloseable = new AutoCloseableRule();
+  private static final String NEW_VERSION = VersionUtil.getVersion();
+  private static final String IMAGE_TAG = "current-test";
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess("process")
+          .startEvent()
+          .serviceTask("task1", s -> s.zeebeJobType("firstTask"))
+          .serviceTask("task2", s -> s.zeebeJobType("secondTask"))
+          .endEvent()
+          .done();
 
   private List<ZeebeBrokerContainer> containers;
   private String initialContactPoints;
@@ -47,47 +65,170 @@ public class RollingUpdateTest {
 
     containers =
         Arrays.asList(
-            manageClosable(new ZeebeBrokerContainer(OLD_VERSION)),
-            manageClosable(new ZeebeBrokerContainer(OLD_VERSION)),
-            manageClosable(new ZeebeBrokerContainer(OLD_VERSION)));
+            new ZeebeBrokerContainer(OLD_VERSION),
+            new ZeebeBrokerContainer(OLD_VERSION),
+            new ZeebeBrokerContainer(OLD_VERSION));
 
     configureBrokerContainer(0, containers);
     configureBrokerContainer(1, containers);
     configureBrokerContainer(2, containers);
   }
 
-  @Test
-  public void shouldBeAbleToRestartContainerWithSameVersion() {
-    // given
-    final var index = 0;
-    final var sameVersion = OLD_VERSION;
-    Startables.deepStart(containers).join();
-    containers.get(index).shutdownGracefully(Duration.ofSeconds(30));
-
-    // when
-    final var zeebeBrokerContainer = replaceBrokerContainer(index, sameVersion);
-
-    // then
-    zeebeBrokerContainer.start();
+  @After
+  public void tearDown() {
+    containers.parallelStream().forEach(Startable::stop);
   }
 
   @Test
   public void shouldBeAbleToRestartContainerWithNewVersion() {
     // given
     final var index = 0;
-    final var newVersion = CURRENT_VERSION;
     Startables.deepStart(containers).join();
     containers.get(index).shutdownGracefully(Duration.ofSeconds(30));
 
     // when
-    final var zeebeBrokerContainer = replaceBrokerContainer(index, newVersion);
+    final var zeebeBrokerContainer = upgradeBroker(index);
 
     // then
-    zeebeBrokerContainer.start();
+    try (final var client = newZeebeClient(containers.get(1))) {
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(100))
+          .untilAsserted(() -> assertTopologyDoesNotContainerBroker(client, index));
+
+      zeebeBrokerContainer.start();
+
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(100))
+          .untilAsserted(() -> assertTopologyContainsUpgradedBroker(client, index));
+    }
   }
 
-  private ZeebeBrokerContainer replaceBrokerContainer(final int index, final String newVersion) {
-    final var broker = new ZeebeBrokerContainer(newVersion);
+  @Test
+  public void shouldPerformRollingUpgrade() {
+    // given
+    Startables.deepStart(containers).join();
+
+    // when
+    final long firstWorkflowInstanceKey;
+    var availableBroker = containers.get(0);
+    try (final var client = newZeebeClient(availableBroker)) {
+      deployProcess(client);
+
+      // potentially retry in case we're faster than the deployment distribution
+      firstWorkflowInstanceKey =
+          Awaitility.await("process instance creation")
+              .atMost(Duration.ofSeconds(5))
+              .pollInterval(Duration.ofMillis(100))
+              .ignoreExceptions()
+              .until(() -> createWorkflowInstance(client), Objects::nonNull)
+              .getWorkflowInstanceKey();
+    }
+
+    for (int i = containers.size() - 1; i >= 0; i--) {
+      try (final var client = newZeebeClient(availableBroker)) {
+        final var brokerId = i;
+        var container = containers.get(i);
+
+        container.shutdownGracefully(Duration.ofSeconds(30));
+
+        // until previous version points to 0.24, we cannot yet tune failure detection to be very
+        // fast, so
+        Awaitility.await("broker is removed from topology")
+            .atMost(Duration.ofSeconds(10))
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() -> assertTopologyDoesNotContainerBroker(client, brokerId));
+
+        container = upgradeBroker(i);
+        container.start();
+        Awaitility.await("upgraded broker is added to topology")
+            .atMost(Duration.ofSeconds(10))
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() -> assertTopologyContainsUpgradedBroker(client, brokerId));
+
+        availableBroker = container;
+      }
+    }
+
+    // then
+    final Map<Long, List<String>> activatedJobs = new HashMap<>();
+    final var expectedOrderedJobs = List.of("firstTask", "secondTask");
+    final JobHandler jobHandler =
+        (jobClient, job) -> {
+          jobClient.newCompleteCommand(job.getKey()).send().join();
+          activatedJobs.compute(
+              job.getWorkflowInstanceKey(),
+              (ignored, list) -> {
+                final var appendedList = Optional.ofNullable(list).orElse(new ArrayList<>());
+                appendedList.add(job.getType());
+                return appendedList;
+              });
+        };
+
+    try (final var client = newZeebeClient(availableBroker)) {
+      final var secondWorkflowInstanceKey = createWorkflowInstance(client).getWorkflowInstanceKey();
+      final var expectedActivatedJobs =
+          Map.of(
+              firstWorkflowInstanceKey,
+              expectedOrderedJobs,
+              secondWorkflowInstanceKey,
+              expectedOrderedJobs);
+      client.newWorker().jobType("firstTask").handler(jobHandler).open();
+      client.newWorker().jobType("secondTask").handler(jobHandler).open();
+
+      Awaitility.await("all jobs have been activated")
+          .atMost(Duration.ofSeconds(5))
+          .untilAsserted(() -> assertThat(activatedJobs).isEqualTo(expectedActivatedJobs));
+    }
+  }
+
+  private WorkflowInstanceEvent createWorkflowInstance(final ZeebeClient client) {
+    return client
+        .newCreateInstanceCommand()
+        .bpmnProcessId("process")
+        .latestVersion()
+        .variables(Map.of("foo", "bar"))
+        .send()
+        .join();
+  }
+
+  private void deployProcess(final ZeebeClient client) {
+    client
+        .newDeployCommand()
+        .addWorkflowModel(PROCESS, "process.bpmn")
+        .send()
+        .join(5, TimeUnit.SECONDS);
+  }
+
+  private void assertTopologyContainsUpgradedBroker(
+      final ZeebeClient zeebeClient, final int brokerId) {
+    final var topology = zeebeClient.newTopologyRequest().send().join();
+    TopologyAssert.assertThat(topology)
+        .isComplete(containers.size(), 1)
+        .hasBrokerSatisfying(
+            brokerInfo -> {
+              assertThat(brokerInfo.getNodeId()).isEqualTo(brokerId);
+              assertThat(brokerInfo.getVersion()).isEqualTo(NEW_VERSION);
+            });
+  }
+
+  private void assertTopologyDoesNotContainerBroker(final ZeebeClient client, final int brokerId) {
+    final var topology = client.newTopologyRequest().send().join();
+    TopologyAssert.assertThat(topology)
+        .doesNotContainBroker(brokerId)
+        .isComplete(containers.size() - 1, 1);
+  }
+
+  private ZeebeClient newZeebeClient(final ZeebeBrokerContainer container) {
+    return ZeebeClient.newClientBuilder()
+        .usePlaintext()
+        .brokerContactPoint(container.getExternalAddress(ZeebePort.GATEWAY))
+        .build();
+  }
+
+  private ZeebeBrokerContainer upgradeBroker(final int index) {
+    final var broker = new ZeebeBrokerContainer(IMAGE_TAG);
     containers.set(index, broker);
     return configureBrokerContainer(index, containers);
   }
@@ -99,24 +240,22 @@ public class RollingUpdateTest {
     final var hostName = "broker-" + index;
     broker.withNetworkAliases(hostName);
 
+    // once old version is 0.24 and more membership configuration is exposed, further tune for fast
+    // failure detection
     return broker
         .withNetwork(network)
         .withEnv("ZEEBE_BROKER_NETWORK_HOST", "0.0.0.0")
         .withEnv("ZEEBE_BROKER_NETWORK_ADVERTISED_HOST", hostName)
         .withEnv("ZEEBE_BROKER_CLUSTER_CLUSTERNAME", "zeebe-cluster")
-        .withEnv("ZEEBE_BROKER_DATA_SNAPSHOTPERIOD", "1m")
-        .withEnv("ZEEBE_BROKER_DATA_LOGSEGMENTSIZE", "1MB")
-        .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "1MB")
+        .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "128KB")
         .withEnv("ZEEBE_BROKER_CLUSTER_NODEID", String.valueOf(index))
         .withEnv("ZEEBE_BROKER_CLUSTER_CLUSTERSIZE", String.valueOf(clusterSize))
         .withEnv("ZEEBE_BROKER_CLUSTER_REPLICATIONFACTOR", String.valueOf(clusterSize))
         .withEnv("ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS", initialContactPoints)
+        .withEnv("ZEEBE_BROKER_CLUSTER_GOSSIPFAILURETIMEOUT", "5000")
+        .withEnv("ZEEBE_BROKER_CLUSTER_GOSSIPINTERVAL", "100")
+        .withEnv("ZEEBE_BROKER_CLUSTER_GOSSIPPROBEINTERVAL", "250")
         .withLogLevel(Level.DEBUG)
         .withDebug(false);
-  }
-
-  private <T extends AutoCloseable> T manageClosable(final T closeable) {
-    autoCloseable.manage(closeable);
-    return closeable;
   }
 }


### PR DESCRIPTION
## Description

This PR builds on the work done in #4964 and adds a new test which simulates a rolling upgrade similar to Kubernetes' `RollingUpgrade` strategy. It starts a cluster of 3 nodes in the last known stable version - once these are ready, it will deploy a new process which has a single service task. It will create a new instance and stop. At this point, it will traverse the list of nodes in reverse order and shut down them gracefully one by one. Once a node is shut down, it will upgrade it, then query a different broker's embedded gateway for the topology until the topology is considered complete. To ensure correctness, when upgrading a broker, we shut it down, wait until it is removed from the other's topology, then restart it and wait for it to be added back.

> A complete topology here refers to a topology with the expected number of brokers, with each broker having the expected number of partitions.

Once the upgraded broker as correctly rejoined the cluster, the procedure is repeated with the next broker, until all of them are upgraded. Finally the test is considered passing if all of the above worked, and we can activate the job of the previously created process instance.

## Related issues

closes #4965 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release annoncement 
