### PR TITLE
chore(qa): add test for message subscription after out of disk space

### DIFF
--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceRecoveryClusteredTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceRecoveryClusteredTest.java
@@ -15,6 +15,7 @@ import io.zeebe.broker.it.clustering.ClusteringRule;
 import io.zeebe.broker.it.util.GrpcClientRule;
 import io.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
 import io.zeebe.client.api.response.DeploymentEvent;
+import io.zeebe.engine.processing.message.MessageObserver;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.protocol.record.intent.DeploymentIntent;
@@ -26,7 +27,6 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -74,7 +74,6 @@ public class DiskSpaceRecoveryClusteredTest {
     clientRule.waitUntilDeploymentIsDone(deploymentKey);
   }
 
-  @Ignore("https://github.com/zeebe-io/zeebe/issues/4786")
   @Test
   public void shouldCorrelateMessageAfterDiskSpaceAvailableAgain() throws InterruptedException {
     // given
@@ -115,6 +114,9 @@ public class DiskSpaceRecoveryClusteredTest {
                     .isEqualTo(2));
 
     waitUntilDiskSpaceAvailable(failingBroker);
+
+    final var timeout = MessageObserver.SUBSCRIPTION_CHECK_INTERVAL.multipliedBy(2);
+    clusteringRule.getClock().addTime(timeout);
 
     // then
     Awaitility.await()


### PR DESCRIPTION
## Description

Re-enable the test for message correlation after out of disk space 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release annoncement 
