### PR TITLE
fix(broker): refactor zeebe partition health monitoring

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/RaftPartitionHealth.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/RaftPartitionHealth.java
@@ -21,6 +21,7 @@ public class RaftPartitionHealth implements HealthMonitorable, RaftFailureListen
   private FailureListener healthMonitor;
   private final ActorControl actor;
   private final RaftFailureListener raftFailureListener;
+  private final String name;
 
   RaftPartitionHealth(
       final RaftPartition atomixRaftPartition,
@@ -30,6 +31,7 @@ public class RaftPartitionHealth implements HealthMonitorable, RaftFailureListen
     this.actor = actor;
     this.raftFailureListener = listener;
     this.atomixRaftPartition.addFailureListener(this);
+    this.name = "Raft-" + atomixRaftPartition.id().id();
   }
 
   @Override
@@ -53,5 +55,9 @@ public class RaftPartitionHealth implements HealthMonitorable, RaftFailureListen
 
   public void close() {
     atomixRaftPartition.removeFailureListener(this);
+  }
+
+  public String getName() {
+    return name;
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartitionHealth.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartitionHealth.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.partitions;
+
+import io.zeebe.util.health.FailureListener;
+import io.zeebe.util.health.HealthMonitorable;
+import io.zeebe.util.health.HealthStatus;
+
+/**
+ * Reflects the health of ZeebePartition. The health is updated by ZeebePartition when role
+ * transitions either succeeded or failed.
+ */
+class ZeebePartitionHealth implements HealthMonitorable {
+  private HealthStatus healthStatus = HealthStatus.UNHEALTHY;
+  private final String name;
+  private FailureListener failureListener;
+
+  public ZeebePartitionHealth(final int partitionId) {
+    this.name = "ZeebePartition-" + partitionId;
+  }
+
+  @Override
+  public HealthStatus getHealthStatus() {
+    return healthStatus;
+  }
+
+  @Override
+  public void addFailureListener(final FailureListener failureListener) {
+    this.failureListener = failureListener;
+  }
+
+  void setHealthStatus(final HealthStatus healthStatus) {
+    final var previousStatus = this.healthStatus;
+    this.healthStatus = healthStatus;
+
+    if (previousStatus != healthStatus && failureListener != null) {
+      switch (healthStatus) {
+        case HEALTHY:
+          failureListener.onRecovered();
+          break;
+        case UNHEALTHY:
+          failureListener.onFailure();
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/util/src/main/java/io/zeebe/util/health/CriticalComponentsHealthMonitor.java
+++ b/util/src/main/java/io/zeebe/util/health/CriticalComponentsHealthMonitor.java
@@ -82,13 +82,20 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
     final var previousStatus = healthStatus;
     healthStatus = status;
 
-    if (failureListener != null && previousStatus != status) {
+    if (previousStatus != status) {
       switch (status) {
         case HEALTHY:
-          failureListener.onRecovered();
+          if (failureListener != null) {
+            failureListener.onRecovered();
+          }
+          log.debug(
+              "The components are healthy. The current health status of components: {}",
+              componentHealth);
           break;
         case UNHEALTHY:
-          failureListener.onFailure();
+          if (failureListener != null) {
+            failureListener.onFailure();
+          }
           log.debug(
               "Detected unhealthy components. The current health status of components: {}",
               componentHealth);


### PR DESCRIPTION
## Description

Add ZeebePartition's health as a health monitorable component to the `criticalComponentsHealthMonitor`.

## Related issues

closes #4943 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release annoncement 
