### PR TITLE
docs(forks): add concurrency considerations

### DIFF
--- a/docs/src/bpmn-workflows/call-activities/call-activities.md
+++ b/docs/src/bpmn-workflows/call-activities/call-activities.md
@@ -33,6 +33,8 @@ When the call activity is activated then **all variables** of the call activity 
 Input mappings can be used to create new local variables in the scope of the call activity. These variables are also copied to the created workflow instance.
 
 By default, all variables of the created workflow instance are propagated to the call activity. This behavior can be customized by defining output mappings at the call activity. The output mappings are applied on completing the call activity.
+This is especially important in the case of a call activity in a parallel flow to avoid overriding variables (e.g. when it is marked as
+[parallel multi-instance](/bpmn-workflows/multi-instance/multi-instance.html#variable-mappings)).
 
 ## Additional Resources
 

--- a/docs/src/bpmn-workflows/data-flow.md
+++ b/docs/src/bpmn-workflows/data-flow.md
@@ -1,14 +1,21 @@
 # Data Flow
 
-Every BPMN workflow instance can have one or more variables. Variables are key-value-pairs and hold the contextual data of the workflow instance that is required by job workers to do their work. They can be provided when a workflow instance is created, when a job is completed, and when a message is correlated.
+Every BPMN workflow instance can have one or more variables. Variables are key-value-pairs and hold
+the contextual data of the workflow instance that is required by job workers to do their work or to
+decide which sequence flows to take. They can be provided when a workflow instance is created, when
+a job is completed, and when a message is correlated.
 
 ![data-flow](/bpmn-workflows/data-flow.png)
 
 ## Job Workers
 
-By default, a job worker gets all variables of a workflow instance. It can limit the data by providing a list of required variables as *fetchVariables*.
+By default, a job worker gets all variables of a workflow instance. It can limit the data by
+providing a list of required variables as *fetchVariables*.
 
-The worker uses the variables to do its work. When the work is done, it completes the job. If the result of the work is needed by follow-up tasks, then the worker set the variables while completing the job. These variables are merged into the workflow instance.
+The worker uses the variables to do its work. When the work is done, it completes the job. If the
+result of the work is needed by follow-up tasks, then the worker sets the variables while completing
+the job. These variables are [merged](/reference/variables.html#variable-propagation) into the
+workflow instance.
 
 ![job-worker](/bpmn-workflows/data-flow-job-worker.png)
 
@@ -16,13 +23,30 @@ If the job worker expects the variables in a different format or under different
 
 ## Variable Scopes vs. Token-Based Data
 
-A workflow can have concurrent paths, for example, when using a parallel gateway. When the execution reaches the parallel gateway then new tokens are spawned which executes the following paths concurrently.
+A workflow can have concurrent paths, for example, when using a parallel gateway. When the execution reaches the parallel gateway then new tokens are spawned which execute the following paths concurrently.
 
-Since the variables are part of the workflow instance and not of the token, they can be read globally from any token. If a token adds a variable or modifies the value of a variable then the changes are also visible to concurrent tokens.  
+Since the variables are part of the workflow instance and not of the token, they can be read globally from any token. If a token adds a variable or modifies the value of a variable then the changes are also visible to concurrent tokens.
 
 ![variable-scopes](/bpmn-workflows/variable-scopes.png)
 
 The visibility of variables is defined by the *variable scopes* of the workflow.
+
+## Concurrency considerations
+When multiple active activities exist in a workflow instance (i.e. there is a form of concurrent
+execution, e.g. usage of a parallel gateway, multiple outgoing sequence flows or a parallel
+multi-instance marker), you may need to take extra care in dealing with variables. When variables
+are altered by one activity, it might also be accessed and altered by another at the same time. Race
+conditions can occur in such workflows.
+
+We recommend taking care when writing variables in a parallel flow. Make sure the variables are
+written to the correct [variable scope](/reference/variables.html#variable-scopes) using variable
+mappings and make sure to complete jobs and publish messages only with the minimum required
+variables.
+
+These type of problems can be avoided by:
+* passing only updated variables
+* using output variable mappings to customize the variable propagation
+* using an embedded subprocess and input variable mappings to limit the visibility and propagation of variables
 
 ## Additional Resources
 

--- a/docs/src/bpmn-workflows/multi-instance/multi-instance.md
+++ b/docs/src/bpmn-workflows/multi-instance/multi-instance.md
@@ -71,6 +71,24 @@ The input mappings can access the local variables of the instance (e.g. `inputEl
 
 The output mappings can be used to update the `outputElement` variable. For example, to extract a part of the job variables.
 
+**Example:** say we have a call activity that is marked as a parallel multi-instance. When the
+called workflow instance completes, its variables get [merged](/reference/variables.html#variable-propagation)
+into the call activity's workflow instance. Its result is collected in the output collection
+variable, but this has become a race condition where each completed child instance again overwrites
+this same variable. We end up with a corrupted output collection. An output mapping can used to
+overcome this, because it restricts which variables get merged. In the case that:
+
+- parallel multi-instance call activity
+- multi-instance output element: `=output`
+- variable in the child instance that holds the result: `x`
+
+The output mapping on the call activity should then be:
+
+```
+source: =x
+target: output
+```
+
 ## Additional Resources
 
 <details>

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -63,14 +63,21 @@ An incident represents an error condition which prevents Zeebe from advancing an
 * [Incident](reference/incidents.md)
 
 ### Job
-A job represents a distinct unit of work within a business process. Jobs are represented by steps in your workflow and are identified by a unique name.
+A job represents a distinct unit of work within a business process. Service tasks represent such
+ jobs in your workflow and are identified by a unique id. A job has a type to allow specific job
+ workers to find jobs that they can work on.
 
 * [Job Workers](basics/job-workers.md#what-is-a-job)
 
 ### Job Activation Timeout
-This is the amount of time the broker will wait for a response from the client after a job has been submitted to the client for processing before it marks the job as completed or failed.  An incomplete job prevents Zeebe from advancing workflow execution to the next step.
+This is the amount of time the broker will wait for a complete or fail response from the job worker after a job has been submitted to the job worker for processing before it marks the job as available again for other job workers.
 
 * [Job Workers](basics/job-workers.md#requesting-jobs-from-the-broker)
+
+### Job Worker
+A special type of client that polls for and executes available jobs. An uncompleted job prevents Zeebe from advancing workflow execution to the next step.
+
+* [Job Workers](basics/job-workers.md)
 
 ### Leader
 In a clustered environment, one broker, the leader, is responsible for workflow execution and housekeeping of data within a partition.  Housekeeping includes, taking snapshots, replication and running exports.
@@ -128,7 +135,10 @@ A worker executes a job.  In the Zeebe nomenclature, these are also referred to 
 * [Job Workers](basics/job-workers.md)
 
 ### Workflow
-A workflow is a defined sequence of distinct steps representing your business logic.  Examples of a workflow could be an e-commerce shopping experience, onboarding a new employee, etc.  In Zeebe, workflows are identified by a unique name and BPMN process id.  The workflow is usually also referred to as the BPMN model.
+A workflow is a defined sequence of distinct steps representing your business logic. Examples of a
+ workflow could be an e-commerce shopping experience, onboarding a new employee, etc. In Zeebe,
+ workflows are identified by a unique process id. The workflow is usually also referred to as the
+ BPMN model.
 
 * [Workflows](basics/workflows.md)
 


### PR DESCRIPTION
## Description

This PR adds multiple concurrency considerations regarding race conditions in the case of:
 - job workers completing jobs with variables
 - clients publishing messages with variables
 - call activities propagating variables

## Related issues

closes #4862

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release annoncement 
