### PR TITLE
[Backport 0.24] Fix IT memory leak

### DIFF
--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -105,14 +105,14 @@ public final class ClusteringRule extends ExternalResource {
   private final Map<Integer, BrokerCfg> brokerCfgs;
   private final List<Integer> partitionIds;
   private final String clusterName;
-  private final ControlledActorClock controlledClock = new ControlledActorClock();
-  private final Map<Integer, LogStream> logstreams = new ConcurrentHashMap<>();
+  private final ControlledActorClock controlledClock;
+  private final Map<Integer, LogStream> logstreams;
 
   // cluster
   private ZeebeClient client;
   private Gateway gateway;
   private CountDownLatch partitionLatch;
-  private final Map<Integer, Leader> partitionLeader = new ConcurrentHashMap<>();
+  private final Map<Integer, Leader> partitionLeader;
 
   public ClusteringRule() {
     this(3);
@@ -155,8 +155,11 @@ public final class ClusteringRule extends ExternalResource {
     this.gatewayConfigurator = gatewayConfigurator;
     this.clientConfigurator = clientConfigurator;
 
+    controlledClock = new ControlledActorClock();
     brokers = new HashMap<>();
     brokerCfgs = new HashMap<>();
+    partitionLeader = new ConcurrentHashMap<>();
+    logstreams = new ConcurrentHashMap<>();
     partitionIds =
         IntStream.range(START_PARTITION_ID, START_PARTITION_ID + partitionCount)
             .boxed()
@@ -219,6 +222,8 @@ public final class ClusteringRule extends ExternalResource {
     brokers.values().parallelStream().forEach(Broker::close);
     brokers.clear();
     brokerCfgs.clear();
+    logstreams.clear();
+    partitionLeader.clear();
   }
 
   public Broker getBroker(final int nodeId) {


### PR DESCRIPTION
## Description
Fixes a memory leak in IT tests.

Removes references to log, which references atomix journal, which reference several readers and writers, which reference 8 MB byte arrays.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4980

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
