### PR TITLE
chore(atomix): fix NettyMessagingServiceTest flaky test

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -204,7 +204,7 @@ public class NettyMessagingServiceTest {
     final String subject = nextSubject();
     final CompletableFuture<byte[]> response =
         netty1.sendAndReceive(
-            address2, subject, "hello world".getBytes(), false, Duration.ofSeconds(5));
+            address2, subject, "hello world".getBytes(), true, Duration.ofSeconds(5));
 
     // when
     netty1.stop().join();


### PR DESCRIPTION
## Description

This PR fixes a broken test `NettyMessagingServiceTest#shouldCompleteExistingRequestFutureExceptionallyWhenMessagingServiceIsClosed`. The issue was that without sending the request as a keepAlive request, the service is not keeping track of it and therefore not cancelling it. I have no idea how this was even passing or flaky, as it should have been failing every time.

## Related issues

closes #4952 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
