### PR TITLE
chore(raft): fix flaky failover test

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftFailOverTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftFailOverTest.java
@@ -342,11 +342,9 @@ public class RaftFailOverTest {
     raftRule.doSnapshot(65);
     // Leader and Follower A Log [65-100].
     // Follower B Log [0-50]
-    final var oldLeader = raftRule.shutdownLeader();
 
     // when
-    // Follower B comes back we should be able to form a healthy cluster again
-    // Follower A need to replicate snapshot to Follower B
+    // Follower B comes back and receives a snapshot from the leader
     raftRule.joinCluster(followerB);
     raftRule.appendEntries(entryCount);
 
@@ -357,13 +355,6 @@ public class RaftFailOverTest {
     // Follower B should have truncated his log to not have any gaps in his log
     // entries after snapshot should be replicated
     assertThat(entries.get(0).index()).isEqualTo(66);
-
-    for (final String member : memberLogs.keySet()) {
-      if (!oldLeader.equals(member)) {
-        final var memberEntries = memberLogs.get(member);
-        assertThat(memberEntries).endsWith(entries.toArray(new Indexed[0]));
-      }
-    }
   }
 
   @Test
@@ -376,7 +367,6 @@ public class RaftFailOverTest {
     raftRule.doSnapshot(65);
     // Leader and Follower A Log [65-100].
     // Follower B Log [0-50]
-    final var oldLeader = raftRule.shutdownLeader();
 
     // Follower B has old log AND snapshot
     final var nodes = raftRule.getNodes();
@@ -394,13 +384,6 @@ public class RaftFailOverTest {
     // Follower B should have truncated his log to not have any gaps in his log
     // entries after snapshot should be replicated
     assertThat(entries.get(0).index()).isEqualTo(66);
-
-    for (final String member : memberLogs.keySet()) {
-      if (!oldLeader.equals(member)) {
-        final var memberEntries = memberLogs.get(member);
-        assertThat(memberEntries).endsWith(entries.toArray(new Indexed[0]));
-      }
-    }
   }
 
   private void assertMemberLogs(final Map<String, List<Indexed<?>>> memberLog) {


### PR DESCRIPTION
## Description

Test was flaky because the assertion that all members have replicated all entries cannot be true all the time. In a 5 node cluster, only 3 nodes have to have all entries. The other nodes can replicate them with a delay. Since for testing truncation we don't have to verify the log replication, we can safely remove that assertion.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4954
closes #4662 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
