### PR TITLE
chore(qa): ignore exceptions in wait conditions so that it retries until timeout

### DIFF
--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -522,6 +522,7 @@ public final class ClusteringRule extends ExternalResource {
     return Awaitility.await()
         .pollInterval(Duration.ofMillis(100))
         .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions()
         .until(
             () -> getLeaderForPartition(partitionId),
             (leader) -> leader.getNodeId() != previousLeader);


### PR DESCRIPTION
## Description

The test was flaky because the condition `awaitOtherLeader` fails due to an exception thrown when evaluating the expression in `until()`. When the exception is throws the condition is prematurely evaluated as failure instead of retrying until the specified time out.  By adding `ignoreExceptions()`, it will be re-evaluated until success or timeout.

## Related issues

closes #4981 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
