### PR TITLE
[BACKPORT] Fix flaky test in NettyMessagingServiceTest

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -204,7 +204,7 @@ public class NettyMessagingServiceTest {
     final String subject = nextSubject();
     final CompletableFuture<byte[]> response =
         netty1.sendAndReceive(
-            address2, subject, "hello world".getBytes(), false, Duration.ofSeconds(5));
+            address2, subject, "hello world".getBytes(), true, Duration.ofSeconds(5));
 
     // when
     netty1.stop().join();


### PR DESCRIPTION
## Description

Backport of #4993 for 0.24. This is not back ported to 0.23 because this test did not exist yet in 0.23. Just plain cherry-picked so nothing new to review afaik.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
