### PR TITLE
chore(broker): clarify ways to specify config file

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1,11 +1,7 @@
 # Zeebe Standalone Broker configuration file (with embedded gateway)
 
 # ! ! ! ! ! ! ! ! ! !
-# In order to activate the settings in this file, please choose one of the following ways:
-# a) rename this file to application.yaml
-# b) remove the *.template suffix and
-#      Set the following environment variable: export SPRING_CONFIG_LOCATION='file:./config/broker.standalone.yaml'
-#      Alternatively, you can also pass it as a command line argument: ./bin/broker --spring.config.location=file:./config/broker.standalone.yaml
+# In order to activate the settings in this file, rename this file to application.yaml.
 # ! ! ! ! ! ! ! ! ! !
 
 # Overview -------------------------------------------

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -1,11 +1,7 @@
 # Zeebe Broker configuration file (without embedded gateway)
 
 # ! ! ! ! ! ! ! ! ! !
-# In order to activate the settings in this file, please choose one of the following ways:
-# a) rename this file to application.yaml
-# b) remove the *.template suffix and
-#      Set the following environment variable: export SPRING_CONFIG_LOCATION='file:./config/broker.yaml'
-#      Alternatively, you can also pass it as a command line argument: ./bin/broker --spring.config.location=file:./config/broker.yaml
+# In order to activate the settings in this file, rename this file to application.yaml.
 # ! ! ! ! ! ! ! ! ! !
 
 # Overview -------------------------------------------

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -1,11 +1,7 @@
 # Zeebe standalone gateway configuration file.
 
 # ! ! ! ! ! ! ! ! ! !
-# In order to activate the settings in this file, please choose one of the following ways:
-# a) rename this file to application.yaml
-# b) remove the *.template suffix and
-#      Set the following environment variable: export SPRING_CONFIG_LOCATION='file:./config/gateway.yaml'
-#      Alternatively, you can also pass it as a command line argument: ./bin/gateway --spring.config.location=file:./config/gateway.yaml
+# In order to activate the settings in this file, rename this file to application.yaml
 # ! ! ! ! ! ! ! ! ! !
 
 # For the configuration of the embedded gateway that is deployed alongside a broker see the gateway section of broker.yaml.template

--- a/docs/src/operations/configuration.md
+++ b/docs/src/operations/configuration.md
@@ -1,11 +1,19 @@
 # Configuration
 
-Zeebe can be configured through configuration files, environment variables or a mix of both. If both configuration files and environment variables are used, then the latter take precedence over configuration files.
+Zeebe can be configured through:
+ * configuration files,
+ * environment variables,
+ * or a mix of both.
+
+If both configuration files and environment variables are present, then environment variables overwrite settings in configuration files.
+
+If you want to make small changes to the configuration, we recommend to use environment variables.
+If you want to make big changes to the configuration, we recommend to use a configuration file.
 
 The configuration will be applied during startup of Zeebe. It is not possible to change the configuration at runtime.
 
 ## Default Configuration
-The default configuration is located in `config/application.yaml`. This configuration contains the most common configuration settings for a standalone broker
+The default configuration is located in `config/application.yaml`. This configuration contains the most common configuration settings for a standalone broker. It also lists the corresponding environment variable for each setting.
 
 > **Note**
 >
@@ -18,7 +26,6 @@ We provide templates that contain all possible configuration settings, along wit
 * [Gateway Configuration Template](/appendix/gateway-config-template.md)
 
 Note that these templates also include the corresponding environment variables to use for every setting.
-
 
 ## Editing the configuration
 You can either start from scratch or start from the configuration templates listed above.
@@ -53,39 +60,32 @@ When it comes to editing individual settings two data types are worth mentioning
   * Human friendly format: `15s` (or `m, h`)
   * Machine friendly format: either duration in milliseconds as long, or [ISO-8601 Duration](ttps://en.wikipedia.org/wiki/ISO_8601#Durations) format (e.g. `PT15S`)
 
-## Passing configuration file to Zeebe
-
-The configuration file can be passed to Zeebe either by adhering to naming conventions, or by explicitly specifying the configuration file through an environment variable or via a command line argument when launching Zeebe.
-
-*Naming conventions*
-
+## Passing Configuration Files to Zeebe
 Rename the configuration file to `application.yaml` and place it in the following location:
 ```shell script
 ./config/application.yaml
 ```
 
-*Environment Variable*
+*Other ways to specify the configuration file*
 
-Rename the configuration file to `*.yaml` and set an environment variable to point to the configuration file:
-```shell script
-export SPRING_CONFIG_LOCATION='file:./[path to config file]'
-```
+Zeebe uses Spring Boot for its configuration parsing. So all other ways to [configure a Spring Boot application](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config) should also work. In particular,
+you can use:
+* `SPRING_CONFIG_ADDITIONAL_LOCATION` to specify an additional configuration file.
+* `SPRING_APPLICATION_JSON` to specify settings in JSON format.
 
-*Command line argument*
+Details can be found in the Srping documentation.
 
-Rename the configuration file to `*.yaml` and add a command line argument to point to the configuration file:
-```shell script
-./bin/broker --spring.config.location=file:./[path to config file]
+> **Note**
+>
+> We recommend not to use `SPRING_CONFIG_LOCATION` as this will replace all existing configuration defaults.
+> When used inappropriately, some features will be disabled or will not be configured properly.
+>
+> If you specify `SPRING_CONFIG_LOCATION`, then specify it like this:
+> ```shell script
+> export SPRING_CONFIG_LOCATION='classpath:/,file:./[path to config file]'
+> ```
+> This will ensure that the defaults defined in the classpath resources will be used (unless explicitly overwritten by the configuration file you provide). If you omit the defaults defined in the classpath, some features may be disabled or will not be configured properly.
 
-or
-
-./bin/gateway --spring.config.location=file:./[path to config file]
-```
-
-
-*Misc*
-
-Zeebe uses Spring Boot for its configuration parsing. So all other ways to [configure a Spring Boot application](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config) should also work.
 
 ## Verifying that configuration was applied
 To verify that the configuration was applied, start Zeebe and look at the log.

--- a/gateway/src/test/resources/configuration/gateway.default.yaml
+++ b/gateway/src/test/resources/configuration/gateway.default.yaml
@@ -1,11 +1,7 @@
 # Zeebe standalone gateway configuration file.
 
 # ! ! ! ! ! ! ! ! ! !
-# In order to activate the settings in this file, please choose one of the following ways:
-# a) rename this file to application.yaml
-# b) remove the *.template suffix and
-#      Set the following environment variable: export SPRING_CONFIG_LOCATION='file:./config/gateway.yaml'
-#      Alternatively, you can also pass it as a command line argument: ./bin/gateway --spring.config.location=file:./config/gateway.yaml
+# In order to activate the settings in this file, rename this file to application.yaml
 # ! ! ! ! ! ! ! ! ! !
 
 # For the configuration of the embedded gateway that is deployed alongside a broker see the gateway section of broker.yaml.template


### PR DESCRIPTION
## Description

* Reduces instructions in config templates
* Clarifies instruction in documentation to also include the classpath when using `SPRING_CONFIG_LOCATION`

## Related issues

closes #4976

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [will be done after approval] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [X] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
