### PR TITLE
[Backport] Improve stability of the InterruptingEventSubprocessTest

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -71,7 +71,7 @@ public final class EngineRule extends ExternalResource {
 
   private static final int PARTITION_ID = Protocol.DEPLOYMENT_PARTITION;
   private static final RecordingExporter RECORDING_EXPORTER = new RecordingExporter();
-  private StreamProcessorRule environmentRule;
+  private final StreamProcessorRule environmentRule;
   private final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
   private final int partitionCount;
@@ -80,7 +80,7 @@ public final class EngineRule extends ExternalResource {
 
   private final Int2ObjectHashMap<SubscriptionCommandMessageHandler> subscriptionHandlers =
       new Int2ObjectHashMap<>();
-  private final ExecutorService subscriptionHandlerExecutor = Executors.newSingleThreadExecutor();
+  private ExecutorService subscriptionHandlerExecutor;
 
   private EngineRule(final int partitionCount) {
     this(partitionCount, false);
@@ -115,6 +115,8 @@ public final class EngineRule extends ExternalResource {
 
   @Override
   protected void before() {
+    subscriptionHandlerExecutor = Executors.newSingleThreadExecutor();
+
     if (!explicitStart) {
       startProcessors();
     }
@@ -123,7 +125,6 @@ public final class EngineRule extends ExternalResource {
   @Override
   protected void after() {
     subscriptionHandlerExecutor.shutdown();
-    environmentRule = null;
     subscriptionHandlers.clear();
   }
 

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -248,6 +248,7 @@ public final class StreamProcessorRule implements TestRule {
     @Override
     protected void after() {
       streams = null;
+      streamProcessingComposite = null;
     }
   }
 

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordStream.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordStream.java
@@ -81,4 +81,9 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return new IncidentRecordStream(
         filter(r -> r.getValueType() == ValueType.INCIDENT).map(Record.class::cast));
   }
+
+  public MessageSubscriptionRecordStream messageSubscriptionRecords() {
+    return new MessageSubscriptionRecordStream(
+        filter(r -> r.getValueType() == ValueType.MESSAGE_SUBSCRIPTION).map(Record.class::cast));
+  }
 }


### PR DESCRIPTION
## Description

Backport of #5008 to `0.24`

## Related issues

closes #4994

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
