### PR TITLE
[Backport] Improve stability of LogStorageAppenderTest

### DIFF
--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -155,29 +156,38 @@ public final class LogStorageAppenderTest {
     final AtomicReference<Throwable> err = new AtomicReference<>();
 
     logStorageRule.setPositionListener(i -> committed.countDown());
-    final long firstPosition = writer.valueWriter(value).tryWrite();
-    schedulerRule.submitActor(appender).join();
-
-    // when
     logStorageRule.setWriteErrorListener(
         throwable -> {
           err.set(throwable);
           failed.countDown();
         });
+
+    final AtomicLong expectedPos = new AtomicLong(INITIAL_POSITION);
     when(subscription.peekBlock(any(), anyInt(), anyBoolean()))
         .then(
             a -> {
-              // change the entry's position
               final Object result = a.callRealMethod();
               final BlockPeek block = a.getArgument(0);
               assertThat(LogEntryDescriptor.getPosition(block.getBuffer(), 0))
-                  .isEqualTo(INITIAL_POSITION + 1);
-              LogEntryDescriptor.setPosition(
-                  block.getBuffer(), DataFrameDescriptor.messageOffset(0), WRONG_POSITION);
+                  .isEqualTo(expectedPos.get());
+
+              // corrupt second entry
+              if (expectedPos.get() != INITIAL_POSITION) {
+                LogEntryDescriptor.setPosition(
+                    block.getBuffer(), DataFrameDescriptor.messageOffset(0), WRONG_POSITION);
+              } else {
+                expectedPos.incrementAndGet();
+              }
+
               return result;
             });
+
+    // when
+    final long firstPosition = writer.valueWriter(value).tryWrite();
+    schedulerRule.submitActor(appender).join();
     assertThat(committed.await(5, TimeUnit.SECONDS)).isTrue();
-    final var position = writer.valueWriter(value).tryWrite();
+
+    final var secondPosition = writer.valueWriter(value).tryWrite();
 
     // then
     assertThat(failed.await(5, TimeUnit.SECONDS)).isTrue();
@@ -186,7 +196,7 @@ public final class LogStorageAppenderTest {
             String.format(
                 "Unexpected position %d was encountered after position %d when appending positions <%d, %d>.",
                 WRONG_POSITION, firstPosition, WRONG_POSITION, WRONG_POSITION));
-    assertThat(reader.seek(position)).isFalse();
+    assertThat(reader.seek(secondPosition)).isFalse();
     assertThat(reader.hasNext()).isFalse();
   }
 


### PR DESCRIPTION
## Description

Backport of #4858 to `0.24`

## Related issues

closes #4849

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
