### PR TITLE
fix(atomix): separate test data folders for parallel tests

### DIFF
--- a/atomix/storage/pom.xml
+++ b/atomix/storage/pom.xml
@@ -14,7 +14,9 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <artifactId>atomix-storage</artifactId>
 
   <modelVersion>4.0.0</modelVersion>
@@ -43,6 +45,13 @@
       <artifactId>kryo</artifactId>
       <groupId>com.esotericsoftware</groupId>
     </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <artifactId>junit</artifactId>
       <groupId>junit</groupId>

--- a/atomix/storage/src/test/java/io/atomix/storage/buffer/FileTesting.java
+++ b/atomix/storage/src/test/java/io/atomix/storage/buffer/FileTesting.java
@@ -16,6 +16,10 @@
  */
 package io.atomix.storage.buffer;
 
+import static io.zeebe.test.util.TestEnvironment.getTestForkNumber;
+import static io.zeebe.test.util.TestEnvironment.getTestMavenId;
+import static java.lang.String.format;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -27,14 +31,23 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.UUID;
 
 public abstract class FileTesting {
+
+  private static final String getTestRunPathElement() {
+    return format("fork-%d_mavenID-%d/", getTestForkNumber(), getTestMavenId());
+  }
+
+  private static final String getFolderNameForTestData() {
+    return "target/test-files/" + getTestRunPathElement();
+  }
+
   public static File createFile() {
-    final File file = new File("target/test-files/" + UUID.randomUUID().toString());
+    final File file = new File(getFolderNameForTestData() + UUID.randomUUID().toString());
     file.getParentFile().mkdirs();
     return file;
   }
 
   public static void cleanFiles() {
-    final Path directory = Paths.get("target/test-files/");
+    final Path directory = Paths.get(getFolderNameForTestData());
     try {
       Files.walkFileTree(
           directory,

--- a/test-util/src/main/java/io/zeebe/test/util/TestEnvironment.java
+++ b/test-util/src/main/java/io/zeebe/test/util/TestEnvironment.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.test.util;
+
+import io.zeebe.util.ZbLogger;
+import org.slf4j.Logger;
+
+public class TestEnvironment {
+  private static final Logger LOG = new ZbLogger("io.zeebe.test.util");
+
+  private static final String TEST_FORK_NUMBER_PROPERTY_NAME = "testForkNumber";
+  private static final String TEST_MAVEN_ID_PROPERTY_NAME = "testMavenId";
+
+  public static int getTestForkNumber() {
+    int testForkNumber = 0;
+    try {
+      final String testForkNumberProperty = System.getProperty(TEST_FORK_NUMBER_PROPERTY_NAME);
+      if (testForkNumberProperty != null) {
+        testForkNumber = Integer.valueOf(testForkNumberProperty);
+      } else {
+        LOG.warn(
+            "No system property '{}' set, using default value {}",
+            TEST_FORK_NUMBER_PROPERTY_NAME,
+            testForkNumber);
+      }
+    } catch (final Exception e) {
+      LOG.warn("Failed to read test fork number system property", e);
+    }
+    return testForkNumber;
+  }
+
+  public static int getTestMavenId() {
+    int testMavenId = 0;
+    try {
+      final String testMavenIdProperty = System.getProperty(TEST_MAVEN_ID_PROPERTY_NAME);
+      if (testMavenIdProperty != null) {
+        testMavenId = Integer.valueOf(testMavenIdProperty);
+      } else {
+        LOG.warn(
+            "No system property '{}' set, using default value {}",
+            TEST_MAVEN_ID_PROPERTY_NAME,
+            testMavenId);
+      }
+    } catch (final Exception e) {
+      LOG.warn("Failed to read test maven id system property", e);
+    }
+    return testMavenId;
+  }
+}

--- a/test-util/src/main/java/io/zeebe/test/util/socket/SocketUtil.java
+++ b/test-util/src/main/java/io/zeebe/test/util/socket/SocketUtil.java
@@ -7,15 +7,13 @@
  */
 package io.zeebe.test.util.socket;
 
+import io.zeebe.test.util.TestEnvironment;
 import io.zeebe.util.ZbLogger;
 import java.net.InetSocketAddress;
 import org.slf4j.Logger;
 
 public final class SocketUtil {
   static final Logger LOG = new ZbLogger("io.zeebe.test.util.SocketUtil");
-
-  private static final String TEST_FORK_NUMBER_PROPERTY_NAME = "testForkNumber";
-  private static final String TEST_MAVEN_ID_PROPERTY_NAME = "testMavenId";
 
   private static final String DEFAULT_HOST = "localhost";
   private static final int BASE_PORT = 25600;
@@ -25,8 +23,8 @@ public final class SocketUtil {
   private static final PortRange PORT_RANGE;
 
   static {
-    final int testForkNumber = getTestForkNumber();
-    final int testMavenId = getTestMavenId();
+    final int testForkNumber = TestEnvironment.getTestForkNumber();
+    final int testMavenId = TestEnvironment.getTestMavenId();
 
     LOG.info(
         "Starting socket assignment with testForkNumber {} and testMavenId {}",
@@ -49,41 +47,5 @@ public final class SocketUtil {
 
   public static InetSocketAddress getNextAddress() {
     return PORT_RANGE.next();
-  }
-
-  private static int getTestForkNumber() {
-    int testForkNumber = 0;
-    try {
-      final String testForkNumberProperty = System.getProperty(TEST_FORK_NUMBER_PROPERTY_NAME);
-      if (testForkNumberProperty != null) {
-        testForkNumber = Integer.valueOf(testForkNumberProperty);
-      } else {
-        LOG.warn(
-            "No system property '{}' set, using default value {}",
-            TEST_FORK_NUMBER_PROPERTY_NAME,
-            testForkNumber);
-      }
-    } catch (final Exception e) {
-      LOG.warn("Failed to read test fork number system property", e);
-    }
-    return testForkNumber;
-  }
-
-  private static int getTestMavenId() {
-    int testMavenId = 0;
-    try {
-      final String testMavenIdProperty = System.getProperty(TEST_MAVEN_ID_PROPERTY_NAME);
-      if (testMavenIdProperty != null) {
-        testMavenId = Integer.valueOf(testMavenIdProperty);
-      } else {
-        LOG.warn(
-            "No system property '{}' set, using default value {}",
-            TEST_MAVEN_ID_PROPERTY_NAME,
-            testMavenId);
-      }
-    } catch (final Exception e) {
-      LOG.warn("Failed to read test maven id system property", e);
-    }
-    return testMavenId;
   }
 }


### PR DESCRIPTION
## Description

Root cause was that different tests running in parallel were using the same folders, and cleaning the folders after each test.

Fix:
* extract methods that read out fork#  (forks are spawned within a Jenkins stage during test) and maven ID (to identify different test stages running simultaneaously)
* use fork# and maven ID to have individual folders for each fork and stage

## Related issues

closes #4838 

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [will be done after this PR is approved] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
