### PR TITLE
chore(atomix): improve raft failover tests

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftAppendTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftAppendTest.java
@@ -48,11 +48,11 @@ public class RaftAppendTest {
     // given
 
     // when
-    raftRule.appendEntry();
+    final long commitIndex = raftRule.appendEntry();
 
     // then
-    raftRule.awaitCommit(2);
-    raftRule.awaitSameLogSizeOnAllNodes();
+    raftRule.awaitCommit(commitIndex);
+    raftRule.awaitSameLogSizeOnAllNodes(commitIndex);
     final var memberLog = raftRule.getMemberLogs();
 
     final var logLength = memberLog.values().stream().map(List::size).findFirst().orElseThrow();
@@ -70,7 +70,7 @@ public class RaftAppendTest {
     final var lastIndex = raftRule.appendEntries(entryCount);
 
     // then
-    raftRule.awaitSameLogSizeOnAllNodes();
+    raftRule.awaitSameLogSizeOnAllNodes(lastIndex);
     final var memberLog = raftRule.getMemberLogs();
 
     final var maxIndex =

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftFailOverTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftFailOverTest.java
@@ -54,7 +54,7 @@ public class RaftFailOverTest {
     final var lastIndex = raftRule.appendEntries(entryCount);
 
     // then
-    raftRule.awaitSameLogSizeOnAllNodes();
+    raftRule.awaitSameLogSizeOnAllNodes(lastIndex);
     final var memberLog = raftRule.getMemberLogs();
 
     final var maxIndex =
@@ -79,7 +79,7 @@ public class RaftFailOverTest {
     final var lastIndex = raftRule.appendEntries(entryCount);
 
     // then
-    raftRule.awaitSameLogSizeOnAllNodes();
+    raftRule.awaitSameLogSizeOnAllNodes(lastIndex);
     final var memberLog = raftRule.getMemberLogs();
 
     final var maxIndex =
@@ -104,7 +104,7 @@ public class RaftFailOverTest {
     final var lastIndex = raftRule.appendEntries(entryCount);
 
     // then
-    raftRule.awaitSameLogSizeOnAllNodes();
+    raftRule.awaitSameLogSizeOnAllNodes(lastIndex);
     final var memberLog = raftRule.getMemberLogs();
 
     final var maxIndex =
@@ -132,8 +132,8 @@ public class RaftFailOverTest {
   @Test
   public void shouldCompactLogOnSnapshot() throws Exception {
     // given
-    raftRule.appendEntries(128);
-    raftRule.awaitSameLogSizeOnAllNodes();
+    final var lastIndex = raftRule.appendEntries(128);
+    raftRule.awaitSameLogSizeOnAllNodes(lastIndex);
     final var memberLogs = raftRule.getMemberLogs();
 
     // when


### PR DESCRIPTION
## Description

* Wait for commit after each append. Otherwise, too many appends can cause leader election which makes the test flaky.
* Improve condition `awaitSameLogSizeOnAllNodes` to check for the expected last index. Else the check is non-deterministic.

## Related issues

Closing several issues as all of their assertion failures looks similar.

closes #4953 
closes #4935 
closes #4617 
closes #4890 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
