### PR TITLE
chore(broker): add retries to container starts

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -91,6 +91,8 @@
     <version.config>1.4.0</version.config>
     <version.kryo>4.0.2</version.kryo>
     <version.awaitility>4.0.3</version.awaitility>
+    <version.failsafe>2.4.0</version.failsafe>
+
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.0.0</plugin.version.antrun>
@@ -656,6 +658,12 @@
         <artifactId>classgraph</artifactId>
         <groupId>io.github.classgraph</groupId>
         <version>${version.classgraph}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>net.jodah</groupId>
+        <artifactId>failsafe</artifactId>
+        <version>${version.failsafe}</version>
       </dependency>
 
     </dependencies>

--- a/upgrade-tests/pom.xml
+++ b/upgrade-tests/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Upgradability Tests</name>
@@ -58,6 +60,10 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+    </dependency>
+    <dependency>    
+      <groupId>net.jodah</groupId>
+      <artifactId>failsafe</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Description

This adds a retry policy to the container starts. The start is retried if a certain exception is thrown.

It adds a dependency to Zeebe tests. The dependency is 100KB and I think we can use it in other tests as well. Over time, we can expand the conditions which warrant a restart.

## Related issues

closes #4395 

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [Will be done after this PR is approved] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
