### PR TITLE
fix(broker): increase request timeout

### DIFF
--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/gateway/GatewayIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/gateway/GatewayIntegrationTest.java
@@ -48,7 +48,7 @@ public final class GatewayIntegrationTest {
         .setHost("0.0.0.0")
         .setPort(SocketUtil.getNextAddress().getPort())
         .setContactPoint(internalApi.toString())
-        .setRequestTimeout(Duration.ofSeconds(3));
+        .setRequestTimeout(Duration.ofSeconds(10));
     configuration.init();
 
     final ControlledActorClock clock = new ControlledActorClock();


### PR DESCRIPTION
## Description

I could not reproduce the test failures with the request timeout that was given. But I could reproduce the test failure when I decreased the timeout. 

The fix is to increase the timeout.

## Related issues

closes #4973 

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [will be done after this PR is approved] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
