### PR TITLE
Improve stability of StreamProcessorHealthTest

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -12,7 +12,6 @@ import static io.zeebe.engine.processing.streamprocessor.TypedRecordProcessors.p
 import static io.zeebe.protocol.record.intent.WorkflowInstanceIntent.ELEMENT_ACTIVATED;
 import static io.zeebe.protocol.record.intent.WorkflowInstanceIntent.ELEMENT_ACTIVATING;
 import static io.zeebe.test.util.TestUtil.waitUntil;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
@@ -85,13 +84,14 @@ public class StreamProcessorHealthTest {
     final long firstPosition =
         streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, 1);
     streamProcessorRule.writeWorkflowInstanceEventWithSource(ELEMENT_ACTIVATED, 1, firstPosition);
-    assertThat(
+
+    waitUntil(
+        () ->
             streamProcessorRule
                 .events()
                 .onlyWorkflowInstanceRecords()
                 .withIntent(ELEMENT_ACTIVATED)
-                .exists())
-        .isTrue();
+                .exists());
 
     streamProcessor = getErrorProneStreamProcessor();
     final var healthStatusCheck = HealthStatusCheck.of(streamProcessor);
@@ -202,13 +202,31 @@ public class StreamProcessorHealthTest {
 
                           invocation.getAndIncrement();
                           if (shouldProcessingThrowException.get()) {
-                            throw new RuntimeException("processing failed");
+                            throw new RuntimeException("Expected failure on processing");
                           }
                         }
                       });
             });
 
     return streamProcessor;
+  }
+
+  private static final class HealthStatusCheck extends Actor {
+    private final StreamProcessor streamProcessor;
+
+    private HealthStatusCheck(final StreamProcessor streamProcessor) {
+      this.streamProcessor = streamProcessor;
+    }
+
+    public static HealthStatusCheck of(final StreamProcessor streamProcessor) {
+      return new HealthStatusCheck(streamProcessor);
+    }
+
+    public boolean hasHealthStatus(final HealthStatus healthStatus) {
+      return actor
+          .call(() -> streamProcessor.getHealthStatus() == healthStatus)
+          .join(5, TimeUnit.SECONDS);
+    }
   }
 
   private final class WrappedStreamWriter implements TypedStreamWriter {
@@ -245,7 +263,7 @@ public class StreamProcessorHealthTest {
     public void appendFollowUpEvent(
         final long key, final Intent intent, final UnpackedObject value) {
       if (shouldFailErrorHandlingInTransaction.get()) {
-        throw new RuntimeException("append followup event failed");
+        throw new RuntimeException("Expected failure on append followup event");
       }
       wrappedWriter.appendFollowUpEvent(key, intent, value);
     }
@@ -257,7 +275,7 @@ public class StreamProcessorHealthTest {
         final UnpackedObject value,
         final Consumer<RecordMetadata> metadata) {
       if (shouldFailErrorHandlingInTransaction.get()) {
-        throw new RuntimeException("append followup event failed");
+        throw new RuntimeException("Expected failure on append followup event");
       }
       wrappedWriter.appendFollowUpEvent(key, intent, value, metadata);
     }
@@ -295,27 +313,9 @@ public class StreamProcessorHealthTest {
     @Override
     public long flush() {
       if (shouldFlushThrowException.get()) {
-        throw new RuntimeException("flush failed");
+        throw new RuntimeException("Expected failure on flush");
       }
       return wrappedWriter.flush();
-    }
-  }
-
-  private static final class HealthStatusCheck extends Actor {
-    private final StreamProcessor streamProcessor;
-
-    private HealthStatusCheck(final StreamProcessor streamProcessor) {
-      this.streamProcessor = streamProcessor;
-    }
-
-    public static HealthStatusCheck of(final StreamProcessor streamProcessor) {
-      return new HealthStatusCheck(streamProcessor);
-    }
-
-    public boolean hasHealthStatus(final HealthStatus healthStatus) {
-      return actor
-          .call(() -> streamProcessor.getHealthStatus() == healthStatus)
-          .join(5, TimeUnit.SECONDS);
     }
   }
 }


### PR DESCRIPTION
## Description

The test fails sometimes because the events are not written to the stream yet. First, the test writes two events and then verifies that one of the events exists by using `streamProcessorRule.events()` that uses a log stream reader. Since the events are written to the buffer first, they're not immediately present in the log stream.

Improving the stability of the test by waiting until the event is written to the stream instead of using an assertion

## Related issues

closes #4678 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
