### PR TITLE
Extend logging on closing the broker

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -89,7 +89,7 @@ public final class ZeebePartition extends Actor
   private final TypedRecordProcessorsFactory typedRecordProcessorsFactory;
   private final CommandApiService commandApiService;
   private final List<PartitionListener> partitionListeners;
-  private final List<AsyncClosable> managedResources = new ArrayList<>();
+  private final List<ClosingStep> closingSteps = new ArrayList<>();
   private final int partitionId;
   private final int maxFragmentSize;
   private final BrokerInfo localBroker;
@@ -129,9 +129,9 @@ public final class ZeebePartition extends Actor
     this.typedRecordProcessorsFactory = typedRecordProcessorsFactory;
     this.commandApiService = commandApiService;
     this.partitionListeners = Collections.unmodifiableList(partitionListeners);
-    this.partitionId = atomixRaftPartition.id().id();
-    this.scheduler = actorScheduler;
-    this.maxFragmentSize = (int) brokerCfg.getNetwork().getMaxMessageSizeInBytes();
+    partitionId = atomixRaftPartition.id().id();
+    scheduler = actorScheduler;
+    maxFragmentSize = (int) brokerCfg.getNetwork().getMaxMessageSizeInBytes();
     this.zeebeIndexMapping = zeebeIndexMapping;
 
     final var exporterEntries = brokerCfg.getExporters().entrySet();
@@ -147,7 +147,7 @@ public final class ZeebePartition extends Actor
       }
     }
 
-    this.actorName = buildActorName(localBroker.getNodeId(), "ZeebePartition-" + partitionId);
+    actorName = buildActorName(localBroker.getNodeId(), "ZeebePartition-" + partitionId);
     criticalComponentsHealthMonitor = new CriticalComponentsHealthMonitor(actor, LOG);
     raftPartitionHealth = new RaftPartitionHealth(atomixRaftPartition, actor, this::onRaftFailed);
     zeebePartitionHealth = new ZeebePartitionHealth(partitionId);
@@ -166,7 +166,7 @@ public final class ZeebePartition extends Actor
   }
 
   private void onRoleChange(final Role newRole, final long newTerm) {
-    this.term = newTerm;
+    term = newTerm;
     switch (newRole) {
       case LEADER:
         if (raftRole != Role.LEADER) {
@@ -205,7 +205,7 @@ public final class ZeebePartition extends Actor
                     t -> {
                       // Compare with the current term in case a new role transition
                       // happened
-                      if (t != null && this.term == newTerm) {
+                      if (t != null && term == newTerm) {
                         onInstallFailure();
                       }
                     });
@@ -231,7 +231,7 @@ public final class ZeebePartition extends Actor
                     t -> {
                       // Compare with the current term in case a new role transition
                       // happened
-                      if (t != null && this.term == newTerm) {
+                      if (t != null && term == newTerm) {
                         onInstallFailure();
                       }
                     });
@@ -381,8 +381,8 @@ public final class ZeebePartition extends Actor
         .onComplete(
             (log, error) -> {
               if (error == null) {
-                managedResources.add(this::closeLogStream);
-                this.logStream = log;
+                addClosingStep("log stream", this::closeLogStream);
+                logStream = log;
                 if (deferredCommitPosition > 0) {
                   logStream.setCommitPosition(deferredCommitPosition);
                   deferredCommitPosition = -1;
@@ -403,20 +403,20 @@ public final class ZeebePartition extends Actor
     persistedSnapshotStore = atomixRaftPartition.getServer().getPersistedSnapshotStore();
 
     final var controller = createSnapshotController();
-    managedResources.add(this::closeSnapshotController);
+    addClosingStep("snapshot controller", this::closeSnapshotController);
     snapshotController = controller;
 
     final LogCompactor logCompactor = new AtomixLogCompactor(atomixRaftPartition.getServer());
     final LogDeletionService deletionService =
         new LogDeletionService(
             localBroker.getNodeId(), partitionId, logCompactor, persistedSnapshotStore);
-    managedResources.add(deletionService);
+    addClosingStep("deletion service", deletionService);
 
     return scheduler.submitActor(deletionService);
   }
 
   private void registerSnapshotListenerForReplication() {
-    managedResources.add(this::removeSnapshotListenerForReplication);
+    addClosingStep("snapshot listener for replication", this::removeSnapshotListenerForReplication);
     persistedSnapshotStore.addSnapshotListener(snapshotController);
   }
 
@@ -428,7 +428,7 @@ public final class ZeebePartition extends Actor
   private StateControllerImpl createSnapshotController() {
     final var runtimeDirectory = atomixRaftPartition.dataDirectory().toPath().resolve("runtime");
     final RaftLogReader reader = createReader();
-    managedResources.add(this::closeStateReplication);
+    addClosingStep("state replication", this::closeStateReplication);
     stateReplication =
         shouldReplicateSnapshots()
             ? new StateReplication(messagingService, partitionId, localBroker.getNodeId())
@@ -446,7 +446,8 @@ public final class ZeebePartition extends Actor
 
   private RaftLogReader createReader() {
     final var reader = atomixRaftPartition.getServer().openReader(-1, Mode.COMMITS);
-    managedResources.add(
+    addClosingStep(
+        "raft log reader",
         () -> {
           reader.close();
           return CompletableActorFuture.completed(null);
@@ -460,7 +461,7 @@ public final class ZeebePartition extends Actor
 
   private void installProcessingPartition(final CompletableActorFuture<Void> installFuture) {
     streamProcessor = createStreamProcessor(zeebeDb);
-    managedResources.add(streamProcessor);
+    addClosingStep("stream processor", streamProcessor);
     streamProcessor
         .openAsync()
         .onComplete(
@@ -501,7 +502,8 @@ public final class ZeebePartition extends Actor
                 metricExporter.exportMetrics();
               }
             });
-    managedResources.add(
+    addClosingStep(
+        "RocksDB metric timer",
         () -> {
           metricsTimer.cancel();
           return CompletableActorFuture.completed(null);
@@ -536,7 +538,7 @@ public final class ZeebePartition extends Actor
             snapshotController,
             logStream,
             snapshotPeriod);
-    managedResources.add(asyncSnapshotDirector);
+    addClosingStep("snapshot director", asyncSnapshotDirector);
     return scheduler.submitActor(asyncSnapshotDirector);
   }
 
@@ -557,21 +559,25 @@ public final class ZeebePartition extends Actor
             .descriptors(exporterDescriptors);
 
     final var exporterDirector = new ExporterDirector(context);
-    managedResources.add(exporterDirector);
+    addClosingStep("exporter director", exporterDirector);
 
     return exporterDirector.startAsync(scheduler);
   }
 
   private CompletableActorFuture<Void> closePartition() {
     streamProcessor = null;
-    Collections.reverse(managedResources);
+    Collections.reverse(closingSteps);
     final var closeActorsFuture = new CompletableActorFuture<Void>();
-    stepByStepClosing(closeActorsFuture, managedResources);
+    stepByStepClosing(closeActorsFuture, closingSteps);
 
     final var closingPartitionFuture = new CompletableActorFuture<Void>();
     closeActorsFuture.onComplete(closingPartitionFuture);
 
     return closingPartitionFuture;
+  }
+
+  private void addClosingStep(final String name, final AsyncClosable closable) {
+    closingSteps.add(new ClosingStep(name, closable));
   }
 
   private ActorFuture<Void> closeLogStream() {
@@ -618,22 +624,31 @@ public final class ZeebePartition extends Actor
   }
 
   private void stepByStepClosing(
-      final CompletableActorFuture<Void> closingFuture, final List<AsyncClosable> actorsToClose) {
+      final CompletableActorFuture<Void> closingFuture, final List<ClosingStep> actorsToClose) {
     if (actorsToClose.isEmpty()) {
       closingFuture.complete(null);
       return;
     }
 
-    final AsyncClosable asyncClosable = actorsToClose.remove(0);
-    asyncClosable
+    final ClosingStep closingStep = actorsToClose.remove(0);
+    LOG.debug("Closing Zeebe-Partition-{}: {}", partitionId, closingStep.getName());
+    closingStep
+        .getClosable()
         .closeAsync()
         .onComplete(
             (v, t) -> {
               if (t == null) {
-                LOG.debug("Closed {} successfully", asyncClosable);
+                LOG.debug(
+                    "Closing Zeebe-Partition-{}: {} closed successfully",
+                    partitionId,
+                    closingStep.getName());
                 stepByStepClosing(closingFuture, actorsToClose);
               } else {
-                LOG.debug("Unexpected exception on closing.", t);
+                LOG.error(
+                    "Closing Zeebe-Partition-{}: {} failed to close",
+                    partitionId,
+                    closingStep.getName(),
+                    t);
                 closingFuture.completeExceptionally(t);
               }
             });
@@ -645,11 +660,11 @@ public final class ZeebePartition extends Actor
       actor.run(
           () -> {
             final long commitPosition = indexed.<ZeebeEntry>cast().entry().highestPosition();
-            if (this.logStream == null) {
-              this.deferredCommitPosition = commitPosition;
+            if (logStream == null) {
+              deferredCommitPosition = commitPosition;
               return;
             }
-            this.logStream.setCommitPosition(commitPosition);
+            logStream.setCommitPosition(commitPosition);
           });
     }
   }
@@ -798,10 +813,29 @@ public final class ZeebePartition extends Actor
       final String name, final HealthMonitorable healthMonitorable) {
     criticalComponentsHealthMonitor.registerComponent(name, healthMonitorable);
 
-    managedResources.add(
+    addClosingStep(
+        "health component registration",
         () -> {
           criticalComponentsHealthMonitor.removeComponent(name);
           return CompletableActorFuture.completed(null);
         });
+  }
+
+  private static final class ClosingStep {
+    private final String name;
+    private final AsyncClosable closable;
+
+    private ClosingStep(final String name, final AsyncClosable closable) {
+      this.name = name;
+      this.closable = closable;
+    }
+
+    private String getName() {
+      return name;
+    }
+
+    private AsyncClosable getClosable() {
+      return closable;
+    }
   }
 }


### PR DESCRIPTION
## Description

* add more logging when closing the Zeebe partiton and the actor scheduler to get more insides when a test is stuck on closing

## Related issues


## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
