### PR TITLE
[Backport] Zip test results and keep reports for flaky tests

### DIFF
--- a/.ci/scripts/distribution/it-java.sh
+++ b/.ci/scripts/distribution/it-java.sh
@@ -1,6 +1,31 @@
-#!/bin/sh -eux
+#!/bin/bash -eux
 
 
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
-mvn -o -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl qa/integration-tests -pl upgrade-tests -DtestMavenId=2
+tmpfile=$(mktemp)
+
+mvn -o -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl qa/integration-tests -pl upgrade-tests -DtestMavenId=2 -Dsurefire.rerunFailingTestsCount=5 | tee ${tmpfile}
+
+status=${PIPESTATUS[0]}
+
+if grep -q "\[WARNING\] Flakes:" ${tmpfile}; then
+
+  tmpfile2=$(mktemp)
+
+  awk '/^\[WARNING\] Flakes:.*$/{flag=1}/^\[ERROR\] Tests run:.*Flakes: [0-9]*$/{print;flag=0}flag' ${tmpfile} > ${tmpfile2}
+
+  grep "\[ERROR\]   Run 1: " ${tmpfile} | awk '{print $4}' >> ./target/FlakyTests.txt
+
+  echo ERROR: Flaky Tests detected>&2
+
+  exit 1
+fi
+
+if [[ $status != 0 ]]; then
+  exit $status;
+fi
+
+if grep -q "\[INFO\] Build failures were ignored\." ${tmpfile}; then
+  exit 1
+fi

--- a/.ci/scripts/distribution/test-java.sh
+++ b/.ci/scripts/distribution/test-java.sh
@@ -1,6 +1,30 @@
-#!/bin/sh -eux
-
+#!/bin/bash -eux
 
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
-mvn -o -B -T1 -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci -Dzeebe.it.skip -DtestMavenId=1
+tmpfile=$(mktemp)
+
+mvn -o -B --fail-never -T1 -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci -Dzeebe.it.skip -DtestMavenId=1 -Dsurefire.rerunFailingTestsCount=5 | tee ${tmpfile}
+
+status=${PIPESTATUS[0]}
+
+if grep -q "\[WARNING\] Flakes:" ${tmpfile}; then
+
+  tmpfile2=$(mktemp)
+
+  awk '/^\[WARNING\] Flakes:.*$/{flag=1}/^\[ERROR\] Tests run:.*Flakes: [0-9]*$/{print;flag=0}flag' ${tmpfile} > ${tmpfile2}
+
+  grep "\[ERROR\]   Run 1: " ${tmpfile2} | awk '{print $4}' >> ./target/FlakyTests.txt
+
+  echo ERROR: Flaky Tests detected>&2
+
+  exit 1
+fi
+
+if [[ $status != 0 ]]; then
+  exit $status;
+fi
+
+if grep -q "\[INFO\] Build failures were ignored\." ${tmpfile}; then
+  exit 1
+fi

--- a/.ci/scripts/distribution/test-java8.sh
+++ b/.ci/scripts/distribution/test-java8.sh
@@ -1,8 +1,34 @@
-#!/bin/sh -eux
-
+#!/bin/bash -eux
 
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
 mvn -v
 
-mvn -o -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -pl clients/java -DtestMavenId=3
+tmpfile=$(mktemp)
+
+mvn -o -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -pl clients/java -DtestMavenId=3 -Dsurefire.rerunFailingTestsCount=5 | tee ${tmpfile}
+
+status=${PIPESTATUS[0]}
+
+
+if grep -q "\[WARNING\] Flakes:" ${tmpfile}; then
+
+  tmpfile2=$(mktemp)
+
+  awk '/^\[WARNING\] Flakes:.*$/{flag=1}/^\[ERROR\] Tests run:.*Flakes: [0-9]*$/{print;flag=0}flag' ${tmpfile} > ${tmpfile2}
+
+  grep "\[ERROR\]   Run 1: " ${tmpfile2} | awk '{print $4}' >> ./target/FlakyTests.txt
+
+  echo ERROR: Flaky Tests detected>&2
+
+  exit 1
+fi
+
+
+if [[ $status != 0 ]]; then
+  exit $status;
+fi
+
+if grep -q "\[INFO\] Build failures were ignored\." ${tmpfile}; then
+  exit 1
+fi

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -763,6 +763,7 @@
                 <value>io.zeebe.ZeebeTestListener</value>
               </property>
             </properties>
+            <reportNameSuffix>${env.SUREFIRE_REPORT_NAME_SUFFIX}</reportNameSuffix>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
## Description

* backport of #4850 to `0.23`
* store dump files if JVM crashes
* align changes from develop branch

## Related issues

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
