### PR TITLE
Improve SnapshotReplicationTest

### DIFF
--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -13,7 +13,6 @@ import io.atomix.raft.snapshot.impl.FileBasedSnapshotMetadata;
 import io.zeebe.broker.Broker;
 import io.zeebe.broker.it.util.GrpcClientRule;
 import io.zeebe.broker.system.configuration.BrokerCfg;
-import io.zeebe.client.ZeebeClient;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.File;
@@ -28,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.zip.CRC32C;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -39,18 +37,11 @@ public final class SnapshotReplicationTest {
   private static final Duration SNAPSHOT_PERIOD = Duration.ofMinutes(5);
   private static final BpmnModelInstance WORKFLOW =
       Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
-  private static final String WORKFLOW_RESOURCE_NAME = "workflow.bpmn";
 
   private final ClusteringRule clusteringRule =
       new ClusteringRule(PARTITION_COUNT, 3, 3, SnapshotReplicationTest::configureBroker);
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
   @Rule public RuleChain ruleChain = RuleChain.outerRule(clusteringRule).around(clientRule);
-  private ZeebeClient client;
-
-  @Before
-  public void init() {
-    client = clientRule.getClient();
-  }
 
   @Test
   public void shouldReplicateSnapshots() {
@@ -106,7 +97,7 @@ public final class SnapshotReplicationTest {
   }
 
   private void triggerSnapshotCreation() {
-    client.newDeployCommand().addWorkflowModel(WORKFLOW, WORKFLOW_RESOURCE_NAME).send().join();
+    clientRule.deployWorkflow(WORKFLOW);
     clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
   }
 


### PR DESCRIPTION
## Description

Wait for the events to be exported by RecordingExporter before triggering snapshot. If events are not exported, it cannot take a snapshot.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4460 
closes #4648 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
