### PR TITLE
chore(ci): temporarily disable external link checker

### DIFF
--- a/.ci/scripts/docs/build.sh
+++ b/.ci/scripts/docs/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -eux
 
 # enable external link checker
-export MDBOOK_OUTPUT__LINKCHECK__FOLLOW_WEB_LINKS='true'
+# export MDBOOK_OUTPUT__LINKCHECK__FOLLOW_WEB_LINKS='true'
 
 cd docs/
 mdbook build


### PR DESCRIPTION
## Description

This PR temporarily disables the external link checker for the docs due to some links being down.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
