### PR TITLE
Use json content type to send bulk request

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
@@ -34,11 +34,9 @@ import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
-import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
-import org.apache.http.nio.entity.NStringEntity;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
@@ -55,7 +53,6 @@ public class ElasticsearchClient {
   public static final String INDEX_DELIMITER = "_";
   public static final String ALIAS_DELIMITER = "-";
   private static final ObjectMapper MAPPER = new ObjectMapper();
-  private static final ContentType CONTENT_TYPE_NDJSON = ContentType.create("application/x-ndjson");
 
   protected final RestClient client;
   private final ElasticsearchExporterConfiguration configuration;
@@ -182,9 +179,7 @@ public class ElasticsearchClient {
   private BulkResponse exportBulk() throws IOException {
     try (final Histogram.Timer timer = metrics.measureFlushDuration()) {
       final var request = new Request("POST", "/_bulk");
-      final var body =
-          new NStringEntity(String.join("\n", bulkRequest) + "\n", CONTENT_TYPE_NDJSON);
-      request.setEntity(body);
+      request.setJsonEntity(String.join("\n", bulkRequest) + "\n");
 
       final var response = client.performRequest(request);
 

--- a/test/src/main/java/io/zeebe/test/exporter/ExporterIntegrationRule.java
+++ b/test/src/main/java/io/zeebe/test/exporter/ExporterIntegrationRule.java
@@ -260,6 +260,7 @@ public class ExporterIntegrationRule extends ExternalResource {
     final Map<String, Object> variables = new HashMap<>();
     variables.put("orderId", "foo-bar-123");
     variables.put("largeValue", "x".repeat(8192));
+    variables.put("unicode", "Á");
 
     final long workflowInstanceKey = createWorkflowInstance("testProcess", variables);
 


### PR DESCRIPTION
## Description

With the content-type `application/x-ndjson` elasticsearch fails to index non ASCII character. The high level rest client was also using `application/json` before, so there should not be a problem to switch back to that.

## Related issues

related to #5059

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
