### PR TITLE
Add more metrics to track startup time

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -245,6 +245,7 @@ public class DefaultRaftServer implements RaftServer {
           .whenComplete(
               (result, error) -> {
                 if (error == null) {
+                  log.debug("Server join completed. Waiting for the server to be READY");
                   context.awaitState(
                       RaftContext.State.READY,
                       state -> {

--- a/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftStartupMetrics.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftStartupMetrics.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.metrics;
+
+import io.prometheus.client.Gauge;
+
+public class RaftStartupMetrics extends RaftMetrics {
+  private static final String NAMESPACE = "atomix";
+  private static final String PARTITION_GROUP_NAME_LABEL = "partitionGroupName";
+  private static final String PARTITION_LABEL = "partition";
+
+  private static final Gauge START_DURATION =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .labelNames(PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
+          .help(
+              "Time taken to start the partition server (in ms). This includes the bootstrap time.")
+          .name("partition_server_startup_time")
+          .register();
+
+  private static final Gauge BOOTSTRAP_DURATION =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .labelNames(PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
+          .help("Time taken to bootstrap the partition server (in ms)")
+          .name("partition_server_bootstrap_time")
+          .register();
+
+  public RaftStartupMetrics(final String partitionName) {
+    super(partitionName);
+  }
+
+  public void observeStartupDuration(final long durationMillis) {
+    START_DURATION.labels(partitionGroupName, partition).set(durationMillis);
+  }
+
+  public void observeBootstrapDuration(final long durationMillis) {
+    BOOTSTRAP_DURATION.labels(partitionGroupName, partition).set(durationMillis);
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/FileBasedSnapshotStore.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/FileBasedSnapshotStore.java
@@ -183,16 +183,18 @@ public final class FileBasedSnapshotStore implements PersistedSnapshotStore {
   private void observeSnapshotSize(final PersistedSnapshot persistedSnapshot) {
     try (final var contents = Files.newDirectoryStream(persistedSnapshot.getPath())) {
       var totalSize = 0L;
-
+      var totalCount = 0L;
       for (final var path : contents) {
         if (Files.isRegularFile(path)) {
           final var size = Files.size(path);
           snapshotMetrics.observeSnapshotFileSize(size);
           totalSize += size;
+          totalCount++;
         }
       }
 
       snapshotMetrics.observeSnapshotSize(totalSize);
+      snapshotMetrics.observeSnapshotChunkCount(totalCount);
     } catch (final IOException e) {
       LOGGER.warn("Failed to observe size for snapshot {}", persistedSnapshot, e);
     }

--- a/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotMetrics.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotMetrics.java
@@ -39,6 +39,13 @@ public final class SnapshotMetrics {
           .name("snapshot_size_bytes")
           .help("Estimated snapshot size on disk")
           .register();
+  private static final Gauge SNAPSHOT_CHUNK_COUNT =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .labelNames(PARTITION_LABEL_NAME)
+          .name("snapshot_chunks_count")
+          .help("Number of chunks in the last snapshot")
+          .register();
   private static final Histogram SNAPSHOT_DURATION =
       Histogram.build()
           .namespace(NAMESPACE)
@@ -67,6 +74,10 @@ public final class SnapshotMetrics {
 
   void observeSnapshotSize(final long sizeInBytes) {
     SNAPSHOT_SIZE.labels(partitionId).set(sizeInBytes);
+  }
+
+  void observeSnapshotChunkCount(final long count) {
+    SNAPSHOT_CHUNK_COUNT.labels(partitionId).set(count);
   }
 
   void observeSnapshotFileSize(final long sizeInBytes) {

--- a/atomix/storage/src/main/java/io/atomix/storage/statistics/JournalMetrics.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/statistics/JournalMetrics.java
@@ -16,32 +16,50 @@
  */
 package io.atomix.storage.statistics;
 
+import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
 
 public class JournalMetrics {
 
+  private static final String NAMESPACE = "atomix";
+  private static final String PARTITION_LABEL = "partition";
   private static final Histogram SEGMENT_CREATION_TIME =
       Histogram.build()
-          .namespace("atomix")
+          .namespace(NAMESPACE)
           .name("segment_creation_time")
           .help("Time spend to create a new segment")
-          .labelNames("partition")
+          .labelNames(PARTITION_LABEL)
           .register();
 
   private static final Histogram SEGMENT_TRUNCATE_TIME =
       Histogram.build()
-          .namespace("atomix")
+          .namespace(NAMESPACE)
           .name("segment_truncate_time")
           .help("Time spend to truncate a segment")
-          .labelNames("partition")
+          .labelNames(PARTITION_LABEL)
           .register();
 
   private static final Histogram SEGMENT_FLUSH_TIME =
       Histogram.build()
-          .namespace("atomix")
+          .namespace(NAMESPACE)
           .name("segment_flush_time")
           .help("Time spend to flush segment to disk")
-          .labelNames("partition")
+          .labelNames(PARTITION_LABEL)
+          .register();
+
+  private static final Gauge SEGMENT_COUNT =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("segment_count")
+          .help("Number of segments")
+          .labelNames(PARTITION_LABEL)
+          .register();
+  private static final Gauge JOURNAL_OPEN_DURATION =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("journal_open_time")
+          .help("Time taken to open the journal")
+          .labelNames(PARTITION_LABEL)
           .register();
 
   private final String logName;
@@ -60,5 +78,17 @@ public class JournalMetrics {
 
   public void observeSegmentTruncation(final Runnable segmentTruncation) {
     SEGMENT_TRUNCATE_TIME.labels(logName).time(segmentTruncation);
+  }
+
+  public void observeJournalOpenDuration(final long durationMillis) {
+    JOURNAL_OPEN_DURATION.labels(logName).set(durationMillis);
+  }
+
+  public void incSegmentCount() {
+    SEGMENT_COUNT.labels(logName).inc();
+  }
+
+  public void decSegmentCount() {
+    SEGMENT_COUNT.labels(logName).dec();
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/metrics/StreamProcessorMetrics.java
+++ b/engine/src/main/java/io/zeebe/engine/metrics/StreamProcessorMetrics.java
@@ -8,14 +8,16 @@
 package io.zeebe.engine.metrics;
 
 import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
 import io.zeebe.protocol.record.RecordType;
 
 public final class StreamProcessorMetrics {
 
+  private static final String NAMESPACE = "zeebe";
   private static final Counter STREAM_PROCESSOR_EVENTS =
       Counter.build()
-          .namespace("zeebe")
+          .namespace(NAMESPACE)
           .name("stream_processor_events_total")
           .help("Number of events processed by stream processor")
           .labelNames("action", "partition")
@@ -23,10 +25,18 @@ public final class StreamProcessorMetrics {
 
   private static final Histogram PROCESSING_LATENCY =
       Histogram.build()
-          .namespace("zeebe")
+          .namespace(NAMESPACE)
           .name("stream_processor_latency")
           .help("Latency of processing in seconds")
           .labelNames("recordType", "partition")
+          .register();
+
+  private static final Gauge STARTUP_RECOVERY_TIME =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("stream_processor_startup_recovery_time")
+          .help("Time taken for startup and recovery of stream processor (in ms)")
+          .labelNames("partition")
           .register();
 
   private final String partitionIdLabel;
@@ -56,5 +66,9 @@ public final class StreamProcessorMetrics {
 
   public void eventSkipped() {
     event("skipped");
+  }
+
+  public void recoveryTime(final long durationMillis) {
+    STARTUP_RECOVERY_TIME.labels(partitionIdLabel).set(durationMillis);
   }
 }

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -12,6 +12,12 @@
   "__requires": [
     {
       "type": "panel",
+      "id": "bargauge",
+      "name": "Bar Gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
       "id": "gauge",
       "name": "Gauge",
       "version": ""
@@ -71,7 +77,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1595865377824,
+  "iteration": 1596122668848,
   "links": [],
   "panels": [
     {
@@ -2445,8 +2451,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "$DS_PROMETHEUS",
-          "description": "On-going snapshot replications from the receiver point-of-view.",
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2456,7 +2461,7 @@
             "y": 19
           },
           "hiddenSeries": false,
-          "id": 108,
+          "id": 182,
           "legend": {
             "avg": false,
             "current": false,
@@ -2482,8 +2487,9 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "zeebe_snapshot_replication_count{namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\"}",
-              "legendFormat": "{{pod}} p{{partition}}",
+              "expr": "zeebe_snapshot_chunks_count{namespace=~\"$namespace\", pod=~\"$pod\"}",
+              "interval": "",
+              "legendFormat": "{{pod}} {{partition}}",
               "refId": "A"
             }
           ],
@@ -2491,7 +2497,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Snapshot Replications",
+          "title": "Number of files in a snapshot",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2596,6 +2602,94 @@
           "yaxes": [
             {
               "format": "ms",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DS_PROMETHEUS",
+          "description": "On-going snapshot replications from the receiver point-of-view.",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          },
+          "hiddenSeries": false,
+          "id": 108,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "zeebe_snapshot_replication_count{namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\"}",
+              "legendFormat": "{{pod}} p{{partition}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Snapshot Replications",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -4707,7 +4801,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 80
+            "y": 9
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -4771,7 +4865,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 80
+            "y": 9
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -4830,7 +4924,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 86
+            "y": 15
           },
           "hiddenSeries": false,
           "id": 79,
@@ -4922,7 +5016,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 86
+            "y": 15
           },
           "hiddenSeries": false,
           "id": 114,
@@ -5015,7 +5109,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 93
+            "y": 22
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5079,7 +5173,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 93
+            "y": 22
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5144,7 +5238,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 100
+            "y": 29
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -5204,7 +5298,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 100
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 72,
@@ -5295,10 +5389,10 @@
           "fill": 0,
           "fillGradient": 0,
           "gridPos": {
-            "h": 7,
-            "w": 24,
+            "h": 8,
+            "w": 12,
             "x": 0,
-            "y": 108
+            "y": 37
           },
           "hiddenSeries": false,
           "id": 95,
@@ -5384,6 +5478,97 @@
           "yaxis": {
             "align": false,
             "alignLevel": 1
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 37
+          },
+          "hiddenSeries": false,
+          "id": 180,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "atomix_segment_count{namespace=~\"$namespace\", pod=~\"$pod\"}",
+              "interval": "",
+              "legendFormat": "{{pod}} {{partition}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of log segements",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:922",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:923",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
           }
         }
       ],
@@ -7227,9 +7412,304 @@
       ],
       "title": "Elasticsearch Exporter",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 176,
+      "panels": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Time taken to start and bootstrap partition servers.",
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 12
+          },
+          "id": 170,
+          "maxPerRow": 6,
+          "options": {
+            "displayMode": "basic",
+            "fieldOptions": {
+              "calcs": [
+                "last"
+              ],
+              "defaults": {
+                "mappings": [],
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 60000
+                    },
+                    {
+                      "color": "red",
+                      "value": 120000
+                    }
+                  ]
+                },
+                "unit": "dtdurationms"
+              },
+              "overrides": [],
+              "values": false
+            },
+            "orientation": "horizontal",
+            "showUnfilled": true
+          },
+          "pluginVersion": "6.7.1",
+          "repeat": "pod",
+          "repeatDirection": "h",
+          "scopedVars": {
+            "pod": {
+              "selected": false,
+              "text": "dd-test-startup-metrics-zeebe-0",
+              "value": "dd-test-startup-metrics-zeebe-0"
+            }
+          },
+          "targets": [
+            {
+              "expr": "atomix_partition_server_startup_time{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}",
+              "interval": "",
+              "legendFormat": " Start {{pod}} p{{partition}}",
+              "refId": "A"
+            },
+            {
+              "expr": "atomix_partition_server_bootstrap_time{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}",
+              "interval": "",
+              "legendFormat": "Bootstrap  {{pod}} p{{partition}}",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Atomix Partition Server Startup time",
+          "type": "bargauge"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Time taken to start and bootstrap partition servers.",
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 8,
+            "y": 12
+          },
+          "id": 183,
+          "maxPerRow": 6,
+          "options": {
+            "displayMode": "basic",
+            "fieldOptions": {
+              "calcs": [
+                "last"
+              ],
+              "defaults": {
+                "mappings": [],
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 60000
+                    },
+                    {
+                      "color": "red",
+                      "value": 120000
+                    }
+                  ]
+                },
+                "unit": "dtdurationms"
+              },
+              "overrides": [],
+              "values": false
+            },
+            "orientation": "horizontal",
+            "showUnfilled": true
+          },
+          "pluginVersion": "6.7.1",
+          "repeat": null,
+          "repeatDirection": "h",
+          "repeatIteration": 1596122668847,
+          "repeatPanelId": 170,
+          "scopedVars": {
+            "pod": {
+              "selected": false,
+              "text": "dd-test-startup-metrics-zeebe-1",
+              "value": "dd-test-startup-metrics-zeebe-1"
+            }
+          },
+          "targets": [
+            {
+              "expr": "atomix_partition_server_startup_time{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}",
+              "interval": "",
+              "legendFormat": " Start {{pod}} p{{partition}}",
+              "refId": "A"
+            },
+            {
+              "expr": "atomix_partition_server_bootstrap_time{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}",
+              "interval": "",
+              "legendFormat": "Bootstrap  {{pod}} p{{partition}}",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Atomix Partition Server Startup time",
+          "type": "bargauge"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Time taken to start and bootstrap partition servers.",
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 16,
+            "y": 12
+          },
+          "id": 184,
+          "maxPerRow": 6,
+          "options": {
+            "displayMode": "basic",
+            "fieldOptions": {
+              "calcs": [
+                "last"
+              ],
+              "defaults": {
+                "mappings": [],
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 60000
+                    },
+                    {
+                      "color": "red",
+                      "value": 120000
+                    }
+                  ]
+                },
+                "unit": "dtdurationms"
+              },
+              "overrides": [],
+              "values": false
+            },
+            "orientation": "horizontal",
+            "showUnfilled": true
+          },
+          "pluginVersion": "6.7.1",
+          "repeat": null,
+          "repeatDirection": "h",
+          "repeatIteration": 1596122668847,
+          "repeatPanelId": 170,
+          "scopedVars": {
+            "pod": {
+              "selected": false,
+              "text": "dd-test-startup-metrics-zeebe-2",
+              "value": "dd-test-startup-metrics-zeebe-2"
+            }
+          },
+          "targets": [
+            {
+              "expr": "atomix_partition_server_startup_time{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}",
+              "interval": "",
+              "legendFormat": " Start {{pod}} p{{partition}}",
+              "refId": "A"
+            },
+            {
+              "expr": "atomix_partition_server_bootstrap_time{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}",
+              "interval": "",
+              "legendFormat": "Bootstrap  {{pod}} p{{partition}}",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Atomix Partition Server Startup time",
+          "type": "bargauge"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Time taken to recover and reprocess events",
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          },
+          "id": 174,
+          "options": {
+            "displayMode": "basic",
+            "fieldOptions": {
+              "calcs": [
+                "last"
+              ],
+              "defaults": {
+                "mappings": [],
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 60000
+                    }
+                  ]
+                },
+                "unit": "dtdurationms"
+              },
+              "overrides": [],
+              "values": false
+            },
+            "orientation": "horizontal",
+            "showUnfilled": true
+          },
+          "pluginVersion": "6.7.1",
+          "targets": [
+            {
+              "expr": "zeebe_stream_processor_startup_recovery_time{namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}",
+              "interval": "",
+              "legendFormat": "{{pod}} p{{partition}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Streamprocessor Recovery Time",
+          "type": "bargauge"
+        }
+      ],
+      "title": "Start up",
+      "type": "row"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 22,
   "style": "dark",
   "tags": [],
@@ -7359,5 +7839,5 @@
   "variables": {
     "list": []
   },
-  "version": 17
+  "version": 9
 }


### PR DESCRIPTION
## Description

Add new metrics for
* Raft server startup and bootstrap time
* Number of log segments
* Number of files in a snapshot
* Streamprocessor recovery/reprocessing time
* Time taken to open the journal

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
