### PR TITLE
feat(clients/go): override gateway address from env

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/root.go
+++ b/clients/go/cmd/zbctl/internal/commands/root.go
@@ -29,7 +29,6 @@ import (
 const (
 	DefaultAddressHost = "127.0.0.1"
 	DefaultAddressPort = "26500"
-	AddressEnvVar      = "ZEEBE_ADDRESS"
 	defaultTimeout     = 10 * time.Second
 )
 
@@ -77,7 +76,7 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&addressFlag, "address", "", "Specify a contact point address. If omitted, will read from the environment variable '"+AddressEnvVar+"' (default '"+fmt.Sprintf("%s:%s", DefaultAddressHost, DefaultAddressPort)+"')")
+	rootCmd.PersistentFlags().StringVar(&addressFlag, "address", "", "Specify a contact point address. If omitted, will read from the environment variable '"+zbc.GatewayAddressEnvVar+"' (default '"+fmt.Sprintf("%s:%s", DefaultAddressHost, DefaultAddressPort)+"')")
 	rootCmd.PersistentFlags().StringVar(&caCertPathFlag, "certPath", "", "Specify a path to a certificate with which to validate gateway requests. If omitted, will read from the environment variable '"+zbc.CaCertificatePath+"'")
 	rootCmd.PersistentFlags().StringVar(&clientIDFlag, "clientId", "", "Specify a client identifier to request an access token. If omitted, will read from the environment variable '"+zbc.OAuthClientIdEnvVar+"'")
 	rootCmd.PersistentFlags().StringVar(&clientSecretFlag, "clientSecret", "", "Specify a client secret to request an access token. If omitted, will read from the environment variable '"+zbc.OAuthClientSecretEnvVar+"'")
@@ -172,9 +171,8 @@ func parseAddress() (address string, port string) {
 
 	if len(addressFlag) > 0 {
 		address = addressFlag
-	} else if addressEnv, exists := os.LookupEnv(AddressEnvVar); exists {
+	} else if addressEnv, exists := os.LookupEnv(zbc.GatewayAddressEnvVar); exists {
 		address = addressEnv
-
 	}
 
 	if strings.Contains(address, ":") {

--- a/clients/go/pkg/zbc/client.go
+++ b/clients/go/pkg/zbc/client.go
@@ -40,6 +40,7 @@ const DefaultKeepAlive = 45 * time.Second
 const InsecureEnvVar = "ZEEBE_INSECURE_CONNECTION"
 const CaCertificatePath = "ZEEBE_CA_CERTIFICATE_PATH"
 const KeepAliveEnvVar = "ZEEBE_KEEP_ALIVE"
+const GatewayAddressVar = "ZEEBE_GATEWAY"
 
 type ClientImpl struct {
 	gateway             pb.GatewayClient
@@ -169,6 +170,10 @@ func applyClientEnvOverrides(config *ClientConfig) error {
 	if caCertificatePath := env.get(CaCertificatePath); caCertificatePath != "" {
 		config.CaCertificatePath = caCertificatePath
 	}
+
+	if gatewayAddress := env.get(GatewayAddressVar); gatewayAddress != "" {
+	    config.GatewayAddress = gatewayAddress
+    }
 
 	if val := env.get(KeepAliveEnvVar); val != "" {
 		keepAlive, err := strconv.ParseUint(val, 10, 64)

--- a/clients/go/pkg/zbc/client.go
+++ b/clients/go/pkg/zbc/client.go
@@ -40,7 +40,7 @@ const DefaultKeepAlive = 45 * time.Second
 const InsecureEnvVar = "ZEEBE_INSECURE_CONNECTION"
 const CaCertificatePath = "ZEEBE_CA_CERTIFICATE_PATH"
 const KeepAliveEnvVar = "ZEEBE_KEEP_ALIVE"
-const GatewayAddressVar = "ZEEBE_GATEWAY"
+const GatewayAddressEnvVar = "ZEEBE_ADDRESS"
 
 type ClientImpl struct {
 	gateway             pb.GatewayClient
@@ -171,9 +171,9 @@ func applyClientEnvOverrides(config *ClientConfig) error {
 		config.CaCertificatePath = caCertificatePath
 	}
 
-	if gatewayAddress := env.get(GatewayAddressVar); gatewayAddress != "" {
-	    config.GatewayAddress = gatewayAddress
-    }
+	if gatewayAddress := env.get(GatewayAddressEnvVar); gatewayAddress != "" {
+		config.GatewayAddress = gatewayAddress
+	}
 
 	if val := env.get(KeepAliveEnvVar); val != "" {
 		keepAlive, err := strconv.ParseUint(val, 10, 64)


### PR DESCRIPTION
## Description

Allow overriding the GatewayAddress from the `ZEEBE_ADDRESS` environment variable.