### PR TITLE
Fix address binding when running tests in parallel

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyBroadcastServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyBroadcastServiceTest.java
@@ -20,8 +20,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import io.atomix.cluster.messaging.ManagedBroadcastService;
 import io.atomix.utils.net.Address;
-import java.io.IOException;
-import java.net.ServerSocket;
+import io.zeebe.test.util.socket.SocketUtil;
 import net.jodah.concurrentunit.ConcurrentTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -55,9 +54,9 @@ public class NettyBroadcastServiceTest extends ConcurrentTestCase {
 
   @Before
   public void setUp() throws Exception {
-    localAddress1 = Address.from("127.0.0.1", findAvailablePort(5001));
-    localAddress2 = Address.from("127.0.0.1", findAvailablePort(5002));
-    groupAddress = Address.from("230.0.0.1", findAvailablePort(1234));
+    localAddress1 = Address.from("127.0.0.1", SocketUtil.getNextAddress().getPort());
+    localAddress2 = Address.from("127.0.0.1", SocketUtil.getNextAddress().getPort());
+    groupAddress = Address.from("230.0.0.1", SocketUtil.getNextAddress().getPort());
 
     netty1 =
         (ManagedBroadcastService)
@@ -94,18 +93,6 @@ public class NettyBroadcastServiceTest extends ConcurrentTestCase {
       } catch (final Exception e) {
         LOGGER.warn("Failed stopping netty2", e);
       }
-    }
-  }
-
-  private static int findAvailablePort(final int defaultPort) {
-    try {
-      final ServerSocket socket = new ServerSocket(0);
-      socket.setReuseAddress(true);
-      final int port = socket.getLocalPort();
-      socket.close();
-      return port;
-    } catch (final IOException ex) {
-      return defaultPort;
     }
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -30,9 +30,8 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.utils.net.Address;
-import java.io.IOException;
+import io.zeebe.test.util.socket.SocketUtil;
 import java.net.ConnectException;
-import java.net.ServerSocket;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.UUID;
@@ -73,38 +72,38 @@ public class NettyMessagingServiceTest {
 
   @Before
   public void setUp() throws Exception {
-    address1 = Address.from(findAvailablePort(5001));
+    address1 = Address.from(SocketUtil.getNextAddress().getPort());
     netty1 =
         (ManagedMessagingService)
             new NettyMessagingService("test", address1, new MessagingConfig()).start().join();
 
-    address2 = Address.from(findAvailablePort(5002));
+    address2 = Address.from(SocketUtil.getNextAddress().getPort());
     netty2 =
         (ManagedMessagingService)
             new NettyMessagingService("test", address2, new MessagingConfig()).start().join();
 
-    addressv11 = Address.from(findAvailablePort(5003));
+    addressv11 = Address.from(SocketUtil.getNextAddress().getPort());
     nettyv11 =
         (ManagedMessagingService)
             new NettyMessagingService("test", addressv11, new MessagingConfig(), ProtocolVersion.V1)
                 .start()
                 .join();
 
-    addressv12 = Address.from(findAvailablePort(5004));
+    addressv12 = Address.from(SocketUtil.getNextAddress().getPort());
     nettyv12 =
         (ManagedMessagingService)
             new NettyMessagingService("test", addressv12, new MessagingConfig(), ProtocolVersion.V1)
                 .start()
                 .join();
 
-    addressv21 = Address.from(findAvailablePort(5005));
+    addressv21 = Address.from(SocketUtil.getNextAddress().getPort());
     nettyv21 =
         (ManagedMessagingService)
             new NettyMessagingService("test", addressv21, new MessagingConfig(), ProtocolVersion.V2)
                 .start()
                 .join();
 
-    addressv22 = Address.from(findAvailablePort(5006));
+    addressv22 = Address.from(SocketUtil.getNextAddress().getPort());
     nettyv22 =
         (ManagedMessagingService)
             new NettyMessagingService("test", addressv22, new MessagingConfig(), ProtocolVersion.V2)
@@ -424,17 +423,5 @@ public class NettyMessagingServiceTest {
     nettyv22.registerHandler(subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
     response = nettyv12.sendAndReceive(addressv22, subject, payload).get(10, TimeUnit.SECONDS);
     assertArrayEquals(payload, response);
-  }
-
-  private static int findAvailablePort(final int defaultPort) {
-    try {
-      final ServerSocket socket = new ServerSocket(0);
-      socket.setReuseAddress(true);
-      final int port = socket.getLocalPort();
-      socket.close();
-      return port;
-    } catch (final IOException ex) {
-      return defaultPort;
-    }
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyUnicastServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyUnicastServiceTest.java
@@ -24,8 +24,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import io.atomix.cluster.messaging.ManagedUnicastService;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.utils.net.Address;
-import java.io.IOException;
-import java.net.ServerSocket;
+import io.zeebe.test.util.socket.SocketUtil;
 import net.jodah.concurrentunit.ConcurrentTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -68,8 +67,8 @@ public class NettyUnicastServiceTest extends ConcurrentTestCase {
 
   @Before
   public void setUp() throws Exception {
-    address1 = Address.from("127.0.0.1", findAvailablePort(5001));
-    address2 = Address.from("127.0.0.1", findAvailablePort(5002));
+    address1 = Address.from("127.0.0.1", SocketUtil.getNextAddress().getPort());
+    address2 = Address.from("127.0.0.1", SocketUtil.getNextAddress().getPort());
 
     service1 = new NettyUnicastService(address1, new MessagingConfig());
     service1.start().join();
@@ -94,18 +93,6 @@ public class NettyUnicastServiceTest extends ConcurrentTestCase {
       } catch (final Exception e) {
         LOGGER.warn("Failed stopping netty2", e);
       }
-    }
-  }
-
-  private static int findAvailablePort(final int defaultPort) {
-    try {
-      final ServerSocket socket = new ServerSocket(0);
-      socket.setReuseAddress(true);
-      final int port = socket.getLocalPort();
-      socket.close();
-      return port;
-    } catch (final IOException ex) {
-      return defaultPort;
     }
   }
 }

--- a/test-util/src/main/java/io/zeebe/test/util/socket/SocketUtil.java
+++ b/test-util/src/main/java/io/zeebe/test/util/socket/SocketUtil.java
@@ -45,7 +45,7 @@ public final class SocketUtil {
 
   private SocketUtil() {}
 
-  public static InetSocketAddress getNextAddress() {
+  public static synchronized InetSocketAddress getNextAddress() {
     return PORT_RANGE.next();
   }
 }


### PR DESCRIPTION
## Description

In the CI, we're running the tests of the multi-module parallel with multi-threads and additionally using a forked JVM for the tests within one module (and reusing the forked JVM). This can lead to different problems, especially using static code (http://maven.apache.org/surefire/maven-failsafe-plugin/examples/fork-options-and-parallel-execution.html).

* replace the homegrown port finding with the SocketUtil to avoid issues when running the tests in parallel
* synchronize the finding of the next port to be safer when running the test in parallel (just in case)

## Related issues

closes #4982
closes #4941
closes #4940
closes #4366

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
