### PR TITLE
[Backport 0.23] compact after exporters removed

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -227,7 +227,11 @@ public final class ExporterDirector extends Actor {
 
     clearExporterState();
 
-    actor.submit(this::readNextEvent);
+    if (state.hasExporters()) {
+      actor.submit(this::readNextEvent);
+    } else {
+      actor.close();
+    }
   }
 
   private void skipRecord(final LoggedEvent currentEvent) {

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -516,10 +516,6 @@ public final class ZeebePartition extends Actor
   private ActorFuture<Void> installExporter(final ZeebeDb zeebeDb) {
     final var exporterDescriptors = exporterRepository.getExporters().values();
 
-    if (exporterDescriptors.isEmpty()) {
-      return CompletableActorFuture.completed(null);
-    }
-
     final ExporterDirectorContext context =
         new ExporterDirectorContext()
             .id(EXPORTER_PROCESSOR_ID)

--- a/broker/src/test/java/io/zeebe/broker/exporter/stream/ExportersStateTest.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/stream/ExportersStateTest.java
@@ -166,4 +166,17 @@ public final class ExportersStateTest {
     // when/then
     assertThat(state.getLowestPosition()).isEqualTo(-1L);
   }
+
+  @Test
+  public void shouldClearState() {
+    // given
+    state.setPosition("e2", 1L);
+
+    // when
+    state.removePosition("e2");
+
+    // then
+    assertThat(state.hasExporters()).isFalse();
+    assertThat(state.getLowestPosition()).isEqualTo(-1L);
+  }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -85,6 +85,7 @@
     <version.config>1.4.0</version.config>
     <version.kryo>4.0.2</version.kryo>
     <version.failsafe>2.4.0</version.failsafe>
+    <version.awaitility>4.0.3</version.awaitility>
 
 
     <!-- maven plugins -->
@@ -191,6 +192,12 @@
         <version>${version.msgpack}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>${version.awaitility}</version>
+        <scope>test</scope>
+      </dependency>
 
       <dependency>
         <groupId>junit</groupId>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe QA Integration Tests</name>
@@ -98,6 +100,12 @@
       <artifactId>zeebe-broker</artifactId>
       <type>test-jar</type>
       <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/BrokerLeaderChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/BrokerLeaderChangeTest.java
@@ -48,7 +48,7 @@ public final class BrokerLeaderChangeTest {
     final int partition = Protocol.START_PARTITION_ID;
     final int oldLeader = clusteringRule.getLeaderForPartition(partition).getNodeId();
 
-    clusteringRule.stopBroker(oldLeader);
+    clusteringRule.stopBrokerAndAwaitNewLeader(oldLeader);
 
     waitUntil(() -> clusteringRule.getLeaderForPartition(partition).getNodeId() != oldLeader);
 
@@ -73,7 +73,7 @@ public final class BrokerLeaderChangeTest {
     final long jobKey = clientRule.createSingleJob(JOB_TYPE);
 
     // when
-    clusteringRule.stopBroker(leaderForPartition.getNodeId());
+    clusteringRule.stopBrokerAndAwaitNewLeader(leaderForPartition.getNodeId());
     final JobCompleter jobCompleter = new JobCompleter(jobKey);
 
     // then

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -242,7 +242,7 @@ public final class ClusteringRule extends ExternalResource {
     return broker;
   }
 
-  private BrokerCfg getBrokerCfg(final int nodeId) {
+  public BrokerCfg getBrokerCfg(final int nodeId) {
     return brokerCfgs.computeIfAbsent(nodeId, this::createBrokerCfg);
   }
 
@@ -437,7 +437,11 @@ public final class ClusteringRule extends ExternalResource {
    * <p>Returns to the user if the broker is back in the cluster.
    */
   public void restartBroker(final int nodeId) {
-    stopBroker(nodeId);
+    stopBrokerAndAwaitNewLeader(nodeId);
+    startBroker(nodeId);
+  }
+
+  public void startBroker(final int nodeId) {
     final Broker broker = getBroker(nodeId).start().join();
     final InetSocketAddress commandApi =
         broker.getConfig().getNetwork().getCommandApi().getAddress();
@@ -512,16 +516,24 @@ public final class ClusteringRule extends ExternalResource {
         .count();
   }
 
+  public void stopBrokerAndAwaitNewLeader(final int nodeId) {
+    final Broker broker = brokers.get(nodeId);
+    if (broker != null) {
+      final InetSocketAddress socketAddress =
+          broker.getConfig().getNetwork().getCommandApi().getAddress();
+      final List<Integer> brokersLeadingPartitions = getBrokersLeadingPartitions(socketAddress);
+      stopBroker(nodeId);
+      waitForNewLeaderOfPartitions(brokersLeadingPartitions, socketAddress);
+    }
+  }
+
   public void stopBroker(final int nodeId) {
     final Broker broker = brokers.remove(nodeId);
     if (broker != null) {
       final InetSocketAddress socketAddress =
           broker.getConfig().getNetwork().getCommandApi().getAddress();
-      final List<Integer> brokersLeadingPartitions = getBrokersLeadingPartitions(socketAddress);
       broker.close();
-
       waitUntilBrokerIsRemovedFromTopology(socketAddress);
-      waitForNewLeaderOfPartitions(brokersLeadingPartitions, socketAddress);
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/GossipClusteringTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/GossipClusteringTest.java
@@ -53,7 +53,7 @@ public final class GossipClusteringTest {
     final InetSocketAddress[] otherBrokers = clusteringRule.getOtherBrokers(2);
 
     // when
-    clusteringRule.stopBroker(2);
+    clusteringRule.stopBrokerAndAwaitNewLeader(2);
 
     // then
     final List<InetSocketAddress> topologyBrokers = clusteringRule.getBrokersInCluster();
@@ -69,7 +69,7 @@ public final class GossipClusteringTest {
         clusteringRule.getOtherBrokers(leaderForPartition.getNodeId());
 
     // when
-    clusteringRule.stopBroker(leaderForPartition.getNodeId());
+    clusteringRule.stopBrokerAndAwaitNewLeader(leaderForPartition.getNodeId());
 
     // then
     final List<InetSocketAddress> topologyBrokers = clusteringRule.getBrokersInCluster();

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
@@ -57,7 +57,7 @@ public final class RestoreTest {
   @Test
   public void shouldReplicateLogEvents() {
     // given
-    clusteringRule.stopBroker(2);
+    clusteringRule.stopBrokerAndAwaitNewLeader(2);
 
     final BpmnModelInstance firstWorkflow =
         Bpmn.createExecutableProcess("process-test1").startEvent().endEvent().done();
@@ -82,7 +82,7 @@ public final class RestoreTest {
     clusteringRule.restartBroker(2);
     clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(2));
 
-    clusteringRule.stopBroker(1);
+    clusteringRule.stopBrokerAndAwaitNewLeader(1);
 
     final long thirdWorkflowKey = clientRule.deployWorkflow(thirdWorkflow);
 
@@ -91,7 +91,7 @@ public final class RestoreTest {
         clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId()));
 
     clusteringRule.restartBroker(1);
-    clusteringRule.stopBroker(0);
+    clusteringRule.stopBrokerAndAwaitNewLeader(0);
 
     // then
     // If restore did not happen, following workflows won't be deployed

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SingleBrokerDataDeletionTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SingleBrokerDataDeletionTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.clustering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.zeebe.broker.Broker;
+import io.zeebe.broker.system.configuration.BrokerCfg;
+import io.zeebe.broker.system.configuration.DataCfg;
+import io.zeebe.broker.system.configuration.ExporterCfg;
+import io.zeebe.exporter.api.Exporter;
+import io.zeebe.exporter.api.context.Controller;
+import io.zeebe.logstreams.log.LogStreamReader;
+import io.zeebe.protocol.record.Record;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.util.unit.DataSize;
+
+public class SingleBrokerDataDeletionTest {
+
+  private static final Duration SNAPSHOT_PERIOD = Duration.ofMinutes(5);
+  private static final int SEGMENT_COUNT = 5;
+
+  @Rule
+  public final ClusteringRule clusteringRule =
+      new ClusteringRule(1, 1, 1, this::configureCustomExporter);
+
+  private final AtomicLong writtenRecords = new AtomicLong(0);
+
+  private void configureCustomExporter(final BrokerCfg brokerCfg) {
+    final DataCfg data = brokerCfg.getData();
+    data.setSnapshotPeriod(SNAPSHOT_PERIOD);
+    data.setLogSegmentSize(DataSize.ofKilobytes(8));
+    data.setLogIndexDensity(5);
+    brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(8));
+
+    final ExporterCfg exporterCfg = new ExporterCfg();
+    exporterCfg.setClassName(ControllableExporter.class.getName());
+    brokerCfg.setExporters(Collections.singletonMap("snapshot-test-exporter", exporterCfg));
+  }
+
+  @Test
+  public void shouldNotCompactNotExportedEvents() {
+    // given
+    final Broker broker = clusteringRule.getBroker(0);
+
+    final var logstream = clusteringRule.getLogStream(1);
+    final var reader = logstream.newLogStreamReader().join();
+
+    // - write records and update the exporter position
+    ControllableExporter.updatePosition(true);
+    fillSegments(broker, SEGMENT_COUNT);
+
+    // - write more records but don't update the exporter position
+    ControllableExporter.updatePosition(false);
+
+    final var filledSegmentCount = SEGMENT_COUNT * 2;
+    fillSegments(broker, filledSegmentCount);
+
+    // - trigger a snapshot creation
+    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
+    final var firstSnapshot = clusteringRule.waitForSnapshotAtBroker(broker);
+
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(getSegmentsCount(broker))
+                    .describedAs("Expected less segments after a snapshot is taken")
+                    .isLessThan(filledSegmentCount));
+
+    // then verify that the log still contains the records that are not exported
+    final var firstNonExportedPosition =
+        ControllableExporter.NOT_EXPORTED_RECORDS.get(0).getPosition();
+
+    assertThat(hasRecordWithPosition(reader, firstNonExportedPosition))
+        .describedAs("Expected first non-exported record to be present in the log but not found.")
+        .isTrue();
+
+    // - write more records and update the exporter position again
+    final var segmentsBeforeSnapshot = getSegmentsCount(broker);
+
+    ControllableExporter.updatePosition(true);
+    fillSegments(broker, segmentsBeforeSnapshot + 1);
+
+    // - trigger the next snapshot creation
+    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
+    clusteringRule.waitForNewSnapshotAtBroker(broker, firstSnapshot);
+
+    // then verify that the log is now compacted after the exporter position was updated
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(getSegmentsCount(broker))
+                    .describedAs("Expected less segments after a snapshot is taken")
+                    .isLessThan(segmentsBeforeSnapshot));
+  }
+
+  @Test
+  public void shouldCompactWhenExporterHasBeenRemoved() {
+    // given
+    final Broker broker = clusteringRule.getBroker(0);
+    ControllableExporter.updatePosition(true);
+    fillSegments(broker, SEGMENT_COUNT);
+    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
+    // create first snapshot with exporter positions
+    final var firstSnapshot = clusteringRule.waitForSnapshotAtBroker(broker);
+
+    // restart with no exporter
+    final var brokerCfg = clusteringRule.getBrokerCfg(0);
+    brokerCfg.setExporters(Map.of());
+    clusteringRule.stopBroker(0);
+    clusteringRule.startBroker(0);
+
+    final var filledSegmentCount = SEGMENT_COUNT * 2;
+    writeSegments(broker, filledSegmentCount);
+
+    // when triggering new snapshot creation
+    final var segmentsCount = getSegmentsCount(broker);
+    clusteringRule.getClock().addTime(SNAPSHOT_PERIOD);
+    final var secondSnapshot = clusteringRule.waitForNewSnapshotAtBroker(broker, firstSnapshot);
+
+    // then
+    assertThat(firstSnapshot).isNotEqualTo(secondSnapshot);
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(getSegmentsCount(broker))
+                    .describedAs("Expected less segments after a snapshot is taken")
+                    .isLessThan(segmentsCount));
+  }
+
+  private void fillSegments(final Broker broker, final int segmentCount) {
+    writeSegments(broker, segmentCount);
+
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(ControllableExporter.EXPORTED_RECORDS.get())
+                    .describedAs("Expected all written records to be exported")
+                    .isGreaterThanOrEqualTo(writtenRecords.get()));
+  }
+
+  private void writeSegments(final Broker broker, final int segmentCount) {
+    while (getSegmentsCount(broker) <= segmentCount) {
+      writeToLog();
+      writtenRecords.incrementAndGet();
+    }
+  }
+
+  private void writeToLog() {
+
+    clusteringRule
+        .getClient()
+        .newPublishMessageCommand()
+        .messageName("msg")
+        .correlationKey("key")
+        .send()
+        .join();
+  }
+
+  private int getSegmentsCount(final Broker broker) {
+    return getSegments(broker).size();
+  }
+
+  private Collection<Path> getSegments(final Broker broker) {
+    try {
+      return Files.list(clusteringRule.getSegmentsDirectory(broker))
+          .filter(path -> path.toString().endsWith(".log"))
+          .collect(Collectors.toList());
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private boolean hasRecordWithPosition(final LogStreamReader reader, final long recordPosition) {
+    await()
+        .until(
+            () -> {
+              try {
+                reader.seek(recordPosition);
+                return reader.hasNext();
+
+              } catch (final Exception ignore) {
+                // may fail if the compaction is not completed yet
+                return false;
+              }
+            });
+
+    final var readerPosition = reader.next().getPosition();
+    return readerPosition == recordPosition;
+  }
+
+  @After
+  public void cleanUp() {
+    ControllableExporter.NOT_EXPORTED_RECORDS.clear();
+    ControllableExporter.updatePosition(true);
+    ControllableExporter.EXPORTED_RECORDS.set(0);
+
+    writtenRecords.set(0);
+  }
+
+  public static class ControllableExporter implements Exporter {
+    static final List<Record> NOT_EXPORTED_RECORDS = new CopyOnWriteArrayList<>();
+    static volatile boolean shouldExport = true;
+
+    static final AtomicLong EXPORTED_RECORDS = new AtomicLong(0);
+
+    private Controller controller;
+
+    static void updatePosition(final boolean flag) {
+      shouldExport = flag;
+    }
+
+    @Override
+    public void open(final Controller controller) {
+      this.controller = controller;
+    }
+
+    @Override
+    public void export(final Record record) {
+      if (shouldExport) {
+        controller.updateLastExportedRecordPosition(record.getPosition());
+      } else {
+        NOT_EXPORTED_RECORDS.add(record);
+      }
+
+      EXPORTED_RECORDS.incrementAndGet();
+    }
+  }
+}

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -84,7 +84,7 @@ public final class SnapshotReplicationTest {
             .orElseThrow();
 
     // when - snapshot
-    clusteringRule.stopBroker(firstFollowerId);
+    clusteringRule.stopBrokerAndAwaitNewLeader(firstFollowerId);
     triggerSnapshotCreation();
     clusteringRule.restartBroker(firstFollowerId);
     clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(secondFollowerId));
@@ -117,7 +117,7 @@ public final class SnapshotReplicationTest {
             .orElseThrow();
 
     // when - snapshot
-    clusteringRule.stopBroker(firstFollowerId);
+    clusteringRule.stopBrokerAndAwaitNewLeader(firstFollowerId);
     triggerSnapshotCreation();
     final var snapshotAtSecondFollower =
         clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(secondFollowerId));


### PR DESCRIPTION
## Description

Backports #5106 and add some other changes to clustering rule and It tests, which are already available in the other branches.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5105

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
