### PR TITLE
chore(benchmarks): add complete job with variables to worker

### DIFF
--- a/benchmarks/project/src/main/java/io/zeebe/App.java
+++ b/benchmarks/project/src/main/java/io/zeebe/App.java
@@ -15,6 +15,7 @@
  */
 package io.zeebe;
 
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigBeanFactory;
 import com.typesafe.config.ConfigFactory;
@@ -22,7 +23,10 @@ import io.prometheus.client.exporter.HTTPServer;
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.api.response.Topology;
 import io.zeebe.config.AppCfg;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.function.Function;
 import me.dinowernli.grpc.prometheus.Configuration;
 import me.dinowernli.grpc.prometheus.MonitoringClientInterceptor;
@@ -75,6 +79,30 @@ abstract class App implements Runnable {
       } catch (Exception e) {
         // retry
       }
+    }
+  }
+
+  protected String readVariables(final String payloadPath) {
+    try {
+      final StringBuilder stringBuilder = new StringBuilder();
+      final var classLoader = App.class.getClassLoader();
+      try (final InputStream variablesStream = classLoader.getResourceAsStream(payloadPath)) {
+        if (variablesStream == null) {
+          throw new IllegalStateException(
+              "Expected to access " + payloadPath + ", but failed to open an input stream.");
+        }
+
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(variablesStream))) {
+          String line;
+          while ((line = br.readLine()) != null) {
+            stringBuilder.append(line).append("\n");
+          }
+        }
+      }
+
+      return stringBuilder.toString();
+    } catch (IOException e) {
+      throw new UncheckedExecutionException(e);
     }
   }
 }

--- a/benchmarks/project/src/main/java/io/zeebe/ResponseChecker.java
+++ b/benchmarks/project/src/main/java/io/zeebe/ResponseChecker.java
@@ -27,10 +27,10 @@ public class ResponseChecker extends Thread {
 
   private static final Logger LOG = LoggerFactory.getLogger(ResponseChecker.class);
 
-  private final BlockingQueue<Future> futures;
+  private final BlockingQueue<Future<?>> futures;
   private volatile boolean shuttingDown = false;
 
-  public ResponseChecker(BlockingQueue<Future> futures) {
+  public ResponseChecker(BlockingQueue<Future<?>> futures) {
     this.futures = futures;
   }
 

--- a/benchmarks/project/src/main/java/io/zeebe/Starter.java
+++ b/benchmarks/project/src/main/java/io/zeebe/Starter.java
@@ -48,7 +48,7 @@ public class Starter extends App {
     final StarterCfg starterCfg = appCfg.getStarter();
     final int rate = starterCfg.getRate();
     final String processId = starterCfg.getProcessId();
-    final BlockingQueue<Future> requestFutures = new ArrayBlockingQueue<>(5_000);
+    final BlockingQueue<Future<?>> requestFutures = new ArrayBlockingQueue<>(5_000);
 
     final ZeebeClient client = createZeebeClient();
 

--- a/benchmarks/project/src/main/java/io/zeebe/Worker.java
+++ b/benchmarks/project/src/main/java/io/zeebe/Worker.java
@@ -37,7 +37,8 @@ public class Worker extends App {
     final WorkerCfg workerCfg = appCfg.getWorker();
     final String jobType = workerCfg.getJobType();
     final long completionDelay = workerCfg.getCompletionDelay().toMillis();
-    final BlockingQueue<Future> requestFutures = new ArrayBlockingQueue<>(10_000);
+    final var variablesToCompleteJobWith = workerCfg.getVariablesToCompleteJobWith();
+    final BlockingQueue<Future<?>> requestFutures = new ArrayBlockingQueue<>(10_000);
 
     final ZeebeClient client = createZeebeClient();
     printTopology(client);
@@ -56,7 +57,7 @@ public class Worker extends App {
                   requestFutures.add(
                       jobClient
                           .newCompleteCommand(job.getKey())
-                          .variables(job.getVariables())
+                          .variables(variablesToCompleteJobWith)
                           .send());
                 })
             .open();

--- a/benchmarks/project/src/main/java/io/zeebe/Worker.java
+++ b/benchmarks/project/src/main/java/io/zeebe/Worker.java
@@ -37,7 +37,7 @@ public class Worker extends App {
     final WorkerCfg workerCfg = appCfg.getWorker();
     final String jobType = workerCfg.getJobType();
     final long completionDelay = workerCfg.getCompletionDelay().toMillis();
-    final var variablesToCompleteJobWith = workerCfg.getVariablesToCompleteJobWith();
+    final var variables = readVariables(workerCfg.getPayloadPath());
     final BlockingQueue<Future<?>> requestFutures = new ArrayBlockingQueue<>(10_000);
 
     final ZeebeClient client = createZeebeClient();
@@ -55,10 +55,7 @@ public class Worker extends App {
                     e.printStackTrace();
                   }
                   requestFutures.add(
-                      jobClient
-                          .newCompleteCommand(job.getKey())
-                          .variables(variablesToCompleteJobWith)
-                          .send());
+                      jobClient.newCompleteCommand(job.getKey()).variables(variables).send());
                 })
             .open();
 

--- a/benchmarks/project/src/main/java/io/zeebe/config/WorkerCfg.java
+++ b/benchmarks/project/src/main/java/io/zeebe/config/WorkerCfg.java
@@ -28,7 +28,7 @@ public class WorkerCfg {
   private Duration pollingDelay;
   private Duration completionDelay;
 
-  private String variablesToCompleteJobWith;
+  private String payloadPath;
 
   public String getJobType() {
     return jobType;
@@ -78,11 +78,11 @@ public class WorkerCfg {
     this.completionDelay = completionDelay;
   }
 
-  public String getVariablesToCompleteJobWith() {
-    return variablesToCompleteJobWith;
+  public String getPayloadPath() {
+    return payloadPath;
   }
 
-  public void setVariablesToCompleteJobWith(String variablesToCompleteJobWith) {
-    this.variablesToCompleteJobWith = variablesToCompleteJobWith;
+  public void setPayloadPath(String payloadPath) {
+    this.payloadPath = payloadPath;
   }
 }

--- a/benchmarks/project/src/main/java/io/zeebe/config/WorkerCfg.java
+++ b/benchmarks/project/src/main/java/io/zeebe/config/WorkerCfg.java
@@ -28,6 +28,8 @@ public class WorkerCfg {
   private Duration pollingDelay;
   private Duration completionDelay;
 
+  private String variablesToCompleteJobWith;
+
   public String getJobType() {
     return jobType;
   }
@@ -74,5 +76,13 @@ public class WorkerCfg {
 
   public void setCompletionDelay(Duration completionDelay) {
     this.completionDelay = completionDelay;
+  }
+
+  public String getVariablesToCompleteJobWith() {
+    return variablesToCompleteJobWith;
+  }
+
+  public void setVariablesToCompleteJobWith(String variablesToCompleteJobWith) {
+    this.variablesToCompleteJobWith = variablesToCompleteJobWith;
   }
 }

--- a/benchmarks/project/src/main/resources/application.conf
+++ b/benchmarks/project/src/main/resources/application.conf
@@ -21,5 +21,6 @@ app {
     capacity = 30
     pollingDelay = 1s
     completionDelay = 300ms
+    variablesToCompleteJobWith = ""
   }
 }

--- a/benchmarks/project/src/main/resources/application.conf
+++ b/benchmarks/project/src/main/resources/application.conf
@@ -21,6 +21,6 @@ app {
     capacity = 30
     pollingDelay = 1s
     completionDelay = 300ms
-    variablesToCompleteJobWith = ""
+    payloadPath = "bpmn/big_payload.json"
   }
 }


### PR DESCRIPTION
## Description

This PR allows the job worker for benchmarks to be configured such
that it completes the jobs it's working on with a specific variable.

This can be configured using: `app.worker.variablesToCompleteJobWith`
which takes a string representation of the variables to send along with
the CompleteJobCommand.

## Related issues

See: #5132

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
