### PR TITLE
Handle snapshot replication from 0.23.x brokers

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -38,6 +38,8 @@ import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.snapshot.PersistedSnapshot;
 import io.atomix.raft.snapshot.PersistedSnapshotListener;
 import io.atomix.raft.snapshot.ReceivedSnapshot;
+import io.atomix.raft.snapshot.SnapshotChunk;
+import io.atomix.raft.snapshot.impl.LegacySnapshotChunk;
 import io.atomix.raft.snapshot.impl.SnapshotChunkImpl;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.storage.log.RaftLogWriter;
@@ -164,14 +166,16 @@ public class PassiveRole extends InactiveRole {
     // If the snapshot already exists locally, do not overwrite it with a replicated snapshot.
     // Simply reply to the
     // request successfully.
-    final var optLatestSnapshot = raft.getPersistedSnapshotStore().getLatestSnapshot();
-    if (optLatestSnapshot.isPresent()) {
-      if (optLatestSnapshot.get().getIndex() >= request.index()) {
-        abortPendingSnapshots();
+    final var latestSnapshotIndex =
+        raft.getPersistedSnapshotStore()
+            .getLatestSnapshot()
+            .map(PersistedSnapshot::getIndex)
+            .orElse(Long.MIN_VALUE);
+    if (latestSnapshotIndex >= request.index()) {
+      abortPendingSnapshots();
 
-        return CompletableFuture.completedFuture(
-            logResponse(InstallResponse.builder().withStatus(RaftResponse.Status.OK).build()));
-      }
+      return CompletableFuture.completedFuture(
+          logResponse(InstallResponse.builder().withStatus(RaftResponse.Status.OK).build()));
     }
 
     if (!request.complete() && request.nextChunkId() == null) {
@@ -185,8 +189,8 @@ public class PassiveRole extends InactiveRole {
                   .build()));
     }
 
-    final var snapshotChunk = new SnapshotChunkImpl();
-    snapshotChunk.wrap(new UnsafeBuffer(request.data()), 0, request.data().capacity());
+    final SnapshotChunk snapshotChunk = decodeSnapshotChunk(request);
+    log.debug("Installing snapshot chunk {}", snapshotChunk);
 
     // If there is no pending snapshot, create a new snapshot.
     if (pendingSnapshot == null) {
@@ -221,7 +225,7 @@ public class PassiveRole extends InactiveRole {
                     .withStatus(RaftResponse.Status.ERROR)
                     .withError(
                         RaftError.Type.ILLEGAL_MEMBER_STATE,
-                        "Request chunk is was received out of order")
+                        "Request chunk was received out of order")
                     .build()));
       }
     }
@@ -383,6 +387,18 @@ public class PassiveRole extends InactiveRole {
                 .withError(
                     RaftError.Type.ILLEGAL_MEMBER_STATE, "Cannot request vote from RESERVE member")
                 .build()));
+  }
+
+  private SnapshotChunk decodeSnapshotChunk(final InstallRequest request) {
+    try {
+      final var snapshotChunkImpl = new SnapshotChunkImpl();
+      snapshotChunkImpl.wrap(new UnsafeBuffer(request.data()), 0, request.data().capacity());
+      return snapshotChunkImpl;
+    } catch (final RuntimeException e) {
+      // fallback for requests sent from pre 0.24.x brokers, where request.data() is the chunk
+      // contents; please remove once we do not support versions below 0.24.x
+      return LegacySnapshotChunk.ofInstallRequest(request);
+    }
   }
 
   private void abortPendingSnapshots() {

--- a/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/LegacySnapshotChunk.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/LegacySnapshotChunk.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.snapshot.impl;
+
+import io.atomix.raft.protocol.InstallRequest;
+import io.atomix.raft.snapshot.SnapshotChunk;
+import io.atomix.utils.time.WallClockTimestamp;
+import io.zeebe.util.buffer.BufferUtil;
+import java.util.Arrays;
+import java.util.Objects;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * An implementation of {@link SnapshotChunk} which is compatible with the snapshot replication
+ * protocol of brokers pre 0.24.x. Should be removed once no versions below 0.24.x are supported.
+ */
+public final class LegacySnapshotChunk implements SnapshotChunk {
+  private final FileBasedSnapshotMetadata metadata;
+  private final String chunkId;
+  private final byte[] content;
+  private final long checksum;
+
+  private LegacySnapshotChunk(
+      final FileBasedSnapshotMetadata metadata,
+      final String chunkId,
+      final byte[] content,
+      final long checksum) {
+    this.metadata = metadata;
+    this.chunkId = chunkId;
+    this.content = content;
+    this.checksum = checksum;
+  }
+
+  public static LegacySnapshotChunk ofInstallRequest(final InstallRequest request) {
+    final var metadata =
+        new FileBasedSnapshotMetadata(
+            request.index(), request.term(), WallClockTimestamp.from(request.timestamp()));
+    final var chunkId = BufferUtil.bufferAsString(new UnsafeBuffer(request.chunkId()));
+    final var content = BufferUtil.bufferAsArray(new UnsafeBuffer(request.data()));
+    final var checksum = SnapshotChunkUtil.createChecksum(content);
+
+    return new LegacySnapshotChunk(metadata, chunkId, content, checksum);
+  }
+
+  @Override
+  public String getSnapshotId() {
+    return metadata.getSnapshotIdAsString();
+  }
+
+  @Override
+  public int getTotalCount() {
+    return FileBasedReceivedSnapshot.TOTAL_COUNT_NULL_VALUE;
+  }
+
+  @Override
+  public String getChunkName() {
+    return chunkId;
+  }
+
+  @Override
+  public long getChecksum() {
+    return checksum;
+  }
+
+  @Override
+  public byte[] getContent() {
+    return content;
+  }
+
+  @Override
+  public long getSnapshotChecksum() {
+    return FileBasedReceivedSnapshot.SNAPSHOT_CHECKSUM_NULL_VALUE;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final LegacySnapshotChunk that = (LegacySnapshotChunk) o;
+    return getChecksum() == that.getChecksum()
+        && Objects.equals(metadata, that.metadata)
+        && Objects.equals(chunkId, that.chunkId)
+        && Arrays.equals(getContent(), that.getContent());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(metadata, chunkId, getChecksum());
+    result = 31 * result + Arrays.hashCode(getContent());
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "LegacySnapshotChunk{"
+        + "metadata="
+        + metadata
+        + ", chunkId='"
+        + chunkId
+        + '\''
+        + ", checksum="
+        + checksum
+        + '}';
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/impl/LegacySnapshotChunkTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/impl/LegacySnapshotChunkTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.snapshot.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.protocol.InstallRequest;
+import java.nio.ByteBuffer;
+import org.junit.Test;
+
+public class LegacySnapshotChunkTest {
+  @Test
+  public void shouldHaveCorrectChunkName() {
+    // given
+    final var request =
+        newInstallRequest(1, 1, System.currentTimeMillis(), "foo", "baz".getBytes());
+
+    // when
+    final var chunk = LegacySnapshotChunk.ofInstallRequest(request);
+
+    // then
+    assertThat(chunk.getChunkName()).isEqualTo("foo");
+  }
+
+  @Test
+  public void shouldHaveCorrectSnapshotId() {
+    // given
+    final var request = newInstallRequest(2, 3, 10, "baz", "baz".getBytes());
+
+    // when
+    final var chunk = LegacySnapshotChunk.ofInstallRequest(request);
+
+    // then
+    assertThat(chunk.getSnapshotId()).isEqualTo("2-3-10");
+  }
+
+  @Test
+  public void shouldHaveNullTotalCount() {
+    // given
+    final var request = newInstallRequest(2, 3, 10, "baz", "baz".getBytes());
+
+    // when
+    final var chunk = LegacySnapshotChunk.ofInstallRequest(request);
+
+    // then
+    assertThat(chunk.getTotalCount()).isEqualTo(FileBasedReceivedSnapshot.TOTAL_COUNT_NULL_VALUE);
+  }
+
+  @Test
+  public void shouldHaveNullSnapshotChecksum() {
+    // given
+    final var request = newInstallRequest(2, 3, 10, "foo", "baz".getBytes());
+
+    // when
+    final var chunk = LegacySnapshotChunk.ofInstallRequest(request);
+
+    // then
+    assertThat(chunk.getSnapshotChecksum())
+        .isEqualTo(FileBasedReceivedSnapshot.SNAPSHOT_CHECKSUM_NULL_VALUE);
+  }
+
+  @Test
+  public void shouldHaveCorrectChecksum() {
+    // given
+    final byte[] content = "baz".getBytes();
+    final long checksum = SnapshotChunkUtil.createChecksum(content);
+    final var request = newInstallRequest(2, 3, 10, "foo", content);
+
+    // when
+    final var chunk = LegacySnapshotChunk.ofInstallRequest(request);
+
+    // then
+    assertThat(chunk.getChecksum()).isEqualTo(checksum);
+  }
+
+  @Test
+  public void shouldHaveCorrectContent() {
+    // given
+    final byte[] content = "baz".getBytes();
+    final var request = newInstallRequest(2, 3, 10, "foo", content);
+
+    // when
+    final var chunk = LegacySnapshotChunk.ofInstallRequest(request);
+
+    // then
+    assertThat(chunk.getContent()).isEqualTo(content);
+  }
+
+  private InstallRequest newInstallRequest(
+      final long index,
+      final int term,
+      final long timestamp,
+      final String chunkName,
+      final byte[] content) {
+    return new InstallRequest(
+        1,
+        MemberId.anonymous(),
+        index,
+        term,
+        timestamp,
+        1,
+        ByteBuffer.wrap(chunkName.getBytes()),
+        null,
+        ByteBuffer.wrap(content),
+        true,
+        true);
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -78,7 +78,7 @@
     <version.asm>8.0.1</version.asm>
     <version.testcontainers>1.14.3</version.testcontainers>
     <version.netflix.concurrency>0.3.6</version.netflix.concurrency>
-    <version.zeebe-test-container>0.32.0</version.zeebe-test-container>
+    <version.zeebe-test-container>0.33.0</version.zeebe-test-container>
     <version.feel-scala>1.11.2</version.feel-scala>
     <version.restassert>4.3.0</version.restassert>
     <version.spring-framework>5.2.7.RELEASE</version.spring-framework>

--- a/test-util/src/main/java/io/zeebe/test/util/asserts/TopologyAssert.java
+++ b/test-util/src/main/java/io/zeebe/test/util/asserts/TopologyAssert.java
@@ -10,6 +10,7 @@ package io.zeebe.test.util.asserts;
 import io.zeebe.client.api.response.BrokerInfo;
 import io.zeebe.client.api.response.Topology;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 
@@ -19,7 +20,7 @@ public class TopologyAssert extends AbstractAssert<TopologyAssert, Topology> {
     super(topology, TopologyAssert.class);
   }
 
-  public static TopologyAssert assertThat(Topology actual) {
+  public static TopologyAssert assertThat(final Topology actual) {
     return new TopologyAssert(actual);
   }
 
@@ -42,6 +43,29 @@ public class TopologyAssert extends AbstractAssert<TopologyAssert, Topology> {
           "Expected <%s> partitions at each broker, but found brokers with different partition count <%s>",
           partitionCount, brokersWithUnexpectedPartitionCount);
     }
+
+    return this;
+  }
+
+  public final TopologyAssert doesNotContainBroker(final int nodeId) {
+    isNotNull();
+
+    final List<Integer> brokers =
+        actual.getBrokers().stream().map(BrokerInfo::getNodeId).collect(Collectors.toList());
+    if (brokers.contains(nodeId)) {
+      failWithMessage(
+          "Expected topology not to contain broker with ID %d, but found the following: [%s]",
+          nodeId, brokers);
+    }
+
+    return this;
+  }
+
+  public final TopologyAssert hasBrokerSatisfying(final Consumer<BrokerInfo> condition) {
+    isNotNull();
+
+    final List<BrokerInfo> brokers = actual.getBrokers();
+    newListAssertInstance(brokers).anySatisfy(condition);
 
     return this;
   }

--- a/upgrade-tests/pom.xml
+++ b/upgrade-tests/pom.xml
@@ -61,6 +61,11 @@
       <groupId>net.jodah</groupId>
       <artifactId>failsafe</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/upgrade-tests/src/test/java/io/zeebe/test/ContainerStateRule.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/ContainerStateRule.java
@@ -98,7 +98,8 @@ class ContainerStateRule extends TestWatcher {
             .withEnv("ZEEBE_BROKER_CLUSTER_CLUSTERNAME", "zeebe-cluster")
             .withNetwork(network)
             .withEmbeddedGateway(gatewayVersion == null)
-            .withLogLevel(Level.DEBUG);
+            .withLogLevel(Level.DEBUG)
+            .withDebug(true);
 
     Failsafe.with(CONTAINER_START_RETRY_POLICY).run(() -> broker.start());
 

--- a/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
@@ -125,7 +125,7 @@ public class RollingUpdateTest {
   }
 
   @Test
-  public void shouldReplicateSnapshotAcrossVersions() throws InterruptedException {
+  public void shouldReplicateSnapshotAcrossVersions() {
     // given
     Startables.deepStart(containers).join();
 
@@ -156,6 +156,7 @@ public class RollingUpdateTest {
           .pollInterval(Duration.ofMillis(100))
           .untilAsserted(() -> assertTopologyDoesNotContainerBroker(client, brokerId));
 
+      // need to create enough records to allow for the creation of a snapshot
       for (int i = 0; i < 100; i++) {
         Awaitility.await("process instance creation")
             .atMost(Duration.ofSeconds(5))
@@ -180,6 +181,7 @@ public class RollingUpdateTest {
           .untilAsserted(() -> assertTopologyContainsUpgradedBroker(client, brokerId));
     }
 
+    // then
     assertBrokerHasAtLeastOneSnapshot(1);
   }
 

--- a/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
@@ -7,30 +7,67 @@
  */
 package io.zeebe.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.api.response.WorkflowInstanceEvent;
+import io.zeebe.client.api.worker.JobHandler;
 import io.zeebe.containers.ZeebeBrokerContainer;
 import io.zeebe.containers.ZeebePort;
-import io.zeebe.test.util.AutoCloseableRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.test.util.asserts.TopologyAssert;
 import io.zeebe.util.VersionUtil;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.agrona.IoUtil;
+import org.awaitility.Awaitility;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.event.Level;
 import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.lifecycle.Startables;
 
 public class RollingUpdateTest {
-  private static final Logger LOG = LoggerFactory.getLogger(ContainerStateRule.class);
   private static final String OLD_VERSION = VersionUtil.getPreviousVersion();
-  private static final String CURRENT_VERSION = "current-test";
+  private static final String NEW_VERSION = VersionUtil.getVersion();
+  private static final String IMAGE_TAG = "current-test";
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess("process")
+          .startEvent()
+          .serviceTask("task1", s -> s.zeebeJobType("firstTask"))
+          .serviceTask("task2", s -> s.zeebeJobType("secondTask"))
+          .endEvent()
+          .done();
 
-  @Rule public AutoCloseableRule autoCloseable = new AutoCloseableRule();
+  private static final File SHARED_DATA;
+
+  static {
+    final var sharedDataPath =
+        Optional.ofNullable(System.getenv("ZEEBE_CI_SHARED_DATA"))
+            .map(Paths::get)
+            .orElse(Paths.get(System.getProperty("tmpdir", "/tmp"), "shared"));
+    SHARED_DATA = sharedDataPath.toAbsolutePath().toFile();
+    IoUtil.ensureDirectoryExists(SHARED_DATA, "temporary folder for Docker");
+  }
+
+  @Rule public TemporaryFolder tmpFolder = new TemporaryFolder(SHARED_DATA);
 
   private List<ZeebeBrokerContainer> containers;
   private String initialContactPoints;
@@ -47,47 +84,230 @@ public class RollingUpdateTest {
 
     containers =
         Arrays.asList(
-            manageClosable(new ZeebeBrokerContainer(OLD_VERSION)),
-            manageClosable(new ZeebeBrokerContainer(OLD_VERSION)),
-            manageClosable(new ZeebeBrokerContainer(OLD_VERSION)));
+            new ZeebeBrokerContainer(OLD_VERSION),
+            new ZeebeBrokerContainer(OLD_VERSION),
+            new ZeebeBrokerContainer(OLD_VERSION));
 
     configureBrokerContainer(0, containers);
     configureBrokerContainer(1, containers);
     configureBrokerContainer(2, containers);
   }
 
-  @Test
-  public void shouldBeAbleToRestartContainerWithSameVersion() {
-    // given
-    final var index = 0;
-    final var sameVersion = OLD_VERSION;
-    Startables.deepStart(containers).join();
-    containers.get(index).shutdownGracefully(Duration.ofSeconds(30));
-
-    // when
-    final var zeebeBrokerContainer = replaceBrokerContainer(index, sameVersion);
-
-    // then
-    zeebeBrokerContainer.start();
+  @After
+  public void tearDown() {
+    containers.parallelStream().forEach(Startable::stop);
   }
 
   @Test
   public void shouldBeAbleToRestartContainerWithNewVersion() {
     // given
     final var index = 0;
-    final var newVersion = CURRENT_VERSION;
     Startables.deepStart(containers).join();
     containers.get(index).shutdownGracefully(Duration.ofSeconds(30));
 
     // when
-    final var zeebeBrokerContainer = replaceBrokerContainer(index, newVersion);
+    final var zeebeBrokerContainer = upgradeBroker(index);
 
     // then
-    zeebeBrokerContainer.start();
+    try (final var client = newZeebeClient(containers.get(1))) {
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(100))
+          .untilAsserted(() -> assertTopologyDoesNotContainerBroker(client, index));
+
+      zeebeBrokerContainer.start();
+
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(100))
+          .untilAsserted(() -> assertTopologyContainsUpgradedBroker(client, index));
+    }
   }
 
-  private ZeebeBrokerContainer replaceBrokerContainer(final int index, final String newVersion) {
-    final var broker = new ZeebeBrokerContainer(newVersion);
+  @Test
+  public void shouldReplicateSnapshotAcrossVersions() throws InterruptedException {
+    // given
+    Startables.deepStart(containers).join();
+
+    // when
+    final var availableBroker = containers.get(0);
+    try (final var client = newZeebeClient(availableBroker)) {
+      deployProcess(client);
+
+      // potentially retry in case we're faster than the deployment distribution
+      Awaitility.await("process instance creation")
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(100))
+          .ignoreExceptions()
+          .until(() -> createWorkflowInstance(client), Objects::nonNull)
+          .getWorkflowInstanceKey();
+    }
+
+    try (final var client = newZeebeClient(availableBroker)) {
+      final var brokerId = 1;
+      var container = containers.get(brokerId);
+
+      container.shutdownGracefully(Duration.ofSeconds(30));
+
+      // until previous version points to 0.24, we cannot yet tune failure detection to be fast,
+      // so wait long enough for the broker to be removed even in slower systems
+      Awaitility.await("broker is removed from topology")
+          .atMost(Duration.ofSeconds(20))
+          .pollInterval(Duration.ofMillis(100))
+          .untilAsserted(() -> assertTopologyDoesNotContainerBroker(client, brokerId));
+
+      for (int i = 0; i < 100; i++) {
+        Awaitility.await("process instance creation")
+            .atMost(Duration.ofSeconds(5))
+            .pollInterval(Duration.ofMillis(100))
+            .ignoreExceptions()
+            .until(() -> createWorkflowInstance(client), Objects::nonNull)
+            .getWorkflowInstanceKey();
+      }
+
+      // wait for a snapshot - even if 0 is not the leader, it will get the replicated snapshot
+      // which is a good indicator we now have a snapshot
+      Awaitility.await("broker 0 has created a snapshot")
+          .atMost(Duration.ofMinutes(2)) // twice the snapshot period
+          .pollInterval(Duration.ofMillis(500))
+          .untilAsserted(() -> assertBrokerHasAtLeastOneSnapshot(0));
+
+      container = upgradeBroker(brokerId);
+      container.start();
+      Awaitility.await("upgraded broker is added to topology")
+          .atMost(Duration.ofSeconds(10))
+          .pollInterval(Duration.ofMillis(100))
+          .untilAsserted(() -> assertTopologyContainsUpgradedBroker(client, brokerId));
+    }
+
+    assertBrokerHasAtLeastOneSnapshot(1);
+  }
+
+  @Test
+  public void shouldPerformRollingUpgrade() {
+    // given
+    Startables.deepStart(containers).join();
+
+    // when
+    final long firstWorkflowInstanceKey;
+    var availableBroker = containers.get(0);
+    try (final var client = newZeebeClient(availableBroker)) {
+      deployProcess(client);
+
+      // potentially retry in case we're faster than the deployment distribution
+      firstWorkflowInstanceKey =
+          Awaitility.await("process instance creation")
+              .atMost(Duration.ofSeconds(5))
+              .pollInterval(Duration.ofMillis(100))
+              .ignoreExceptions()
+              .until(() -> createWorkflowInstance(client), Objects::nonNull)
+              .getWorkflowInstanceKey();
+    }
+
+    for (int i = containers.size() - 1; i >= 0; i--) {
+      try (final var client = newZeebeClient(availableBroker)) {
+        final var brokerId = i;
+        var container = containers.get(i);
+
+        container.shutdownGracefully(Duration.ofSeconds(30));
+
+        // until previous version points to 0.24, we cannot yet tune failure detection to be fast,
+        // so wait long enough for the broker to be removed even in slower systems
+        Awaitility.await("broker is removed from topology")
+            .atMost(Duration.ofSeconds(20))
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() -> assertTopologyDoesNotContainerBroker(client, brokerId));
+
+        container = upgradeBroker(i);
+        container.start();
+        Awaitility.await("upgraded broker is added to topology")
+            .atMost(Duration.ofSeconds(10))
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(() -> assertTopologyContainsUpgradedBroker(client, brokerId));
+
+        availableBroker = container;
+      }
+    }
+
+    // then
+    final Map<Long, List<String>> activatedJobs = new HashMap<>();
+    final var expectedOrderedJobs = List.of("firstTask", "secondTask");
+    final JobHandler jobHandler =
+        (jobClient, job) -> {
+          jobClient.newCompleteCommand(job.getKey()).send().join();
+          activatedJobs.compute(
+              job.getWorkflowInstanceKey(),
+              (ignored, list) -> {
+                final var appendedList =
+                    Optional.ofNullable(list).orElse(new CopyOnWriteArrayList<>());
+                appendedList.add(job.getType());
+                return appendedList;
+              });
+        };
+
+    try (final var client = newZeebeClient(availableBroker)) {
+      final var secondWorkflowInstanceKey = createWorkflowInstance(client).getWorkflowInstanceKey();
+      final var expectedActivatedJobs =
+          Map.of(
+              firstWorkflowInstanceKey,
+              expectedOrderedJobs,
+              secondWorkflowInstanceKey,
+              expectedOrderedJobs);
+      client.newWorker().jobType("firstTask").handler(jobHandler).open();
+      client.newWorker().jobType("secondTask").handler(jobHandler).open();
+
+      Awaitility.await("all jobs have been activated")
+          .atMost(Duration.ofSeconds(5))
+          .untilAsserted(() -> assertThat(activatedJobs).isEqualTo(expectedActivatedJobs));
+    }
+  }
+
+  private WorkflowInstanceEvent createWorkflowInstance(final ZeebeClient client) {
+    return client
+        .newCreateInstanceCommand()
+        .bpmnProcessId("process")
+        .latestVersion()
+        .variables(Map.of("foo", "bar"))
+        .send()
+        .join();
+  }
+
+  private void deployProcess(final ZeebeClient client) {
+    client
+        .newDeployCommand()
+        .addWorkflowModel(PROCESS, "process.bpmn")
+        .send()
+        .join(10, TimeUnit.SECONDS);
+  }
+
+  private void assertTopologyContainsUpgradedBroker(
+      final ZeebeClient zeebeClient, final int brokerId) {
+    final var topology = zeebeClient.newTopologyRequest().send().join();
+    TopologyAssert.assertThat(topology)
+        .isComplete(containers.size(), 1)
+        .hasBrokerSatisfying(
+            brokerInfo -> {
+              assertThat(brokerInfo.getNodeId()).isEqualTo(brokerId);
+              assertThat(brokerInfo.getVersion()).isEqualTo(NEW_VERSION);
+            });
+  }
+
+  private void assertTopologyDoesNotContainerBroker(final ZeebeClient client, final int brokerId) {
+    final var topology = client.newTopologyRequest().send().join();
+    TopologyAssert.assertThat(topology)
+        .doesNotContainBroker(brokerId)
+        .isComplete(containers.size() - 1, 1);
+  }
+
+  private ZeebeClient newZeebeClient(final ZeebeBrokerContainer container) {
+    return ZeebeClient.newClientBuilder()
+        .usePlaintext()
+        .brokerContactPoint(container.getExternalAddress(ZeebePort.GATEWAY))
+        .build();
+  }
+
+  private ZeebeBrokerContainer upgradeBroker(final int index) {
+    final var broker = new ZeebeBrokerContainer(IMAGE_TAG);
     containers.set(index, broker);
     return configureBrokerContainer(index, containers);
   }
@@ -97,26 +317,39 @@ public class RollingUpdateTest {
     final int clusterSize = brokers.size();
     final var broker = brokers.get(index);
     final var hostName = "broker-" + index;
+    final var volumePath = getBrokerVolumePath(index);
     broker.withNetworkAliases(hostName);
 
+    // once old version is 0.24 and more membership configuration is exposed, further tune for fast
+    // failure detection
     return broker
         .withNetwork(network)
         .withEnv("ZEEBE_BROKER_NETWORK_HOST", "0.0.0.0")
         .withEnv("ZEEBE_BROKER_NETWORK_ADVERTISED_HOST", hostName)
         .withEnv("ZEEBE_BROKER_CLUSTER_CLUSTERNAME", "zeebe-cluster")
-        .withEnv("ZEEBE_BROKER_DATA_SNAPSHOTPERIOD", "1m")
-        .withEnv("ZEEBE_BROKER_DATA_LOGSEGMENTSIZE", "1MB")
-        .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "1MB")
+        .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "128KB")
         .withEnv("ZEEBE_BROKER_CLUSTER_NODEID", String.valueOf(index))
         .withEnv("ZEEBE_BROKER_CLUSTER_CLUSTERSIZE", String.valueOf(clusterSize))
         .withEnv("ZEEBE_BROKER_CLUSTER_REPLICATIONFACTOR", String.valueOf(clusterSize))
         .withEnv("ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS", initialContactPoints)
-        .withLogLevel(Level.DEBUG)
-        .withDebug(false);
+        .withEnv("ZEEBE_BROKER_CLUSTER_GOSSIPFAILURETIMEOUT", "5000")
+        .withEnv("ZEEBE_BROKER_CLUSTER_GOSSIPINTERVAL", "100")
+        .withEnv("ZEEBE_BROKER_CLUSTER_GOSSIPPROBEINTERVAL", "100")
+        .withEnv("ZEEBE_BROKER_DATA_SNAPSHOTPERIOD", "1m")
+        .withFileSystemBind(volumePath.toString(), "/usr/local/zeebe/data")
+        .withLogLevel(Level.DEBUG);
   }
 
-  private <T extends AutoCloseable> T manageClosable(final T closeable) {
-    autoCloseable.manage(closeable);
-    return closeable;
+  private Path getBrokerVolumePath(final int index) {
+    final var file = new File(tmpFolder.getRoot(), "broker-" + index);
+    IoUtil.ensureDirectoryExists(file, "broker shared data folder");
+
+    return file.toPath().toAbsolutePath();
+  }
+
+  private void assertBrokerHasAtLeastOneSnapshot(final int index) {
+    final var path = getBrokerVolumePath(index);
+    final var snapshotPath = path.resolve("raft-partition/partitions/1/snapshots");
+    assertThat(snapshotPath).isNotEmptyDirectory();
   }
 }


### PR DESCRIPTION
## Description

This PR allows a 0.24.x broker to receive and replicate a snapshot being sent by a 0.23.x broker, fixing the rolling upgrade problem on start up. It essentially does so by attempting to decode the SBE message, and if it fails to do so, falling back to interpreting it as an old request where the data is the chunk data, building a snapshot chunk out of the install request instead.

This means there is no checksum checks (neither for the chunk nor the total snapshot) if it comes from a 0.23.x, which is essentially the behaviour of the 0.23.x snapshot replication.

## Related issues

closes #5102 
closes #5035 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

> Not necessary to back port as it affects only 0.24.x, but should be forward ported to develop.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
