### PR TITLE
chore(.ci): tag release with Go compatible version

### DIFF
--- a/.ci/scripts/release/github-release.sh
+++ b/.ci/scripts/release/github-release.sh
@@ -10,6 +10,9 @@ GITHUB_RELEASE=${PWD}/github-release
 
 ${GITHUB_RELEASE} release --user ${GITHUB_ORG} --repo ${GITHUB_REPO} --tag ${RELEASE_VERSION} --draft --name "Zeebe ${RELEASE_VERSION}" --description ""
 
+git tag clients/go/v${RELEASE_VERSION}
+git push origin clients/go/v${RELEASE_VERSION} 
+
 function upload {
   pushd ${1}
 


### PR DESCRIPTION
## Description

During the release, push a tag with the format "clients/go/vX.Y.Z". This will allow users of the Go client to specify versions as "vX.Y.Z" and go modules will find the correct tag without modifying it to a pseudo-version. I will also open two related PRs: one here to update the Go docs (currently, we're telling users to "go get" the client) and another one in the go getting started guide (which I used to test the tag format) with a refactor and a script to help us update it after releases.

## Related issues

closes #5126 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
