### PR TITLE
[Backport 0.23] chore(test): assign dynamic ports to brokers

### DIFF
--- a/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.broker;
 
+import static io.zeebe.broker.test.EmbeddedBrokerRule.assignSocketAddresses;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.zeebe.broker.system.configuration.BrokerCfg;
@@ -36,6 +37,7 @@ public final class SimpleBrokerStartTest {
   public void shouldFailToStartBrokerWithSmallTimeout() {
     // given
     final var brokerCfg = new BrokerCfg();
+    assignSocketAddresses(brokerCfg);
     brokerCfg.setStepTimeout(Duration.ofMillis(1));
 
     final var broker = new Broker(brokerCfg, newTemporaryFolder.getAbsolutePath(), null);
@@ -65,7 +67,9 @@ public final class SimpleBrokerStartTest {
   public void shouldCallPartitionListenerAfterStart() throws Exception {
     // given
     final var brokerCfg = new BrokerCfg();
+    assignSocketAddresses(brokerCfg);
     final var broker = new Broker(brokerCfg, newTemporaryFolder.getAbsolutePath(), null);
+
     final var leaderLatch = new CountDownLatch(1);
     broker.addPartitionListener(
         new PartitionListener() {


### PR DESCRIPTION
## Description

Backport of #5129 to 0.23


## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [X] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
