### PR TITLE
Reenable rolling upgrade test

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -194,9 +194,7 @@ public class PassiveRole extends InactiveRole {
           logResponse(
               InstallResponse.builder()
                   .withStatus(RaftResponse.Status.ERROR)
-                  .withError(
-                      RaftError.Type.APPLICATION_ERROR,
-                      "Failed to parse incoming snapshot chunk: " + e.getMessage())
+                  .withError(RaftError.Type.APPLICATION_ERROR, "Failed to parse request data")
                   .build()));
     }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -164,14 +164,16 @@ public class PassiveRole extends InactiveRole {
     // If the snapshot already exists locally, do not overwrite it with a replicated snapshot.
     // Simply reply to the
     // request successfully.
-    final var optLatestSnapshot = raft.getPersistedSnapshotStore().getLatestSnapshot();
-    if (optLatestSnapshot.isPresent()) {
-      if (optLatestSnapshot.get().getIndex() >= request.index()) {
-        abortPendingSnapshots();
+    final var latestIndex =
+        raft.getPersistedSnapshotStore()
+            .getLatestSnapshot()
+            .map(PersistedSnapshot::getIndex)
+            .orElse(Long.MIN_VALUE);
+    if (latestIndex >= request.index()) {
+      abortPendingSnapshots();
 
-        return CompletableFuture.completedFuture(
-            logResponse(InstallResponse.builder().withStatus(RaftResponse.Status.OK).build()));
-      }
+      return CompletableFuture.completedFuture(
+          logResponse(InstallResponse.builder().withStatus(RaftResponse.Status.OK).build()));
     }
 
     if (!request.complete() && request.nextChunkId() == null) {
@@ -186,7 +188,18 @@ public class PassiveRole extends InactiveRole {
     }
 
     final var snapshotChunk = new SnapshotChunkImpl();
-    snapshotChunk.wrap(new UnsafeBuffer(request.data()), 0, request.data().capacity());
+    try {
+      snapshotChunk.wrap(new UnsafeBuffer(request.data()), 0, request.data().capacity());
+    } catch (final RuntimeException e) {
+      return CompletableFuture.completedFuture(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(RaftResponse.Status.ERROR)
+                  .withError(
+                      RaftError.Type.APPLICATION_ERROR,
+                      "Failed to parse incoming snapshot chunk: " + e.getMessage())
+                  .build()));
+    }
 
     // If there is no pending snapshot, create a new snapshot.
     if (pendingSnapshot == null) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -188,9 +188,8 @@ public class PassiveRole extends InactiveRole {
     }
 
     final var snapshotChunk = new SnapshotChunkImpl();
-    try {
-      snapshotChunk.wrap(new UnsafeBuffer(request.data()), 0, request.data().capacity());
-    } catch (final RuntimeException e) {
+    final var snapshotChunkBuffer = new UnsafeBuffer(request.data());
+    if (!snapshotChunk.tryWrap(snapshotChunkBuffer)) {
       return CompletableFuture.completedFuture(
           logResponse(
               InstallResponse.builder()

--- a/atomix/cluster/src/main/java/io/atomix/raft/snapshot/SbeBufferWriterReader.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/snapshot/SbeBufferWriterReader.java
@@ -71,8 +71,13 @@ public abstract class SbeBufferWriterReader<
   public boolean tryWrap(final DirectBuffer buffer, final int offset, final int length) {
     headerDecoder.wrap(buffer, offset);
 
-    return headerDecoder.schemaId() == getBodyDecoder().sbeSchemaId()
-        && headerDecoder.templateId() == getBodyDecoder().sbeTemplateId();
+    if (headerDecoder.schemaId() == getBodyDecoder().sbeSchemaId()
+        && headerDecoder.templateId() == getBodyDecoder().sbeTemplateId()) {
+      wrap(buffer, offset, length);
+      return true;
+    }
+
+    return false;
   }
 
   public ByteBuffer toByteBuffer() {

--- a/broker/src/main/java/io/zeebe/broker/engine/impl/DeploymentDistributorImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/DeploymentDistributorImpl.java
@@ -257,7 +257,6 @@ public final class DeploymentDistributorImpl implements DeploymentDistributor {
     final DirectBuffer responseBuffer = new UnsafeBuffer(response);
 
     if (pushDeploymentResponse.tryWrap(responseBuffer)) {
-      pushDeploymentResponse.wrap(responseBuffer);
       if (handlePushResponse()) {
         final IntArrayList missingResponses = getPartitionResponses(topic);
         missingResponses.removeInt(pushDeploymentResponse.partitionId());

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/encoding/SbeBufferWriterReader.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/encoding/SbeBufferWriterReader.java
@@ -71,8 +71,13 @@ public abstract class SbeBufferWriterReader<
   public boolean tryWrap(final DirectBuffer buffer, final int offset, final int length) {
     headerDecoder.wrap(buffer, offset);
 
-    return headerDecoder.schemaId() == getBodyDecoder().sbeSchemaId()
-        && headerDecoder.templateId() == getBodyDecoder().sbeTemplateId();
+    if (headerDecoder.schemaId() == getBodyDecoder().sbeSchemaId()
+        && headerDecoder.templateId() == getBodyDecoder().sbeTemplateId()) {
+      wrap(buffer, offset, length);
+      return true;
+    }
+
+    return false;
   }
 
   public ByteBuffer toByteBuffer() {

--- a/upgrade-tests/pom.xml
+++ b/upgrade-tests/pom.xml
@@ -59,10 +59,14 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
     </dependency>
-    <dependency>    
+    <dependency>
       <groupId>net.jodah</groupId>
       <artifactId>failsafe</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
     </dependency>
   </dependencies>
 

--- a/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
@@ -8,6 +8,7 @@
 package io.zeebe.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeThat;
 
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.api.response.WorkflowInstanceEvent;
@@ -18,6 +19,9 @@ import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.test.util.asserts.TopologyAssert;
 import io.zeebe.util.VersionUtil;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -29,17 +33,19 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.agrona.IoUtil;
 import org.awaitility.Awaitility;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.event.Level;
 import org.testcontainers.containers.Network;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.lifecycle.Startables;
 
-@Ignore
 public class RollingUpdateTest {
   private static final String OLD_VERSION = VersionUtil.getPreviousVersion();
   private static final String NEW_VERSION = VersionUtil.getVersion();
@@ -51,6 +57,19 @@ public class RollingUpdateTest {
           .serviceTask("task2", s -> s.zeebeJobType("secondTask"))
           .endEvent()
           .done();
+
+  private static final File SHARED_DATA;
+
+  static {
+    final var sharedDataPath =
+        Optional.ofNullable(System.getenv("ZEEBE_CI_SHARED_DATA"))
+            .map(Paths::get)
+            .orElse(Paths.get(System.getProperty("tmpdir", "/tmp"), "shared"));
+    SHARED_DATA = sharedDataPath.toAbsolutePath().toFile();
+    IoUtil.ensureDirectoryExists(SHARED_DATA, "temporary folder for Docker");
+  }
+
+  @Rule public TemporaryFolder tmpFolder = new TemporaryFolder(SHARED_DATA);
 
   private List<ZeebeBrokerContainer> containers;
   private String initialContactPoints;
@@ -83,6 +102,8 @@ public class RollingUpdateTest {
 
   @Test
   public void shouldBeAbleToRestartContainerWithNewVersion() {
+    assumeNewVersionIsRollingUpgradeCompatible();
+
     // given
     final var index = 0;
     Startables.deepStart(containers).join();
@@ -108,7 +129,70 @@ public class RollingUpdateTest {
   }
 
   @Test
+  public void shouldReplicateSnapshotAcrossVersions() {
+    assumeNewVersionIsRollingUpgradeCompatible();
+
+    // given
+    Startables.deepStart(containers).join();
+
+    // when
+    final var availableBroker = containers.get(0);
+    try (final var client = newZeebeClient(availableBroker)) {
+      deployProcess(client);
+
+      // potentially retry in case we're faster than the deployment distribution
+      Awaitility.await("process instance creation")
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(100))
+          .ignoreExceptions()
+          .until(() -> createWorkflowInstance(client), Objects::nonNull)
+          .getWorkflowInstanceKey();
+    }
+
+    try (final var client = newZeebeClient(availableBroker)) {
+      final var brokerId = 1;
+      var container = containers.get(brokerId);
+
+      container.shutdownGracefully(Duration.ofSeconds(30));
+
+      // until previous version points to 0.24, we cannot yet tune failure detection to be fast,
+      // so wait long enough for the broker to be removed even in slower systems
+      Awaitility.await("broker is removed from topology")
+          .atMost(Duration.ofSeconds(20))
+          .pollInterval(Duration.ofMillis(100))
+          .untilAsserted(() -> assertTopologyDoesNotContainerBroker(client, brokerId));
+
+      for (int i = 0; i < 100; i++) {
+        Awaitility.await("process instance creation")
+            .atMost(Duration.ofSeconds(5))
+            .pollInterval(Duration.ofMillis(100))
+            .ignoreExceptions()
+            .until(() -> createWorkflowInstance(client), Objects::nonNull)
+            .getWorkflowInstanceKey();
+      }
+
+      // wait for a snapshot - even if 0 is not the leader, it will get the replicated snapshot
+      // which is a good indicator we now have a snapshot
+      Awaitility.await("broker 0 has created a snapshot")
+          .atMost(Duration.ofMinutes(2)) // twice the snapshot period
+          .pollInterval(Duration.ofMillis(500))
+          .untilAsserted(() -> assertBrokerHasAtLeastOneSnapshot(0));
+
+      container = upgradeBroker(brokerId);
+      container.start();
+      Awaitility.await("upgraded broker is added to topology")
+          .atMost(Duration.ofSeconds(10))
+          .pollInterval(Duration.ofMillis(100))
+          .untilAsserted(() -> assertTopologyContainsUpgradedBroker(client, brokerId));
+    }
+
+    assertBrokerHasAtLeastOneSnapshot(1);
+  }
+
+  @Test
   public void shouldPerformRollingUpgrade() {
+    assumeNewVersionIsRollingUpgradeCompatible();
+
     // given
     Startables.deepStart(containers).join();
 
@@ -186,6 +270,13 @@ public class RollingUpdateTest {
     }
   }
 
+  private void assumeNewVersionIsRollingUpgradeCompatible() {
+    assumeThat(
+        "new version is rolling upgrade compatible",
+        NEW_VERSION,
+        Matchers.not(Matchers.startsWith("0.25")));
+  }
+
   private WorkflowInstanceEvent createWorkflowInstance(final ZeebeClient client) {
     return client
         .newCreateInstanceCommand()
@@ -241,10 +332,9 @@ public class RollingUpdateTest {
     final int clusterSize = brokers.size();
     final var broker = brokers.get(index);
     final var hostName = "broker-" + index;
+    final var volumePath = getBrokerVolumePath(index);
     broker.withNetworkAliases(hostName);
 
-    // once old version is 0.24 and more membership configuration is exposed, further tune for fast
-    // failure detection
     return broker
         .withNetwork(network)
         .withEnv("ZEEBE_BROKER_NETWORK_HOST", "0.0.0.0")
@@ -255,10 +345,23 @@ public class RollingUpdateTest {
         .withEnv("ZEEBE_BROKER_CLUSTER_CLUSTERSIZE", String.valueOf(clusterSize))
         .withEnv("ZEEBE_BROKER_CLUSTER_REPLICATIONFACTOR", String.valueOf(clusterSize))
         .withEnv("ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS", initialContactPoints)
-        .withEnv("ZEEBE_BROKER_CLUSTER_GOSSIPFAILURETIMEOUT", "5000")
-        .withEnv("ZEEBE_BROKER_CLUSTER_GOSSIPINTERVAL", "100")
-        .withEnv("ZEEBE_BROKER_CLUSTER_GOSSIPPROBEINTERVAL", "100")
-        .withLogLevel(Level.DEBUG)
-        .withDebug(false);
+        .withEnv("ZEEBE_BROKER_CLUSTER_MEMBERSHIP_BROADCASTUPDATES", "true")
+        .withEnv("ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SYNCINTERVAL", "250ms")
+        .withEnv("ZEEBE_BROKER_DATA_SNAPSHOTPERIOD", "1m")
+        .withFileSystemBind(volumePath.toString(), "/usr/local/zeebe/data")
+        .withLogLevel(Level.DEBUG);
+  }
+
+  private Path getBrokerVolumePath(final int index) {
+    final var file = new File(tmpFolder.getRoot(), "broker-" + index);
+    IoUtil.ensureDirectoryExists(file, "broker shared data folder");
+
+    return file.toPath().toAbsolutePath();
+  }
+
+  private void assertBrokerHasAtLeastOneSnapshot(final int index) {
+    final var path = getBrokerVolumePath(index);
+    final var snapshotPath = path.resolve("raft-partition/partitions/1/snapshots");
+    assertThat(snapshotPath).isNotEmptyDirectory();
   }
 }

--- a/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
@@ -60,6 +60,10 @@ public class RollingUpdateTest {
 
   private static final File SHARED_DATA;
 
+  // There's an issue when running tests with a docker-in-docker sibling on our CI platform, where
+  // mounting shared folders to /tmp on the test container fails to persist anything. So on CI we
+  // use a different mount point, but locally it makes sense to use /tmp to ensure the folder is
+  // later removed.
   static {
     final var sharedDataPath =
         Optional.ofNullable(System.getenv("ZEEBE_CI_SHARED_DATA"))


### PR DESCRIPTION
## Description

This PR forward-ports #5133 for the latest version, but disables the tests individually based on the target new version. This is because 0.25 is currently not backwards compatible (in terms of the rolling upgrade) with 0.24. The junit assumption API is used instead of a plain `@Ignore` annotation as it gives us more control over the condition where the test is ignored. In this case, as long as the target version (`NEW_VERSION`) starts with 0.25, we will skip those tests. This means after the release they will be automatically enabled. This isn't ideal, and suggestions are more than welcome.

The PR also adds minimal error handling when the follower fails to deserialization a snapshot chunk, which may happen not only because of backwards compatibility issues but generally due to network issues, bugs, etc. Unfortunately there is no specific deserialization exception so `RuntimeException` is used there.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
