### PR TITLE
feat(clients/go): zbctl deploy w/ custom resource name

### DIFF
--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -79,7 +79,7 @@ var tests = []struct {
 	},
 	{
 		name:       "deploy workflow",
-		cmd:        "--insecure deploy testdata/model.bpmn",
+		cmd:        "--insecure deploy testdata/model.bpmn testdata/job_model.bpmn --resourceNames=model.bpmn,job.bpmn",
 		goldenFile: "testdata/deploy.golden",
 	},
 	{

--- a/clients/go/cmd/zbctl/testdata/deploy.golden
+++ b/clients/go/cmd/zbctl/testdata/deploy.golden
@@ -4,8 +4,14 @@
     {
       "bpmnProcessId": "process",
       "version": 1,
-      "workflowKey": 2251799813685249,
-      "resourceName": "testdata/model.bpmn"
+      "workflowKey": 2251799813685345,
+      "resourceName": "model.bpmn"
+    },
+    {
+      "bpmnProcessId": "jobProcess",
+      "version": 1,
+      "workflowKey": 2251799813685346,
+      "resourceName": "job.bpmn"
     }
   ]
 }

--- a/clients/go/cmd/zbctl/testdata/help.golden
+++ b/clients/go/cmd/zbctl/testdata/help.golden
@@ -14,7 +14,7 @@ Available Commands:
   cancel      Cancel resource
   complete    Complete a resource
   create      Create resources
-  deploy      Creates new workflow defined by provided BPMN or YAML file as workflowPath
+  deploy      Creates a new workflow for each BPMN or YAML resource provided
   fail        Fail a resource
   generate    Generate documentation
   help        Help about any command

--- a/clients/go/internal/embedded/embedded.go
+++ b/clients/go/internal/embedded/embedded.go
@@ -182,8 +182,9 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
-	"VERSION": &bintree{version, map[string]*bintree{}},
+	"VERSION": {version, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory
@@ -232,4 +233,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-


### PR DESCRIPTION
## Description

Allow `zbctl` users to specify custom resource names when deploying workflows.

## Related issues

closes #5144

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
