### PR TITLE
fix(broker): environmentalise sed -i in benchmarks

### DIFF
--- a/benchmarks/setup/newBenchmark.sh
+++ b/benchmarks/setup/newBenchmark.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+
+GO_OS=${GO_OS:-"linux"}
+
+function detect_os {
+    # Detect the OS name
+    case "$(uname -s)" in
+      Darwin)
+        host_os=darwin
+        ;;
+      Linux)
+        host_os=linux
+        ;;
+      *)
+        echo "Unsupported host OS. Must be Linux or Mac OS X." >&2
+        exit 1
+        ;;
+    esac
+
+   GO_OS="${host_os}"
+}
+
+detect_os
+
 set -exo pipefail
 
 if [ -z $1 ]
@@ -19,4 +42,9 @@ kubens $namespace
 cp -rv default/ $namespace
 cd $namespace
 
-sed -i "s/default/$namespace/g" Makefile starter.yaml timer.yaml simpleStarter.yaml worker.yaml
+if [ "${GO_OS}" == "darwin" ]; then
+    sed -i '' -e "s/default/$namespace/g" Makefile starter.yaml timer.yaml simpleStarter.yaml worker.yaml
+else
+    sed -i -e "s/default/$namespace/g" Makefile starter.yaml timer.yaml simpleStarter.yaml worker.yaml
+fi
+


### PR DESCRIPTION
## Description

sed -i needs a different syntax on Mac OS. 

This patch detects the OS and uses the appropriate syntax.

Closes #4508