### PR TITLE
Replicate snapshots faster

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -20,6 +20,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import io.atomix.raft.snapshot.SnapshotChunkReader;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.storage.journal.JournalReader.Mode;
@@ -50,6 +51,7 @@ public final class RaftMemberContext {
   private int failures;
   private long failureTime;
   private volatile RaftLogReader reader;
+  private SnapshotChunkReader snapshotChunkReader;
 
   RaftMemberContext(final DefaultRaftMember member, final RaftClusterContext cluster) {
     this.member = checkNotNull(member, "member cannot be null").setCluster(cluster);
@@ -404,5 +406,13 @@ public final class RaftMemberContext {
    */
   public void setSnapshotIndex(final long snapshotIndex) {
     this.snapshotIndex = snapshotIndex;
+  }
+
+  public void setSnapshotChunkReader(final SnapshotChunkReader snapshotChunkReader) {
+    this.snapshotChunkReader = snapshotChunkReader;
+  }
+
+  public SnapshotChunkReader getSnapshotChunkReader() {
+    return snapshotChunkReader;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -86,7 +86,7 @@ public final class FollowerRole extends ActiveRole {
   @Override
   public CompletableFuture<InstallResponse> onInstall(final InstallRequest request) {
     final CompletableFuture<InstallResponse> future = super.onInstall(request);
-    if (isRequestFromCurrentLeader(request.term(), request.leader())) {
+    if (isRequestFromCurrentLeader(request.currentTerm(), request.leader())) {
       resetHeartbeatTimeout();
     }
     return future;

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -284,27 +284,6 @@ final class LeaderAppender extends AbstractAppender {
     }
   }
 
-  private void tryToReplicateSnapshot(final RaftMemberContext member) {
-    final var optSnapshot = raft.getPersistedSnapshotStore().getLatestSnapshot();
-
-    if (optSnapshot.isPresent()
-        && member.getSnapshotIndex() < optSnapshot.get().getIndex()
-        && optSnapshot.get().getIndex() >= member.getLogReader().getCurrentIndex()) {
-      if (!member.canInstall()) {
-        return;
-      }
-
-      final var persistedSnapshot = optSnapshot.get();
-      log.debug(
-          "Replicating snapshot {} to {}",
-          persistedSnapshot.getIndex(),
-          member.getMember().memberId());
-      sendInstallRequest(member, buildInstallRequest(member, persistedSnapshot));
-    } else if (member.canAppend()) {
-      sendAppendRequest(member, buildAppendRequest(member, -1));
-    }
-  }
-
   @Override
   protected boolean hasMoreEntries(final RaftMemberContext member) {
     // If the member's nextIndex is an entry in the local log then more entries can be sent.
@@ -361,6 +340,28 @@ final class LeaderAppender extends AbstractAppender {
         future ->
             future.completeExceptionally(
                 new RaftException.ProtocolException("Failed to reach consensus")));
+  }
+
+  private void tryToReplicateSnapshot(final RaftMemberContext member) {
+    final var optSnapshot = raft.getPersistedSnapshotStore().getLatestSnapshot();
+
+    if (optSnapshot.isPresent()
+        && member.getSnapshotIndex() < optSnapshot.get().getIndex()
+        && optSnapshot.get().getIndex() >= member.getLogReader().getCurrentIndex()) {
+      if (!member.canInstall()) {
+        return;
+      }
+
+      final var persistedSnapshot = optSnapshot.get();
+      log.debug(
+          "Replicating snapshot {} to {}",
+          persistedSnapshot.getIndex(),
+          member.getMember().memberId());
+      buildInstallRequest(member, persistedSnapshot)
+          .ifPresent(installRequest -> sendInstallRequest(member, installRequest));
+    } else if (member.canAppend()) {
+      sendAppendRequest(member, buildAppendRequest(member, -1));
+    }
   }
 
   /** Records a failed heartbeat. */


### PR DESCRIPTION
## Description

FileBasedSnapshotChunkReader constructor read all files to calculate checksum. When we create a new instance of the reader for each install request, it affects the overall snapshot replication duration. The performance impact is visible when the snapshot contains more than 1000 files. So instead of creating a new reader each time, we create the reader once and iterate over the chunks to build each install request.

## Related issues

closes #5135 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
