### PR TITLE
Elasticsearch exporter: limit the memory size of a bulk 

### DIFF
--- a/broker/src/test/resources/system/elasticexporter.yaml
+++ b/broker/src/test/resources/system/elasticexporter.yaml
@@ -1,4 +1,3 @@
-
 zeebe:
   broker:
     exporters:
@@ -16,6 +15,7 @@ zeebe:
         #   bulk:
         #     delay: 5
         #     size: 1000
+        #     memoryLimit: 10485760
         #
           authentication:
             username: elastic

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -462,6 +462,7 @@
         #   bulk:
         #     delay: 5
         #     size: 1000
+        #     memoryLimit: 10485760
         #
         #   authentication:
         #     username: elastic

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -414,6 +414,7 @@
         #   bulk:
         #     delay: 5
         #     size: 1000
+        #     memoryLimit: 10485760
         #
         #   authentication:
         #     username: elastic

--- a/exporters/elasticsearch-exporter/README.md
+++ b/exporters/elasticsearch-exporter/README.md
@@ -38,24 +38,27 @@ it should be flushed (regardless of size) can be controlled by configuration.
 For example:
 
 ```yaml
-...  
+...
   exporters:
     elasticsearch:
       args:
         delay: 5
         size: 1000
+        memoryLimit: 10485760
 ```
 
 With the above example, the exporter would aggregate records and flush them to Elasticsearch
 either:
   1. when it has aggregated 1000 records
-  2. 5 seconds have elapsed since the last flush (regardless of how many records were aggregated)
+  2. when the batch memory size exceeds 10 MB
+  3. 5 seconds have elapsed since the last flush (regardless of how many records were aggregated)
 
 More specifically, each option configures the following:
 
 * `delay` (`integer`): a specific delay, in seconds, before we force flush the current batch. This ensures
 that even when we have low traffic of records we still export every once in a while.
-* `size` (`integer`): how big a batch should be before we export.
+* `size` (`integer`): how many records a batch should have before we export.
+* `memoryLimit` (`integer`): the size of the bulk, in bytes, before we export.
 
 ### Index
 
@@ -74,11 +77,11 @@ For example:
         index:
           prefix: zeebe-record
           createTemplate: true
-          
+
           command: false
           event: true
           rejection: false
-          
+
           deployment: false
           incident: true
           job: false
@@ -118,28 +121,29 @@ Here is a complete, default configuration example:
       #
       # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_..."
       #
-      
+
       className: io.zeebe.exporter.ElasticsearchExporter
-     
+
       args:
         url: http://localhost:9200
-     
+
         bulk:
           delay: 5
           size: 1000
-     
+          memoryLimit: 10485760
+
         authentication:
           username: elastic
           password: changeme
-     
+
         index:
           prefix: zeebe-record
           createTemplate: true
-     
+
           command: false
           event: true
           rejection: false
-     
+
           deployment: true
           error: true
           incident: true
@@ -152,7 +156,7 @@ Here is a complete, default configuration example:
           workflowInstance: true
           workflowInstanceCreation: false
           workflowInstanceSubscription: false
-     
+
           ignoreVariablesAbove: 32677
 
 ```

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
@@ -140,6 +140,9 @@ public class ElasticsearchClient {
     final int bulkSize = bulkRequest.size();
     metrics.recordBulkSize(bulkSize);
 
+    final var bulkMemorySize = getBulkMemorySize();
+    metrics.recordBulkMemorySize(bulkMemorySize);
+
     final BulkResponse bulkResponse;
     try {
       bulkResponse = exportBulk();
@@ -188,7 +191,12 @@ public class ElasticsearchClient {
   }
 
   public boolean shouldFlush() {
-    return bulkRequest.size() >= configuration.bulk.size;
+    return bulkRequest.size() >= configuration.bulk.size
+        || getBulkMemorySize() >= configuration.bulk.memoryLimit;
+  }
+
+  private int getBulkMemorySize() {
+    return bulkRequest.stream().mapToInt(String::length).sum();
   }
 
   /** @return true if request was acknowledged */

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
@@ -22,6 +22,9 @@ public class ElasticsearchExporter implements Exporter {
 
   public static final String ZEEBE_RECORD_TEMPLATE_JSON = "/zeebe-record-template.json";
 
+  // by default, the bulk request may not be bigger than 100MB
+  private static final int RECOMMENDED_MAX_BULK_MEMORY_LIMIT = 100 * 1024 * 1024;
+
   private Logger log;
   private Controller controller;
 
@@ -91,6 +94,12 @@ public class ElasticsearchExporter implements Exporter {
           String.format(
               "Elasticsearch prefix must not contain underscore. Current value: %s",
               configuration.index.prefix));
+    }
+
+    if (configuration.bulk.memoryLimit > RECOMMENDED_MAX_BULK_MEMORY_LIMIT) {
+      log.warn(
+          "The bulk memory limit is set to more than {} bytes. It is recommended to set the limit between 5 to 15 MB.",
+          RECOMMENDED_MAX_BULK_MEMORY_LIMIT);
     }
   }
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -166,10 +166,19 @@ public class ElasticsearchExporterConfiguration {
     public int delay = 5;
     // bulk size before flush
     public int size = 1_000;
+    // memory limit of the bulk in bytes before flush
+    public int memoryLimit = 10 * 1024 * 1024;
 
     @Override
     public String toString() {
-      return "BulkConfiguration{" + "delay=" + delay + ", size=" + size + '}';
+      return "BulkConfiguration{"
+          + "delay="
+          + delay
+          + ", size="
+          + size
+          + ", memoryLimit="
+          + memoryLimit
+          + '}';
     }
   }
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchMetrics.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchMetrics.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.exporter;
 
+import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
 
 public class ElasticsearchMetrics {
@@ -28,6 +29,14 @@ public class ElasticsearchMetrics {
           .labelNames("partition")
           .register();
 
+  private static final Gauge BULK_MEMORY_SIZE =
+      Gauge.build()
+          .namespace("zeebe_elasticsearch_exporter")
+          .name("bulk_memory_size")
+          .help("Exporter bulk memory size")
+          .labelNames("partition")
+          .register();
+
   private final String partitionIdLabel;
 
   public ElasticsearchMetrics(final int partitionId) {
@@ -40,5 +49,9 @@ public class ElasticsearchMetrics {
 
   public void recordBulkSize(final int bulkSize) {
     BULK_SIZE.labels(partitionIdLabel).observe(bulkSize);
+  }
+
+  public void recordBulkMemorySize(final int bulkMemorySize) {
+    BULK_MEMORY_SIZE.labels(partitionIdLabel).set(bulkMemorySize);
   }
 }

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchClientTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchClientTest.java
@@ -21,6 +21,7 @@ import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.value.VariableRecordValue;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Test;
@@ -163,5 +164,44 @@ public class ElasticsearchClientTest extends AbstractElasticsearchExporterIntegr
 
     // then
     assertThat(bulkRequest).hasSize(1);
+  }
+
+  @Test
+  public void shouldFlushOnMemoryLimit() {
+    // given
+    final var bulkMemoryLimit = 1024;
+    final var recordSize = 2;
+
+    configuration.bulk.memoryLimit = bulkMemoryLimit;
+    configuration.bulk.size = Integer.MAX_VALUE;
+    configuration.bulk.delay = Integer.MAX_VALUE;
+
+    final var variableValue1 = "x".repeat(bulkMemoryLimit / recordSize);
+    final var variableValue2 = "y".repeat(bulkMemoryLimit / recordSize);
+    final Function<String, String> jsonRecord =
+        (String value) -> String.format("{\"value\":\"%s\"}", value);
+
+    final VariableRecordValue recordValue = mock(VariableRecordValue.class);
+    when(recordValue.getValue()).thenReturn(variableValue1);
+
+    final Record<VariableRecordValue> recordMock = mock(Record.class);
+    when(recordMock.getKey()).thenReturn(1L);
+    when(recordMock.getPartitionId()).thenReturn(1);
+    when(recordMock.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(recordMock.getValue()).thenReturn(recordValue);
+    when(recordMock.toJson()).thenReturn(jsonRecord.apply(variableValue1));
+
+    // when
+    client.index(recordMock);
+
+    assertThat(client.shouldFlush()).isFalse();
+
+    when(recordMock.getKey()).thenReturn(2L);
+    when(recordMock.toJson()).thenReturn(jsonRecord.apply(variableValue2));
+
+    client.index(recordMock);
+
+    // then
+    assertThat(client.shouldFlush()).isTrue();
   }
 }

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -77,7 +77,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1596196141101,
+  "iteration": 1597737695016,
   "links": [],
   "panels": [
     {
@@ -7187,10 +7187,10 @@
           "dataFormat": "tsbuckets",
           "datasource": "$DS_PROMETHEUS",
           "gridPos": {
-            "h": 9,
-            "w": 12,
+            "h": 10,
+            "w": 8,
             "x": 0,
-            "y": 39
+            "y": 51
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7200,7 +7200,6 @@
             "show": false
           },
           "links": [],
-          "options": {},
           "reverseYBuckets": false,
           "targets": [
             {
@@ -7251,10 +7250,10 @@
           "dataFormat": "tsbuckets",
           "datasource": "$DS_PROMETHEUS",
           "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 39
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 51
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -7264,7 +7263,6 @@
             "show": false
           },
           "links": [],
-          "options": {},
           "reverseYBuckets": false,
           "targets": [
             {
@@ -7306,6 +7304,101 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$DS_PROMETHEUS",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 51
+          },
+          "hiddenSeries": false,
+          "id": 185,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "zeebe_elasticsearch_exporter_bulk_memory_size{namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{pod}} p{{partition}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Elasticsearch Exporter (Bulk Memory Size)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:359",
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:360",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DS_PROMETHEUS",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -7315,9 +7408,10 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 48
+            "y": 61
           },
           "height": "400",
+          "hiddenSeries": false,
           "id": 52,
           "legend": {
             "alignAsTable": true,
@@ -7843,5 +7937,5 @@
   "variables": {
     "list": []
   },
-  "version": 9
+  "version": 11
 }


### PR DESCRIPTION
## Description

* new configuration to limit the memory size of the bulk before flushing it, default is 10 MB
* new metric for the bulk memory size
* adjust documentation and configuration templates

## Related issues

closes #4951 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the release announcement 
