### PR TITLE
Fix race condition between reprocessing and pausing stream processor

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -331,6 +331,10 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
     }
   }
 
+  public Phase getCurrentPhase() {
+    return phase;
+  }
+
   @Override
   public void addFailureListener(final FailureListener failureListener) {
     actor.run(() -> this.failureListener = failureListener);
@@ -359,7 +363,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
         });
   }
 
-  private enum Phase {
+  protected enum Phase {
     REPROCESSING,
     PROCESSING,
     FAILED,

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorLifecycleAware.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorLifecycleAware.java
@@ -12,11 +12,21 @@ public interface StreamProcessorLifecycleAware {
   /** Callback after reprocessing was successful and before regular processing begins */
   default void onRecovered(final ReadonlyProcessingContext context) {}
 
+  /** Callback which is called when StreamProcessor is on closing phase. */
   default void onClose() {}
 
+  /** Callback which is called when the StreamProcessor failed, during startup or processing. */
   default void onFailed() {}
 
+  /**
+   * Callback which is called when the processing is paused, will only called after onRecovered was
+   * called before.
+   */
   default void onPaused() {}
 
+  /**
+   * Callback which is called when the processing is resumed, will only called after onPaused was
+   * called before.
+   */
   default void onResumed() {}
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/EngineReprocessingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/EngineReprocessingTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.streamprocessor;
+
+import static io.zeebe.protocol.record.intent.WorkflowInstanceIntent.ELEMENT_ACTIVATED;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.test.util.stream.StreamWrapperException;
+import java.time.Duration;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class EngineReprocessingTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final BpmnModelInstance SIMPLE_FLOW =
+      Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done();
+  private static final int PARTITION_ID = 1;
+  private static final long MAX_TEST_WAIT_TIME = Duration.ofSeconds(1).toMillis();
+
+  @Rule public EngineRule engineRule = EngineRule.singlePartition();
+
+  @Before
+  public void init() {
+    RecordingExporter.setMaximumWaitTime(MAX_TEST_WAIT_TIME);
+    engineRule.deployment().withXmlResource(SIMPLE_FLOW).deploy();
+    final var instanceCount = 10;
+    IntStream.range(0, instanceCount)
+        .forEach(i -> engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).create());
+
+    Awaitility.await()
+        .until(
+            () ->
+                RecordingExporter.workflowInstanceRecords()
+                    .withElementType(BpmnElementType.PROCESS)
+                    .withIntent(ELEMENT_ACTIVATED)
+                    .limit(instanceCount)
+                    .count(),
+            (count) -> count == instanceCount);
+
+    engineRule.stop();
+  }
+
+  @After
+  public void tearDown() {
+    RecordingExporter.setMaximumWaitTime(RecordingExporter.DEFAULT_MAX_WAIT_TIME);
+  }
+
+  @Test
+  public void shouldReprocess() {
+    // given - reprocess
+    final int lastSize = RecordingExporter.getRecords().size();
+    // we need to reset the record exporter
+    RecordingExporter.reset();
+    engineRule.start();
+
+    // when - then
+    Awaitility.await("Await reprocessing of " + lastSize)
+        .until(() -> RecordingExporter.getRecords().size(), (size) -> size >= lastSize);
+  }
+
+  @Test
+  public void shouldContinueProcessingAfterReprocessing() {
+    // given - reprocess
+    final int lastSize = RecordingExporter.getRecords().size();
+    // we need to reset the record exporter
+    RecordingExporter.reset();
+    engineRule.start();
+
+    Awaitility.await("Await reprocessing of " + lastSize)
+        .until(() -> RecordingExporter.getRecords().size(), (size) -> size >= lastSize);
+
+    // when - then
+    engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+  }
+
+  @Test
+  public void shouldNotContinueProcessingWhenPausedDuringReprocessing() {
+    // given - reprocess
+    final int lastSize = RecordingExporter.getRecords().size();
+    // we need to reset the record exporter
+    RecordingExporter.reset();
+    engineRule.start();
+    engineRule.pauseProcessing(PARTITION_ID);
+
+    // when
+    Awaitility.await("Await reprocessing of " + lastSize)
+        .until(() -> RecordingExporter.getRecords().size(), (size) -> size >= lastSize);
+
+    // then
+    Assert.assertThrows(
+        StreamWrapperException.class,
+        () -> engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).create());
+  }
+
+  @Test
+  public void shouldContinueAfterReprocessWhenProcessingWasResumed() {
+    // given
+    final int lastSize = RecordingExporter.getRecords().size();
+    // we need to reset the record exporter
+    RecordingExporter.reset();
+    engineRule.start();
+    engineRule.pauseProcessing(PARTITION_ID);
+    engineRule.resumeProcessing(PARTITION_ID);
+
+    Awaitility.await("Await reprocessing of " + lastSize)
+        .until(() -> RecordingExporter.getRecords().size(), (size) -> size >= lastSize);
+
+    // when
+    engineRule.workflowInstance().ofBpmnProcessId(PROCESS_ID).create();
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorReprocessingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorReprocessingTest.java
@@ -28,14 +28,19 @@ import io.zeebe.engine.util.StreamProcessorRule;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.test.util.stream.StreamWrapper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InOrder;
+import org.mockito.Mockito;
 import org.mockito.verification.VerificationWithTimeout;
 
 public final class StreamProcessorReprocessingTest {
@@ -84,6 +89,171 @@ public final class StreamProcessorReprocessingTest {
         .processRecord(eq(secondPosition), any(), any(), any(), any());
     inOrder.verify(typedRecordProcessor, TIMEOUT.times(2)).onClose();
 
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldStopProcessingWhenPaused() throws Exception {
+    // given - bunch of events to reprocess
+    IntStream.range(0, 5000)
+        .forEach(i -> streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, i));
+    final long sourceEvent = streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, 1);
+    streamProcessorRule.writeWorkflowInstanceEventWithSource(
+        WorkflowInstanceIntent.ELEMENT_ACTIVATED, 1, sourceEvent);
+
+    Awaitility.await()
+        .until(
+            () ->
+                streamProcessorRule
+                    .events()
+                    .onlyWorkflowInstanceRecords()
+                    .withIntent(ELEMENT_ACTIVATED),
+            StreamWrapper::exists);
+
+    final var onRecoveredLatch = new CountDownLatch(1);
+    final var typedRecordProcessor = mock(TypedRecordProcessor.class);
+    final var streamProcessor =
+        streamProcessorRule.startTypedStreamProcessor(
+            (processors, context) ->
+                processors
+                    .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor)
+                    .withListener(
+                        new StreamProcessorLifecycleAware() {
+                          @Override
+                          public void onRecovered(final ReadonlyProcessingContext context) {
+                            onRecoveredLatch.countDown();
+                          }
+                        }));
+
+    // when
+    streamProcessor.pauseProcessing();
+    final var success = onRecoveredLatch.await(15, TimeUnit.SECONDS);
+
+    // then
+    assertThat(success).isTrue();
+    Mockito.clearInvocations(typedRecordProcessor);
+    streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, 0xcafe);
+
+    verify(typedRecordProcessor, TIMEOUT.times(0))
+        .processRecord(anyLong(), any(), any(), any(), any());
+    verify(typedRecordProcessor, TIMEOUT.times(0)).processRecord(any(), any(), any(), any());
+    verify(typedRecordProcessor, TIMEOUT.times(0)).processRecord(any(), any(), any());
+  }
+
+  @Test
+  public void shouldContinueToProcessWhenResumed() throws Exception {
+    // given - bunch of events to reprocess
+    IntStream.range(0, 5000)
+        .forEach(i -> streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, i));
+    final long sourceEvent = streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, 1);
+    streamProcessorRule.writeWorkflowInstanceEventWithSource(
+        WorkflowInstanceIntent.ELEMENT_ACTIVATED, 1, sourceEvent);
+
+    Awaitility.await()
+        .until(
+            () ->
+                streamProcessorRule
+                    .events()
+                    .onlyWorkflowInstanceRecords()
+                    .withIntent(ELEMENT_ACTIVATED),
+            StreamWrapper::exists);
+
+    // when
+    final var countDownLatch = new CountDownLatch(1);
+    final var typedRecordProcessor = mock(TypedRecordProcessor.class);
+    final var streamProcessor =
+        streamProcessorRule.startTypedStreamProcessor(
+            (processors, context) ->
+                processors
+                    .onEvent(ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor)
+                    .withListener(
+                        new StreamProcessorLifecycleAware() {
+                          @Override
+                          public void onRecovered(final ReadonlyProcessingContext context) {
+                            countDownLatch.countDown();
+                          }
+                        }));
+    streamProcessor.pauseProcessing();
+    streamProcessor.resumeProcessing();
+    final var success = countDownLatch.await(15, TimeUnit.SECONDS);
+
+    // then
+    assertThat(success).isTrue();
+    Mockito.clearInvocations(typedRecordProcessor);
+    streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, 0xcafe);
+
+    verify(typedRecordProcessor, TIMEOUT.times(1))
+        .processRecord(anyLong(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void shouldCallOnPausedAfterOnRecovered() {
+    // given - bunch of events to reprocess
+    IntStream.range(0, 5000)
+        .forEach(i -> streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, i));
+    final long sourceEvent = streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, 1);
+    streamProcessorRule.writeWorkflowInstanceEventWithSource(
+        WorkflowInstanceIntent.ELEMENT_ACTIVATED, 1, sourceEvent);
+
+    Awaitility.await()
+        .until(
+            () ->
+                streamProcessorRule
+                    .events()
+                    .onlyWorkflowInstanceRecords()
+                    .withIntent(ELEMENT_ACTIVATED),
+            StreamWrapper::exists);
+
+    // when
+    final var lifecycleAware = mock(StreamProcessorLifecycleAware.class);
+    final var streamProcessor =
+        streamProcessorRule.startTypedStreamProcessor(
+            (processors, context) -> processors.withListener(lifecycleAware));
+    streamProcessor.pauseProcessing();
+    streamProcessor.resumeProcessing();
+
+    // then
+    final InOrder inOrder = inOrder(lifecycleAware);
+    // reprocessing
+    inOrder.verify(lifecycleAware, TIMEOUT.times(1)).onRecovered(any());
+    inOrder.verify(lifecycleAware, TIMEOUT.times(1)).onPaused();
+    inOrder.verify(lifecycleAware, TIMEOUT.times(1)).onResumed();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldCallOnPausedBeforeOnResumedNoMatterWhenResumedWasCalled() {
+    // given - bunch of events to reprocess
+    IntStream.range(0, 5000)
+        .forEach(i -> streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, i));
+    final long sourceEvent = streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, 1);
+    streamProcessorRule.writeWorkflowInstanceEventWithSource(
+        WorkflowInstanceIntent.ELEMENT_ACTIVATED, 1, sourceEvent);
+
+    Awaitility.await()
+        .until(
+            () ->
+                streamProcessorRule
+                    .events()
+                    .onlyWorkflowInstanceRecords()
+                    .withIntent(ELEMENT_ACTIVATED),
+            StreamWrapper::exists);
+
+    // when
+    final var lifecycleAware = mock(StreamProcessorLifecycleAware.class);
+    final var streamProcessor =
+        streamProcessorRule.startTypedStreamProcessor(
+            (processors, context) -> processors.withListener(lifecycleAware));
+    streamProcessor.resumeProcessing();
+    streamProcessor.pauseProcessing();
+    streamProcessor.resumeProcessing();
+
+    // then
+    final InOrder inOrder = inOrder(lifecycleAware);
+    // reprocessing
+    inOrder.verify(lifecycleAware, TIMEOUT.times(1)).onRecovered(any());
+    inOrder.verify(lifecycleAware, TIMEOUT.times(1)).onPaused();
+    inOrder.verify(lifecycleAware, TIMEOUT.times(1)).onResumed();
     inOrder.verifyNoMoreInteractions();
   }
 
@@ -339,6 +509,7 @@ public final class StreamProcessorReprocessingTest {
     streamProcessorRule.writeWorkflowInstanceEvent(
         ELEMENT_ACTIVATING); // should be processed and included in the snapshot
     onProcessedListenerLatch.await();
+    streamProcessorRule.snapshot();
     streamProcessorRule.closeStreamProcessor();
 
     // when
@@ -395,6 +566,7 @@ public final class StreamProcessorReprocessingTest {
     final long snapshotPosition =
         streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, 1);
     onProcessedListenerLatch.await();
+    streamProcessorRule.snapshot();
     streamProcessorRule.closeStreamProcessor();
     final long lastSourceEvent =
         streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, 1);

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -276,6 +276,13 @@ public final class EngineRule extends ExternalResource {
     return environmentRule.getCommandResponseWriter();
   }
 
+  public void pauseProcessing(final int partitionId) {
+    environmentRule.pauseProcessing(partitionId);
+  }
+
+  public void resumeProcessing(final int partitionId) {
+    environmentRule.resumeProcessing(partitionId);
+  }
   /////////////////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////// PROCESSOR EXPORTER CROSSOVER ///////////////////////////////////
   /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
@@ -74,6 +74,18 @@ public class StreamProcessingComposite {
         }));
   }
 
+  public void pauseProcessing(final int partitionId) {
+    streams.pauseProcessing(getLogName(partitionId));
+  }
+
+  public void resumeProcessing(final int partitionId) {
+    streams.resumeProcessing(getLogName(partitionId));
+  }
+
+  public void snapshot(final int partitionId) {
+    streams.snapshot(getLogName(partitionId));
+  }
+
   public void closeStreamProcessor(final int partitionId) {
     try {
       streams.closeProcessor(getLogName(partitionId));

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -133,6 +133,14 @@ public final class StreamProcessorRule implements TestRule {
     return streamProcessingComposite.startTypedStreamProcessor(partitionId, factory);
   }
 
+  public void pauseProcessing(final int partitionId) {
+    streamProcessingComposite.pauseProcessing(partitionId);
+  }
+
+  public void resumeProcessing(final int partitionId) {
+    streamProcessingComposite.resumeProcessing(partitionId);
+  }
+
   public void closeStreamProcessor(final int partitionId) {
     streamProcessingComposite.closeStreamProcessor(partitionId);
   }
@@ -220,6 +228,11 @@ public final class StreamProcessorRule implements TestRule {
       final Intent intent,
       final UnpackedObject value) {
     return streamProcessingComposite.writeCommand(requestStreamId, requestId, intent, value);
+  }
+
+  public void snapshot() {
+    final var partitionId = this.startPartitionId;
+    streamProcessingComposite.snapshot(partitionId);
   }
 
   private class SetupRule extends ExternalResource {

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -37,6 +37,7 @@ import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.test.util.AutoCloseableRule;
+import io.zeebe.util.FileUtil;
 import io.zeebe.util.Loggers;
 import io.zeebe.util.sched.ActorScheduler;
 import java.io.IOException;
@@ -44,7 +45,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -54,7 +54,8 @@ import java.util.stream.StreamSupport;
 import org.junit.rules.TemporaryFolder;
 
 public final class TestStreams {
-  static final Duration SNAPSHOT_INTERVAL = Duration.ofMinutes(1);
+
+  private static final String SNAPSHOT_FOLDER = "snapshot";
   private static final Map<Class<?>, ValueType> VALUE_TYPES = new HashMap<>();
 
   static {
@@ -69,7 +70,7 @@ public final class TestStreams {
   private final Consumer<TypedRecord> mockOnProcessedListener;
   private final Map<String, LogContext> logContextMap = new HashMap<>();
   private final Map<String, ProcessorContext> streamContextMap = new HashMap<>();
-  private StreamProcessor streamProcessor;
+  private boolean snapshotWasTaken = false;
 
   public TestStreams(
       final TemporaryFolder dataDirectory,
@@ -198,20 +199,25 @@ public final class TestStreams {
       final ZeebeDbFactory zeebeDbFactory,
       final TypedRecordProcessorFactory typedRecordProcessorFactory) {
     final SynchronousLogStream stream = getLogStream(log);
-    return buildStreamProcessor(
-        stream, zeebeDbFactory, typedRecordProcessorFactory, SNAPSHOT_INTERVAL);
+    return buildStreamProcessor(stream, zeebeDbFactory, typedRecordProcessorFactory);
   }
 
   private StreamProcessor buildStreamProcessor(
       final SynchronousLogStream stream,
       final ZeebeDbFactory zeebeDbFactory,
-      final TypedRecordProcessorFactory factory,
-      final Duration snapshotInterval) {
+      final TypedRecordProcessorFactory factory) {
     final var storage = createRuntimeFolder(stream);
+    final var snapshot = storage.getParent().resolve(SNAPSHOT_FOLDER);
+
+    final ZeebeDb<?> zeebeDb;
+    if (snapshotWasTaken) {
+      zeebeDb = zeebeDbFactory.createDb(snapshot.toFile());
+    } else {
+      zeebeDb = zeebeDbFactory.createDb(storage.toFile());
+    }
     final String logName = stream.getLogName();
 
-    final var zeebeDb = zeebeDbFactory.createDb(storage.toFile());
-    streamProcessor =
+    final StreamProcessor streamProcessor =
         StreamProcessor.builder()
             .logStream(stream.getAsyncLogStream())
             .zeebeDb(zeebeDb)
@@ -224,11 +230,27 @@ public final class TestStreams {
 
     final LogContext context = logContextMap.get(logName);
     final ProcessorContext processorContext =
-        ProcessorContext.createStreamContext(context, streamProcessor, zeebeDb);
+        ProcessorContext.createStreamContext(context, streamProcessor, zeebeDb, storage, snapshot);
     streamContextMap.put(logName, processorContext);
     closeables.manage(processorContext);
 
     return streamProcessor;
+  }
+
+  public void pauseProcessing(final String streamName) {
+    streamContextMap.get(streamName).streamProcessor.pauseProcessing();
+    LOG.info("Paused processing for stream {}", streamName);
+  }
+
+  public void resumeProcessing(final String streamName) {
+    streamContextMap.get(streamName).streamProcessor.resumeProcessing();
+    LOG.info("Resume processing for stream {}", streamName);
+  }
+
+  public void snapshot(final String streamName) {
+    streamContextMap.get(streamName).snapshot();
+    snapshotWasTaken = true;
+    LOG.info("Snapshot database for stream {}", streamName);
   }
 
   public void closeProcessor(final String streamName) throws Exception {
@@ -255,8 +277,8 @@ public final class TestStreams {
   public static class FluentLogWriter {
 
     protected final RecordMetadata metadata = new RecordMetadata();
-    protected UnpackedObject value;
     protected final LogStreamRecordWriter writer;
+    protected UnpackedObject value;
     protected long key = -1;
     private long sourceRecordPosition = -1;
 
@@ -368,27 +390,41 @@ public final class TestStreams {
   }
 
   private static final class ProcessorContext implements AutoCloseable {
-
     private final LogContext logContext;
     private final ZeebeDb zeebeDb;
-
-    private boolean closed = false;
     private final StreamProcessor streamProcessor;
+    private final Path runtimePath;
+    private final Path snapshotPath;
+    private boolean closed = false;
 
     private ProcessorContext(
-        final LogContext logContext, final StreamProcessor streamProcessor, final ZeebeDb zeebeDb) {
+        final LogContext logContext,
+        final StreamProcessor streamProcessor,
+        final ZeebeDb zeebeDb,
+        final Path runtimePath,
+        final Path snapshotPath) {
       this.logContext = logContext;
       this.streamProcessor = streamProcessor;
       this.zeebeDb = zeebeDb;
+      this.runtimePath = runtimePath;
+      this.snapshotPath = snapshotPath;
     }
 
     public static ProcessorContext createStreamContext(
-        final LogContext logContext, final StreamProcessor streamProcessor, final ZeebeDb zeebeDb) {
-      return new ProcessorContext(logContext, streamProcessor, zeebeDb);
+        final LogContext logContext,
+        final StreamProcessor streamProcessor,
+        final ZeebeDb zeebeDb,
+        final Path runtimePath,
+        final Path snapshotPath) {
+      return new ProcessorContext(logContext, streamProcessor, zeebeDb, runtimePath, snapshotPath);
     }
 
     public SynchronousLogStream getLogStream() {
       return logContext.getLogStream();
+    }
+
+    public void snapshot() {
+      zeebeDb.createSnapshot(snapshotPath.toFile());
     }
 
     @Override
@@ -399,6 +435,9 @@ public final class TestStreams {
       Loggers.IO_LOGGER.debug("Close stream processor");
       streamProcessor.closeAsync().join();
       zeebeDb.close();
+      if (runtimePath.toFile().exists()) {
+        FileUtil.deleteFolder(runtimePath);
+      }
       closed = true;
     }
   }

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
@@ -52,12 +52,19 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public final class RecordingExporter implements Exporter {
-  private static final long MAX_WAIT = Duration.ofSeconds(5).toMillis();
+  public static final long DEFAULT_MAX_WAIT_TIME = Duration.ofSeconds(5).toMillis();
+
   private static final List<Record<?>> RECORDS = new CopyOnWriteArrayList<>();
   private static final Lock LOCK = new ReentrantLock();
   private static final Condition IS_EMPTY = LOCK.newCondition();
 
+  private static long maximumWaitTime = DEFAULT_MAX_WAIT_TIME;
+
   private Controller controller;
+
+  public static void setMaximumWaitTime(final long maximumWaitTime) {
+    RecordingExporter.maximumWaitTime = maximumWaitTime;
+  }
 
   @Override
   public void open(final Controller controller) {
@@ -241,7 +248,7 @@ public final class RecordingExporter implements Exporter {
       LOCK.lock();
       try {
         long now = System.currentTimeMillis();
-        final long endTime = now + MAX_WAIT;
+        final long endTime = now + maximumWaitTime;
         while (isEmpty() && endTime > now) {
           final long waitTime = endTime - now;
           try {


### PR DESCRIPTION
## Description

Add new reprocessing tests to reproduce two bugs, which happen during reprocessing and pausing/resuming the stream processor. Changed default behavior of stopping stream processor, after closing stream processor runtime is deleted.
Deletion of runtime actually causes reprocessing, before it hasn't happened.
Add new method to take snapshot explicitly in test, to test recovery with snapshot.

The bug issue happened during reprocessing, when the stream processor was paused. It happen that after reprocessing the state was reset to processing, instead of paused. If resuming before reprocessing was done, this caused NPE's, since processors/listeners haven't been initialized yet.

Changed stream processor life cycle aware guarantees, it is now guaranteed that `onRecovered` is called as first method. After that `onPaused` can happen and `onResume`. Before we haven't had these guarantees.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/5156
closes https://github.com/zeebe-io/zeebe/issues/5149

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
