### PR TITLE
chore(ci): add flaky test extraction plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,7 @@ pipeline {
 
                 stage('Unit (Java)') {
                     environment {
-                      SUREFIRE_REPORT_NAME_SUFFIX = 'java'
+                      SUREFIRE_REPORT_NAME_SUFFIX = 'java-testrun'
                     }
 
                     steps {
@@ -143,13 +143,13 @@ pipeline {
 
                     post {
                         always {
-                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}.xml", keepLongStdio: true
+                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
                         }
                     }
                 }
                 stage('Unit 8 (Java 8)') {
                     environment {
-                      SUREFIRE_REPORT_NAME_SUFFIX = 'java8'
+                      SUREFIRE_REPORT_NAME_SUFFIX = 'java8-testrun'
                     }
 
                     steps {
@@ -162,14 +162,14 @@ pipeline {
 
                     post {
                         always {
-                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}.xml", keepLongStdio: true
+                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
                         }
                     }
                 }
 
                 stage('IT (Java)') {
                     environment {
-                      SUREFIRE_REPORT_NAME_SUFFIX = 'it'
+                      SUREFIRE_REPORT_NAME_SUFFIX = 'it-testrun'
                     }
 
                     steps {
@@ -182,7 +182,7 @@ pipeline {
 
                     post {
                         always {
-                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}.xml", keepLongStdio: true
+                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
                         }
                     }
                 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1176,6 +1176,20 @@
           </executions>
         </plugin>
 
+        <plugin>
+          <groupId>io.zeebe</groupId>
+          <artifactId>flaky-test-extractor-maven-plugin</artifactId>
+          <version>2.0.0</version>
+          <executions>
+            <execution>
+              <phase>post-integration-test</phase>
+              <goals>
+                <goal>extract-flaky-tests</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
       </plugins>
 
     </pluginManagement>
@@ -1219,6 +1233,11 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>io.zeebe</groupId>
+        <artifactId>flaky-test-extractor-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## Description

* Adds the flaky test extractor plugin
* changes suffix for test runs

The flaky test extractor plugin:
* It scans a folder for Surefire test run XML files
* If it finds flaky test results in a file `TEST-com.example.Test-{SUFFIX}.xml`
* It creates a new file `TEST-com.example.Test-{SUFFIX}-FLAKY.xml`

Therefore the wildcards were adapted and the suffix was made a little more descriptive,

## Related issues

closes #4897 

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
