### PR TITLE
Benchmark worker completes jobs async

### DIFF
--- a/benchmarks/project/src/main/java/io/zeebe/DelayedCommandSender.java
+++ b/benchmarks/project/src/main/java/io/zeebe/DelayedCommandSender.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe;
+
+import io.zeebe.Worker.DelayedCommand;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Future;
+
+public class DelayedCommandSender extends Thread {
+
+  private volatile boolean shuttingDown = false;
+  private final BlockingDeque<DelayedCommand> commands;
+  private final BlockingQueue<Future<?>> requestFutures;
+
+  public DelayedCommandSender(
+      final BlockingDeque<DelayedCommand> delayedCommands,
+      final BlockingQueue<Future<?>> requestFutures) {
+    this.commands = delayedCommands;
+    this.requestFutures = requestFutures;
+  }
+
+  @Override
+  public void run() {
+    while (!shuttingDown) {
+      try {
+        final var delayedCommand = commands.takeFirst();
+        if (!delayedCommand.hasExpired()) {
+          commands.addFirst(delayedCommand);
+        } else {
+          requestFutures.add(delayedCommand.getCommand().send());
+        }
+      } catch (InterruptedException e) {
+        // ignore and retry
+      }
+    }
+  }
+
+  public void close() {
+    shuttingDown = true;
+    interrupt();
+  }
+}

--- a/benchmarks/project/src/main/java/io/zeebe/config/WorkerCfg.java
+++ b/benchmarks/project/src/main/java/io/zeebe/config/WorkerCfg.java
@@ -27,6 +27,7 @@ public class WorkerCfg {
   private int capacity;
   private Duration pollingDelay;
   private Duration completionDelay;
+  private boolean completeJobsAsync;
 
   private String payloadPath;
 
@@ -84,5 +85,13 @@ public class WorkerCfg {
 
   public void setPayloadPath(String payloadPath) {
     this.payloadPath = payloadPath;
+  }
+
+  public boolean isCompleteJobsAsync() {
+    return completeJobsAsync;
+  }
+
+  public void setCompleteJobsAsync(boolean completeJobsAsync) {
+    this.completeJobsAsync = completeJobsAsync;
   }
 }

--- a/benchmarks/project/src/main/resources/application.conf
+++ b/benchmarks/project/src/main/resources/application.conf
@@ -21,6 +21,7 @@ app {
     capacity = 30
     pollingDelay = 1s
     completionDelay = 300ms
+    completeJobsAsync = false
     payloadPath = "bpmn/big_payload.json"
   }
 }


### PR DESCRIPTION
## Description

This PR adds support to complete jobs async in our benchmark's job worker. By default, this is disabled for backwards functional equality, but can be enabled using `app.worker.completeJobsAsync`.

This ability can be useful in benchmarks where workers are expected to have a specific average duration between activating and completing a specific job. When disabled, the worker may activate a batch of jobs but processes these individually, each time sleeping the `app.worker.completionDelay` time before completing the next. This results in a longer job lifetime for the jobs that were activated in the batch but are worked on last. Enabling `app.worker.completeJobsAsync` removes this blocking between the jobs and tries to complete jobs as soon as that specific job's completion delay has expired.

## Related issues

This is useful in the benchmarks for #5132

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to backport the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the release announcement 
