### PR TITLE
[Backport 0.23] Elasticsearch exporter: limit the memory size of a bulk

### DIFF
--- a/broker/src/test/resources/system/elasticexporter.yaml
+++ b/broker/src/test/resources/system/elasticexporter.yaml
@@ -1,4 +1,3 @@
-
 zeebe:
   broker:
     exporters:
@@ -16,6 +15,7 @@ zeebe:
         #   bulk:
         #     delay: 5
         #     size: 1000
+        #     memoryLimit: 10485760
         #
           authentication:
             username: elastic

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -301,6 +301,7 @@
         #   bulk:
         #     delay: 5
         #     size: 1000
+        #     memoryLimit: 10485760
         #
         #   authentication:
         #     username: elastic

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -258,6 +258,7 @@
         #   bulk:
         #     delay: 5
         #     size: 1000
+        #     memoryLimit: 10485760
         #
         #   authentication:
         #     username: elastic

--- a/exporters/elasticsearch-exporter/README.md
+++ b/exporters/elasticsearch-exporter/README.md
@@ -38,24 +38,27 @@ it should be flushed (regardless of size) can be controlled by configuration.
 For example:
 
 ```yaml
-...  
+...
   exporters:
     elasticsearch:
       args:
         delay: 5
         size: 1000
+        memoryLimit: 10485760
 ```
 
 With the above example, the exporter would aggregate records and flush them to Elasticsearch
 either:
   1. when it has aggregated 1000 records
-  2. 5 seconds have elapsed since the last flush (regardless of how many records were aggregated)
+  2. when the batch memory size exceeds 10 MB
+  3. 5 seconds have elapsed since the last flush (regardless of how many records were aggregated)
 
 More specifically, each option configures the following:
 
 * `delay` (`integer`): a specific delay, in seconds, before we force flush the current batch. This ensures
 that even when we have low traffic of records we still export every once in a while.
-* `size` (`integer`): how big a batch should be before we export.
+* `size` (`integer`): how many records a batch should have before we export.
+* `memoryLimit` (`integer`): the size of the bulk, in bytes, before we export.
 
 ### Index
 
@@ -74,11 +77,11 @@ For example:
         index:
           prefix: zeebe-record
           createTemplate: true
-          
+
           command: false
           event: true
           rejection: false
-          
+
           deployment: false
           incident: true
           job: false
@@ -118,28 +121,29 @@ Here is a complete, default configuration example:
       #
       # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_..."
       #
-      
+
       className: io.zeebe.exporter.ElasticsearchExporter
-     
+
       args:
         url: http://localhost:9200
-     
+
         bulk:
           delay: 5
           size: 1000
-     
+          memoryLimit: 10485760
+
         authentication:
           username: elastic
           password: changeme
-     
+
         index:
           prefix: zeebe-record
           createTemplate: true
-     
+
           command: false
           event: true
           rejection: false
-     
+
           deployment: true
           error: true
           incident: true
@@ -152,7 +156,7 @@ Here is a complete, default configuration example:
           workflowInstance: true
           workflowInstanceCreation: false
           workflowInstanceSubscription: false
-     
+
           ignoreVariablesAbove: 32677
 
 ```

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
@@ -22,6 +22,9 @@ public class ElasticsearchExporter implements Exporter {
 
   public static final String ZEEBE_RECORD_TEMPLATE_JSON = "/zeebe-record-template.json";
 
+  // by default, the bulk request may not be bigger than 100MB
+  private static final int RECOMMENDED_MAX_BULK_MEMORY_LIMIT = 100 * 1024 * 1024;
+
   private Logger log;
   private Controller controller;
 
@@ -50,6 +53,12 @@ public class ElasticsearchExporter implements Exporter {
           String.format(
               "Elasticsearch prefix must not contain underscore. Current value: %s",
               configuration.index.prefix));
+    }
+
+    if (configuration.bulk.memoryLimit > RECOMMENDED_MAX_BULK_MEMORY_LIMIT) {
+      log.warn(
+          "The bulk memory limit is set to more than {} bytes. It is recommended to set the limit between 5 to 15 MB.",
+          RECOMMENDED_MAX_BULK_MEMORY_LIMIT);
     }
   }
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -166,10 +166,19 @@ public class ElasticsearchExporterConfiguration {
     public int delay = 5;
     // bulk size before flush
     public int size = 1_000;
+    // memory limit of the bulk in bytes before flush
+    public int memoryLimit = 10 * 1024 * 1024;
 
     @Override
     public String toString() {
-      return "BulkConfiguration{" + "delay=" + delay + ", size=" + size + '}';
+      return "BulkConfiguration{"
+          + "delay="
+          + delay
+          + ", size="
+          + size
+          + ", memoryLimit="
+          + memoryLimit
+          + '}';
     }
   }
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchMetrics.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchMetrics.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.exporter;
 
+import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
 
 public class ElasticsearchMetrics {
@@ -28,6 +29,14 @@ public class ElasticsearchMetrics {
           .labelNames("partition")
           .register();
 
+  private static final Gauge BULK_MEMORY_SIZE =
+      Gauge.build()
+          .namespace("zeebe_elasticsearch_exporter")
+          .name("bulk_memory_size")
+          .help("Exporter bulk memory size")
+          .labelNames("partition")
+          .register();
+
   private final String partitionIdLabel;
 
   public ElasticsearchMetrics(final int partitionId) {
@@ -40,5 +49,9 @@ public class ElasticsearchMetrics {
 
   public void recordBulkSize(final int bulkSize) {
     BULK_SIZE.labels(partitionIdLabel).observe(bulkSize);
+  }
+
+  public void recordBulkMemorySize(final int bulkMemorySize) {
+    BULK_MEMORY_SIZE.labels(partitionIdLabel).set(bulkMemorySize);
   }
 }

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchClientTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/ElasticsearchClientTest.java
@@ -20,6 +20,7 @@ import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.value.VariableRecordValue;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +35,7 @@ public class ElasticsearchClientTest {
   private ElasticsearchExporterConfiguration configuration;
   private Logger logSpy;
   private ElasticsearchClient client;
-  private BulkRequest bulkRequest = new BulkRequest();
+  private final BulkRequest bulkRequest = new BulkRequest();
 
   @Before
   public void setUp() {
@@ -123,5 +124,46 @@ public class ElasticsearchClientTest {
 
     // then
     assertThat(bulkRequest.numberOfActions()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldFlushOnMemoryLimit() {
+    // given
+    final var bulkMemoryLimit = 1024;
+    final var recordSize = 2;
+
+    configuration.bulk.memoryLimit = bulkMemoryLimit;
+    configuration.bulk.size = Integer.MAX_VALUE;
+    configuration.bulk.delay = Integer.MAX_VALUE;
+
+    final var variableValue1 = "x".repeat(bulkMemoryLimit / recordSize);
+    final var variableValue2 = "y".repeat(bulkMemoryLimit / recordSize);
+    final Function<String, String> jsonRecord =
+        (String value) -> String.format("{\"value\":\"%s\"}", value);
+
+    final VariableRecordValue recordValue = mock(VariableRecordValue.class);
+    when(recordValue.getValue()).thenReturn(variableValue1);
+
+    final Record<VariableRecordValue> recordMock = mock(Record.class);
+    when(recordMock.getKey()).thenReturn(1L);
+    when(recordMock.getPosition()).thenReturn(1L);
+    when(recordMock.getPartitionId()).thenReturn(1);
+    when(recordMock.getValueType()).thenReturn(ValueType.VARIABLE);
+    when(recordMock.getValue()).thenReturn(recordValue);
+    when(recordMock.toJson()).thenReturn(jsonRecord.apply(variableValue1));
+
+    // when
+    client.index(recordMock);
+
+    assertThat(client.shouldFlush()).isFalse();
+
+    when(recordMock.getKey()).thenReturn(2L);
+    when(recordMock.getPosition()).thenReturn(2L);
+    when(recordMock.toJson()).thenReturn(jsonRecord.apply(variableValue2));
+
+    client.index(recordMock);
+
+    // then
+    assertThat(client.shouldFlush()).isTrue();
   }
 }

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -11,6 +11,18 @@
   ],
   "__requires": [
     {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar Gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
@@ -64,7 +76,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1584614330956,
+  "iteration": 1597737695016,
   "links": [],
   "panels": [
     {
@@ -4810,10 +4822,10 @@
           "dataFormat": "tsbuckets",
           "datasource": "$DS_PROMETHEUS",
           "gridPos": {
-            "h": 9,
-            "w": 12,
+            "h": 10,
+            "w": 8,
             "x": 0,
-            "y": 39
+            "y": 51
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -4823,7 +4835,6 @@
             "show": false
           },
           "links": [],
-          "options": {},
           "reverseYBuckets": false,
           "targets": [
             {
@@ -4874,10 +4885,10 @@
           "dataFormat": "tsbuckets",
           "datasource": "$DS_PROMETHEUS",
           "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 12,
-            "y": 39
+            "h": 10,
+            "w": 8,
+            "x": 8,
+            "y": 51
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -4887,7 +4898,6 @@
             "show": false
           },
           "links": [],
-          "options": {},
           "reverseYBuckets": false,
           "targets": [
             {
@@ -4929,6 +4939,101 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$DS_PROMETHEUS",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 16,
+            "y": 51
+          },
+          "hiddenSeries": false,
+          "id": 185,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "zeebe_elasticsearch_exporter_bulk_memory_size{namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{pod}} p{{partition}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Elasticsearch Exporter (Bulk Memory Size)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:359",
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:360",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DS_PROMETHEUS",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -4938,9 +5043,10 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 48
+            "y": 61
           },
           "height": "400",
+          "hiddenSeries": false,
           "id": 52,
           "legend": {
             "alignAsTable": true,
@@ -5164,5 +5270,5 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "I4lo7_EZk",
-  "version": 1
+  "version": 11
 }


### PR DESCRIPTION
## Description

Backport of #5190 

## Related issues

closes #4951