### PR TITLE
Fix flaky StreamProcessor test

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
@@ -686,8 +686,8 @@ public final class StreamProcessorTest {
 
     @Override
     public void accept(final TypedRecord typedRecord) {
-      getLatch().countDown();
       lastProcessedRecord = typedRecord;
+      getLatch().countDown();
     }
 
     private AwaitableProcessedListener expect(final int expectedCount) {


### PR DESCRIPTION
## Description

 Fixes race condition between countDown latch and assign field
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #4544 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
