### PR TITLE
Use generic type instead of raw type in Export Interface

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/exporter/debug/DebugHttpExporter.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/debug/DebugHttpExporter.java
@@ -31,7 +31,7 @@ public final class DebugHttpExporter implements Exporter {
   }
 
   @Override
-  public void export(final Record record) {
+  public void export(final Record<?> record) {
     try {
       httpServer.add(record);
     } catch (final Exception e) {

--- a/broker/src/main/java/io/zeebe/broker/exporter/debug/DebugLogExporter.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/debug/DebugLogExporter.java
@@ -71,7 +71,7 @@ public class DebugLogExporter implements Exporter {
   }
 
   @Override
-  public void export(final Record record) {
+  public void export(final Record<?> record) {
     try {
       logger.log("{}", objectMapper.writeValueAsString(record));
     } catch (final JsonProcessingException e) {

--- a/broker/src/main/java/io/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -56,7 +56,7 @@ public class MetricsExporter implements Exporter {
   }
 
   @Override
-  public void export(final Record record) {
+  public void export(final Record<?> record) {
     if (record.getRecordType() != RecordType.EVENT) {
       controller.updateLastExportedRecordPosition(record.getPosition());
       return;

--- a/broker/src/test/java/io/zeebe/broker/exporter/ExporterManagerPartitionTest.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/ExporterManagerPartitionTest.java
@@ -93,7 +93,7 @@ public final class ExporterManagerPartitionTest {
     }
 
     @Override
-    public void export(final Record record) {
+    public void export(final Record<?> record) {
       if (record.getValueType() == ValueType.JOB && record.getIntent() == JobIntent.CREATED) {
         EXPORT_LATCH.countDown();
       }

--- a/broker/src/test/java/io/zeebe/broker/exporter/repo/ExporterRepositoryTest.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/repo/ExporterRepositoryTest.java
@@ -148,6 +148,6 @@ public final class ExporterRepositoryTest {
     }
 
     @Override
-    public void export(final Record record) {}
+    public void export(final Record<?> record) {}
   }
 }

--- a/broker/src/test/java/io/zeebe/broker/exporter/util/ControlledTestExporter.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/util/ControlledTestExporter.java
@@ -16,13 +16,13 @@ import java.util.List;
 import java.util.function.Consumer;
 
 public class ControlledTestExporter implements Exporter {
-  private final List<Record> exportedRecords = new ArrayList<>();
+  private final List<Record<?>> exportedRecords = new ArrayList<>();
 
   private boolean shouldAutoUpdatePosition;
   private Consumer<Context> onConfigure;
   private Consumer<Controller> onOpen;
   private Runnable onClose;
-  private Consumer<Record> onExport;
+  private Consumer<Record<?>> onExport;
 
   private Context context;
   private Controller controller;
@@ -47,7 +47,7 @@ public class ControlledTestExporter implements Exporter {
     return this;
   }
 
-  public ControlledTestExporter onExport(final Consumer<Record> callback) {
+  public ControlledTestExporter onExport(final Consumer<Record<?>> callback) {
     onExport = callback;
     return this;
   }
@@ -68,7 +68,7 @@ public class ControlledTestExporter implements Exporter {
     this.controller = controller;
   }
 
-  public List<Record> getExportedRecords() {
+  public List<Record<?>> getExportedRecords() {
     return exportedRecords;
   }
 
@@ -98,8 +98,8 @@ public class ControlledTestExporter implements Exporter {
   }
 
   @Override
-  public void export(final Record record) {
-    final Record copiedRecord = record.clone();
+  public void export(final Record<?> record) {
+    final Record<?> copiedRecord = record.clone();
     if (onExport != null) {
       onExport.accept(copiedRecord);
     }

--- a/broker/src/test/java/io/zeebe/broker/exporter/util/PojoConfigurationExporter.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/util/PojoConfigurationExporter.java
@@ -21,13 +21,13 @@ public final class PojoConfigurationExporter implements Exporter {
   }
 
   @Override
-  public void export(final Record record) {}
+  public void export(final Record<?> record) {}
 
   public PojoExporterConfiguration getConfiguration() {
     return configuration;
   }
 
-  public final class PojoExporterConfiguration {
+  public static final class PojoExporterConfiguration {
 
     private String foo = "";
     private int x;
@@ -58,7 +58,7 @@ public final class PojoConfigurationExporter implements Exporter {
     }
   }
 
-  public final class PojoExporterConfigurationPart {
+  public static final class PojoExporterConfigurationPart {
     private String bar;
     private double y;
 

--- a/broker/src/test/java/io/zeebe/broker/exporter/util/TestJarExporter.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/util/TestJarExporter.java
@@ -15,5 +15,5 @@ public final class TestJarExporter implements Exporter {
   public static final String FOO = "bar";
 
   @Override
-  public void export(final Record record) {}
+  public void export(final Record<?> record) {}
 }

--- a/exporter-api/src/main/java/io/zeebe/exporter/api/Exporter.java
+++ b/exporter-api/src/main/java/io/zeebe/exporter/api/Exporter.java
@@ -72,5 +72,5 @@ public interface Exporter {
    *
    * @param record the record to export
    */
-  void export(Record record);
+  void export(Record<?> record);
 }

--- a/exporter-api/src/test/java/io/zeebe/exporter/api/ExporterTest.java
+++ b/exporter-api/src/test/java/io/zeebe/exporter/api/ExporterTest.java
@@ -37,7 +37,7 @@ public final class ExporterTest {
           }
 
           @Override
-          public void export(final Record record) {}
+          public void export(final Record<?> record) {}
         };
 
     // then

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporter.java
@@ -75,7 +75,7 @@ public class ElasticsearchExporter implements Exporter {
   }
 
   @Override
-  public void export(final Record record) {
+  public void export(final Record<?> record) {
     if (!indexTemplatesCreated) {
       createIndexTemplates();
     }
@@ -188,7 +188,7 @@ public class ElasticsearchExporter implements Exporter {
     }
   }
 
-  private class ElasticsearchRecordFilter implements Context.RecordFilter {
+  private static class ElasticsearchRecordFilter implements Context.RecordFilter {
 
     private final ElasticsearchExporterConfiguration configuration;
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
@@ -180,7 +180,7 @@ public final class ClusteredDataDeletionTest {
   }
 
   public static class TestExporter implements Exporter {
-    static final List<Record> RECORDS = new CopyOnWriteArrayList<>();
+    static final List<Record<?>> RECORDS = new CopyOnWriteArrayList<>();
     private Controller controller;
 
     @Override
@@ -189,7 +189,7 @@ public final class ClusteredDataDeletionTest {
     }
 
     @Override
-    public void export(final Record record) {
+    public void export(final Record<?> record) {
       RECORDS.add(record);
       controller.updateLastExportedRecordPosition(record.getPosition());
     }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SingleBrokerDataDeletionTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SingleBrokerDataDeletionTest.java
@@ -219,7 +219,7 @@ public class SingleBrokerDataDeletionTest {
   }
 
   public static class ControllableExporter implements Exporter {
-    static final List<Record> NOT_EXPORTED_RECORDS = new CopyOnWriteArrayList<>();
+    static final List<Record<?>> NOT_EXPORTED_RECORDS = new CopyOnWriteArrayList<>();
     static volatile boolean shouldExport = true;
 
     static final AtomicLong EXPORTED_RECORDS = new AtomicLong(0);
@@ -236,7 +236,7 @@ public class SingleBrokerDataDeletionTest {
     }
 
     @Override
-    public void export(final Record record) {
+    public void export(final Record<?> record) {
       if (shouldExport) {
         controller.updateLastExportedRecordPosition(record.getPosition());
       } else {

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
@@ -65,7 +65,7 @@ public final class RecordingExporter implements Exporter {
   }
 
   @Override
-  public void export(final Record record) {
+  public void export(final Record<?> record) {
     LOCK.lock();
     try {
       RECORDS.add(record.clone());


### PR DESCRIPTION
## Description
Changes raw type to generic wildcard type in export interface. Using raw type is in general bad practice and should be avoided. It was introduced by java to be backwards compatible with older java code. 

For more information see:

 * http://www.javapractices.com/topic/TopicAction.do?Id=224
 * https://www.programcreek.com/2013/12/raw-type-set-vs-unbounded-wildcard-set/
 * https://docs.oracle.com/javase/tutorial/java/generics/rawTypes.html

This removes then also unnecessary java warning we had during build and warnings in intellij.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/4275

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
