### PR TITLE
chore(atomix): allow backwards compat. proto changes

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -25,7 +25,8 @@ import io.atomix.cluster.messaging.ManagedUnicastService;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.messaging.UnicastService;
 import io.atomix.utils.net.Address;
-import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.FallbackNamespace;
+import io.atomix.utils.serializer.NamespaceImpl;
 import io.atomix.utils.serializer.Namespaces;
 import io.atomix.utils.serializer.Serializer;
 import io.netty.bootstrap.Bootstrap;
@@ -56,24 +57,22 @@ public class NettyUnicastService implements ManagedUnicastService {
   private static final Logger LOGGER = LoggerFactory.getLogger(NettyUnicastService.class);
   private static final Serializer SERIALIZER =
       Serializer.using(
-          Namespace.builder()
-              .register(Namespaces.BASIC)
-              .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
-              .register(Message.class)
-              .register(new AddressSerializer(), Address.class)
-              .setCompatible(true)
-              .build());
+          new FallbackNamespace(
+              new NamespaceImpl.Builder()
+                  .register(Namespaces.BASIC)
+                  .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+                  .register(Message.class)
+                  .register(new AddressSerializer(), Address.class)));
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   private final Address address;
   private final MessagingConfig config;
-  private EventLoopGroup group;
-  private DatagramChannel channel;
-
   private final Map<String, Map<BiConsumer<Address, byte[]>, Executor>> listeners =
       Maps.newConcurrentMap();
   private final AtomicBoolean started = new AtomicBoolean();
+  private EventLoopGroup group;
+  private DatagramChannel channel;
 
   public NettyUnicastService(final Address address, final MessagingConfig config) {
     this.address = address;

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -41,7 +41,9 @@ import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
 import io.atomix.utils.memory.MemorySize;
+import io.atomix.utils.serializer.FallbackNamespace;
 import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.NamespaceImpl;
 import io.atomix.utils.serializer.Namespaces;
 import io.zeebe.snapshots.raft.ReceivableSnapshotStoreFactory;
 import java.io.File;
@@ -278,14 +280,13 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
 
     @Override
     public Namespace namespace() {
-      return Namespace.builder()
-          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID + 100)
-          .register(RaftPartitionGroupConfig.class)
-          .register(RaftStorageConfig.class)
-          .register(Void.class) // RaftCompactionConfig
-          .register(StorageLevel.class)
-          .setCompatible(true)
-          .build();
+      return new FallbackNamespace(
+          new NamespaceImpl.Builder()
+              .nextId(Namespaces.BEGIN_USER_CUSTOM_ID + 100)
+              .register(RaftPartitionGroupConfig.class)
+              .register(RaftStorageConfig.class)
+              .register(Void.class) // RaftCompactionConfig
+              .register(StorageLevel.class));
     }
 
     @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
@@ -56,73 +56,73 @@ public final class RaftNamespaces {
 
   /** Raft protocol namespace. */
   public static final Namespace RAFT_PROTOCOL =
-      Namespace.builder()
-          .register(Namespaces.BASIC)
-          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
-          .register(Void.class) // OpenSessionRequest
-          .register(Void.class) // OpenSessionResponse
-          .register(Void.class) // CloseSessionRequest
-          .register(Void.class) // CloseSessionResponse
-          .register(Void.class) // KeepAliveRequest
-          .register(Void.class) // KeepAliveResponse
-          .register(Void.class) // HeartbeatRequest
-          .register(Void.class) // HeartbeatResponse
-          .register(Void.class) // QueryRequest
-          .register(Void.class) // QueryResponse
-          .register(Void.class) // CommandRequest
-          .register(Void.class) // CommandResponse
-          .register(Void.class) // MetadataRequest
-          .register(Void.class) // MetadataResponse
-          .register(JoinRequest.class)
-          .register(JoinResponse.class)
-          .register(LeaveRequest.class)
-          .register(LeaveResponse.class)
-          .register(ConfigureRequest.class)
-          .register(ConfigureResponse.class)
-          .register(ReconfigureRequest.class)
-          .register(ReconfigureResponse.class)
-          .register(InstallRequest.class)
-          .register(InstallResponse.class)
-          .register(PollRequest.class)
-          .register(PollResponse.class)
-          .register(VoteRequest.class)
-          .register(VoteResponse.class)
-          .register(AppendRequest.class)
-          .register(AppendResponse.class)
-          .register(Void.class) // PublishRequest
-          .register(Void.class) // ResetRequest
-          .register(RaftResponse.Status.class)
-          .register(RaftError.class)
-          .register(RaftError.Type.class)
-          .register(Void.class) // ReadConsistency
-          .register(Void.class) // SessionMetadata
-          .register(Void.class) // CloseSessionEntry
-          .register(Void.class) // CommandEntry
-          .register(ConfigurationEntry.class)
-          .register(InitializeEntry.class)
-          .register(Void.class) // KeepAliveEntry
-          .register(Void.class) // MetadataEntry
-          .register(Void.class) // OpenSessionEntry
-          .register(Void.class) // QueryEntry
-          .register(Void.class) // PrimitiveOperation
-          .register(Void.class) // PrimitiveEvent
-          .register(Void.class) // DefaultEventType
-          .register(Void.class) // DefaultOperationId
-          .register(Void.class) // OperationType
-          .register(Void.class) // ReadConsistency
-          .register(ArrayList.class)
-          .register(LinkedList.class)
-          .register(Collections.emptyList().getClass())
-          .register(HashSet.class)
-          .register(DefaultRaftMember.class)
-          .register(MemberId.class)
-          .register(Void.class) // SessionId
-          .register(RaftMember.Type.class)
-          .register(Instant.class)
-          .register(Configuration.class)
-          .register(ZeebeEntry.class)
-          .setCompatible(true)
-          .build("RaftProtocol");
+      new FallbackNamespace(
+          new Builder()
+              .register(Namespaces.BASIC)
+              .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+              .register(Void.class) // OpenSessionRequest
+              .register(Void.class) // OpenSessionResponse
+              .register(Void.class) // CloseSessionRequest
+              .register(Void.class) // CloseSessionResponse
+              .register(Void.class) // KeepAliveRequest
+              .register(Void.class) // KeepAliveResponse
+              .register(Void.class) // HeartbeatRequest
+              .register(Void.class) // HeartbeatResponse
+              .register(Void.class) // QueryRequest
+              .register(Void.class) // QueryResponse
+              .register(Void.class) // CommandRequest
+              .register(Void.class) // CommandResponse
+              .register(Void.class) // MetadataRequest
+              .register(Void.class) // MetadataResponse
+              .register(JoinRequest.class)
+              .register(JoinResponse.class)
+              .register(LeaveRequest.class)
+              .register(LeaveResponse.class)
+              .register(ConfigureRequest.class)
+              .register(ConfigureResponse.class)
+              .register(ReconfigureRequest.class)
+              .register(ReconfigureResponse.class)
+              .register(InstallRequest.class)
+              .register(InstallResponse.class)
+              .register(PollRequest.class)
+              .register(PollResponse.class)
+              .register(VoteRequest.class)
+              .register(VoteResponse.class)
+              .register(AppendRequest.class)
+              .register(AppendResponse.class)
+              .register(Void.class) // PublishRequest
+              .register(Void.class) // ResetRequest
+              .register(RaftResponse.Status.class)
+              .register(RaftError.class)
+              .register(RaftError.Type.class)
+              .register(Void.class) // ReadConsistency
+              .register(Void.class) // SessionMetadata
+              .register(Void.class) // CloseSessionEntry
+              .register(Void.class) // CommandEntry
+              .register(ConfigurationEntry.class)
+              .register(InitializeEntry.class)
+              .register(Void.class) // KeepAliveEntry
+              .register(Void.class) // MetadataEntry
+              .register(Void.class) // OpenSessionEntry
+              .register(Void.class) // QueryEntry
+              .register(Void.class) // PrimitiveOperation
+              .register(Void.class) // PrimitiveEvent
+              .register(Void.class) // DefaultEventType
+              .register(Void.class) // DefaultOperationId
+              .register(Void.class) // OperationType
+              .register(Void.class) // ReadConsistency
+              .register(ArrayList.class)
+              .register(LinkedList.class)
+              .register(Collections.emptyList().getClass())
+              .register(HashSet.class)
+              .register(DefaultRaftMember.class)
+              .register(MemberId.class)
+              .register(Void.class) // SessionId
+              .register(RaftMember.Type.class)
+              .register(Instant.class)
+              .register(Configuration.class)
+              .register(ZeebeEntry.class)
+              .name("RaftProtocol"));
 
   /**
    * Raft storage namespace.
@@ -130,40 +130,32 @@ public final class RaftNamespaces {
    * <p>*Be aware* we use the Void type for replaced/removed types to keep the id's of used types,
    * otherwise we break compatibility.
    */
-  public static final FallbackNamespace RAFT_STORAGE;
-
-  static {
-    final Namespace legacy = registerStorageClasses().build("RaftStorage");
-    final Namespace compatible =
-        registerStorageClasses().setCompatible(true).build("RaftStorage-compatible");
-    RAFT_STORAGE = new FallbackNamespace(legacy, compatible);
-  }
+  public static final FallbackNamespace RAFT_STORAGE =
+      new FallbackNamespace(
+          new Builder()
+              .register(Namespaces.BASIC)
+              .nextId(Namespaces.BEGIN_USER_CUSTOM_ID + 100)
+              .register(Void.class) // CloseSessionEntry
+              .register(Void.class) // CommandEntry
+              .register(ConfigurationEntry.class)
+              .register(InitializeEntry.class)
+              .register(Void.class) // KeepAliveEntry
+              .register(Void.class) // MetadataEntry
+              .register(Void.class) // OpenSessionEntry
+              .register(Void.class) // QueryEntry
+              .register(Void.class) // PrimitiveOperation
+              .register(Void.class) // DefaultOperationId
+              .register(Void.class) // OperationType
+              .register(Void.class) // ReadConsistency
+              .register(ArrayList.class)
+              .register(HashSet.class)
+              .register(DefaultRaftMember.class)
+              .register(MemberId.class)
+              .register(RaftMember.Type.class)
+              .register(Instant.class)
+              .register(Configuration.class)
+              .register(ZeebeEntry.class)
+              .name("RaftStorage"));
 
   private RaftNamespaces() {}
-
-  private static Builder registerStorageClasses() {
-    return Namespace.builder()
-        .register(Namespaces.BASIC)
-        .nextId(Namespaces.BEGIN_USER_CUSTOM_ID + 100)
-        .register(Void.class) // CloseSessionEntry
-        .register(Void.class) // CommandEntry
-        .register(ConfigurationEntry.class)
-        .register(InitializeEntry.class)
-        .register(Void.class) // KeepAliveEntry
-        .register(Void.class) // MetadataEntry
-        .register(Void.class) // OpenSessionEntry
-        .register(Void.class) // QueryEntry
-        .register(Void.class) // PrimitiveOperation
-        .register(Void.class) // DefaultOperationId
-        .register(Void.class) // OperationType
-        .register(Void.class) // ReadConsistency
-        .register(ArrayList.class)
-        .register(HashSet.class)
-        .register(DefaultRaftMember.class)
-        .register(MemberId.class)
-        .register(RaftMember.Type.class)
-        .register(Instant.class)
-        .register(Configuration.class)
-        .register(ZeebeEntry.class);
-  }
 }

--- a/atomix/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
+++ b/atomix/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
@@ -25,7 +25,9 @@ import static org.junit.Assert.assertTrue;
 import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.JournalReader.Mode;
 import io.atomix.storage.journal.index.SparseJournalIndex;
+import io.atomix.utils.serializer.FallbackNamespace;
 import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.NamespaceImpl;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -52,7 +54,8 @@ public abstract class AbstractJournalTest {
 
   protected static final TestEntry ENTRY = new TestEntry(32);
   private static final Namespace NAMESPACE =
-      Namespace.builder().register(TestEntry.class).register(byte[].class).build();
+      new FallbackNamespace(
+          new NamespaceImpl.Builder().register(TestEntry.class).register(byte[].class));
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 

--- a/atomix/storage/src/test/java/io/atomix/storage/journal/FileChannelJournalSegmentReaderTest.java
+++ b/atomix/storage/src/test/java/io/atomix/storage/journal/FileChannelJournalSegmentReaderTest.java
@@ -21,7 +21,9 @@ import static org.junit.Assert.assertTrue;
 import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.JournalReader.Mode;
 import io.atomix.storage.journal.index.SparseJournalIndex;
+import io.atomix.utils.serializer.FallbackNamespace;
 import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.NamespaceImpl;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -33,7 +35,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class FileChannelJournalSegmentReaderTest {
-  private static final Namespace NAMESPACE = Namespace.builder().register(Integer.class).build();
+  private static final Namespace NAMESPACE =
+      new FallbackNamespace(new NamespaceImpl.Builder().register(Integer.class));
   private static final Integer ENTRY = 1;
   private static final int ENTRY_SIZE =
       NAMESPACE.serialize(ENTRY).length + Integer.BYTES; // padding for checksum;

--- a/atomix/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.utils.serializer;
 
+import com.google.common.collect.ImmutableList;
+import io.atomix.utils.serializer.NamespaceImpl.RegistrationBlock;
 import java.nio.ByteBuffer;
 
 public interface Namespace {
@@ -28,15 +30,6 @@ public interface Namespace {
    * @return serialized bytes
    */
   byte[] serialize(final Object obj);
-
-  /**
-   * Serializes given object to byte array using Kryo instance in pool.
-   *
-   * @param obj Object to serialize
-   * @param bufferSize maximum size of serialized bytes
-   * @return serialized bytes
-   */
-  byte[] serialize(final Object obj, final int bufferSize);
 
   /**
    * Serializes given object to byte buffer using Kryo instance in pool.
@@ -64,12 +57,5 @@ public interface Namespace {
    */
   <T> T deserialize(final ByteBuffer buffer);
 
-  /**
-   * Creates a new {@link Namespace} builder.
-   *
-   * @return builder
-   */
-  static NamespaceImpl.Builder builder() {
-    return new NamespaceImpl.Builder();
-  }
+  ImmutableList<RegistrationBlock> getRegisteredBlocks();
 }

--- a/atomix/utils/src/main/java/io/atomix/utils/serializer/Namespaces.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/serializer/Namespaces.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multisets;
 import com.google.common.collect.Sets;
 import io.atomix.utils.Version;
+import io.atomix.utils.serializer.NamespaceImpl.Builder;
 import io.atomix.utils.serializer.serializers.ArraysAsListSerializer;
 import io.atomix.utils.serializer.serializers.AtomicBooleanSerializer;
 import io.atomix.utils.serializer.serializers.AtomicIntegerSerializer;
@@ -53,73 +54,73 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public final class Namespaces {
-  public static final int BASIC_MAX_SIZE = 50;
-  public static final NamespaceImpl BASIC =
-      Namespace.builder()
-          .nextId(NamespaceImpl.FLOATING_ID)
-          .register(byte[].class)
-          .register(new AtomicBooleanSerializer(), AtomicBoolean.class)
-          .register(new AtomicIntegerSerializer(), AtomicInteger.class)
-          .register(new AtomicLongSerializer(), AtomicLong.class)
-          .register(
-              new ImmutableListSerializer(),
-              ImmutableList.class,
-              ImmutableList.of(1).getClass(),
-              ImmutableList.of(1, 2).getClass(),
-              ImmutableList.of(1, 2, 3).subList(1, 3).getClass())
-          .register(
-              new ImmutableSetSerializer(),
-              ImmutableSet.class,
-              ImmutableSet.of().getClass(),
-              ImmutableSet.of(1).getClass(),
-              ImmutableSet.of(1, 2).getClass())
-          .register(
-              new ImmutableMapSerializer(),
-              ImmutableMap.class,
-              ImmutableMap.of().getClass(),
-              ImmutableMap.of("a", 1).getClass(),
-              ImmutableMap.of("R", 2, "D", 2).getClass())
-          .register(Collections.unmodifiableSet(Collections.emptySet()).getClass())
-          .register(HashMap.class)
-          .register(ConcurrentHashMap.class)
-          .register(CopyOnWriteArraySet.class)
-          .register(
-              ArrayList.class,
-              LinkedList.class,
-              HashSet.class,
-              LinkedHashSet.class,
-              ArrayDeque.class)
-          .register(HashMultiset.class)
-          .register(Multisets.immutableEntry("", 0).getClass())
-          .register(Sets.class)
-          .register(Maps.immutableEntry("a", "b").getClass())
-          .register(new ArraysAsListSerializer(), Arrays.asList().getClass())
-          .register(Collections.singletonList(1).getClass())
-          .register(Duration.class)
-          .register(Collections.emptySet().getClass())
-          .register(Optional.class)
-          .register(Collections.emptyList().getClass())
-          .register(Collections.singleton(Object.class).getClass())
-          .register(Properties.class)
-          .register(int[].class)
-          .register(long[].class)
-          .register(short[].class)
-          .register(double[].class)
-          .register(float[].class)
-          .register(char[].class)
-          .register(String[].class)
-          .register(boolean[].class)
-          .register(Object[].class)
-          .register(LogicalTimestamp.class)
-          .register(WallClockTimestamp.class)
-          .register(Version.class)
-          .register(
-              new ByteBufferSerializer(),
-              ByteBuffer.class,
-              ByteBuffer.allocate(1).getClass(),
-              ByteBuffer.allocateDirect(1).getClass())
-          .setCompatible(true)
-          .build("BASIC");
+
+  public static final Namespace BASIC =
+      new FallbackNamespace(
+          new Builder()
+              .nextId(NamespaceImpl.FLOATING_ID)
+              .register(byte[].class)
+              .register(new AtomicBooleanSerializer(), AtomicBoolean.class)
+              .register(new AtomicIntegerSerializer(), AtomicInteger.class)
+              .register(new AtomicLongSerializer(), AtomicLong.class)
+              .register(
+                  new ImmutableListSerializer(),
+                  ImmutableList.class,
+                  ImmutableList.of(1).getClass(),
+                  ImmutableList.of(1, 2).getClass(),
+                  ImmutableList.of(1, 2, 3).subList(1, 3).getClass())
+              .register(
+                  new ImmutableSetSerializer(),
+                  ImmutableSet.class,
+                  ImmutableSet.of().getClass(),
+                  ImmutableSet.of(1).getClass(),
+                  ImmutableSet.of(1, 2).getClass())
+              .register(
+                  new ImmutableMapSerializer(),
+                  ImmutableMap.class,
+                  ImmutableMap.of().getClass(),
+                  ImmutableMap.of("a", 1).getClass(),
+                  ImmutableMap.of("R", 2, "D", 2).getClass())
+              .register(Collections.unmodifiableSet(Collections.emptySet()).getClass())
+              .register(HashMap.class)
+              .register(ConcurrentHashMap.class)
+              .register(CopyOnWriteArraySet.class)
+              .register(
+                  ArrayList.class,
+                  LinkedList.class,
+                  HashSet.class,
+                  LinkedHashSet.class,
+                  ArrayDeque.class)
+              .register(HashMultiset.class)
+              .register(Multisets.immutableEntry("", 0).getClass())
+              .register(Sets.class)
+              .register(Maps.immutableEntry("a", "b").getClass())
+              .register(new ArraysAsListSerializer(), Arrays.asList().getClass())
+              .register(Collections.singletonList(1).getClass())
+              .register(Duration.class)
+              .register(Collections.emptySet().getClass())
+              .register(Optional.class)
+              .register(Collections.emptyList().getClass())
+              .register(Collections.singleton(Object.class).getClass())
+              .register(Properties.class)
+              .register(int[].class)
+              .register(long[].class)
+              .register(short[].class)
+              .register(double[].class)
+              .register(float[].class)
+              .register(char[].class)
+              .register(String[].class)
+              .register(boolean[].class)
+              .register(Object[].class)
+              .register(LogicalTimestamp.class)
+              .register(WallClockTimestamp.class)
+              .register(Version.class)
+              .register(
+                  new ByteBufferSerializer(),
+                  ByteBuffer.class,
+                  ByteBuffer.allocate(1).getClass(),
+                  ByteBuffer.allocateDirect(1).getClass())
+              .name("BASIC"));
 
   /** Kryo registration Id for user custom registration. */
   public static final int BEGIN_USER_CUSTOM_ID = 500;

--- a/atomix/utils/src/main/java/io/atomix/utils/serializer/SerializerBuilder.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/serializer/SerializerBuilder.java
@@ -22,7 +22,9 @@ import io.atomix.utils.Builder;
 public class SerializerBuilder implements Builder<Serializer> {
   private final String name;
   private final NamespaceImpl.Builder namespaceBuilder =
-      Namespace.builder().register(Namespaces.BASIC).nextId(Namespaces.BEGIN_USER_CUSTOM_ID);
+      new NamespaceImpl.Builder()
+          .register(Namespaces.BASIC)
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID);
 
   public SerializerBuilder() {
     this(null);
@@ -121,6 +123,7 @@ public class SerializerBuilder implements Builder<Serializer> {
 
   @Override
   public Serializer build() {
-    return Serializer.using(name != null ? namespaceBuilder.build(name) : namespaceBuilder.build());
+    return Serializer.using(
+        new FallbackNamespace(name != null ? namespaceBuilder.name(name) : namespaceBuilder));
   }
 }

--- a/atomix/utils/src/test/java/io/atomix/utils/serializer/FallbackNamespaceTest.java
+++ b/atomix/utils/src/test/java/io/atomix/utils/serializer/FallbackNamespaceTest.java
@@ -16,6 +16,8 @@
 package io.atomix.utils.serializer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -23,6 +25,7 @@ import static org.mockito.Mockito.times;
 import java.nio.ByteBuffer;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 public class FallbackNamespaceTest {
@@ -30,71 +33,132 @@ public class FallbackNamespaceTest {
   private static final String COMPAT_FIELD = "compatible";
   private static final String LEGACY_FIELD = "legacy";
 
-  private final Namespace legacy = spy(Namespace.builder().register(TestClass.class).build());
-  private final Namespace compatible =
-      spy(Namespace.builder().register(TestClass.class).setCompatible(true).build());
-  private final FallbackNamespace fallback = new FallbackNamespace(legacy, compatible);
+  private static final NamespaceImpl LEGACY =
+      spy(new NamespaceImpl.Builder().register(TestClass.class).build());
+  private static final NamespaceImpl COMPATIBLE =
+      spy(new NamespaceImpl.Builder().register(TestClass.class).setCompatible(true).build());
 
-  private final byte[] legacyBytes = legacy.serialize(new TestClass(LEGACY_FIELD));
-  private final ByteBuffer legacyBuffer = ByteBuffer.wrap(legacyBytes);
+  private static final byte[] COMPAT_BYTES = COMPATIBLE.serialize(new TestClass(COMPAT_FIELD));
+  private static final ByteBuffer COMPAT_BUFFER = ByteBuffer.wrap(COMPAT_BYTES);
+  private static final byte[] LEGACY_BYTES;
+  private static final ByteBuffer LEGACY_BUFFER;
 
-  private final byte[] compatibleBytes = compatible.serialize(new TestClass(COMPAT_FIELD));
-  private final ByteBuffer compatibleBuffer = ByteBuffer.wrap(compatibleBytes);
+  static {
+    final byte[] dataBytes = LEGACY.serialize(new TestClass(LEGACY_FIELD));
+    LEGACY_BYTES = new byte[dataBytes.length - 2];
+    System.arraycopy(dataBytes, 2, LEGACY_BYTES, 0, LEGACY_BYTES.length);
+
+    LEGACY_BUFFER = ByteBuffer.wrap(LEGACY_BYTES);
+  }
+
+  private final FallbackNamespace fallback = new FallbackNamespace(LEGACY, COMPATIBLE);
 
   @Before
   public void setup() {
-    reset(compatible);
-    reset(legacy);
+    COMPAT_BUFFER.clear();
+    LEGACY_BUFFER.clear();
+
+    reset(COMPATIBLE);
+    reset(LEGACY);
   }
 
   @Test
-  public void shouldDeserializeBytesWithCompatibleFirst() {
+  public void shouldDeserializeBytesAsNewWithV1Header() {
     // when
-    final Object object = fallback.deserialize(compatibleBytes);
+    final Object object = fallback.deserialize(COMPAT_BYTES);
 
     // then
     assertThat(object).isInstanceOf(TestClass.class);
     assertThat(((TestClass) object).testField).isEqualTo(COMPAT_FIELD);
 
-    Mockito.verify(compatible, times(1)).deserialize(compatibleBytes);
-    Mockito.verifyNoInteractions(legacy);
+    Mockito.verify(COMPATIBLE, times(1)).deserialize(ArgumentMatchers.any(byte[].class), anyInt());
+    Mockito.verifyNoInteractions(LEGACY);
+  }
+
+  @Test
+  public void shouldDeserializeBufferAsNewWithV1Header() {
+    // when
+    final Object object = fallback.deserialize(COMPAT_BUFFER);
+
+    // then
+    assertThat(object).isInstanceOf(TestClass.class);
+    assertThat(((TestClass) object).testField).isEqualTo(COMPAT_FIELD);
+
+    Mockito.verify(COMPATIBLE, times(1)).deserialize(ArgumentMatchers.any(ByteBuffer.class));
+    Mockito.verifyNoInteractions(LEGACY);
+  }
+
+  @Test
+  public void shouldDeserializeBytesAsOldWithoutHeader() {
+    // when
+    final Object object = fallback.deserialize(LEGACY_BYTES);
+
+    // then
+    assertThat(object).isInstanceOf(TestClass.class);
+    assertThat(((TestClass) object).testField).isEqualTo(LEGACY_FIELD);
+
+    Mockito.verify(LEGACY, times(1)).deserialize(ArgumentMatchers.any(byte[].class));
+    Mockito.verifyNoInteractions(COMPATIBLE);
+  }
+
+  @Test
+  public void shouldDeserializeBufferAsOldWithoutHeader() {
+    // when
+    final Object object = fallback.deserialize(LEGACY_BUFFER);
+
+    // then
+    assertThat(object).isInstanceOf(TestClass.class);
+    assertThat(((TestClass) object).testField).isEqualTo(LEGACY_FIELD);
+
+    Mockito.verify(LEGACY, times(1)).deserialize(ArgumentMatchers.any(ByteBuffer.class));
+    Mockito.verifyNoInteractions(COMPATIBLE);
+  }
+
+  @Test
+  public void shouldDeserializeBytesAsLegacyWithUnknownVersion() {
+    // when
+    final byte[] unknownVersion = {0x1F, (byte) 0xFF};
+    assertThatThrownBy(() -> fallback.deserialize(unknownVersion));
+
+    // then
+    Mockito.verify(LEGACY, times(1)).deserialize(unknownVersion);
+    Mockito.verifyNoInteractions(COMPATIBLE);
   }
 
   @Test
   public void shouldDeserializeBufferWithCompatibleFirst() {
     // when
-    final Object object = fallback.deserialize(compatibleBuffer);
+    final Object object = fallback.deserialize(COMPAT_BUFFER);
 
     // then
     assertThat(object).isInstanceOf(TestClass.class);
     assertThat(((TestClass) object).testField).isEqualTo(COMPAT_FIELD);
 
-    Mockito.verify(compatible, times(1)).deserialize(compatibleBuffer);
-    Mockito.verifyNoInteractions(legacy);
+    Mockito.verify(COMPATIBLE, times(1)).deserialize(COMPAT_BUFFER);
+    Mockito.verifyNoInteractions(LEGACY);
   }
 
   @Test
-  public void shouldDeserializeBytesWithLegacyIfCompatibleFails() {
+  public void shouldFallbackToLegacyIfDeserializingBytesFails() {
     // when
-    final TestClass object = fallback.deserialize(legacyBytes);
+    final byte[] bytes = {0x01, (byte) 0xFF};
+    assertThatThrownBy(() -> fallback.deserialize(bytes));
 
     // then
-    assertThat(object.testField).isEqualTo(LEGACY_FIELD);
-
-    Mockito.verify(compatible, times(1)).deserialize(legacyBytes);
-    Mockito.verify(legacy, times(1)).deserialize(legacyBytes);
+    Mockito.verify(COMPATIBLE, times(1)).deserialize(ArgumentMatchers.any(byte[].class), anyInt());
+    Mockito.verify(LEGACY, times(1)).deserialize(bytes);
   }
 
   @Test
-  public void shouldDeserializeBufferWithLegacyIfCompatibleFails() {
+  public void shouldFallbackToLegacyIfDeserializingBufferFails() {
     // when
-    final TestClass object = fallback.deserialize(legacyBuffer);
+    final byte[] bytes = {0x01, (byte) 0xFF};
+    final ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    assertThatThrownBy(() -> fallback.deserialize(buffer));
 
     // then
-    assertThat(object.testField).isEqualTo(LEGACY_FIELD);
-
-    Mockito.verify(compatible, times(1)).deserialize(legacyBuffer);
-    Mockito.verify(legacy, times(1)).deserialize(legacyBuffer);
+    Mockito.verify(COMPATIBLE, times(1)).deserialize(buffer);
+    Mockito.verify(LEGACY, times(1)).deserialize(buffer);
   }
 
   @Test
@@ -104,11 +168,19 @@ public class FallbackNamespaceTest {
     final byte[] bytes = fallback.serialize(original);
 
     // then
-    final TestClass deserialized = compatible.deserialize(bytes);
+    final TestClass deserialized = fallback.deserialize(bytes);
     assertThat(deserialized.testField).isEqualTo("test");
+    Mockito.verify(COMPATIBLE, times(1)).serialize(original);
+  }
 
-    Mockito.verify(compatible, times(1)).serialize(original);
-    Mockito.verifyNoInteractions(legacy);
+  @Test
+  public void shouldSerializeWithVersionHeader() {
+    // when
+    final TestClass original = new TestClass("test");
+    final byte[] bytes = fallback.serialize(original);
+
+    // then
+    assertThat(bytes).startsWith(NamespaceImpl.VERSION_HEADER);
   }
 
   private static class TestClass {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -129,7 +129,7 @@
     <extension.version.os-maven-plugin>1.6.2</extension.version.os-maven-plugin>
 
     <!-- version against which backwards compatibility is checked -->
-    <backwards.compat.version>0.24.0</backwards.compat.version>
+    <backwards.compat.version>0.24.4</backwards.compat.version>
     <ignored.changes.file>ignored-changes.xml</ignored.changes.file>
   </properties>
 

--- a/upgrade-tests/pom.xml
+++ b/upgrade-tests/pom.xml
@@ -64,10 +64,6 @@
       <artifactId>failsafe</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
@@ -8,7 +8,6 @@
 package io.zeebe.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assume.assumeThat;
 
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.api.response.WorkflowInstanceEvent;
@@ -36,7 +35,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.agrona.IoUtil;
 import org.awaitility.Awaitility;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -106,8 +104,6 @@ public class RollingUpdateTest {
 
   @Test
   public void shouldBeAbleToRestartContainerWithNewVersion() {
-    assumeNewVersionIsRollingUpgradeCompatible();
-
     // given
     final var index = 0;
     Startables.deepStart(containers).join();
@@ -134,8 +130,6 @@ public class RollingUpdateTest {
 
   @Test
   public void shouldReplicateSnapshotAcrossVersions() {
-    assumeNewVersionIsRollingUpgradeCompatible();
-
     // given
     Startables.deepStart(containers).join();
 
@@ -195,8 +189,6 @@ public class RollingUpdateTest {
 
   @Test
   public void shouldPerformRollingUpgrade() {
-    assumeNewVersionIsRollingUpgradeCompatible();
-
     // given
     Startables.deepStart(containers).join();
 
@@ -272,13 +264,6 @@ public class RollingUpdateTest {
           .atMost(Duration.ofSeconds(5))
           .untilAsserted(() -> assertThat(activatedJobs).isEqualTo(expectedActivatedJobs));
     }
-  }
-
-  private void assumeNewVersionIsRollingUpgradeCompatible() {
-    assumeThat(
-        "new version is rolling upgrade compatible",
-        NEW_VERSION,
-        Matchers.not(Matchers.startsWith("0.25")));
   }
 
   private WorkflowInstanceEvent createWorkflowInstance(final ZeebeClient client) {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Enable us to do backwards compatible changes to the protocol. PR https://github.com/zeebe-io/zeebe/pull/5244 prepared 0.24 for these changes so this PR shouldn't break the rolling upgrade path from 0.24 to 0.25. The RollingUpdateTest is using 0.24.4 to test the rolling upgrade but 0.24.4 wasn't released yet so the test won't pass. When 0.24.4 is released, this PR can be marked ready for review.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5223

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
