### PR TITLE
Add new processing metrics

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -8,6 +8,7 @@
 package io.zeebe.broker.exporter.stream;
 
 import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
 import io.zeebe.protocol.record.ValueType;
 
 public final class ExporterMetrics {
@@ -18,6 +19,22 @@ public final class ExporterMetrics {
           .name("exporter_events_total")
           .help("Number of events processed by exporter")
           .labelNames("action", "partition", "valueType")
+          .register();
+
+  private static final Gauge LAST_EXPORTED_POSITION =
+      Gauge.build()
+          .namespace("zeebe")
+          .name("exporter_last_exported_position")
+          .help("The last exported position by exporter and partition.")
+          .labelNames("exporter", "partition")
+          .register();
+
+  private static final Gauge LAST_UPDATED_EXPORTED_POSITION =
+      Gauge.build()
+          .namespace("zeebe")
+          .name("exporter_last_updated_exported_position")
+          .help("The last exported position which was also updated/commited by the exporter.")
+          .labelNames("exporter", "partition")
           .register();
 
   private final String partitionIdLabel;
@@ -36,5 +53,13 @@ public final class ExporterMetrics {
 
   public void eventSkipped(final ValueType valueType) {
     event("skipped", valueType);
+  }
+
+  public void setLastUpdatedExportedPosition(final String exporter, final long position) {
+    LAST_UPDATED_EXPORTED_POSITION.labels(exporter, partitionIdLabel).set(position);
+  }
+
+  public void setLastExportedPosition(final String exporter, final long position) {
+    LAST_EXPORTED_POSITION.labels(exporter, partitionIdLabel).set(position);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/metrics/StreamProcessorMetrics.java
+++ b/engine/src/main/java/io/zeebe/engine/metrics/StreamProcessorMetrics.java
@@ -23,6 +23,14 @@ public final class StreamProcessorMetrics {
           .labelNames("action", "partition")
           .register();
 
+  private static final Gauge LAST_PROCESSED_POSITION =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("stream_processor_last_processed_position")
+          .help("The last position the stream processor has processed.")
+          .labelNames("partition")
+          .register();
+
   private static final Histogram PROCESSING_LATENCY =
       Histogram.build()
           .namespace(NAMESPACE)
@@ -70,5 +78,9 @@ public final class StreamProcessorMetrics {
 
   public void recoveryTime(final long durationMillis) {
     STARTUP_RECOVERY_TIME.labels(partitionIdLabel).set(durationMillis);
+  }
+
+  public void setLastProcessedPosition(final long position) {
+    LAST_PROCESSED_POSITION.labels(partitionIdLabel).set(position);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -387,6 +387,7 @@ public final class ProcessingStateMachine {
                         });
               }
               lastSuccessfulProcessedEventPosition = currentEvent.getPosition();
+              metrics.setLastProcessedPosition(lastSuccessfulProcessedEventPosition);
               lastWrittenEventPosition = writtenEventPosition;
               return true;
             },

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/AppenderMetrics.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/AppenderMetrics.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.logstreams.impl.log;
+
+import io.prometheus.client.Gauge;
+
+public class AppenderMetrics {
+
+  private static final Gauge LAST_COMMITTED_POSITION =
+      Gauge.build()
+          .namespace("zeebe")
+          .name("log_appender_last_committed_position")
+          .help("The last committed position.")
+          .labelNames("partition")
+          .register();
+
+  private static final Gauge LAST_APPENDED_POSITION =
+      Gauge.build()
+          .namespace("zeebe")
+          .name("log_appender_last_appended_position")
+          .help("The last appended position by the appender.")
+          .labelNames("partition")
+          .register();
+
+  private final String partitionLabel;
+
+  public AppenderMetrics(final String partitionLabel) {
+    this.partitionLabel = partitionLabel;
+  }
+
+  public void setLastCommittedPosition(final long position) {
+    LAST_COMMITTED_POSITION.labels(partitionLabel).set(position);
+  }
+
+  public void setLastAppendedPosition(final long position) {
+    LAST_APPENDED_POSITION.labels(partitionLabel).set(position);
+  }
+}

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/Listener.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/Listener.java
@@ -21,7 +21,9 @@ public final class Listener implements AppendListener {
   }
 
   @Override
-  public void onWrite(final long address) {}
+  public void onWrite(final long address) {
+    appender.notifyWritePosition(highestPosition);
+  }
 
   @Override
   public void onWriteError(final Throwable error) {

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -83,7 +83,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1598534375933,
+  "iteration": 1598608874627,
   "links": [],
   "panels": [
     {
@@ -1496,6 +1496,587 @@
         "x": 0,
         "y": 1
       },
+      "id": 203,
+      "panels": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Shows how many positions are not updated by exporters per partition. Means what is the difference between last committed exporter position and committed log position.",
+          "gridPos": {
+            "h": 4,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "id": 192,
+          "options": {
+            "fieldOptions": {
+              "calcs": [
+                "last"
+              ],
+              "defaults": {
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1000
+                    }
+                  ]
+                }
+              },
+              "overrides": [],
+              "values": false
+            },
+            "orientation": "auto",
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "6.7.1",
+          "targets": [
+            {
+              "expr": "zeebe_exporter_last_exported_position{namespace=~\"$namespace\", partition=~\"$partition\"} - zeebe_exporter_last_updated_exported_position{namespace=~\"$namespace\", partition=~\"$partition\"}",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{exporter}} {{partition}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Number of records exported but not acknowledged",
+          "type": "gauge"
+        },
+        {
+          "columns": [],
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Shows the position, which was appended last by the leader per partition.",
+          "fontSize": "80%",
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 12,
+            "y": 2
+          },
+          "id": 196,
+          "pageSize": null,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "styles": [
+            {
+              "$$hashKey": "object:7009",
+              "alias": "Time",
+              "align": "auto",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "$$hashKey": "object:7010",
+              "alias": "Position",
+              "align": "center",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "Value",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "$$hashKey": "object:7858",
+              "alias": "Partition",
+              "align": "center",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 0,
+              "mappingType": 1,
+              "pattern": "partition",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "sum by (partition) (zeebe_log_appender_last_appended_position{namespace=~\"$namespace\", partition=~\"$partition\"})",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Last appended position",
+          "transform": "table",
+          "type": "table"
+        },
+        {
+          "columns": [],
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Shows the last committed log position.",
+          "fontSize": "80%",
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 16,
+            "y": 2
+          },
+          "id": 200,
+          "pageSize": null,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "styles": [
+            {
+              "$$hashKey": "object:7009",
+              "alias": "Time",
+              "align": "auto",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "$$hashKey": "object:7010",
+              "alias": "Position",
+              "align": "center",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "Value",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "$$hashKey": "object:7858",
+              "alias": "Partition",
+              "align": "center",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 0,
+              "mappingType": 1,
+              "pattern": "partition",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "sum by (partition) (zeebe_log_appender_last_committed_position{namespace=~\"$namespace\", partition=~\"$partition\"})",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Last committed position",
+          "transform": "table",
+          "type": "table"
+        },
+        {
+          "columns": [],
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Shows the last processed position by the stream processor per partition.",
+          "fontSize": "80%",
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 20,
+            "y": 2
+          },
+          "id": 198,
+          "pageSize": null,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "styles": [
+            {
+              "$$hashKey": "object:7009",
+              "alias": "Time",
+              "align": "auto",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "$$hashKey": "object:7010",
+              "alias": "Position",
+              "align": "center",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "Value",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "$$hashKey": "object:7858",
+              "alias": "Partition",
+              "align": "center",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 0,
+              "mappingType": 1,
+              "pattern": "partition",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "sum by (partition) (zeebe_stream_processor_last_processed_position{namespace=~\"$namespace\", partition=~\"$partition\"})",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            },
+            {
+              "expr": "",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Last processed position",
+          "transform": "table",
+          "type": "table"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Shows how many records are not exported yet.",
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 0,
+            "y": 6
+          },
+          "id": 194,
+          "options": {
+            "fieldOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "defaults": {
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1000
+                    }
+                  ]
+                }
+              },
+              "overrides": [],
+              "values": false
+            },
+            "orientation": "auto",
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "6.7.1",
+          "targets": [
+            {
+              "expr": "sum (zeebe_log_appender_last_committed_position{namespace=~\"$namespace\", partition=~\"$partition\"}) by (partition) - sum (zeebe_exporter_last_exported_position{namespace=~\"$namespace\", partition=~\"$partition\", exporter=\"elasticsearch\"}) by (partition)",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "Exporter {{partition}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Number of records not exported",
+          "type": "gauge"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Shows how many records the stream processor has not processed yet.",
+          "gridPos": {
+            "h": 6,
+            "w": 7,
+            "x": 5,
+            "y": 6
+          },
+          "id": 189,
+          "options": {
+            "fieldOptions": {
+              "calcs": [
+                "last"
+              ],
+              "defaults": {
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1000
+                    }
+                  ]
+                }
+              },
+              "overrides": [],
+              "values": false
+            },
+            "orientation": "auto",
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "6.7.1",
+          "targets": [
+            {
+              "expr": "zeebe_log_appender_last_committed_position{namespace=~\"$namespace\", partition=~\"$partition\"} - zeebe_stream_processor_last_processed_position{namespace=~\"$namespace\", partition=~\"$partition\"}",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Partition {{partition}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Number of records not processed",
+          "type": "gauge"
+        },
+        {
+          "columns": [],
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Shows the last exported position which was committed by the given exporter per partition.",
+          "fontSize": "80%",
+          "gridPos": {
+            "h": 6,
+            "w": 7,
+            "x": 12,
+            "y": 6
+          },
+          "id": 199,
+          "pageSize": null,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "styles": [
+            {
+              "$$hashKey": "object:7009",
+              "alias": "Time",
+              "align": "auto",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "$$hashKey": "object:7010",
+              "alias": "Position",
+              "align": "center",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "Value",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "$$hashKey": "object:7858",
+              "alias": "Partition",
+              "align": "center",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 0,
+              "mappingType": 1,
+              "pattern": "partition",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "sum by (exporter, partition) (zeebe_exporter_last_updated_exported_position{namespace=~\"$namespace\", partition=~\"$partition\"})",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Last updated exported position",
+          "transform": "table",
+          "type": "table"
+        },
+        {
+          "columns": [],
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "Shows the last exported position per partition.",
+          "fontSize": "80%",
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 19,
+            "y": 6
+          },
+          "id": 201,
+          "pageSize": null,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "styles": [
+            {
+              "$$hashKey": "object:7009",
+              "alias": "Time",
+              "align": "auto",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "$$hashKey": "object:7010",
+              "alias": "Position",
+              "align": "center",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "Value",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            },
+            {
+              "$$hashKey": "object:7858",
+              "alias": "Partition",
+              "align": "center",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 0,
+              "mappingType": 1,
+              "pattern": "partition",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "sum by (partition) (zeebe_exporter_last_exported_position{namespace=~\"$namespace\", partition=~\"$partition\", exporter=\"elasticsearch\"})",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            },
+            {
+              "expr": "",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Last exported position",
+          "transform": "table",
+          "type": "table"
+        }
+      ],
+      "title": "Processing",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
       "id": 44,
       "panels": [
         {
@@ -1506,7 +2087,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 13
           },
           "hideTimeOverride": false,
           "id": 12,
@@ -1564,7 +2145,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 13
           },
           "hideTimeOverride": false,
           "id": 13,
@@ -1627,7 +2208,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 49
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 2,
@@ -1724,7 +2305,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 49
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 3,
@@ -1821,7 +2402,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 55
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 4,
@@ -1918,7 +2499,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 55
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 5,
@@ -2015,7 +2596,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 61
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 15,
@@ -2119,7 +2700,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 61
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 18,
@@ -2208,7 +2789,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 2
+        "y": 3
       },
       "id": 100,
       "panels": [
@@ -2794,7 +3375,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 3
+        "y": 4
       },
       "id": 42,
       "panels": [
@@ -3498,7 +4079,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 5
       },
       "id": 120,
       "panels": [
@@ -3865,7 +4446,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 6
       },
       "id": 46,
       "panels": [
@@ -4200,7 +4781,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 7
       },
       "id": 48,
       "panels": [
@@ -4593,7 +5174,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 8
       },
       "id": 162,
       "panels": [
@@ -4856,7 +5437,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 9
       },
       "id": 76,
       "panels": [
@@ -5659,7 +6240,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 10
       },
       "id": 140,
       "panels": [
@@ -7241,7 +7822,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 11
       },
       "id": 50,
       "panels": [
@@ -7591,7 +8172,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 12
       },
       "id": 176,
       "panels": [


### PR DESCRIPTION
## Description

Adds new processing, exporting and log append metrics. With help of the metric, we can see what was the last appended, last committed position and how far behind is the processor and the exporters.

![processing](https://user-images.githubusercontent.com/2758593/91563172-b741ac00-e93e-11ea-8b53-78ca05bc0a4e.png)

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/5241

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
