### PR TITLE
docs(operate): add JIRA link in userguide

### DIFF
--- a/docs/src/operate-user-guide/operate-feedback-and-questions.md
+++ b/docs/src/operate-user-guide/operate-feedback-and-questions.md
@@ -1,5 +1,9 @@
 # Giving Feedback And Asking Questions
 
-If you have questions or feedback about Operate, the [Zeebe user forum](https://forum.zeebe.io) is the best way to get in touch with us. Please use the “Operate” tag when you create a post. 
+If you have questions or feedback about Operate, the [Zeebe user forum](https://forum.zeebe.io) is the best way to get in touch with us. Please use the “Operate” tag when you create a post.
 
-If you’re interested in an Operate enterprise license so that you can use Operate in production, [please contact us](mailto:feedback@zeebe.io) so that we can notify you when an enterprise edition of Operate becomes available. 
+If you’re interested in an Operate enterprise license so that you can use Operate in production, [please contact us](mailto:feedback@zeebe.io) so that we can notify you when an enterprise edition of Operate becomes available.
+
+Did you find a problem in Operate? Or do you have a suggestion for an improvement?
+You can create an issue in the [Operate JIRA](https://jira.camunda.com/browse/OPE) project to let us know.
+


### PR DESCRIPTION
Related with OPE-1066

## Description

Add JIRA link in Operate User Guide 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
