### PR TITLE
Increase default disk usage watermarks

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -20,8 +20,8 @@ import org.springframework.util.unit.DataSize;
 public final class DataCfg implements ConfigurationEntry {
   public static final String DEFAULT_DIRECTORY = "data";
   private static final DataSize DEFAULT_DATA_SIZE = DataSize.ofMegabytes(512);
-  private static final double DEFAULT_DISK_USAGE_REPLICATION_WATERMARK = 0.9;
-  private static final double DEFAULT_DISK_USAGE_COMMAND_WATERMARK = 0.8;
+  private static final double DEFAULT_DISK_USAGE_REPLICATION_WATERMARK = 0.99;
+  private static final double DEFAULT_DISK_USAGE_COMMAND_WATERMARK = 0.97;
   private static final Duration DEFAULT_DISK_USAGE_MONITORING_DELAY = Duration.ofSeconds(1);
 
   // Hint: do not use Collections.singletonList as this does not support replaceAll

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -187,14 +187,14 @@
       # The value is specified as a percentage of the total disk space.
       # The value should be in the range (0, 1).
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK
-      # diskUsageCommandWatermark = 0.8
+      # diskUsageCommandWatermark = 0.97
 
       # When the disk usage is above this value, this broker will stop writing replicated events it receives from other brokers.
       # The value is specified as a percentage of the total disk space.
       # The value should be in the range (0, 1).
       # It is recommended that diskUsageReplicationWatermark > diskUsageCommandWatermark
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
-      # diskUsageReplicationWatermark = 0.9
+      # diskUsageReplicationWatermark = 0.99
 
       # Sets the interval at which the disk usage is monitored
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGINTERVAL

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -139,14 +139,14 @@
       # The value is specified as a percentage of the total disk space.
       # The value should be in the range (0, 1).
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK
-      # diskUsageCommandWatermark = 0.8
+      # diskUsageCommandWatermark = 0.97
 
       # When the disk usage is above this value, this broker will stop writing replicated events it receives from other brokers.
       # The value is specified as a percentage of the total disk space.
       # The value should be in the range (0, 1).
       # It is recommended that diskUsageReplicationWatermark > diskUsageCommandWatermark
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
-      # diskUsageReplicationWatermark = 0.9
+      # diskUsageReplicationWatermark = 0.99
 
       # Sets the interval at which the disk usage is monitored
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGINTERVAL

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -91,6 +91,7 @@
       * [Authorization](operations/authorization.md)
     * [Health Status](operations/health.md)
     * [Configuring Backpressure](operations/backpressure.md)
+    * [Disk Space](operations/disk-space.md)
 * [Zeebe on Kubernetes](kubernetes/index.md)
     * [Prerequisites](kubernetes/prerequisites.md)
     * [Installing HELM Charts](kubernetes/installing-helm.md)

--- a/docs/src/operations/disk-space.md
+++ b/docs/src/operations/disk-space.md
@@ -1,0 +1,16 @@
+# Disk space
+
+Zeebe uses the local disk for storage of it's persistent data. Therefore if the Zeebe broker runs out of disk space the system is in an invalid state, as the broker cannot
+update it's state.
+
+To prevent the system to end in an unrecoverable state Zeebe expects a minimum size of free disk space available. If this limit is violated the broker will reject new
+requests, to allow the operations team to free more disk space and the broker to continue to update it's state.
+
+
+Zeebe can be configured with the following settings for the disk usage watermarks:
+
+* **zeebe.broker.data.diskUsageReplicationWatermark**: the fraction of used disk space before the replication is paused (default: 0.99)
+* **zeebe.broker.data.diskUsageCommandWatermark**: the fraction of used disk space before new user commands are rejected (default: 0.97), this has to be less then `diskUsageReplicationWatermark`
+* **zeebe.broker.data.diskUsageMonitoringInterval**: the interval in which the disk space usage is checked (default 1 second)
+
+For **production** use cases we recommend to set the values for `diskUsageReplicationWatermark` and `diskUsageCommandWatermark` to smaller values, for example `diskUsageReplicationWatermark=0.9` and `diskUsageCommandWatermark=0.8`.


### PR DESCRIPTION
## Description

- increase disk usage replication watermark from 0.9 to 0.99
- increase disk usage command watermark from 0.8 to 0.97
- add section about disk space and watermarks

## Related issues

closes #5199

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
