### PR TITLE
Add flag to disable disk usage watermarks

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -535,7 +535,7 @@ public final class RaftStorage {
      * @return the Raft log builder
      */
     public Builder withFreeDiskSpace(final long freeDiskSpace) {
-      checkArgument(freeDiskSpace > 0, "freeDiskSpace must be positive");
+      checkArgument(freeDiskSpace >= 0, "freeDiskSpace must be positive");
       this.freeDiskSpace = freeDiskSpace;
       return this;
     }

--- a/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
@@ -832,7 +832,7 @@ public class SegmentedJournal<E> implements Journal<E> {
      * @throws IllegalArgumentException if the {@code freeDiskSpace} is not positive
      */
     public Builder<E> withFreeDiskSpace(final long freeDiskSpace) {
-      checkArgument(freeDiskSpace > 0, "minFreeDiskSpace must be positive");
+      checkArgument(freeDiskSpace >= 0, "minFreeDiskSpace must be positive");
       this.freeDiskSpace = freeDiskSpace;
       return this;
     }

--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -292,9 +292,14 @@ public final class Broker implements AutoCloseable {
 
   private AutoCloseable diskSpaceMonitorStep(final DataCfg data) {
     diskSpaceUsageMonitor = new DiskSpaceUsageMonitor(data);
-    scheduleActor(diskSpaceUsageMonitor);
-    diskSpaceUsageListeners.forEach(l -> diskSpaceUsageMonitor.addDiskUsageListener(l));
-    return () -> diskSpaceUsageMonitor.close();
+    if (data.isDiskUsageMonitoringEnabled()) {
+      scheduleActor(diskSpaceUsageMonitor);
+      diskSpaceUsageListeners.forEach(l -> diskSpaceUsageMonitor.addDiskUsageListener(l));
+      return () -> diskSpaceUsageMonitor.close();
+    } else {
+      LOG.info("Skipping start of disk space usage monitor, as it is disabled by configuration");
+      return () -> {};
+    }
   }
 
   private AutoCloseable managementRequestStep(final BrokerInfo localBroker) {

--- a/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -95,22 +95,23 @@ public final class SystemContext {
     }
 
     final var diskUsageCommandWatermark = dataCfg.getDiskUsageCommandWatermark();
-    if (!(diskUsageCommandWatermark > 0 && diskUsageCommandWatermark < 1)) {
+    if (!(diskUsageCommandWatermark > 0 && diskUsageCommandWatermark <= 1)) {
       throw new IllegalArgumentException(
           String.format(
-              "Expected diskUsageCommandWatermark to be in the range (0,1), but found %f",
+              "Expected diskUsageCommandWatermark to be in the range (0,1], but found %f",
               diskUsageCommandWatermark));
     }
 
     final var diskUsageReplicationWatermark = dataCfg.getDiskUsageReplicationWatermark();
-    if (!(diskUsageReplicationWatermark > 0 && diskUsageReplicationWatermark < 1)) {
+    if (!(diskUsageReplicationWatermark > 0 && diskUsageReplicationWatermark <= 1)) {
       throw new IllegalArgumentException(
           String.format(
-              "Expected diskUsageReplicationWatermark to be in the range (0,1), but found %f",
+              "Expected diskUsageReplicationWatermark to be in the range (0,1], but found %f",
               diskUsageReplicationWatermark));
     }
 
-    if (diskUsageCommandWatermark >= diskUsageReplicationWatermark) {
+    if (data.isDiskUsageWatermarkEnabled()
+        && diskUsageCommandWatermark >= diskUsageReplicationWatermark) {
       throw new IllegalArgumentException(
           String.format(
               "diskUsageCommandWatermark (%f) must be less than diskUsageReplicationWatermark (%f)",

--- a/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 
 public final class SystemContext {
+
   public static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private static final String BROKER_ID_LOG_PROPERTY = "broker-id";
   private static final String NODE_ID_ERROR_MSG =
@@ -110,7 +111,7 @@ public final class SystemContext {
               diskUsageReplicationWatermark));
     }
 
-    if (data.isDiskUsageWatermarkEnabled()
+    if (data.isDiskUsageMonitoringEnabled()
         && diskUsageCommandWatermark >= diskUsageReplicationWatermark) {
       throw new IllegalArgumentException(
           String.format(

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -26,7 +26,7 @@ public final class DataCfg implements ConfigurationEntry {
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
 
   private static final DataSize DEFAULT_DATA_SIZE = DataSize.ofMegabytes(512);
-  private static final boolean DEFAULT_DISK_USAGE_WATERMARK_ENABLED = true;
+  private static final boolean DEFAULT_DISK_USAGE_MONITORING_ENABLED = true;
   private static final double DEFAULT_DISK_USAGE_REPLICATION_WATERMARK = 0.99;
   private static final double DEFAULT_DISK_USAGE_COMMAND_WATERMARK = 0.97;
   private static final Duration DEFAULT_DISK_USAGE_MONITORING_DELAY = Duration.ofSeconds(1);
@@ -42,7 +42,7 @@ public final class DataCfg implements ConfigurationEntry {
   private int logIndexDensity = 100;
 
   private boolean useMmap = false;
-  private boolean diskUsageWatermarkEnabled = DEFAULT_DISK_USAGE_WATERMARK_ENABLED;
+  private boolean diskUsageMonitoringEnabled = DEFAULT_DISK_USAGE_MONITORING_ENABLED;
   private double diskUsageReplicationWatermark = DEFAULT_DISK_USAGE_REPLICATION_WATERMARK;
   private double diskUsageCommandWatermark = DEFAULT_DISK_USAGE_COMMAND_WATERMARK;
   private Duration diskUsageMonitoringInterval = DEFAULT_DISK_USAGE_MONITORING_DELAY;
@@ -50,7 +50,7 @@ public final class DataCfg implements ConfigurationEntry {
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     directories.replaceAll(d -> ConfigurationUtil.toAbsolutePath(d, brokerBase));
-    if (!diskUsageWatermarkEnabled) {
+    if (!diskUsageMonitoringEnabled) {
       LOG.info(
           "Disk usage watermarks are disabled, setting all watermarks to {}",
           DISABLED_DISK_USAGE_WATERMARK);
@@ -107,12 +107,12 @@ public final class DataCfg implements ConfigurationEntry {
     return useMmap() ? StorageLevel.MAPPED : StorageLevel.DISK;
   }
 
-  public boolean isDiskUsageWatermarkEnabled() {
-    return diskUsageWatermarkEnabled;
+  public boolean isDiskUsageMonitoringEnabled() {
+    return diskUsageMonitoringEnabled;
   }
 
-  public void setDiskUsageWatermarkEnabled(final boolean diskUsageWatermarkEnabled) {
-    this.diskUsageWatermarkEnabled = diskUsageWatermarkEnabled;
+  public void setDiskUsageMonitoringEnabled(final boolean diskUsageMonitoringEnabled) {
+    this.diskUsageMonitoringEnabled = diskUsageMonitoringEnabled;
   }
 
   public double getDiskUsageCommandWatermark() {
@@ -162,8 +162,8 @@ public final class DataCfg implements ConfigurationEntry {
         + logIndexDensity
         + ", useMmap="
         + useMmap
-        + ", diskUsageWatermarkEnabled="
-        + diskUsageWatermarkEnabled
+        + ", diskUsageMonitoringEnabled="
+        + diskUsageMonitoringEnabled
         + ", diskUsageReplicationWatermark="
         + diskUsageReplicationWatermark
         + ", diskUsageCommandWatermark="

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -10,19 +10,27 @@ package io.zeebe.broker.system.configuration;
 import static io.zeebe.util.StringUtil.LIST_SANITIZER;
 
 import io.atomix.storage.StorageLevel;
+import io.zeebe.broker.Loggers;
 import java.io.File;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import org.slf4j.Logger;
 import org.springframework.util.unit.DataSize;
 
 public final class DataCfg implements ConfigurationEntry {
+
   public static final String DEFAULT_DIRECTORY = "data";
+
+  private static final Logger LOG = Loggers.SYSTEM_LOGGER;
+
   private static final DataSize DEFAULT_DATA_SIZE = DataSize.ofMegabytes(512);
+  private static final boolean DEFAULT_DISK_USAGE_WATERMARK_ENABLED = true;
   private static final double DEFAULT_DISK_USAGE_REPLICATION_WATERMARK = 0.99;
   private static final double DEFAULT_DISK_USAGE_COMMAND_WATERMARK = 0.97;
   private static final Duration DEFAULT_DISK_USAGE_MONITORING_DELAY = Duration.ofSeconds(1);
+  private static final double DISABLED_DISK_USAGE_WATERMARK = 1.0;
 
   // Hint: do not use Collections.singletonList as this does not support replaceAll
   private List<String> directories = Arrays.asList(DEFAULT_DIRECTORY);
@@ -34,6 +42,7 @@ public final class DataCfg implements ConfigurationEntry {
   private int logIndexDensity = 100;
 
   private boolean useMmap = false;
+  private boolean diskUsageWatermarkEnabled = DEFAULT_DISK_USAGE_WATERMARK_ENABLED;
   private double diskUsageReplicationWatermark = DEFAULT_DISK_USAGE_REPLICATION_WATERMARK;
   private double diskUsageCommandWatermark = DEFAULT_DISK_USAGE_COMMAND_WATERMARK;
   private Duration diskUsageMonitoringInterval = DEFAULT_DISK_USAGE_MONITORING_DELAY;
@@ -41,6 +50,13 @@ public final class DataCfg implements ConfigurationEntry {
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     directories.replaceAll(d -> ConfigurationUtil.toAbsolutePath(d, brokerBase));
+    if (!diskUsageWatermarkEnabled) {
+      LOG.info(
+          "Disk usage watermarks are disabled, setting all watermarks to {}",
+          DISABLED_DISK_USAGE_WATERMARK);
+      diskUsageReplicationWatermark = DISABLED_DISK_USAGE_WATERMARK;
+      diskUsageCommandWatermark = DISABLED_DISK_USAGE_WATERMARK;
+    }
   }
 
   public List<String> getDirectories() {
@@ -91,6 +107,14 @@ public final class DataCfg implements ConfigurationEntry {
     return useMmap() ? StorageLevel.MAPPED : StorageLevel.DISK;
   }
 
+  public boolean isDiskUsageWatermarkEnabled() {
+    return diskUsageWatermarkEnabled;
+  }
+
+  public void setDiskUsageWatermarkEnabled(final boolean diskUsageWatermarkEnabled) {
+    this.diskUsageWatermarkEnabled = diskUsageWatermarkEnabled;
+  }
+
   public double getDiskUsageCommandWatermark() {
     return diskUsageCommandWatermark;
   }
@@ -138,6 +162,8 @@ public final class DataCfg implements ConfigurationEntry {
         + logIndexDensity
         + ", useMmap="
         + useMmap
+        + ", diskUsageWatermarkEnabled="
+        + diskUsageWatermarkEnabled
         + ", diskUsageReplicationWatermark="
         + diskUsageReplicationWatermark
         + ", diskUsageCommandWatermark="

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
@@ -67,4 +67,21 @@ public class DataCfgTest {
     final var actual = sutDataCfg.getAtomixStorageLevel();
     assertThat(actual).isEqualTo(StorageLevel.DISK);
   }
+
+  @Test
+  public void shouldSetWatermarksTo1IfDisabled() {
+    // given
+    final DataCfg dataCfg = new DataCfg();
+    dataCfg.setDiskUsageCommandWatermark(0.1);
+    dataCfg.setDiskUsageReplicationWatermark(0.2);
+    dataCfg.setDiskUsageWatermarkEnabled(false);
+
+    // when
+    dataCfg.init(new BrokerCfg(), "/base");
+
+    // then
+    assertThat(dataCfg.isDiskUsageWatermarkEnabled()).isEqualTo(false);
+    assertThat(dataCfg.getDiskUsageCommandWatermark()).isEqualTo(1.0);
+    assertThat(dataCfg.getDiskUsageReplicationWatermark()).isEqualTo(1.0);
+  }
 }

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
@@ -74,13 +74,13 @@ public class DataCfgTest {
     final DataCfg dataCfg = new DataCfg();
     dataCfg.setDiskUsageCommandWatermark(0.1);
     dataCfg.setDiskUsageReplicationWatermark(0.2);
-    dataCfg.setDiskUsageWatermarkEnabled(false);
+    dataCfg.setDiskUsageMonitoringEnabled(false);
 
     // when
     dataCfg.init(new BrokerCfg(), "/base");
 
     // then
-    assertThat(dataCfg.isDiskUsageWatermarkEnabled()).isEqualTo(false);
+    assertThat(dataCfg.isDiskUsageMonitoringEnabled()).isEqualTo(false);
     assertThat(dataCfg.getDiskUsageCommandWatermark()).isEqualTo(1.0);
     assertThat(dataCfg.getDiskUsageReplicationWatermark()).isEqualTo(1.0);
   }

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -135,15 +135,23 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_SNAPSHOTPERIOD.
       # snapshotPeriod: 15m
 
+      # Configure whether to monitor disk usage to prevent out of disk space issues.
+      # If set to false the broker might run out of disk space and end in a non recoverable state.
+      # If set to true the disk space will be monitored and the broker will reject commands and pause replication
+      # if the thresholds of diskUsageCommandWatermark and diskUsageReplicationWatermark are reached.
+      #
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGENABLED
+      # diskUsageMonitoringEnabled = true
+
       # When the disk usage is above this value all client commands will be rejected.
       # The value is specified as a percentage of the total disk space.
-      # The value should be in the range (0, 1).
+      # The value should be in the range (0, 1].
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK
       # diskUsageCommandWatermark = 0.97
 
       # When the disk usage is above this value, this broker will stop writing replicated events it receives from other brokers.
       # The value is specified as a percentage of the total disk space.
-      # The value should be in the range (0, 1).
+      # The value should be in the range (0, 1].
       # It is recommended that diskUsageReplicationWatermark > diskUsageCommandWatermark
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
       # diskUsageReplicationWatermark = 0.99

--- a/docs/src/operations/disk-space.md
+++ b/docs/src/operations/disk-space.md
@@ -9,6 +9,7 @@ requests, to allow the operations team to free more disk space and the broker to
 
 Zeebe can be configured with the following settings for the disk usage watermarks:
 
+* **zeebe.broker.data.diskUsageMonitoringEnabled**: configure if disk usage should be monitored (default: true)
 * **zeebe.broker.data.diskUsageReplicationWatermark**: the fraction of used disk space before the replication is paused (default: 0.99)
 * **zeebe.broker.data.diskUsageCommandWatermark**: the fraction of used disk space before new user commands are rejected (default: 0.97), this has to be less then `diskUsageReplicationWatermark`
 * **zeebe.broker.data.diskUsageMonitoringInterval**: the interval in which the disk space usage is checked (default 1 second)


### PR DESCRIPTION
## Description

On disabling watermarks for disk usage the watermarks are set to 1, meaning the whole disk space can be used.

## Related issues

closes #5214 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
