### PR TITLE
chore(atomix): reduce storage buffers

### DIFF
--- a/atomix/storage/pom.xml
+++ b/atomix/storage/pom.xml
@@ -51,6 +51,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <artifactId>junit</artifactId>
       <groupId>junit</groupId>
       <scope>test</scope>

--- a/atomix/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentReader.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentReader.java
@@ -53,8 +53,8 @@ class FileChannelJournalSegmentReader<E> implements JournalReader<E> {
     this.maxEntrySize = maxEntrySize;
     this.index = index;
     this.namespace = namespace;
-    memory = ByteBuffer.allocate((maxEntrySize + Integer.BYTES + Integer.BYTES) * 2);
     this.segment = segment;
+    memory = ByteBuffer.allocate((maxEntrySize + Integer.BYTES + Integer.BYTES));
     reset();
   }
 

--- a/atomix/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentWriter.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentWriter.java
@@ -65,7 +65,7 @@ class FileChannelJournalSegmentWriter<E> implements JournalWriter<E> {
     this.segment = segment;
     this.maxEntrySize = maxEntrySize;
     this.index = index;
-    memory = ByteBuffer.allocate((maxEntrySize + Integer.BYTES + Integer.BYTES) * 2);
+    memory = ByteBuffer.allocate((maxEntrySize + Integer.BYTES + Integer.BYTES));
     memory.limit(0);
     this.namespace = namespace;
     firstIndex = segment.index();


### PR DESCRIPTION
## Description

We know that in atomix the large read and write buffers are problematic and are double the size of the max message size, but this is not really necessary. In order to reduce the cache misses and improve the performance I reduced the buffer sizes to the max message size + additional headers.

## Benchmark

I run a benchmark over the week end and got good  results.


### Base

#### General
![base-general](https://user-images.githubusercontent.com/2758593/91721314-da679800-eb98-11ea-83c5-2680965824b7.png)

#### Back pressure
![base-pressure](https://user-images.githubusercontent.com/2758593/91721320-db98c500-eb98-11ea-960d-700c0218d68c.png)

#### Latency
![base-latency](https://user-images.githubusercontent.com/2758593/91721318-db002e80-eb98-11ea-9c4b-0a2325965eb1.png)

### Reduced Buffers

#### General

![reduce-general](https://user-images.githubusercontent.com/2758593/91721373-ee12fe80-eb98-11ea-9389-c129325c8c18.png)

#### Back pressure

![reduce-backpressure](https://user-images.githubusercontent.com/2758593/91721398-fa975700-eb98-11ea-9c28-f6683a586438.png)

#### Latency

![reduce-latency](https://user-images.githubusercontent.com/2758593/91721417-ff5c0b00-eb98-11ea-985a-6381fb98dd1b.png)

<!-- Please explain the changes you made here. -->

## Last 4 days

Comparison between last 4 days:

| Base | Reduced Buffers |
|---------|-----------------------|
| ![last-4-days-base](https://user-images.githubusercontent.com/2758593/91722982-5fec4780-eb9b-11ea-8337-81b499ed424f.png) | ![last-4-days-reduce-buffers](https://user-images.githubusercontent.com/2758593/91723002-667abf00-eb9b-11ea-8129-48c0c0f2067c.png) |



## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/zeebe-io/zeebe/issues/4249

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
