### PR TITLE
Fix disk monitor notification on startup and during failover

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -103,6 +103,7 @@ public final class ZeebePartition extends Actor
   private final ZeebePartitionHealth zeebePartitionHealth;
   private long term;
   private StreamProcessor streamProcessor;
+  private boolean diskSpaceAvailable;
 
   public ZeebePartition(
       final BrokerInfo localBroker,
@@ -145,6 +146,7 @@ public final class ZeebePartition extends Actor
     zeebePartitionHealth = new ZeebePartitionHealth(partitionId);
     healthMetrics = new HealthMetrics(partitionId);
     healthMetrics.setUnhealthy();
+    diskSpaceAvailable = true;
   }
 
   /**
@@ -459,6 +461,9 @@ public final class ZeebePartition extends Actor
         .onComplete(
             (value, processorFail) -> {
               if (processorFail == null) {
+                if (!diskSpaceAvailable) {
+                  streamProcessor.pauseProcessing();
+                }
                 registerHealthComponent(streamProcessor.getName(), streamProcessor);
                 final DataCfg dataCfg = brokerCfg.getData();
                 installSnapshotDirector(streamProcessor, dataCfg)
@@ -754,6 +759,7 @@ public final class ZeebePartition extends Actor
   public void onDiskSpaceNotAvailable() {
     actor.call(
         () -> {
+          diskSpaceAvailable = false;
           if (streamProcessor != null) {
             LOG.warn("Disk space usage is above threshold. Pausing stream processor.");
             streamProcessor.pauseProcessing();
@@ -765,6 +771,7 @@ public final class ZeebePartition extends Actor
   public void onDiskSpaceAvailable() {
     actor.call(
         () -> {
+          diskSpaceAvailable = true;
           if (streamProcessor != null) {
             LOG.info("Disk space usage is below threshold. Resuming stream processor.");
             streamProcessor.resumeProcessing();

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceMonitoringFailOverTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceMonitoringFailOverTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.Broker;
+import io.zeebe.broker.it.clustering.ClusteringRule;
+import io.zeebe.broker.it.util.GrpcClientRule;
+import io.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+import org.springframework.util.unit.DataSize;
+
+public class DiskSpaceMonitoringFailOverTest {
+  private final Timeout testTimeout = Timeout.seconds(120);
+  private final ClusteringRule clusteringRule =
+      new ClusteringRule(
+          1,
+          3,
+          3,
+          cfg -> {
+            cfg.getData().setDiskUsageMonitoringInterval(Duration.ofSeconds(1));
+          });
+  private final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(testTimeout).around(clusteringRule).around(clientRule);
+
+  @Test
+  public void shouldNotBeHealthyAfterLeaderChangeWhenNoDiskSpaceAvailable()
+      throws InterruptedException {
+    // given
+    final var leaderId = clusteringRule.getLeaderForPartition(1).getNodeId();
+    final var followers =
+        clusteringRule.getBrokers().stream()
+            .filter(b -> b.getConfig().getCluster().getNodeId() != leaderId)
+            .collect(Collectors.toList());
+    // Force rescan of healthcheck
+    clusteringRule.getClock().addTime(Duration.ofSeconds(60));
+
+    followers.forEach(
+        broker ->
+            Awaitility.await()
+                .timeout(Duration.ofSeconds(30))
+                .untilAsserted(
+                    () ->
+                        assertThat(
+                                clusteringRule.isBrokerHealthy(
+                                    broker.getConfig().getCluster().getNodeId()))
+                            .isTrue()));
+    // When one of the follower becomes the new leader, it should be out of disk space already
+    for (final Broker broker : followers) {
+      waitUntilDiskSpaceNotAvailable(broker);
+    }
+
+    // when
+    clusteringRule.stopBrokerAndAwaitNewLeader(leaderId);
+    final var newLeaderId = clusteringRule.getLeaderForPartition(1).getNodeId();
+
+    // then
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(60))
+        .untilAsserted(() -> assertThat(clusteringRule.isBrokerHealthy(newLeaderId)).isFalse());
+  }
+
+  private void waitUntilDiskSpaceNotAvailable(final Broker broker) throws InterruptedException {
+    final var diskSpaceMonitor = broker.getDiskSpaceUsageMonitor();
+
+    final CountDownLatch diskSpaceNotAvailable = new CountDownLatch(1);
+    diskSpaceMonitor.addDiskUsageListener(
+        new DiskSpaceUsageListener() {
+          @Override
+          public void onDiskSpaceNotAvailable() {
+            diskSpaceNotAvailable.countDown();
+          }
+
+          @Override
+          public void onDiskSpaceAvailable() {}
+        });
+
+    diskSpaceMonitor.setFreeDiskSpaceSupplier(() -> DataSize.ofGigabytes(0).toBytes());
+
+    clusteringRule.getClock().addTime(Duration.ofSeconds(1));
+
+    // when
+    assertThat(diskSpaceNotAvailable.await(2, TimeUnit.SECONDS)).isTrue();
+  }
+}


### PR DESCRIPTION
## Description

* Check for disk availability immediately on start
* Notify listeners if disk is not available when they are added
* Pause streamprocessor if no disk available during a leader change

## Related issues

closes #5093 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
