### PR TITLE
Fix FEEL expression with list access

### DIFF
--- a/expression-language/src/main/scala/io/zeebe/el/impl/feel/MessagePackContext.scala
+++ b/expression-language/src/main/scala/io/zeebe/el/impl/feel/MessagePackContext.scala
@@ -15,14 +15,14 @@ import org.camunda.feel.context.{CustomContext, VariableProvider}
 
 class MessagePackContext(
                           reader: MsgPackReader,
-                          offset: Int,
+                          bufferOffset: Int,
                           size: Int
                         ) extends CustomContext {
 
   private val valueOffsets: Map[String, (Int, Int)] = readValueOffsets(reader, size)
-  private val length = reader.getOffset - offset
+  private val length = reader.getOffset - bufferOffset
 
-  val messagePackMap: DirectBuffer = cloneBuffer(reader.getBuffer, offset, length)
+  val messagePackMap: DirectBuffer = cloneBuffer(reader.getBuffer, bufferOffset, length)
 
   override val variableProvider: VariableProvider = new MessagePackMapVariableProvider(messagePackMap)
 
@@ -58,7 +58,7 @@ class MessagePackContext(
       reader.skipValue()
       val valueLength = reader.getOffset - valueOffset
 
-      key -> (valueOffset, valueLength)
+      key -> (valueOffset - bufferOffset, valueLength)
     }
 
     offsets.toMap

--- a/expression-language/src/main/scala/io/zeebe/el/impl/feel/MessagePackValueMapper.scala
+++ b/expression-language/src/main/scala/io/zeebe/el/impl/feel/MessagePackValueMapper.scala
@@ -58,7 +58,7 @@ class MessagePackValueMapper extends CustomValueMapper {
       case MsgPackType.MAP => {
         val context = new MessagePackContext(
           reader = reader,
-          offset = offset,
+          bufferOffset = offset,
           size = token.getSize
         )
 

--- a/expression-language/src/test/java/io/zeebe/el/FeelExpressionTest.java
+++ b/expression-language/src/test/java/io/zeebe/el/FeelExpressionTest.java
@@ -10,6 +10,7 @@ package io.zeebe.el;
 import static io.zeebe.test.util.MsgPackUtil.asMsgPack;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
@@ -127,6 +128,33 @@ public class FeelExpressionTest {
 
     assertThat(evaluationResult.getType()).isEqualTo(ResultType.STRING);
     assertThat(evaluationResult.getString()).isEqualTo("FOO");
+  }
+
+  @Test
+  public void accessListElement() {
+    final var context = Map.of("x", asMsgPack("[\"a\",\"b\"]"));
+    final var evaluationResult = evaluateExpression("x[1]", context::get);
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.STRING);
+    assertThat(evaluationResult.getString()).isEqualTo("a");
+  }
+
+  @Test
+  public void accessPropertyOfListElement() {
+    final var context = Map.of("x", asMsgPack("[{\"y\":\"a\"},{\"y\":\"b\"}]"));
+    final var evaluationResult = evaluateExpression("x[2].y", context::get);
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.STRING);
+    assertThat(evaluationResult.getString()).isEqualTo("b");
+  }
+
+  @Test
+  public void listProjection() {
+    final var context = Map.of("x", asMsgPack("[{\"y\":1},{\"y\":2}]"));
+    final var evaluationResult = evaluateExpression("x.y", context::get);
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.ARRAY);
+    assertThat(evaluationResult.getList()).isEqualTo(List.of(asMsgPack("1"), asMsgPack("2")));
   }
 
   private EvaluationResult evaluateExpression(


### PR DESCRIPTION
## Description

* an exception occurred when a context was wrapped in a list and an expression accessed a property of the context
* the MessagePack mapper/context used a wrong index/offset when accessing the buffer

## Related issues

closes #5086 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
