### PR TITLE
Improve atomix startup and snapshot replication logs

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -245,7 +245,7 @@ public class DefaultRaftServer implements RaftServer {
           .whenComplete(
               (result, error) -> {
                 if (error == null) {
-                  log.debug("Server join completed. Waiting for the server to be READY");
+                  log.info("Server join completed. Waiting for the server to be READY");
                   context.awaitState(
                       RaftContext.State.READY,
                       state -> {

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -688,6 +688,9 @@ public class RaftContext implements AutoCloseable {
   public void setFirstCommitIndex(final long firstCommitIndex) {
     if (this.firstCommitIndex == 0) {
       this.firstCommitIndex = firstCommitIndex;
+      log.info(
+          "Setting firstCommitIndex to {}. RaftServer is ready only after it has committed events upto this index",
+          firstCommitIndex);
     }
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -20,6 +20,7 @@ import com.google.common.base.Throwables;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftException;
+import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.cluster.RaftMember;
@@ -675,7 +676,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
     if (!isRunning()) {
       appendListener.onWriteError(
-          new IllegalStateException("LeaderRole is closed and cannot be used as appender"));
+          new NoLeader("LeaderRole is closed and cannot be used as appender"));
       return;
     }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.storage.log.RaftLogReader;
@@ -370,7 +371,7 @@ public class LeaderRoleTest {
     verify(context, timeout(1000)).transition(Role.FOLLOWER);
     verify(writer, timeout(1000)).append(any(RaftLogEntry.class));
 
-    assertTrue(catchedError.get() instanceof IllegalStateException);
+    assertTrue(catchedError.get() instanceof NoLeader);
     assertEquals(
         "LeaderRole is closed and cannot be used as appender", catchedError.get().getMessage());
   }

--- a/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshot.java
@@ -123,6 +123,9 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
 
   @Override
   public String toString() {
-    return "DbSnapshot{" + "directory=" + directory + ", metadata=" + metadata + '}';
+    return "FileBasedSnapshot{" +
+        "directory=" + directory +
+        ", metadata=" + metadata +
+        '}';
   }
 }

--- a/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshot.java
@@ -123,9 +123,6 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
 
   @Override
   public String toString() {
-    return "FileBasedSnapshot{" +
-        "directory=" + directory +
-        ", metadata=" + metadata +
-        '}';
+    return "FileBasedSnapshot{" + "directory=" + directory + ", metadata=" + metadata + '}';
   }
 }

--- a/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotMetadata.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotMetadata.java
@@ -122,34 +122,37 @@ public final class FileBasedSnapshotMetadata implements SnapshotId {
 
   @Override
   public int hashCode() {
-    return Objects.hash(getIndex(), getTerm(), getTimestamp());
+    return Objects.hash(index, term, processedPosition, exporterPosition);
   }
 
   @Override
-  public boolean equals(final Object other) {
-    if (this == other) {
+  public boolean equals(final Object o) {
+    if (this == o) {
       return true;
     }
-
-    if (other == null || getClass() != other.getClass()) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
-    final FileBasedSnapshotMetadata that = (FileBasedSnapshotMetadata) other;
-    return getIndex() == that.getIndex()
-        && getTerm() == that.getTerm()
-        && Objects.equals(getTimestamp(), that.getTimestamp());
+    final FileBasedSnapshotMetadata that = (FileBasedSnapshotMetadata) o;
+    return index == that.index
+        && term == that.term
+        && processedPosition == that.processedPosition
+        && exporterPosition == that.exporterPosition;
   }
 
   @Override
   public String toString() {
-    return "DbSnapshotMetadata{"
+    return "FileBasedSnapshotMetadata{"
         + "index="
         + index
         + ", term="
         + term
         + ", timestamp="
         + timestamp
+        + ", processedPosition="
+        + processedPosition
+        + ", exporterPosition="
+        + exporterPosition
         + '}';
   }
 }

--- a/util/src/main/java/io/zeebe/util/health/CriticalComponentsHealthMonitor.java
+++ b/util/src/main/java/io/zeebe/util/health/CriticalComponentsHealthMonitor.java
@@ -139,7 +139,7 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
     }
 
     private void onComponentRecovered() {
-      log.debug("{} recovered, marking it as healthy", componentName);
+      log.info("{} recovered, marking it as healthy", componentName);
       componentHealth.computeIfPresent(componentName, (k, v) -> HealthStatus.HEALTHY);
       calculateHealth();
     }


### PR DESCRIPTION
## Description

* Add more logs at info level during raft startup
* Add more logs for snapshot replication at info level
* Improve error log when appender fails

## Related issues

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
