### PR TITLE
chore(dist): expose spring endpoints for configuring loggers

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -1,12 +1,14 @@
 management.endpoint.health.show-details=always
 management.health.elasticsearch.enabled=false
 management.health.ping.enabled=false
+management.endpoints.web.exposure.include=health,prometheus,loggers
 #Metrics related configurations
-management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.prometheus.enabled=true
 management.metrics.export.prometheus.enabled=true
 management.endpoint.health.group.startup.include=gatewayStarted
 management.endpoint.health.group.startup.show-details=never
 management.endpoint.health.group.liveness.include=gatewayStarted,livenessGatewayResponsive,livenessGatewayClusterAwareness,livenessGatewayPartitionLeaderAwareness,livenessDiskSpace,livenessMemory
 management.endpoint.health.group.liveness.show-details=never
+#Allow runtime configuration of log levels
+management.endpoint.loggers.enabled=true
 


### PR DESCRIPTION
## Description

Enable spring endpoints for configuring log levels during runtime

## Related issues

closes #5281

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
