### PR TITLE
Use atomix_role for calculating variables in dashboard

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -83,7 +83,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1598954942581,
+  "iteration": 1599223056776,
   "links": [],
   "panels": [
     {
@@ -9043,7 +9043,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "Prometheus",
           "value": "Prometheus"
         },
@@ -9063,7 +9063,7 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(zeebe_health, namespace)",
+        "definition": "label_values(atomix_role, namespace)",
         "hide": 0,
         "includeAll": true,
         "index": -1,
@@ -9071,7 +9071,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(zeebe_health, namespace)",
+        "query": "label_values(atomix_role, namespace)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -9086,7 +9086,7 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(zeebe_health{namespace=~\"$namespace\"}, pod)",
+        "definition": "label_values(atomix_role{namespace=~\"$namespace\"}, pod)",
         "hide": 0,
         "includeAll": true,
         "index": -1,
@@ -9094,7 +9094,7 @@
         "multi": true,
         "name": "pod",
         "options": [],
-        "query": "label_values(zeebe_health{namespace=~\"$namespace\"}, pod)",
+        "query": "label_values(atomix_role{namespace=~\"$namespace\"}, pod)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -9109,7 +9109,7 @@
         "allValue": ".*",
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(zeebe_health{namespace=~\"$namespace\", pod=~\"$pod\"}, partition)",
+        "definition": "label_values(atomix_role{namespace=~\"$namespace\", pod=~\"$pod\"}, partition)",
         "hide": 0,
         "includeAll": true,
         "index": -1,
@@ -9117,7 +9117,7 @@
         "multi": true,
         "name": "partition",
         "options": [],
-        "query": "label_values(zeebe_health{namespace=~\"$namespace\", pod=~\"$pod\"}, partition)",
+        "query": "label_values(atomix_role{namespace=~\"$namespace\", pod=~\"$pod\"}, partition)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -9165,5 +9165,5 @@
   "variables": {
     "list": []
   },
-  "version": 14
+  "version": 15
 }


### PR DESCRIPTION
## Description

When using `zeebe_health` to calculate variables in the dashboard, we cannot see the metrics during the cluster startup because metric `zeebe_health` is only available after a broker is successfully started. In this PR we use `atomix_role` to calculate the variables - namespace,pod and partition.  The metric`atomix_role` is updated immediately after a raft partition is created, before leader election or cluster join is started. Hence the metrics will be viewable even if the cluster did not start successfully.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
