### PR TITLE
fix(clients/java): Set a defaultRequestTimeout as 10 seconds

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -48,7 +48,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private Duration defaultJobTimeout = Duration.ofMinutes(5);
   private Duration defaultJobPollInterval = Duration.ofMillis(100);
   private Duration defaultMessageTimeToLive = Duration.ofHours(1);
-  private Duration defaultRequestTimeout = Duration.ofSeconds(20);
+  private Duration defaultRequestTimeout = Duration.ofSeconds(10);
   private boolean usePlaintextConnection = false;
   private String certificatePath;
   private CredentialsProvider credentialsProvider;

--- a/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
@@ -58,7 +58,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultJobTimeout()).isEqualTo(Duration.ofMinutes(5));
       assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
       assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
-      assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(20));
+      assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
     }
   }
 


### PR DESCRIPTION
## Description

Set a defaultRequestTimeout as 10 seconds

## Related issues

closes #4762 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
