### PR TITLE
chore(benchmarks): change default diskusage watermarks

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -67,6 +67,10 @@ env:
     value: "true"
   - name: ATOMIX_LOG_LEVEL
     value: INFO
+  - name: ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK
+    value: "0.8"
+  - name: ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
+    value: "0.9"
 
 # RESOURCES
 resources:


### PR DESCRIPTION
## Description

After #5259, the default diskusage watermarks are high and not optimal for the workloads that we are running in our benchmarks.
In this PR we set the default watermarks for our benchmarks to previous defaults - 0.8 and 0.9 respectively.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
