### PR TITLE
Use correct algorithm name for fixed limit backpressure 

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/backpressure/BackpressureCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/backpressure/BackpressureCfg.java
@@ -15,7 +15,7 @@ public final class BackpressureCfg implements ConfigurationEntry {
   private boolean useWindowed = true;
   private LimitAlgorithm algorithm = LimitAlgorithm.VEGAS;
   private final AIMDCfg aimd = new AIMDCfg();
-  private final FixedLimitCfg fixedLimit = new FixedLimitCfg();
+  private final FixedCfg fixed = new FixedCfg();
   private final VegasCfg vegas = new VegasCfg();
   private final GradientCfg gradient = new GradientCfg();
   private final Gradient2Cfg gradient2 = new Gradient2Cfg();
@@ -49,8 +49,8 @@ public final class BackpressureCfg implements ConfigurationEntry {
     return aimd;
   }
 
-  public FixedLimitCfg getFixedLimit() {
-    return fixedLimit;
+  public FixedCfg getFixed() {
+    return fixed;
   }
 
   public VegasCfg getVegas() {
@@ -77,8 +77,8 @@ public final class BackpressureCfg implements ConfigurationEntry {
         + '\''
         + ", aimd="
         + aimd
-        + ", fixedLimit="
-        + fixedLimit
+        + ", fixed="
+        + fixed
         + ", vegas="
         + vegas
         + ", gradient="

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/backpressure/FixedCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/backpressure/FixedCfg.java
@@ -9,7 +9,7 @@ package io.zeebe.broker.system.configuration.backpressure;
 
 import static io.zeebe.broker.system.configuration.ConfigurationUtil.checkPositive;
 
-public class FixedLimitCfg {
+public class FixedCfg {
 
   private int limit = 20;
 
@@ -24,6 +24,6 @@ public class FixedLimitCfg {
 
   @Override
   public String toString() {
-    return "FixedLimitCfg{" + "limit=" + limit + '}';
+    return "FixedCfg{" + "limit=" + limit + '}';
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/transport/backpressure/PartitionAwareRequestLimiter.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/backpressure/PartitionAwareRequestLimiter.java
@@ -19,7 +19,7 @@ import com.netflix.concurrency.limits.limit.WindowedLimit;
 import io.zeebe.broker.system.configuration.backpressure.AIMDCfg;
 import io.zeebe.broker.system.configuration.backpressure.BackpressureCfg;
 import io.zeebe.broker.system.configuration.backpressure.BackpressureCfg.LimitAlgorithm;
-import io.zeebe.broker.system.configuration.backpressure.FixedLimitCfg;
+import io.zeebe.broker.system.configuration.backpressure.FixedCfg;
 import io.zeebe.broker.system.configuration.backpressure.Gradient2Cfg;
 import io.zeebe.broker.system.configuration.backpressure.GradientCfg;
 import io.zeebe.broker.system.configuration.backpressure.VegasCfg;
@@ -58,8 +58,8 @@ public final class PartitionAwareRequestLimiter {
         limit = () -> getAIMD(aimdCfg);
         break;
       case FIXED:
-        final FixedLimitCfg fixedLimitCfg = backpressureCfg.getFixedLimit();
-        limit = () -> FixedLimit.of(fixedLimitCfg.getLimit());
+        final FixedCfg fixedCfg = backpressureCfg.getFixed();
+        limit = () -> FixedLimit.of(fixedCfg.getLimit());
         break;
       case GRADIENT:
         final GradientCfg gradientCfg = backpressureCfg.getGradient();

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/BackpressureCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/BackpressureCfgTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.zeebe.broker.system.configuration.backpressure.BackpressureCfg;
 import io.zeebe.broker.system.configuration.backpressure.BackpressureCfg.LimitAlgorithm;
-import io.zeebe.broker.system.configuration.backpressure.FixedLimitCfg;
+import io.zeebe.broker.system.configuration.backpressure.FixedCfg;
 import io.zeebe.broker.system.configuration.backpressure.Gradient2Cfg;
 import io.zeebe.broker.system.configuration.backpressure.GradientCfg;
 import io.zeebe.broker.system.configuration.backpressure.VegasCfg;
@@ -56,13 +56,15 @@ public final class BackpressureCfgTest {
   }
 
   @Test
-  public void shouldSetFixedLimitCfg() {
+  public void shouldSetFixedCfg() {
     // when
-    final BrokerCfg cfg = readConfig("backpressure-cfg");
-    final FixedLimitCfg fixedLimitCfg = cfg.getBackpressure().getFixedLimit();
+    final BrokerCfg cfg = readConfig("backpressure-fixed-cfg");
+    final LimitAlgorithm algorithm = cfg.getBackpressure().getAlgorithm();
+    final FixedCfg fixedCfg = cfg.getBackpressure().getFixed();
 
     // then
-    assertThat(fixedLimitCfg.getLimit()).isEqualTo(12);
+    assertThat(algorithm).isEqualTo(LimitAlgorithm.FIXED);
+    assertThat(fixedCfg.getLimit()).isEqualTo(13);
   }
 
   @Test

--- a/broker/src/test/java/io/zeebe/broker/transport/backpressure/PartitionAwareRateLimiterTest.java
+++ b/broker/src/test/java/io/zeebe/broker/transport/backpressure/PartitionAwareRateLimiterTest.java
@@ -25,7 +25,7 @@ public final class PartitionAwareRateLimiterTest {
   public void setUp() {
     final var backpressureCfg = new BackpressureCfg();
     backpressureCfg.setAlgorithm("fixed");
-    backpressureCfg.getFixedLimit().setLimit(1);
+    backpressureCfg.getFixed().setLimit(1);
     partitionedLimiter =
         io.zeebe.broker.transport.backpressure.PartitionAwareRequestLimiter.newLimiter(
             backpressureCfg);

--- a/broker/src/test/resources/system/backpressure-cfg.yaml
+++ b/broker/src/test/resources/system/backpressure-cfg.yaml
@@ -10,7 +10,7 @@ zeebe:
         minLimit: 5
         maxLimit: 150
         backoffRatio: 0.75
-      fixedLimit:
+      fixed:
         limit: 12
       vegas:
         alpha: 4

--- a/broker/src/test/resources/system/backpressure-fixed-cfg.yaml
+++ b/broker/src/test/resources/system/backpressure-fixed-cfg.yaml
@@ -1,0 +1,6 @@
+zeebe:
+  broker:
+    backpressure:
+      algorithm: fixed
+      fixed:
+        limit: 13

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -324,9 +324,9 @@
       # useWindowed: true
 
       # The algorithm configures which algorithm to use for the backpressure.
-      # It should be one of vegas, aimd, fixedLimit, gradient, or gradient2.
+      # It should be one of vegas, aimd, fixed, gradient, or gradient2.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_BACKPRESSURE_ALGORITHM
-      # algorithm: "vegas"
+      # algorithm: "fixed"
 
       # Configure the parameters for "aimd" algorithm.
       # AIMD increases the limit for every successful response and decrease the limit for every request timeout.
@@ -350,9 +350,9 @@
         # backoffRatio: 0.9
 
       # Configure the parameters for "fixed" algorithm
-      # fixedLimit:
-        # Set a fixed limit. This setting can also be overridden using the environment variable ZEEBE_BROKER_BACKPRESSURE_FIXEDLIMIT_LIMIT
-        # limit: 20
+      # fixed:
+        # Set a fixed limit. This setting can also be overridden using the environment variable ZEEBE_BROKER_BACKPRESSURE_FIXED_LIMIT
+        # limit: 10
 
       # Configure the parameters for "vegas" algorithm
       # Vegas is an adaptive limit algorithm based on TCP Vegas congestion control algorithm.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -284,7 +284,7 @@
       # useWindowed: true
 
       # The algorithm configures which algorithm to use for the backpressure.
-      # It should be one of vegas, aimd, fixedLimit, gradient, or gradient2.
+      # It should be one of vegas, aimd, fixed, gradient, or gradient2.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_BACKPRESSURE_ALGORITHM
       # algorithm: "vegas"
 
@@ -310,8 +310,8 @@
         # backoffRatio: 0.9
 
       # Configure the parameters for "fixed" algorithm
-      # fixedLimit:
-        # Set a fixed limit. This setting can also be overridden using the environment variable ZEEBE_BROKER_BACKPRESSURE_FIXEDLIMIT_LIMIT
+      # fixed:
+        # Set a fixed limit. This setting can also be overridden using the environment variable ZEEBE_BROKER_BACKPRESSURE_FIXED_LIMIT
         # limit: 20
 
       # Configure the parameters for "vegas" algorithm


### PR DESCRIPTION
## Description

Fixes the mismatch between documentation and implementation of the back pressure algorithm "fixed".

This is split out of the PR #5267

## Related issues

closes #5257 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
