### PR TITLE
fix(clients/java): Set a defaultRequestTimeout as 10 seconds

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -48,7 +48,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private Duration defaultJobTimeout = Duration.ofMinutes(5);
   private Duration defaultJobPollInterval = Duration.ofMillis(100);
   private Duration defaultMessageTimeToLive = Duration.ofHours(1);
-  private Duration defaultRequestTimeout = Duration.ofSeconds(20);
+  private Duration defaultRequestTimeout = Duration.ofSeconds(10);
   private boolean usePlaintextConnection = false;
   private String certificatePath;
   private CredentialsProvider credentialsProvider;

--- a/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
@@ -58,7 +58,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultJobTimeout()).isEqualTo(Duration.ofMinutes(5));
       assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
       assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
-      assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(20));
+      assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
     }
   }
 

--- a/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
@@ -10,7 +10,6 @@ package io.zeebe.test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.zeebe.client.api.response.ActivateJobsResponse;
-import io.zeebe.client.api.response.ActivatedJob;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.test.UpgradeTestCase.TestCaseBuilder;
@@ -46,6 +45,7 @@ public class UpgradeTest {
   public static final String CHILD_PROCESS_ID = "childProc";
   private static final String CURRENT_VERSION = "current-test";
   private static final String TASK = "task";
+  private static final String JOB = TASK;
   private static final String MESSAGE = "message";
   private static final File SHARED_DATA;
 
@@ -150,19 +150,8 @@ public class UpgradeTest {
                 .createInstance()
                 .afterUpgrade(
                     (state, wfKey, key) -> {
-                      final ActivatedJob job =
-                          state
-                              .client()
-                              .newActivateJobsCommand()
-                              .jobType(TASK)
-                              .maxJobsToActivate(1)
-                              .send()
-                              .join()
-                              .getJobs()
-                              .iterator()
-                              .next();
-
-                      state.client().newCompleteCommand(job.getKey()).send().join();
+                      final var jobKey = activateJob(state);
+                      completeJob(state, wfKey, jobKey);
                       TestUtil.waitUntil(
                           () -> state.hasLogContaining(CHILD_PROCESS_ID, "COMPLETED"));
                     })
@@ -229,10 +218,13 @@ public class UpgradeTest {
   }
 
   private static long activateJob(final ContainerStateRule state) {
+    TestUtil.waitUntil(() -> state.hasElementInState(JOB, "CREATED"));
+
     final ActivateJobsResponse jobsResponse =
         state.client().newActivateJobsCommand().jobType(TASK).maxJobsToActivate(1).send().join();
+    assertThat(jobsResponse.getJobs()).hasSize(1);
 
-    TestUtil.waitUntil(() -> state.hasElementInState(TASK, "ACTIVATED"));
+    TestUtil.waitUntil(() -> state.hasElementInState(JOB, "ACTIVATED"));
     return jobsResponse.getJobs().get(0).getKey();
   }
 


### PR DESCRIPTION
## Description

Backport of #5302 

## Related issues

closes #4762 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [X] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
