### PR TITLE
chore(parent): upgrade Zeebe Test Container to 1.0.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -82,7 +82,7 @@
     <version.asm>8.0.1</version.asm>
     <version.testcontainers>1.14.3</version.testcontainers>
     <version.netflix.concurrency>0.3.6</version.netflix.concurrency>
-    <version.zeebe-test-container>0.33.0</version.zeebe-test-container>
+    <version.zeebe-test-container>1.0.0</version.zeebe-test-container>
     <version.feel-scala>1.11.2</version.feel-scala>
     <version.restassert>4.3.1</version.restassert>
     <version.spring-framework>5.2.8.RELEASE</version.spring-framework>

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/BrokerMonitoringEndpointTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/BrokerMonitoringEndpointTest.java
@@ -15,26 +15,26 @@ import io.restassured.filter.log.RequestLoggingFilter;
 import io.restassured.filter.log.ResponseLoggingFilter;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
-import io.zeebe.containers.ZeebeBrokerContainer;
-import java.io.IOException;
+import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.ZeebePort;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public final class BrokerMonitoringEndpointTest {
 
-  static ZeebeBrokerContainer sutBroker;
+  static ZeebeContainer sutBroker;
 
   static RequestSpecification brokerServerSpec;
 
   @BeforeClass
   public static void setUpClass() {
-    sutBroker = new ZeebeBrokerContainer("current-test").withClusterName("zeebe-cluster");
+    sutBroker = new ZeebeContainer("camunda/zeebe:current-test");
 
     sutBroker.start();
 
-    final Integer monitoringPort = sutBroker.getMappedPort(9600);
-    final String containerIPAddress = sutBroker.getContainerIpAddress();
+    final Integer monitoringPort = sutBroker.getMappedPort(ZeebePort.MONITORING.getPort());
+    final String containerIPAddress = sutBroker.getExternalHost();
 
     brokerServerSpec =
         new RequestSpecBuilder()
@@ -68,7 +68,7 @@ public final class BrokerMonitoringEndpointTest {
   }
 
   @Test
-  public void shouldGetReadyStatus() throws IOException, InterruptedException {
+  public void shouldGetReadyStatus() {
     given()
         .spec(brokerServerSpec)
         .when()
@@ -78,7 +78,7 @@ public final class BrokerMonitoringEndpointTest {
   }
 
   @Test
-  public void shouldGetHealthStatus() throws IOException, InterruptedException {
+  public void shouldGetHealthStatus() {
     given()
         .spec(brokerServerSpec)
         .when()

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceRecoveryITTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceRecoveryITTest.java
@@ -14,7 +14,7 @@ import static org.awaitility.Awaitility.await;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Volume;
 import io.zeebe.client.ZeebeClient;
-import io.zeebe.containers.ZeebeBrokerContainer;
+import io.zeebe.containers.ZeebeContainer;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -28,30 +28,28 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 public class DiskSpaceRecoveryITTest {
-  static ZeebeBrokerContainer zeebeBroker;
+  static ZeebeContainer zeebeBroker;
   private static final Logger LOG = LoggerFactory.getLogger(DiskSpaceRecoveryITTest.class);
   private static final String VOLUME_NAME = "data-DiskSpaceRecoveryITTest";
   private static ElasticsearchContainer elastic;
-  private static String elasticHostUrl;
+  private static final String ELASTIC_HOST = "http://elastic:9200";
   private ZeebeClient client;
 
   @Before
   public void setUp() {
-    elasticHostUrl = "http://elastic:9200";
-    zeebeBroker = new ZeebeBrokerContainer("current-test");
-    configureZeebe(zeebeBroker, elasticHostUrl);
+    zeebeBroker = new ZeebeContainer("camunda/zeebe:current-test");
+    configureZeebe(zeebeBroker);
     final var network = zeebeBroker.getNetwork();
     elastic = createElastic(network);
   }
 
-  private static ZeebeBrokerContainer configureZeebe(
-      final ZeebeBrokerContainer zeebeBroker, final String elasticHost) {
+  private static ZeebeContainer configureZeebe(final ZeebeContainer zeebeBroker) {
 
     zeebeBroker
         .withEnv(
             "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME",
             "io.zeebe.exporter.ElasticsearchExporter")
-        .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL", elasticHost)
+        .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL", ELASTIC_HOST)
         .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_DELAY", "1")
         .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE", "1")
         .withEnv("ZEEBE_BROKER_DATA_SNAPSHOTPERIOD", "1m")

--- a/upgrade-tests/src/test/java/io/zeebe/test/ContainerStateRule.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/ContainerStateRule.java
@@ -8,9 +8,8 @@
 package io.zeebe.test;
 
 import io.zeebe.client.ZeebeClient;
-import io.zeebe.containers.ZeebeBrokerContainer;
-import io.zeebe.containers.ZeebePort;
-import io.zeebe.containers.ZeebeStandaloneGatewayContainer;
+import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.ZeebeGatewayContainer;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -22,7 +21,6 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.event.Level;
 import org.testcontainers.containers.ContainerFetchException;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.Network;
@@ -49,8 +47,8 @@ class ContainerStateRule extends TestWatcher {
             });
   }
 
-  private ZeebeBrokerContainer broker;
-  private ZeebeStandaloneGatewayContainer gateway;
+  private ZeebeContainer broker;
+  private ZeebeGatewayContainer gateway;
   private ZeebeClient client;
   private Network network;
 
@@ -91,31 +89,27 @@ class ContainerStateRule extends TestWatcher {
   }
 
   public void start() {
+    final String contactPoint;
     network = Network.newNetwork();
     broker =
-        new ZeebeBrokerContainer(brokerVersion)
+        new ZeebeContainer("camunda/zeebe:" + brokerVersion)
             .withFileSystemBind(volumePath, "/usr/local/zeebe/data")
-            .withEnv("ZEEBE_BROKER_CLUSTER_CLUSTERNAME", "zeebe-cluster")
-            .withNetwork(network)
-            .withEmbeddedGateway(gatewayVersion == null)
-            .withLogLevel(Level.DEBUG)
-            .withDebug(false);
+            .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
+            .withEnv("ZEEBE_DEBUG", "true")
+            .withNetwork(network);
+    Failsafe.with(CONTAINER_START_RETRY_POLICY).run(() -> broker.self().start());
 
-    Failsafe.with(CONTAINER_START_RETRY_POLICY).run(() -> broker.start());
-
-    String contactPoint = broker.getExternalAddress(ZeebePort.GATEWAY);
-
-    if (gatewayVersion != null) {
+    if (gatewayVersion == null) {
+      contactPoint = broker.getExternalGatewayAddress();
+    } else {
       gateway =
-          new ZeebeStandaloneGatewayContainer(gatewayVersion)
-              .withEnv("ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT", broker.getContactPoint())
-              .withEnv("ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME", "zeebe-cluster")
-              .withNetwork(network)
-              .withLogLevel(Level.DEBUG);
+          new ZeebeGatewayContainer(gatewayVersion)
+              .withEnv("ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT", broker.getInternalClusterAddress())
+              .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
+              .withNetwork(network);
 
-      Failsafe.with(CONTAINER_START_RETRY_POLICY).run(() -> gateway.start());
-
-      contactPoint = gateway.getExternalAddress(ZeebePort.GATEWAY);
+      Failsafe.with(CONTAINER_START_RETRY_POLICY).run(() -> gateway.self().start());
+      contactPoint = gateway.getExternalGatewayAddress();
     }
 
     client = ZeebeClient.newClientBuilder().brokerContactPoint(contactPoint).usePlaintext().build();
@@ -186,7 +180,7 @@ class ContainerStateRule extends TestWatcher {
     }
 
     if (gateway != null) {
-      gateway.close();
+      gateway.shutdownGracefully(CLOSE_TIMEOUT);
       gateway = null;
     }
 


### PR DESCRIPTION
## Description

This PRs updates Zeebe Test Container to 1.0.0, including any necessary code changes. It's not currently possible to run the `RollingUpgradeTest`, so to test it yourself, you can verify it works by changing the tests to upgrade from `current-test` to `current-test` instead of `0.24.0` to `current-test`.

I wouldn't back port this, as this affects only tests. I'm aware this may make back porting later regression tests more complicated though, so I'm open to discussion (note that this doesn't really affect 0.23 which will be phased out soon, but could be useful for 0.24).

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
