### PR TITLE
Control variable propagation of call activities with new attribute

### DIFF
--- a/bpmn-model/pom.xml
+++ b/bpmn-model/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe BPMN model API</name>
@@ -57,6 +59,16 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <ignored>
+            <ignored>
+              <!-- ignore new methods in the Zeebe element instance interfaces -->
+              <className>io/zeebe/model/bpmn/instance/zeebe/*</className>
+              <differenceType>7012</differenceType>
+              <method>*</method>
+            </ignored>
+          </ignored>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractCallActivityBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractCallActivityBuilder.java
@@ -53,4 +53,11 @@ public class AbstractCallActivityBuilder<B extends AbstractCallActivityBuilder<B
     calledElement.setProcessId(asZeebeExpression(processIdExpression));
     return myself;
   }
+
+  public B zeebePropagateAllChildVariables(final boolean propagateAllChildVariables) {
+    final ZeebeCalledElement calledElement =
+        getCreateSingleExtensionElement(ZeebeCalledElement.class);
+    calledElement.setPropagateAllChildVariablesEnabled(propagateAllChildVariables);
+    return myself;
+  }
 }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -34,6 +34,7 @@ public class ZeebeConstants {
   public static final String ATTRIBUTE_OUTPUT_ELEMENT = "outputElement";
 
   public static final String ATTRIBUTE_PROCESS_ID = "processId";
+  public static final String ATTRIBUTE_PROPAGATE_ALL_CHILD_VARIABLES = "propagateAllChildVariables";
 
   public static final String ELEMENT_HEADER = "header";
   public static final String ELEMENT_INPUT = "input";

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledElementImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledElementImpl.java
@@ -28,6 +28,7 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
     implements ZeebeCalledElement {
 
   private static Attribute<String> processIdAttribute;
+  private static Attribute<Boolean> propagateAllChildVariablesAttribute;
 
   public ZeebeCalledElementImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -43,6 +44,17 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
     processIdAttribute.setValue(this, processId);
   }
 
+  @Override
+  public boolean isPropagateAllChildVariablesEnabled() {
+    return propagateAllChildVariablesAttribute.getValue(this);
+  }
+
+  @Override
+  public void setPropagateAllChildVariablesEnabled(
+      final boolean propagateAllChildVariablesEnabled) {
+    propagateAllChildVariablesAttribute.setValue(this, propagateAllChildVariablesEnabled);
+  }
+
   public static void registerType(final ModelBuilder modelBuilder) {
     final ModelElementTypeBuilder typeBuilder =
         modelBuilder
@@ -54,6 +66,13 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
         typeBuilder
             .stringAttribute(ZeebeConstants.ATTRIBUTE_PROCESS_ID)
             .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    propagateAllChildVariablesAttribute =
+        typeBuilder
+            .booleanAttribute(ZeebeConstants.ATTRIBUTE_PROPAGATE_ALL_CHILD_VARIABLES)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .defaultValue(true)
             .build();
 
     typeBuilder.build();

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElement.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElement.java
@@ -22,4 +22,8 @@ public interface ZeebeCalledElement extends BpmnModelElementInstance {
   String getProcessId();
 
   void setProcessId(String processId);
+
+  boolean isPropagateAllChildVariablesEnabled();
+
+  void setPropagateAllChildVariablesEnabled(boolean propagateAllChildVariablesEnabled);
 }

--- a/docs/src/bpmn-workflows/call-activities/call-activities.md
+++ b/docs/src/bpmn-workflows/call-activities/call-activities.md
@@ -32,9 +32,9 @@ When the call activity is activated then **all variables** of the call activity 
 
 Input mappings can be used to create new local variables in the scope of the call activity. These variables are also copied to the created workflow instance.
 
-By default, all variables of the created workflow instance are propagated to the call activity. This behavior can be customized by defining output mappings at the call activity. The output mappings are applied on completing the call activity.
-This is especially important in the case of a call activity in a parallel flow to avoid overriding variables (e.g. when it is marked as
-[parallel multi-instance](/bpmn-workflows/multi-instance/multi-instance.html#variable-mappings)).
+If the attribute `propagateAllChildVariables` is set (default: `true`) then all variables of the created workflow instance are propagated to the call activity. This behavior can be customized by defining output mappings at the call activity. The output mappings are applied on completing the call activity and only those variables that are defined in the output mappings are propagated.
+
+It is recommended to disable the attribute `propagateAllChildVariables` or define output mappings if the call activity is in a parallel flow (e.g. when it is marked as [parallel multi-instance](/bpmn-workflows/multi-instance/multi-instance.html#variable-mappings)). Otherwise, it can happen that variables are overridden accidentally when they are changed in the parallel flow.
 
 ## Additional Resources
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -136,7 +136,12 @@ public final class CallActivityProcessor
     switch (currentState) {
       case ELEMENT_ACTIVATED:
         stateTransitionBehavior.transitionToCompleting(callActivityContext);
-        stateBehavior.propagateTemporaryVariables(childContext, callActivityContext);
+
+        if (element.getOutputMappings().isPresent()
+            || element.isPropagateAllChildVariablesEnabled()) {
+          stateBehavior.propagateTemporaryVariables(childContext, callActivityContext);
+        }
+
         break;
       case ELEMENT_TERMINATING:
         // the call activity is already terminating, it doesn't matter that the child completed

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
@@ -13,6 +13,8 @@ public class ExecutableCallActivity extends ExecutableActivity {
 
   private Expression calledElementProcessId;
 
+  private boolean propagateAllChildVariablesEnabled;
+
   public ExecutableCallActivity(final String id) {
     super(id);
   }
@@ -23,5 +25,14 @@ public class ExecutableCallActivity extends ExecutableActivity {
 
   public void setCalledElementProcessId(final Expression calledElementProcessIdExpression) {
     calledElementProcessId = calledElementProcessIdExpression;
+  }
+
+  public boolean isPropagateAllChildVariablesEnabled() {
+    return propagateAllChildVariablesEnabled;
+  }
+
+  public void setPropagateAllChildVariablesEnabled(
+      final boolean propagateAllChildVariablesEnabled) {
+    this.propagateAllChildVariablesEnabled = propagateAllChildVariablesEnabled;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformer/CallActivityTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformer/CallActivityTransformer.java
@@ -44,5 +44,9 @@ public final class CallActivityTransformer implements ModelElementTransformer<Ca
     final var expression = expressionLanguage.parseExpression(processId);
 
     callActivity.setCalledElementProcessId(expression);
+
+    final var propagateAllChildVariablesEnabled =
+        calledElement.isPropagateAllChildVariablesEnabled();
+    callActivity.setPropagateAllChildVariablesEnabled(propagateAllChildVariablesEnabled);
   }
 }


### PR DESCRIPTION


## Description

* add a new Zeebe attribute `propagateAllChildVariables` for call activities to control if variables should be copied from a child instance
* the new attribute is set by default to be backward-compatible and not change the existing behavior

## Related issues

closes #4860 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
