### PR TITLE
docs(readme): Fix the configuration link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To learn more about what we're currently working on, please visit the [roadmap](
 * [Core Concepts](https://docs.zeebe.io/basics/index.html)
 * [Getting Started Tutorial](https://docs.zeebe.io/getting-started/index.html)
 * [BPMN Workflows](https://docs.zeebe.io/bpmn-workflows/index.html)
-* [Configuration](https://docs.zeebe.io/operations/the-zeebecfgyaml-file.html)
+* [Configuration](https://docs.zeebe.io/operations/configuration.html)
 * [Java Client](https://docs.zeebe.io/java-client/index.html)
 * [Go Client](https://docs.zeebe.io/go-client/index.html)
 


### PR DESCRIPTION
## Description

The configuration link now points to the https://docs.zeebe.io/operations/configuration.html

## Related issues

closes #5311 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [X] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
