### PR TITLE
Upgrade Zeebe Test Container to 1.0.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -78,7 +78,7 @@
     <version.asm>8.0.1</version.asm>
     <version.testcontainers>1.14.3</version.testcontainers>
     <version.netflix.concurrency>0.3.6</version.netflix.concurrency>
-    <version.zeebe-test-container>0.33.0</version.zeebe-test-container>
+    <version.zeebe-test-container>1.0.0</version.zeebe-test-container>
     <version.feel-scala>1.11.2</version.feel-scala>
     <version.restassert>4.3.0</version.restassert>
     <version.spring-framework>5.2.7.RELEASE</version.spring-framework>
@@ -402,6 +402,12 @@
         <groupId>io.zeebe</groupId>
         <artifactId>zeebe-test-container</artifactId>
         <version>${version.zeebe-test-container}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/gateway/GatewayLivenessProbeIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/gateway/GatewayLivenessProbeIntegrationTest.java
@@ -8,26 +8,23 @@
 package io.zeebe.broker.it.gateway;
 
 import static io.restassured.RestAssured.given;
-import static io.zeebe.test.util.asserts.TopologyAssert.assertThat;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
 
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.filter.log.RequestLoggingFilter;
 import io.restassured.filter.log.ResponseLoggingFilter;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
-import io.zeebe.client.ZeebeClient;
 import io.zeebe.containers.ZeebeBrokerContainer;
+import io.zeebe.containers.ZeebeGatewayContainer;
 import io.zeebe.containers.ZeebePort;
-import io.zeebe.containers.ZeebeStandaloneGatewayContainer;
+import java.time.Duration;
 import java.util.stream.Stream;
+import org.awaitility.Awaitility;
 import org.junit.Test;
 import org.testcontainers.lifecycle.Startable;
 
 public class GatewayLivenessProbeIntegrationTest {
 
-  public static final int MONITORING_PORT_IN_CONTAINER = 9600;
   public static final String PATH_LIVENESS_PROBE = "/live";
 
   @Test
@@ -35,30 +32,19 @@ public class GatewayLivenessProbeIntegrationTest {
     // --- given ---------------------------------------
 
     // create a broker and a standalone gateway
-    final ZeebeBrokerContainer broker =
-        new ZeebeBrokerContainer("current-test").withClusterName("zeebe-cluster");
-    final ZeebeStandaloneGatewayContainer gateway =
-        new ZeebeStandaloneGatewayContainer("current-test")
+    final ZeebeBrokerContainer broker = new ZeebeBrokerContainer("camunda/zeebe:current-test");
+    final ZeebeGatewayContainer gateway =
+        new ZeebeGatewayContainer("camunda/zeebe:current-test")
             .withNetwork(broker.getNetwork())
-            .withClusterName("zeebe-cluster")
-            .withExposedPorts(
-                MONITORING_PORT_IN_CONTAINER); // make sure they are on the same network
-    // configure broker so it doesn't start an embedded gateway
-    broker.withEmbeddedGateway(false).withHost("zeebe-0");
-    gateway
-        .withContactPoint(broker.getInternalAddress(ZeebePort.INTERNAL_API))
-        .withEnv("ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT", broker.getContactPoint());
+            .withEnv("ZEEBE_GATEWAY_MONITORING_ENABLED", "true")
+            .withEnv("ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT", broker.getInternalClusterAddress());
+    gateway.addExposedPorts(ZeebePort.MONITORING.getPort());
 
     // start both containers
     Stream.of(gateway, broker).parallel().forEach(Startable::start);
 
-    final ZeebeClient zeebeClient = createZeebeClient(gateway);
-
-    // wait a little while to give the broker and gateway a chance to find each other
-    await().atMost(60, SECONDS).untilAsserted(() -> assertTopologyIsComplete(zeebeClient));
-
-    final Integer actuatorPort = gateway.getMappedPort(MONITORING_PORT_IN_CONTAINER);
-    final String containerIPAddress = gateway.getContainerIpAddress();
+    final Integer actuatorPort = gateway.getMappedPort(ZeebePort.MONITORING.getPort());
+    final String containerIPAddress = gateway.getExternalHost();
 
     final RequestSpecification gatewayServerSpec =
         new RequestSpecBuilder()
@@ -70,27 +56,40 @@ public class GatewayLivenessProbeIntegrationTest {
             .build();
 
     // --- when + then ---------------------------------------
-    given().spec(gatewayServerSpec).when().get(PATH_LIVENESS_PROBE).then().statusCode(200);
+    // most of the liveness health indicators are delayed health indicators which are scheduled at
+    // a fixed rate of 5 seconds, so it may take up to 5 seconds for all the indicators to be
+    // checked
+    Awaitility.await("wait for indicator to turn UP")
+        .atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(100))
+        .untilAsserted(
+            () ->
+                given()
+                    .spec(gatewayServerSpec)
+                    .when()
+                    .get(PATH_LIVENESS_PROBE)
+                    .then()
+                    .statusCode(200));
 
     // --- shutdown ------------------------------------------
     Stream.of(gateway, broker).parallel().forEach(Startable::stop);
   }
 
-  private void assertTopologyIsComplete(final ZeebeClient zeebeClient) {
-    final var topology = zeebeClient.newTopologyRequest().send().join();
-    assertThat(topology).isComplete(1, 1);
-  }
-
   @Test
-  public void shouldReportLivenessDownIfNotConnectedToBroker() throws InterruptedException {
+  public void shouldReportLivenessDownIfNotConnectedToBroker() {
     // --- given ---------------------------------------
-    final ZeebeStandaloneGatewayContainer gateway =
-        new ZeebeStandaloneGatewayContainer("current-test")
-            .withExposedPorts(MONITORING_PORT_IN_CONTAINER);
+    final ZeebeGatewayContainer gateway =
+        new ZeebeGatewayContainer("camunda/zeebe:current-test")
+            .withEnv("ZEEBE_GATEWAY_MONITORING_ENABLED", "true")
+            .withTopologyCheck(
+                ZeebeGatewayContainer.newDefaultTopologyCheck()
+                    .forPartitionsCount(0)
+                    .forBrokersCount(0));
+    gateway.addExposedPorts(ZeebePort.MONITORING.getPort());
     gateway.start();
 
-    final Integer actuatorPort = gateway.getMappedPort(MONITORING_PORT_IN_CONTAINER);
-    final String containerIPAddress = gateway.getContainerIpAddress();
+    final Integer actuatorPort = gateway.getMappedPort(ZeebePort.MONITORING.getPort());
+    final String containerIPAddress = gateway.getExternalHost();
 
     final RequestSpecification gatewayServerSpec =
         new RequestSpecBuilder()
@@ -106,12 +105,5 @@ public class GatewayLivenessProbeIntegrationTest {
 
     // --- shutdown ------------------------------------------
     gateway.stop();
-  }
-
-  private static ZeebeClient createZeebeClient(final ZeebeStandaloneGatewayContainer gateway) {
-    return ZeebeClient.newClientBuilder()
-        .brokerContactPoint(gateway.getExternalAddress(ZeebePort.GATEWAY))
-        .usePlaintext()
-        .build();
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/BrokerMonitoringEndpointTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/BrokerMonitoringEndpointTest.java
@@ -15,26 +15,26 @@ import io.restassured.filter.log.RequestLoggingFilter;
 import io.restassured.filter.log.ResponseLoggingFilter;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
-import io.zeebe.containers.ZeebeBrokerContainer;
-import java.io.IOException;
+import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.ZeebePort;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public final class BrokerMonitoringEndpointTest {
 
-  static ZeebeBrokerContainer sutBroker;
+  static ZeebeContainer sutBroker;
 
   static RequestSpecification brokerServerSpec;
 
   @BeforeClass
   public static void setUpClass() {
-    sutBroker = new ZeebeBrokerContainer("current-test").withClusterName("zeebe-cluster");
+    sutBroker = new ZeebeContainer("camunda/zeebe:current-test");
 
     sutBroker.start();
 
-    final Integer monitoringPort = sutBroker.getMappedPort(9600);
-    final String containerIPAddress = sutBroker.getContainerIpAddress();
+    final Integer monitoringPort = sutBroker.getMappedPort(ZeebePort.MONITORING.getPort());
+    final String containerIPAddress = sutBroker.getExternalHost();
 
     brokerServerSpec =
         new RequestSpecBuilder()
@@ -68,7 +68,7 @@ public final class BrokerMonitoringEndpointTest {
   }
 
   @Test
-  public void shouldGetReadyStatus() throws IOException, InterruptedException {
+  public void shouldGetReadyStatus() {
     given()
         .spec(brokerServerSpec)
         .when()
@@ -78,7 +78,7 @@ public final class BrokerMonitoringEndpointTest {
   }
 
   @Test
-  public void shouldGetHealthStatus() throws IOException, InterruptedException {
+  public void shouldGetHealthStatus() {
     given()
         .spec(brokerServerSpec)
         .when()

--- a/util/src/main/java/io/zeebe/util/sched/ActorExecutor.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorExecutor.java
@@ -83,6 +83,7 @@ public final class ActorExecutor {
       Loggers.ACTOR_LOGGER.debug("Closing blocking task runner: closed successfully");
 
     } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
       Loggers.ACTOR_LOGGER.error(
           "Closing blocking task runner: interrupted while awaiting termination", e);
     }


### PR DESCRIPTION
## Description

This PR backports the upgrade of Zeebe Test Container to 1.0.0 for 0.24. There is no backport for 0.23 as that version will soon be phased out, and the back port is not a simple cherry pick.

I had to make some adjustments when cherry picking, so please review again - I also fixed some flakiness which I ran into (see https://github.com/zeebe-io/zeebe/issues/4632), for which I'll open another PR for develop.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
