### PR TITLE
Fixes GatewayLivenessProbeIntegrationTest flaky test

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -414,6 +414,12 @@
         <groupId>io.zeebe</groupId>
         <artifactId>zeebe-test-container</artifactId>
         <version>${version.zeebe-test-container}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

This PR fixes a flaky integration test for the liveness probe of the gateway. My understanding is, as all the liveness indicators are `DelayedHealthIndicator` instances, scheduled at a fixed rate of 5 seconds, it may take up to 5 seconds after the gateway has found the broker (in the worst case scenario) for the indicator to go UP - so sometimes the check is a little too fast. I admit I'm not 100% familiar with that part of the code so correct me if I misunderstood how it works.

It also cleans up some dead code from a previous PR.

## Related issues

closes #4632 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
