### PR TITLE
Expose rocksdb ColumnFamilyOptions

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -46,6 +46,7 @@ public final class DataCfg implements ConfigurationEntry {
   private double diskUsageReplicationWatermark = DEFAULT_DISK_USAGE_REPLICATION_WATERMARK;
   private double diskUsageCommandWatermark = DEFAULT_DISK_USAGE_COMMAND_WATERMARK;
   private Duration diskUsageMonitoringInterval = DEFAULT_DISK_USAGE_MONITORING_DELAY;
+  private RocksdbCfg rocksdb = new RocksdbCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -149,6 +150,14 @@ public final class DataCfg implements ConfigurationEntry {
     this.diskUsageMonitoringInterval = diskUsageMonitoringInterval;
   }
 
+  public RocksdbCfg getRocksdb() {
+    return rocksdb;
+  }
+
+  public void setRocksdb(final RocksdbCfg rocksdb) {
+    this.rocksdb = rocksdb;
+  }
+
   @Override
   public String toString() {
     return "DataCfg{"
@@ -170,6 +179,8 @@ public final class DataCfg implements ConfigurationEntry {
         + diskUsageCommandWatermark
         + ", diskUsageMonitoringInterval="
         + diskUsageMonitoringInterval
+        + ", rocksdb="
+        + rocksdb
         + '}';
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.configuration;
+
+import java.util.Properties;
+
+public final class RocksdbCfg {
+
+  private Properties columnFamilyOptions;
+
+  public Properties getColumnFamilyOptions() {
+    if (columnFamilyOptions == null) {
+      return new Properties();
+    }
+    return columnFamilyOptions;
+  }
+
+  public void setColumnFamilyOptions(final Properties columnFamilyOptions) {
+    this.columnFamilyOptions = columnFamilyOptions;
+  }
+}

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -435,9 +435,10 @@ public final class ZeebePartition extends Actor
             ? new StateReplication(messagingService, partitionId, localBroker.getNodeId())
             : new NoneSnapshotReplication();
 
+    final var databaseCfg = brokerCfg.getData().getRocksdb();
     return new StateControllerImpl(
         partitionId,
-        DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+        DefaultZeebeDbFactory.defaultFactory(databaseCfg.getColumnFamilyOptions()),
         snapshotStoreSupplier.getConstructableSnapshotStore(atomixRaftPartition.name()),
         snapshotStoreSupplier.getReceivableSnapshotStore(atomixRaftPartition.name()),
         runtimeDirectory,

--- a/broker/src/test/java/io/zeebe/broker/exporter/stream/ExportersStateTest.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/stream/ExportersStateTest.java
@@ -39,7 +39,7 @@ public final class ExportersStateTest {
   public void setup() throws Exception {
     final File dbDirectory = temporaryFolder.newFolder();
 
-    db = DefaultZeebeDbFactory.DEFAULT_DB_FACTORY.createDb(dbDirectory);
+    db = DefaultZeebeDbFactory.defaultFactory().createDb(dbDirectory);
     state = new ExportersState(db, db.createContext());
   }
 

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/BackpressureCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/BackpressureCfgTest.java
@@ -15,8 +15,6 @@ import io.zeebe.broker.system.configuration.backpressure.FixedCfg;
 import io.zeebe.broker.system.configuration.backpressure.Gradient2Cfg;
 import io.zeebe.broker.system.configuration.backpressure.GradientCfg;
 import io.zeebe.broker.system.configuration.backpressure.VegasCfg;
-import io.zeebe.test.util.TestConfigurationFactory;
-import io.zeebe.util.Environment;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,14 +22,12 @@ import org.junit.Test;
 
 public final class BackpressureCfgTest {
 
-  public static final String BROKER_BASE = "test";
-
   public final Map<String, String> environment = new HashMap<>();
 
   @Test
   public void shouldSetBackpressureConfig() {
     // when
-    final BrokerCfg cfg = readConfig("backpressure-cfg");
+    final BrokerCfg cfg = TestConfigReader.readConfig("backpressure-cfg", environment);
     final BackpressureCfg backpressure = cfg.getBackpressure();
 
     // then
@@ -43,7 +39,7 @@ public final class BackpressureCfgTest {
   @Test
   public void shouldSetAimdConfig() {
     // when
-    final BrokerCfg cfg = readConfig("backpressure-cfg");
+    final BrokerCfg cfg = TestConfigReader.readConfig("backpressure-cfg", environment);
     final BackpressureCfg backpressure = cfg.getBackpressure();
     final var aimd = backpressure.getAimd();
 
@@ -58,7 +54,7 @@ public final class BackpressureCfgTest {
   @Test
   public void shouldSetFixedCfg() {
     // when
-    final BrokerCfg cfg = readConfig("backpressure-fixed-cfg");
+    final BrokerCfg cfg = TestConfigReader.readConfig("backpressure-fixed-cfg", environment);
     final LimitAlgorithm algorithm = cfg.getBackpressure().getAlgorithm();
     final FixedCfg fixedCfg = cfg.getBackpressure().getFixed();
 
@@ -70,7 +66,7 @@ public final class BackpressureCfgTest {
   @Test
   public void shouldSetVegasCfg() {
     // when
-    final BrokerCfg cfg = readConfig("backpressure-cfg");
+    final BrokerCfg cfg = TestConfigReader.readConfig("backpressure-cfg", environment);
     final VegasCfg vegasCfg = cfg.getBackpressure().getVegas();
 
     // then
@@ -82,7 +78,7 @@ public final class BackpressureCfgTest {
   @Test
   public void shouldSetGradientCfg() {
     // when
-    final BrokerCfg cfg = readConfig("backpressure-cfg");
+    final BrokerCfg cfg = TestConfigReader.readConfig("backpressure-cfg", environment);
     final GradientCfg gradientCfg = cfg.getBackpressure().getGradient();
 
     // then
@@ -94,7 +90,7 @@ public final class BackpressureCfgTest {
   @Test
   public void shouldSetGradient2Cfg() {
     // when
-    final BrokerCfg cfg = readConfig("backpressure-cfg");
+    final BrokerCfg cfg = TestConfigReader.readConfig("backpressure-cfg", environment);
     final Gradient2Cfg gradient2Cfg = cfg.getBackpressure().getGradient2();
     // then
     assertThat(gradient2Cfg.getMinLimit()).isEqualTo(3);
@@ -132,18 +128,5 @@ public final class BackpressureCfgTest {
     backpressure.setAlgorithm("aimd");
     // then
     assertThat(backpressure.getAlgorithm()).isEqualTo(LimitAlgorithm.AIMD);
-  }
-
-  private BrokerCfg readConfig(final String name) {
-    final String configPath = "/system/" + name + ".yaml";
-
-    final Environment environmentVariables = new Environment(environment);
-
-    final BrokerCfg config =
-        new TestConfigurationFactory()
-            .create(environmentVariables, "zeebe.broker", configPath, BrokerCfg.class);
-    config.init(BROKER_BASE, environmentVariables);
-
-    return config;
   }
 }

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -26,8 +26,6 @@ import io.zeebe.broker.exporter.debug.DebugLogExporter;
 import io.zeebe.broker.exporter.metrics.MetricsExporter;
 import io.zeebe.broker.system.configuration.backpressure.BackpressureCfg;
 import io.zeebe.broker.system.configuration.backpressure.BackpressureCfg.LimitAlgorithm;
-import io.zeebe.test.util.TestConfigurationFactory;
-import io.zeebe.util.Environment;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Arrays;
@@ -369,7 +367,7 @@ public final class BrokerCfgTest {
   @Test
   public void shouldReadSpecificSystemClusterConfiguration() {
     // given
-    final BrokerCfg cfg = readConfig("cluster-cfg");
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
     final ClusterCfg cfgCluster = cfg.getCluster();
 
     // when - then
@@ -383,7 +381,7 @@ public final class BrokerCfgTest {
   @Test
   public void shouldCreatePartitionIds() {
     // given
-    final BrokerCfg cfg = readConfig("cluster-cfg");
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
     final ClusterCfg cfgCluster = cfg.getCluster();
 
     // when - then
@@ -399,7 +397,7 @@ public final class BrokerCfgTest {
     environment.put(ZEEBE_BROKER_CLUSTER_REPLICATION_FACTOR, "2");
 
     // when
-    final BrokerCfg cfg = readConfig("cluster-cfg");
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
     final ClusterCfg cfgCluster = cfg.getCluster();
 
     // then
@@ -412,7 +410,7 @@ public final class BrokerCfgTest {
     environment.put(ZEEBE_BROKER_CLUSTER_PARTITIONS_COUNT, "2");
 
     // when
-    final BrokerCfg cfg = readConfig("cluster-cfg");
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
     final ClusterCfg cfgCluster = cfg.getCluster();
 
     // then
@@ -425,7 +423,7 @@ public final class BrokerCfgTest {
     environment.put(ZEEBE_BROKER_CLUSTER_CLUSTER_SIZE, "2");
 
     // when
-    final BrokerCfg cfg = readConfig("cluster-cfg");
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
     final ClusterCfg cfgCluster = cfg.getCluster();
 
     // then
@@ -441,7 +439,7 @@ public final class BrokerCfgTest {
     environment.put(ZEEBE_BROKER_CLUSTER_NODE_ID, "4");
 
     // when
-    final BrokerCfg cfg = readConfig("cluster-cfg");
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
     final ClusterCfg cfgCluster = cfg.getCluster();
 
     // then
@@ -472,7 +470,7 @@ public final class BrokerCfgTest {
   @Test
   public void shouldSetBackpressureConfig() {
     // when
-    final BrokerCfg cfg = readConfig("backpressure-cfg");
+    final BrokerCfg cfg = TestConfigReader.readConfig("backpressure-cfg", environment);
     final BackpressureCfg backpressure = cfg.getBackpressure();
 
     // then
@@ -554,7 +552,7 @@ public final class BrokerCfgTest {
     final ExporterCfg expected = new ExporterCfg();
     expected.setClassName("io.zeebe.exporter.ElasticsearchExporter");
 
-    final BrokerCfg actual = readConfig("exporters");
+    final BrokerCfg actual = TestConfigReader.readConfig("exporters", environment);
 
     // then
     assertThat(actual.getExporters()).hasSize(1);
@@ -574,7 +572,7 @@ public final class BrokerCfgTest {
   @Test
   public void shouldNotPrintConfidentialInformation() throws Exception {
     // given
-    final var brokerCfg = readConfig("elasticexporter");
+    final var brokerCfg = TestConfigReader.readConfig("elasticexporter", environment);
 
     // when
     final var json = brokerCfg.toJson();
@@ -593,7 +591,7 @@ public final class BrokerCfgTest {
   @Test
   public void shouldSetCustomMembershipConfig() {
     // when
-    final BrokerCfg brokerCfg = readConfig("membership-cfg");
+    final BrokerCfg brokerCfg = TestConfigReader.readConfig("membership-cfg", environment);
 
     // then
     final var membershipCfg = brokerCfg.getCluster().getMembership();
@@ -610,26 +608,13 @@ public final class BrokerCfgTest {
     assertThat(membershipCfg.getSyncInterval()).isEqualTo(Duration.ofSeconds(25));
   }
 
-  private BrokerCfg readConfig(final String name) {
-    final String configPath = "/system/" + name + ".yaml";
-
-    final Environment environmentVariables = new Environment(environment);
-
-    final BrokerCfg config =
-        new TestConfigurationFactory()
-            .create(environmentVariables, "zeebe.broker", configPath, BrokerCfg.class);
-    config.init(BROKER_BASE, environmentVariables);
-
-    return config;
-  }
-
   private void assertDefaultNodeId(final int nodeId) {
     assertNodeId("default", nodeId);
     assertNodeId("empty", nodeId);
   }
 
   private void assertNodeId(final String configFileName, final int nodeId) {
-    final BrokerCfg cfg = readConfig(configFileName);
+    final BrokerCfg cfg = TestConfigReader.readConfig(configFileName, environment);
     assertThat(cfg.getCluster().getNodeId()).isEqualTo(nodeId);
   }
 
@@ -639,7 +624,7 @@ public final class BrokerCfgTest {
   }
 
   private void assertClusterName(final String configFileName, final String clusterName) {
-    final BrokerCfg cfg = readConfig(configFileName);
+    final BrokerCfg cfg = TestConfigReader.readConfig(configFileName, environment);
     assertThat(cfg.getCluster().getClusterName()).isEqualTo(clusterName);
   }
 
@@ -649,7 +634,7 @@ public final class BrokerCfgTest {
   }
 
   private void assertStepTimeout(final String configFileName, final Duration stepTimeout) {
-    final BrokerCfg cfg = readConfig(configFileName);
+    final BrokerCfg cfg = TestConfigReader.readConfig(configFileName, environment);
     assertThat(cfg.getStepTimeout()).isEqualTo(stepTimeout);
   }
 
@@ -660,7 +645,7 @@ public final class BrokerCfgTest {
 
   private void assertPorts(
       final String configFileName, final int command, final int internal, final int monitoring) {
-    final BrokerCfg brokerCfg = readConfig(configFileName);
+    final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);
     final NetworkCfg network = brokerCfg.getNetwork();
     assertThat(network.getCommandApi().getAddress().getPort()).isEqualTo(command);
     assertThat(network.getCommandApi().getAdvertisedAddress().getPort()).isEqualTo(command);
@@ -679,7 +664,7 @@ public final class BrokerCfgTest {
   }
 
   private void assertUseMmap(final String configFileName, final boolean useMmap) {
-    final var config = readConfig(configFileName);
+    final var config = TestConfigReader.readConfig(configFileName, environment);
     final var data = config.getData();
     assertThat(data.useMmap()).isEqualTo(useMmap);
   }
@@ -695,7 +680,7 @@ public final class BrokerCfgTest {
       final String command,
       final String internal,
       final String monitoring) {
-    final BrokerCfg brokerCfg = readConfig(configFileName);
+    final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);
     final NetworkCfg networkCfg = brokerCfg.getNetwork();
     assertThat(networkCfg.getHost()).isEqualTo(host);
     assertThat(brokerCfg.getGateway().getNetwork().getHost()).isEqualTo(gateway);
@@ -705,14 +690,14 @@ public final class BrokerCfgTest {
   }
 
   private void assertAdvertisedHost(final String configFileName, final String host) {
-    final BrokerCfg brokerCfg = readConfig(configFileName);
+    final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);
     final NetworkCfg networkCfg = brokerCfg.getNetwork();
     assertThat(networkCfg.getCommandApi().getAdvertisedAddress().getHostName()).isEqualTo(host);
   }
 
   private void assertAdvertisedAddress(
       final String configFileName, final String host, final int port) {
-    final BrokerCfg brokerCfg = readConfig(configFileName);
+    final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);
     final NetworkCfg networkCfg = brokerCfg.getNetwork();
     assertThat(networkCfg.getCommandApi().getAdvertisedAddress().getHostName()).isEqualTo(host);
     assertThat(networkCfg.getCommandApi().getAdvertisedAddress().getPort()).isEqualTo(port);
@@ -732,7 +717,7 @@ public final class BrokerCfgTest {
   }
 
   private void assertContactPoints(final String configFileName, final List<String> contactPoints) {
-    final ClusterCfg cfg = readConfig(configFileName).getCluster();
+    final ClusterCfg cfg = TestConfigReader.readConfig(configFileName, environment).getCluster();
     assertThat(cfg.getInitialContactPoints()).containsExactlyElementsOf(contactPoints);
   }
 
@@ -746,7 +731,7 @@ public final class BrokerCfgTest {
   }
 
   private void assertDirectories(final String configFileName, final List<String> directories) {
-    final DataCfg cfg = readConfig(configFileName).getData();
+    final DataCfg cfg = TestConfigReader.readConfig(configFileName, environment).getData();
     final List<String> expected =
         directories.stream()
             .map(d -> Paths.get(BROKER_BASE, d).toString())
@@ -760,7 +745,8 @@ public final class BrokerCfgTest {
   }
 
   private void assertEmbeddedGatewayEnabled(final String configFileName, final boolean enabled) {
-    final EmbeddedGatewayCfg gatewayCfg = readConfig(configFileName).getGateway();
+    final EmbeddedGatewayCfg gatewayCfg =
+        TestConfigReader.readConfig(configFileName, environment).getGateway();
     assertThat(gatewayCfg.isEnable()).isEqualTo(enabled);
   }
 
@@ -771,7 +757,7 @@ public final class BrokerCfgTest {
 
   private void assertDebugLogExporter(final String configFileName, final boolean prettyPrint) {
     final ExporterCfg exporterCfg = DebugLogExporter.defaultConfig(prettyPrint);
-    final BrokerCfg brokerCfg = readConfig(configFileName);
+    final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);
 
     assertThat(brokerCfg.getExporters().values())
         .usingRecursiveFieldByFieldElementComparator()
@@ -785,7 +771,7 @@ public final class BrokerCfgTest {
 
   private void assertMetricsExporter(final String configFileName) {
     final ExporterCfg exporterCfg = MetricsExporter.defaultConfig();
-    final BrokerCfg brokerCfg = readConfig(configFileName);
+    final BrokerCfg brokerCfg = TestConfigReader.readConfig(configFileName, environment);
 
     assertThat(brokerCfg.getExporters().values())
         .usingRecursiveFieldByFieldElementComparator()
@@ -811,7 +797,7 @@ public final class BrokerCfgTest {
       final int replicationFactor,
       final int clusterSize,
       final List<String> initialContactPoints) {
-    final BrokerCfg cfg = readConfig(configFileName);
+    final BrokerCfg cfg = TestConfigReader.readConfig(configFileName, environment);
     final ClusterCfg cfgCluster = cfg.getCluster();
 
     assertThat(cfgCluster.getNodeId()).isEqualTo(nodeId);

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/RocksdbCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/RocksdbCfgTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public final class RocksdbCfgTest {
+
+  public final Map<String, String> environment = new HashMap<>();
+
+  @Test
+  public void shouldSetColumnFamilyOptionsConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getData().getRocksdb();
+
+    // then
+    final var columnFamilyOptions = rocksdb.getColumnFamilyOptions();
+    assertThat(columnFamilyOptions).containsEntry("compaction_pri", "kOldestSmallestSeqFirst");
+    assertThat(columnFamilyOptions).containsEntry("write_buffer_size", "67108864");
+  }
+}

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/TestConfigReader.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/TestConfigReader.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.configuration;
+
+import io.zeebe.test.util.TestConfigurationFactory;
+import io.zeebe.util.Environment;
+import java.util.Map;
+
+public final class TestConfigReader {
+
+  private static final String BROKER_BASE = "test";
+
+  public static BrokerCfg readConfig(final String name, final Map<String, String> environment) {
+    final String configPath = "/system/" + name + ".yaml";
+
+    final Environment environmentVariables = new Environment(environment);
+
+    final BrokerCfg config =
+        new TestConfigurationFactory()
+            .create(environmentVariables, "zeebe.broker", configPath, BrokerCfg.class);
+    config.init(BROKER_BASE, environmentVariables);
+
+    return config;
+  }
+}

--- a/broker/src/test/resources/system/rocksdb-cfg.yaml
+++ b/broker/src/test/resources/system/rocksdb-cfg.yaml
@@ -1,0 +1,7 @@
+zeebe:
+  broker:
+    data:
+      rocksdb:
+        columnFamilyOptions:
+          compaction_pri: "kOldestSmallestSeqFirst"
+          write_buffer_size: 67108864

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -200,6 +200,17 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGINTERVAL
       # diskUsageMonitoringInterval = 1s
 
+      # rocksdb:
+        # Specify custom column family options overwriting Zeebe's own defaults.
+        # WARNING: This setting requires in-depth knowledge of Zeebe's embedded database: RocksDB.
+        # The expected property key names and values are derived from RocksDB's C implementation,
+        # and are not limited to the provided examples below. Please look in RocksDB's SCM repo
+        # for the files: `cf_options.h` and `options_helper.cc`.
+        # WARNING: This setting should not be overridden using environment variables.
+        # columnFamilyOptions:
+          # compaction_pri: "kOldestSmallestSeqFirst"
+          # write_buffer_size: 67108864
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -160,6 +160,17 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGINTERVAL
       # diskUsageMonitoringInterval = 1s
 
+      # rocksdb:
+        # Specify custom column family options overwriting Zeebe's own defaults.
+        # WARNING: This setting requires in-depth knowledge of Zeebe's embedded database: RocksDB.
+        # The expected property key names and values are derived from RocksDB's C implementation,
+        # and are not limited to the provided examples below. Please look in RocksDB's SCM repo
+        # for the files: `cf_options.h` and `options_helper.cc`.
+        # WARNING: This setting should not be overridden using environment variables.
+        # columnFamilyOptions:
+          # compaction_pri: "kOldestSmallestSeqFirst"
+          # write_buffer_size: 67108864
+
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 

--- a/engine/src/main/java/io/zeebe/engine/state/DefaultZeebeDbFactory.java
+++ b/engine/src/main/java/io/zeebe/engine/state/DefaultZeebeDbFactory.java
@@ -11,34 +11,64 @@ import io.zeebe.db.ZeebeDb;
 import io.zeebe.db.ZeebeDbFactory;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDBMetricExporter;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import java.util.Properties;
 import java.util.function.BiFunction;
 
 public final class DefaultZeebeDbFactory {
 
-  /**
-   * The default zeebe database factory, which is used in most of the places except for the
-   * exporters.
-   */
-  public static final ZeebeDbFactory<ZbColumnFamilies> DEFAULT_DB_FACTORY =
-      defaultFactory(ZbColumnFamilies.class);
-
   public static final BiFunction<String, ZeebeDb<ZbColumnFamilies>, ZeebeRocksDBMetricExporter>
       DEFAULT_DB_METRIC_EXPORTER_FACTORY =
-          (partitionId, database) -> {
-            return new ZeebeRocksDBMetricExporter<>(partitionId, database, ZbColumnFamilies.class);
-          };
+          (partitionId, database) ->
+              new ZeebeRocksDBMetricExporter<>(partitionId, database, ZbColumnFamilies.class);
+
+  /**
+   * Returns the default zeebe database factory, which is used in most of the places except for the
+   * exporters.
+   *
+   * @return the created zeebe database factory
+   */
+  public static ZeebeDbFactory<ZbColumnFamilies> defaultFactory() {
+    return defaultFactory(new Properties());
+  }
+
+  /**
+   * Returns the default zeebe database factory, which is used in most of the places except for the
+   * exporters.
+   *
+   * @param userProvidedColumnFamilyOptions additional column family options
+   * @return the created zeebe database factory
+   */
+  public static ZeebeDbFactory<ZbColumnFamilies> defaultFactory(
+      final Properties userProvidedColumnFamilyOptions) {
+    return defaultFactory(ZbColumnFamilies.class, userProvidedColumnFamilyOptions);
+  }
 
   /**
    * Returns the default zeebe database factory which is used in the broker.
    *
-   * @param columnFamilyNamesClass the enum class, which contains the column family names
    * @param <ColumnFamilyNames> the type of the enum
+   * @param columnFamilyNamesClass the enum class, which contains the column family names
    * @return the created zeebe database factory
    */
   public static <ColumnFamilyNames extends Enum<ColumnFamilyNames>>
       ZeebeDbFactory<ColumnFamilyNames> defaultFactory(
           final Class<ColumnFamilyNames> columnFamilyNamesClass) {
+    return defaultFactory(columnFamilyNamesClass, new Properties());
+  }
+
+  /**
+   * Returns the default zeebe database factory which is used in the broker.
+   *
+   * @param <ColumnFamilyNames> the type of the enum
+   * @param columnFamilyNamesClass the enum class, which contains the column family names
+   * @param userProvidedColumnFamilyOptions additional column family options
+   * @return the created zeebe database factory
+   */
+  public static <ColumnFamilyNames extends Enum<ColumnFamilyNames>>
+      ZeebeDbFactory<ColumnFamilyNames> defaultFactory(
+          final Class<ColumnFamilyNames> columnFamilyNamesClass,
+          final Properties userProvidedColumnFamilyOptions) {
     // one place to replace the zeebe database implementation
-    return ZeebeRocksDbFactory.newFactory(columnFamilyNamesClass);
+    return ZeebeRocksDbFactory.newFactory(columnFamilyNamesClass, userProvidedColumnFamilyOptions);
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
@@ -100,7 +100,7 @@ public final class SkipFailingEventsTest {
 
     streams.startStreamProcessor(
         STREAM_NAME,
-        DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+        DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
           return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
@@ -139,7 +139,7 @@ public final class SkipFailingEventsTest {
     // given
     streams.startStreamProcessor(
         STREAM_NAME,
-        DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+        DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
           return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
@@ -187,7 +187,7 @@ public final class SkipFailingEventsTest {
 
     streams.startStreamProcessor(
         STREAM_NAME,
-        DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+        DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
           return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
@@ -267,7 +267,7 @@ public final class SkipFailingEventsTest {
     final CountDownLatch latch = new CountDownLatch(1);
     streams.startStreamProcessor(
         STREAM_NAME,
-        DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+        DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
           return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
@@ -325,7 +325,7 @@ public final class SkipFailingEventsTest {
 
     streams.startStreamProcessor(
         STREAM_NAME,
-        DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+        DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
           return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
@@ -399,7 +399,7 @@ public final class SkipFailingEventsTest {
 
     streams.startStreamProcessor(
         STREAM_NAME,
-        DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+        DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
           return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorInconsistentPositionTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorInconsistentPositionTest.java
@@ -7,7 +7,6 @@
  */
 package io.zeebe.engine.processing.streamprocessor;
 
-import static io.zeebe.engine.state.DefaultZeebeDbFactory.DEFAULT_DB_FACTORY;
 import static io.zeebe.engine.util.StreamProcessingComposite.getLogName;
 import static io.zeebe.protocol.record.intent.WorkflowInstanceIntent.ELEMENT_ACTIVATED;
 import static io.zeebe.protocol.record.intent.WorkflowInstanceIntent.ELEMENT_ACTIVATING;
@@ -17,6 +16,7 @@ import static io.zeebe.test.util.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import io.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.zeebe.engine.util.ListLogStorage;
 import io.zeebe.engine.util.RecordStream;
 import io.zeebe.engine.util.StreamProcessingComposite;
@@ -58,9 +58,9 @@ public final class StreamProcessorInconsistentPositionTest {
     testStreams.createLogStream(getLogName(2), 2, listLogStorage);
 
     firstStreamProcessorComposite =
-        new StreamProcessingComposite(testStreams, 1, DEFAULT_DB_FACTORY);
+        new StreamProcessingComposite(testStreams, 1, DefaultZeebeDbFactory.defaultFactory());
     secondStreamProcessorComposite =
-        new StreamProcessingComposite(testStreams, 2, DEFAULT_DB_FACTORY);
+        new StreamProcessingComposite(testStreams, 2, DefaultZeebeDbFactory.defaultFactory());
   }
 
   @After

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
@@ -75,7 +75,7 @@ public final class TypedStreamProcessorTest {
     // given
     streams.startStreamProcessor(
         STREAM_NAME,
-        DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+        DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) ->
             TypedRecordProcessors.processors(keyGenerator)
                 .onCommand(ValueType.DEPLOYMENT, DeploymentIntent.CREATE, new BatchProcessor()));
@@ -108,7 +108,7 @@ public final class TypedStreamProcessorTest {
     // given
     streams.startStreamProcessor(
         STREAM_NAME,
-        DefaultZeebeDbFactory.DEFAULT_DB_FACTORY,
+        DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) ->
             TypedRecordProcessors.processors(keyGenerator)
                 .onCommand(

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -92,7 +92,7 @@ public final class EngineRule extends ExternalResource {
     this.explicitStart = explicitStart;
     environmentRule =
         new StreamProcessorRule(
-            PARTITION_ID, partitionCount, DefaultZeebeDbFactory.DEFAULT_DB_FACTORY);
+            PARTITION_ID, partitionCount, DefaultZeebeDbFactory.defaultFactory());
   }
 
   public static EngineRule singlePartition() {

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -69,11 +69,11 @@ public final class StreamProcessorRule implements TestRule {
   }
 
   public StreamProcessorRule(final int partitionId) {
-    this(partitionId, 1, DefaultZeebeDbFactory.DEFAULT_DB_FACTORY);
+    this(partitionId, 1, DefaultZeebeDbFactory.defaultFactory());
   }
 
   public StreamProcessorRule(final int partitionId, final TemporaryFolder temporaryFolder) {
-    this(partitionId, 1, DefaultZeebeDbFactory.DEFAULT_DB_FACTORY, temporaryFolder);
+    this(partitionId, 1, DefaultZeebeDbFactory.defaultFactory(), temporaryFolder);
   }
 
   public StreamProcessorRule(

--- a/engine/src/test/java/io/zeebe/engine/util/ZeebeStateRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/ZeebeStateRule.java
@@ -60,7 +60,7 @@ public final class ZeebeStateRule extends ExternalResource {
   public ZeebeDb<ZbColumnFamilies> createNewDb() {
     try {
       final ZeebeDb<ZbColumnFamilies> db =
-          DefaultZeebeDbFactory.DEFAULT_DB_FACTORY.createDb(tempFolder.newFolder());
+          DefaultZeebeDbFactory.defaultFactory().createDb(tempFolder.newFolder());
 
       return db;
     } catch (final Exception e) {

--- a/zb-db/src/test/java/io/zeebe/db/impl/DefaultZeebeDbFactory.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/DefaultZeebeDbFactory.java
@@ -9,6 +9,7 @@ package io.zeebe.db.impl;
 
 import io.zeebe.db.ZeebeDbFactory;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import java.util.Properties;
 
 public final class DefaultZeebeDbFactory {
 
@@ -16,5 +17,12 @@ public final class DefaultZeebeDbFactory {
       ZeebeDbFactory<ColumnFamilyType> getDefaultFactory(
           final Class<ColumnFamilyType> columnFamilyTypeClass) {
     return ZeebeRocksDbFactory.newFactory(columnFamilyTypeClass);
+  }
+
+  public static <ColumnFamilyType extends Enum<ColumnFamilyType>>
+      ZeebeDbFactory<ColumnFamilyType> getDefaultFactory(
+          final Class<ColumnFamilyType> columnFamilyTypeClass,
+          final Properties columnFamilyOptions) {
+    return ZeebeRocksDbFactory.newFactory(columnFamilyTypeClass, columnFamilyOptions);
   }
 }

--- a/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -12,10 +12,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.zeebe.db.ZeebeDb;
 import io.zeebe.db.ZeebeDbFactory;
 import io.zeebe.db.impl.DefaultColumnFamily;
+import io.zeebe.util.ByteValue;
 import java.io.File;
+import java.util.Properties;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.CompactionPriority;
 
 public final class ZeebeRocksDbFactoryTest {
 
@@ -57,5 +61,33 @@ public final class ZeebeRocksDbFactoryTest {
 
     firstDb.close();
     secondDb.close();
+  }
+
+  @Test
+  public void shouldOverwriteDefaultColumnFamilyOptions() {
+    // given
+    final var customProperties = new Properties();
+    customProperties.put("write_buffer_size", String.valueOf(ByteValue.ofMegabytes(16)));
+    customProperties.put("compaction_pri", "kByCompensatedSize");
+
+    final var factoryWithDefaults =
+        (ZeebeRocksDbFactory<DefaultColumnFamily>)
+            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class);
+    final var factoryWithCustomOptions =
+        (ZeebeRocksDbFactory<DefaultColumnFamily>)
+            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class, customProperties);
+
+    // when
+    final var defaults = factoryWithDefaults.createColumnFamilyOptions();
+    final var customOptions = factoryWithCustomOptions.createColumnFamilyOptions();
+
+    // then
+    assertThat(defaults)
+        .extracting(ColumnFamilyOptions::writeBufferSize, ColumnFamilyOptions::compactionPriority)
+        .containsExactly(ByteValue.ofMegabytes(64), CompactionPriority.OldestSmallestSeqFirst);
+
+    assertThat(customOptions)
+        .extracting(ColumnFamilyOptions::writeBufferSize, ColumnFamilyOptions::compactionPriority)
+        .containsExactly(ByteValue.ofMegabytes(16), CompactionPriority.ByCompensatedSize);
   }
 }


### PR DESCRIPTION
## Description

This PR adds a new `database` config property to the `data` config.
This DatabaseCfg allows users to set an advanced config property named
`columnFamilyOptions` which is a multiline properties definition.

These column family options can be used to overwrite our RocksDB
ColumnFamilyOption defaults. Use these options with care since you can
easily break Zeebe by changing these values too much. However, it can be
interesting for more advanced users to optimise these values for better
performance on their specific hardware or for their specific usecase.

Please not that the expected property key names and values are derived
from the C implementation. Please look at RocksDBs SCM repo for the
files: cf_options.h and options_helper.cc.

## Related issues

closes #5279 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] ~~If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions~~

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
