### PR TITLE
feat(clients/java): Add gatewayAddress method & deprecate brokerContactPoint method

### DIFF
--- a/clients/java/ignored-changes.xml
+++ b/clients/java/ignored-changes.xml
@@ -28,4 +28,14 @@
     <method>ZeebeClientCredentials(java.lang.String, long, java.lang.String, java.lang.String)</method>
     <differenceType>7004</differenceType>
   </difference>
+  <difference>
+    <className>io/zeebe/client/ZeebeClientBuilder</className>
+    <method>io.zeebe.client.ZeebeClientBuilder gatewayAddress(java.lang.String)</method>
+    <differenceType>7012</differenceType>
+  </difference>
+  <difference>
+    <className>io/zeebe/client/ZeebeClientConfiguration</className>
+    <method>java.lang.String getGatewayAddress()</method>
+    <differenceType>7012</differenceType>
+  </difference>
 </differences>

--- a/clients/java/src/main/java/io/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/zeebe/client/ClientProperties.java
@@ -18,8 +18,15 @@ package io.zeebe.client;
 import java.time.Duration;
 
 public final class ClientProperties {
-  /** @see ZeebeClientBuilder#brokerContactPoint(String) */
-  public static final String BROKER_CONTACTPOINT = "zeebe.client.broker.contactPoint";
+  /**
+   * @see ZeebeClientBuilder#brokerContactPoint(String)
+   * @deprecated Use {@link #GATEWAY_ADDRESS}. It's deprecated since 0.25.0, and will be removed in
+   *     0.26.0
+   */
+  @Deprecated public static final String BROKER_CONTACTPOINT = "zeebe.client.broker.contactPoint";
+
+  /** @see ZeebeClientBuilder#gatewayAddress(String) */
+  public static final String GATEWAY_ADDRESS = "zeebe.client.gateway.address";
 
   /** @see ZeebeClientBuilder#numJobWorkerExecutionThreads(int) */
   public static final String JOB_WORKER_EXECUTION_THREADS = "zeebe.client.worker.threads";

--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
@@ -32,10 +32,19 @@ public interface ZeebeClientBuilder {
 
   /**
    * @param contactPoint the IP socket address of a broker that the client can initially connect to.
-   *     Must be in format <code>host:port</code>. The default value is <code>127.0.0.1:51015</code>
-   *     .
+   *     Must be in format <code>host:port</code>. The default value is <code>0.0.0.0:26500</code> .
+   * @deprecated Use {@link #gatewayAddress(java.lang.String)}. It's deprecated since 0.25.0, and
+   *     will be removed in 0.26.0
    */
+  @Deprecated
   ZeebeClientBuilder brokerContactPoint(String contactPoint);
+
+  /**
+   * @param gatewayAddress the IP socket address of a gateway that the client can initially connect
+   *     to. Must be in format <code>host:port</code>. The default value is <code>0.0.0.0:26500
+   *     </code> .
+   */
+  ZeebeClientBuilder gatewayAddress(String gatewayAddress);
 
   /**
    * @param maxJobsActive Default value for {@link JobWorkerBuilderStep3#maxJobsActive(int)}.

--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientConfiguration.java
@@ -20,8 +20,16 @@ import java.time.Duration;
 import java.util.List;
 
 public interface ZeebeClientConfiguration {
-  /** @see ZeebeClientBuilder#brokerContactPoint(String) */
+  /**
+   * @see ZeebeClientBuilder#brokerContactPoint(String)
+   * @deprecated Use {@link #getGatewayAddress()}. It's deprecated since 0.25.0, and will be removed
+   *     in 0.26.0
+   */
+  @Deprecated
   String getBrokerContactPoint();
+
+  /** @see ZeebeClientBuilder#gatewayAddress(String) */
+  String getGatewayAddress();
 
   /** @see ZeebeClientBuilder#numJobWorkerExecutionThreads(int) */
   int getNumJobWorkerExecutionThreads();

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -35,13 +35,19 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
+@SuppressWarnings({
+  "java:S4144",
+  "java:S1448",
+  "java:S1541",
+  "java:S138"
+}) // Because method getBrokerContactPoint will be removed and this issue will be fixed
 public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientConfiguration {
   public static final String PLAINTEXT_CONNECTION_VAR = "ZEEBE_INSECURE_CONNECTION";
   public static final String CA_CERTIFICATE_VAR = "ZEEBE_CA_CERTIFICATE_PATH";
   public static final String KEEP_ALIVE_VAR = "ZEEBE_KEEP_ALIVE";
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
-  private String brokerContactPoint = "0.0.0.0:26500";
+  private String gatewayAddress = "0.0.0.0:26500";
   private int jobWorkerMaxJobsActive = 32;
   private int numJobWorkerExecutionThreads = 1;
   private String defaultJobWorkerName = "default";
@@ -56,7 +62,12 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public String getBrokerContactPoint() {
-    return brokerContactPoint;
+    return gatewayAddress;
+  }
+
+  @Override
+  public String getGatewayAddress() {
+    return gatewayAddress;
   }
 
   @Override
@@ -121,6 +132,11 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public ZeebeClientBuilder withProperties(final Properties properties) {
+
+    if (properties.containsKey(ClientProperties.GATEWAY_ADDRESS)) {
+      gatewayAddress(properties.getProperty(ClientProperties.GATEWAY_ADDRESS));
+    }
+
     if (properties.containsKey(ClientProperties.BROKER_CONTACTPOINT)) {
       brokerContactPoint(properties.getProperty(ClientProperties.BROKER_CONTACTPOINT));
     }
@@ -179,7 +195,13 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public ZeebeClientBuilder brokerContactPoint(final String contactPoint) {
-    brokerContactPoint = contactPoint;
+    gatewayAddress = contactPoint;
+    return this;
+  }
+
+  @Override
+  public ZeebeClientBuilder gatewayAddress(final String gatewayAddress) {
+    this.gatewayAddress = gatewayAddress;
     return this;
   }
 
@@ -289,7 +311,8 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   public String toString() {
     final StringBuilder sb = new StringBuilder();
 
-    appendProperty(sb, "brokerContactPoint", brokerContactPoint);
+    appendProperty(sb, "brokerContactPoint", gatewayAddress);
+    appendProperty(sb, "gatewayAddress", gatewayAddress);
     appendProperty(sb, "jobWorkerMaxJobsActive", jobWorkerMaxJobsActive);
     appendProperty(sb, "numJobWorkerExecutionThreads", numJobWorkerExecutionThreads);
     appendProperty(sb, "defaultJobWorkerName", defaultJobWorkerName);
@@ -317,9 +340,9 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private CredentialsProvider createDefaultCredentialsProvider() {
     final OAuthCredentialsProviderBuilder builder =
         CredentialsProvider.newCredentialsProviderBuilder();
-    final int separatorIndex = brokerContactPoint.lastIndexOf(':');
+    final int separatorIndex = gatewayAddress.lastIndexOf(':');
     if (separatorIndex > 0) {
-      builder.audience(brokerContactPoint.substring(0, separatorIndex));
+      builder.audience(gatewayAddress.substring(0, separatorIndex));
     }
 
     return builder.build();

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
@@ -114,7 +114,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
     final URI address;
 
     try {
-      address = new URI("zb://" + config.getBrokerContactPoint());
+      address = new URI("zb://" + config.getGatewayAddress());
     } catch (final URISyntaxException e) {
       throw new RuntimeException("Failed to parse broker contact point", e);
     }

--- a/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
@@ -172,4 +172,34 @@ public final class ZeebeClientTest extends ClientTest {
     assertThatThrownBy(() -> new ZeebeClientBuilderImpl().build())
         .isInstanceOf(IllegalArgumentException.class);
   }
+
+  @Test
+  public void shouldBrokerContactPointReturnTheSameAsGatewayAddress() {
+    // given
+    final String gatewayAddress = "localhost:26500";
+    try (final ZeebeClient client =
+        ZeebeClient.newClientBuilder().gatewayAddress(gatewayAddress).build()) {
+      // when
+      final ZeebeClientConfiguration configuration = client.getConfiguration();
+      // then
+      assertThat(configuration.getGatewayAddress())
+          .isEqualTo(configuration.getBrokerContactPoint())
+          .isEqualTo(gatewayAddress);
+    }
+  }
+
+  @Test
+  public void shouldGatewayAddressReturnsTheSameAsBrokerContactPoint() {
+    // given
+    final String gatewayAddress = "localhost:26500";
+    try (final ZeebeClient client =
+        ZeebeClient.newClientBuilder().brokerContactPoint(gatewayAddress).build()) {
+      // when
+      final ZeebeClientConfiguration configuration = client.getConfiguration();
+      // then
+      assertThat(configuration.getBrokerContactPoint())
+          .isEqualTo(configuration.getGatewayAddress())
+          .isEqualTo(gatewayAddress);
+    }
+  }
 }

--- a/docs/src/clients/java-client/get-started.md
+++ b/docs/src/clients/java-client/get-started.md
@@ -77,7 +77,7 @@ public class App
     {
         final ZeebeClient client = ZeebeClient.newClientBuilder()
             // change the contact point if needed
-            .brokerContactPoint("127.0.0.1:26500")
+            .gatewayAddress("127.0.0.1:26500")
             .usePlaintext()
             .build();
 

--- a/docs/src/clients/java-client/setup.md
+++ b/docs/src/clients/java-client/setup.md
@@ -25,7 +25,7 @@ In Java code, instantiate the client as follows:
 
 ```java
 ZeebeClient client = ZeebeClient.newClientBuilder()
-  .brokerContactPoint("127.0.0.1:26500")
+  .gatewayAddress("127.0.0.1:26500")
   .usePlaintext()
   .build();
 ```

--- a/docs/src/operations/authorization.md
+++ b/docs/src/operations/authorization.md
@@ -17,7 +17,7 @@ public class MyCredentialsProvider implements CredentialsProvider {
     */
     @Override
     public void applyCredentials(final Metadata headers) {
-      final Key<String> authHeaderkey = Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);     
+      final Key<String> authHeaderkey = Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
       headers.put(authHeaderKey, "Bearer someToken");
     }
 
@@ -29,7 +29,7 @@ public class MyCredentialsProvider implements CredentialsProvider {
       return ((StatusRuntimeException) throwable).getStatus() == Status.DEADLINE_EXCEEDED;
     }
 }
-``` 
+```
 
 After implementing the CredentialsProvider, we can simply provide it when building a client:
 
@@ -38,7 +38,7 @@ public class SecureClient {
     public static void main(final String[] args) {
       final ZeebeClient client = ZeebeClient.newClientBuilder().credentialsProvider(new MyCredentialsProvider()).build();
 
-      // continue...    
+      // continue...
     }
 }
 ```
@@ -108,10 +108,10 @@ public class AuthorizedClient {
 
         final ZeebeClient client =
             new ZeebeClientBuilderImpl()
-                .brokerContactPoint("cluster.endpoint.com:443")
+                .gatewayAddress("cluster.endpoint.com:443")
                 .credentialsProvider(provider)
                 .build();
-    
+
         System.out.println(client.newTopologyRequest().send().join().toString());
     }
 }
@@ -124,7 +124,7 @@ public class AuthorizedClient {
     public void main(final String[] args) {
         final ZeebeClient client =
             new ZeebeClientBuilderImpl()
-                .brokerContactPoint("cluster.endpoint.com:443")
+                .gatewayAddress("cluster.endpoint.com:443")
                 .build();
 
         System.out.println(client.newTopologyRequest().send().join().toString());
@@ -134,7 +134,7 @@ public class AuthorizedClient {
 
 The client will create an OAuthCredentialProvider with the credentials specified through the environment variables and the audience will be extracted from the address specified through the ZeebeClientBuilder.
 
-> **Note:** Zeebe's Java client will not prevent you from adding credentials to gRPC calls while using an insecure connection but you should be aware that doing so will expose your access token by transmiting it in plaintext. 
+> **Note:** Zeebe's Java client will not prevent you from adding credentials to gRPC calls while using an insecure connection but you should be aware that doing so will expose your access token by transmiting it in plaintext.
 
 ### Go
 ```go
@@ -204,7 +204,7 @@ func main() {
 }
 ```
 
-> **Note:** Like the Java client, the Go client will not prevent you from adding credentials to gRPC calls while using an insecure connection but doing so will expose your access token. 
+> **Note:** Like the Java client, the Go client will not prevent you from adding credentials to gRPC calls while using an insecure connection but doing so will expose your access token.
 
 
 ### Environment Variables


### PR DESCRIPTION
## Description

I create the `gatewayAddress` method in the client builder, configuration, and deprecate the `brokerContactPoint` method.
**Note**: To keep PR small I've decided to move part with switching to the new method in internal parts of the project (inner logic, tests) to another PR.

## Related issues
#2973 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
