### PR TITLE
chore(ci): use GitHub app credential for organization

### DIFF
--- a/.ci/jobs/github_zeebe_io.dsl
+++ b/.ci/jobs/github_zeebe_io.dsl
@@ -8,7 +8,7 @@ organizationFolder('zeebe-io') {
     organizations {
         github {
             repoOwner('zeebe-io')
-            credentialsId('camunda-jenkins-github')
+            credentialsId('github-zeebe-app')
 
             traits {
                 cleanBeforeCheckoutTrait {


### PR DESCRIPTION
## Description

As all Jenkins instances maintained by the infrastructure team use the same GitHub account we used to run into API limits every once in a while due to the limit of 5000 requests per hour.
As a first step, Jenkins instances with an organization folder will be adjusted to use a GitHub App credential, which allows 15000 requests per hour, and on top of that, those are unique to the Jenkins instance of a team itself.

It will change the credential used in the zeebe-io organization.
Repositories will be scanned with the new credential and the git checkout will use the new credential as well. GitHub status reports for those affected repositories will be reported back through the new GitHub App.
Releases will continue to use the `camunda-jenkins` GitHub account as defined in the pipelines of those repositories.

## Related issues

[INFRA-1778](https://jira.camunda.com/browse/INFRA-1778)

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

* [ ] reviewed by an Infra team member

**Zeebe related**

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
