### PR TITLE
chore(engine): update last processed position after reprocessing

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -184,7 +184,7 @@ public final class AsyncSnapshotDirector extends Actor {
                   final var snapshot = pendingSnapshot.persist();
 
                   LOG.info(
-                      "Current commit position {} is greater then {}, snapshot {} is valid and has been persisted.",
+                      "Current commit position {} is greater than {}, snapshot {} is valid and has been persisted.",
                       currentCommitPosition,
                       lastWrittenEventPosition,
                       snapshot.getId());

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -443,4 +443,11 @@ public final class ProcessingStateMachine {
   public boolean isMakingProgress() {
     return !onErrorHandlingLoop;
   }
+
+  public void startProcessing(final long lastReprocessedPosition) {
+    if (lastSuccessfulProcessedEventPosition == StreamProcessor.UNSET_POSITION) {
+      lastSuccessfulProcessedEventPosition = lastReprocessedPosition;
+    }
+    actor.submit(this::readNextEvent);
+  }
 }


### PR DESCRIPTION
## Description

When the broker is out of disk space, stream processor is paused immediately after reprocessing. Then the last processed position was not updated. As a result, no snapshots are taken because `AsyncSnapshotDirector` assumes there is nothing processed, even though new snapshots can be taken because exporter position has changed. So the logs are not compacted and the brokers cannot recover from out of disk space.
In this PR, we initialize streamprocessor's `lastProcessedPosition` to the last reprocessed position. Then we can take new snapshots even if nothing new has been processed.

## Related issues

closes #5329

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
