### PR TITLE
chore(upgrade-tests): close network after tests

### DIFF
--- a/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
@@ -101,6 +101,7 @@ public class RollingUpdateTest {
   @After
   public void tearDown() {
     containers.parallelStream().forEach(Startable::stop);
+    network.close();
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR ensures we close the network at the end of the rolling update tests. There was an issue where if Network objects are collected fast enough, you may run out of IPv4 pools for them.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
