### PR TITLE
Add NPE guard on concurrent modifications

### DIFF
--- a/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
@@ -51,7 +51,7 @@ public final class AtomixLogStorageReader implements LogStorageReader {
       return LogStorage.OP_RESULT_NO_DATA;
     }
 
-    final var result =
+    final long result =
         findEntry(address)
             .map(indexed -> wrapEntryData(indexed, readBuffer))
             .orElse(LogStorage.OP_RESULT_NO_DATA);
@@ -154,7 +154,7 @@ public final class AtomixLogStorageReader implements LogStorageReader {
 
     while (reader.hasNext()) {
       final var entry = reader.next();
-      if (entry.type().equals(ZeebeEntry.class)) {
+      if (entry != null && ZeebeEntry.class.equals(entry.type())) {
         return Optional.of(entry.cast());
       }
     }


### PR DESCRIPTION
## Description

This PR adds a `NullPointerException` guard clause in case of concurrent modifications of the underlying Atomix journal reader. Please refer to the original issue for motivation.

## Related issues

closes #4806 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
