### PR TITLE
[Backport 0.23] Transition to follower when leader receives a config request from a newer term

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -39,6 +39,8 @@ import io.atomix.raft.protocol.CloseSessionRequest;
 import io.atomix.raft.protocol.CloseSessionResponse;
 import io.atomix.raft.protocol.CommandRequest;
 import io.atomix.raft.protocol.CommandResponse;
+import io.atomix.raft.protocol.ConfigureRequest;
+import io.atomix.raft.protocol.ConfigureResponse;
 import io.atomix.raft.protocol.JoinRequest;
 import io.atomix.raft.protocol.JoinResponse;
 import io.atomix.raft.protocol.KeepAliveRequest;
@@ -101,7 +103,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
   public LeaderRole(final RaftContext context) {
     super(context);
-    this.appender = new LeaderAppender(this);
+    appender = new LeaderAppender(this);
   }
 
   @Override
@@ -1105,6 +1107,14 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
                         configuring = 0;
                       });
             });
+  }
+
+  @Override
+  public CompletableFuture<ConfigureResponse> onConfigure(final ConfigureRequest request) {
+    if (updateTermAndLeader(request.term(), request.leader())) {
+      raft.transition(Role.FOLLOWER);
+    }
+    return super.onConfigure(request);
   }
 
   @Override


### PR DESCRIPTION
## Description

Backport #5361 

## Related issues

closes #5360

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
