### PR TITLE
Fix voting for two candidates at same term

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -954,8 +954,7 @@ public class RaftContext implements AutoCloseable {
         }
       }
 
-      lastVotedFor = null;
-      meta.storeVote(null);
+      log.trace("Set leader {}", this.leader);
     }
   }
 


### PR DESCRIPTION
## Description

* According to raft `lastVotedFor` should be the candidate that this node voted for in the current term. But, we were reseting lastVotedFor whenever we update the leader. `lastVotedFor` should be reset only when incrementing the term.

## Related issues

closes #5356 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
