### PR TITLE
Improve flaky DiskSpaceMonitoringFailover test

### DIFF
--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -630,7 +630,7 @@ public final class ClusteringRule extends ExternalResource {
   public void waitForTopology(final Predicate<List<BrokerInfo>> topologyPredicate) {
     Awaitility.await()
         .pollInterval(Duration.ofMillis(100))
-        .atMost(Duration.ofSeconds(10))
+        .atMost(Duration.ofSeconds(60))
         .ignoreExceptions()
         .until(() -> getTopologyFromClient().getBrokers(), topologyPredicate);
   }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceMonitoringFailOverTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceMonitoringFailOverTest.java
@@ -71,6 +71,9 @@ public class DiskSpaceMonitoringFailOverTest {
     clusteringRule.stopBrokerAndAwaitNewLeader(leaderId);
     final var newLeaderId = clusteringRule.getLeaderForPartition(1).getNodeId();
 
+    // Force rescan of healthcheck
+    clusteringRule.getClock().addTime(Duration.ofSeconds(60));
+
     // then
     Awaitility.await()
         .timeout(Duration.ofSeconds(60))


### PR DESCRIPTION
## Description

The tests were failing because of two different reasons. In one, the test fails because it times out while awaiting the health status to be unhealthy. Since the health monitoring is only scans periodically with an interval of 60s, sometimes it has to wait for 60s until the condition is true. In the second case, the tests fails because it times out in waiting for the new leader to be elected. In both cases we could see in the logs that the health status became unhealthy and a new leader was elected. But the test fails because of the timing. This PR improves the test by 
* Increase the clock by monitoring interval to force rescan the health before awaiting the condition
* Increase the timeout in waitForTopology as sometimes 10s is not enough to complete a new leader election. 

## Related issues

closes #5369

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
