### PR TITLE
fix(test): Avoid using default/shared snapshot store factory

### DIFF
--- a/atomix/core/pom.xml
+++ b/atomix/core/pom.xml
@@ -14,7 +14,9 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <artifactId>atomix</artifactId>
 
   <build>
@@ -43,6 +45,11 @@
     <dependency>
       <artifactId>atomix-utils</artifactId>
       <groupId>io.zeebe</groupId>
+    </dependency>
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-snapshots</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/atomix/core/src/test/java/io/atomix/core/RaftRolesTest.java
+++ b/atomix/core/src/test/java/io/atomix/core/RaftRolesTest.java
@@ -26,6 +26,7 @@ import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.RaftPartitionGroup;
+import io.zeebe.snapshots.broker.impl.FileBasedSnapshotStoreFactory;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -271,6 +272,7 @@ public final class RaftRolesTest {
                   .withMembers(memberIds)
                   .withDataDirectory(
                       new File(new File(atomixRule.getDataDir(), "log"), "" + nodeId))
+                  .withSnapshotStoreFactory(new FileBasedSnapshotStoreFactory())
                   .build();
 
           final Atomix atomix = builder.withPartitionGroups(partitionGroup).build();


### PR DESCRIPTION
## Description
This fixes flaky `RaftRolesTest`.

Note that I was unable to reproduce the flaky test. This fix is based on a code review, taking lessons learned from other similar flaky test symptoms. 

To verify the fix, I built the fix 10 times. The flaky test did not occur in these 10 builds. This is significant, because this test fails in develop up to 40% of times.

The root cause for the behavior seems to have been the use of a default `FileBasedSnapshotStoreFactory` that is initialized as a static construct in `RaftStorageConfig`:

```
  private static final ReceivableSnapshotStoreFactory DEFAULT_SNAPSHOT_STORE_FACTORY =
      new FileBasedSnapshotStoreFactory();
...
  private ReceivableSnapshotStoreFactory persistedSnapshotStoreFactory =
      DEFAULT_SNAPSHOT_STORE_FACTORY;
```
The factory keeps a cache of snapshot stores it has created. The key for the map is the name of the partition:
```
    return partitionSnapshotStores.computeIfAbsent(
        partitionName,
        p ->
            new FileBasedSnapshotStore(
                new SnapshotMetrics(partitionName), snapshotDirectory, pendingDirectory));
```

The hypothesis for the flaky test is that different tests used the default factory while running in parallel. In this situation, the factory can enter an inconsistent state if a snapshot store is deleted and then used after it has been deleted. The issue #5383 was created to address the inconsistent state.

The fix is to explicitly set a new factory for the test.

## Related issues

closes #4440

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
