### PR TITLE
Update acknowledged position of up to date exporters when skipping records

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -119,6 +119,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-msgpack-value</artifactId>
     </dependency>

--- a/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,7 +59,6 @@ public final class ExporterDirectorTest {
   @Rule public final ExporterRule rule = new ExporterRule(PARTITION_ID);
   private final List<ControlledTestExporter> exporters = new ArrayList<>();
   private final List<ExporterDescriptor> exporterDescriptors = new ArrayList<>();
-  private ExportersState state;
 
   @Before
   public void init() {
@@ -82,6 +82,134 @@ public final class ExporterDirectorTest {
 
   private void startExporterDirector(final List<ExporterDescriptor> exporterDescriptors) {
     rule.startExporterDirector(exporterDescriptors);
+  }
+
+  @Test
+  public void shouldUpdatePositionWhenInitialRecordsAreSkipped() {
+    // given
+    final ControlledTestExporter tailingExporter = exporters.get(1);
+    exporters.forEach(
+        e ->
+            e.onConfigure(withFilter(List.of(RecordType.COMMAND), List.of(ValueType.DEPLOYMENT)))
+                .shouldAutoUpdatePosition(false));
+
+    // when
+    startExporterDirector(exporterDescriptors);
+    final ExportersState state = rule.getExportersState();
+    final long skippedRecordPosition =
+        rule.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+    rule.writeCommand(DeploymentIntent.CREATE, new DeploymentRecord());
+
+    // then
+    Awaitility.await("director has read all records until now")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(tailingExporter.getExportedRecords()).hasSize(1));
+    assertThat(state.getPosition(EXPORTER_ID_1)).isEqualTo(skippedRecordPosition);
+    assertThat(state.getPosition(EXPORTER_ID_2)).isEqualTo(skippedRecordPosition);
+  }
+
+  @Test
+  public void shouldUpdatePositionOfUpToDateExportersOnSkipRecord() {
+    // given
+    final ControlledTestExporter filteringExporter = exporters.get(0);
+    final ControlledTestExporter tailingExporter = exporters.get(1);
+    tailingExporter
+        .onConfigure(withFilter(List.of(RecordType.COMMAND), List.of(ValueType.DEPLOYMENT)))
+        .shouldAutoUpdatePosition(false);
+    filteringExporter
+        .onConfigure(withFilter(List.of(RecordType.COMMAND), List.of(ValueType.DEPLOYMENT)))
+        .shouldAutoUpdatePosition(false);
+
+    // when
+    startExporterDirector(exporterDescriptors);
+    final ExportersState state = rule.getExportersState();
+
+    // accepted by both
+    final long firstRecordPosition =
+        rule.writeCommand(DeploymentIntent.CREATE, new DeploymentRecord());
+    Awaitility.await("filteringExporter has exported the first record")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(filteringExporter.getExportedRecords()).hasSize(1));
+    filteringExporter.getController().updateLastExportedRecordPosition(firstRecordPosition);
+    // skipped entirely
+    final long skippedRecordPosition =
+        rule.writeCommand(IncidentIntent.CREATE, new IncidentRecord());
+    // accepted by both again
+    rule.writeCommand(DeploymentIntent.CREATE, new DeploymentRecord());
+
+    // then
+    Awaitility.await("director has read all records until now")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(tailingExporter.getExportedRecords()).hasSize(2));
+    assertThat(state.getPosition(EXPORTER_ID_1)).isEqualTo(skippedRecordPosition);
+    assertThat(state.getPosition(EXPORTER_ID_2)).isEqualTo(-1L);
+  }
+
+  @Test
+  public void shouldUpdateIfSkippingInitialRecordForSingleExporter() {
+    final ControlledTestExporter filteringExporter = exporters.get(0);
+    final ControlledTestExporter tailingExporter = exporters.get(1);
+    tailingExporter
+        .onConfigure(
+            withFilter(
+                List.of(RecordType.COMMAND, RecordType.EVENT), List.of(ValueType.DEPLOYMENT)))
+        .shouldAutoUpdatePosition(false);
+    filteringExporter
+        .onConfigure(withFilter(List.of(RecordType.COMMAND), List.of(ValueType.DEPLOYMENT)))
+        .shouldAutoUpdatePosition(false);
+
+    // when
+    startExporterDirector(exporterDescriptors);
+    final ExportersState state = rule.getExportersState();
+
+    // skipped only by filteringExporter
+    final long skippedRecordPosition =
+        rule.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+    // accepted by both
+    rule.writeCommand(DeploymentIntent.CREATE, new DeploymentRecord());
+
+    // then
+    Awaitility.await("director has read all records until now")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(tailingExporter.getExportedRecords()).hasSize(2));
+    assertThat(state.getPosition(EXPORTER_ID_1)).isEqualTo(skippedRecordPosition);
+    assertThat(state.getPosition(EXPORTER_ID_2)).isEqualTo(-1L);
+  }
+
+  @Test
+  public void shouldUpdateIfRecordSkipsSingleUpToDateExporter() throws InterruptedException {
+    final ControlledTestExporter filteringExporter = exporters.get(0);
+    final ControlledTestExporter tailingExporter = exporters.get(1);
+    tailingExporter
+        .onConfigure(
+            withFilter(
+                List.of(RecordType.COMMAND, RecordType.EVENT), List.of(ValueType.DEPLOYMENT)))
+        .shouldAutoUpdatePosition(false);
+    filteringExporter
+        .onConfigure(withFilter(List.of(RecordType.COMMAND), List.of(ValueType.DEPLOYMENT)))
+        .shouldAutoUpdatePosition(false);
+
+    // when
+    startExporterDirector(exporterDescriptors);
+    final ExportersState state = rule.getExportersState();
+
+    // accepted by both
+    final long firstRecordPosition =
+        rule.writeCommand(DeploymentIntent.CREATE, new DeploymentRecord());
+    Awaitility.await("filteringExporter has exported the first record")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(filteringExporter.getExportedRecords()).hasSize(1));
+    filteringExporter.getController().updateLastExportedRecordPosition(firstRecordPosition);
+    // skipped only by filteringExporter
+    final long skippedRecordPosition =
+        rule.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+
+    // then
+    Awaitility.await("director has read all records until now")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(tailingExporter.getExportedRecords()).hasSize(2));
+    assertThat(state.getPosition(EXPORTER_ID_1)).isEqualTo(skippedRecordPosition);
+    assertThat(state.getPosition(EXPORTER_ID_2)).isEqualTo(-1L);
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR fixes an issue where the last exported position was never updated if all subsequent records were skipped by the `ExporterDirector`. The fix is to keep track of the last unacknowledged position of an exporter - that is, the position of the last record which was passed on via `Exporter#export(Record<?>)`. When skipping a record (either because all exporters are filtering it out, or because a single one is), iff the exporter's last acknowledged position is greater than or equal to its last unacknowledged position, and the position of the record to be skipped is greater than the last acknowledged position, then we can safely increase the last acknowledged position to the new value. This is safe to do as we know that there are no unacknowledged records between the last acknowledged one, and the one we're about to skip.

## Related issues

closes #3166 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
