### PR TITLE
Specify the Java source version during Sonar analysis

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1414,6 +1414,7 @@
         <sonar.cpd.exclusions>
           broker/src/main/java/io/zeebe/broker/system/configuration/backpressure/Gradient2Cfg.java,broker/src/main/java/io/zeebe/broker/system/configuration/backpressure/GradientCfg.java
         </sonar.cpd.exclusions>
+        <sonar.java.source>${version.java}</sonar.java.source>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
## Description

We previously did not specify any Java source version during Sonar analysis, which means that it was using the JVM version (11) - this caused some false positive warnings for modules which are still under source level 8, such as the client (see #5345 for example). By specifying the `sonar.java.source` property to `version.java`, we can see from the logs that for each analyzed module, Sonar is picking up the right version for it.

## Related issues

Came out of PR #5345 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
