### PR TITLE
[Backport 0.24] fix(gateway): map exception to correct error code

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -10,6 +10,7 @@ package io.zeebe.gateway.impl.job;
 import static io.zeebe.util.sched.clock.ActorClock.currentTimeMillis;
 
 import io.grpc.stub.StreamObserver;
+import io.zeebe.gateway.EndpointManager;
 import io.zeebe.gateway.Loggers;
 import io.zeebe.gateway.cmd.BrokerErrorException;
 import io.zeebe.gateway.impl.broker.BrokerClient;
@@ -37,6 +38,8 @@ public final class LongPollingActivateJobsHandler extends Actor implements Activ
 
   private static final String JOBS_AVAILABLE_TOPIC = "jobsAvailable";
   private static final Logger LOG = Loggers.GATEWAY_LOGGER;
+  private static final String ERROR_MSG_ACTIVATED_EXHAUSTED =
+      "Expected to activate jobs of type '%s', but no jobs available and at least one broker returned 'RESOURCE_EXHAUSTED'. Please try again later.";
 
   private final RoundRobinActivateJobsHandler activateJobsHandler;
   private final BrokerClient brokerClient;
@@ -97,7 +100,7 @@ public final class LongPollingActivateJobsHandler extends Actor implements Activ
         });
   }
 
-  private InFlightLongPollingActivateJobsRequestsState getJobTypeState(String jobType) {
+  private InFlightLongPollingActivateJobsRequestsState getJobTypeState(final String jobType) {
     return jobTypeState.computeIfAbsent(
         jobType, type -> new InFlightLongPollingActivateJobsRequestsState(type, metrics));
   }
@@ -139,13 +142,14 @@ public final class LongPollingActivateJobsHandler extends Actor implements Activ
         actor.submit(
             () -> {
               state.removeActiveRequest(request);
+              final var type = request.getType();
+              final var errorMsg = String.format(ERROR_MSG_ACTIVATED_EXHAUSTED, type);
               request
                   .getResponseObserver()
                   .onError(
-                      new BrokerErrorException(
-                          new BrokerError(
-                              ErrorCode.RESOURCE_EXHAUSTED,
-                              "Some brokers returned resource exhausted")));
+                      EndpointManager.convertThrowable(
+                          new BrokerErrorException(
+                              new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, errorMsg))));
             });
       } else {
         actor.submit(

--- a/gateway/src/test/java/io/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.verify;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
-import io.zeebe.gateway.EndpointManager;
 import io.zeebe.gateway.api.util.StubbedBrokerClient;
 import io.zeebe.gateway.api.util.StubbedBrokerClient.RequestHandler;
 import io.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
@@ -456,8 +455,7 @@ public final class LongPollingActivateJobsTest {
     verify(request.getResponseObserver(), never()).onCompleted();
 
     final StatusRuntimeException statusRuntimeException =
-        EndpointManager.convertThrowable(throwableCaptor.getValue());
-
+        (StatusRuntimeException) throwableCaptor.getValue();
     assertThat(statusRuntimeException.getStatus().getCode()).isEqualTo(Code.RESOURCE_EXHAUSTED);
   }
 


### PR DESCRIPTION
## Description

backports #5228

- Previous BrokerException was directly returned to the client, it is now mapped to the correct StatusException and code.
- The error message was rewritten to make more clear what has happened.

## Related issues

fixes #5187
closes #5387

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
