### PR TITLE
[Backport 0.23] fix(gateway): map exception to correct error code

### DIFF
--- a/gateway/src/test/java/io/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/job/LongPollingActivateJobsTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.verify;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
-import io.zeebe.gateway.EndpointManager;
 import io.zeebe.gateway.api.util.StubbedBrokerClient;
 import io.zeebe.gateway.api.util.StubbedBrokerClient.RequestHandler;
 import io.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
@@ -456,8 +455,7 @@ public final class LongPollingActivateJobsTest {
     verify(request.getResponseObserver(), never()).onCompleted();
 
     final StatusRuntimeException statusRuntimeException =
-        EndpointManager.convertThrowable(throwableCaptor.getValue());
-
+        (StatusRuntimeException) throwableCaptor.getValue();
     assertThat(statusRuntimeException.getStatus().getCode()).isEqualTo(Code.RESOURCE_EXHAUSTED);
   }
 


### PR DESCRIPTION
## Description

backports #5228

- Previous BrokerException was directly returned to the client, it is now mapped to the correct StatusException and code.
- The error message was rewritten to make more clear what has happened.

## Related issues

fixes #5187

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
