### PR TITLE
[backport to 0.24] Avoid using default/shared snapshot store factory

### DIFF
--- a/atomix/core/pom.xml
+++ b/atomix/core/pom.xml
@@ -14,7 +14,9 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <artifactId>atomix</artifactId>
 
   <build>

--- a/atomix/core/src/test/java/io/atomix/core/RaftRolesTest.java
+++ b/atomix/core/src/test/java/io/atomix/core/RaftRolesTest.java
@@ -26,6 +26,7 @@ import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.RaftPartitionGroup;
+import io.atomix.raft.snapshot.impl.FileBasedSnapshotStoreFactory;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -271,6 +272,7 @@ public final class RaftRolesTest {
                   .withMembers(memberIds)
                   .withDataDirectory(
                       new File(new File(atomixRule.getDataDir(), "log"), "" + nodeId))
+                  .withSnapshotStoreFactory(new FileBasedSnapshotStoreFactory())
                   .build();
 
           final Atomix atomix = builder.withPartitionGroups(partitionGroup).build();


### PR DESCRIPTION
## Description
Backport of fix for #4440

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [X] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
