### PR TITLE
Operate tasklist els config docs

### DIFF
--- a/docs/src/operate-deployment-guide/configuration.md
+++ b/docs/src/operate-deployment-guide/configuration.md
@@ -21,12 +21,14 @@ with `camunda.operate`. The following parts are configurable:
 Operate stores and reads data in/from Elasticsearch.
 
 ## Settings to connect
+Either set `host` and `port` (deprecated) or `url` (recommended)
 
 Name | Description | Default value
 -----|-------------|--------------
 camunda.operate.elasticsearch.clusterName | Clustername of Elasticsearch | elasticsearch
 camunda.operate.elasticsearch.host | Hostname where Elasticsearch is running | localhost
 camunda.operate.elasticsearch.port | Port of Elasticsearch REST API | 9200
+camunda.operate.elasticsearch.url | URL of Elasticsearch REST API | http://localhost:9200
 
 ## A snippet from application.yml:
 
@@ -35,10 +37,8 @@ camunda.operate:
   elasticsearch:
     # Cluster name
     clusterName: elasticsearch
-    # Host
-    host: localhost
-    # Transport port
-    port: 9200
+    # Url
+    url: http://localhost:9200
 ```
 
 # Zeebe Broker Connection
@@ -66,12 +66,14 @@ Operate imports data from Elasticsearch indices created and filled in by [Zeebe 
 Therefore settings for this Elasticsearch connection must be defined and must correspond to the settings on Zeebe side.
 
 ## Settings to connect and import:
+Either set `host` and `port` (deprecated) or `url` (recommended)
 
 Name | Description | Default value
 -----|-------------|--------------
 camunda.operate.zeebeElasticsearch.clusterName | Cluster name of Elasticsearch | elasticsearch
 camunda.operate.zeebeElasticsearch.host | Hostname where Elasticsearch is running | localhost
 camunda.operate.zeebeElasticsearch.port | Port of Elasticsearch REST API | 9200
+camunda.operate.zeebeElasticsearch.url | URL of Elasticsearch REST API | http://localhost:9200
 camunda.operate.zeebeElasticsearch.prefix | Index prefix as configured in Zeebe Elasticsearch exporter | zeebe-record
 
 ## A snippet from application.yml:
@@ -81,10 +83,8 @@ camunda.operate:
   zeebeElasticsearch:
     # Cluster name
     clusterName: elasticsearch
-    # Host
-    host: localhost
-    # Transport port
-    port: 9200
+    # Url
+    url: http://localhost:9200
     # Index prefix, configured in Zeebe Elasticsearch exporter
     prefix: zeebe-record
 ```
@@ -194,10 +194,8 @@ camunda.operate:
   elasticsearch:
     # Cluster name
     clusterName: elasticsearch
-    # Host
-    host: localhost
-    # Transport port
-    port: 9200
+    # Url
+    url: http://localhost:9200
   # Zeebe instance
   zeebe:
     # Broker contact point
@@ -206,10 +204,8 @@ camunda.operate:
   zeebeElasticsearch:
     # Cluster name
     clusterName: elasticsearch
-    # Host
-    host: localhost
-    # Transport port
-    port: 9200
+    # Url
+    url: http://localhost:9200
     # Index prefix, configured in Zeebe Elasticsearch exporter
     prefix: zeebe-record
 ```

--- a/docs/src/operate-deployment-guide/configuration.md
+++ b/docs/src/operate-deployment-guide/configuration.md
@@ -21,6 +21,9 @@ with `camunda.operate`. The following parts are configurable:
 Operate stores and reads data in/from Elasticsearch.
 
 ## Settings to connect
+Operate supports [basic authentication](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/setting-up-authentication.html) for elasticsearch.
+Set the appropriate username/password combination in the configuration to use it.
+
 Either set `host` and `port` (deprecated) or `url` (recommended)
 
 Name | Description | Default value
@@ -29,6 +32,8 @@ camunda.operate.elasticsearch.clusterName | Clustername of Elasticsearch | elast
 camunda.operate.elasticsearch.host | Hostname where Elasticsearch is running | localhost
 camunda.operate.elasticsearch.port | Port of Elasticsearch REST API | 9200
 camunda.operate.elasticsearch.url | URL of Elasticsearch REST API | http://localhost:9200
+camunda.operate.elasticsearch.username | Username to access Elasticsearch REST API | -
+camunda.operate.elasticsearch.password | Password to access Elasticsearch REST API | -
 
 ## A snippet from application.yml:
 
@@ -75,6 +80,8 @@ camunda.operate.zeebeElasticsearch.host | Hostname where Elasticsearch is runnin
 camunda.operate.zeebeElasticsearch.port | Port of Elasticsearch REST API | 9200
 camunda.operate.zeebeElasticsearch.url | URL of Elasticsearch REST API | http://localhost:9200
 camunda.operate.zeebeElasticsearch.prefix | Index prefix as configured in Zeebe Elasticsearch exporter | zeebe-record
+camunda.operate.zeebeElasticsearch.username | Username to access Elasticsearch REST API | -
+camunda.operate.zeebeElasticsearch.password | Password to access Elasticsearch REST API | -
 
 ## A snippet from application.yml:
 

--- a/docs/src/tasklist-deployment-guide/configuration.md
+++ b/docs/src/tasklist-deployment-guide/configuration.md
@@ -18,11 +18,15 @@ with `zeebe.tasklist`. The following parts are configurable:
 Tasklist stores and reads data in/from Elasticsearch.
 
 ## Settings to connect
+Tasklist supports [basic authentication](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/setting-up-authentication.html) for elasticsearch.
+Set the appropriate username/password combination in the configuration to use it.
 
 Name | Description | Default value
 -----|-------------|--------------
 zeebe.tasklist.elasticsearch.clusterName | Clustername of Elasticsearch | elasticsearch
 zeebe.tasklist.elasticsearch.url | URL of Elasticsearch REST API  | http://localhost:9200
+zeebe.tasklist.elasticsearch.username | Username to access Elasticsearch REST API | -
+zeebe.tasklist.elasticsearch.password | Password to access Elasticsearch REST API | -
 
 ## A snippet from application.yml:
 
@@ -66,6 +70,8 @@ Name | Description | Default value
 zeebe.tasklist.zeebeElasticsearch.clusterName | Cluster name of Elasticsearch | elasticsearch
 zeebe.tasklist.zeebeElasticsearch.url | URL of Elasticsearch REST API| http://localhost:9200
 zeebe.tasklist.zeebeElasticsearch.prefix | Index prefix as configured in Zeebe Elasticsearch exporter | zeebe-record
+zeebe.tasklist.zeebeElasticsearch.username | Username to access Elasticsearch REST API | -
+zeebe.tasklist.zeebeElasticsearch.password | Password to access Elasticsearch REST API | -
 
 ## A snippet from application.yml:
 

--- a/docs/src/tasklist-deployment-guide/configuration.md
+++ b/docs/src/tasklist-deployment-guide/configuration.md
@@ -1,7 +1,7 @@
 # Introduction
 
 Tasklist is a Spring Boot application. That means all ways to [configure](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config)
-a Spring Boot application can be applied. By default the configuration for Tasklist is stored in a YAML file `application.yml`. All Tasklist related settings are prefixed
+a Spring Boot application can be applied. By default, the configuration for Tasklist is stored in a YAML file `application.yml`. All Tasklist related settings are prefixed
 with `zeebe.tasklist`. The following parts are configurable:
 
  * [Elasticsearch Connection](#elasticsearch)
@@ -22,8 +22,7 @@ Tasklist stores and reads data in/from Elasticsearch.
 Name | Description | Default value
 -----|-------------|--------------
 zeebe.tasklist.elasticsearch.clusterName | Clustername of Elasticsearch | elasticsearch
-zeebe.tasklist.elasticsearch.host | Hostname where Elasticsearch is running | localhost
-zeebe.tasklist.elasticsearch.port | Port of Elasticsearch REST API | 9200
+zeebe.tasklist.elasticsearch.url | URL of Elasticsearch REST API  | http://localhost:9200
 
 ## A snippet from application.yml:
 
@@ -32,10 +31,8 @@ zeebe.tasklist:
   elasticsearch:
     # Cluster name
     clusterName: elasticsearch
-    # Host
-    host: localhost
-    # Transport port
-    port: 9200
+    # Url
+    url: http://localhost:9200
 ```
 
 # Zeebe Broker Connection
@@ -67,8 +64,7 @@ Therefore settings for this Elasticsearch connection must be defined and must co
 Name | Description | Default value
 -----|-------------|--------------
 zeebe.tasklist.zeebeElasticsearch.clusterName | Cluster name of Elasticsearch | elasticsearch
-zeebe.tasklist.zeebeElasticsearch.host | Hostname where Elasticsearch is running | localhost
-zeebe.tasklist.zeebeElasticsearch.port | Port of Elasticsearch REST API | 9200
+zeebe.tasklist.zeebeElasticsearch.url | URL of Elasticsearch REST API| http://localhost:9200
 zeebe.tasklist.zeebeElasticsearch.prefix | Index prefix as configured in Zeebe Elasticsearch exporter | zeebe-record
 
 ## A snippet from application.yml:
@@ -78,10 +74,8 @@ zeebe.tasklist:
   zeebeElasticsearch:
     # Cluster name
     clusterName: elasticsearch
-    # Host
-    host: localhost
-    # Transport port
-    port: 9200
+    # Url
+    url: http://localhost:9200
     # Index prefix, configured in Zeebe Elasticsearch exporter
     prefix: zeebe-record
 ```
@@ -188,10 +182,8 @@ zeebe.tasklist:
   elasticsearch:
     # Cluster name
     clusterName: elasticsearch
-    # Host
-    host: localhost
-    # Transport port
-    port: 9200
+    # Url
+    url: http://localhost:9200
   # Zeebe instance
   zeebe:
     # Broker contact point
@@ -200,10 +192,8 @@ zeebe.tasklist:
   zeebeElasticsearch:
     # Cluster name
     clusterName: elasticsearch
-    # Host
-    host: localhost
-    # Transport port
-    port: 9200
+    # Url
+    url: http://localhost:9200
     # Index prefix, configured in Zeebe Elasticsearch exporter
     prefix: zeebe-record
 ```


### PR DESCRIPTION
## Description

- Add documentation for elasticsearch url for operate and tasklist
- Add documentation for elasticsearch basic authentication for operate and tasklist 
  -  Documentation for [OPE-1006](https://jira.camunda.com/browse/OPE-1006)

Exists also in 'new' cloud documentation space:
* https://github.com/camunda-cloud/camunda-cloud-documentation/tree/operate-docs-9
* https://github.com/camunda-cloud/camunda-cloud-documentation/tree/tasklist-docs-8


## Related issues

<!-- Which issues are closed by this PR or are related -->


## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
