### PR TITLE
Admin api for brokers

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Broker</name>
@@ -221,6 +223,11 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator</artifactId>
     </dependency>
 
   </dependencies>

--- a/broker/src/main/java/io/zeebe/broker/SpringBrokerBridge.java
+++ b/broker/src/main/java/io/zeebe/broker/SpringBrokerBridge.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.broker;
 
+import io.zeebe.broker.system.management.BrokerAdminService;
 import io.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -20,13 +21,23 @@ import org.springframework.stereotype.Component;
 public class SpringBrokerBridge {
 
   private Supplier<BrokerHealthCheckService> healthCheckServiceSupplier;
+  private Supplier<BrokerAdminService> adminServiceSupplier;
 
   public void registerBrokerHealthCheckServiceSupplier(
-      Supplier<BrokerHealthCheckService> healthCheckServiceSupplier) {
+      final Supplier<BrokerHealthCheckService> healthCheckServiceSupplier) {
     this.healthCheckServiceSupplier = healthCheckServiceSupplier;
   }
 
   public Optional<BrokerHealthCheckService> getBrokerHealthCheckService() {
     return Optional.ofNullable(healthCheckServiceSupplier).map(Supplier::get);
+  }
+
+  public void registerBrokerAdminServiceSupplier(
+      final Supplier<BrokerAdminService> adminServiceSupplier) {
+    this.adminServiceSupplier = adminServiceSupplier;
+  }
+
+  public Optional<BrokerAdminService> getAdminService() {
+    return Optional.ofNullable(adminServiceSupplier).map(Supplier::get);
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.management;
+
+import java.util.Map;
+
+public interface BrokerAdminService {
+
+  /** Request a partition to pause its StreamProcessor */
+  void pauseStreamProcessing();
+
+  /** Request a partition to resume its StreamProcessor */
+  void resumeStreamProcessing();
+
+  /**
+   * Trigger a snapshot. Partition will attempt to take a snapshot instead of waiting for the
+   * snapshot interval.
+   */
+  void takeSnapshot();
+
+  /**
+   * Prepares for upgrade by pausing stream processors and triggering snapshots. It is not normally
+   * required to call this before every upgrade. However, this is useful as an upgrade procedure to
+   * mitigate the effects of some known bugs.
+   */
+  void prepareForUpgrade();
+
+  /**
+   * Returns {@link PartitionStatus} of all partitions running on this broker.
+   *
+   * @return a map of partition id and partition status
+   */
+  Map<Integer, PartitionStatus> getPartitionStatus();
+}

--- a/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminServiceEndpoint.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminServiceEndpoint.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.management;
+
+import io.zeebe.broker.SpringBrokerBridge;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.stereotype.Component;
+
+@Component
+@Endpoint(id = "partitions")
+public class BrokerAdminServiceEndpoint {
+
+  @Autowired private SpringBrokerBridge springBrokerBridge;
+
+  private final Map<String, Runnable> operations = new HashMap<>();
+
+  public BrokerAdminServiceEndpoint() {
+    operations.put("pauseProcessing", this::pauseProcessing);
+    operations.put("resumeProcessing", this::resumeProcessing);
+    operations.put("takeSnapshot", this::takeSnapshot);
+    operations.put("prepareUpgrade", this::prepareUpgrade);
+  }
+
+  @WriteOperation
+  public Map<Integer, PartitionStatus> trigger(@Selector final String operation) {
+    final var runnable = operations.get(operation);
+    if (runnable != null) {
+      runnable.run();
+      return partitionStatus();
+    }
+    // Not a valid operation
+    return null;
+  }
+
+  private Map<Integer, PartitionStatus> pauseProcessing() {
+    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::pauseStreamProcessing);
+    return partitionStatus();
+  }
+
+  private Map<Integer, PartitionStatus> resumeProcessing() {
+    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::resumeStreamProcessing);
+    return partitionStatus();
+  }
+
+  private Map<Integer, PartitionStatus> takeSnapshot() {
+    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::takeSnapshot);
+    return partitionStatus();
+  }
+
+  private Map<Integer, PartitionStatus> prepareUpgrade() {
+    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::prepareForUpgrade);
+    return partitionStatus();
+  }
+
+  @ReadOperation
+  public Map<Integer, PartitionStatus> partitionStatus() {
+    return springBrokerBridge
+        .getAdminService()
+        .map(BrokerAdminService::getPartitionStatus)
+        .orElse(Map.of());
+  }
+}

--- a/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminServiceImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminServiceImpl.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.management;
+
+import io.zeebe.broker.Loggers;
+import io.zeebe.broker.system.partitions.ZeebePartition;
+import io.zeebe.engine.processing.streamprocessor.StreamProcessor;
+import io.zeebe.snapshots.broker.impl.FileBasedSnapshotMetadata;
+import io.zeebe.snapshots.raft.PersistedSnapshot;
+import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.future.ActorFuture;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+
+/**
+ * A service that exposes interface to control some of the core functionalities of the broker such
+ * as * Pause stream processing * Force take a snapshot
+ *
+ * <p>This is intended to be used only by advanced users
+ */
+public class BrokerAdminServiceImpl extends Actor implements BrokerAdminService {
+
+  private static final Logger LOG = Loggers.SYSTEM_LOGGER;
+  private final List<ZeebePartition> partitions;
+
+  public BrokerAdminServiceImpl(final List<ZeebePartition> partitions) {
+    this.partitions = partitions;
+  }
+
+  @Override
+  public void pauseStreamProcessing() {
+    actor.call(this::pauseStreamProcessingOnAllPartitions);
+  }
+
+  @Override
+  public void resumeStreamProcessing() {
+    actor.call(this::unpauseStreamProcessingOnAllPartitions);
+  }
+
+  @Override
+  public void takeSnapshot() {
+    actor.call(() -> takeSnapshotOnAllPartitions(partitions));
+  }
+
+  @Override
+  public void prepareForUpgrade() {
+    actor.call(this::prepareAllPartitionsForSafeUpgrade);
+  }
+
+  @Override
+  public Map<Integer, PartitionStatus> getPartitionStatus() {
+    final CompletableFuture<Map<Integer, PartitionStatus>> future = new CompletableFuture<>();
+    final Map<Integer, PartitionStatus> partitionStatuses = new ConcurrentHashMap<>();
+    actor.call(
+        () -> {
+          final var statusFutures =
+              partitions.stream()
+                  .map(
+                      partition ->
+                          getPartitionStatus(partition)
+                              .whenComplete(
+                                  (ps, error) -> {
+                                    if (error == null) {
+                                      partitionStatuses.put(partition.getPartitionId(), ps);
+                                    }
+                                  }))
+                  .collect(Collectors.toList());
+          CompletableFuture.allOf(statusFutures.toArray(CompletableFuture[]::new))
+              .thenAccept(r -> future.complete(partitionStatuses));
+        });
+    return future.join();
+  }
+
+  private CompletableFuture<PartitionStatus> getPartitionStatus(final ZeebePartition partition) {
+    final CompletableFuture<PartitionStatus> partitionStatus = new CompletableFuture<>();
+    getStreamProcessor(partition)
+        .onComplete(
+            (streamProcessor, throwable) -> {
+              if (throwable != null) {
+                partitionStatus.completeExceptionally(throwable);
+                return;
+              }
+              streamProcessor.ifPresentOrElse(
+                  sp -> getLeaderPartitionStatus(partition, sp, partitionStatus),
+                  () -> getFollowerPartitionStatus(partition, partitionStatus));
+            });
+    return partitionStatus;
+  }
+
+  private void getFollowerPartitionStatus(
+      final ZeebePartition partition, final CompletableFuture<PartitionStatus> partitionStatus) {
+    final var snapshotId = getSnapshotId(partition);
+    final var status = PartitionStatus.ofFollower(snapshotId.orElse(null));
+    partitionStatus.complete(status);
+  }
+
+  private void getLeaderPartitionStatus(
+      final ZeebePartition partition,
+      final StreamProcessor streamProcessor,
+      final CompletableFuture<PartitionStatus> partitionStatus) {
+    final var positionFuture = streamProcessor.getLastProcessedPositionAsync();
+    positionFuture.onComplete(
+        (processedPosition, positionRetrieveError) -> {
+          if (positionRetrieveError != null) {
+            partitionStatus.completeExceptionally(positionRetrieveError);
+            return;
+          }
+
+          streamProcessor
+              .getCurrentPhase()
+              .onComplete(
+                  (phase, phaseError) -> {
+                    if (phaseError != null) {
+                      partitionStatus.completeExceptionally(phaseError);
+                      return;
+                    }
+
+                    final var snapshotId = getSnapshotId(partition);
+                    final var processedPositionInSnapshot =
+                        snapshotId
+                            .flatMap(s -> FileBasedSnapshotMetadata.ofFileName(s))
+                            .map(FileBasedSnapshotMetadata::getProcessedPosition)
+                            .orElse(null);
+                    final var status =
+                        PartitionStatus.ofLeader(
+                            processedPosition,
+                            snapshotId.orElse(null),
+                            processedPositionInSnapshot,
+                            phase);
+                    partitionStatus.complete(status);
+                  });
+        });
+  }
+
+  private Optional<String> getSnapshotId(final ZeebePartition partition) {
+    return partition.getSnapshotStore().getLatestSnapshot().map(PersistedSnapshot::getId);
+  }
+
+  private ActorFuture<Optional<StreamProcessor>> getStreamProcessor(
+      final ZeebePartition partition) {
+    return partition.getStreamProcessor();
+  }
+
+  private void prepareAllPartitionsForSafeUpgrade() {
+    LOG.info("Preparing for safe upgrade.");
+
+    final var pauseCompleted = pauseStreamProcessingOnAllPartitions();
+
+    actor.runOnCompletion(pauseCompleted, t -> takeSnapshotOnAllPartitions(partitions));
+  }
+
+  private List<ActorFuture<Void>> pauseStreamProcessingOnAllPartitions() {
+    LOG.info("Pausing StreamProcessor on all partitions.");
+    return partitions.stream().map(ZeebePartition::pauseProcessing).collect(Collectors.toList());
+  }
+
+  private void unpauseStreamProcessingOnAllPartitions() {
+    LOG.info("Resuming paused StreamProcessor on all partitions.");
+    partitions.forEach(ZeebePartition::resumeProcessing);
+  }
+
+  private void takeSnapshotOnAllPartitions(final List<ZeebePartition> partitions) {
+    LOG.info("Triggering Snapshots on all partitions.");
+    partitions.forEach(ZeebePartition::triggerSnapshot);
+  }
+}

--- a/broker/src/main/java/io/zeebe/broker/system/management/PartitionStatus.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/PartitionStatus.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.management;
+
+import io.atomix.raft.RaftServer.Role;
+import io.zeebe.engine.processing.streamprocessor.StreamProcessor.Phase;
+
+public final class PartitionStatus {
+
+  private final Role role;
+  private final String snapshotId;
+
+  private final Long processedPosition;
+
+  private final Long processedPositionInSnapshot;
+
+  private final Phase streamProcessorPhase;
+
+  private PartitionStatus(
+      final Role role,
+      final Long processedPosition,
+      final String snapshotId,
+      final Long processedPositionInSnapshot,
+      final Phase streamProcessorPhase) {
+    this.role = role;
+    this.processedPosition = processedPosition;
+    this.snapshotId = snapshotId;
+    this.processedPositionInSnapshot = processedPositionInSnapshot;
+    this.streamProcessorPhase = streamProcessorPhase;
+  }
+
+  public static PartitionStatus ofLeader(
+      final Long processedPosition,
+      final String snapshotId,
+      final Long processedPositionInSnapshot,
+      final Phase streamProcessorPhase) {
+    return new PartitionStatus(
+        Role.LEADER,
+        processedPosition,
+        snapshotId,
+        processedPositionInSnapshot,
+        streamProcessorPhase);
+  }
+
+  public static PartitionStatus ofFollower(final String snapshotId) {
+    return new PartitionStatus(Role.FOLLOWER, null, snapshotId, null, null);
+  }
+
+  public Role getRole() {
+    return role;
+  }
+
+  public long getProcessedPosition() {
+    return processedPosition;
+  }
+
+  public String getSnapshotId() {
+    return snapshotId;
+  }
+
+  public Long getProcessedPositionInSnapshot() {
+    return processedPositionInSnapshot;
+  }
+
+  public Phase getStreamProcessorPhase() {
+    return streamProcessorPhase;
+  }
+}

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -101,6 +101,10 @@ public final class AsyncSnapshotDirector extends Actor {
     return getName() + "-wait-for-endPosition-committed";
   }
 
+  public void forceSnapshot() {
+    actor.call(this::prepareTakingSnapshot);
+  }
+
   private void prepareTakingSnapshot() {
     if (takingSnapshot) {
       return;

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 management.endpoint.health.show-details=always
 management.health.elasticsearch.enabled=false
 management.health.ping.enabled=false
-management.endpoints.web.exposure.include=health,prometheus,loggers
+management.endpoints.web.exposure.include=health,prometheus,loggers,partitions
 #Metrics related configurations
 management.endpoint.prometheus.enabled=true
 management.metrics.export.prometheus.enabled=true
@@ -11,4 +11,6 @@ management.endpoint.health.group.liveness.include=gatewayStarted,livenessGateway
 management.endpoint.health.group.liveness.show-details=never
 #Allow runtime configuration of log levels
 management.endpoint.loggers.enabled=true
+#Allow partitions api - this allows to trigger snapshots and pause processing
+management.endpoint.partitions.enabled=true
 

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -341,8 +341,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
     return actor.call(() -> phase);
   }
 
-  public void pauseProcessing() {
-    actor.call(
+  public ActorFuture<Void> pauseProcessing() {
+    return actor.call(
         () ->
             recoverFuture.onComplete(
                 (v, t) -> {
@@ -370,7 +370,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
                 }));
   }
 
-  protected enum Phase {
+  public enum Phase {
     REPROCESSING,
     PROCESSING,
     FAILED,

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1202,6 +1202,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <parameters>true</parameters>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/system/BrokerAdminServiceTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/system/BrokerAdminServiceTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.system;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.it.util.GrpcClientRule;
+import io.zeebe.broker.system.management.BrokerAdminService;
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.engine.processing.streamprocessor.StreamProcessor.Phase;
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+
+public class BrokerAdminServiceTest {
+  private final Timeout testTimeout = Timeout.seconds(60);
+  private final EmbeddedBrokerRule embeddedBrokerRule =
+      new EmbeddedBrokerRule(
+          cfg -> {
+            cfg.getData().setLogIndexDensity(1);
+            cfg.getCluster().setPartitionsCount(2);
+          });
+  private final GrpcClientRule clientRule = new GrpcClientRule(embeddedBrokerRule);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(testTimeout).around(embeddedBrokerRule).around(clientRule);
+
+  private BrokerAdminService brokerAdminService;
+
+  @Before
+  public void before() {
+    final var broker = embeddedBrokerRule.getBroker();
+    brokerAdminService = broker.getBrokerAdminService();
+  }
+
+  @Test
+  public void shouldTakeSnapshotWhenRequested() {
+    // given
+    clientRule.createSingleJob("test");
+
+    // when
+    brokerAdminService.takeSnapshot();
+
+    // then
+    waitForSnapshotAtBroker(brokerAdminService);
+  }
+
+  @Test
+  public void shouldPauseStreamProcessorWhenRequested() {
+    // given
+    clientRule.createSingleJob("test");
+
+    // when
+    brokerAdminService.pauseStreamProcessing();
+
+    // then
+    assertStreamProcessorPhase(brokerAdminService, Phase.PAUSED);
+  }
+
+  @Test
+  public void shouldUnPauseStreamProcessorWhenRequested() {
+    // given
+    clientRule.createSingleJob("test");
+
+    // when
+    brokerAdminService.pauseStreamProcessing();
+    assertStreamProcessorPhase(brokerAdminService, Phase.PAUSED);
+    brokerAdminService.resumeStreamProcessing();
+
+    // then
+    assertStreamProcessorPhase(brokerAdminService, Phase.PROCESSING);
+  }
+
+  @Test
+  public void shouldPauseStreamProcessorAndTakeSnapshotWhenPrepareUgrade() {
+    // given
+    clientRule.createSingleJob("test");
+
+    // when
+    brokerAdminService.prepareForUpgrade();
+
+    // then
+    waitForSnapshotAtBroker(brokerAdminService);
+
+    assertStreamProcessorPhase(brokerAdminService, Phase.PAUSED);
+    assertProcessedPositionIsInSnapshot(brokerAdminService);
+  }
+
+  private void assertStreamProcessorPhase(
+      final BrokerAdminService brokerAdminService, final Phase expected) {
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                brokerAdminService
+                    .getPartitionStatus()
+                    .forEach(
+                        (p, status) ->
+                            assertThat(status.getStreamProcessorPhase()).isEqualTo(expected)));
+  }
+
+  private void assertProcessedPositionIsInSnapshot(final BrokerAdminService brokerAdminService) {
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                brokerAdminService
+                    .getPartitionStatus()
+                    .forEach(
+                        (p, status) ->
+                            assertThat(status.getProcessedPosition())
+                                .isEqualTo(status.getProcessedPositionInSnapshot())));
+  }
+
+  private void waitForSnapshotAtBroker(final BrokerAdminService adminService) {
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                adminService
+                    .getPartitionStatus()
+                    .values()
+                    .forEach(
+                        status -> assertThat(status.getProcessedPositionInSnapshot()).isNotNull()));
+  }
+}


### PR DESCRIPTION
## Description

Expose an interface to trigger following functions externally
 * trigger snapshots on all partitions
 * pause processing on all partitions
 * resume processing on all partitions
 * prepare for upgrade - which internally pause processing and trigger snapshots
 * query status of partitions

The endpoint can be enable/disabled by configuration.

## Related issues

closes #5405

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
