### PR TITLE
[Backport 0.24] Use ip and port to map to a channel pool instead of host address

### DIFF
--- a/atomix/utils/src/main/java/io/atomix/utils/net/Address.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/net/Address.java
@@ -18,6 +18,7 @@ package io.atomix.utils.net;
 
 import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Objects;
 
@@ -27,7 +28,7 @@ public final class Address {
   private final String host;
   private final int port;
   private transient volatile Type type;
-  private transient volatile InetAddress address;
+  private volatile InetSocketAddress socketAddress;
 
   public Address(final String host, final int port) {
     this(host, port, null);
@@ -36,9 +37,11 @@ public final class Address {
   public Address(final String host, final int port, final InetAddress address) {
     this.host = host;
     this.port = port;
-    this.address = address;
     if (address != null) {
       this.type = address instanceof Inet6Address ? Type.IPV6 : Type.IPV4;
+      socketAddress = new InetSocketAddress(address, port);
+    } else {
+      socketAddress = new InetSocketAddress(host, port);
     }
   }
 
@@ -154,30 +157,39 @@ public final class Address {
    */
   public InetAddress address(final boolean resolve) {
     if (resolve) {
-      address = resolveAddress();
-      return address;
+      socketAddress = resolveAddress();
+      return socketAddress.getAddress();
     }
 
-    if (address == null) {
+    // Try to resolve address, if not successful return null
+    if (socketAddress.isUnresolved()) {
       synchronized (this) {
-        if (address == null) {
-          address = resolveAddress();
+        if (socketAddress.isUnresolved()) {
+          socketAddress = resolveAddress();
         }
       }
     }
-    return address;
+    return socketAddress.getAddress();
+  }
+
+  public InetSocketAddress socketAddress() {
+    return socketAddress;
   }
 
   /**
    * Resolves the IP address from the hostname.
    *
-   * @return the resolved IP address or {@code null} if the IP could not be resolved
+   * @return an InetSocketAddress with the resolved IP address and port or {@code null} if the IP
+   *     could not be resolved
    */
-  private InetAddress resolveAddress() {
+  private InetSocketAddress resolveAddress() {
     try {
-      return InetAddress.getByName(host);
+      return new InetSocketAddress(InetAddress.getByName(host), port);
     } catch (final UnknownHostException e) {
-      return null;
+      if (socketAddress.isUnresolved()) {
+        return socketAddress;
+      }
+      return new InetSocketAddress(host, port);
     }
   }
 


### PR DESCRIPTION
## Description

Backport #5200 

## Related issues

closes #5116 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
