### PR TITLE
docs(operate+tasklist): add shards and replicas configuration docs

### DIFF
--- a/docs/src/operate-deployment-guide/configuration.md
+++ b/docs/src/operate-deployment-guide/configuration.md
@@ -28,6 +28,18 @@ camunda.operate.elasticsearch.clusterName | Clustername of Elasticsearch | elast
 camunda.operate.elasticsearch.host | Hostname where Elasticsearch is running | localhost
 camunda.operate.elasticsearch.port | Port of Elasticsearch REST API | 9200
 
+## Settings for shards and replicas
+
+Operate create a setting index template that Elasticsearch uses it for all operate indices.
+These settings can be changed.
+
+The settings are:
+
+Name|Description|Default value
+----|-----------|--------------
+camunda.operate.elasticsearch.numberOfShards| How many shards Elasticsearch uses for all Operate indices| 1
+camunda.operate.elasticsearch.numberOfReplicas| How many replicas Elasticsearch uses for all Operate indices| 0
+
 ## A snippet from application.yml:
 
 ```yaml

--- a/docs/src/tasklist-deployment-guide/configuration.md
+++ b/docs/src/tasklist-deployment-guide/configuration.md
@@ -25,6 +25,19 @@ zeebe.tasklist.elasticsearch.clusterName | Clustername of Elasticsearch | elasti
 zeebe.tasklist.elasticsearch.host | Hostname where Elasticsearch is running | localhost
 zeebe.tasklist.elasticsearch.port | Port of Elasticsearch REST API | 9200
 
+## Settings for shards and replicas
+
+Tasklist create a setting index template that Elasticsearch uses it for all tasklist indices.
+These settings can be changed.
+
+The settings are:
+
+Name|Description|Default value
+----|-----------|--------------
+zeebe.tasklist.elasticsearch.numberOfShards| How many shards Elasticsearch uses for all Tasklist indices| 1
+zeebe.tasklist.elasticsearch.numberOfReplicas| How many replicas Elasticsearch uses for all Tasklist indices| 0
+
+
 ## A snippet from application.yml:
 
 ```yaml


### PR DESCRIPTION
Related with OPE-962 and ztl-357

## Description

* Add documentation for configuration of Operate and Tasklist shards and replicas in Elasticsearch

## Related issues
[OPE-962](https://jira.camunda.com/browse/OPE-962) and [ztl-357](https://github.com/zeebe-io/zeebe-tasklist/issues/357)
<!-- Which issues are closed by this PR or are related -->


## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
