### PR TITLE
Fix flaky test MultiInstanceActivityTest.shouldTriggerInterruptingBoundaryEvent

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceActivityTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceActivityTest.java
@@ -939,12 +939,17 @@ public final class MultiInstanceActivityTest {
 
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size() - 1);
 
+    // make sure message subcription is opened, before publishing
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+        .withWorkflowInstanceKey(workflowInstanceKey)
+        .await();
+
     // when
     ENGINE
         .message()
         .withName(MESSAGE_NAME)
         .withCorrelationKey(MESSAGE_CORRELATION_KEY)
-        .withTimeToLive(0)
+        .withTimeToLive(0) // must be 0 because engine is re-used in tests
         .publish();
 
     // then


### PR DESCRIPTION
## Description

Fix flaky test: MultiInstanceActivityTest.shouldTriggerInterruptingBoundaryEvent

## Related issues

closes #5097

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
