### PR TITLE
[Backport 0.23] Updates exporter position when skipping if possible

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -114,6 +114,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-msgpack-value</artifactId>
     </dependency>

--- a/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -22,6 +22,7 @@ import io.zeebe.logstreams.log.LogStreamReader;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.util.LangUtil;
@@ -51,6 +52,8 @@ public final class ExporterDirector extends Actor {
       "Expected to find event with the snapshot position %s in log stream, but nothing was found. Failed to recover '%s'.";
 
   private static final Logger LOG = Loggers.EXPORTER_LOGGER;
+  private static final String SKIP_POSITION_UPDATE_ERROR_MESSAGE =
+      "Failed to update exporter position when skipping filtered record, can be skipped, but may indicate an issue if it occurs often";
   private final AtomicBoolean isOpened = new AtomicBoolean(false);
   private final List<ExporterContainer> containers;
   private final LogStream logStream;
@@ -131,7 +134,7 @@ public final class ExporterDirector extends Actor {
       eventFilter = createEventFilter(containers);
       LOG.debug("Set event filter for exporters: {}", eventFilter);
 
-    } catch (final Throwable e) {
+    } catch (final Exception e) {
       onFailure();
       LangUtil.rethrowUnchecked(e);
     }
@@ -218,6 +221,7 @@ public final class ExporterDirector extends Actor {
     // start reading
     for (final ExporterContainer container : containers) {
       container.position = state.getPosition(container.getId());
+      container.lastUnacknowledgedPosition = container.position;
       if (container.position == ExportersState.VALUE_NOT_FOUND) {
         state.setPosition(container.getId(), -1L);
       }
@@ -236,8 +240,17 @@ public final class ExporterDirector extends Actor {
 
   private void skipRecord(final LoggedEvent currentEvent) {
     final RecordMetadata metadata = new RecordMetadata();
+    final long eventPosition = currentEvent.getPosition();
+
     currentEvent.readMetadata(metadata);
     metrics.eventSkipped(metadata.getValueType());
+
+    // increase position of all up to date exporters - an up to date exporter is one which has
+    // acknowledged the last record we passed to it
+    for (final ExporterContainer container : containers) {
+      container.updatePositionOnSkipIfUpToDate(eventPosition);
+    }
+
     actor.submit(this::readNextEvent);
   }
 
@@ -349,9 +362,12 @@ public final class ExporterDirector extends Actor {
         final ExporterContainer container = containers.get(exporterIndex);
 
         try {
-          if (container.position < typedEvent.getPosition()
-              && container.acceptRecord(rawMetadata)) {
-            container.exporter.export(typedEvent);
+          if (container.position < typedEvent.getPosition()) {
+            if (container.acceptRecord(rawMetadata)) {
+              container.export(typedEvent);
+            } else {
+              container.updatePositionOnSkipIfUpToDate(typedEvent.getPosition());
+            }
           }
 
           exporterIndex++;
@@ -410,6 +426,7 @@ public final class ExporterDirector extends Actor {
     private final ExporterContext context;
     private final Exporter exporter;
     private long position;
+    private long lastUnacknowledgedPosition;
 
     ExporterContainer(final ExporterDescriptor descriptor) {
       context =
@@ -419,13 +436,36 @@ public final class ExporterDirector extends Actor {
       exporter = descriptor.newInstance();
     }
 
+    private void export(final Record<?> record) {
+      exporter.export(record);
+      lastUnacknowledgedPosition = record.getPosition();
+    }
+
+    /**
+     * Updates the exporter's position if it is up to date - that is, if it's last acknowledged
+     * position is greater than or equal to its last unacknowledged position. This is safe to do
+     * when skipping records as it means we passed no record to this exporter between both.
+     *
+     * @param eventPosition the new, up to date position
+     */
+    private void updatePositionOnSkipIfUpToDate(final long eventPosition) {
+      if (position >= lastUnacknowledgedPosition && position < eventPosition) {
+        try {
+          updateExporterLastExportedRecordPosition(eventPosition);
+        } catch (final Exception e) {
+          LOG.warn(SKIP_POSITION_UPDATE_ERROR_MESSAGE, e);
+        }
+      }
+    }
+
+    private void updateExporterLastExportedRecordPosition(final long eventPosition) {
+      state.setPosition(getId(), eventPosition);
+      position = eventPosition;
+    }
+
     @Override
     public void updateLastExportedRecordPosition(final long position) {
-      actor.run(
-          () -> {
-            state.setPosition(getId(), position);
-            this.position = position;
-          });
+      actor.run(() -> updateExporterLastExportedRecordPosition(position));
     }
 
     @Override

--- a/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,7 +59,6 @@ public final class ExporterDirectorTest {
   @Rule public final ExporterRule rule = new ExporterRule(PARTITION_ID);
   private final List<ControlledTestExporter> exporters = new ArrayList<>();
   private final List<ExporterDescriptor> exporterDescriptors = new ArrayList<>();
-  private ExportersState state;
 
   @Before
   public void init() {
@@ -82,6 +82,134 @@ public final class ExporterDirectorTest {
 
   private void startExporterDirector(final List<ExporterDescriptor> exporterDescriptors) {
     rule.startExporterDirector(exporterDescriptors);
+  }
+
+  @Test
+  public void shouldUpdatePositionWhenInitialRecordsAreSkipped() {
+    // given
+    final ControlledTestExporter tailingExporter = exporters.get(1);
+    exporters.forEach(
+        e ->
+            e.onConfigure(withFilter(List.of(RecordType.COMMAND), List.of(ValueType.DEPLOYMENT)))
+                .shouldAutoUpdatePosition(false));
+
+    // when
+    startExporterDirector(exporterDescriptors);
+    final ExportersState state = rule.getExportersState();
+    final long skippedRecordPosition =
+        rule.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+    rule.writeCommand(DeploymentIntent.CREATE, new DeploymentRecord());
+
+    // then
+    Awaitility.await("director has read all records until now")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(tailingExporter.getExportedRecords()).hasSize(1));
+    assertThat(state.getPosition(EXPORTER_ID_1)).isEqualTo(skippedRecordPosition);
+    assertThat(state.getPosition(EXPORTER_ID_2)).isEqualTo(skippedRecordPosition);
+  }
+
+  @Test
+  public void shouldUpdatePositionOfUpToDateExportersOnSkipRecord() {
+    // given
+    final ControlledTestExporter filteringExporter = exporters.get(0);
+    final ControlledTestExporter tailingExporter = exporters.get(1);
+    tailingExporter
+        .onConfigure(withFilter(List.of(RecordType.COMMAND), List.of(ValueType.DEPLOYMENT)))
+        .shouldAutoUpdatePosition(false);
+    filteringExporter
+        .onConfigure(withFilter(List.of(RecordType.COMMAND), List.of(ValueType.DEPLOYMENT)))
+        .shouldAutoUpdatePosition(false);
+
+    // when
+    startExporterDirector(exporterDescriptors);
+    final ExportersState state = rule.getExportersState();
+
+    // accepted by both
+    final long firstRecordPosition =
+        rule.writeCommand(DeploymentIntent.CREATE, new DeploymentRecord());
+    Awaitility.await("filteringExporter has exported the first record")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(filteringExporter.getExportedRecords()).hasSize(1));
+    filteringExporter.getController().updateLastExportedRecordPosition(firstRecordPosition);
+    // skipped entirely
+    final long skippedRecordPosition =
+        rule.writeCommand(IncidentIntent.CREATE, new IncidentRecord());
+    // accepted by both again
+    rule.writeCommand(DeploymentIntent.CREATE, new DeploymentRecord());
+
+    // then
+    Awaitility.await("director has read all records until now")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(tailingExporter.getExportedRecords()).hasSize(2));
+    assertThat(state.getPosition(EXPORTER_ID_1)).isEqualTo(skippedRecordPosition);
+    assertThat(state.getPosition(EXPORTER_ID_2)).isEqualTo(-1L);
+  }
+
+  @Test
+  public void shouldUpdateIfSkippingInitialRecordForSingleExporter() {
+    final ControlledTestExporter filteringExporter = exporters.get(0);
+    final ControlledTestExporter tailingExporter = exporters.get(1);
+    tailingExporter
+        .onConfigure(
+            withFilter(
+                List.of(RecordType.COMMAND, RecordType.EVENT), List.of(ValueType.DEPLOYMENT)))
+        .shouldAutoUpdatePosition(false);
+    filteringExporter
+        .onConfigure(withFilter(List.of(RecordType.COMMAND), List.of(ValueType.DEPLOYMENT)))
+        .shouldAutoUpdatePosition(false);
+
+    // when
+    startExporterDirector(exporterDescriptors);
+    final ExportersState state = rule.getExportersState();
+
+    // skipped only by filteringExporter
+    final long skippedRecordPosition =
+        rule.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+    // accepted by both
+    rule.writeCommand(DeploymentIntent.CREATE, new DeploymentRecord());
+
+    // then
+    Awaitility.await("director has read all records until now")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(tailingExporter.getExportedRecords()).hasSize(2));
+    assertThat(state.getPosition(EXPORTER_ID_1)).isEqualTo(skippedRecordPosition);
+    assertThat(state.getPosition(EXPORTER_ID_2)).isEqualTo(-1L);
+  }
+
+  @Test
+  public void shouldUpdateIfRecordSkipsSingleUpToDateExporter() throws InterruptedException {
+    final ControlledTestExporter filteringExporter = exporters.get(0);
+    final ControlledTestExporter tailingExporter = exporters.get(1);
+    tailingExporter
+        .onConfigure(
+            withFilter(
+                List.of(RecordType.COMMAND, RecordType.EVENT), List.of(ValueType.DEPLOYMENT)))
+        .shouldAutoUpdatePosition(false);
+    filteringExporter
+        .onConfigure(withFilter(List.of(RecordType.COMMAND), List.of(ValueType.DEPLOYMENT)))
+        .shouldAutoUpdatePosition(false);
+
+    // when
+    startExporterDirector(exporterDescriptors);
+    final ExportersState state = rule.getExportersState();
+
+    // accepted by both
+    final long firstRecordPosition =
+        rule.writeCommand(DeploymentIntent.CREATE, new DeploymentRecord());
+    Awaitility.await("filteringExporter has exported the first record")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(filteringExporter.getExportedRecords()).hasSize(1));
+    filteringExporter.getController().updateLastExportedRecordPosition(firstRecordPosition);
+    // skipped only by filteringExporter
+    final long skippedRecordPosition =
+        rule.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+
+    // then
+    Awaitility.await("director has read all records until now")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(tailingExporter.getExportedRecords()).hasSize(2));
+    assertThat(state.getPosition(EXPORTER_ID_1)).isEqualTo(skippedRecordPosition);
+    assertThat(state.getPosition(EXPORTER_ID_2)).isEqualTo(-1L);
   }
 
   @Test


### PR DESCRIPTION
## Description

Backport of #5434. A simple cherry-pick of the 0.24 back port to avoid the merge conflict again (see the 0.24 backport issue on this).

## Related issues

closes #3166

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
