### PR TITLE
chore(broker): support env vars to set column family options

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -58,6 +58,7 @@ public final class DataCfg implements ConfigurationEntry {
       diskUsageReplicationWatermark = DISABLED_DISK_USAGE_WATERMARK;
       diskUsageCommandWatermark = DISABLED_DISK_USAGE_WATERMARK;
     }
+    rocksdb.init(globalConfig, brokerBase);
   }
 
   public List<String> getDirectories() {

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -7,20 +7,62 @@
  */
 package io.zeebe.broker.system.configuration;
 
+import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
-public final class RocksdbCfg {
+public final class RocksdbCfg implements ConfigurationEntry {
 
   private Properties columnFamilyOptions;
 
-  public Properties getColumnFamilyOptions() {
+  @Override
+  public void init(final BrokerCfg globalConfig, final String brokerBase) {
     if (columnFamilyOptions == null) {
-      return new Properties();
+      // lazy init to not have to deal with null when using these options
+      columnFamilyOptions = new Properties();
+    } else {
+      // Since (some of) the columnFamilyOptions may have been provided as environment variables,
+      // we must do some transformations on the entries of this properties object.
+      columnFamilyOptions = initColumnFamilyOptions(columnFamilyOptions);
     }
+  }
+
+  private static Properties initColumnFamilyOptions(final Properties original) {
+    final var result = new Properties();
+    original.entrySet().stream()
+        .map(RocksDBColumnFamilyOption::new)
+        .forEach(entry -> result.put(entry.key, entry.value));
+    return result;
+  }
+
+  public Properties getColumnFamilyOptions() {
     return columnFamilyOptions;
   }
 
   public void setColumnFamilyOptions(final Properties columnFamilyOptions) {
     this.columnFamilyOptions = columnFamilyOptions;
+  }
+
+  private static final class RocksDBColumnFamilyOption {
+
+    private static final Pattern DOT_CHAR_PATTERN = Pattern.compile("\\.");
+    private static final String UNDERSCORE_CHAR = "_";
+    private final String key;
+    private final Object value;
+
+    private RocksDBColumnFamilyOption(final Entry<Object, Object> entry) {
+      Objects.requireNonNull(entry.getKey());
+      // The key of the entry may contain dot chars when provided as an Environment Variable.
+      // These should always be replaced with underscores to match the available property names.
+      // For example: `ZEEBE_BROKER_DATA_ROCKSDB_COLUMNFAMILYOPTIONS_WRITE_BUFFER_SIZE=8388608`
+      // would result in a key with name `write.buffer.size`, but should be `write_buffer_size`.
+      key = replaceAllDotCharsWithUnderscore(entry.getKey().toString());
+      value = entry.getValue(); // the value can stay the same
+    }
+
+    private static String replaceAllDotCharsWithUnderscore(final String key) {
+      return DOT_CHAR_PATTERN.matcher(key).replaceAll(UNDERSCORE_CHAR);
+    }
   }
 }

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/RocksdbCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/RocksdbCfgTest.java
@@ -28,4 +28,18 @@ public final class RocksdbCfgTest {
     assertThat(columnFamilyOptions).containsEntry("compaction_pri", "kOldestSmallestSeqFirst");
     assertThat(columnFamilyOptions).containsEntry("write_buffer_size", "67108864");
   }
+
+  @Test
+  public void shouldSetColumnFamilyOptionsConfigFromEnvironmentVariables() {
+    // given
+    environment.put("zeebe.broker.data.rocksdb.columnFamilyOptions.arena.block.size", "16777216");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getData().getRocksdb();
+
+    // then keys should contain underscores
+    final var columnFamilyOptions = rocksdb.getColumnFamilyOptions();
+    assertThat(columnFamilyOptions).containsEntry("arena_block_size", "16777216");
+  }
 }

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -205,8 +205,9 @@
         # WARNING: This setting requires in-depth knowledge of Zeebe's embedded database: RocksDB.
         # The expected property key names and values are derived from RocksDB's C implementation,
         # and are not limited to the provided examples below. Please look in RocksDB's SCM repo
-        # for the files: `cf_options.h` and `options_helper.cc`.
-        # WARNING: This setting should not be overridden using environment variables.
+        # for the files: `cf_options.h` and `options_helper.cc`. This setting can also be overridden
+        # using the environment variable ZEEBE_BROKER_DATA_ROCKSDB_COLUMNFAMILYOPTIONS_{PROPERTY_KEY_NAME}
+        # For example, `write_buffer_size` can be set using `ZEEBE_BROKER_DATA_ROCKSDB_COLUMNFAMILYOPTIONS_WRITE_BUFFER_SIZE`.
         # columnFamilyOptions:
           # compaction_pri: "kOldestSmallestSeqFirst"
           # write_buffer_size: 67108864

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -165,8 +165,9 @@
         # WARNING: This setting requires in-depth knowledge of Zeebe's embedded database: RocksDB.
         # The expected property key names and values are derived from RocksDB's C implementation,
         # and are not limited to the provided examples below. Please look in RocksDB's SCM repo
-        # for the files: `cf_options.h` and `options_helper.cc`.
-        # WARNING: This setting should not be overridden using environment variables.
+        # for the files: `cf_options.h` and `options_helper.cc`. This setting can also be overridden
+        # using the environment variable ZEEBE_BROKER_DATA_ROCKSDB_COLUMNFAMILYOPTIONS_{PROPERTY_KEY_NAME}
+        # For example, `write_buffer_size` can be set using `ZEEBE_BROKER_DATA_ROCKSDB_COLUMNFAMILYOPTIONS_WRITE_BUFFER_SIZE`.
         # columnFamilyOptions:
           # compaction_pri: "kOldestSmallestSeqFirst"
           # write_buffer_size: 67108864


### PR DESCRIPTION
## Description

Replaces dots in the key names of RocksDbCfg.columnFamilyOptions with underscores.

## Related issues

closes #5364 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
