### PR TITLE
Records contains the version of the broker

### DIFF
--- a/broker/src/test/java/io/zeebe/broker/engine/RecordVersionTest.java
+++ b/broker/src/test/java/io/zeebe/broker/engine/RecordVersionTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.intent.DeploymentIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceCreationIntent;
+import io.zeebe.test.broker.protocol.commandapi.CommandApiRule;
+import io.zeebe.test.util.BrokerClassRuleHelper;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.util.VersionUtil;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public final class RecordVersionTest {
+
+  private static final String PROCESS_ID = "process";
+
+  private static final String EXPECTED_VERSION =
+      VersionUtil.getVersion().replaceAll("-SNAPSHOT", "");
+
+  private static final EmbeddedBrokerRule BROKER_RULE = new EmbeddedBrokerRule();
+  private static final CommandApiRule API_RULE = new CommandApiRule(BROKER_RULE::getAtomix);
+  @ClassRule public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(API_RULE);
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void deploymentRecordsShouldHaveBrokerVersion() {
+    // given
+    final var workflow = Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done();
+
+    deployWorkflow(workflow);
+
+    // then
+    assertThat(RecordingExporter.deploymentRecords().limit(4))
+        .hasSize(4)
+        .extracting(Record::getBrokerVersion)
+        .containsOnly(EXPECTED_VERSION);
+  }
+
+  @Test
+  public void workflowInstanceRecordsShouldHaveBrokerVersion() {
+    // given
+    final var workflow = Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done();
+
+    deployWorkflow(workflow);
+    final var workflowInstanceKey = createWorkflowInstance(PROCESS_ID);
+
+    // then
+    assertThat(RecordingExporter.records().limitToWorkflowInstance(workflowInstanceKey))
+        .extracting(Record::getBrokerVersion)
+        .containsOnly(EXPECTED_VERSION);
+  }
+
+  @Test
+  public void messageSubscriptionRecordsShouldHaveBrokerVersion() {
+    // given
+    final var workflow =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .intermediateCatchEvent(
+                "catch", e -> e.message(m -> m.name("test").zeebeCorrelationKeyExpression("123")))
+            .endEvent()
+            .done();
+
+    deployWorkflow(workflow);
+    final var workflowInstanceKey = createWorkflowInstance(PROCESS_ID);
+
+    // then
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .limit(2))
+        .hasSize(2)
+        .extracting(Record::getBrokerVersion)
+        .containsOnly(EXPECTED_VERSION);
+
+    assertThat(
+            RecordingExporter.workflowInstanceSubscriptionRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .limit(2))
+        .hasSize(2)
+        .extracting(Record::getBrokerVersion)
+        .containsOnly(EXPECTED_VERSION);
+  }
+
+  private void deployWorkflow(final BpmnModelInstance workflow) {
+    final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+    Bpmn.writeModelToStream(outStream, workflow);
+    final byte[] resource = outStream.toByteArray();
+
+    API_RULE
+        .createCmdRequest()
+        .type(ValueType.DEPLOYMENT, DeploymentIntent.CREATE)
+        .command()
+        .put(
+            "resources",
+            List.of(
+                Map.of(
+                    "resourceName",
+                    "process.bpmn",
+                    "resourceType",
+                    "BPMN_XML",
+                    "resource",
+                    resource)))
+        .done()
+        .send();
+  }
+
+  private long createWorkflowInstance(final String processId) {
+    final var response =
+        API_RULE
+            .createCmdRequest()
+            .type(ValueType.WORKFLOW_INSTANCE_CREATION, WorkflowInstanceCreationIntent.CREATE)
+            .command()
+            .put("bpmnProcessId", processId)
+            .done()
+            .sendAndAwait();
+
+    return (Long) response.getValue().get("workflowInstanceKey");
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processing/incident/IncidentRecordWrapper.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/incident/IncidentRecordWrapper.java
@@ -70,6 +70,11 @@ final class IncidentRecordWrapper implements TypedRecord<WorkflowInstanceRecord>
   }
 
   @Override
+  public String getBrokerVersion() {
+    return null;
+  }
+
+  @Override
   public ValueType getValueType() {
     return null;
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/TypedEventImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/TypedEventImpl.java
@@ -77,6 +77,11 @@ public final class TypedEventImpl implements TypedRecord {
   }
 
   @Override
+  public String getBrokerVersion() {
+    return metadata.getBrokerVersion().toString();
+  }
+
+  @Override
   public ValueType getValueType() {
     return metadata.getValueType();
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriterImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriterImpl.java
@@ -12,7 +12,6 @@ import static io.zeebe.engine.processing.streamprocessor.TypedEventRegistry.EVEN
 import io.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.zeebe.logstreams.log.LogStreamBatchWriter.LogEntryBuilder;
 import io.zeebe.msgpack.UnpackedObject;
-import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.RejectionType;
@@ -31,7 +30,6 @@ public class TypedCommandWriterImpl implements TypedCommandWriter {
   protected long sourceRecordPosition = -1;
 
   public TypedCommandWriterImpl(final LogStreamBatchWriter batchWriter) {
-    metadata.protocolVersion(Protocol.PROTOCOL_VERSION);
     this.batchWriter = batchWriter;
     typeRegistry = new HashMap<>();
     EVENT_REGISTRY.forEach((e, c) -> typeRegistry.put(c, e));

--- a/engine/src/test/java/io/zeebe/engine/util/MockTypedRecord.java
+++ b/engine/src/test/java/io/zeebe/engine/util/MockTypedRecord.java
@@ -109,6 +109,11 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   }
 
   @Override
+  public String getBrokerVersion() {
+    return metadata.getBrokerVersion().toString();
+  }
+
+  @Override
   public ValueType getValueType() {
     return metadata.getValueType();
   }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -44,6 +44,9 @@
         },
         "valueType": {
           "type": "keyword"
+        },
+        "brokerVersion": {
+          "type": "keyword"
         }
       }
     }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/CopiedRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/CopiedRecord.java
@@ -29,6 +29,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   private final int partitionId;
   private final RejectionType rejectionType;
   private final String rejectionReason;
+  private final String brokerVersion;
 
   public CopiedRecord(
       final T recordValue,
@@ -50,6 +51,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     rejectionType = metadata.getRejectionType();
     rejectionReason = metadata.getRejectionReason();
     valueType = metadata.getValueType();
+    brokerVersion = metadata.getBrokerVersion().toString();
   }
 
   private CopiedRecord(final CopiedRecord<T> copiedRecord) {
@@ -81,6 +83,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     rejectionType = copiedRecord.rejectionType;
     rejectionReason = copiedRecord.rejectionReason;
     valueType = copiedRecord.valueType;
+    brokerVersion = copiedRecord.brokerVersion;
   }
 
   @Override
@@ -126,6 +129,11 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   @Override
   public String getRejectionReason() {
     return rejectionReason;
+  }
+
+  @Override
+  public String getBrokerVersion() {
+    return brokerVersion;
   }
 
   @Override

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/VersionInfo.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/VersionInfo.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.protocol.impl.record;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public final class VersionInfo {
+
+  public static final VersionInfo UNKNOWN = new VersionInfo(0, 0, 0);
+
+  private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+).*");
+
+  private final int majorVersion;
+  private final int minorVersion;
+  private final int patchVersion;
+
+  public VersionInfo(final int majorVersion, final int minorVersion, final int patchVersion) {
+    this.majorVersion = majorVersion;
+    this.minorVersion = minorVersion;
+    this.patchVersion = patchVersion;
+  }
+
+  public static VersionInfo parse(final String version) {
+    final var matcher = VERSION_PATTERN.matcher(version);
+    if (matcher.matches()) {
+      final var major = Integer.parseInt(matcher.group(1));
+      final var minor = Integer.parseInt(matcher.group(2));
+      final var patch = Integer.parseInt(matcher.group(3));
+      return new VersionInfo(major, minor, patch);
+
+    } else {
+      return UNKNOWN;
+    }
+  }
+
+  public int getMajorVersion() {
+    return majorVersion;
+  }
+
+  public int getMinorVersion() {
+    return minorVersion;
+  }
+
+  public int getPatchVersion() {
+    return patchVersion;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(majorVersion, minorVersion, patchVersion);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final VersionInfo that = (VersionInfo) o;
+    return majorVersion == that.majorVersion
+        && minorVersion == that.minorVersion
+        && patchVersion == that.patchVersion;
+  }
+
+  @Override
+  public String toString() {
+    return majorVersion + "." + minorVersion + "." + patchVersion;
+  }
+}

--- a/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -16,6 +16,7 @@ import io.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.zeebe.protocol.impl.record.CopiedRecord;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.zeebe.protocol.impl.record.VersionInfo;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
@@ -95,6 +96,7 @@ public final class JsonSerializableToJsonTest {
 
               final DeploymentIntent intent = DeploymentIntent.CREATE;
               final int protocolVersion = 1;
+              final VersionInfo brokerVersion = new VersionInfo(1, 2, 3);
               final ValueType valueType = ValueType.DEPLOYMENT;
 
               final RecordType recordType = RecordType.COMMAND;
@@ -106,6 +108,7 @@ public final class JsonSerializableToJsonTest {
               recordMetadata
                   .intent(intent)
                   .protocolVersion(protocolVersion)
+                  .brokerVersion(brokerVersion)
                   .valueType(valueType)
                   .recordType(recordType)
                   .rejectionReason(rejectionReason)
@@ -142,7 +145,7 @@ public final class JsonSerializableToJsonTest {
               return new CopiedRecord<>(
                   record, recordMetadata, key, 0, position, sourcePosition, timestamp);
             },
-        "{'partitionId':0,'recordType':'COMMAND','intent':'CREATE','valueType':'DEPLOYMENT','rejectionType':'INVALID_ARGUMENT','rejectionReason':'fails','key':1234,'position':4321,'sourceRecordPosition':231,'value':{'deployedWorkflows':[{'bpmnProcessId':'testProcess','version':12,'resourceName':'resource','workflowKey':123}],'resources':[{'resourceName':'resource','resourceType':'BPMN_XML','resource':'Y29udGVudHM='}]},'timestamp':2191}"
+        "{'partitionId':0,'recordType':'COMMAND','intent':'CREATE','valueType':'DEPLOYMENT','rejectionType':'INVALID_ARGUMENT','rejectionReason':'fails','key':1234,'position':4321,'sourceRecordPosition':231,'value':{'deployedWorkflows':[{'bpmnProcessId':'testProcess','version':12,'resourceName':'resource','workflowKey':123}],'resources':[{'resourceName':'resource','resourceType':'BPMN_XML','resource':'Y29udGVudHM='}]},'timestamp':2191, 'brokerVersion':'1.2.3'}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       //////////////////////////////////// DeploymentRecord ///////////////////////////////////////

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Protocol</name>
@@ -23,7 +25,7 @@
   <properties>
     <version.java>8</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
-    <protocol.version>1</protocol.version>
+    <protocol.version>2</protocol.version>
   </properties>
 
   <dependencies>
@@ -112,9 +114,19 @@
           </dependency>
         </dependencies>
       </plugin>
-      <plugin> 
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <ignored>
+            <ignored>
+              <!-- ignore new methods in the Record interface -->
+              <className>io/zeebe/protocol/record/Record</className>
+              <method>*</method>
+              <differenceType>7012</differenceType>
+            </ignored>
+          </ignored>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/protocol/src/main/java/io/zeebe/protocol/record/Record.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/Record.java
@@ -71,6 +71,9 @@ public interface Record<T extends RecordValue> extends JsonSerializable, Cloneab
    */
   String getRejectionReason();
 
+  /** @return the version of the broker that wrote this record */
+  String getBrokerVersion();
+
   /** @return the type of the record (e.g. job, workflow, workflow instance, etc.) */
   ValueType getValueType();
 

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -56,6 +56,13 @@
       <validValue name="LEADER">0</validValue>
       <validValue name="FOLLOWER">1</validValue>
     </enum>
+
+    <composite name="Version" description="Version information">
+      <type name="majorVersion" primitiveType="int32"/>
+      <type name="minorVersion" primitiveType="int32"/>
+      <type name="patchVersion" primitiveType="int32"/>
+    </composite>
+
   </types>
 
   <!-- L1 General Messages 0 - 99 -->
@@ -97,6 +104,7 @@
     <field name="intent" id="6" type="uint8"/>
     <!-- populated when RecordType is COMMAND_REJECTION -->
     <field name="rejectionType" id="7" type="RejectionType"/>
+    <field name="brokerVersion" id="9" type="Version" sinceVersion="2" presence="optional" />
     <!-- populated when RecordType is COMMAND_REJECTION, UTF-8-encoded String -->
     <data name="rejectionReason" id="8" type="varDataEncoding"/>
   </sbe:message>

--- a/test-util/src/test/java/io/zeebe/test/util/record/RecordingExporterTest.java
+++ b/test-util/src/test/java/io/zeebe/test/util/record/RecordingExporterTest.java
@@ -100,6 +100,11 @@ public final class RecordingExporterTest {
     }
 
     @Override
+    public String getBrokerVersion() {
+      return null;
+    }
+
+    @Override
     public ValueType getValueType() {
       return VALUE_TYPE;
     }

--- a/test/src/main/java/io/zeebe/test/exporter/record/MockRecord.java
+++ b/test/src/main/java/io/zeebe/test/exporter/record/MockRecord.java
@@ -101,6 +101,11 @@ public class MockRecord extends ExporterMappedObject implements Record, Cloneabl
   }
 
   @Override
+  public String getBrokerVersion() {
+    return metadata.getBrokerVersion();
+  }
+
+  @Override
   public ValueType getValueType() {
     return metadata.getValueType();
   }

--- a/test/src/main/java/io/zeebe/test/exporter/record/MockRecordMetadata.java
+++ b/test/src/main/java/io/zeebe/test/exporter/record/MockRecordMetadata.java
@@ -22,6 +22,7 @@ public class MockRecordMetadata extends ExporterMappedObject implements Cloneabl
   private RejectionType rejectionType = RejectionType.NULL_VAL;
   private String rejectionReason = "";
   private ValueType valueType = ValueType.WORKFLOW_INSTANCE_CREATION;
+  private String brokerVersion = "";
 
   public MockRecordMetadata() {}
 
@@ -94,6 +95,14 @@ public class MockRecordMetadata extends ExporterMappedObject implements Cloneabl
     return this;
   }
 
+  public String getBrokerVersion() {
+    return brokerVersion;
+  }
+
+  public void setBrokerVersion(final String brokerVersion) {
+    this.brokerVersion = brokerVersion;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -102,7 +111,8 @@ public class MockRecordMetadata extends ExporterMappedObject implements Cloneabl
         getRecordType(),
         getRejectionType(),
         getRejectionReason(),
-        getValueType());
+        getValueType(),
+        getBrokerVersion());
   }
 
   @Override
@@ -120,7 +130,8 @@ public class MockRecordMetadata extends ExporterMappedObject implements Cloneabl
         && getRecordType() == metadata.getRecordType()
         && getRejectionType() == metadata.getRejectionType()
         && Objects.equals(getRejectionReason(), metadata.getRejectionReason())
-        && getValueType() == metadata.getValueType();
+        && getValueType() == metadata.getValueType()
+        && Objects.equals(getBrokerVersion(), metadata.getBrokerVersion());
   }
 
   @Override
@@ -145,6 +156,9 @@ public class MockRecordMetadata extends ExporterMappedObject implements Cloneabl
         + rejectionType
         + ", rejectionReason='"
         + rejectionReason
+        + '\''
+        + ", brokerVersion='"
+        + brokerVersion
         + '\''
         + ", valueType="
         + valueType


### PR DESCRIPTION
##  Description

* add the version of the broker to the record metadata that wrote the record
* expose the version in the exporter API
* add a new property in the ES record template

## Related issues

closes #5379 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
