### PR TITLE
Lowered log level to WARN (fix:#5396)

### DIFF
--- a/transport/src/main/java/io/zeebe/transport/impl/AtomixServerTransport.java
+++ b/transport/src/main/java/io/zeebe/transport/impl/AtomixServerTransport.java
@@ -145,7 +145,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
         () -> {
           final var requestMap = partitionsRequestMap.get(partitionId);
           if (requestMap == null) {
-            LOG.error(
+            LOG.warn(
                 "Node is no longer leader for partition {}, tried to respond on request with id {}",
                 partitionId,
                 requestId);


### PR DESCRIPTION
## Description

Lowered the log level of AtomixServerTransport#sendResponse on leader change, from error to warn as discussed with @npepinpe on issue #5396 

## Related issues

#5396 
