### PR TITLE
[Backport 0.24] Detect reprocessing issues

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processor/InconsistentReprocessingException.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/InconsistentReprocessingException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor;
+
+public final class InconsistentReprocessingException extends RuntimeException {
+
+  private static final String FAILURE_MESSAGE =
+      "Reprocessing issue detected! Restore the data from a backup and follow the recommended upgrade procedure.";
+
+  public InconsistentReprocessingException(
+      final String message, final TypedRecord<?> actualRecord) {
+    super(
+        String.format(
+            FAILURE_MESSAGE + " [cause: \"%s\", log-stream-record: %s]",
+            message,
+            actualRecord.toJson()));
+  }
+
+  public InconsistentReprocessingException(
+      final String message,
+      final TypedRecord<?> actualRecord,
+      final ReprocessingRecord reprocessingRecord) {
+    super(
+        String.format(
+            FAILURE_MESSAGE + " [cause: \"%s\", log-stream-record: %s, reprocessing-record: %s]",
+            message,
+            actualRecord.toJson(),
+            reprocessingRecord.toString()));
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/ReprocessingRecord.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ReprocessingRecord.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor;
+
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.intent.Intent;
+
+public final class ReprocessingRecord {
+
+  private final long key;
+  private final long sourceRecordPosition;
+  private final Intent intent;
+  private final RecordType recordType;
+
+  ReprocessingRecord(
+      final long key,
+      final long sourceRecordPosition,
+      final Intent intent,
+      final RecordType recordType) {
+    this.key = key;
+    this.sourceRecordPosition = sourceRecordPosition;
+    this.intent = intent;
+    this.recordType = recordType;
+  }
+
+  public long getKey() {
+    return key;
+  }
+
+  public long getSourceRecordPosition() {
+    return sourceRecordPosition;
+  }
+
+  public Intent getIntent() {
+    return intent;
+  }
+
+  @Override
+  public String toString() {
+    return "{"
+        + "key="
+        + key
+        + ", sourceRecordPosition="
+        + sourceRecordPosition
+        + ", intent="
+        + intent.getClass().getSimpleName()
+        + ":"
+        + intent.name()
+        + ", recordType="
+        + recordType
+        + "}";
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processor/ReprocessingStreamWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ReprocessingStreamWriter.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processor;
+
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.RejectionType;
+import io.zeebe.protocol.record.intent.Intent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public final class ReprocessingStreamWriter implements TypedStreamWriter {
+
+  private final List<ReprocessingRecord> records = new ArrayList<>();
+
+  private long sourceRecordPosition = -1L;
+
+  @Override
+  public void appendRejection(
+      final TypedRecord<? extends UnpackedObject> command,
+      final RejectionType type,
+      final String reason) {
+
+    final var record =
+        new ReprocessingRecord(
+            command.getKey(),
+            sourceRecordPosition,
+            command.getIntent(),
+            RecordType.COMMAND_REJECTION);
+    records.add(record);
+  }
+
+  @Override
+  public void appendRejection(
+      final TypedRecord<? extends UnpackedObject> command,
+      final RejectionType type,
+      final String reason,
+      final Consumer<RecordMetadata> metadata) {
+
+    final var record =
+        new ReprocessingRecord(
+            command.getKey(),
+            sourceRecordPosition,
+            command.getIntent(),
+            RecordType.COMMAND_REJECTION);
+    records.add(record);
+  }
+
+  @Override
+  public void appendNewEvent(final long key, final Intent intent, final UnpackedObject value) {
+
+    final var record = new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.EVENT);
+    records.add(record);
+  }
+
+  @Override
+  public void appendFollowUpEvent(final long key, final Intent intent, final UnpackedObject value) {
+
+    final var record = new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.EVENT);
+    records.add(record);
+  }
+
+  @Override
+  public void appendFollowUpEvent(
+      final long key,
+      final Intent intent,
+      final UnpackedObject value,
+      final Consumer<RecordMetadata> metadata) {
+
+    final var record = new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.EVENT);
+    records.add(record);
+  }
+
+  @Override
+  public void configureSourceContext(final long sourceRecordPosition) {
+    this.sourceRecordPosition = sourceRecordPosition;
+  }
+
+  @Override
+  public void appendNewCommand(final Intent intent, final UnpackedObject value) {
+
+    final var record =
+        new ReprocessingRecord(-1L, sourceRecordPosition, intent, RecordType.COMMAND);
+    records.add(record);
+  }
+
+  @Override
+  public void appendFollowUpCommand(
+      final long key, final Intent intent, final UnpackedObject value) {
+
+    final var record =
+        new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.COMMAND);
+    records.add(record);
+  }
+
+  @Override
+  public void appendFollowUpCommand(
+      final long key,
+      final Intent intent,
+      final UnpackedObject value,
+      final Consumer<RecordMetadata> metadata) {
+
+    final var record =
+        new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.COMMAND);
+    records.add(record);
+  }
+
+  @Override
+  public void reset() {
+    sourceRecordPosition = -1;
+  }
+
+  @Override
+  public long flush() {
+    return 0;
+  }
+
+  public List<ReprocessingRecord> getRecords() {
+    return records;
+  }
+
+  public void removeRecord(final long recordKey, final long sourceRecordPosition) {
+    records.removeIf(
+        record ->
+            record.getKey() == recordKey
+                && record.getSourceRecordPosition() == sourceRecordPosition);
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReprocessingIssueDetectionTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReprocessingIssueDetectionTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.streamprocessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.engine.util.RecordToWrite;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.protocol.record.value.JobRecordValue;
+import io.zeebe.protocol.record.value.WorkflowInstanceRecordValue;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.zeebe.util.health.HealthStatus;
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class ReprocessingIssueDetectionTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private long workflowInstanceKey;
+  private Record<JobRecordValue> jobCreated;
+  private Record<WorkflowInstanceRecordValue> serviceTaskActivated;
+  private Record<WorkflowInstanceRecordValue> processActivated;
+
+  @Before
+  public void setup() {
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .done())
+        .deploy();
+
+    workflowInstanceKey = engine.workflowInstance().ofBpmnProcessId("process").create();
+
+    processActivated =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    jobCreated = RecordingExporter.jobRecords(JobIntent.CREATED).getFirst();
+
+    serviceTaskActivated =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst();
+
+    engine.stop();
+  }
+
+  @Test
+  public void shouldDetectNoIssues() {
+    // given
+    engine.writeRecords(
+        RecordToWrite.command()
+            .job(JobIntent.COMPLETE, jobCreated.getValue())
+            .key(jobCreated.getKey()),
+        RecordToWrite.event()
+            .job(JobIntent.COMPLETED, jobCreated.getValue())
+            .key(jobCreated.getKey())
+            .causedBy(0),
+        RecordToWrite.event()
+            .workflowInstance(
+                WorkflowInstanceIntent.ELEMENT_COMPLETING, serviceTaskActivated.getValue())
+            .key(serviceTaskActivated.getKey())
+            .causedBy(1));
+
+    // when
+    engine.start();
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .filterRootScope()
+                .limitToWorkflowInstanceCompleted())
+        .extracting(Record::getIntent)
+        .contains(WorkflowInstanceIntent.ELEMENT_COMPLETED);
+
+    final var streamProcessor = engine.getStreamProcessor(1);
+    assertThat(streamProcessor.isFailed()).isFalse();
+    assertThat(streamProcessor.getHealthStatus()).isEqualTo(HealthStatus.HEALTHY);
+  }
+
+  @Test
+  public void shouldDetectDifferentKey() {
+    // given
+    engine.writeRecords(
+        RecordToWrite.command()
+            .job(JobIntent.COMPLETE, jobCreated.getValue())
+            .key(jobCreated.getKey()),
+        RecordToWrite.event()
+            .job(JobIntent.COMPLETED, jobCreated.getValue())
+            .key(jobCreated.getKey())
+            .causedBy(0),
+        // expected the key to be serviceTaskActivated.getKey()
+        RecordToWrite.event()
+            .workflowInstance(
+                WorkflowInstanceIntent.ELEMENT_COMPLETING, serviceTaskActivated.getValue())
+            .key(123L)
+            .causedBy(1));
+
+    // when
+    engine.start();
+
+    // then
+    final var streamProcessor = engine.getStreamProcessor(1);
+
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              assertThat(streamProcessor.isFailed()).isTrue();
+              assertThat(streamProcessor.getHealthStatus()).isEqualTo(HealthStatus.UNHEALTHY);
+            });
+  }
+
+  @Test
+  public void shouldDetectDifferentIntent() {
+    // given
+    engine.writeRecords(
+        RecordToWrite.command()
+            .job(JobIntent.COMPLETE, jobCreated.getValue())
+            .key(jobCreated.getKey()),
+        RecordToWrite.event()
+            .job(JobIntent.COMPLETED, jobCreated.getValue())
+            .key(jobCreated.getKey())
+            .causedBy(0),
+        // expected the intent to be ELEMENT_COMPLETING
+        RecordToWrite.event()
+            .workflowInstance(
+                WorkflowInstanceIntent.ELEMENT_TERMINATING, serviceTaskActivated.getValue())
+            .key(serviceTaskActivated.getKey())
+            .causedBy(1));
+
+    // when
+    engine.start();
+
+    // then
+    final var streamProcessor = engine.getStreamProcessor(1);
+
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              assertThat(streamProcessor.isFailed()).isTrue();
+              assertThat(streamProcessor.getHealthStatus()).isEqualTo(HealthStatus.UNHEALTHY);
+            });
+  }
+
+  @Test
+  public void shouldDetectMissingRecordOnLogStream() {
+    // given
+    engine.writeRecords(
+        RecordToWrite.command()
+            .workflowInstance(WorkflowInstanceIntent.CANCEL, processActivated.getValue())
+            .key(workflowInstanceKey),
+        RecordToWrite.event()
+            .workflowInstance(
+                WorkflowInstanceIntent.ELEMENT_TERMINATING, processActivated.getValue())
+            .key(workflowInstanceKey)
+            .causedBy(0),
+        // expected the follow-up event with intent ELEMENT_TERMINATING for the service task
+        RecordToWrite.command()
+            .job(JobIntent.COMPLETE, jobCreated.getValue())
+            .key(jobCreated.getKey()),
+        RecordToWrite.event()
+            .job(JobIntent.COMPLETED, jobCreated.getValue())
+            .key(jobCreated.getKey())
+            .causedBy(2));
+
+    // when
+    engine.start();
+
+    // then
+    final var streamProcessor = engine.getStreamProcessor(1);
+
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              assertThat(streamProcessor.isFailed()).isTrue();
+              assertThat(streamProcessor.getHealthStatus()).isEqualTo(HealthStatus.UNHEALTHY);
+            });
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/timer/ConcurrentTimerEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/timer/ConcurrentTimerEventTest.java
@@ -152,10 +152,6 @@ public final class ConcurrentTimerEventTest {
             .workflowInstance(WorkflowInstanceIntent.ELEMENT_TERMINATING, eventActivated.getValue())
             .key(eventActivated.getKey())
             .causedBy(1),
-        RecordToWrite.event()
-            .workflowInstance(WorkflowInstanceIntent.ELEMENT_TERMINATED, eventActivated.getValue())
-            .key(eventActivated.getKey())
-            .causedBy(2),
         RecordToWrite.command()
             .timer(TimerIntent.TRIGGER, timerCreated.getValue())
             .key(timerCreated.getKey()));

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import io.zeebe.engine.processor.CommandResponseWriter;
 import io.zeebe.engine.processor.ReadonlyProcessingContext;
 import io.zeebe.engine.processor.RecordValues;
+import io.zeebe.engine.processor.StreamProcessor;
 import io.zeebe.engine.processor.StreamProcessorLifecycleAware;
 import io.zeebe.engine.processor.TypedEventImpl;
 import io.zeebe.engine.processor.workflow.EngineProcessors;
@@ -219,6 +220,10 @@ public final class EngineRule extends ExternalResource {
 
   public ZeebeState getZeebeState() {
     return environmentRule.getZeebeState();
+  }
+
+  public StreamProcessor getStreamProcessor(final int partitionId) {
+    return environmentRule.getStreamProcessor(partitionId);
   }
 
   public DeploymentClient deployment() {

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
@@ -82,6 +82,10 @@ public class StreamProcessingComposite {
     }
   }
 
+  public StreamProcessor getStreamProcessor(final int partitionId) {
+    return streams.getStreamProcessor(getLogName(partitionId));
+  }
+
   public ZeebeState getZeebeState() {
     return zeebeState;
   }

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -141,6 +141,10 @@ public final class StreamProcessorRule implements TestRule {
     closeStreamProcessor(startPartitionId);
   }
 
+  public StreamProcessor getStreamProcessor(final int partitionId) {
+    return streamProcessingComposite.getStreamProcessor(partitionId);
+  }
+
   public CommandResponseWriter getCommandResponseWriter() {
     return streams.getMockedResponseWriter();
   }

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -47,6 +47,8 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -234,6 +236,13 @@ public final class TestStreams {
   public void closeProcessor(final String streamName) throws Exception {
     streamContextMap.remove(streamName).close();
     LOG.info("Closed stream {}", streamName);
+  }
+
+  public StreamProcessor getStreamProcessor(final String streamName) {
+    return Optional.ofNullable(streamContextMap.get(streamName))
+        .map(c -> c.streamProcessor)
+        .orElseThrow(
+            () -> new NoSuchElementException("No stream processor found with name: " + streamName));
   }
 
   public long writeBatch(final String logName, final RecordToWrite[] recordToWrites) {

--- a/upgrade-tests/src/test/java/io/zeebe/test/ContainerStateRule.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/ContainerStateRule.java
@@ -78,7 +78,7 @@ class ContainerStateRule extends TestWatcher {
   }
 
   public ContainerStateRule broker(final String version, final String volumePath) {
-    this.brokerVersion = version;
+    brokerVersion = version;
     this.volumePath = volumePath;
     return this;
   }

--- a/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
+++ b/upgrade-tests/src/test/java/io/zeebe/test/UpgradeTest.java
@@ -14,9 +14,11 @@ import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.test.UpgradeTestCase.TestCaseBuilder;
 import io.zeebe.test.util.TestUtil;
+import io.zeebe.util.FileUtil;
 import io.zeebe.util.VersionUtil;
 import io.zeebe.util.collection.Tuple;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Arrays;
@@ -25,7 +27,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.agrona.IoUtil;
-import org.assertj.core.util.Files;
+import org.awaitility.Awaitility;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -146,13 +149,54 @@ public class UpgradeTest {
                     new Tuple<>(parentWorkflow(), PROCESS_ID),
                     new Tuple<>(childWorkflow(), CHILD_PROCESS_ID))
                 .createInstance()
+                .beforeUpgrade(UpgradeTest::activateJob)
                 .afterUpgrade(
-                    (state, wfKey, key) -> {
-                      final var jobKey = activateJob(state);
-                      completeJob(state, wfKey, jobKey);
+                    (state, wfKey, jobKey) -> {
+                      state.client().newCompleteCommand(jobKey).send().join();
                       TestUtil.waitUntil(
                           () -> state.hasLogContaining(CHILD_PROCESS_ID, "COMPLETED"));
                     })
+                .done()
+          },
+          {
+            "parallel gateway",
+            scenario()
+                .deployWorkflow(
+                    Bpmn.createExecutableProcess(PROCESS_ID)
+                        .startEvent()
+                        .parallelGateway("fork")
+                        .serviceTask(TASK, t -> t.zeebeJobType(TASK))
+                        .parallelGateway("join")
+                        .moveToNode("fork")
+                        .sequenceFlowId("to-join")
+                        .connectTo("join")
+                        .endEvent()
+                        .done())
+                .createInstance()
+                .beforeUpgrade(UpgradeTest::activateJob)
+                .afterUpgrade(UpgradeTest::completeJob)
+                .done()
+          },
+          {
+            "exclusive gateway",
+            scenario()
+                .deployWorkflow(
+                    Bpmn.createExecutableProcess(PROCESS_ID)
+                        .startEvent()
+                        .exclusiveGateway()
+                        .sequenceFlowId("s1")
+                        .conditionExpression("x > 5")
+                        .serviceTask(TASK, t -> t.zeebeJobType(TASK))
+                        .endEvent()
+                        .moveToLastExclusiveGateway()
+                        .sequenceFlowId("s2")
+                        .defaultFlow()
+                        .serviceTask("other-task", t -> t.zeebeJobType("other-task"))
+                        .endEvent()
+                        .done())
+                .createInstance(Map.of("x", 10))
+                .beforeUpgrade(UpgradeTest::activateJob)
+                .afterUpgrade(UpgradeTest::completeJob)
                 .done()
           }
         });
@@ -180,6 +224,7 @@ public class UpgradeTest {
     upgradeZeebe(false);
   }
 
+  @Ignore("https://github.com/zeebe-io/zeebe/issues/5385")
   @Test
   public void upgradeWithoutSnapshot() {
     upgradeZeebe(true);
@@ -195,9 +240,24 @@ public class UpgradeTest {
     state.close();
     final File snapshot = new File(tmpFolder.getRoot(), "raft-partition/partitions/1/snapshots/");
 
-    assertThat(snapshot).exists();
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () ->
+                assertThat(snapshot)
+                    .describedAs("Expected that a snapshot is created")
+                    .exists()
+                    .isNotEmptyDirectory());
+
     if (deleteSnapshot) {
-      Files.delete(snapshot);
+
+      try {
+        FileUtil.deleteFolder(snapshot.toPath());
+      } catch (final IOException e) {
+        e.printStackTrace();
+      }
+
+      assertThat(snapshot).describedAs("Expected that the snapshot is deleted").doesNotExist();
     }
 
     // then
@@ -253,6 +313,7 @@ public class UpgradeTest {
         .messageName(MESSAGE)
         .correlationKey("123")
         .timeToLive(Duration.ofMinutes(5))
+        .variables(Map.of("x", 1))
         .send()
         .join();
 


### PR DESCRIPTION
## Description

Backport of #5421

It is mainly a cherry-pick. Only the `UpgradeTest` is a bit different. I ignored the `upgradeWithoutSnapshot()` test case instead of `upgradeWithSnapshot()` because the snapshot is created but can not be deleted. :sweat_smile:  

## Related issues

closes #5381
