### PR TITLE
[backport to 0.23] fix(flaky-test): Change boundaries of port ranges for each stage

### DIFF
--- a/test-util/src/main/java/io/zeebe/test/util/TestEnvironment.java
+++ b/test-util/src/main/java/io/zeebe/test/util/TestEnvironment.java
@@ -16,6 +16,11 @@ public class TestEnvironment {
   private static final String TEST_FORK_NUMBER_PROPERTY_NAME = "testForkNumber";
   private static final String TEST_MAVEN_ID_PROPERTY_NAME = "testMavenId";
 
+  /**
+   * Returns the test fork number
+   *
+   * @return test fork number
+   */
   public static int getTestForkNumber() {
     int testForkNumber = 0;
     try {
@@ -34,6 +39,12 @@ public class TestEnvironment {
     return testForkNumber;
   }
 
+  /**
+   * Returns the test maven ID that maps to a test stage in Jenkins (e.g. junit = 1; it = 2; junit8
+   * = 3
+   *
+   * @return test maven ID that maps to a test stage in Jenkins (e.g. junit = 1; it = 2; junit8 = 3
+   */
   public static int getTestMavenId() {
     int testMavenId = 0;
     try {

--- a/test-util/src/main/java/io/zeebe/test/util/socket/SocketUtil.java
+++ b/test-util/src/main/java/io/zeebe/test/util/socket/SocketUtil.java
@@ -17,13 +17,18 @@ public final class SocketUtil {
 
   private static final String DEFAULT_HOST = "localhost";
   private static final int BASE_PORT = 25600;
-  private static final int RANGE_SIZE = 100;
+  private static final int PORT_RANGE_PER_TEST_FORK = 100;
+  private static final int MAX_TEST_FORKS_PER_STAGE = 39;
+  private static final int PORT_RANGE_PER_TEST_STAGE =
+      PORT_RANGE_PER_TEST_FORK * MAX_TEST_FORKS_PER_STAGE; // 3900
+  private static final int MAX_TEST_STAGES = 10;
 
   private static final int TEST_FORK_NUMBER;
   private static final PortRange PORT_RANGE;
 
   static {
     final int testForkNumber = TestEnvironment.getTestForkNumber();
+    // test stage in Jenkins (junit8, junit, it)
     final int testMavenId = TestEnvironment.getTestMavenId();
 
     LOG.info(
@@ -32,13 +37,16 @@ public final class SocketUtil {
         testMavenId);
 
     // ensure limits to stay in available port range
-    assert testForkNumber < 39 : "System property test fork number has to be smaller then 39";
-    assert testMavenId < 10 : "System property test maven id has to be smaller then 10";
+    assert testForkNumber < MAX_TEST_FORKS_PER_STAGE
+        : "System property test fork number has to be smaller than " + MAX_TEST_FORKS_PER_STAGE;
+    assert testMavenId < MAX_TEST_STAGES
+        : "System property test maven id has to be smaller than " + MAX_TEST_STAGES;
 
-    final int testOffset = testForkNumber * 10 + testMavenId;
+    final int testOffset =
+        testMavenId * PORT_RANGE_PER_TEST_STAGE + testForkNumber * PORT_RANGE_PER_TEST_FORK;
+    final int min = BASE_PORT + testOffset;
+    final int max = min + PORT_RANGE_PER_TEST_FORK;
 
-    final int min = BASE_PORT + testOffset * RANGE_SIZE;
-    final int max = min + RANGE_SIZE;
     TEST_FORK_NUMBER = testForkNumber;
     PORT_RANGE = new PortRange(DEFAULT_HOST, TEST_FORK_NUMBER, min, max);
   }


### PR DESCRIPTION
## Description

backport of #4841 to 0.23

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [X] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
