### PR TITLE
Improve build notification on zeebe-ci slack channel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -290,7 +290,12 @@ pipeline {
         }
         changed {
             script {
-                if (env.BRANCH_NAME == 'develop' && !agentDisconnected()) {
+                if (env.BRANCH_NAME != 'develop' || agentDisconnected()) {
+                    return
+                }
+
+                if (hasBuildResultChanged()) {
+                    echo "Send slack message"
                     slackSend(
                         channel: "#zeebe-ci${jenkins.model.JenkinsLocationConfiguration.get()?.getUrl()?.contains('stage') ? '-stage' : ''}",
                         message: "Zeebe ${env.BRANCH_NAME} build ${currentBuild.absoluteUrl} changed status to ${currentBuild.currentResult}")


### PR DESCRIPTION
## Description

This PR uses a new shared function to determine whether the build has actually changed or not (i.e. it is fixed, it has regressed, it's new or it didn't change).

## Related issues

closes: #5460

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
