### PR TITLE
Documentation: Fixes to the guide on how to run Zeebe on Kubernetes

### DIFF
--- a/docs/src/kubernetes/installing-helm.md
+++ b/docs/src/kubernetes/installing-helm.md
@@ -41,10 +41,10 @@ Once this is done, we are ready to install any of the Helm Charts hosted in the 
 In this section we are going to install all the available Zeebe components inside a Kubernetes Cluster. Notice that this Kubernetes cluster can have already running services and Zeebe is going to installed just as another set of services. 
 
 ```
-> helm install --name <RELEASE NAME> zeebe/zeebe-full
+> helm install <RELEASE NAME> zeebe/zeebe-full
 ```
 
-> Note: change <RELEASE NAME> with a name of your choice
+> Note: change <RELEASE NAME> with a name of your choice or use `--generate-name` option instead
 > Notice that you can add the `-n` flag to specify in which Kubernetes namespace the components should be installed.
 
 Installing all the components in a cluster requires all the Docker images to be downloaded to the remote cluster, depending on which Cloud Provider you are using, the amount of time that it will take to fetch all the images will vary. 
@@ -84,7 +84,7 @@ Check that each Pod has at least 1/1 running instances. You can always tail the 
 
 In order to interact with the services inside the cluster you need to use `port-forward` to route traffic from your environment to the cluster. 
 ```
-> kubectl port-forward svc/<RELEASE NAME>-zeebe 26500:26500
+> kubectl port-forward svc/<RELEASE NAME>-zeebe-gateway 26500:26500
 ```
 
 Now you can connect and execute operations against your newly created Zeebe cluster. 


### PR DESCRIPTION
## Description

This pull request corrects the documentation related to running of Zeebe on Kubernetes.

## Related issues

None.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
