### PR TITLE
docs(appendix+kubernetes): Fix mistakes in documentation guides

### DIFF
--- a/docs/src/appendix/gateway-health-probes.md
+++ b/docs/src/appendix/gateway-health-probes.md
@@ -31,7 +31,7 @@ In the default configuration, the liveness probe is comprised of the following h
 * Liveness Disk Space - checks that the free disk space is greater than 1 MB
 * Liveness Memory - checks that at least 1% of max memory (heap) are still available
 
-Note that health indicators with the *liveness* prefix are intended to be customized for the livness probe. This allows defining tighter thresholds (e.g. for free memory 1% for liveness vs. 10% for health), as well as adding tolerance for short downtimes (e.g. gateway has no awereness of other nodes in the cluster for more than 5 minutes).
+Note that health indicators with the *liveness* prefix are intended to be customized for the liveness probe. This allows defining tighter thresholds (e.g. for free memory 1% for liveness vs. 10% for health), as well as adding tolerance for short downtimes (e.g. gateway has no awareness of other nodes in the cluster for more than 5 minutes).
 
 ## Customizing Health Probes
 
@@ -57,7 +57,7 @@ Settings for gateway started health indicator:
 
 ### Gateway Responsive
 
-Settings for gateway repsonsiveness health indicator:
+Settings for gateway responsiveness health indicator:
 * `management.health.gateway-responsive.enabled=true` - enables (default) or disables this health indicator
 * `management.health.gateway-responsive.requestTimeout=500ms` - defines the timeout for the request; if the test completes before the timeout, the health status is _UP_, otherwise it is _DOWN_
 * `management.health.liveness.gateway-responsive.requestTimeout=5s` - defines the timeout for the request for liveness probe; if the request completes before the timeout, the health status is _UP_

--- a/docs/src/kubernetes/accessing-operate.md
+++ b/docs/src/kubernetes/accessing-operate.md
@@ -23,7 +23,7 @@ If you are running in Kubernetes KIND, you will need to `port-forward` to the In
 > kubectl port-forward svc/<RELEASE NAME>-nginx-ingress-controller 8080:80
 ```
 
-Then you should be able to access Operate pointing your broswer at [http://localhost:8080](http://localhost:8080/)
+Then you should be able to access Operate pointing your browser at [http://localhost:8080](http://localhost:8080/)
 
 ![Operate Login](/kubernetes/operate-login.png)
 

--- a/docs/src/kubernetes/index.md
+++ b/docs/src/kubernetes/index.md
@@ -4,7 +4,7 @@
 
 This section covers the fundamentals of how to run Zeebe in Kubernetes. There are several alternatives on how to deploy applications to a Kubernetes Cluster, but the following sections are using Helm charts to deploy a set of components into your cluster. 
 
-Helm allows you to choose exactly what chart (set of components) do you want to install and how these components needs to be configured. These Helm Charts are continously being improved and released to the Official [Zeebe Helm Chart Repository http://helm.zeebe.io](http://helm.zeebe.io)
+Helm allows you to choose exactly what chart (set of components) do you want to install and how these components needs to be configured. These Helm Charts are continuously being improved and released to the Official [Zeebe Helm Chart Repository http://helm.zeebe.io](http://helm.zeebe.io)
 
 You are free to choose your Kubernetes provider, our Helm charts are not cloud provider specific and we encourage [reporting issues here](http://github.com/zeebe-io/zeebe-full-helm/issues) if you find them. 
 

--- a/docs/src/kubernetes/installing-helm.md
+++ b/docs/src/kubernetes/installing-helm.md
@@ -1,11 +1,11 @@
 ## Zeebe Helm Charts
 
-[Helm](https://github.com/helm/helm) is a package manager for Kubernetes resources. Helm allows us to install a set of components by just referencing a package name and it allows us to override configurations to accomodate these packages to different scenarios. Helm also provide dependency management between  charts, meaning that charts can depend on other charts allowing us to aggregate a set of components together that can be installed with a single command. 
+[Helm](https://github.com/helm/helm) is a package manager for Kubernetes resources. Helm allows us to install a set of components by just referencing a package name and it allows us to override configurations to accommodate these packages to different scenarios. Helm also provide dependency management between  charts, meaning that charts can depend on other charts allowing us to aggregate a set of components together that can be installed with a single command. 
 
 
 As part of the Zeebe project, we are providing 3 Zeebe Helm Charts: 
 - **Zeebe Cluster**: Deploys a Zeebe Cluster with 3 brokers using the camunda/zeebe docker image. This Chart depends on ElasticSearch Helm Chart and optionally on Kibana Helm Chart. This chart is hosted in the following repository, where you can find more information about its configuration: [http://github.com/zeebe-io/zeebe-cluster-helm/](http://github.com/zeebe-io/zeebe-cluster-helm/)
-- **Zeebe Operate**: Deploys Zeebe Operate which conects to an existing ElasticSearch. This chart source code can be located here: [http://github.com/zeebe-io/zeebe-operate-helm/](http://github.com/zeebe-io/zeebe-operate-helm/)
+- **Zeebe Operate**: Deploys Zeebe Operate which connects to an existing ElasticSearch. This chart source code can be located here: [http://github.com/zeebe-io/zeebe-operate-helm/](http://github.com/zeebe-io/zeebe-operate-helm/)
 - **Zeebe Full** (Parent): Deploys a Zeebe Cluster + Operate + Ingress Controller. This parent chart can be located here: [http://github.com/zeebe-io/zeebe-full-helm/](http://github.com/zeebe-io/zeebe-full-helm/)
 
 ![Charts](/kubernetes/zeebe-helm-charts.png)
@@ -27,7 +27,7 @@ This install Helm server side components in your cluster and it will enable the 
 
 ### Add Zeebe Helm Repository
 
-The next step is to add the Zeebe official Helm Chart repository to your installation. Once this is done, Helm will be able to fetch and install Charts hostested in [http://helm.zeebe.io](http://helm.zeebe.io).
+The next step is to add the Zeebe official Helm Chart repository to your installation. Once this is done, Helm will be able to fetch and install Charts hosted in [http://helm.zeebe.io](http://helm.zeebe.io).
 ```
 > helm repo add zeebe https://helm.zeebe.io
 > helm repo update


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Resolved some mistakes in the form of typos for certain words in the Appendix and Kubernetes documentation pages

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
