### PR TITLE
[Backport 0.23] Admin api for brokers

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -180,12 +180,12 @@ public final class Broker implements AutoCloseable {
     }
     startContext.addStep("cluster services", () -> atomix.start().join());
     startContext.addStep("topology manager", () -> topologyManagerStep(clusterCfg, localBroker));
+    startContext.addStep("Upgrade manager", this::addBrokerAdminService);
     startContext.addStep("metric's server", () -> monitoringServerStep(networkCfg, localBroker));
     startContext.addStep(
         "leader management request handler", () -> managementRequestStep(localBroker));
     startContext.addStep(
         "zeebe partitions", () -> partitionsStep(brokerCfg, clusterCfg, localBroker));
-    startContext.addStep("Upgrade manager", this::addBrokerAdminService);
 
     return startContext;
   }
@@ -298,7 +298,11 @@ public final class Broker implements AutoCloseable {
     final SocketBindingCfg monitoringApi = networkCfg.getMonitoringApi();
     final BrokerHttpServer httpServer =
         new BrokerHttpServer(
-            monitoringApi.getHost(), monitoringApi.getPort(), METRICS_REGISTRY, healthCheckService);
+            monitoringApi.getHost(),
+            monitoringApi.getPort(),
+            METRICS_REGISTRY,
+            healthCheckService,
+            brokerAdminService);
     return () -> {
       httpServer.close();
       healthCheckService.close();

--- a/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.management;
+
+import java.util.Map;
+
+public interface BrokerAdminService {
+
+  /** Request a partition to pause its StreamProcessor */
+  void pauseStreamProcessing();
+
+  /** Request a partition to resume its StreamProcessor */
+  void resumeStreamProcessing();
+
+  /**
+   * Trigger a snapshot. Partition will attempt to take a snapshot instead of waiting for the
+   * snapshot interval.
+   */
+  void takeSnapshot();
+
+  /**
+   * Prepares for upgrade by pausing stream processors and triggering snapshots. It is not normally
+   * required to call this before every upgrade. However, this is useful as an upgrade procedure to
+   * mitigate the effects of some known bugs.
+   */
+  void prepareForUpgrade();
+
+  /**
+   * Returns {@link PartitionStatus} of all partitions running on this broker.
+   *
+   * @return a map of partition id and partition status
+   */
+  Map<Integer, PartitionStatus> getPartitionStatus();
+}

--- a/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminServiceImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminServiceImpl.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.management;
+
+import io.zeebe.broker.Loggers;
+import io.zeebe.broker.system.partitions.ZeebePartition;
+import io.zeebe.engine.processor.AsyncSnapshotDirector;
+import io.zeebe.engine.processor.StreamProcessor;
+import io.zeebe.logstreams.state.Snapshot;
+import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+
+/**
+ * A service that exposes interface to control some of the core functionalities of the broker such
+ * as * Pause stream processing * Force take a snapshot
+ *
+ * <p>This is intended to be used only by advanced users
+ */
+public class BrokerAdminServiceImpl extends Actor implements BrokerAdminService {
+
+  private static final Logger LOG = Loggers.SYSTEM_LOGGER;
+  private final List<ZeebePartition> partitions;
+
+  public BrokerAdminServiceImpl(final List<ZeebePartition> partitions) {
+    this.partitions = partitions;
+  }
+
+  @Override
+  public void pauseStreamProcessing() {
+    actor.call(this::pauseStreamProcessingOnAllPartitions);
+  }
+
+  @Override
+  public void resumeStreamProcessing() {
+    actor.call(this::unpauseStreamProcessingOnAllPartitions);
+  }
+
+  @Override
+  public void takeSnapshot() {
+    actor.call(() -> takeSnapshotOnAllPartitions(partitions));
+  }
+
+  @Override
+  public void prepareForUpgrade() {
+    actor.call(this::prepareAllPartitionsForSafeUpgrade);
+  }
+
+  @Override
+  public Map<Integer, PartitionStatus> getPartitionStatus() {
+    final CompletableFuture<Map<Integer, PartitionStatus>> future = new CompletableFuture<>();
+    final Map<Integer, PartitionStatus> partitionStatuses = new ConcurrentHashMap<>();
+    actor.call(
+        () -> {
+          final var statusFutures =
+              partitions.stream()
+                  .map(
+                      partition ->
+                          getPartitionStatus(partition)
+                              .whenComplete(
+                                  (ps, error) -> {
+                                    if (error == null) {
+                                      partitionStatuses.put(partition.getPartitionId(), ps);
+                                    }
+                                  }))
+                  .collect(Collectors.toList());
+          CompletableFuture.allOf(statusFutures.toArray(CompletableFuture[]::new))
+              .thenAccept(r -> future.complete(partitionStatuses));
+        });
+    return future.join();
+  }
+
+  private CompletableFuture<PartitionStatus> getPartitionStatus(final ZeebePartition partition) {
+    final CompletableFuture<PartitionStatus> partitionStatus = new CompletableFuture<>();
+    getStreamProcessor(partition)
+        .onComplete(
+            (streamProcessor, throwable) -> {
+              if (throwable != null) {
+                partitionStatus.completeExceptionally(throwable);
+                return;
+              }
+              streamProcessor.ifPresentOrElse(
+                  sp -> getLeaderPartitionStatus(partition, sp, partitionStatus),
+                  () -> getFollowerPartitionStatus(partition, partitionStatus));
+            });
+    return partitionStatus;
+  }
+
+  private void getFollowerPartitionStatus(
+      final ZeebePartition partition, final CompletableFuture<PartitionStatus> partitionStatus) {
+    final var snapshotId = getSnapshotId(partition);
+    final var status = PartitionStatus.ofFollower(snapshotId.orElse(null));
+    partitionStatus.complete(status);
+  }
+
+  private void getLeaderPartitionStatus(
+      final ZeebePartition partition,
+      final StreamProcessor streamProcessor,
+      final CompletableFuture<PartitionStatus> partitionStatus) {
+    final var positionFuture = streamProcessor.getLastProcessedPositionAsync();
+    positionFuture.onComplete(
+        (processedPosition, positionRetrieveError) -> {
+          if (positionRetrieveError != null) {
+            partitionStatus.completeExceptionally(positionRetrieveError);
+            return;
+          }
+
+          streamProcessor
+              .getCurrentPhase()
+              .onComplete(
+                  (phase, phaseError) -> {
+                    if (phaseError != null) {
+                      partitionStatus.completeExceptionally(phaseError);
+                      return;
+                    }
+
+                    final var snapshotId = getSnapshotId(partition);
+                    getProcessedPositionInSnapshot(partition)
+                        .onComplete(
+                            (processedPositionInSnapshot, posInSnapshotError) -> {
+                              if (posInSnapshotError != null) {
+                                partitionStatus.completeExceptionally(posInSnapshotError);
+                                return;
+                              }
+                              final var status =
+                                  PartitionStatus.ofLeader(
+                                      processedPosition,
+                                      snapshotId.orElse(null),
+                                      processedPositionInSnapshot,
+                                      phase);
+                              partitionStatus.complete(status);
+                            });
+                  });
+        });
+  }
+
+  private ActorFuture<Long> getProcessedPositionInSnapshot(final ZeebePartition partition) {
+    final CompletableActorFuture<Long> processedPosition = new CompletableActorFuture<>();
+    partition
+        .getAsyncSnapshotDirector()
+        .onComplete(
+            (asyncSnapshotDirector, throwable) -> {
+              if (throwable == null) {
+                asyncSnapshotDirector
+                    .map(AsyncSnapshotDirector::getProcessedPositionInLastCommittedSnapshot)
+                    .ifPresentOrElse(
+                        future -> future.onComplete(processedPosition),
+                        () -> processedPosition.complete(null));
+              } else {
+                processedPosition.completeExceptionally(throwable);
+              }
+            });
+    return processedPosition;
+  }
+
+  private Optional<String> getSnapshotId(final ZeebePartition partition) {
+    return partition
+        .getSnapshotStore()
+        .getLatestSnapshot()
+        .map(Snapshot::getPath)
+        .map(p -> p.getFileName().toString());
+  }
+
+  private ActorFuture<Optional<StreamProcessor>> getStreamProcessor(
+      final ZeebePartition partition) {
+    return partition.getStreamProcessor();
+  }
+
+  private void prepareAllPartitionsForSafeUpgrade() {
+    LOG.info("Preparing for safe upgrade.");
+
+    final var pauseCompleted = pauseStreamProcessingOnAllPartitions();
+
+    actor.runOnCompletion(pauseCompleted, t -> takeSnapshotOnAllPartitions(partitions));
+  }
+
+  private List<ActorFuture<Void>> pauseStreamProcessingOnAllPartitions() {
+    LOG.info("Pausing StreamProcessor on all partitions.");
+    return partitions.stream().map(ZeebePartition::pauseProcessing).collect(Collectors.toList());
+  }
+
+  private void unpauseStreamProcessingOnAllPartitions() {
+    LOG.info("Resuming paused StreamProcessor on all partitions.");
+    partitions.forEach(ZeebePartition::resumeProcessing);
+  }
+
+  private void takeSnapshotOnAllPartitions(final List<ZeebePartition> partitions) {
+    LOG.info("Triggering Snapshots on all partitions.");
+    partitions.forEach(ZeebePartition::triggerSnapshot);
+  }
+}

--- a/broker/src/main/java/io/zeebe/broker/system/management/PartitionStatus.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/PartitionStatus.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.management;
+
+import io.atomix.raft.RaftServer.Role;
+import io.zeebe.engine.processor.StreamProcessor.Phase;
+
+public final class PartitionStatus {
+
+  private final Role role;
+  private final String snapshotId;
+
+  private final Long processedPosition;
+
+  private final Long processedPositionInSnapshot;
+
+  private final Phase streamProcessorPhase;
+
+  private PartitionStatus(
+      final Role role,
+      final Long processedPosition,
+      final String snapshotId,
+      final Long processedPositionInSnapshot,
+      final Phase streamProcessorPhase) {
+    this.role = role;
+    this.processedPosition = processedPosition;
+    this.snapshotId = snapshotId;
+    this.processedPositionInSnapshot = processedPositionInSnapshot;
+    this.streamProcessorPhase = streamProcessorPhase;
+  }
+
+  public static PartitionStatus ofLeader(
+      final Long processedPosition,
+      final String snapshotId,
+      final Long processedPositionInSnapshot,
+      final Phase streamProcessorPhase) {
+    return new PartitionStatus(
+        Role.LEADER,
+        processedPosition,
+        snapshotId,
+        processedPositionInSnapshot,
+        streamProcessorPhase);
+  }
+
+  public static PartitionStatus ofFollower(final String snapshotId) {
+    return new PartitionStatus(Role.FOLLOWER, null, snapshotId, null, null);
+  }
+
+  public Role getRole() {
+    return role;
+  }
+
+  public Long getProcessedPosition() {
+    return processedPosition;
+  }
+
+  public String getSnapshotId() {
+    return snapshotId;
+  }
+
+  public Long getProcessedPositionInSnapshot() {
+    return processedPositionInSnapshot;
+  }
+
+  public Phase getStreamProcessorPhase() {
+    return streamProcessorPhase;
+  }
+}

--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHttpServerInitializer.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHttpServerInitializer.java
@@ -11,23 +11,30 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.prometheus.client.CollectorRegistry;
+import io.zeebe.broker.system.management.BrokerAdminService;
 
 public final class BrokerHttpServerInitializer extends ChannelInitializer<SocketChannel> {
 
   private final CollectorRegistry metricsRegistry;
   private final BrokerHealthCheckService brokerHealthCheckService;
+  private final BrokerAdminService brokerAdminService;
 
   public BrokerHttpServerInitializer(
       final CollectorRegistry metricsRegistry,
-      final BrokerHealthCheckService brokerHealthCheckService) {
+      final BrokerHealthCheckService brokerHealthCheckService,
+      final BrokerAdminService brokerAdminService) {
     this.metricsRegistry = metricsRegistry;
     this.brokerHealthCheckService = brokerHealthCheckService;
+    this.brokerAdminService = brokerAdminService;
   }
 
   @Override
   protected void initChannel(final SocketChannel ch) {
     ch.pipeline()
         .addLast("codec", new HttpServerCodec())
-        .addLast("request", new BrokerHttpServerHandler(metricsRegistry, brokerHealthCheckService));
+        .addLast(
+            "request",
+            new BrokerHttpServerHandler(
+                metricsRegistry, brokerHealthCheckService, brokerAdminService));
   }
 }

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Distribution</name>
@@ -179,10 +181,17 @@
             </goals>
             <configuration>
               <target>
-                <copy file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl" tofile="${project.build.directory}/zeebe-broker/bin/zbctl" failonerror="${zbctl.force}" />
-                <copy file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.exe" tofile="${project.build.directory}/zeebe-broker/bin/zbctl.exe" failonerror="${zbctl.force}" />
-                <copy file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.darwin" tofile="${project.build.directory}/zeebe-broker/bin/zbctl.darwin" failonerror="${zbctl.force}" />
-                <chmod dir="${project.build.directory}/zeebe-broker/bin" perm="ugo+rx" includes="zbctl*" failonerror="${zbctl.force}" />
+                <copy file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl"
+                  tofile="${project.build.directory}/zeebe-broker/bin/zbctl"
+                  failonerror="${zbctl.force}"/>
+                <copy file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.exe"
+                  tofile="${project.build.directory}/zeebe-broker/bin/zbctl.exe"
+                  failonerror="${zbctl.force}"/>
+                <copy file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.darwin"
+                  tofile="${project.build.directory}/zeebe-broker/bin/zbctl.darwin"
+                  failonerror="${zbctl.force}"/>
+                <chmod dir="${project.build.directory}/zeebe-broker/bin" perm="ugo+rx"
+                  includes="zbctl*" failonerror="${zbctl.force}"/>
               </target>
             </configuration>
           </execution>

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -57,6 +57,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
   private final String actorName;
   private FailureListener failureListener;
   private volatile long lastTickTime;
+  private ActorFuture<Void> recoverFuture;
+  private boolean shouldProcess = true;
 
   protected StreamProcessor(final StreamProcessorBuilder processorBuilder) {
     this.actorScheduler = processorBuilder.getActorScheduler();
@@ -99,7 +101,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
 
       initProcessors();
 
-      processingStateMachine = new ProcessingStateMachine(processingContext, this::isOpened);
+      processingStateMachine =
+          new ProcessingStateMachine(processingContext, this::shouldProcessNext);
 
       healthCheckTick();
       openFuture.complete(null);
@@ -107,8 +110,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
       final ReProcessingStateMachine reProcessingStateMachine =
           new ReProcessingStateMachine(processingContext);
 
-      final ActorFuture<Void> recoverFuture =
-          reProcessingStateMachine.startRecover(snapshotPosition);
+      recoverFuture = reProcessingStateMachine.startRecover(snapshotPosition);
 
       actor.runOnCompletion(
           recoverFuture,
@@ -276,6 +278,10 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
     }
   }
 
+  private boolean shouldProcessNext() {
+    return isOpened() && shouldProcess;
+  }
+
   public boolean isOpened() {
     return isOpened.get();
   }
@@ -294,6 +300,35 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
 
   public ActorFuture<Long> getLastWrittenPositionAsync() {
     return actor.call(processingStateMachine::getLastWrittenEventPosition);
+  }
+
+  public ActorFuture<Void> pauseProcessing() {
+    return actor.call(
+        () ->
+            recoverFuture.onComplete(
+                (v, t) -> {
+                  if (shouldProcess) {
+                    lifecycleAwareListeners.forEach(StreamProcessorLifecycleAware::onPaused);
+                    shouldProcess = false;
+                    phase = Phase.PAUSED;
+                    LOG.debug("Paused processing for partition {}", partitionId);
+                  }
+                }));
+  }
+
+  public void resumeProcessing() {
+    actor.call(
+        () ->
+            recoverFuture.onComplete(
+                (v, t) -> {
+                  if (!shouldProcess) {
+                    lifecycleAwareListeners.forEach(StreamProcessorLifecycleAware::onResumed);
+                    shouldProcess = true;
+                    phase = Phase.PROCESSING;
+                    actor.submit(processingStateMachine::readNextEvent);
+                    LOG.debug("Resumed processing for partition {}", partitionId);
+                  }
+                }));
   }
 
   @Override
@@ -322,6 +357,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
   private enum Phase {
     REPROCESSING,
     PROCESSING,
+    PAUSED,
     FAILED
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessor.java
@@ -354,7 +354,11 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
     actor.run(() -> this.failureListener = failureListener);
   }
 
-  private enum Phase {
+  public ActorFuture<Phase> getCurrentPhase() {
+    return actor.call(() -> phase);
+  }
+
+  public enum Phase {
     REPROCESSING,
     PROCESSING,
     PAUSED,

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorLifecycleAware.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorLifecycleAware.java
@@ -13,4 +13,10 @@ public interface StreamProcessorLifecycleAware {
   default void onRecovered(final ReadonlyProcessingContext context) {}
 
   default void onClose() {}
+
+  default void onFailed() {}
+
+  default void onPaused() {}
+
+  default void onResumed() {}
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/workflow/timer/DueDateTimerChecker.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/workflow/timer/DueDateTimerChecker.java
@@ -100,4 +100,19 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
     // check if timers are due after restart
     triggerTimers();
   }
+
+  @Override
+  public void onPaused() {
+    if (scheduledTimer != null) {
+      scheduledTimer.cancel();
+      scheduledTimer = null;
+    }
+  }
+
+  @Override
+  public void onResumed() {
+    if (scheduledTimer == null) {
+      triggerTimers();
+    }
+  }
 }

--- a/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/StreamProcessorTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InOrder;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Parent</name>
@@ -82,7 +84,6 @@
     <version.feel-scala>1.12.2</version.feel-scala>
     <version.spring-framework>5.2.5.RELEASE</version.spring-framework>
     <version.spring-boot>2.2.6.RELEASE</version.spring-boot>
-    <version.spring-boot>2.2.5.RELEASE</version.spring-boot>
     <version.classgraph>4.8.68</version.classgraph>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.config>1.4.0</version.config>
@@ -924,7 +925,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -1017,7 +1018,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <dependencyConvergence />
+                  <dependencyConvergence/>
                 </rules>
               </configuration>
             </execution>
@@ -1076,6 +1077,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <parameters>true</parameters>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -369,7 +369,7 @@ public final class ClusteringRule extends ExternalResource {
             () -> {
               try {
                 return client.newTopologyRequest().send().join();
-              } catch (Exception e) {
+              } catch (final Exception e) {
                 LOG.trace("Topology request failed: ", e);
                 return null;
               }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/system/BrokerAdminServiceTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/system/BrokerAdminServiceTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.system;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.raft.RaftServer.Role;
+import io.zeebe.broker.Broker;
+import io.zeebe.broker.it.clustering.ClusteringRule;
+import io.zeebe.broker.it.util.GrpcClientRule;
+import io.zeebe.broker.system.management.BrokerAdminService;
+import io.zeebe.engine.processor.StreamProcessor.Phase;
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+
+public class BrokerAdminServiceTest {
+  private final Timeout testTimeout = Timeout.seconds(60);
+  private final ClusteringRule clusteringRule =
+      new ClusteringRule(
+          1,
+          3,
+          3,
+          cfg -> {
+            cfg.getData().setLogIndexDensity(1);
+          });
+  private final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(testTimeout).around(clusteringRule).around(clientRule);
+
+  private BrokerAdminService leaderAdminService;
+  private Broker leader;
+
+  @Before
+  public void before() {
+    leader = clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId());
+    leaderAdminService = leader.getBrokerAdminService();
+  }
+
+  @Test
+  public void shouldReportPartitionStatus() {
+    // given
+    final var followers =
+        clusteringRule.getOtherBrokerObjects(clusteringRule.getLeaderForPartition(1).getNodeId());
+
+    // when
+    final var followerStatus =
+        followers.stream()
+            .map(Broker::getBrokerAdminService)
+            .map(BrokerAdminService::getPartitionStatus)
+            .map(status -> status.get(1));
+
+    final var leaderStatus = leaderAdminService.getPartitionStatus().get(1);
+
+    // then
+    followerStatus.forEach(
+        partitionStatus -> {
+          assertThat(partitionStatus.getRole()).isEqualTo(Role.FOLLOWER);
+          assertThat(partitionStatus.getProcessedPosition()).isNull();
+          assertThat(partitionStatus.getSnapshotId()).isNull();
+          assertThat(partitionStatus.getProcessedPositionInSnapshot()).isNull();
+          assertThat(partitionStatus.getStreamProcessorPhase()).isNull();
+        });
+
+    assertThat(leaderStatus.getRole()).isEqualTo(Role.LEADER);
+    assertThat(leaderStatus.getProcessedPosition()).isEqualTo(-1);
+    assertThat(leaderStatus.getSnapshotId()).isNull();
+    assertThat(leaderStatus.getProcessedPositionInSnapshot()).isEqualTo(-1);
+    assertThat(leaderStatus.getStreamProcessorPhase()).isEqualTo(Phase.PROCESSING);
+  }
+
+  @Test
+  public void shouldTakeSnapshotWhenRequested() {
+    // given
+    clientRule.createSingleJob("test");
+
+    // when
+    leaderAdminService.takeSnapshot();
+
+    // then
+    waitForSnapshotAtBroker(leaderAdminService);
+  }
+
+  @Test
+  public void shouldPauseStreamProcessorWhenRequested() {
+    // given
+    clientRule.createSingleJob("test");
+
+    // when
+    leaderAdminService.pauseStreamProcessing();
+
+    // then
+    assertStreamProcessorPhase(leaderAdminService, Phase.PAUSED);
+  }
+
+  @Test
+  public void shouldUnPauseStreamProcessorWhenRequested() {
+    // given
+    clientRule.createSingleJob("test");
+
+    // when
+    leaderAdminService.pauseStreamProcessing();
+    assertStreamProcessorPhase(leaderAdminService, Phase.PAUSED);
+    leaderAdminService.resumeStreamProcessing();
+
+    // then
+    assertStreamProcessorPhase(leaderAdminService, Phase.PROCESSING);
+  }
+
+  @Test
+  public void shouldPauseStreamProcessorAndTakeSnapshotWhenPrepareUgrade() {
+    // given
+    clientRule.createSingleJob("test");
+
+    // when
+    leaderAdminService.prepareForUpgrade();
+
+    // then
+    waitForSnapshotAtBroker(leaderAdminService);
+
+    assertStreamProcessorPhase(leaderAdminService, Phase.PAUSED);
+    assertProcessedPositionIsInSnapshot(leaderAdminService);
+  }
+
+  private void assertStreamProcessorPhase(
+      final BrokerAdminService brokerAdminService, final Phase expected) {
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                brokerAdminService
+                    .getPartitionStatus()
+                    .forEach(
+                        (p, status) ->
+                            assertThat(status.getStreamProcessorPhase()).isEqualTo(expected)));
+  }
+
+  private void assertProcessedPositionIsInSnapshot(final BrokerAdminService brokerAdminService) {
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                brokerAdminService
+                    .getPartitionStatus()
+                    .forEach(
+                        (p, status) ->
+                            assertThat(status.getProcessedPosition())
+                                .isEqualTo(status.getProcessedPositionInSnapshot())));
+  }
+
+  private void waitForSnapshotAtBroker(final BrokerAdminService adminService) {
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                adminService
+                    .getPartitionStatus()
+                    .values()
+                    .forEach(
+                        status -> assertThat(status.getProcessedPositionInSnapshot()).isNotNull()));
+  }
+}


### PR DESCRIPTION
## Description

Mostly backport from #5408 and #5451 
Api is exposed over http server. Since it is not exposed via spring actuators the endpoints cannot be disabled. Following endpoints are available.
   * `http://localhost:9600/partitions`
   * `http://localhost:9600/partitions/pauseProcessing`
   * `http://localhost:9600/partitions/resumeProcessing`
   * `http://localhost:9600/partitions/takeSnapshot`
   * `http://localhost:9600/partitions/prepareUpgrade`

## Related issues

closes #5405 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
