### PR TITLE
Fix flaky CancelWorkflowInstanceConcurrentlyTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ faces-config.NavData
 *.DS_Store
 .java-version
 .gradle
+.worktree
 work/
 public/
 tngp-data

--- a/engine/src/test/java/io/zeebe/engine/processing/workflowinstance/CancelWorkflowInstanceConcurrentlyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/workflowinstance/CancelWorkflowInstanceConcurrentlyTest.java
@@ -144,6 +144,7 @@ public final class CancelWorkflowInstanceConcurrentlyTest {
     createdJob =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withWorkflowInstanceKey(workflowInstanceKey)
+            .limit(2)
             .withType(JOB_TYPE)
             .getFirst();
 


### PR DESCRIPTION
## Description

There was a timing issue in the multi-instance scenario, where the test
did not wait for both of the jobs to be created. Then when re-starting
the engine, reprocessing occurs including the verification of
reprocessing which would then fail because of this inconsistency.

By waiting for 2 jobs to be created and then taking the 1 of the correct
type, instead of just waiting for the 1 job, the test has become stable.

## Related issues

closes #3606 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
