### PR TITLE
chore(broker): donot detect streamprocessor as unhealthy when paused

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -190,7 +190,7 @@ public final class Broker implements AutoCloseable {
     startContext.addStep(
         "zeebe partitions", () -> partitionsStep(brokerCfg, clusterCfg, localBroker));
     startContext.addStep("register diskspace usage listeners", () -> addDiskSpaceUsageListeners());
-    startContext.addStep("Upgrade manager", this::addBrokerAdminService);
+    startContext.addStep("upgrade manager", this::addBrokerAdminService);
 
     return startContext;
   }

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -248,7 +248,7 @@ public final class ZeebePartition extends Actor
   }
 
   private void transitionToInactive(final CompletableActorFuture<Void> transitionComplete) {
-    zeebePartitionHealth.setHealthStatus(HealthStatus.UNHEALTHY);
+    zeebePartitionHealth.setServicesInstalled(false);
     closePartition()
         .onComplete(
             (nothing, error) -> {
@@ -752,7 +752,7 @@ public final class ZeebePartition extends Actor
   }
 
   private void onInstallFailure() {
-    zeebePartitionHealth.setHealthStatus(HealthStatus.UNHEALTHY);
+    zeebePartitionHealth.setServicesInstalled(false);
     if (atomixRaftPartition.getRole() == Role.LEADER) {
       LOG.info("Unexpected failures occurred when installing leader services, stepping down");
       atomixRaftPartition.stepDown();
@@ -760,7 +760,7 @@ public final class ZeebePartition extends Actor
   }
 
   private void onRecoveredInternal() {
-    zeebePartitionHealth.setHealthStatus(HealthStatus.HEALTHY);
+    zeebePartitionHealth.setServicesInstalled(true);
   }
 
   @Override
@@ -778,6 +778,7 @@ public final class ZeebePartition extends Actor
     actor.call(
         () -> {
           diskSpaceAvailable = false;
+          zeebePartitionHealth.setDiskSpaceAvailable(false);
           if (streamProcessor != null) {
             LOG.warn("Disk space usage is above threshold. Pausing stream processor.");
             streamProcessor.pauseProcessing();
@@ -790,6 +791,7 @@ public final class ZeebePartition extends Actor
     actor.call(
         () -> {
           diskSpaceAvailable = true;
+          zeebePartitionHealth.setDiskSpaceAvailable(false);
           if (streamProcessor != null && !isPaused()) {
             LOG.info("Disk space usage is below threshold. Resuming stream processor.");
             streamProcessor.resumeProcessing();

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -324,7 +324,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
     // If healthCheckTick was not invoked it indicates the actor is blocked in a runUntilDone loop.
     if (ActorClock.currentTimeMillis() - lastTickTime > HEALTH_CHECK_TICK_DURATION.toMillis() * 2) {
       return HealthStatus.UNHEALTHY;
-    } else if (phase == Phase.PAUSED || phase == Phase.FAILED) {
+    } else if (phase == Phase.FAILED) {
       return HealthStatus.UNHEALTHY;
     } else {
       return HealthStatus.HEALTHY;


### PR DESCRIPTION
## Description

StreamProcessor is not detected as unhealthy when it is paused. Instead ZeebePartition is detected as unhealthy when disk space is not available.

## Related issues

closes #5443

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
