### PR TITLE
Update local helm repo's on creating benchmark

### DIFF
--- a/benchmarks/setup/newBenchmark.sh
+++ b/benchmarks/setup/newBenchmark.sh
@@ -48,3 +48,5 @@ else
     sed -i -e "s/default/$namespace/g" Makefile starter.yaml timer.yaml simpleStarter.yaml worker.yaml
 fi
 
+# get latest updates from zeebe repo
+helm repo update


### PR DESCRIPTION
## Description

 We often forget to update our local help repos, this adds it to the benchmark creation script such we do it always when we create a new benchmark
<!-- Please explain the changes you made here. -->

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
