### PR TITLE
[Backport 0.24] Don't update exporter position to smaller value

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.exporter.stream;
+
+import io.zeebe.broker.Loggers;
+import io.zeebe.broker.exporter.context.ExporterContext;
+import io.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.zeebe.engine.processor.TypedRecord;
+import io.zeebe.exporter.api.Exporter;
+import io.zeebe.exporter.api.context.Context;
+import io.zeebe.exporter.api.context.Controller;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.util.sched.ActorControl;
+import java.time.Duration;
+import org.slf4j.Logger;
+
+final class ExporterContainer implements Controller {
+
+  private static final Logger LOG = Loggers.EXPORTER_LOGGER;
+
+  private static final String SKIP_POSITION_UPDATE_ERROR_MESSAGE =
+      "Failed to update exporter position when skipping filtered record, can be skipped, but may indicate an issue if it occurs often";
+
+  private final ExporterContext context;
+  private final Exporter exporter;
+  private long position;
+  private long lastUnacknowledgedPosition;
+  private ExportersState exportersState;
+  private ActorControl actor;
+
+  ExporterContainer(final ExporterDescriptor descriptor) {
+    context =
+        new ExporterContext(
+            Loggers.getExporterLogger(descriptor.getId()), descriptor.getConfiguration());
+
+    exporter = descriptor.newInstance();
+  }
+
+  void initContainer(final ActorControl actor, final ExportersState state) {
+    this.actor = actor;
+    exportersState = state;
+  }
+
+  void initPosition() {
+    position = exportersState.getPosition(getId());
+    lastUnacknowledgedPosition = position;
+    if (position == ExportersState.VALUE_NOT_FOUND) {
+      exportersState.setPosition(getId(), -1L);
+    }
+  }
+
+  void openExporter() {
+    LOG.debug("Open exporter with id '{}'", getId());
+    exporter.open(this);
+  }
+
+  public ExporterContext getContext() {
+    return context;
+  }
+
+  public Exporter getExporter() {
+    return exporter;
+  }
+
+  public long getPosition() {
+    return position;
+  }
+
+  long getLastUnacknowledgedPosition() {
+    return lastUnacknowledgedPosition;
+  }
+
+  /**
+   * Updates the exporter's position if it is up to date - that is, if it's last acknowledged
+   * position is greater than or equal to its last unacknowledged position. This is safe to do when
+   * skipping records as it means we passed no record to this exporter between both.
+   *
+   * @param eventPosition the new, up to date position
+   */
+  void updatePositionOnSkipIfUpToDate(final long eventPosition) {
+    if (position >= lastUnacknowledgedPosition && position < eventPosition) {
+      try {
+        updateExporterLastExportedRecordPosition(eventPosition);
+      } catch (final Exception e) {
+        LOG.warn(SKIP_POSITION_UPDATE_ERROR_MESSAGE, e);
+      }
+    }
+  }
+
+  private void updateExporterLastExportedRecordPosition(final long eventPosition) {
+    if (position < eventPosition) {
+      exportersState.setPosition(getId(), eventPosition);
+      position = eventPosition;
+    }
+  }
+
+  @Override
+  public void updateLastExportedRecordPosition(final long position) {
+    actor.run(() -> updateExporterLastExportedRecordPosition(position));
+  }
+
+  @Override
+  public void scheduleTask(final Duration delay, final Runnable task) {
+    actor.runDelayed(delay, task);
+  }
+
+  public String getId() {
+    return context.getConfiguration().getId();
+  }
+
+  private boolean acceptRecord(final RecordMetadata metadata) {
+    final Context.RecordFilter filter = context.getFilter();
+    return filter.acceptType(metadata.getRecordType())
+        && filter.acceptValue(metadata.getValueType());
+  }
+
+  void configureExporter() throws Exception {
+    LOG.debug("Configure exporter with id '{}'", getId());
+    exporter.configure(context);
+  }
+
+  boolean exportRecord(final RecordMetadata rawMetadata, final TypedRecord typedEvent) {
+    try {
+      if (position < typedEvent.getPosition()) {
+        if (acceptRecord(rawMetadata)) {
+          export(typedEvent);
+        } else {
+          updatePositionOnSkipIfUpToDate(typedEvent.getPosition());
+        }
+      }
+      return true;
+    } catch (final Exception ex) {
+      context.getLogger().error("Error on exporting record with key {}", typedEvent.getKey(), ex);
+      return false;
+    }
+  }
+
+  private void export(final Record<?> record) {
+    exporter.export(record);
+    lastUnacknowledgedPosition = record.getPosition();
+  }
+
+  public void close() {
+    try {
+      exporter.close();
+    } catch (final Exception e) {
+      context.getLogger().error("Error on close", e);
+    }
+  }
+}

--- a/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -71,19 +71,19 @@ public final class ExporterDirector extends Actor {
   private boolean inExportingPhase;
 
   public ExporterDirector(final ExporterDirectorContext context) {
-    this.name = context.getName();
-    this.containers =
+    name = context.getName();
+    containers =
         context.getDescriptors().stream().map(ExporterContainer::new).collect(Collectors.toList());
 
-    this.logStream = Objects.requireNonNull(context.getLogStream());
+    logStream = Objects.requireNonNull(context.getLogStream());
     final int partitionId = logStream.getPartitionId();
-    this.recordExporter = new RecordExporter(containers, partitionId);
-    this.exportingRetryStrategy = new BackOffRetryStrategy(actor, Duration.ofSeconds(10));
-    this.recordWrapStrategy = new EndlessRetryStrategy(actor);
+    recordExporter = new RecordExporter(containers, partitionId);
+    exportingRetryStrategy = new BackOffRetryStrategy(actor, Duration.ofSeconds(10));
+    recordWrapStrategy = new EndlessRetryStrategy(actor);
 
-    this.zeebeDb = context.getZeebeDb();
+    zeebeDb = context.getZeebeDb();
 
-    this.metrics = new ExporterMetrics(partitionId);
+    metrics = new ExporterMetrics(partitionId);
   }
 
   public ActorFuture<Void> startAsync(final ActorScheduler actorScheduler) {
@@ -170,7 +170,7 @@ public final class ExporterDirector extends Actor {
   }
 
   private void recoverFromSnapshot() {
-    this.state = new ExportersState(zeebeDb, zeebeDb.createContext());
+    state = new ExportersState(zeebeDb, zeebeDb.createContext());
 
     final long snapshotPosition = state.getLowestPosition();
     final boolean failedToRecoverReader = !logStreamReader.seekToNextEvent(snapshotPosition);
@@ -423,6 +423,7 @@ public final class ExporterDirector extends Actor {
   }
 
   private class ExporterContainer implements Controller {
+
     private final ExporterContext context;
     private final Exporter exporter;
     private long position;
@@ -459,7 +460,7 @@ public final class ExporterDirector extends Actor {
     }
 
     private void updateExporterLastExportedRecordPosition(final long eventPosition) {
-      state.setPosition(getId(), eventPosition);
+      state.setPositionIfGreater(getId(), eventPosition);
       position = eventPosition;
     }
 

--- a/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -8,21 +8,16 @@
 package io.zeebe.broker.exporter.stream;
 
 import io.zeebe.broker.Loggers;
-import io.zeebe.broker.exporter.context.ExporterContext;
-import io.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.zeebe.db.ZeebeDb;
 import io.zeebe.engine.processor.EventFilter;
 import io.zeebe.engine.processor.RecordValues;
 import io.zeebe.engine.processor.TypedEventImpl;
-import io.zeebe.exporter.api.Exporter;
 import io.zeebe.exporter.api.context.Context;
-import io.zeebe.exporter.api.context.Controller;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
-import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.util.LangUtil;
@@ -52,8 +47,6 @@ public final class ExporterDirector extends Actor {
       "Expected to find event with the snapshot position %s in log stream, but nothing was found. Failed to recover '%s'.";
 
   private static final Logger LOG = Loggers.EXPORTER_LOGGER;
-  private static final String SKIP_POSITION_UPDATE_ERROR_MESSAGE =
-      "Failed to update exporter position when skipping filtered record, can be skipped, but may indicate an issue if it occurs often";
   private final AtomicBoolean isOpened = new AtomicBoolean(false);
   private final List<ExporterContainer> containers;
   private final LogStream logStream;
@@ -127,8 +120,8 @@ public final class ExporterDirector extends Actor {
       recoverFromSnapshot();
 
       for (final ExporterContainer container : containers) {
-        LOG.debug("Configure exporter with id '{}'", container.getId());
-        container.exporter.configure(container.context);
+        container.initContainer(actor, state);
+        container.configureExporter();
       }
 
       eventFilter = createEventFilter(containers);
@@ -160,13 +153,7 @@ public final class ExporterDirector extends Actor {
   @Override
   protected void onActorCloseRequested() {
     isOpened.set(false);
-    for (final ExporterContainer container : containers) {
-      try {
-        container.exporter.close();
-      } catch (final Exception e) {
-        container.context.getLogger().error("Error on close", e);
-      }
-    }
+    containers.forEach(ExporterContainer::close);
   }
 
   private void recoverFromSnapshot() {
@@ -188,7 +175,7 @@ public final class ExporterDirector extends Actor {
   private ExporterEventFilter createEventFilter(final List<ExporterContainer> containers) {
 
     final List<Context.RecordFilter> recordFilters =
-        containers.stream().map(c -> c.context.getFilter()).collect(Collectors.toList());
+        containers.stream().map(c -> c.getContext().getFilter()).collect(Collectors.toList());
 
     final Map<RecordType, Boolean> acceptRecordTypes =
         Arrays.stream(RecordType.values())
@@ -220,13 +207,8 @@ public final class ExporterDirector extends Actor {
 
     // start reading
     for (final ExporterContainer container : containers) {
-      container.position = state.getPosition(container.getId());
-      container.lastUnacknowledgedPosition = container.position;
-      if (container.position == ExportersState.VALUE_NOT_FOUND) {
-        state.setPosition(container.getId(), -1L);
-      }
-      LOG.debug("Open exporter with id '{}'", container.getId());
-      container.exporter.open(container);
+      container.initPosition();
+      container.openExporter();
     }
 
     clearExporterState();
@@ -361,21 +343,9 @@ public final class ExporterDirector extends Actor {
       while (exporterIndex < exportersCount) {
         final ExporterContainer container = containers.get(exporterIndex);
 
-        try {
-          if (container.position < typedEvent.getPosition()) {
-            if (container.acceptRecord(rawMetadata)) {
-              container.export(typedEvent);
-            } else {
-              container.updatePositionOnSkipIfUpToDate(typedEvent.getPosition());
-            }
-          }
-
+        if (container.exportRecord(rawMetadata, typedEvent)) {
           exporterIndex++;
-        } catch (final Exception ex) {
-          container
-              .context
-              .getLogger()
-              .error("Error on exporting record with key {}", typedEvent.getKey(), ex);
+        } else {
           return false;
         }
       }
@@ -419,69 +389,6 @@ public final class ExporterDirector extends Actor {
           + ", acceptValueTypes="
           + acceptValueTypes
           + '}';
-    }
-  }
-
-  private class ExporterContainer implements Controller {
-
-    private final ExporterContext context;
-    private final Exporter exporter;
-    private long position;
-    private long lastUnacknowledgedPosition;
-
-    ExporterContainer(final ExporterDescriptor descriptor) {
-      context =
-          new ExporterContext(
-              Loggers.getExporterLogger(descriptor.getId()), descriptor.getConfiguration());
-
-      exporter = descriptor.newInstance();
-    }
-
-    private void export(final Record<?> record) {
-      exporter.export(record);
-      lastUnacknowledgedPosition = record.getPosition();
-    }
-
-    /**
-     * Updates the exporter's position if it is up to date - that is, if it's last acknowledged
-     * position is greater than or equal to its last unacknowledged position. This is safe to do
-     * when skipping records as it means we passed no record to this exporter between both.
-     *
-     * @param eventPosition the new, up to date position
-     */
-    private void updatePositionOnSkipIfUpToDate(final long eventPosition) {
-      if (position >= lastUnacknowledgedPosition && position < eventPosition) {
-        try {
-          updateExporterLastExportedRecordPosition(eventPosition);
-        } catch (final Exception e) {
-          LOG.warn(SKIP_POSITION_UPDATE_ERROR_MESSAGE, e);
-        }
-      }
-    }
-
-    private void updateExporterLastExportedRecordPosition(final long eventPosition) {
-      state.setPositionIfGreater(getId(), eventPosition);
-      position = eventPosition;
-    }
-
-    @Override
-    public void updateLastExportedRecordPosition(final long position) {
-      actor.run(() -> updateExporterLastExportedRecordPosition(position));
-    }
-
-    @Override
-    public void scheduleTask(final Duration delay, final Runnable task) {
-      actor.runDelayed(delay, task);
-    }
-
-    private String getId() {
-      return context.getConfiguration().getId();
-    }
-
-    private boolean acceptRecord(final RecordMetadata metadata) {
-      final Context.RecordFilter filter = context.getFilter();
-      return filter.acceptType(metadata.getRecordType())
-          && filter.acceptValue(metadata.getValueType());
     }
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/exporter/stream/ExportersState.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/stream/ExportersState.java
@@ -34,23 +34,6 @@ public final class ExportersState {
     setPosition(position);
   }
 
-  public void setPositionIfGreater(final String exporterId, final long position) {
-    this.exporterId.wrapString(exporterId);
-
-    setPositionIfGreater(position);
-  }
-
-  private void setPositionIfGreater(final long position) {
-    // not that performant then rocksdb merge but
-    // was currently simpler and easier to implement
-    // if necessary change it again to merge
-
-    final long oldPosition = getPosition();
-    if (oldPosition < position) {
-      setPosition(position);
-    }
-  }
-
   public long getPosition(final String exporterId) {
     this.exporterId.wrapString(exporterId);
     return getPosition();

--- a/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.exporter.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.zeebe.engine.processor.TypedRecord;
+import io.zeebe.engine.state.DefaultZeebeDbFactory;
+import io.zeebe.engine.state.ZbColumnFamilies;
+import io.zeebe.exporter.api.Exporter;
+import io.zeebe.exporter.api.context.Context;
+import io.zeebe.exporter.api.context.Controller;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.util.sched.Actor;
+import io.zeebe.util.sched.ActorControl;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ExporterContainerTest {
+
+  @Rule public final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
+  @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+  private TestActor testActor;
+  private ExportersState exportersState;
+  private FakeExporter exporter;
+  private ExporterContainer exporterContainer;
+
+  @Before
+  public void setup() throws IOException {
+    testActor = new TestActor();
+    actorSchedulerRule.submitActor(testActor).join();
+    final var dbFactory = DefaultZeebeDbFactory.defaultFactory(ZbColumnFamilies.class);
+    final var db = dbFactory.createDb(tempFolder.newFolder());
+    exportersState = new ExportersState(db, db.createContext());
+
+    final var exporterDescriptor =
+        new ExporterDescriptor("fakeExporter", FakeExporter.class, Map.of("key", "value"));
+    exporterContainer = new ExporterContainer(exporterDescriptor);
+    exporter = (FakeExporter) exporterContainer.getExporter();
+    exporterContainer.initContainer(testActor.getActor(), exportersState);
+  }
+
+  @Test
+  public void shouldConfigureExporter() throws Exception {
+    // given
+
+    // when
+    exporterContainer.configureExporter();
+
+    // then
+    assertThat(exporter.getContext()).isNotNull();
+    assertThat(exporter.getContext().getLogger()).isNotNull();
+    assertThat(exporter.getContext().getConfiguration()).isNotNull();
+    assertThat(exporter.getContext().getConfiguration().getId()).isEqualTo("fakeExporter");
+    assertThat(exporter.getContext().getConfiguration().getArguments())
+        .isEqualTo(Map.of("key", "value"));
+  }
+
+  @Test
+  public void shouldOpenExporter() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+
+    // when
+    exporterContainer.openExporter();
+
+    // then
+    assertThat(exporter.getController()).isNotNull();
+    assertThat(exporter.getController()).isEqualTo(exporterContainer);
+  }
+
+  @Test
+  public void shouldInitPositionToDefaultIfNotExistInState() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+
+    // when
+    exporterContainer.initPosition();
+
+    // then
+    assertThat(exporterContainer.getPosition()).isEqualTo(-1);
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(-1);
+  }
+
+  @Test
+  public void shouldInitPositionWithStateValues() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    exportersState.setPosition("fakeExporter", 0xCAFE);
+
+    // when
+    exporterContainer.initPosition();
+
+    // then
+    assertThat(exporterContainer.getPosition()).isEqualTo(0xCAFE);
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(0xCAFE);
+  }
+
+  @Test
+  public void shouldNotExportWhenRecordPositionIsSmaller() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    exportersState.setPosition("fakeExporter", 0xCAFE);
+    exporterContainer.initPosition();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata();
+
+    // when
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // then
+    assertThat(exporter.getRecord()).isNull();
+  }
+
+  @Test
+  public void shouldUpdateUnacknowledgedPositionOnExport() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    exportersState.setPosition("fakeExporter", 0);
+    exporterContainer.initPosition();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata();
+
+    // when
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // then
+    assertThat(exporter.getRecord()).isNotNull();
+    assertThat(exporter.getRecord()).isEqualTo(mockedRecord);
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldUpdateUnacknowledgedPositionMultipleTimes() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    exportersState.setPosition("fakeExporter", 0);
+    exporterContainer.initPosition();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata();
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // when
+    final var secondRecord = mock(TypedRecord.class);
+    when(secondRecord.getPosition()).thenReturn(2L);
+    exporterContainer.exportRecord(recordMetadata, secondRecord);
+
+    // then
+    assertThat(exporter.getRecord()).isNotNull();
+    assertThat(exporter.getRecord()).isEqualTo(secondRecord);
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(2);
+    assertThat(exporterContainer.getPosition()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldUpdateExporterPosition() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    exportersState.setPosition("fakeExporter", 0);
+    exporterContainer.initPosition();
+    exporterContainer.openExporter();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata();
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // when
+    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+    testActor.awaitPreviousCall();
+
+    // then
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isEqualTo(1);
+    assertThat(exportersState.getPosition("fakeExporter")).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldNotUpdateExporterPositionToSmallerValue() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    exportersState.setPosition("fakeExporter", 0);
+    exporterContainer.initPosition();
+    exporterContainer.openExporter();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata();
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // when
+    exporterContainer.updateLastExportedRecordPosition(-1);
+    testActor.awaitPreviousCall();
+
+    // then
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isEqualTo(0);
+    assertThat(exportersState.getPosition("fakeExporter")).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldNotUpdateExporterPositionInDifferentOrder() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    exportersState.setPosition("fakeExporter", 0);
+    exporterContainer.initPosition();
+    exporterContainer.openExporter();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata();
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+    when(mockedRecord.getPosition()).thenReturn(2L);
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // when
+    exporterContainer.updateLastExportedRecordPosition(2);
+    exporterContainer.updateLastExportedRecordPosition(1);
+    testActor.awaitPreviousCall();
+
+    // then
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(2);
+    assertThat(exporterContainer.getPosition()).isEqualTo(2);
+    assertThat(exportersState.getPosition("fakeExporter")).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldUpdatePositionsWhenRecordIsFiltered() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    exporter.getContext().setFilter(new AlwaysRejectingFilter());
+    exportersState.setPosition("fakeExporter", 0);
+    exporterContainer.initPosition();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata();
+
+    // when
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // then
+    assertThat(exporter.getRecord()).isNull();
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(0);
+    assertThat(exporterContainer.getPosition()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldUpdatePositionsWhenRecordIsFilteredAndPositionsAreEqual() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    exportersState.setPosition("fakeExporter", 0);
+    exporterContainer.initPosition();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata();
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+    testActor.awaitPreviousCall();
+
+    // when
+    exporter.getContext().setFilter(new AlwaysRejectingFilter());
+    when(mockedRecord.getPosition()).thenReturn(2L);
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // then
+    assertThat(exporter.getRecord()).isNotNull();
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldNotUpdatePositionsWhenRecordIsFilteredAndLastEventWasUnacknowledged()
+      throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    exportersState.setPosition("fakeExporter", 0);
+    exporterContainer.initPosition();
+
+    final var firstRecord = mock(TypedRecord.class);
+    when(firstRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata();
+    exporterContainer.exportRecord(recordMetadata, firstRecord);
+
+    // when
+    final var secondRecord = mock(TypedRecord.class);
+    when(secondRecord.getPosition()).thenReturn(2L);
+    exporter.getContext().setFilter(new AlwaysRejectingFilter());
+    exporterContainer.exportRecord(recordMetadata, secondRecord);
+
+    // then
+    assertThat(exporter.getRecord()).isNotNull();
+    assertThat(exporter.getRecord()).isEqualTo(firstRecord);
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldCloseExporter() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    exportersState.setPosition("fakeExporter", 0);
+    exporterContainer.initPosition();
+
+    // when
+    exporterContainer.close();
+
+    // then
+    assertThat(exporter.isClosed()).isTrue();
+  }
+
+  private static final class AlwaysRejectingFilter implements Context.RecordFilter {
+
+    @Override
+    public boolean acceptType(final RecordType recordType) {
+      return false;
+    }
+
+    @Override
+    public boolean acceptValue(final ValueType valueType) {
+      return false;
+    }
+  }
+
+  private static final class TestActor extends Actor {
+
+    public ActorControl getActor() {
+      return actor;
+    }
+
+    public void awaitPreviousCall() {
+      // call is enqueued in queue and will be run after the previous call
+      // when we await the call we can be sure that the previous call is also done
+      actor.call(() -> null).join();
+    }
+  }
+
+  public static final class FakeExporter implements Exporter {
+
+    private Context context;
+    private Controller controller;
+    private Record<?> record;
+    private boolean closed;
+
+    public Context getContext() {
+      return context;
+    }
+
+    public Controller getController() {
+      return controller;
+    }
+
+    public Record<?> getRecord() {
+      return record;
+    }
+
+    public boolean isClosed() {
+      return closed;
+    }
+
+    @Override
+    public void configure(final Context context) {
+      this.context = context;
+    }
+
+    @Override
+    public void open(final Controller controller) {
+      this.controller = controller;
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+
+    @Override
+    public void export(final Record record) {
+      this.record = record;
+    }
+  }
+}

--- a/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -417,6 +417,27 @@ public final class ExporterDirectorTest {
   }
 
   @Test
+  public void shouldNotUpdatePositionToSmallerValue() throws Exception {
+    // given
+    final CountDownLatch latch = new CountDownLatch(1);
+    final var controlledTestExporter = exporters.get(0);
+    controlledTestExporter.onOpen(c -> latch.countDown());
+    startExporterDirector(exporterDescriptors);
+    latch.await();
+    exporters.get(0).getController().updateLastExportedRecordPosition(1);
+    final var firstPosition =
+        Awaitility.await()
+            .until(() -> rule.getExportersState().getPosition("exporter-1"), (pos) -> pos > -1);
+
+    // when
+    exporters.get(0).getController().updateLastExportedRecordPosition(-1);
+
+    // then
+    final var secondPosition = rule.getExportersState().getPosition("exporter-1");
+    assertThat(secondPosition).isEqualTo(firstPosition);
+  }
+
+  @Test
   public void shouldUpdateLastExportedPositionOnClose() throws Exception {
     // given
     startExporterDirector(exporterDescriptors);

--- a/broker/src/test/java/io/zeebe/broker/exporter/stream/ExportersStateTest.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/stream/ExportersStateTest.java
@@ -89,47 +89,6 @@ public final class ExportersStateTest {
   }
 
   @Test
-  public void shouldSetPositionSinceSomethingIsGreaterThanNothing() {
-    // given
-    final String id = "exporter";
-    final long position = 12312;
-
-    // when
-    state.setPositionIfGreater(id, position);
-
-    // then
-    assertThat(state.getPosition(id)).isEqualTo(position);
-  }
-
-  @Test
-  public void shouldNotSetPositionIfLowerThanExisting() {
-    // given
-    final String id = "exporter";
-    final long position = 12313;
-
-    // when
-    state.setPosition(id, position);
-    state.setPositionIfGreater(id, position - 1);
-
-    // then
-    assertThat(state.getPosition(id)).isEqualTo(position);
-  }
-
-  @Test
-  public void shouldSetPositionIfGreaterThanExisting() {
-    // given
-    final String id = "exporter";
-    final long position = 123;
-
-    // when
-    state.setPosition(id, position - 1);
-    state.setPositionIfGreater(id, position);
-
-    // then
-    assertThat(state.getPosition(id)).isEqualTo(position);
-  }
-
-  @Test
   public void shouldRemovePosition() {
     // given
     state.setPosition("e1", 1L);


### PR DESCRIPTION
## Description

Backports https://github.com/zeebe-io/zeebe/pull/5462
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5294 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
