### PR TITLE
fix(broker): Log Invalid Static Config When Detected

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
@@ -189,9 +189,22 @@ public final class TopologyManagerImpl extends Actor
     final BrokerInfo brokerInfo = BrokerInfo.fromProperties(eventSource.properties());
     if (brokerInfo != null && !isStaticConfigValid(brokerInfo)) {
       LOG.error(
-          "Static configuration of node {} differs from local node {}",
+          "Static configuration of node {} differs from local node {}: "
+              + "NodeId: 0 <= {} < {}, "
+              + "ClusterSize: {} == {}, "
+              + "PartitionsCount: {} == {}, "
+              + "ReplicationFactor: {} == {}.",
           eventSource.id(),
-          atomix.getMembershipService().getLocalMember().id());
+          atomix.getMembershipService().getLocalMember().id(),
+          brokerInfo.getNodeId(),
+          localBroker.getClusterSize(),
+          brokerInfo.getClusterSize(),
+          localBroker.getClusterSize(),
+          brokerInfo.getPartitionsCount(),
+          localBroker.getPartitionsCount(),
+          brokerInfo.getReplicationFactor(),
+          localBroker.getReplicationFactor());
+
       return null;
     }
     return brokerInfo;


### PR DESCRIPTION
## Description

This change is to log the differences for the static
configuration and local configuration. Only the
values checked in isStaticConfigValid are logged.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5394

## Definition of Done


Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
