### PR TITLE
[Backport 0.24] Fix flaky CancelWorkflowInstanceConcurrentlyTest again

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/CancelWorkflowInstanceConcurrentlyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processor/workflow/instance/CancelWorkflowInstanceConcurrentlyTest.java
@@ -106,6 +106,9 @@ public final class CancelWorkflowInstanceConcurrentlyTest {
   public BpmnModelInstance workflow;
 
   @Parameter(2)
+  public int expectedActivatableJobs;
+
+  @Parameter(3)
   public List<String> expectedTerminatedElementIds;
 
   private long workflowInstanceKey;
@@ -115,10 +118,10 @@ public final class CancelWorkflowInstanceConcurrentlyTest {
   @Parameters(name = "{0}")
   public static Object[][] parameters() {
     return new Object[][] {
-      {"sequential flow", SEQUENTIAL_FLOW, Arrays.asList(PROCESS_ID)},
-      {"parallel flow", PARALLEL_FLOW, Arrays.asList("parallel-task", PROCESS_ID)},
-      {"sub-process", SUB_PROCESS, Arrays.asList("parallel-task", "sub-process", PROCESS_ID)},
-      {"multi-instance", MULTI_INSTANCE, Arrays.asList(ELEMENT_ID, ELEMENT_ID, PROCESS_ID)},
+      {"sequential flow", SEQUENTIAL_FLOW, 1, Arrays.asList(PROCESS_ID)},
+      {"parallel flow", PARALLEL_FLOW, 2, Arrays.asList("parallel-task", PROCESS_ID)},
+      {"sub-process", SUB_PROCESS, 2, Arrays.asList("parallel-task", "sub-process", PROCESS_ID)},
+      {"multi-instance", MULTI_INSTANCE, 2, Arrays.asList(ELEMENT_ID, ELEMENT_ID, PROCESS_ID)},
     };
   }
 
@@ -141,10 +144,16 @@ public final class CancelWorkflowInstanceConcurrentlyTest {
             .withElementType(BpmnElementType.SERVICE_TASK)
             .getFirst();
 
+    // wait for all jobs to appear
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .limit(expectedActivatableJobs))
+        .hasSize(expectedActivatableJobs);
+
     createdJob =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withWorkflowInstanceKey(workflowInstanceKey)
-            .limit(2)
             .withType(JOB_TYPE)
             .getFirst();
 


### PR DESCRIPTION
## Description

The test has multiple scenarios, and the sequential scenario actually
only expects 1 job to become activatable.

In addition, in the scenarios where we expect 2 jobs to become
activatable, it was not enough to just limit the stream to 2 when only
grabbing one specific one. This because it might not be clear which job
is created first. Therefore, the tests should always first assert that
all expected jobs have been created and then continue.

## Related issues

backports #5550 
closes #3606 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
