### PR TITLE
chore(atomix): expose internal raft configs

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -230,18 +230,10 @@ public interface RaftServer {
    */
   void removeRoleChangeListener(RaftRoleChangeListener listener);
 
-  /**
-   * Adds a failure listener
-   *
-   * @param failureListener
-   */
+  /** Adds a failure listener */
   void addFailureListener(Runnable failureListener);
 
-  /**
-   * Removes a failure listener
-   *
-   * @param failureListener
-   */
+  /** Removes a failure listener */
   void removeFailureListener(Runnable failureListener);
 
   /**
@@ -576,6 +568,8 @@ public interface RaftServer {
     protected ThreadContextFactory threadContextFactory;
     protected Supplier<JournalIndex> journalIndexFactory;
     protected EntryValidator entryValidator = new NoopEntryValidator();
+    protected int maxAppendsPerFollower = 2;
+    protected int maxAppendBatchSize = 32 * 1024;
 
     protected Builder(final MemberId localMemberId) {
       this.localMemberId = checkNotNull(localMemberId, "localMemberId cannot be null");
@@ -688,6 +682,30 @@ public interface RaftServer {
     public Builder withThreadPoolSize(final int threadPoolSize) {
       checkArgument(threadPoolSize > 0, "threadPoolSize must be positive");
       this.threadPoolSize = threadPoolSize;
+      return this;
+    }
+
+    /**
+     * Sets the maximum append requests which are sent per follower at once. Default is 2.
+     *
+     * @param maxAppendsPerFollower the maximum appends send per follower
+     * @return The server builder.
+     */
+    public Builder withMaxAppendsPerFollower(final int maxAppendsPerFollower) {
+      checkArgument(maxAppendsPerFollower > 0, "maxAppendsPerFollower must be positive");
+      this.maxAppendsPerFollower = maxAppendsPerFollower;
+      return this;
+    }
+
+    /**
+     * Sets the maximum batch size, which is sent per append request. Default size is 32 KB.
+     *
+     * @param maxAppendBatchSize the maximum batch size per append
+     * @return The server builder.
+     */
+    public Builder withMaxAppendBatchSize(final int maxAppendBatchSize) {
+      checkArgument(maxAppendBatchSize > 0, "maxAppendBatchSize must be positive");
+      this.maxAppendBatchSize = maxAppendBatchSize;
       return this;
     }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -315,7 +315,9 @@ public class DefaultRaftServer implements RaftServer {
               protocol,
               storage,
               threadContextFactory,
-              closeOnStop);
+              closeOnStop,
+              maxAppendBatchSize,
+              maxAppendsPerFollower);
       raft.setElectionTimeout(electionTimeout);
       raft.setHeartbeatInterval(heartbeatInterval);
       raft.setEntryValidator(entryValidator);

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -17,6 +17,7 @@
 package io.atomix.raft.partition;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.Lists;
@@ -372,6 +373,30 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
      */
     public Builder withHeartbeatInterval(final Duration heartbeatInterval) {
       config.setHeartbeatInterval(heartbeatInterval);
+      return this;
+    }
+
+    /**
+     * Sets the maximum append requests which are sent per follower at once. Default is 2.
+     *
+     * @param maxAppendsPerFollower the maximum appends send per follower
+     * @return the Raft partition group builder
+     */
+    public Builder withMaxAppendsPerFollower(final int maxAppendsPerFollower) {
+      checkArgument(maxAppendsPerFollower > 0, "maxAppendsPerFollower must be positive");
+      config.setMaxAppendsPerFollower(maxAppendsPerFollower);
+      return this;
+    }
+
+    /**
+     * Sets the maximum batch size, which is sent per append request. Default size is 32 KB.
+     *
+     * @param maxAppendBatchSize the maximum batch size per append
+     * @return the Raft partition group builder
+     */
+    public Builder withMaxAppendBatchSize(final int maxAppendBatchSize) {
+      checkArgument(maxAppendBatchSize > 0, "maxAppendBatchSize must be positive");
+      config.setMaxAppendBatchSize(maxAppendBatchSize);
       return this;
     }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroupConfig.java
@@ -37,6 +37,8 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
   private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
   private RaftStorageConfig storageConfig = new RaftStorageConfig();
+  private int maxAppendsPerFollower = 2;
+  private int maxAppendBatchSize = 32 * 1024;
 
   @Optional("EntryValidator")
   private EntryValidator entryValidator = new NoopEntryValidator();
@@ -164,6 +166,22 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   public RaftPartitionGroupConfig setEntryValidator(final EntryValidator entryValidator) {
     this.entryValidator = entryValidator;
     return this;
+  }
+
+  public int getMaxAppendsPerFollower() {
+    return maxAppendsPerFollower;
+  }
+
+  public void setMaxAppendsPerFollower(final int maxAppendsPerFollower) {
+    this.maxAppendsPerFollower = maxAppendsPerFollower;
+  }
+
+  public int getMaxAppendBatchSize() {
+    return maxAppendBatchSize;
+  }
+
+  public void setMaxAppendBatchSize(final int maxAppendBatchSize) {
+    this.maxAppendBatchSize = maxAppendBatchSize;
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -177,6 +177,8 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
         .withProtocol(createServerProtocol())
         .withHeartbeatInterval(config.getHeartbeatInterval())
         .withElectionTimeout(config.getElectionTimeout())
+        .withMaxAppendBatchSize(config.getMaxAppendBatchSize())
+        .withMaxAppendsPerFollower(config.getMaxAppendsPerFollower())
         .withStorage(createRaftStorage())
         .withThreadContextFactory(threadContextFactory)
         .withJournalIndexFactory(journalIndexFactory)

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractAppender.java
@@ -51,7 +51,7 @@ import org.slf4j.Logger;
 /** Abstract appender. */
 abstract class AbstractAppender implements AutoCloseable {
 
-  private static final int MAX_BATCH_SIZE = 1024 * 32;
+  protected final int maxBatchSizePerAppend;
   protected final Logger log;
   protected final RaftContext raft;
   protected boolean open = true;
@@ -64,6 +64,7 @@ abstract class AbstractAppender implements AutoCloseable {
         ContextualLoggerFactory.getLogger(
             getClass(), LoggerContext.builder(RaftServer.class).addValue(raft.getName()).build());
     metrics = new LeaderMetrics(raft.getName());
+    maxBatchSizePerAppend = raft.getMaxAppendBatchSize();
   }
 
   /**
@@ -160,7 +161,7 @@ abstract class AbstractAppender implements AutoCloseable {
       final Indexed<RaftLogEntry> entry = reader.next();
       entries.add(entry.entry());
       size += entry.size();
-      if (entry.index() == lastIndex || size >= MAX_BATCH_SIZE) {
+      if (entry.index() == lastIndex || size >= maxBatchSizePerAppend) {
         break;
       }
     }

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -34,6 +34,7 @@ import org.agrona.IoUtil;
 import org.slf4j.Logger;
 
 public final class AtomixFactory {
+
   public static final String GROUP_NAME = "raft-partition";
 
   private static final Logger LOG = Loggers.CLUSTERING_LOGGER;
@@ -105,6 +106,8 @@ public final class AtomixFactory {
             .withMembers(getRaftGroupMembers(clusterCfg))
             .withDataDirectory(raftDirectory)
             .withSnapshotStoreFactory(snapshotStoreFactory)
+            .withMaxAppendBatchSize((int) clusterCfg.getMaxAppendBatchSizeInBytes())
+            .withMaxAppendsPerFollower(clusterCfg.getMaxAppendsPerFollower())
             .withStorageLevel(dataCfg.getAtomixStorageLevel())
             .withEntryValidator(new ZeebeEntryValidator())
             .withFlushOnCommit()

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -96,6 +96,7 @@ public final class AtomixFactory {
     IoUtil.ensureDirectoryExists(raftDirectory, "Raft data directory");
 
     final ClusterCfg clusterCfg = configuration.getCluster();
+    final var experimentalCfg = configuration.getExperimental();
     final DataCfg dataCfg = configuration.getData();
     final NetworkCfg networkCfg = configuration.getNetwork();
 
@@ -106,8 +107,8 @@ public final class AtomixFactory {
             .withMembers(getRaftGroupMembers(clusterCfg))
             .withDataDirectory(raftDirectory)
             .withSnapshotStoreFactory(snapshotStoreFactory)
-            .withMaxAppendBatchSize((int) clusterCfg.getMaxAppendBatchSizeInBytes())
-            .withMaxAppendsPerFollower(clusterCfg.getMaxAppendsPerFollower())
+            .withMaxAppendBatchSize((int) experimentalCfg.getMaxAppendBatchSizeInBytes())
+            .withMaxAppendsPerFollower(experimentalCfg.getMaxAppendsPerFollower())
             .withStorageLevel(dataCfg.getAtomixStorageLevel())
             .withEntryValidator(new ZeebeEntryValidator())
             .withFlushOnCommit()

--- a/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -67,6 +67,7 @@ public final class SystemContext {
   private void validateConfiguration() {
     final ClusterCfg cluster = brokerCfg.getCluster();
     final DataCfg data = brokerCfg.getData();
+    final var experimental = brokerCfg.getExperimental();
 
     final int partitionCount = cluster.getPartitionsCount();
     if (partitionCount < 1) {
@@ -79,7 +80,7 @@ public final class SystemContext {
       throw new IllegalArgumentException(String.format(NODE_ID_ERROR_MSG, nodeId, clusterSize));
     }
 
-    final var maxAppendBatchSize = cluster.getMaxAppendBatchSize();
+    final var maxAppendBatchSize = experimental.getMaxAppendBatchSize();
     if (maxAppendBatchSize.isNegative() || maxAppendBatchSize.toBytes() >= Integer.MAX_VALUE) {
       throw new IllegalArgumentException(
           String.format(MAX_BATCH_SIZE_ERROR_MSG, Integer.MAX_VALUE, maxAppendBatchSize));

--- a/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -34,6 +34,9 @@ public final class SystemContext {
       "Snapshot period %s needs to be larger then or equals to one minute.";
   private static final String MMAP_REPLICATION_ERROR_MSG =
       "Using memory mapped storage level is currently unsafe with replication enabled; if you wish to use replication, set useMmap flag to false (e.g. ZEEBE_BROKER_DATA_USEMMAP=false)";
+  private static final String MAX_BATCH_SIZE_ERROR_MSG =
+      "Expected to have an append batch size maximum which is non negative and smaller then Integer.MAX_VALUE, but was '%s'.";
+
   protected final BrokerCfg brokerCfg;
   private Map<String, String> diagnosticContext;
   private ActorScheduler scheduler;
@@ -74,6 +77,12 @@ public final class SystemContext {
     final int nodeId = cluster.getNodeId();
     if (nodeId < 0 || nodeId >= clusterSize) {
       throw new IllegalArgumentException(String.format(NODE_ID_ERROR_MSG, nodeId, clusterSize));
+    }
+
+    final var maxAppendBatchSize = cluster.getMaxAppendBatchSize();
+    if (maxAppendBatchSize.isNegative() || maxAppendBatchSize.toBytes() >= Integer.MAX_VALUE) {
+      throw new IllegalArgumentException(
+          String.format(MAX_BATCH_SIZE_ERROR_MSG, maxAppendBatchSize));
     }
 
     final StorageLevel storageLevel = data.getAtomixStorageLevel();

--- a/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -35,7 +35,7 @@ public final class SystemContext {
   private static final String MMAP_REPLICATION_ERROR_MSG =
       "Using memory mapped storage level is currently unsafe with replication enabled; if you wish to use replication, set useMmap flag to false (e.g. ZEEBE_BROKER_DATA_USEMMAP=false)";
   private static final String MAX_BATCH_SIZE_ERROR_MSG =
-      "Expected to have an append batch size maximum which is non negative and smaller then Integer.MAX_VALUE, but was '%s'.";
+      "Expected to have an append batch size maximum which is non negative and smaller then '%d', but was '%s'.";
 
   protected final BrokerCfg brokerCfg;
   private Map<String, String> diagnosticContext;
@@ -82,7 +82,7 @@ public final class SystemContext {
     final var maxAppendBatchSize = cluster.getMaxAppendBatchSize();
     if (maxAppendBatchSize.isNegative() || maxAppendBatchSize.toBytes() >= Integer.MAX_VALUE) {
       throw new IllegalArgumentException(
-          String.format(MAX_BATCH_SIZE_ERROR_MSG, maxAppendBatchSize));
+          String.format(MAX_BATCH_SIZE_ERROR_MSG, Integer.MAX_VALUE, maxAppendBatchSize));
     }
 
     final StorageLevel storageLevel = data.getAtomixStorageLevel();

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
@@ -34,6 +34,7 @@ public final class BrokerCfg {
   private Map<String, ExporterCfg> exporters = new HashMap<>();
   private EmbeddedGatewayCfg gateway = new EmbeddedGatewayCfg();
   private BackpressureCfg backpressure = new BackpressureCfg();
+  private ExperimentalCfg experimental = new ExperimentalCfg();
 
   private Duration stepTimeout = Duration.ofMinutes(5);
   private boolean executionMetricsExporterEnabled;
@@ -142,6 +143,14 @@ public final class BrokerCfg {
     this.executionMetricsExporterEnabled = executionMetricsExporterEnabled;
   }
 
+  public ExperimentalCfg getExperimental() {
+    return experimental;
+  }
+
+  public void setExperimental(final ExperimentalCfg experimental) {
+    this.experimental = experimental;
+  }
+
   @Override
   public String toString() {
     return "BrokerCfg{"
@@ -159,9 +168,11 @@ public final class BrokerCfg {
         + gateway
         + ", backpressure="
         + backpressure
+        + ", experimental="
+        + experimental
         + ", stepTimeout="
         + stepTimeout
-        + ", executionMetricsExporter="
+        + ", executionMetricsExporterEnabled="
         + executionMetricsExporterEnabled
         + '}';
   }

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/ClusterCfg.java
@@ -12,9 +12,8 @@ import static io.zeebe.util.StringUtil.LIST_SANITIZER;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-import org.agrona.collections.IntArrayList;
-import org.springframework.util.unit.DataSize;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public final class ClusterCfg implements ConfigurationEntry {
 
@@ -24,8 +23,6 @@ public final class ClusterCfg implements ConfigurationEntry {
   public static final int DEFAULT_REPLICATION_FACTOR = 1;
   public static final int DEFAULT_CLUSTER_SIZE = 1;
   public static final String DEFAULT_CLUSTER_NAME = "zeebe-cluster";
-  public static final int DEFAULT_MAX_APPENDS_PER_FOLLOWER = 2;
-  public static final DataSize DEFAULT_MAX_APPEND_BATCH_SIZE = DataSize.ofKilobytes(32);
 
   private List<String> initialContactPoints = DEFAULT_CONTACT_POINTS;
 
@@ -36,8 +33,6 @@ public final class ClusterCfg implements ConfigurationEntry {
   private int clusterSize = DEFAULT_CLUSTER_SIZE;
   private String clusterName = DEFAULT_CLUSTER_NAME;
   private MembershipCfg membership = new MembershipCfg();
-  private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
-  private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -45,13 +40,10 @@ public final class ClusterCfg implements ConfigurationEntry {
   }
 
   private void initPartitionIds() {
-    final IntArrayList list = new IntArrayList();
-    for (int i = START_PARTITION_ID; i < START_PARTITION_ID + partitionsCount; i++) {
-      final int partitionId = i;
-      list.add(partitionId);
-    }
-
-    partitionIds = Collections.unmodifiableList(list);
+    partitionIds =
+        IntStream.range(START_PARTITION_ID, START_PARTITION_ID + partitionsCount)
+            .boxed()
+            .collect(Collectors.toList());
   }
 
   public List<String> getInitialContactPoints() {
@@ -114,26 +106,6 @@ public final class ClusterCfg implements ConfigurationEntry {
     this.membership = membership;
   }
 
-  public int getMaxAppendsPerFollower() {
-    return maxAppendsPerFollower;
-  }
-
-  public void setMaxAppendsPerFollower(final int maxAppendsPerFollower) {
-    this.maxAppendsPerFollower = maxAppendsPerFollower;
-  }
-
-  public DataSize getMaxAppendBatchSize() {
-    return maxAppendBatchSize;
-  }
-
-  public long getMaxAppendBatchSizeInBytes() {
-    return Optional.ofNullable(maxAppendBatchSize).orElse(DEFAULT_MAX_APPEND_BATCH_SIZE).toBytes();
-  }
-
-  public void setMaxAppendBatchSize(final DataSize maxAppendBatchSize) {
-    this.maxAppendBatchSize = maxAppendBatchSize;
-  }
-
   @Override
   public String toString() {
     return "ClusterCfg{"
@@ -154,10 +126,6 @@ public final class ClusterCfg implements ConfigurationEntry {
         + '\''
         + ", membership="
         + membership
-        + ", maxAppendsPerFollower="
-        + maxAppendsPerFollower
-        + ", maxAppendBatchSize="
-        + maxAppendBatchSize
         + '}';
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/ClusterCfg.java
@@ -12,15 +12,20 @@ import static io.zeebe.util.StringUtil.LIST_SANITIZER;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.agrona.collections.IntArrayList;
+import org.springframework.util.unit.DataSize;
 
 public final class ClusterCfg implements ConfigurationEntry {
+
   public static final List<String> DEFAULT_CONTACT_POINTS = Collections.emptyList();
   public static final int DEFAULT_NODE_ID = 0;
   public static final int DEFAULT_PARTITIONS_COUNT = 1;
   public static final int DEFAULT_REPLICATION_FACTOR = 1;
   public static final int DEFAULT_CLUSTER_SIZE = 1;
   public static final String DEFAULT_CLUSTER_NAME = "zeebe-cluster";
+  public static final int DEFAULT_MAX_APPENDS_PER_FOLLOWER = 2;
+  public static final DataSize DEFAULT_MAX_APPEND_BATCH_SIZE = DataSize.ofKilobytes(32);
 
   private List<String> initialContactPoints = DEFAULT_CONTACT_POINTS;
 
@@ -31,6 +36,8 @@ public final class ClusterCfg implements ConfigurationEntry {
   private int clusterSize = DEFAULT_CLUSTER_SIZE;
   private String clusterName = DEFAULT_CLUSTER_NAME;
   private MembershipCfg membership = new MembershipCfg();
+  private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
+  private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -107,11 +114,34 @@ public final class ClusterCfg implements ConfigurationEntry {
     this.membership = membership;
   }
 
+  public int getMaxAppendsPerFollower() {
+    return maxAppendsPerFollower;
+  }
+
+  public void setMaxAppendsPerFollower(final int maxAppendsPerFollower) {
+    this.maxAppendsPerFollower = maxAppendsPerFollower;
+  }
+
+  public DataSize getMaxAppendBatchSize() {
+    return maxAppendBatchSize;
+  }
+
+  public long getMaxAppendBatchSizeInBytes() {
+    return Optional.ofNullable(maxAppendBatchSize).orElse(DEFAULT_MAX_APPEND_BATCH_SIZE).toBytes();
+  }
+
+  public void setMaxAppendBatchSize(final DataSize maxAppendBatchSize) {
+    this.maxAppendBatchSize = maxAppendBatchSize;
+  }
+
   @Override
   public String toString() {
-
     return "ClusterCfg{"
-        + "nodeId="
+        + "initialContactPoints="
+        + initialContactPoints
+        + ", partitionIds="
+        + partitionIds
+        + ", nodeId="
         + nodeId
         + ", partitionsCount="
         + partitionsCount
@@ -119,8 +149,15 @@ public final class ClusterCfg implements ConfigurationEntry {
         + replicationFactor
         + ", clusterSize="
         + clusterSize
-        + ", initialContactPoints="
-        + initialContactPoints
+        + ", clusterName='"
+        + clusterName
+        + '\''
+        + ", membership="
+        + membership
+        + ", maxAppendsPerFollower="
+        + maxAppendsPerFollower
+        + ", maxAppendBatchSize="
+        + maxAppendBatchSize
         + '}';
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.configuration;
+
+import java.util.Optional;
+import org.springframework.util.unit.DataSize;
+
+/**
+ * Be aware that all configuration which are part of this class are experimental, which means they
+ * are subject to change and to drop. It might be that also some of them are actually dangerous so
+ * be aware when you change one of these!
+ */
+public class ExperimentalCfg {
+
+  public static final int DEFAULT_MAX_APPENDS_PER_FOLLOWER = 2;
+  public static final DataSize DEFAULT_MAX_APPEND_BATCH_SIZE = DataSize.ofKilobytes(32);
+
+  private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
+  private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;
+
+  public int getMaxAppendsPerFollower() {
+    return maxAppendsPerFollower;
+  }
+
+  public void setMaxAppendsPerFollower(final int maxAppendsPerFollower) {
+    this.maxAppendsPerFollower = maxAppendsPerFollower;
+  }
+
+  public DataSize getMaxAppendBatchSize() {
+    return maxAppendBatchSize;
+  }
+
+  public long getMaxAppendBatchSizeInBytes() {
+    return Optional.ofNullable(maxAppendBatchSize).orElse(DEFAULT_MAX_APPEND_BATCH_SIZE).toBytes();
+  }
+
+  public void setMaxAppendBatchSize(final DataSize maxAppendBatchSize) {
+    this.maxAppendBatchSize = maxAppendBatchSize;
+  }
+
+  @Override
+  public String toString() {
+    return "ExperimentalCfg{"
+        + "maxAppendsPerFollower="
+        + maxAppendsPerFollower
+        + ", maxAppendBatchSize="
+        + maxAppendBatchSize
+        + '}';
+  }
+}

--- a/broker/src/test/java/io/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/SystemContextTest.java
@@ -123,7 +123,7 @@ public final class SystemContextTest {
   public void shouldThrowExceptionIfBatchSizeIsNegative() {
     // given
     final BrokerCfg brokerCfg = new BrokerCfg();
-    brokerCfg.getCluster().setMaxAppendBatchSize(DataSize.of(-1, DataUnit.BYTES));
+    brokerCfg.getExperimental().setMaxAppendBatchSize(DataSize.of(-1, DataUnit.BYTES));
 
     // expect
     expectedException.expect(IllegalArgumentException.class);
@@ -137,7 +137,7 @@ public final class SystemContextTest {
   public void shouldThrowExceptionIfBatchSizeIsTooLarge() {
     // given
     final BrokerCfg brokerCfg = new BrokerCfg();
-    brokerCfg.getCluster().setMaxAppendBatchSize(DataSize.of(3, DataUnit.GIGABYTES));
+    brokerCfg.getExperimental().setMaxAppendBatchSize(DataSize.of(3, DataUnit.GIGABYTES));
 
     // expect
     expectedException.expect(IllegalArgumentException.class);

--- a/broker/src/test/java/io/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/SystemContextTest.java
@@ -15,6 +15,8 @@ import java.time.Duration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.util.unit.DataSize;
+import org.springframework.util.unit.DataUnit;
 
 public final class SystemContextTest {
 
@@ -113,6 +115,34 @@ public final class SystemContextTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage(
         "Snapshot period PT1S needs to be larger then or equals to one minute.");
+
+    initSystemContext(brokerCfg);
+  }
+
+  @Test
+  public void shouldThrowExceptionIfBatchSizeIsNegative() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().setMaxAppendBatchSize(DataSize.of(-1, DataUnit.BYTES));
+
+    // expect
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(
+        "Expected to have an append batch size maximum which is non negative and smaller then Integer.MAX_VALUE, but was '-1B'.");
+
+    initSystemContext(brokerCfg);
+  }
+
+  @Test
+  public void shouldThrowExceptionIfBatchSizeIsTooLarge() {
+    // given
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().setMaxAppendBatchSize(DataSize.of(3, DataUnit.GIGABYTES));
+
+    // expect
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(
+        "Expected to have an append batch size maximum which is non negative and smaller then Integer.MAX_VALUE, but was '3221225472B'.");
 
     initSystemContext(brokerCfg);
   }

--- a/broker/src/test/java/io/zeebe/broker/system/SystemContextTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/SystemContextTest.java
@@ -128,7 +128,7 @@ public final class SystemContextTest {
     // expect
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage(
-        "Expected to have an append batch size maximum which is non negative and smaller then Integer.MAX_VALUE, but was '-1B'.");
+        "Expected to have an append batch size maximum which is non negative and smaller then '2147483647', but was '-1B'.");
 
     initSystemContext(brokerCfg);
   }
@@ -142,7 +142,7 @@ public final class SystemContextTest {
     // expect
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage(
-        "Expected to have an append batch size maximum which is non negative and smaller then Integer.MAX_VALUE, but was '3221225472B'.");
+        "Expected to have an append batch size maximum which is non negative and smaller then '2147483647', but was '3221225472B'.");
 
     initSystemContext(brokerCfg);
   }

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -57,9 +57,9 @@ public final class BrokerCfgTest {
   private static final String ZEEBE_BROKER_CLUSTER_CLUSTER_NAME =
       "zeebe.broker.cluster.clusterName";
   private static final String ZEEBE_BROKER_CLUSTER_MAX_APPENDS_PER_FOLLOWER =
-      "zeebe.broker.cluster.maxAppendsPerFollower";
+      "zeebe.broker.experimental.maxAppendsPerFollower";
   private static final String ZEEBE_BROKER_CLUSTER_MAX_APPEND_BATCH_SIZE =
-      "zeebe.broker.cluster.maxAppendBatchSize";
+      "zeebe.broker.experimental.maxAppendBatchSize";
 
   private static final String ZEEBE_BROKER_DATA_DIRECTORIES = "zeebe.broker.data.directories";
 
@@ -441,23 +441,23 @@ public final class BrokerCfgTest {
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
-    final ClusterCfg cfgCluster = cfg.getCluster();
+    final ExperimentalCfg experimentalCfg = cfg.getExperimental();
 
     // then
-    assertThat(cfgCluster.getMaxAppendsPerFollower()).isEqualTo(8);
+    assertThat(experimentalCfg.getMaxAppendsPerFollower()).isEqualTo(8);
   }
 
   @Test
   public void shouldOverrideMaxAppendBatchSizeViaEnvironment() {
     // given
-    environment.put(ZEEBE_BROKER_CLUSTER_MAX_APPEND_BATCH_SIZE, "32KB");
+    environment.put(ZEEBE_BROKER_CLUSTER_MAX_APPEND_BATCH_SIZE, "256KB");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
-    final ClusterCfg cfgCluster = cfg.getCluster();
+    final ExperimentalCfg experimentalCfg = cfg.getExperimental();
 
     // then
-    assertThat(cfgCluster.getMaxAppendBatchSize()).isEqualTo(16 * 1024);
+    assertThat(experimentalCfg.getMaxAppendBatchSizeInBytes()).isEqualTo(256 * 1024);
   }
 
   @Test

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -56,6 +56,10 @@ public final class BrokerCfgTest {
       "zeebe.broker.cluster.clusterSize";
   private static final String ZEEBE_BROKER_CLUSTER_CLUSTER_NAME =
       "zeebe.broker.cluster.clusterName";
+  private static final String ZEEBE_BROKER_CLUSTER_MAX_APPENDS_PER_FOLLOWER =
+      "zeebe.broker.cluster.maxAppendsPerFollower";
+  private static final String ZEEBE_BROKER_CLUSTER_MAX_APPEND_BATCH_SIZE =
+      "zeebe.broker.cluster.maxAppendBatchSize";
 
   private static final String ZEEBE_BROKER_DATA_DIRECTORIES = "zeebe.broker.data.directories";
 
@@ -428,6 +432,32 @@ public final class BrokerCfgTest {
 
     // then
     assertThat(cfgCluster.getClusterSize()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldOverrideMaxAppendsViaEnvironment() {
+    // given
+    environment.put(ZEEBE_BROKER_CLUSTER_MAX_APPENDS_PER_FOLLOWER, "8");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
+    final ClusterCfg cfgCluster = cfg.getCluster();
+
+    // then
+    assertThat(cfgCluster.getMaxAppendsPerFollower()).isEqualTo(8);
+  }
+
+  @Test
+  public void shouldOverrideMaxAppendBatchSizeViaEnvironment() {
+    // given
+    environment.put(ZEEBE_BROKER_CLUSTER_MAX_APPEND_BATCH_SIZE, "32KB");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
+    final ClusterCfg cfgCluster = cfg.getCluster();
+
+    // then
+    assertThat(cfgCluster.getMaxAppendBatchSize()).isEqualTo(16 * 1024);
   }
 
   @Test

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/ClusterCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/ClusterCfgTest.java
@@ -30,4 +30,17 @@ public final class ClusterCfgTest {
 
     assertThat(actual).isEqualTo(expected);
   }
+
+  @Test
+  public void shouldGeneratePartitionIds() {
+    // given
+    final ClusterCfg clusterCfg = new ClusterCfg();
+    clusterCfg.setPartitionsCount(8);
+
+    // when
+    clusterCfg.init(new BrokerCfg(), "");
+
+    // then
+    assertThat(clusterCfg.getPartitionIds()).containsExactly(1, 2, 3, 4, 5, 6, 7, 8);
+  }
 }

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -502,3 +502,15 @@
         #     workflowInstanceSubscription: false
         #
         #     ignoreVariablesAbove: 32677
+    # experimental
+      # Be aware that all configuration's which are part of the experimental section
+      # are subject to change and can be dropped at any time.
+      # It might be that also some of them are actually dangerous so be aware when you change one of these!
+
+      # Sets the maximum of appends which are send per follower.
+      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_MAX_APPENDS_PER_FOLLOWER
+      # maxAppendsPerFollower = 2
+
+      # Sets the maximum batch size, which is send per append request to a follower.
+      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_MAX_APPEND_BATCH_SIZE
+      # maxAppendBatchSize = 32KB;


### PR DESCRIPTION
## Description

Exposes the following configurations:

The MAX_APPENDS is used to limit how many appends are send to one follower at once. Currently it is static and set to two. It is likely that this configure can help to improve the throughput. In order to test different numbers we need to make it configurable.


The MAX_BATCH_SIZE is used to limit how many data is sent as a batch to a follower. Currently it is static and set to 32 kb. It is likely that this configure can help to improve the throughput. In order to test different numbers we need to make it configurable.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/5477
closes https://github.com/zeebe-io/zeebe/issues/5472

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
