### PR TITLE
chore(broker): Set the default backpressure algorithm as FIXED

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/backpressure/BackpressureCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/backpressure/BackpressureCfg.java
@@ -13,7 +13,7 @@ public final class BackpressureCfg implements ConfigurationEntry {
 
   private boolean enabled = true;
   private boolean useWindowed = true;
-  private LimitAlgorithm algorithm = LimitAlgorithm.VEGAS;
+  private LimitAlgorithm algorithm = LimitAlgorithm.FIXED;
   private final AIMDCfg aimd = new AIMDCfg();
   private final FixedCfg fixed = new FixedCfg();
   private final VegasCfg vegas = new VegasCfg();

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/backpressure/FixedCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/backpressure/FixedCfg.java
@@ -11,7 +11,7 @@ import static io.zeebe.broker.system.configuration.ConfigurationUtil.checkPositi
 
 public class FixedCfg {
 
-  private int limit = 20;
+  private int limit = 10;
 
   public int getLimit() {
     return limit;


### PR DESCRIPTION
## Description

As mentioned here: https://github.com/zeebe-io/zeebe/issues/5113#issuecomment-682679016 I've set the default backpressure algorithm as FIXED and limit as 10.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5113 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [X] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
