### PR TITLE
Adds new experimental flag to disable explicit flush in the consensus module

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -355,7 +355,7 @@ public class RaftContext implements AutoCloseable {
     if (commitIndex > previousCommitIndex) {
       this.commitIndex = commitIndex;
       logWriter.commit(Math.min(commitIndex, logWriter.getLastIndex()));
-      if (raftLog.isFlushOnCommit() && isLeader()) {
+      if (raftLog.shouldFlushExplicitly() && isLeader()) {
         // leader counts itself in quorum, so in order to commit the leader must persist
         logWriter.flush();
       }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -478,22 +478,13 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
     }
 
     /**
-     * Enables flush on commit.
-     *
-     * @return the Raft partition group builder
-     */
-    public Builder withFlushOnCommit() {
-      return withFlushOnCommit(true);
-    }
-
-    /**
      * Sets whether to flush logs to disk on commit.
      *
-     * @param flushOnCommit whether to flush logs to disk on commit
+     * @param flushExplicitly whether to flush logs to disk on commit
      * @return the Raft partition group builder
      */
-    public Builder withFlushOnCommit(final boolean flushOnCommit) {
-      config.getStorageConfig().setFlushOnCommit(flushOnCommit);
+    public Builder withFlushExplicitly(final boolean flushExplicitly) {
+      config.getStorageConfig().setFlushExplicitly(flushExplicitly);
       return this;
     }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
@@ -31,7 +31,7 @@ public class RaftStorageConfig {
   private static final StorageLevel DEFAULT_STORAGE_LEVEL = StorageLevel.DISK;
   private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
   private static final int DEFAULT_MAX_ENTRY_SIZE = 1024 * 1024;
-  private static final boolean DEFAULT_FLUSH_ON_COMMIT = false;
+  private static final boolean DEFAULT_FLUSH_EXPLICITLY = true;
   private static final long DEFAULT_FREE_DISK_SPACE = 1024L * 1024 * 1024 * 1; // 1GB
   private static final ReceivableSnapshotStoreFactory DEFAULT_SNAPSHOT_STORE_FACTORY =
       new FileBasedSnapshotStoreFactory();
@@ -40,7 +40,7 @@ public class RaftStorageConfig {
   private StorageLevel level = DEFAULT_STORAGE_LEVEL;
   private int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
   private long segmentSize = DEFAULT_MAX_SEGMENT_SIZE;
-  private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
+  private boolean flushExplicitly = DEFAULT_FLUSH_EXPLICITLY;
   private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
 
   @Optional("SnapshotStoreFactory")
@@ -120,22 +120,24 @@ public class RaftStorageConfig {
   }
 
   /**
-   * Returns whether to flush logs to disk on commit.
+   * Returns whether to flush logs to disk to guarantee correctness. If true, followers will flush
+   * on every append, and the leader will flush on commit.
    *
-   * @return whether to flush logs to disk on commit
+   * @return whether to flush logs to disk
    */
-  public boolean isFlushOnCommit() {
-    return flushOnCommit;
+  public boolean shouldFlushExplicitly() {
+    return flushExplicitly;
   }
 
   /**
-   * Sets whether to flush logs to disk on commit.
+   * Sets whether to flush logs to disk to guarantee correctness. If true, followers will flush on
+   * every append, and the leader will flush on commit.
    *
-   * @param flushOnCommit whether to flush logs to disk on commit
+   * @param flushExplicitly whether to flush logs to disk
    * @return the Raft partition group configuration
    */
-  public RaftStorageConfig setFlushOnCommit(final boolean flushOnCommit) {
-    this.flushOnCommit = flushOnCommit;
+  public RaftStorageConfig setFlushExplicitly(final boolean flushExplicitly) {
+    this.flushExplicitly = flushExplicitly;
     return this;
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -317,7 +317,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
         .withStorageLevel(storageConfig.getLevel())
         .withMaxSegmentSize((int) storageConfig.getSegmentSize().bytes())
         .withMaxEntrySize((int) storageConfig.getMaxEntrySize().bytes())
-        .withFlushOnCommit(storageConfig.isFlushOnCommit())
+        .withFlushExplicitly(storageConfig.shouldFlushExplicitly())
         .withFreeDiskSpace(storageConfig.getFreeDiskSpace())
         .withNamespace(RaftNamespaces.RAFT_STORAGE)
         .withSnapshotStore(persistedSnapshotStore)

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -610,7 +610,9 @@ public class PassiveRole extends InactiveRole {
     }
 
     // Make sure all entries are flushed before ack to ensure we have persisted what we acknowledge
-    raft.getLogWriter().flush();
+    if (raft.getLog().shouldFlushExplicitly()) {
+      raft.getLogWriter().flush();
+    }
 
     // Return a successful append response.
     succeedAppend(lastLogIndex, future);

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -378,7 +378,7 @@ public final class RaftStorage {
     private static final boolean DEFAULT_DYNAMIC_COMPACTION = true;
     private static final long DEFAULT_FREE_DISK_SPACE = 1024L * 1024 * 1024; // 1GB
     private static final double DEFAULT_FREE_MEMORY_BUFFER = .2;
-    private static final boolean DEFAULT_FLUSH_ON_COMMIT = true;
+    private static final boolean DEFAULT_FLUSH_EXPLICITLY = true;
     private static final boolean DEFAULT_RETAIN_STALE_SNAPSHOTS = false;
 
     private String prefix = DEFAULT_PREFIX;
@@ -389,7 +389,7 @@ public final class RaftStorage {
     private int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
     private int maxEntriesPerSegment = DEFAULT_MAX_ENTRIES_PER_SEGMENT;
     private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
-    private boolean flushExplicitly = DEFAULT_FLUSH_ON_COMMIT;
+    private boolean flushExplicitly = DEFAULT_FLUSH_EXPLICITLY;
     private boolean retainStaleSnapshots = DEFAULT_RETAIN_STALE_SNAPSHOTS;
     private StorageStatistics storageStatistics;
     private ReceivableSnapshotStore persistedSnapshotStore;

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -68,7 +68,7 @@ public final class RaftStorage {
   private final int maxEntrySize;
   private final int maxEntriesPerSegment;
   private final long freeDiskSpace;
-  private final boolean flushOnCommit;
+  private final boolean flushExplicitly;
   private final boolean retainStaleSnapshots;
   private final StorageStatistics statistics;
   private final ReceivableSnapshotStore persistedSnapshotStore;
@@ -83,7 +83,7 @@ public final class RaftStorage {
       final int maxEntrySize,
       final int maxEntriesPerSegment,
       final long freeDiskSpace,
-      final boolean flushOnCommit,
+      final boolean flushExplicitly,
       final boolean retainStaleSnapshots,
       final StorageStatistics storageStatistics,
       final ReceivableSnapshotStore persistedSnapshotStore,
@@ -96,7 +96,7 @@ public final class RaftStorage {
     this.maxEntrySize = maxEntrySize;
     this.maxEntriesPerSegment = maxEntriesPerSegment;
     this.freeDiskSpace = freeDiskSpace;
-    this.flushOnCommit = flushOnCommit;
+    this.flushExplicitly = flushExplicitly;
     this.retainStaleSnapshots = retainStaleSnapshots;
     statistics = storageStatistics;
     this.persistedSnapshotStore = persistedSnapshotStore;
@@ -295,7 +295,7 @@ public final class RaftStorage {
         .withMaxEntrySize(maxEntrySize)
         .withFreeDiskSpace(freeDiskSpace)
         .withMaxEntriesPerSegment(maxEntriesPerSegment)
-        .withFlushOnCommit(flushOnCommit)
+        .withFlushExplicitly(flushExplicitly)
         .withJournalIndexFactory(journalIndexFactory)
         .build();
   }
@@ -334,8 +334,8 @@ public final class RaftStorage {
    *
    * @return Whether to flush buffers to disk when entries are committed.
    */
-  public boolean isFlushOnCommit() {
-    return flushOnCommit;
+  public boolean isFlushExplicitly() {
+    return flushExplicitly;
   }
 
   /**
@@ -389,7 +389,7 @@ public final class RaftStorage {
     private int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
     private int maxEntriesPerSegment = DEFAULT_MAX_ENTRIES_PER_SEGMENT;
     private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
-    private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
+    private boolean flushExplicitly = DEFAULT_FLUSH_ON_COMMIT;
     private boolean retainStaleSnapshots = DEFAULT_RETAIN_STALE_SNAPSHOTS;
     private StorageStatistics storageStatistics;
     private ReceivableSnapshotStore persistedSnapshotStore;
@@ -541,31 +541,14 @@ public final class RaftStorage {
     }
 
     /**
-     * Enables flushing buffers to disk when entries are committed to a segment, returning the
-     * builder for method chaining.
+     * Sets whether to flush logs to disk to guarantee correctness. If true, followers will flush on
+     * every append, and the leader will flush on commit.
      *
-     * <p>When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk
-     * each time an entry is committed in a given segment.
-     *
-     * @return The storage builder.
+     * @param flushExplicitly whether to flush buffers to disk
+     * @return the storage builder.
      */
-    public Builder withFlushOnCommit() {
-      return withFlushOnCommit(true);
-    }
-
-    /**
-     * Sets whether to flush buffers to disk when entries are committed to a segment, returning the
-     * builder for method chaining.
-     *
-     * <p>When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk
-     * each time an entry is committed in a given segment.
-     *
-     * @param flushOnCommit Whether to flush buffers to disk when entries are committed to a
-     *     segment.
-     * @return The storage builder.
-     */
-    public Builder withFlushOnCommit(final boolean flushOnCommit) {
-      this.flushOnCommit = flushOnCommit;
+    public Builder withFlushExplicitly(final boolean flushExplicitly) {
+      this.flushExplicitly = flushExplicitly;
       return this;
     }
 
@@ -640,7 +623,7 @@ public final class RaftStorage {
           maxEntrySize,
           maxEntriesPerSegment,
           freeDiskSpace,
-          flushOnCommit,
+          flushExplicitly,
           retainStaleSnapshots,
           Optional.ofNullable(storageStatistics).orElse(new StorageStatistics(directory)),
           persistedSnapshotStore,

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -31,11 +31,14 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
 
   private final SegmentedJournal<RaftLogEntry> journal;
   private final RaftLogWriter writer;
+  private final boolean flushExplicitly;
   private volatile long commitIndex;
 
-  protected RaftLog(final SegmentedJournal<RaftLogEntry> journal) {
+  protected RaftLog(final SegmentedJournal<RaftLogEntry> journal, final boolean flushExplicitly) {
     super(journal);
     this.journal = journal;
+    this.flushExplicitly = flushExplicitly;
+
     writer = new RaftLogWriter(journal.writer());
   }
 
@@ -113,8 +116,8 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
     commitIndex = index;
   }
 
-  public boolean isFlushOnCommit() {
-    return journal.isFlushOnCommit();
+  public boolean shouldFlushExplicitly() {
+    return flushExplicitly;
   }
 
   /** Raft log builder. */
@@ -122,6 +125,7 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
 
     private final SegmentedJournal.Builder<RaftLogEntry> journalBuilder =
         SegmentedJournal.builder();
+    private boolean flushExplicitly = true;
 
     protected Builder() {}
 
@@ -255,18 +259,18 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
     }
 
     /**
-     * Sets whether to flush buffers to disk when entries are committed to a segment, returning the
-     * builder for method chaining.
+     * Sets whether or not to flush buffered I/O explicitly at various points, returning the builder
+     * for chaining.
      *
-     * <p>When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk
-     * each time an entry is committed in a given segment.
+     * <p>Enabling this ensures that entries are flushed on followers before acknowledging a write,
+     * and are flushed on the leader before marking an entry as committed. This guarantees the
+     * correctness of various Raft properties.
      *
-     * @param flushOnCommit Whether to flush buffers to disk when entries are committed to a
-     *     segment.
-     * @return The storage builder.
+     * @param flushExplicitly whether to flush explicitly or not
+     * @return this builder for chaining
      */
-    public Builder withFlushOnCommit(final boolean flushOnCommit) {
-      journalBuilder.withFlushOnCommit(flushOnCommit);
+    public Builder withFlushExplicitly(final boolean flushExplicitly) {
+      this.flushExplicitly = flushExplicitly;
       return this;
     }
 
@@ -277,7 +281,7 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
 
     @Override
     public RaftLog build() {
-      return new RaftLog(journalBuilder.build());
+      return new RaftLog(journalBuilder.build(), flushExplicitly);
     }
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/RaftStorageTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/RaftStorageTest.java
@@ -45,7 +45,7 @@ public class RaftStorageTest {
     assertEquals(1024 * 1024 * 32, storage.maxLogSegmentSize());
     assertEquals(1024 * 1024, storage.maxLogEntriesPerSegment());
     assertEquals(1024L * 1024 * 1024, storage.freeDiskSpace());
-    assertTrue(storage.isFlushOnCommit());
+    assertTrue(storage.isFlushExplicitly());
     assertFalse(storage.isRetainStaleSnapshots());
     assertTrue(storage.statistics().getFreeMemory() > 0);
   }
@@ -59,7 +59,7 @@ public class RaftStorageTest {
             .withMaxSegmentSize(1024 * 1024)
             .withMaxEntriesPerSegment(1024)
             .withFreeDiskSpace(100)
-            .withFlushOnCommit(false)
+            .withFlushExplicitly(false)
             .withRetainStaleSnapshots()
             .build();
     assertEquals("foo", storage.prefix());
@@ -67,16 +67,19 @@ public class RaftStorageTest {
     assertEquals(1024 * 1024, storage.maxLogSegmentSize());
     assertEquals(1024, storage.maxLogEntriesPerSegment());
     assertEquals(100, storage.freeDiskSpace());
-    assertFalse(storage.isFlushOnCommit());
+    assertFalse(storage.isFlushExplicitly());
     assertTrue(storage.isRetainStaleSnapshots());
   }
 
   @Test
   public void testCustomConfiguration2() throws Exception {
     final RaftStorage storage =
-        RaftStorage.builder().withDirectory(PATH.toString() + "/baz").withFlushOnCommit().build();
+        RaftStorage.builder()
+            .withDirectory(PATH.toString() + "/baz")
+            .withFlushExplicitly(true)
+            .build();
     assertEquals(new File(PATH.toFile(), "baz"), storage.directory());
-    assertTrue(storage.isFlushOnCommit());
+    assertTrue(storage.isFlushExplicitly());
   }
 
   @Test

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
@@ -118,7 +118,7 @@ public class ZeebeTestNode {
         .withMembers(members.toArray(new Member[0]))
         .withNumPartitions(1)
         .withPartitionSize(members.size())
-        .withFlushOnCommit()
+        .withFlushExplicitly(true)
         .withStorageLevel(StorageLevel.DISK)
         .withSegmentSize(1024L)
         .withMaxEntrySize(512)

--- a/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
@@ -58,7 +58,6 @@ public class SegmentedJournal<E> implements Journal<E> {
   private final int maxSegmentSize;
   private final int maxEntrySize;
   private final int maxEntriesPerSegment;
-  private final boolean flushOnCommit;
   private final SegmentedJournalWriter<E> writer;
   private volatile long commitIndex;
   private final NavigableMap<Long, JournalSegment<E>> segments = new ConcurrentSkipListMap<>();
@@ -75,7 +74,6 @@ public class SegmentedJournal<E> implements Journal<E> {
       final int maxSegmentSize,
       final int maxEntrySize,
       final int maxEntriesPerSegment,
-      final boolean flushOnCommit,
       final Supplier<JournalIndex> journalIndexFactory,
       final long minFreeSpace) {
     this.name = checkNotNull(name, "name cannot be null");
@@ -85,7 +83,6 @@ public class SegmentedJournal<E> implements Journal<E> {
     this.maxSegmentSize = maxSegmentSize;
     this.maxEntrySize = maxEntrySize;
     this.maxEntriesPerSegment = maxEntriesPerSegment;
-    this.flushOnCommit = flushOnCommit;
     journalMetrics = new JournalMetrics(name);
     this.journalIndexFactory =
         journalIndexFactory == null
@@ -669,15 +666,6 @@ public class SegmentedJournal<E> implements Journal<E> {
   }
 
   /**
-   * Returns whether {@code flushOnCommit} is enabled for the log.
-   *
-   * @return Indicates whether {@code flushOnCommit} is enabled for the log.
-   */
-  public boolean isFlushOnCommit() {
-    return flushOnCommit;
-  }
-
-  /**
    * Returns the Raft log commit index.
    *
    * @return The Raft log commit index.
@@ -713,7 +701,6 @@ public class SegmentedJournal<E> implements Journal<E> {
     protected int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
     protected int maxEntriesPerSegment = DEFAULT_MAX_ENTRIES_PER_SEGMENT;
 
-    private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
     private Supplier<JournalIndex> journalIndexFactory;
     private long freeDiskSpace = DEFAULT_MIN_FREE_DISK_SPACE;
 
@@ -856,35 +843,6 @@ public class SegmentedJournal<E> implements Journal<E> {
       return this;
     }
 
-    /**
-     * Enables flushing buffers to disk when entries are committed to a segment, returning the
-     * builder for method chaining.
-     *
-     * <p>When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk
-     * each time an entry is committed in a given segment.
-     *
-     * @return The storage builder.
-     */
-    public Builder<E> withFlushOnCommit() {
-      return withFlushOnCommit(true);
-    }
-
-    /**
-     * Sets whether to flush buffers to disk when entries are committed to a segment, returning the
-     * builder for method chaining.
-     *
-     * <p>When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk
-     * each time an entry is committed in a given segment.
-     *
-     * @param flushOnCommit Whether to flush buffers to disk when entries are committed to a
-     *     segment.
-     * @return The storage builder.
-     */
-    public Builder<E> withFlushOnCommit(final boolean flushOnCommit) {
-      this.flushOnCommit = flushOnCommit;
-      return this;
-    }
-
     public Builder<E> withJournalIndexFactory(final Supplier<JournalIndex> journalIndexFactory) {
       this.journalIndexFactory = journalIndexFactory;
       return this;
@@ -900,7 +858,6 @@ public class SegmentedJournal<E> implements Journal<E> {
           maxSegmentSize,
           maxEntrySize,
           maxEntriesPerSegment,
-          flushOnCommit,
           journalIndexFactory,
           freeDiskSpace);
     }

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -111,7 +111,7 @@ public final class AtomixFactory {
             .withMaxAppendsPerFollower(experimentalCfg.getMaxAppendsPerFollower())
             .withStorageLevel(dataCfg.getAtomixStorageLevel())
             .withEntryValidator(new ZeebeEntryValidator())
-            .withFlushOnCommit()
+            .withFlushExplicitly(!experimentalCfg.isDisableExplicitRaftFlush())
             .withFreeDiskSpace(dataCfg.getFreeDiskSpaceReplicationWatermark());
 
     // by default, the Atomix max entry size is 1 MB

--- a/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/SystemContext.java
@@ -33,6 +33,9 @@ public final class SystemContext {
       "Snapshot period %s needs to be larger then or equals to one minute.";
   private static final String MAX_BATCH_SIZE_ERROR_MSG =
       "Expected to have an append batch size maximum which is non negative and smaller then '%d', but was '%s'.";
+  private static final String REPLICATION_WITH_DISABLED_FLUSH_WARNING =
+      "Disabling explicit flushing is an experimental feature and can lead to inconsistencies "
+          + "and/or data loss! Please refer to the documentation whether or not you should use this!";
 
   protected final BrokerCfg brokerCfg;
   private Map<String, String> diagnosticContext;
@@ -118,6 +121,10 @@ public final class SystemContext {
           String.format(
               "diskUsageCommandWatermark (%f) must be less than diskUsageReplicationWatermark (%f)",
               diskUsageCommandWatermark, diskUsageReplicationWatermark));
+    }
+
+    if (experimental.isDisableExplicitRaftFlush()) {
+      LOG.warn(REPLICATION_WITH_DISABLED_FLUSH_WARNING);
     }
   }
 

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -19,9 +19,11 @@ public class ExperimentalCfg {
 
   public static final int DEFAULT_MAX_APPENDS_PER_FOLLOWER = 2;
   public static final DataSize DEFAULT_MAX_APPEND_BATCH_SIZE = DataSize.ofKilobytes(32);
+  public static final boolean DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH = false;
 
   private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
   private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;
+  private boolean disableExplicitRaftFlush = DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH;
 
   public int getMaxAppendsPerFollower() {
     return maxAppendsPerFollower;
@@ -35,12 +37,20 @@ public class ExperimentalCfg {
     return maxAppendBatchSize;
   }
 
+  public void setMaxAppendBatchSize(final DataSize maxAppendBatchSize) {
+    this.maxAppendBatchSize = maxAppendBatchSize;
+  }
+
   public long getMaxAppendBatchSizeInBytes() {
     return Optional.ofNullable(maxAppendBatchSize).orElse(DEFAULT_MAX_APPEND_BATCH_SIZE).toBytes();
   }
 
-  public void setMaxAppendBatchSize(final DataSize maxAppendBatchSize) {
-    this.maxAppendBatchSize = maxAppendBatchSize;
+  public boolean isDisableExplicitRaftFlush() {
+    return disableExplicitRaftFlush;
+  }
+
+  public void setDisableExplicitRaftFlush(final boolean disableExplicitRaftFlush) {
+    this.disableExplicitRaftFlush = disableExplicitRaftFlush;
   }
 
   @Override
@@ -50,6 +60,8 @@ public class ExperimentalCfg {
         + maxAppendsPerFollower
         + ", maxAppendBatchSize="
         + maxAppendBatchSize
+        + ", disableExplicitRaftFlush="
+        + disableExplicitRaftFlush
         + '}';
   }
 }

--- a/broker/src/test/java/io/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
+++ b/broker/src/test/java/io/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
@@ -60,6 +60,36 @@ public final class AtomixFactoryTest {
     assertThat(config.getStorageConfig().getLevel()).isEqualTo(StorageLevel.DISK);
   }
 
+  @Test
+  public void shouldDisableExplicitFlush() {
+    // given
+    final var brokerConfig = newConfig();
+    brokerConfig.getExperimental().setDisableExplicitRaftFlush(true);
+
+    // when
+    final var atomix =
+        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory());
+
+    // then
+    final var config = getPartitionGroupConfig(atomix);
+    assertThat(config.getStorageConfig().shouldFlushExplicitly()).isFalse();
+  }
+
+  @Test
+  public void shouldEnableExplicitFlush() {
+    // given
+    final var brokerConfig = newConfig();
+    brokerConfig.getExperimental().setDisableExplicitRaftFlush(false);
+
+    // when
+    final var atomix =
+        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory());
+
+    // then
+    final var config = getPartitionGroupConfig(atomix);
+    assertThat(config.getStorageConfig().shouldFlushExplicitly()).isTrue();
+  }
+
   private RaftPartitionGroup getPartitionGroup(final Atomix atomix) {
     return (RaftPartitionGroup)
         atomix.getPartitionService().getPartitionGroup(AtomixFactory.GROUP_NAME);

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -60,6 +60,8 @@ public final class BrokerCfgTest {
       "zeebe.broker.experimental.maxAppendsPerFollower";
   private static final String ZEEBE_BROKER_CLUSTER_MAX_APPEND_BATCH_SIZE =
       "zeebe.broker.experimental.maxAppendBatchSize";
+  private static final String ZEEBE_BROKER_EXPERIMENTAL_DISABLEEXPLICITRAFTFLUSH =
+      "zeebe.broker.experimental.disableExplicitRaftFlush";
 
   private static final String ZEEBE_BROKER_DATA_DIRECTORIES = "zeebe.broker.data.directories";
 
@@ -461,6 +463,19 @@ public final class BrokerCfgTest {
   }
 
   @Test
+  public void shouldOverrideDisableExplicitRaftFlushViaEnvironment() {
+    // given
+    environment.put(ZEEBE_BROKER_EXPERIMENTAL_DISABLEEXPLICITRAFTFLUSH, "true");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
+    final ExperimentalCfg experimentalCfg = cfg.getExperimental();
+
+    // then
+    assertThat(experimentalCfg.isDisableExplicitRaftFlush()).isTrue();
+  }
+
+  @Test
   public void shouldOverrideAllClusterPropertiesViaEnvironment() {
     // given
     environment.put(ZEEBE_BROKER_CLUSTER_CLUSTER_SIZE, "1");
@@ -585,9 +600,10 @@ public final class BrokerCfgTest {
     final BrokerCfg actual = TestConfigReader.readConfig("exporters", environment);
 
     // then
-    assertThat(actual.getExporters()).hasSize(1);
-    assertThat(actual.getExporters()).containsKey("elasticsearch");
-    assertThat(actual.getExporters().get("elasticsearch")).isEqualTo(expected);
+    assertThat(actual.getExporters())
+        .hasSize(1)
+        .containsKey("elasticsearch")
+        .containsEntry("elasticsearch", expected);
   }
 
   @Test

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
@@ -243,7 +243,7 @@ public final class AtomixLogStorageRule extends ExternalResource
 
   private RaftStorage.Builder buildDefaultStorage() {
     return RaftStorage.builder()
-        .withFlushOnCommit()
+        .withFlushExplicitly(true)
         .withStorageLevel(StorageLevel.DISK)
         .withNamespace(RaftNamespaces.RAFT_STORAGE)
         .withRetainStaleSnapshots();


### PR DESCRIPTION
## Description

This PR adds a new experimental flag as `zeebe.broker.experimental.disableExplicitRaftFlush`, which defaults to false. When true, it will disable explicit flushing on the Raft side - flushing on commit on the leader, and flushing on append on the follower.

The flag is worded in the negative, as the default behaviour is to always explicitly flush for correctness, and users should take care when disabling this. There is also a warning printed out if replication is enabled, as this can lead to inconsistency issues; when replication factor is 1, at worst you simply suffer data loss on crash.

There are unfortunately no acceptance tests, as I with the current set up I found it quite hard to add. Let me know if you have an idea there.

Ideally we'd like this in 0.25 so users can already start experimenting with this - in some use cases, this can give a nice performance boost, and the consequences (e.g. data loss when replication is disabled) can be ignored.

## Related issues

closes #5570

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
