### PR TITLE
Allow configuring raft threadcontext

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -39,6 +39,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
@@ -559,6 +560,7 @@ public interface RaftServer {
     protected RaftThreadContextFactory threadContextFactory;
     protected Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
     protected Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
+    protected Supplier<Random> randomFactory;
     protected Supplier<JournalIndex> journalIndexFactory;
     protected EntryValidator entryValidator = new NoopEntryValidator();
     protected int maxAppendsPerFollower = 2;
@@ -625,6 +627,18 @@ public interface RaftServer {
     public Builder withThreadContextFactory(final RaftThreadContextFactory threadContextFactory) {
       this.threadContextFactory =
           checkNotNull(threadContextFactory, "threadContextFactory cannot be null");
+      return this;
+    }
+
+    /**
+     * Sets the factory that creates a {@link Random}. Raft uses it to randomize election timeouts.
+     * This factory is useful in testing, when we want to control the execution.
+     *
+     * @param randomFactory
+     * @return The Raft server builder.
+     */
+    public Builder withRandomFactory(final Supplier<Random> randomFactory) {
+      this.randomFactory = checkNotNull(randomFactory, "randomFactory cannot be null");
       return this;
     }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftThreadContextFactory.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftThreadContextFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import io.atomix.utils.concurrent.ThreadContext;
+import java.util.concurrent.ThreadFactory;
+import java.util.function.Consumer;
+
+public interface RaftThreadContextFactory {
+  ThreadContext createContext(ThreadFactory factory, Consumer<Throwable> unCaughtExceptionHandler);
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -30,6 +30,7 @@ import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
 import java.util.Collection;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -295,6 +296,7 @@ public class DefaultRaftServer implements RaftServer {
           threadContextFactory == null
               ? new DefaultRaftSingleThreadContextFactory()
               : threadContextFactory;
+      final Supplier<Random> randomSupplier = randomFactory == null ? Random::new : randomFactory;
 
       final RaftContext raft =
           new RaftContext(
@@ -305,7 +307,8 @@ public class DefaultRaftServer implements RaftServer {
               storage,
               singleThreadFactory,
               maxAppendBatchSize,
-              maxAppendsPerFollower);
+              maxAppendsPerFollower,
+              randomSupplier);
       raft.setElectionTimeout(electionTimeout);
       raft.setHeartbeatInterval(heartbeatInterval);
       raft.setEntryValidator(entryValidator);

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftSingleThreadContextFactory.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftSingleThreadContextFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.impl;
+
+import io.atomix.raft.RaftThreadContextFactory;
+import io.atomix.utils.concurrent.SingleThreadContext;
+import io.atomix.utils.concurrent.ThreadContext;
+import java.util.concurrent.ThreadFactory;
+import java.util.function.Consumer;
+
+public class DefaultRaftSingleThreadContextFactory implements RaftThreadContextFactory {
+
+  @Override
+  public ThreadContext createContext(
+      final ThreadFactory factory, final Consumer<Throwable> unCaughtExceptionHandler) {
+    return new SingleThreadContext(factory, unCaughtExceptionHandler);
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -60,6 +60,7 @@ import io.atomix.utils.logging.LoggerContext;
 import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -110,6 +111,8 @@ public class RaftContext implements AutoCloseable {
   private EntryValidator entryValidator;
   private final int maxAppendBatchSize;
   private final int maxAppendsPerFollower;
+  // Used for randomizing election timeout
+  private final Random random;
 
   public RaftContext(
       final String name,
@@ -119,11 +122,13 @@ public class RaftContext implements AutoCloseable {
       final RaftStorage storage,
       final RaftThreadContextFactory threadContextFactory,
       final int maxAppendBatchSize,
-      final int maxAppendsPerFollower) {
+      final int maxAppendsPerFollower,
+      final Supplier<Random> randomFactory) {
     this.name = checkNotNull(name, "name cannot be null");
     this.membershipService = checkNotNull(membershipService, "membershipService cannot be null");
     this.protocol = checkNotNull(protocol, "protocol cannot be null");
     this.storage = checkNotNull(storage, "storage cannot be null");
+    random = randomFactory.get();
     log =
         ContextualLoggerFactory.getLogger(
             getClass(), LoggerContext.builder(RaftServer.class).addValue(name).build());
@@ -954,6 +959,10 @@ public class RaftContext implements AutoCloseable {
 
   public RaftReplicationMetrics getReplicationMetrics() {
     return replicationMetrics;
+  }
+
+  public Random getRandom() {
+    return random;
   }
 
   /** Raft server state. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -28,7 +28,6 @@ import io.atomix.raft.RaftRoleChangeListener;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
 import io.atomix.storage.journal.index.JournalIndex;
-import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.zeebe.util.ZbLogger;
 import java.io.File;
 import java.util.Collection;
@@ -47,7 +46,6 @@ public class RaftPartition implements Partition {
   private final PartitionId partitionId;
   private final RaftPartitionGroupConfig config;
   private final File dataDirectory;
-  private final ThreadContextFactory threadContextFactory;
   private final Set<RaftRoleChangeListener> deferredRoleChangeListeners =
       new CopyOnWriteArraySet<>();
   private final Set<RaftFailureListener> raftFailureListeners = new CopyOnWriteArraySet<>();
@@ -58,12 +56,10 @@ public class RaftPartition implements Partition {
   public RaftPartition(
       final PartitionId partitionId,
       final RaftPartitionGroupConfig config,
-      final File dataDirectory,
-      final ThreadContextFactory threadContextFactory) {
+      final File dataDirectory) {
     this.partitionId = partitionId;
     this.config = config;
     this.dataDirectory = dataDirectory;
-    this.threadContextFactory = threadContextFactory;
   }
 
   public void addRoleChangeListener(final RaftRoleChangeListener listener) {
@@ -154,7 +150,6 @@ public class RaftPartition implements Partition {
         managementService.getMembershipService().getLocalMember().id(),
         managementService.getMembershipService(),
         managementService.getMessagingService(),
-        threadContextFactory,
         journalIndexFactory);
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -37,7 +37,6 @@ import io.atomix.storage.journal.JournalReader.Mode;
 import io.atomix.storage.journal.index.JournalIndex;
 import io.atomix.utils.Managed;
 import io.atomix.utils.concurrent.Futures;
-import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
 import io.atomix.utils.serializer.Serializer;
@@ -67,7 +66,6 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
   private final RaftPartitionGroupConfig config;
   private final ClusterMembershipService membershipService;
   private final ClusterCommunicationService clusterCommunicator;
-  private final ThreadContextFactory threadContextFactory;
   private final Set<RaftRoleChangeListener> deferredRoleChangeListeners =
       new CopyOnWriteArraySet<>();
   private final Set<Runnable> deferredFailureListeners = new CopyOnWriteArraySet<>();
@@ -82,14 +80,12 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
       final MemberId localMemberId,
       final ClusterMembershipService membershipService,
       final ClusterCommunicationService clusterCommunicator,
-      final ThreadContextFactory threadContextFactory,
       final Supplier<JournalIndex> journalIndexFactory) {
     this.partition = partition;
     this.config = config;
     this.localMemberId = localMemberId;
     this.membershipService = membershipService;
     this.clusterCommunicator = clusterCommunicator;
-    this.threadContextFactory = threadContextFactory;
     this.journalIndexFactory = journalIndexFactory;
     log =
         ContextualLoggerFactory.getLogger(
@@ -180,7 +176,6 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
         .withMaxAppendBatchSize(config.getMaxAppendBatchSize())
         .withMaxAppendsPerFollower(config.getMaxAppendsPerFollower())
         .withStorage(createRaftStorage())
-        .withThreadContextFactory(threadContextFactory)
         .withJournalIndexFactory(journalIndexFactory)
         .withEntryValidator(config.getEntryValidator())
         .build();

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/CandidateRole.java
@@ -32,7 +32,6 @@ import io.atomix.storage.journal.Indexed;
 import io.atomix.utils.concurrent.Scheduled;
 import java.time.Duration;
 import java.util.HashSet;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -41,7 +40,6 @@ import java.util.stream.Collectors;
 /** Candidate state. */
 public final class CandidateRole extends ActiveRole {
 
-  private final Random random = new Random();
   private Scheduled currentTimer;
 
   public CandidateRole(final RaftContext context) {
@@ -135,7 +133,9 @@ public final class CandidateRole extends ActiveRole {
 
     final Duration delay =
         raft.getElectionTimeout()
-            .plus(Duration.ofMillis(random.nextInt((int) raft.getElectionTimeout().toMillis())));
+            .plus(
+                Duration.ofMillis(
+                    raft.getRandom().nextInt((int) raft.getElectionTimeout().toMillis())));
     currentTimer =
         raft.getThreadContext()
             .schedule(

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -39,7 +39,6 @@ import io.atomix.raft.utils.Quorum;
 import io.atomix.storage.journal.Indexed;
 import io.atomix.utils.concurrent.Scheduled;
 import java.time.Duration;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -48,7 +47,6 @@ import java.util.stream.Collectors;
 /** Follower state. */
 public final class FollowerRole extends ActiveRole {
 
-  private final Random random = new Random();
   private Scheduled heartbeatTimer;
   private final ClusterMembershipEventListener clusterListener = this::handleClusterEvent;
   private long lastHeartbeat;
@@ -241,7 +239,9 @@ public final class FollowerRole extends ActiveRole {
     // being election timeout and 2 * election timeout.
     final Duration delay =
         raft.getElectionTimeout()
-            .plus(Duration.ofMillis(random.nextInt((int) raft.getElectionTimeout().toMillis())));
+            .plus(
+                Duration.ofMillis(
+                    raft.getRandom().nextInt((int) raft.getElectionTimeout().toMillis())));
     heartbeatTimer = raft.getThreadContext().schedule(delay, () -> onHeartbeatTimeout(delay));
   }
 


### PR DESCRIPTION
## Description

For randomized property tests,  it is required to control the execution of raft. This PR enables us to inject 
* ThreadContext
* Random instance
to RaftContext. In tests, we can then use a controllable thread executor similar to ControllableActorScheduler. It is also useful to control the randomized election timeouts. So we can now insert a Random instance to generate reproducible election timeouts.

This PR is a prerequisite for introducing randomized property test for raft.

## Related issues

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
