### PR TITLE
Try fix flaky HealthMonitoringTest and DeploymentClusteredTest

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -50,6 +50,7 @@ public class DefaultRaftServer implements RaftServer {
       new AtomicReference<>();
   private final AtomicReference<CompletableFuture<Void>> closeFutureRef = new AtomicReference<>();
   private volatile boolean started;
+  private volatile boolean stopped = false;
 
   public DefaultRaftServer(final RaftContext context) {
     this.context = checkNotNull(context, "context cannot be null");
@@ -124,9 +125,14 @@ public class DefaultRaftServer implements RaftServer {
    *
    * @return A completable future to be completed once the server has been shutdown.
    */
+  @Override
   public CompletableFuture<Void> shutdown() {
-    if (!started) {
+    if (!started && !stopped) {
       return Futures.exceptionalFuture(new IllegalStateException("Server not running"));
+    }
+
+    if (stopped) {
+      return Futures.completedFuture(null);
     }
 
     final CompletableFuture<Void> future = new AtomixFuture<>();
@@ -134,12 +140,12 @@ public class DefaultRaftServer implements RaftServer {
         .getThreadContext()
         .execute(
             () -> {
+              stopped = true;
               started = false;
               context.transition(Role.INACTIVE);
               context.close();
               future.complete(null);
             });
-
     return future;
   }
 
@@ -148,8 +154,9 @@ public class DefaultRaftServer implements RaftServer {
    *
    * @return A completable future to be completed once the server has left the cluster.
    */
+  @Override
   public CompletableFuture<Void> leave() {
-    if (!started) {
+    if (!started || stopped) {
       return CompletableFuture.completedFuture(null);
     }
 
@@ -194,8 +201,9 @@ public class DefaultRaftServer implements RaftServer {
    *
    * @return Indicates whether the server is running.
    */
+  @Override
   public boolean isRunning() {
-    return started && context.isRunning();
+    return started && !stopped && context.isRunning();
   }
 
   @Override
@@ -241,6 +249,7 @@ public class DefaultRaftServer implements RaftServer {
     }
 
     if (openFutureRef.compareAndSet(null, new AtomixFuture<>())) {
+      stopped = false;
       joiner
           .get()
           .whenComplete(

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/HealthMonitoringTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/HealthMonitoringTest.java
@@ -9,35 +9,25 @@ package io.zeebe.broker.it.health;
 
 import static io.zeebe.broker.clustering.atomix.AtomixFactory.GROUP_NAME;
 import static io.zeebe.protocol.Protocol.START_PARTITION_ID;
-import static io.zeebe.test.util.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.partition.RaftPartition;
 import io.zeebe.broker.Broker;
-import io.zeebe.broker.it.util.GrpcClientRule;
 import io.zeebe.broker.test.EmbeddedBrokerRule;
 import java.time.Duration;
+import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
 
 public class HealthMonitoringTest {
-  private static final String JOB_TYPE = "testTask";
-  private static final Duration SNAPSHOT_PERIOD = Duration.ofMinutes(5);
-  private final Timeout testTimeout = Timeout.seconds(120);
-  private final EmbeddedBrokerRule embeddedBrokerRule =
-      new EmbeddedBrokerRule(
-          cfg -> {
-            cfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD);
-            cfg.getData().setLogIndexDensity(1);
-          });
-  private final GrpcClientRule clientRule = new GrpcClientRule(embeddedBrokerRule);
 
-  @Rule
-  public RuleChain ruleChain =
-      RuleChain.outerRule(testTimeout).around(embeddedBrokerRule).around(clientRule);
+  private final EmbeddedBrokerRule embeddedBrokerRule = new EmbeddedBrokerRule();
+  private final Timeout timeout = Timeout.seconds(120);
+
+  @Rule public final RuleChain chain = RuleChain.outerRule(timeout).around(embeddedBrokerRule);
 
   @Test
   public void shouldReportUnhealthyWhenRaftInactive() {
@@ -46,7 +36,7 @@ public class HealthMonitoringTest {
     assertThat(isBrokerHealthy()).isTrue();
 
     // when
-    final RaftPartition raftPartition =
+    final var raftPartition =
         (RaftPartition)
             leader
                 .getAtomix()
@@ -56,7 +46,7 @@ public class HealthMonitoringTest {
     raftPartition.getServer().stop();
 
     // then
-    waitUntil(() -> !isBrokerHealthy());
+    Awaitility.waitAtMost(Duration.ofMinutes(1)).until(() -> !isBrokerHealthy());
   }
 
   private boolean isBrokerHealthy() {


### PR DESCRIPTION
## Description

HealthMonitoringTest and DeploymentClusteredTest are both flaky. The
test timesout due to the outerrule (timeout) wrapped around the
embeddedbrokerrule.

At least for the health monitoring test it was clear that a lot of time
was spend waiting for the broker to finish, because the raft partition
server was already stopped inside the test and could then later not be
stopped by the after of the embeddedbrokerrule.

This PR allows calling the shutdown method of DefaultRaftServer
multiple times by keeping track of a stopped flag. The server is only
allowed to stop if it is started and not already stopped. If it is
already stopped it can just return.

It also refactors the HealthMonitoringTest a bit to focus on what matters.

It does not fix the flakyness of these tests, but was an attempt for it.

## Related issues

see #5005
and #5013

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
