### PR TITLE
Add randomized property tests for raft

### DIFF
--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -14,7 +14,9 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <artifactId>atomix-cluster</artifactId>
 
   <dependencies>
@@ -128,6 +130,32 @@
       <groupId>uk.co.real-logic</groupId>
       <artifactId>sbe-tool</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.jmock</groupId>
+      <artifactId>jmock</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.bytebuddy</groupId>
+          <artifactId>byte-buddy</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <modelVersion>4.0.0</modelVersion>
@@ -201,6 +229,7 @@
           <usedDependencies>
             <!-- dependency used but plugin seems to report a false positive here -->
             <dependency>uk.co.real-logic:sbe-tool</dependency>
+            <dependency>net.jqwik:jqwik</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.partition.impl.RaftNamespaces;
+import io.atomix.raft.protocol.ControllableRaftServerProtocol;
+import io.atomix.raft.roles.LeaderRole;
+import io.atomix.raft.snapshot.TestSnapshotStore;
+import io.atomix.raft.storage.RaftStorage;
+import io.atomix.raft.zeebe.NoopEntryValidator;
+import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
+import io.atomix.storage.StorageLevel;
+import io.atomix.storage.journal.JournalReader;
+import io.atomix.storage.journal.JournalReader.Mode;
+import io.zeebe.util.collection.Tuple;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.jmock.lib.concurrent.DeterministicScheduler;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Uses a DeterministicScheduler and controllable messaging layer to get a deterministic execution
+ * of raft threads. Note:- Currently there is some non-determinism hidden in the raft. Hence the
+ * resulting execution is not fully deterministic.
+ */
+public final class ControllableRaftContexts {
+
+  private final Map<MemberId, ControllableRaftServerProtocol> serverProtocols = new HashMap<>();
+  private final Map<MemberId, Queue<Tuple<Runnable, CompletableFuture>>> messageQueue =
+      new HashMap<>();
+  private final Map<MemberId, DeterministicSingleThreadContext> deterministicExecutors =
+      new HashMap<>();
+
+  private Path directory;
+
+  private final int nodeCount;
+  private final Map<MemberId, RaftContext> raftServers = new HashMap<>();
+  private Duration electionTimeout;
+  private Duration hearbeatTimeout;
+  private int nextEntry = 0;
+
+  // Used only for verification. Map[term -> leader]
+  private final Map<Long, MemberId> leadersAtTerms = new HashMap<>();
+
+  public ControllableRaftContexts(final int nodeCount) {
+    this.nodeCount = nodeCount;
+  }
+
+  public Map<MemberId, RaftContext> getRaftServers() {
+    return raftServers;
+  }
+
+  public RaftContext getRaftContext(final int memberId) {
+    return raftServers.get(MemberId.from(String.valueOf(memberId)));
+  }
+
+  public RaftContext getRaftContext(final MemberId memberId) {
+    return raftServers.get(memberId);
+  }
+
+  public void setup(final Path directory, final Random random) throws Exception {
+    this.directory = directory;
+    if (nodeCount > 0) {
+      createRaftContexts(nodeCount, random);
+    }
+    joinRaftServers();
+    electionTimeout = getRaftContext(0).getElectionTimeout();
+    hearbeatTimeout = getRaftContext(0).getHeartbeatInterval();
+
+    // expecting 0 to be the leader
+    tickHeartbeatTimeout(0);
+  }
+
+  public void shudown() throws IOException {
+    raftServers.forEach((m, c) -> c.close());
+    raftServers.clear();
+    serverProtocols.clear();
+    deterministicExecutors.forEach((m, e) -> e.close());
+    deterministicExecutors.clear();
+    messageQueue.clear();
+    leadersAtTerms.clear();
+    directory = null;
+  }
+
+  private void joinRaftServers() throws InterruptedException, ExecutionException, TimeoutException {
+    final Set<CompletableFuture<Void>> futures = new HashSet<>();
+    final var servers = getRaftServers();
+    final var serverIds = new ArrayList<>(servers.keySet());
+    final long electionTimeout =
+        servers.get(MemberId.from(String.valueOf(0))).getElectionTimeout().toMillis();
+    Collections.sort(serverIds);
+    servers.forEach(
+        (memberId, raftContext) -> futures.add(raftContext.getCluster().bootstrap(serverIds)));
+
+    runUntilDone(0);
+    // trigger election on 0 so that 0 is initially the leader
+    getDeterministicScheduler(MemberId.from(String.valueOf(0)))
+        .tick(2 * electionTimeout, TimeUnit.MILLISECONDS);
+    final var joinFuture = CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+
+    // Should trigger executions and message delivery
+    while (!joinFuture.isDone()) {
+      processAllMessage();
+      runUntilDone();
+    }
+    joinFuture.get(1, TimeUnit.SECONDS);
+  }
+
+  private void createRaftContexts(final int nodeCount, final Random random) {
+    for (int i = 0; i < nodeCount; i++) {
+      final var memberId = MemberId.from(String.valueOf(i));
+      raftServers.put(memberId, createRaftContext(memberId, random));
+    }
+  }
+
+  public RaftContext createRaftContext(final MemberId memberId, final Random random) {
+    final var raft =
+        new RaftContext(
+            memberId.id() + "-partition-1",
+            memberId,
+            mock(ClusterMembershipService.class),
+            new ControllableRaftServerProtocol(memberId, serverProtocols, messageQueue),
+            createStorage(memberId),
+            getRaftThreadContextFactory(memberId),
+            32 * 1024, // Copied from defaults
+            2, // Copied from defaults
+            () -> random);
+    raft.setEntryValidator(new NoopEntryValidator());
+    return raft;
+  }
+
+  private RaftThreadContextFactory getRaftThreadContextFactory(final MemberId memberId) {
+    return (factory, uncaughtExceptionHandler) ->
+        deterministicExecutors.computeIfAbsent(
+            memberId,
+            m ->
+                (DeterministicSingleThreadContext)
+                    DeterministicSingleThreadContext.createContext());
+  }
+
+  private RaftStorage createStorage(final MemberId memberId) {
+    return createStorage(memberId, Function.identity());
+  }
+
+  private RaftStorage createStorage(
+      final MemberId memberId,
+      final Function<RaftStorage.Builder, RaftStorage.Builder> configurator) {
+    final var memberDirectory = getMemberDirectory(directory, memberId.toString());
+    final RaftStorage.Builder defaults =
+        RaftStorage.builder()
+            .withStorageLevel(StorageLevel.DISK)
+            .withDirectory(memberDirectory)
+            .withMaxSegmentSize(1024 * 10)
+            .withFreeDiskSpace(100)
+            .withSnapshotStore(new TestSnapshotStore(new AtomicReference<>()))
+            .withNamespace(RaftNamespaces.RAFT_STORAGE);
+    return configurator.apply(defaults).build();
+  }
+
+  private File getMemberDirectory(final Path directory, final String s) {
+    return new File(directory.toFile(), s);
+  }
+
+  public ControllableRaftServerProtocol getServerProtocol(final MemberId memberId) {
+    return serverProtocols.get(memberId);
+  }
+
+  public ControllableRaftServerProtocol getServerProtocol(final int memberId) {
+    return getServerProtocol(MemberId.from(String.valueOf(memberId)));
+  }
+
+  public DeterministicScheduler getDeterministicScheduler(final MemberId memberId) {
+    return deterministicExecutors.get(memberId).getDeterministicScheduler();
+  }
+
+  public DeterministicScheduler getDeterministicScheduler(final int memberId) {
+    return getDeterministicScheduler(MemberId.from(String.valueOf(memberId)));
+  }
+
+  // ------ Methods to control the execution of raft threads --------
+
+  // run until there are no more task to process
+  public void runUntilDone() {
+    final var serverIds = raftServers.keySet();
+    serverIds.forEach(memberId -> getDeterministicScheduler(memberId).runUntilIdle());
+  }
+
+  // run until there are no more tasks to processon member's scheduler
+  public void runUntilDone(final int memberId) {
+    getServerProtocol(memberId).receiveAll();
+    getDeterministicScheduler(memberId).runUntilIdle();
+  }
+
+  public void runUntilDone(final MemberId memberId) {
+    getDeterministicScheduler(memberId).runUntilIdle();
+  }
+
+  public void runNextTask(final MemberId memberId) {
+    final var scheduler = getDeterministicScheduler(memberId);
+    if (!scheduler.isIdle()) {
+      scheduler.runNextPendingCommand();
+    }
+  }
+
+  // Submit all messages from the incoming queue to the schedulers to process
+  public void processAllMessage() {
+    final var serverIds = raftServers.keySet();
+    serverIds.forEach(memberId -> getServerProtocol(memberId).receiveAll());
+  }
+
+  public void processAllMessage(final MemberId memberId) {
+    getServerProtocol(memberId).receiveAll();
+  }
+
+  // Submit the next message from the incoming queue to the scheduler of memberid.
+  public void processNextMessage(final MemberId memberId) {
+    getServerProtocol(memberId).receiveNextMessage();
+  }
+
+  public void tickElectionTimeout(final int memberId) {
+    getDeterministicScheduler(memberId).tick(electionTimeout.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  public void tickElectionTimeout(final MemberId memberId) {
+    getDeterministicScheduler(memberId).tick(electionTimeout.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  public void tickHeartbeatTimeout(final int memberId) {
+    getDeterministicScheduler(memberId).tick(hearbeatTimeout.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  public void tickHeartbeatTimeout(final MemberId memberId) {
+    getDeterministicScheduler(memberId).tick(hearbeatTimeout.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  public void tick(final MemberId memberId, final Duration time) {
+    getDeterministicScheduler(memberId).tick(time.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  // Execute an append on memberid. If memberid is not the the leader, the append will be rejected.
+  private void clientAppend(final MemberId memberId) {
+    final var role = getRaftContext(memberId).getRaftRole();
+    if (role instanceof LeaderRole) {
+      LoggerFactory.getLogger("TEST").info("Appending on leader {}", memberId.id());
+      final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, nextEntry++);
+      final LeaderRole leaderRole = (LeaderRole) role;
+      leaderRole.appendEntry(0, 1, data, mock(AppendListener.class));
+    }
+  }
+
+  // Find current leader and execute an append
+  public void clientAppendOnLeader() {
+    final var leaderTerm = leadersAtTerms.keySet().stream().max(Long::compareTo);
+    if (leaderTerm.isPresent()) {
+      final var leader = leadersAtTerms.get(leaderTerm.get());
+      if (leader != null) {
+        clientAppend(leader);
+      }
+    }
+  }
+
+  // ----------------------- Verifications -----------------------------
+
+  // Verify that committed entries in all logs are equal
+  public void assertAllLogsEqual() {
+    final var readers =
+        raftServers.values().stream()
+            .collect(
+                Collectors.toMap(Function.identity(), s -> s.getLog().openReader(0, Mode.COMMITS)));
+    long index = 0;
+    while (true) {
+      final var entries =
+          readers.keySet().stream()
+              .filter(s -> readers.get(s).hasNext())
+              .collect(Collectors.toMap(s -> s.getName(), s -> readers.get(s).next()));
+      if (entries.size() == 0) {
+        break;
+      }
+      assertThat(entries.values().stream().distinct().count())
+          .withFailMessage(
+              "Expected to find the same entry at a committed index on all nodes, but found %s",
+              entries)
+          .isEqualTo(1);
+      index++;
+    }
+    final var commitIndexOnLeader =
+        raftServers.values().stream()
+            .map(RaftContext::getCommitIndex)
+            .max(Long::compareTo)
+            .orElseThrow();
+    assertThat(index).isEqualTo(commitIndexOnLeader);
+    readers.values().forEach(JournalReader::close);
+  }
+
+  public void assertOnlyOneLeader() {
+    raftServers.values().forEach(s -> updateAndVerifyLeaderTerm(s));
+  }
+
+  private void updateAndVerifyLeaderTerm(final RaftContext s) {
+    final long term = s.getTerm();
+    if (s.getLeader() != null) {
+      final var leader = s.getLeader().memberId();
+      if (leadersAtTerms.containsKey(term)) {
+        final var knownLeader = leadersAtTerms.get(term);
+        assertThat(knownLeader)
+            .withFailMessage("Found two leaders %s %s at term %s", knownLeader, leader, term)
+            .isEqualTo(leader);
+      } else {
+        leadersAtTerms.put(term, leader);
+      }
+    }
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/DeterministicSingleThreadContext.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/DeterministicSingleThreadContext.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import static org.junit.Assert.fail;
+
+import io.atomix.utils.concurrent.Scheduled;
+import io.atomix.utils.concurrent.ScheduledFutureImpl;
+import io.atomix.utils.concurrent.ThreadContext;
+import java.time.Duration;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.jmock.lib.concurrent.DeterministicScheduler;
+
+public final class DeterministicSingleThreadContext implements ThreadContext {
+
+  private final DeterministicScheduler deterministicScheduler;
+
+  private DeterministicSingleThreadContext(final DeterministicScheduler executor) {
+    deterministicScheduler = executor;
+  }
+
+  public DeterministicScheduler getDeterministicScheduler() {
+    return deterministicScheduler;
+  }
+
+  public static ThreadContext createContext() {
+    return new DeterministicSingleThreadContext(new DeterministicScheduler());
+  }
+
+  @Override
+  public Scheduled schedule(final long delay, final TimeUnit timeUnit, final Runnable command) {
+    final var future =
+        deterministicScheduler.schedule(new WrappedRunnable(command), delay, timeUnit);
+    return new ScheduledFutureImpl<>(future);
+  }
+
+  @Override
+  public Scheduled schedule(final Duration delay, final Runnable command) {
+    final var future =
+        deterministicScheduler.schedule(
+            new WrappedRunnable(command), delay.toMillis(), TimeUnit.MILLISECONDS);
+    return new ScheduledFutureImpl<>(future);
+  }
+
+  @Override
+  public Scheduled schedule(
+      final long initialDelay,
+      final long interval,
+      final TimeUnit timeUnit,
+      final Runnable command) {
+    final ScheduledFuture<?> future =
+        deterministicScheduler.scheduleAtFixedRate(
+            new WrappedRunnable(command), initialDelay, interval, timeUnit);
+    return new ScheduledFutureImpl<>(future);
+  }
+
+  @Override
+  public Scheduled schedule(
+      final Duration initialDelay, final Duration interval, final Runnable command) {
+    final ScheduledFuture<?> future =
+        deterministicScheduler.scheduleAtFixedRate(
+            new WrappedRunnable(command),
+            initialDelay.toMillis(),
+            interval.toMillis(),
+            TimeUnit.MILLISECONDS);
+    return new ScheduledFutureImpl<>(future);
+  }
+
+  @Override
+  public void execute(final Runnable command) {
+    deterministicScheduler.execute(new WrappedRunnable(command));
+  }
+
+  @Override
+  public boolean isCurrentContext() {
+    return true;
+  }
+
+  @Override
+  public void checkThread() {
+    // always assume running on the right context
+  }
+
+  @Override
+  public boolean isBlocked() {
+    return false;
+  }
+
+  @Override
+  public void block() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void unblock() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void close() {
+    // do nothing
+  }
+
+  static final class WrappedRunnable implements Runnable {
+
+    private final Runnable command;
+
+    WrappedRunnable(final Runnable command) {
+      this.command = command;
+    }
+
+    @Override
+    public void run() {
+      try {
+        command.run();
+      } catch (final Exception e) {
+        e.printStackTrace();
+        fail("Uncaught exception");
+      }
+    }
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import io.atomix.cluster.MemberId;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+/** An operation that can be executed on a raft member */
+public final class RaftOperation {
+
+  private final BiConsumer<ControllableRaftContexts, MemberId> operation;
+  private final String name;
+
+  private RaftOperation(
+      final String name, final BiConsumer<ControllableRaftContexts, MemberId> operation) {
+    this.name = name;
+    this.operation = operation;
+  }
+
+  public static RaftOperation of(
+      final String name, final BiConsumer<ControllableRaftContexts, MemberId> operation) {
+    return new RaftOperation(name, operation);
+  }
+
+  public void run(final ControllableRaftContexts raftContext, final MemberId memberId) {
+    operation.accept(raftContext, memberId);
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  /** Returns a list of RaftOperation */
+  public static List<RaftOperation> getDefaultRaftOperations() {
+    final List<RaftOperation> defaultRaftOperation = new ArrayList<>();
+    defaultRaftOperation.add(
+        RaftOperation.of(
+            "Run next task", (raftContexts, memberId) -> raftContexts.runNextTask(memberId)));
+    defaultRaftOperation.add(
+        RaftOperation.of(
+            "Receive next message",
+            (raftContexts, memberId) -> raftContexts.processNextMessage(memberId)));
+    defaultRaftOperation.add(
+        RaftOperation.of(
+            "Tick electionTimeout",
+            (raftContexts, memberId) -> raftContexts.tickElectionTimeout(memberId)));
+    defaultRaftOperation.add(
+        RaftOperation.of(
+            "Tick heartbeatTimeout",
+            (raftContexts, memberId) -> raftContexts.tickHeartbeatTimeout(memberId)));
+    defaultRaftOperation.add(
+        RaftOperation.of(
+            "Tick 50ms", (raftContexts, m) -> raftContexts.tick(m, Duration.ofMillis(50))));
+    defaultRaftOperation.add(
+        RaftOperation.of(
+            "Append on leader", (raftContexts, m) -> raftContexts.clientAppendOnLeader()));
+    defaultRaftOperation.add(
+        RaftOperation.of(
+            "Drop next message",
+            (raftContexts, m) -> raftContexts.getServerProtocol(m).dropNextMessage()));
+    return defaultRaftOperation;
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import io.atomix.cluster.MemberId;
+import io.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.EdgeCasesMode;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.ShrinkingMode;
+import net.jqwik.api.lifecycle.AfterTry;
+import net.jqwik.api.lifecycle.BeforeProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RandomizedRaftTest {
+
+  private static final int OPERATION_SIZE = 10000;
+  private static final Logger LOG = LoggerFactory.getLogger(RandomizedRaftTest.class);
+  private ControllableRaftContexts raftContexts;
+  private List<RaftOperation> operations;
+  private List<MemberId> raftMembers;
+  private Path raftDataDirectory;
+
+  @BeforeProperty
+  public void initOperations() {
+    // Need members ids to generate pair operations
+    final var servers =
+        IntStream.range(0, 3)
+            .mapToObj(String::valueOf)
+            .map(MemberId::from)
+            .collect(Collectors.toList());
+    operations = RaftOperation.getDefaultRaftOperations();
+    raftMembers = servers;
+  }
+
+  @AfterTry
+  public void shutDownRaftNodes() throws IOException {
+    raftContexts.shudown();
+    FileUtil.deleteFolder(raftDataDirectory);
+    raftDataDirectory = null;
+  }
+
+  @Property(tries = 10, shrinking = ShrinkingMode.OFF, edgeCases = EdgeCasesMode.NONE)
+  void raftProperty(
+      @ForAll("raftOperations") final List<RaftOperation> raftOperations,
+      @ForAll("raftMembers") final List<MemberId> raftMembers,
+      @ForAll("seeds") final long seed)
+      throws Exception {
+
+    setUpRaftNodes(new Random(seed));
+
+    int step = 0;
+    final var memberIter = raftMembers.iterator();
+    for (final RaftOperation operation : raftOperations) {
+      step++;
+
+      final MemberId member = memberIter.next();
+      LOG.info("{} on {}", operation, member);
+      operation.run(raftContexts, member);
+      raftContexts.assertOnlyOneLeader();
+
+      if (step % 100 == 0) { // reading logs after every operation can be too slow
+        raftContexts.assertAllLogsEqual();
+        step = 0;
+      }
+    }
+
+    raftContexts.assertAllLogsEqual();
+  }
+
+  @Provide
+  Arbitrary<List<RaftOperation>> raftOperations() {
+    final var operation = Arbitraries.of(operations);
+    return operation.list().ofSize(OPERATION_SIZE);
+  }
+
+  @Provide
+  Arbitrary<List<MemberId>> raftMembers() {
+    final var members = Arbitraries.of(raftMembers);
+    return members.list().ofSize(OPERATION_SIZE);
+  }
+
+  @Provide
+  Arbitrary<Long> seeds() {
+    return Arbitraries.longs();
+  }
+
+  private void setUpRaftNodes(final Random random) throws Exception {
+    // Couldnot make @TempDir annotation work
+    raftDataDirectory = Files.createTempDirectory(null);
+    raftContexts = new ControllableRaftContexts(3);
+    raftContexts.setup(raftDataDirectory, random);
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.protocol;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.utils.concurrent.Futures;
+import io.zeebe.util.collection.Tuple;
+import java.net.ConnectException;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Controllable raft server protocol. The messages are delivered only when explicitly instructed and
+ * messages can be dropped.
+ */
+public class ControllableRaftServerProtocol implements RaftServerProtocol {
+
+  private Function<JoinRequest, CompletableFuture<JoinResponse>> joinHandler;
+  private Function<LeaveRequest, CompletableFuture<LeaveResponse>> leaveHandler;
+  private Function<ConfigureRequest, CompletableFuture<ConfigureResponse>> configureHandler;
+  private Function<ReconfigureRequest, CompletableFuture<ReconfigureResponse>> reconfigureHandler;
+  private Function<InstallRequest, CompletableFuture<InstallResponse>> installHandler;
+  private Function<TransferRequest, CompletableFuture<TransferResponse>> transferHandler;
+  private Function<PollRequest, CompletableFuture<PollResponse>> pollHandler;
+  private Function<VoteRequest, CompletableFuture<VoteResponse>> voteHandler;
+  private Function<AppendRequest, CompletableFuture<AppendResponse>> appendHandler;
+  private final Map<MemberId, ControllableRaftServerProtocol> servers;
+  // Incoming messages to each member
+  private final Map<MemberId, Queue<Tuple<Runnable, CompletableFuture>>> messageQueue;
+  private final MemberId localMemberId;
+
+  public ControllableRaftServerProtocol(
+      final MemberId memberId,
+      final Map<MemberId, ControllableRaftServerProtocol> servers,
+      final Map<MemberId, Queue<Tuple<Runnable, CompletableFuture>>> messageQueue) {
+    this.servers = servers;
+    this.messageQueue = messageQueue;
+    localMemberId = memberId;
+    messageQueue.put(memberId, new LinkedList<>());
+    servers.put(memberId, this);
+  }
+
+  public void receiveNextMessage() {
+    final var rcvQueue = messageQueue.get(localMemberId);
+    if (!rcvQueue.isEmpty()) {
+      rcvQueue.poll().getLeft().run();
+    }
+  }
+
+  public void receiveAll() {
+    final var rcvQueue = messageQueue.get(localMemberId);
+    while (!rcvQueue.isEmpty()) {
+      rcvQueue.poll().getLeft().run();
+    }
+  }
+
+  // drop next message from the incoming queue
+  public void dropNextMessage() {
+    final var nextMessage =
+        messageQueue.computeIfAbsent(localMemberId, t -> new LinkedList<>()).poll();
+    if (nextMessage != null) {
+      Optional.ofNullable(nextMessage.getRight())
+          .ifPresent(
+              f -> {
+                LoggerFactory.getLogger("TEST:")
+                    .info("Dropped a message to {}", localMemberId.id());
+                // RaftServers excepts exceptions from the messaging layer to detect timeouts
+                f.completeExceptionally(new TimeoutException());
+              });
+    }
+  }
+
+  ControllableRaftServerProtocol server(final MemberId memberId) {
+    return servers.get(memberId);
+  }
+
+  // Add a message to the outgoing queue
+  private void send(
+      final MemberId memberId,
+      final Runnable requestHandler,
+      final CompletableFuture responseFuture) {
+    final var message = new Tuple<>(requestHandler, responseFuture);
+    messageQueue.computeIfAbsent(memberId, m -> new LinkedList<>()).add(message);
+  }
+
+  @Override
+  public CompletableFuture<JoinResponse> join(final MemberId memberId, final JoinRequest request) {
+    final var responseFuture = new CompletableFuture<JoinResponse>();
+    send(
+        memberId,
+        () ->
+            getServer(memberId)
+                .thenCompose(listener -> listener.join(request))
+                .thenAccept(
+                    response -> send(localMemberId, () -> responseFuture.complete(response), null)),
+        responseFuture);
+    return responseFuture;
+  }
+
+  @Override
+  public CompletableFuture<LeaveResponse> leave(
+      final MemberId memberId, final LeaveRequest request) {
+    final var responseFuture = new CompletableFuture<LeaveResponse>();
+    send(
+        memberId,
+        () ->
+            getServer(memberId)
+                .thenCompose(listener -> listener.leave(request))
+                .thenAccept(
+                    response -> send(localMemberId, () -> responseFuture.complete(response), null)),
+        responseFuture);
+    return responseFuture;
+  }
+
+  @Override
+  public CompletableFuture<ConfigureResponse> configure(
+      final MemberId memberId, final ConfigureRequest request) {
+    final var responseFuture = new CompletableFuture<ConfigureResponse>();
+    send(
+        memberId,
+        () ->
+            getServer(memberId)
+                .thenCompose(listener -> listener.configure(request))
+                .thenAccept(
+                    response -> send(localMemberId, () -> responseFuture.complete(response), null)),
+        responseFuture);
+    return responseFuture;
+  }
+
+  @Override
+  public CompletableFuture<ReconfigureResponse> reconfigure(
+      final MemberId memberId, final ReconfigureRequest request) {
+    final var responseFuture = new CompletableFuture<ReconfigureResponse>();
+    send(
+        memberId,
+        () ->
+            getServer(memberId)
+                .thenCompose(listener -> listener.reconfigure(request))
+                .thenAccept(
+                    response -> send(localMemberId, () -> responseFuture.complete(response), null)),
+        responseFuture);
+    return responseFuture;
+  }
+
+  @Override
+  public CompletableFuture<InstallResponse> install(
+      final MemberId memberId, final InstallRequest request) {
+    final var responseFuture = new CompletableFuture<InstallResponse>();
+    send(
+        memberId,
+        () ->
+            getServer(memberId)
+                .thenCompose(listener -> listener.install(request))
+                .thenAccept(
+                    response -> send(localMemberId, () -> responseFuture.complete(response), null)),
+        responseFuture);
+    return responseFuture;
+  }
+
+  @Override
+  public CompletableFuture<TransferResponse> transfer(
+      final MemberId memberId, final TransferRequest request) {
+    final var responseFuture = new CompletableFuture<TransferResponse>();
+    send(
+        memberId,
+        () ->
+            getServer(memberId)
+                .thenCompose(listener -> listener.transfer(request))
+                .thenAccept(
+                    response -> send(localMemberId, () -> responseFuture.complete(response), null)),
+        responseFuture);
+    return responseFuture;
+  }
+
+  @Override
+  public CompletableFuture<PollResponse> poll(final MemberId memberId, final PollRequest request) {
+    final var responseFuture = new CompletableFuture<PollResponse>();
+    send(
+        memberId,
+        () ->
+            getServer(memberId)
+                .thenCompose(listener -> listener.poll(request))
+                .thenAccept(
+                    response -> send(localMemberId, () -> responseFuture.complete(response), null)),
+        responseFuture);
+    return responseFuture;
+  }
+
+  @Override
+  public CompletableFuture<VoteResponse> vote(final MemberId memberId, final VoteRequest request) {
+    final var responseFuture = new CompletableFuture<VoteResponse>();
+    send(
+        memberId,
+        () ->
+            getServer(memberId)
+                .thenCompose(listener -> listener.vote(request))
+                .thenAccept(
+                    response -> send(localMemberId, () -> responseFuture.complete(response), null)),
+        responseFuture);
+    return responseFuture;
+  }
+
+  @Override
+  public CompletableFuture<AppendResponse> append(
+      final MemberId memberId, final AppendRequest request) {
+    final var responseFuture = new CompletableFuture<AppendResponse>();
+    send(
+        memberId,
+        () ->
+            getServer(memberId)
+                .thenCompose(listener -> listener.append(request))
+                .thenAccept(
+                    response -> send(localMemberId, () -> responseFuture.complete(response), null)),
+        responseFuture);
+    return responseFuture;
+  }
+
+  @Override
+  public void registerJoinHandler(
+      final Function<JoinRequest, CompletableFuture<JoinResponse>> handler) {
+    joinHandler = handler;
+  }
+
+  @Override
+  public void unregisterJoinHandler() {
+    joinHandler = null;
+  }
+
+  @Override
+  public void registerLeaveHandler(
+      final Function<LeaveRequest, CompletableFuture<LeaveResponse>> handler) {
+    leaveHandler = handler;
+  }
+
+  @Override
+  public void unregisterLeaveHandler() {
+    leaveHandler = null;
+  }
+
+  @Override
+  public void registerTransferHandler(
+      final Function<TransferRequest, CompletableFuture<TransferResponse>> handler) {
+    transferHandler = handler;
+  }
+
+  @Override
+  public void unregisterTransferHandler() {
+    transferHandler = null;
+  }
+
+  @Override
+  public void registerConfigureHandler(
+      final Function<ConfigureRequest, CompletableFuture<ConfigureResponse>> handler) {
+    configureHandler = handler;
+  }
+
+  @Override
+  public void unregisterConfigureHandler() {
+    configureHandler = null;
+  }
+
+  @Override
+  public void registerReconfigureHandler(
+      final Function<ReconfigureRequest, CompletableFuture<ReconfigureResponse>> handler) {
+    reconfigureHandler = handler;
+  }
+
+  @Override
+  public void unregisterReconfigureHandler() {
+    reconfigureHandler = null;
+  }
+
+  @Override
+  public void registerInstallHandler(
+      final Function<InstallRequest, CompletableFuture<InstallResponse>> handler) {
+    installHandler = handler;
+  }
+
+  @Override
+  public void unregisterInstallHandler() {
+    installHandler = null;
+  }
+
+  @Override
+  public void registerPollHandler(
+      final Function<PollRequest, CompletableFuture<PollResponse>> handler) {
+    pollHandler = handler;
+  }
+
+  @Override
+  public void unregisterPollHandler() {
+    pollHandler = null;
+  }
+
+  @Override
+  public void registerVoteHandler(
+      final Function<VoteRequest, CompletableFuture<VoteResponse>> handler) {
+    voteHandler = handler;
+  }
+
+  @Override
+  public void unregisterVoteHandler() {
+    voteHandler = null;
+  }
+
+  @Override
+  public void registerAppendHandler(
+      final Function<AppendRequest, CompletableFuture<AppendResponse>> handler) {
+    appendHandler = handler;
+  }
+
+  @Override
+  public void unregisterAppendHandler() {
+    appendHandler = null;
+  }
+
+  private CompletableFuture<ControllableRaftServerProtocol> getServer(final MemberId memberId) {
+    final ControllableRaftServerProtocol server = server(memberId);
+    if (server != null) {
+      return Futures.completedFuture(server);
+    } else {
+      return Futures.exceptionalFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<AppendResponse> append(final AppendRequest request) {
+    if (appendHandler != null) {
+      return appendHandler.apply(request);
+    } else {
+      return Futures.exceptionalFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<VoteResponse> vote(final VoteRequest request) {
+    if (voteHandler != null) {
+      return voteHandler.apply(request);
+    } else {
+      return Futures.exceptionalFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<PollResponse> poll(final PollRequest request) {
+    if (pollHandler != null) {
+      return pollHandler.apply(request);
+    } else {
+      return Futures.exceptionalFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<TransferResponse> transfer(final TransferRequest request) {
+    if (transferHandler != null) {
+      return transferHandler.apply(request);
+    } else {
+      return Futures.exceptionalFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<InstallResponse> install(final InstallRequest request) {
+    if (installHandler != null) {
+      return installHandler.apply(request);
+    } else {
+      return Futures.exceptionalFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<ReconfigureResponse> reconfigure(final ReconfigureRequest request) {
+    if (reconfigureHandler != null) {
+      return reconfigureHandler.apply(request);
+    } else {
+      return Futures.exceptionalFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<ConfigureResponse> configure(final ConfigureRequest request) {
+    if (configureHandler != null) {
+      return configureHandler.apply(request);
+    } else {
+      return Futures.exceptionalFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<LeaveResponse> leave(final LeaveRequest request) {
+    if (leaveHandler != null) {
+      return leaveHandler.apply(request);
+    } else {
+      return Futures.exceptionalFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<JoinResponse> join(final JoinRequest request) {
+    if (joinHandler != null) {
+      return joinHandler.apply(request);
+    } else {
+      return Futures.exceptionalFuture(new ConnectException());
+    }
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
@@ -71,7 +71,7 @@ public class TestSnapshotStore implements ReceivableSnapshotStore {
   @Override
   public long getCurrentSnapshotIndex() {
     if (currentPersistedSnapshot.get() == null) {
-      return -1;
+      return 0;
     }
     return currentPersistedSnapshot.get().getIndex();
   }

--- a/atomix/utils/src/main/java/io/atomix/utils/concurrent/ScheduledFutureImpl.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/concurrent/ScheduledFutureImpl.java
@@ -19,10 +19,10 @@ package io.atomix.utils.concurrent;
 import java.util.concurrent.Future;
 
 /** Simple wrapper class that delegates to a non-interruptible future */
-final class ScheduledFutureImpl<T> implements Scheduled {
+public final class ScheduledFutureImpl<T> implements Scheduled {
   private final Future<T> future;
 
-  ScheduledFutureImpl(final Future<T> future) {
+  public ScheduledFutureImpl(final Future<T> future) {
     this.future = future;
   }
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -96,6 +96,8 @@
     <version.kryo>4.0.2</version.kryo>
     <version.awaitility>4.0.3</version.awaitility>
     <version.failsafe>2.4.0</version.failsafe>
+    <version.jqwik>1.3.6</version.jqwik>
+    <version.jmock>2.11.0</version.jmock>
 
 
     <!-- maven plugins -->
@@ -575,6 +577,23 @@
         <version>${version.testcontainers}</version>
       </dependency>
 
+
+      <dependency>
+        <groupId>net.jqwik</groupId>
+        <artifactId>jqwik</artifactId>
+        <version>${version.jqwik}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>net.jqwik</groupId>
+        <artifactId>jqwik-api</artifactId>
+        <version>${version.jqwik}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jmock</groupId>
+        <artifactId>jmock</artifactId>
+        <version>${version.jmock}</version>
+      </dependency>
 
       <dependency>
         <groupId>com.netflix.concurrency-limits</groupId>


### PR DESCRIPTION
## Description

Testing a distributed or concurrent program is difficult. There are so many combinations of concurrent operations possible. It is not possible to test all cases. Hence we introduce a randomized test for the raft protocol implementation. For each run of this test, it runs a fixed number of *tries*. Each try generates a random sequence of operations that can be applied to the raft replicas. While running these operations, the tests verifies some properties that should be guaranteed by the raft. The scheduling and message delivery is controlled via these operations. The properties that we verify are:
1. There is only one leader at a term
2. The committed entries are same on all replicas

In one run, it only tests a few sequences. This test will be run with each build and PR. So overtime, the tests will be run with many different sequences of operations. Thus overtime, any existing bugs will be revealed, or confidence in the raft implementation will increase. We have already found and fixed two bugs with this approach - https://github.com/zeebe-io/zeebe/issues/5360 and https://github.com/zeebe-io/zeebe/issues/5356

For the randomized test we use a property based testing framework - [jqwik](https://jqwik.net/).

Current limitations:
- Due to some unknown non-determinism within the raft implementation, test failures may not be reproducible by reusing the seed.

General limitations:
- These tests cannot be used for testing liveness (eg:- join process completes, leader election completes with in a specific duration etc.)
- A passing test does not mean there are no bugs. So if you make changes to raft, also add tests to verify your specific changes.

Depends on #5588 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
