### PR TITLE
Improve OauthCredentialProvider in Go Client

### DIFF
--- a/clients/go/pkg/zbc/oauthCredentialsProvider.go
+++ b/clients/go/pkg/zbc/oauthCredentialsProvider.go
@@ -138,10 +138,10 @@ func NewOAuthCredentialsProvider(config *OAuthProviderConfig) (*OAuthCredentials
 }
 
 func (p *OAuthCredentialsProvider) getCredentials(ctx context.Context) (*oauth2.Token, error) {
-	if p.token == nil {
+	if p.token == nil || !p.token.Valid() {
 		credentials := p.getCachedToken()
 
-		if credentials != nil {
+		if credentials != nil && credentials.Valid() {
 			p.token = credentials
 			return credentials, nil
 		}


### PR DESCRIPTION
## Description
The OAuthCredentialProvider checks the validity of the tokens before injecting them in the http headers. If the token is invalid it tries to refresh the token. 

Furthermore, the cache is not repopulated every time a cached token is requested but only once on provider creation. This reduces disk read operations as the information is in memory anyways.

## Related issues

closes #5625 

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
