### PR TITLE
Fix concurrent partition closing

### DIFF
--- a/broker/src/test/java/io/zeebe/broker/system/partitions/ZeebePartitionTransitionIntegrationTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/ZeebePartitionTransitionIntegrationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.partitions;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.partition.RaftPartition;
+import io.zeebe.broker.system.partitions.impl.PartitionTransitionImpl;
+import io.zeebe.util.health.CriticalComponentsHealthMonitor;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+public class ZeebePartitionTransitionIntegrationTest {
+
+  @Rule public ActorSchedulerRule schedulerRule = new ActorSchedulerRule();
+
+  private PartitionContext ctx;
+  private PartitionTransition transition;
+
+  @Before
+  public void setup() {
+    ctx = mock(PartitionContext.class);
+    final NoopPartitionStep firstComponent = spy(new NoopPartitionStep());
+    final NoopPartitionStep secondComponent = spy(new NoopPartitionStep());
+    transition =
+        spy(new PartitionTransitionImpl(ctx, List.of(firstComponent), List.of(secondComponent)));
+
+    final RaftPartition raftPartition = mock(RaftPartition.class);
+    when(raftPartition.id()).thenReturn(new PartitionId("", 0));
+    when(raftPartition.getRole()).thenReturn(Role.INACTIVE);
+
+    final CriticalComponentsHealthMonitor healthMonitor =
+        mock(CriticalComponentsHealthMonitor.class);
+
+    when(ctx.getRaftPartition()).thenReturn(raftPartition);
+    when(ctx.getComponentHealthMonitor()).thenReturn(healthMonitor);
+  }
+
+  @Test
+  public void shouldTransitionToAndCloseInSequence() {
+    // given
+    final ZeebePartition partition = new ZeebePartition(ctx, transition);
+    schedulerRule.submitActor(partition);
+    partition.onNewRole(Role.LEADER, 1);
+    partition.onNewRole(Role.FOLLOWER, 1);
+
+    // when
+    partition.closeAsync().join();
+
+    // then
+    final InOrder inOrder = Mockito.inOrder(transition);
+    inOrder.verify(transition).toInactive();
+    inOrder.verify(transition).toLeader();
+    inOrder.verify(transition).toFollower();
+    inOrder.verify(transition).toInactive();
+  }
+
+  private static class NoopPartitionStep implements PartitionStep {
+
+    @Override
+    public ActorFuture<Void> open(final PartitionContext context) {
+      return CompletableActorFuture.completed(null);
+    }
+
+    @Override
+    public ActorFuture<Void> close(final PartitionContext context) {
+      return CompletableActorFuture.completed(null);
+    }
+
+    @Override
+    public String getName() {
+      return "NoopComponent";
+    }
+  }
+}

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/PartitionTransitionTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/PartitionTransitionTest.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.broker.system.partitions.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -20,7 +21,6 @@ import io.zeebe.util.sched.future.CompletableActorFuture;
 import io.zeebe.util.sched.testing.ControlledActorSchedulerRule;
 import java.util.Collections;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,10 +56,10 @@ public class PartitionTransitionTest {
                     .toLeader()
                     .onComplete(
                         (nothing, err) -> {
-                          Assertions.assertThat(err).isNull();
+                          assertThat(err).isNull();
                           partitionTransition
                               .toInactive()
-                              .onComplete((nothing1, err1) -> Assertions.assertThat(err1).isNull());
+                              .onComplete((nothing1, err1) -> assertThat(err1).isNull());
                         }));
 
     schedulerRule.submitActor(actor);
@@ -71,6 +71,210 @@ public class PartitionTransitionTest {
     order.verify(secondComponent).open(ctx);
     order.verify(secondComponent).close(ctx);
     order.verify(firstComponent).close(ctx);
+  }
+
+  @Test
+  public void shouldTransitionFromLeaderToFollowerInSequence() {
+    // given
+    final NoopPartitionStep leaderComponent = spy(new NoopPartitionStep());
+    final NoopPartitionStep followerComponent = spy(new NoopPartitionStep());
+    final PartitionTransitionImpl partitionTransition =
+        new PartitionTransitionImpl(ctx, List.of(leaderComponent), List.of(followerComponent));
+
+    // when
+    final Actor actor =
+        Actor.wrap(
+            actorCtrl -> {
+              partitionTransition.toLeader();
+              partitionTransition.toFollower();
+            });
+
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+
+    // then
+    final InOrder order = inOrder(leaderComponent, followerComponent);
+    order.verify(leaderComponent).open(ctx);
+    order.verify(leaderComponent).close(ctx);
+    order.verify(followerComponent).open(ctx);
+    order.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldTransitionFromFollowerToLeaderInSequence() {
+    // given
+    final NoopPartitionStep leaderComponent = spy(new NoopPartitionStep());
+    final NoopPartitionStep followerComponent = spy(new NoopPartitionStep());
+    final PartitionTransitionImpl partitionTransition =
+        new PartitionTransitionImpl(ctx, List.of(leaderComponent), List.of(followerComponent));
+
+    // when
+    final Actor actor =
+        Actor.wrap(
+            actorCtrl -> {
+              partitionTransition.toFollower();
+              partitionTransition.toLeader();
+            });
+
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+
+    // then
+    final InOrder order = inOrder(leaderComponent, followerComponent);
+    order.verify(followerComponent).open(ctx);
+    order.verify(followerComponent).close(ctx);
+    order.verify(leaderComponent).open(ctx);
+    order.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldTransitionFromFollowerToInactiveInSequence() {
+    // given
+    final NoopPartitionStep leaderComponent = spy(new NoopPartitionStep());
+    final NoopPartitionStep followerComponent = spy(new NoopPartitionStep());
+    final PartitionTransitionImpl partitionTransition =
+        new PartitionTransitionImpl(ctx, List.of(leaderComponent), List.of(followerComponent));
+
+    // when
+    final Actor actor =
+        Actor.wrap(
+            actorCtrl -> {
+              partitionTransition.toFollower();
+              partitionTransition.toInactive();
+            });
+
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+
+    // then
+    final InOrder order = inOrder(leaderComponent, followerComponent);
+    order.verify(followerComponent).open(ctx);
+    order.verify(followerComponent).close(ctx);
+  }
+
+  @Test
+  public void shouldTransitionFromLeaderToInactiveInSequence() {
+    // given
+    final NoopPartitionStep leaderComponent = spy(new NoopPartitionStep());
+    final NoopPartitionStep followerComponent = spy(new NoopPartitionStep());
+    final PartitionTransitionImpl partitionTransition =
+        new PartitionTransitionImpl(ctx, List.of(leaderComponent), List.of(followerComponent));
+
+    // when
+    final Actor actor =
+        Actor.wrap(
+            actorCtrl -> {
+              partitionTransition.toLeader();
+              partitionTransition.toInactive();
+            });
+
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+
+    // then
+    final InOrder order = inOrder(leaderComponent);
+    order.verify(leaderComponent).open(ctx);
+    order.verify(leaderComponent).close(ctx);
+  }
+
+  @Test
+  public void shouldTransitionFromInactiveToLeaderInSequence() {
+    // given
+    final NoopPartitionStep leaderComponent = spy(new NoopPartitionStep());
+    final NoopPartitionStep followerComponent = spy(new NoopPartitionStep());
+    final PartitionTransitionImpl partitionTransition =
+        new PartitionTransitionImpl(ctx, List.of(leaderComponent), List.of(followerComponent));
+
+    // when
+    final Actor actor =
+        Actor.wrap(
+            actorCtrl -> {
+              partitionTransition.toInactive();
+              partitionTransition.toLeader();
+            });
+
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+
+    // then
+    final InOrder order = inOrder(leaderComponent);
+    order.verify(leaderComponent).open(ctx);
+  }
+
+  @Test
+  public void shouldTransitionFromInactiveToFollowerInSequence() {
+    // given
+    final NoopPartitionStep leaderComponent = spy(new NoopPartitionStep());
+    final NoopPartitionStep followerComponent = spy(new NoopPartitionStep());
+    final PartitionTransitionImpl partitionTransition =
+        new PartitionTransitionImpl(ctx, List.of(leaderComponent), List.of(followerComponent));
+
+    // when
+    final Actor actor =
+        Actor.wrap(
+            actorCtrl -> {
+              partitionTransition.toInactive();
+              partitionTransition.toFollower();
+            });
+
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+
+    // then
+    final InOrder order = inOrder(followerComponent);
+    order.verify(followerComponent).open(ctx);
+  }
+
+  @Test
+  public void shouldTransitionFromLeaderToLeaderInSequence() {
+    // given
+    final NoopPartitionStep leaderComponent = spy(new NoopPartitionStep());
+    final NoopPartitionStep followerComponent = spy(new NoopPartitionStep());
+    final PartitionTransitionImpl partitionTransition =
+        new PartitionTransitionImpl(ctx, List.of(leaderComponent), List.of(followerComponent));
+
+    // when
+    final Actor actor =
+        Actor.wrap(
+            actorCtrl -> {
+              partitionTransition.toLeader();
+              partitionTransition.toLeader();
+            });
+
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+
+    // then
+    final InOrder order = inOrder(leaderComponent);
+    order.verify(leaderComponent).open(ctx);
+    order.verify(leaderComponent).close(ctx);
+    order.verify(leaderComponent).open(ctx);
+  }
+
+  @Test
+  public void shouldTransitionFromFollowerToFollowerInSequence() {
+    // given
+    final NoopPartitionStep leaderComponent = spy(new NoopPartitionStep());
+    final NoopPartitionStep followerComponent = spy(new NoopPartitionStep());
+    final PartitionTransitionImpl partitionTransition =
+        new PartitionTransitionImpl(ctx, List.of(leaderComponent), List.of(followerComponent));
+
+    // when
+    final Actor actor =
+        Actor.wrap(
+            actorCtrl -> {
+              partitionTransition.toFollower();
+              partitionTransition.toFollower();
+            });
+
+    schedulerRule.submitActor(actor);
+    schedulerRule.workUntilDone();
+
+    // then
+    final InOrder order = inOrder(followerComponent);
+    order.verify(followerComponent).open(ctx);
+    order.verify(followerComponent).close(ctx);
+    order.verify(followerComponent).open(ctx);
   }
 
   private static class NoopPartitionStep implements PartitionStep {

--- a/util/src/main/java/io/zeebe/util/sched/ActorTask.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorTask.java
@@ -20,6 +20,8 @@ import java.util.Queue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A task executed by the scheduler. For each actor (instance), exactly one task is created. Each
@@ -27,6 +29,8 @@ import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
  */
 @SuppressWarnings("restriction")
 public class ActorTask {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ActorTask.class);
 
   public final CompletableActorFuture<Void> closeFuture = new CompletableActorFuture<>();
   final Actor actor;
@@ -306,6 +310,7 @@ public class ActorTask {
     // discard next jobs
     ActorJob next;
     while ((next = fastLaneJobs.poll()) != null) {
+      LOG.debug("Discard job {} from fastLane of Actor {}.", next, actor.getName());
       failJob(next);
     }
   }


### PR DESCRIPTION

## Description

Allows to close and transition in order. Previous multiple transitions
and closing have worked against each other, which means it can lead to
unexpected outcomes or dead locks. See for example https://github.com/zeebe-io/zeebe/issues/5005#issuecomment-712122753

Transitions are now executed in a sequential order. The closing will
await the current transition, before starting the next transition and
closing all resources.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5005 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
