### PR TITLE
Add run/stop scripts for benchmarks

### DIFF
--- a/benchmarks/setup/runBenchmarks.sh
+++ b/benchmarks/setup/runBenchmarks.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+trap 'echo Terminated $0; exit' INT;
+
+if [ -z $1 ]
+then
+  echo "Please provide at least 1 namespace name! Usage: ./runBenchmarks.sh namespace1 namespace2 etc"
+  exit 1
+fi
+
+namespaces=$@
+
+for n in $namespaces; do
+    echo "Start benchmark for: $n"
+    cd $n
+    kubens $n
+    make clean zeebe starter worker
+    cd -
+    echo ""
+done

--- a/benchmarks/setup/stopBenchmarks.sh
+++ b/benchmarks/setup/stopBenchmarks.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+trap 'echo Terminated $0; exit' INT;
+
+if [ -z $1 ]
+then
+  echo "Please provide at least 1 namespace name! Usage: ./stopBenchmarks.sh namespace1 namespace2 etc"
+  exit 1
+fi
+
+namespaces=$@
+
+for n in $namespaces; do
+    echo "Stop benchmark for: $n"
+    cd $n
+    kubens $n
+    make clean
+    cd -
+    echo ""
+done


### PR DESCRIPTION
## Description
These scripts allow to start and stop multiple benchmarks sequentially.
It can be used when these steps become annoying to perform when running
multiple benchmarks.

## Related issues

none

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
