### PR TITLE
chore(ci): add TCK tests to build

### DIFF
--- a/.ci/docker/Dockerfile_zeebe-hazelcast-exporter
+++ b/.ci/docker/Dockerfile_zeebe-hazelcast-exporter
@@ -1,0 +1,12 @@
+FROM camunda/zeebe:current-test
+
+RUN apt-get -qq update
+RUN apt-get install --no-install-recommends -qq -y curl
+
+RUN mkdir /usr/local/zeebe/exporters
+RUN curl -L https://github.com/zeebe-io/zeebe-hazelcast-exporter/releases/download/0.10.0/zeebe-hazelcast-exporter-0.10.0-jar-with-dependencies.jar --output /usr/local/zeebe/exporters/zeebe-hazelcast-exporter-jar-with-dependencies.jar
+
+ENV ZEEBE_BROKER_EXPORTERS_HAZELCAST_CLASSNAME=io.zeebe.hazelcast.exporter.HazelcastExporter
+ENV ZEEBE_BROKER_EXPORTERS_HAZELCAST_JARPATH=exporters/zeebe-hazelcast-exporter-jar-with-dependencies.jar
+
+EXPOSE 26500 26501 26502 9600 5701

--- a/.ci/scripts/distribution/test-tck.sh
+++ b/.ci/scripts/distribution/test-tck.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -xeu
+
+git clone https://github.com/zeebe-io/bpmn-tck.git
+
+cd bpmn-tck
+# ./bpmn-tck/
+
+mvn -B test -DzeebeImage=zeebe-hazelcast-exporter -DzeebeImageVersion=current-test
+
+cd ..
+# ./

--- a/.ci/scripts/docker/build_zeebe-hazelcast-exporter.sh
+++ b/.ci/scripts/docker/build_zeebe-hazelcast-exporter.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -eux
+
+echo "Building Zeebe with Hazelast exporter Docker image zeebe-hazelcast-exporter:current-test"
+docker build --no-cache -f .ci/docker/Dockerfile_zeebe-hazelcast-exporter . -t zeebe-hazelcast-exporter:current-test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,6 +92,7 @@ pipeline {
 
                 container('docker') {
                     sh '.ci/scripts/docker/build.sh'
+                    sh '.ci/scripts/docker/build_zeebe-hazelcast-exporter.sh'
                 }
             }
         }
@@ -183,6 +184,20 @@ pipeline {
                     post {
                         always {
                             junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
+                        }
+                    }
+                }
+
+                stage('BPMN TCK') {
+                    steps {
+                        container('maven') {
+                            sh '.ci/scripts/distribution/test-tck.sh'
+                        }
+                    }
+
+                    post {
+                        always {
+                            junit testResults: "bpmn-tck/**/*/TEST*.xml", keepLongStdio: true
                         }
                     }
                 }


### PR DESCRIPTION
## Description

* Adds steps to the build pipeline to run the BPMN TCK tests against the current version of Zeebe.

## Related issues

closes #5595 

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)