### PR TITLE
chore(ci): enable build status collection for all branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -286,6 +286,12 @@ pipeline {
 
                     build job: currentBuild.projectName, propagate: false, quietPeriod: 60, wait: false
                 }
+
+                String userReason = null
+                if (currentBuild.description ==~ /.*Flaky Tests.*/) {
+                    userReason = 'flaky-tests'
+                }
+                org.camunda.helper.CIAnalytics.trackBuildStatus(this, userReason)
             }
         }
         changed {


### PR DESCRIPTION
## Description

With this PR internal build status collection (as part of [CI analytics](https://confluence.camunda.com/display/SRE/CI+Analytics)) will be enabled for all branches of the Zeebe repository. Precautions were taken to avoid problems/downtime of any CI analytics component to affect build success rate. In case of failure the Zeebe CI builds will just continue fine.

See https://github.com/camunda/jenkins-global-shared-library/pull/118

## Related issues

Related to INFRA-1613