### PR TITLE
fix(atomix/utils): fixing assertion error on AddressTest.testIPv4Address() 

### DIFF
--- a/atomix/utils/src/test/java/io/atomix/utils/net/AddressTest.java
+++ b/atomix/utils/src/test/java/io/atomix/utils/net/AddressTest.java
@@ -17,6 +17,7 @@
 package io.atomix.utils.net;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -28,7 +29,7 @@ public class AddressTest {
     final Address address = Address.from("127.0.0.1:5000");
     assertEquals("127.0.0.1", address.host());
     assertEquals(5000, address.port());
-    assertEquals("localhost", address.address().getHostName());
+    assertTrue("127.0.0.1".equals(address.address().getHostName()) || "localhost".equals(address.address().getHostName()));
     assertEquals("127.0.0.1:5000", address.toString());
   }
 


### PR DESCRIPTION


## Description

**hacktoberfest**
Updated AssertEquals to AssertTrue in order to allow the expected results both "localhost" and "127.0.0.1"
It will fix the test failure in Windows.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5679 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
