### PR TITLE
chore(ci): use Camunda maven settings and nexus cache to avoid download erros

### DIFF
--- a/.ci/scripts/distribution/test-tck.sh
+++ b/.ci/scripts/distribution/test-tck.sh
@@ -5,7 +5,7 @@ git clone https://github.com/zeebe-io/bpmn-tck.git
 cd bpmn-tck
 # ./bpmn-tck/
 
-mvn -B test -DzeebeImage=zeebe-hazelcast-exporter -DzeebeImageVersion=current-test
+mvn -B test -s ${MAVEN_SETTINGS_XML} -DzeebeImage=zeebe-hazelcast-exporter -DzeebeImageVersion=current-test
 
 cd ..
 # ./

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,7 +191,9 @@ pipeline {
                 stage('BPMN TCK') {
                     steps {
                         container('maven') {
-                            sh '.ci/scripts/distribution/test-tck.sh'
+                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                                sh '.ci/scripts/distribution/test-tck.sh'
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Description

This fixes the stability issues of the new BPMN TCK build stage. The stability issues arose because downloads of external dependencies from Maven central failed.

* Adds maven settings to the Maven build
* Part of the maven settings is a Nexus repository config
* this repo is internal to Camunda and has caching, so the download issues should disappear

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
