### PR TITLE
chore(benchmark): not wait for deletion

### DIFF
--- a/benchmarks/setup/deleteBenchmark.sh
+++ b/benchmarks/setup/deleteBenchmark.sh
@@ -15,5 +15,5 @@ fi
 namespace=$1
 
 kubens default
-kubectl delete namespace $namespace
+kubectl delete namespace $namespace --wait=false
 rm -r $namespace


### PR DESCRIPTION
## Description

Makes the deletion of the namespace async, is useful if you want to delete more then one benchmark which I often do :see_no_evil: 
<!-- Please explain the changes you made here. -->

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
