### PR TITLE
chore(monitor): fix io panels

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -83,7 +83,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1603718010459,
+  "iteration": 1603780843903,
   "links": [],
   "panels": [
     {
@@ -4142,7 +4142,8 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_fs_reads_bytes_total{namespace=~\"$namespace\", pod=~\"$namespace.*\"}[1m])) by (pod)",
+              "expr": "sum(rate(container_fs_reads_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])) by (pod)",
+              "interval": "",
               "legendFormat": "{{pod}}",
               "refId": "A"
             }
@@ -4230,7 +4231,8 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_fs_writes_bytes_total{namespace=~\"$namespace\", pod=~\"$namespace.*\"}[1m])) by (pod)",
+              "expr": "sum(rate(container_fs_writes_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])) by (pod)",
+              "interval": "",
               "legendFormat": "{{pod}}",
               "refId": "A"
             }
@@ -4318,7 +4320,8 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$namespace.*\"}[1m])) by (pod)",
+              "expr": "sum(rate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])) by (pod)",
+              "interval": "",
               "legendFormat": "{{pod}}",
               "refId": "A"
             }
@@ -4406,7 +4409,8 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$namespace.*\"}[1m])) by (pod)",
+              "expr": "sum(rate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[1m])) by (pod)",
+              "interval": "",
               "legendFormat": "{{pod}}",
               "refId": "A"
             }
@@ -9283,5 +9287,5 @@
   "variables": {
     "list": []
   },
-  "version": 18
+  "version": 19
 }


### PR DESCRIPTION
## Description

Fixes the io panels in our camunda cloud setup, which were broken for a long time.
See discussion in https://github.com/camunda-cloud/monitoring/issues/242

Before:

![broker](https://user-images.githubusercontent.com/2758593/97266546-eda98380-1828-11eb-90bf-872b71e41ef8.png)

Fixed:

![fixed](https://user-images.githubusercontent.com/2758593/97266551-f13d0a80-1828-11eb-8806-7d9418a7285f.png)

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda-cloud/monitoring/issues/242

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
