### PR TITLE
chore(ci): disable discovery of Pull Requests for zeebe-io on Jenkins

### DIFF
--- a/.ci/jobs/github_zeebe_io.dsl
+++ b/.ci/jobs/github_zeebe_io.dsl
@@ -44,10 +44,10 @@ organizationFolder('zeebe-io') {
     configure {
 
         def traits = it / navigators / 'org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator' / traits
-        traits << 'org.jenkinsci.plugins.github__branch__source.OriginPullRequestDiscoveryTrait' {
-            strategyId 2
-        }
-
+        // Note: disable discovery of Pull Requests as of https://jira.camunda.com/browse/INFRA-1924
+        // traits << 'org.jenkinsci.plugins.github__branch__source.OriginPullRequestDiscoveryTrait' {
+        //     strategyId 2
+        // }
     }
 
 }


### PR DESCRIPTION
## Description

This is a trial as outcome of discussion https://camunda.slack.com/archives/CSQ2E3BT4/p1603790731010200 where:
- branches will continue to be build (also branches that have a PR open)
- bors uses the branch build status so no problem, see https://github.com/zeebe-io/zeebe/blob/develop/bors.toml#L2
- only one build status reported as part of PRs, not two anymore
- lowers load on CI and can save costs

## Related issues

Related to INFRA-1924