### PR TITLE
chore(ci): move the IT (Java) stage to another agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,11 +168,35 @@ pipeline {
                 }
 
                 stage('IT (Java)') {
+                    agent {
+                        kubernetes {
+                            cloud 'zeebe-ci'
+                            label "zeebe-ci-build_${buildName}_it"
+                            defaultContainer 'jnlp'
+                            yamlFile '.ci/podSpecs/distribution.yml'
+                        }
+                    }
+
                     environment {
                         SUREFIRE_REPORT_NAME_SUFFIX = 'it-testrun'
+                        NEXUS = credentials("camunda-nexus")
+                        IMAGE = "camunda/zeebe"
+                        VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
+                        TAG = 'current-test'
                     }
 
                     steps {
+                        container('maven') {
+                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                                sh '.ci/scripts/distribution/prepare.sh'
+                                sh '.ci/scripts/distribution/build-java.sh'
+                                sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
+                            }
+                        }
+                        container('docker') {
+                            sh '.ci/scripts/docker/build.sh'
+                            sh '.ci/scripts/docker/build_zeebe-hazelcast-exporter.sh'
+                        }
                         container('maven') {
                             configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
                                 sh '.ci/scripts/distribution/it-java.sh'


### PR DESCRIPTION
## Description

The IT (Java) stage often leads to a build failure due to flaky tests. These happen due to timeouts, that seem to occur due to not enough resources. 

This PR moves the execution of the IT (Java) stage to another node using a different k8s label.

## Related issues

NA

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
