### PR TITLE
Parallelise IT build steps to default flow

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,61 +42,96 @@ pipeline {
     }
 
     stages {
-        stage('Prepare') {
-            steps {
-                script {
-                    commit_summary = sh([returnStdout: true, script: 'git show -s --format=%s']).trim()
-                    displayNameFull = "#" + BUILD_NUMBER + ': ' + commit_summary
+        stage('Build') {
+            parallel {
+                stage('Default') {
+                    stages {
+                        stage('Prepare') {
+                            steps {
+                                script {
+                                    commit_summary = sh([returnStdout: true, script: 'git show -s --format=%s']).trim()
+                                    displayNameFull = "#" + BUILD_NUMBER + ': ' + commit_summary
 
-                    if (displayNameFull.length() <= 45) {
-                        currentBuild.displayName = displayNameFull
-                    } else {
-                        displayStringHardTruncate = displayNameFull.take(45)
-                        currentBuild.displayName = displayStringHardTruncate.take(displayStringHardTruncate.lastIndexOf(" "))
+                                    if (displayNameFull.length() <= 45) {
+                                    currentBuild.displayName = displayNameFull
+                                    } else {
+                                    displayStringHardTruncate = displayNameFull.take(45)
+                                    currentBuild.displayName = displayStringHardTruncate.take(displayStringHardTruncate.lastIndexOf(" "))
+                                    }
+                                }
+                                container('maven') {
+                                    sh '.ci/scripts/distribution/prepare.sh'
+                                }
+                                container('maven-jdk8') {
+                                    sh '.ci/scripts/distribution/prepare.sh'
+                                }
+                                container('golang') {
+                                    sh '.ci/scripts/distribution/prepare-go.sh'
+                                }
+                            }
+                        }
+
+                        stage('Build (Java)') {
+                            steps {
+                                container('maven') {
+                                    configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                                        sh '.ci/scripts/distribution/build-java.sh'
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
-                container('maven') {
-                    sh '.ci/scripts/distribution/prepare.sh'
-                }
-                container('maven-jdk8') {
-                    sh '.ci/scripts/distribution/prepare.sh'
-                }
-                container('golang') {
-                    sh '.ci/scripts/distribution/prepare-go.sh'
-                }
 
-            }
-        }
+                stage('IT') {
+                    agent {
+                        kubernetes {
+                            cloud 'zeebe-ci'
+                            label "zeebe-ci-build_${buildName}_it"
+                            defaultContainer 'jnlp'
+                            yamlFile '.ci/podSpecs/distribution.yml'
+                        }
+                    }
+                    stages {
+                        stage('Prepare') {
+                            steps {
+                                container('maven') {
+                                    sh '.ci/scripts/distribution/prepare.sh'
+                                }
+                            }
+                        }
 
-        stage('Build (Java)') {
-            steps {
-                container('maven') {
-                    configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-                        sh '.ci/scripts/distribution/build-java.sh'
+                        stage('Build (Java)') {
+                            steps {
+                                container('maven') {
+                                    configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                                        sh '.ci/scripts/distribution/build-java.sh'
+                                    }
+                                }
+                            }
+                        }
+
+                        stage('Prepare Upgrade Tests') {
+                            environment {
+                                IMAGE = "camunda/zeebe"
+                                VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
+                                TAG = 'current-test'
+                            }
+                            steps {
+                                container('maven') {
+                                    sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
+                                }
+
+                                container('docker') {
+                                    sh '.ci/scripts/docker/build.sh'
+                                    sh '.ci/scripts/docker/build_zeebe-hazelcast-exporter.sh'
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
-
-        stage('Prepare Tests') {
-            environment {
-                IMAGE = "camunda/zeebe"
-                VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
-                TAG = 'current-test'
-            }
-
-            steps {
-                container('maven') {
-                    sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
-                }
-
-                container('docker') {
-                    sh '.ci/scripts/docker/build.sh'
-                    sh '.ci/scripts/docker/build_zeebe-hazelcast-exporter.sh'
-                }
-            }
-        }
-
 
         stage('Test') {
             parallel {
@@ -110,7 +145,6 @@ pipeline {
                             sh '.ci/scripts/distribution/test-go.sh'
                         }
                     }
-
                     post {
                         always {
                             junit testResults: "**/*/TEST-go.xml", keepLongStdio: true
@@ -132,7 +166,6 @@ pipeline {
                     environment {
                         SUREFIRE_REPORT_NAME_SUFFIX = 'java-testrun'
                     }
-
                     steps {
                         container('maven') {
                             configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
@@ -140,18 +173,17 @@ pipeline {
                             }
                         }
                     }
-
                     post {
                         always {
                             junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
                         }
                     }
                 }
+
                 stage('Unit 8 (Java 8)') {
                     environment {
                         SUREFIRE_REPORT_NAME_SUFFIX = 'java8-testrun'
                     }
-
                     steps {
                         container('maven-jdk8') {
                             configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
@@ -159,51 +191,6 @@ pipeline {
                             }
                         }
                     }
-
-                    post {
-                        always {
-                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
-                        }
-                    }
-                }
-
-                stage('IT (Java)') {
-                    agent {
-                        kubernetes {
-                            cloud 'zeebe-ci'
-                            label "zeebe-ci-build_${buildName}_it"
-                            defaultContainer 'jnlp'
-                            yamlFile '.ci/podSpecs/distribution.yml'
-                        }
-                    }
-
-                    environment {
-                        SUREFIRE_REPORT_NAME_SUFFIX = 'it-testrun'
-                        NEXUS = credentials("camunda-nexus")
-                        IMAGE = "camunda/zeebe"
-                        VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
-                        TAG = 'current-test'
-                    }
-
-                    steps {
-                        container('maven') {
-                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-                                sh '.ci/scripts/distribution/prepare.sh'
-                                sh '.ci/scripts/distribution/build-java.sh'
-                                sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
-                            }
-                        }
-                        container('docker') {
-                            sh '.ci/scripts/docker/build.sh'
-                            sh '.ci/scripts/docker/build_zeebe-hazelcast-exporter.sh'
-                        }
-                        container('maven') {
-                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-                                sh '.ci/scripts/distribution/it-java.sh'
-                            }
-                        }
-                    }
-
                     post {
                         always {
                             junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
@@ -219,10 +206,46 @@ pipeline {
                             }
                         }
                     }
-
                     post {
                         always {
                             junit testResults: "bpmn-tck/**/*/TEST*.xml", keepLongStdio: true
+                        }
+                    }
+                }
+
+                stage('IT (Java)') {
+                    agent {
+                        kubernetes {
+                            cloud 'zeebe-ci'
+                            label "zeebe-ci-build_${buildName}_it"
+                            defaultContainer 'jnlp'
+                            yamlFile '.ci/podSpecs/distribution.yml'
+                        }
+                    }
+                    environment {
+                        SUREFIRE_REPORT_NAME_SUFFIX = 'it-testrun'
+                        NEXUS = credentials("camunda-nexus")
+                    }
+                    steps {
+                        container('maven') {
+                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                                sh '.ci/scripts/distribution/it-java.sh'
+                            }
+                        }
+                    }
+                    post {
+                        always {
+                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
+                        }
+                        failure {
+                            zip zipFile: 'test-reports.zip', archive: true, glob: "**/*/surefire-reports/**"
+                            archive "**/hs_err_*.log"
+
+                            script {
+                            if (fileExists('./target/FlakyTests.txt')) {
+                                currentBuild.description = "Flaky Tests: <br>" + readFile('./target/FlakyTests.txt').split('\n').join('<br>')
+                            }
+                            }
                         }
                     }
                 }
@@ -231,13 +254,13 @@ pipeline {
             post {
                 always {
                     jacoco(
-                            execPattern: '**/*.exec',
-                            classPattern: '**/target/classes',
-                            sourcePattern: '**/src/main/java,**/generated-sources/protobuf/java,**/generated-sources/assertj-assertions,**/generated-sources/sbe',
-                            exclusionPattern: '**/io/zeebe/gateway/protocol/**,'
-                                    + '**/*Encoder.class,**/*Decoder.class,**/MetaAttribute.class,'
-                                    + '**/io/zeebe/protocol/record/**/*Assert.class,**/io/zeebe/protocol/record/Assertions.class,', // classes from generated resources
-                            runAlways: true
+                        execPattern: '**/*.exec',
+                        classPattern: '**/target/classes',
+                        sourcePattern: '**/src/main/java,**/generated-sources/protobuf/java,**/generated-sources/assertj-assertions,**/generated-sources/sbe',
+                        exclusionPattern: '**/io/zeebe/gateway/protocol/**,'
+                                + '**/*Encoder.class,**/*Decoder.class,**/MetaAttribute.class,'
+                                + '**/io/zeebe/protocol/record/**/*Assert.class,**/io/zeebe/protocol/record/Assertions.class,', // classes from generated resources
+                        runAlways: true
                     )
                     zip zipFile: 'test-coverage-reports.zip', archive: true, glob: "**/target/site/jacoco/**"
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,11 +168,35 @@ pipeline {
                 }
 
                 stage('IT (Java)') {
+                    agent {
+                        kubernetes {
+                            cloud 'zeebe-ci'
+                            label "zeebe-ci-build_${buildName}_it"
+                            defaultContainer 'jnlp'
+                            yamlFile '.ci/podSpecs/distribution.yml'
+                        }
+                    }
+
                     environment {
                         SUREFIRE_REPORT_NAME_SUFFIX = 'it-testrun'
+                        NEXUS = credentials("camunda-nexus")
+                        IMAGE = "camunda/zeebe"
+                        VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
+                        TAG = 'current-test'
                     }
 
                     steps {
+                        container('maven') {
+                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                                sh '.ci/scripts/distribution/prepare.sh'
+                                sh '.ci/scripts/distribution/build-java.sh'
+                                sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
+                            }
+                        }
+                        container('docker') {
+                            sh '.ci/scripts/docker/build.sh'
+                            sh '.ci/scripts/docker/build_zeebe-hazelcast-exporter.sh'
+                        }
                         container('maven') {
                             configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
                                 sh '.ci/scripts/distribution/it-java.sh'


### PR DESCRIPTION
## Description

https://github.com/zeebe-io/zeebe/pull/5717 moved the `IT (Java)` stage to another agent. But to make that work it needs to rebuild artifacts that are missing on that agent. This PR provides a playground to investigate changes to the pipeline to optimise this.

## Related issues

NA

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
