### PR TITLE
chore(broker): start embedded gateway after cluster services

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -210,6 +210,7 @@ public final class Broker implements AutoCloseable {
         "command api handler", () -> commandApiHandlerStep(brokerCfg, localBroker));
     startContext.addStep("subscription api", () -> subscriptionAPIStep(localBroker));
 
+    startContext.addStep("cluster services", () -> atomix.start().join());
     if (brokerCfg.getGateway().isEnable()) {
       startContext.addStep(
           "embedded gateway",
@@ -218,7 +219,6 @@ public final class Broker implements AutoCloseable {
             return embeddedGatewayService;
           });
     }
-    startContext.addStep("cluster services", () -> atomix.start().join());
     startContext.addStep("topology manager", () -> topologyManagerStep(clusterCfg, localBroker));
     startContext.addStep("monitoring services", () -> monitoringServerStep(localBroker));
     startContext.addStep("disk space monitor", () -> diskSpaceMonitorStep(brokerCfg.getData()));

--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -211,6 +211,7 @@ public final class Broker implements AutoCloseable {
     startContext.addStep("subscription api", () -> subscriptionAPIStep(localBroker));
 
     startContext.addStep("cluster services", () -> atomix.start().join());
+    startContext.addStep("topology manager", () -> topologyManagerStep(clusterCfg, localBroker));
     if (brokerCfg.getGateway().isEnable()) {
       startContext.addStep(
           "embedded gateway",
@@ -219,7 +220,6 @@ public final class Broker implements AutoCloseable {
             return embeddedGatewayService;
           });
     }
-    startContext.addStep("topology manager", () -> topologyManagerStep(clusterCfg, localBroker));
     startContext.addStep("monitoring services", () -> monitoringServerStep(localBroker));
     startContext.addStep("disk space monitor", () -> diskSpaceMonitorStep(brokerCfg.getData()));
     startContext.addStep(


### PR DESCRIPTION
## Description

I've moved an embedded gateway start step after cluster services start step.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5613 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
