### PR TITLE
chore(ci): stash/unstash build artifacts

### DIFF
--- a/.ci/scripts/distribution/it-java.sh
+++ b/.ci/scripts/distribution/it-java.sh
@@ -5,7 +5,9 @@ export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
 tmpfile=$(mktemp)
 
-mvn -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl qa/integration-tests -pl update-tests -DtestMavenId=2 -Dsurefire.rerunFailingTestsCount=7 | tee ${tmpfile}
+mvn -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} initialize -Pprepare-offline -pl qa/integration-tests -pl update-tests
+
+mvn -o -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl qa/integration-tests -pl update-tests -DtestMavenId=2 -Dsurefire.rerunFailingTestsCount=7 | tee ${tmpfile}
 
 status=${PIPESTATUS[0]}
 

--- a/.ci/scripts/distribution/it-java.sh
+++ b/.ci/scripts/distribution/it-java.sh
@@ -5,7 +5,7 @@ export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
 tmpfile=$(mktemp)
 
-mvn -o -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl qa/integration-tests -pl update-tests -DtestMavenId=2 -Dsurefire.rerunFailingTestsCount=7 | tee ${tmpfile}
+mvn -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl qa/integration-tests -pl update-tests -DtestMavenId=2 -Dsurefire.rerunFailingTestsCount=7 | tee ${tmpfile}
 
 status=${PIPESTATUS[0]}
 

--- a/.ci/scripts/distribution/it-java.sh
+++ b/.ci/scripts/distribution/it-java.sh
@@ -5,7 +5,7 @@ export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
 tmpfile=$(mktemp)
 
-mvn -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} initialize -Pprepare-offline -pl qa/integration-tests -pl update-tests
+mvn -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} test-compile -Pprepare-offline -pl qa/integration-tests -pl update-tests
 
 mvn -o -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl qa/integration-tests -pl update-tests -DtestMavenId=2 -Dsurefire.rerunFailingTestsCount=7 | tee ${tmpfile}
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1104,6 +1104,8 @@
           <executions>
             <execution>
               <id>analyze-dependencies</id>
+              <!-- The analyze-only goal assumes that the test-compile phase has been executed -->
+              <phase>verify</phase>
               <goals>
                 <goal>analyze-only</goal>
               </goals>
@@ -1111,12 +1113,18 @@
                 <failOnWarning>true</failOnWarning>
                 <outputXML>true</outputXML>
                 <!-- dependencies not directly used in all projects during tests -->
-                <ignoredUnusedDeclaredDependencies>
+                <ignoredUnusedDeclaredDependencies combine.children="append">
                   <dep>org.apache.logging.log4j:log4j-slf4j-impl</dep>
                   <dep>org.apache.logging.log4j:log4j-core</dep>
                   <dep>io.zeebe:zeebe-build-tools</dep>
                   <dep>io.zeebe:zeebe-gateway-protocol</dep>
                   <dep>org.ow2.asm:asm</dep>
+                  <dep>org.apache.maven.surefire:surefire-junit4</dep>
+                  <dep>org.apache.maven.surefire:surefire-junit47</dep>
+                  <dep>org.apache.maven.surefire:surefire-junit-platform</dep>
+                  <dep>org.junit.jupiter:junit-jupiter-engine</dep>
+                  <dep>org.junit.vintage:junit-vintage-engine</dep>
+                  <dep>org.codehaus.plexus:plexus-utils:jar:1.1</dep>
                 </ignoredUnusedDeclaredDependencies>
               </configuration>
             </execution>
@@ -1320,8 +1328,7 @@
       with mvn dependency:go-offline and then run the tests in offline mode. But the plugin misses
       to download the surefire-junit dependency, therefore define an explicit dependency while downloading.
 
-      The dependency:go-offline is now replaced with go-offline-maven-plugin to better deal with dynamic
-      dependencies. Usage: mvn initialize -Pprepare-offline
+      Usage: mvn initialize -Pprepare-offline
     -->
     <profile>
       <id>prepare-offline</id>
@@ -1354,6 +1361,12 @@
           <artifactId>junit-vintage-engine</artifactId>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+          <version>1.1</version>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
       <build>
         <plugins>
@@ -1365,26 +1378,9 @@
                 <id>go-offline</id>
                 <phase>initialize</phase>
                 <goals>
+                  <goal>resolve-plugins</goal>
                   <goal>go-offline</goal>
                 </goals>
-              </execution>
-              
-              <!-- The analyze-only goal assumes that the test-compile phase has been executed -->
-              <execution>
-                <id>analyze-dependencies</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>analyze-only</goal>
-                </goals>
-                <configuration>
-                  <ignoredUnusedDeclaredDependencies combine.children="append">
-                    <dep>org.apache.maven.surefire:surefire-junit4</dep>
-                    <dep>org.apache.maven.surefire:surefire-junit47</dep>
-                    <dep>org.apache.maven.surefire:surefire-junit-platform</dep>
-                    <dep>org.junit.jupiter:junit-jupiter-engine</dep>
-                    <dep>org.junit.vintage:junit-vintage-engine</dep>
-                  </ignoredUnusedDeclaredDependencies>
-                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -126,7 +126,6 @@
     <plugin.version.dependency-analyzer>1.11.1</plugin.version.dependency-analyzer>
     <plugin.version.jacoco>0.8.6</plugin.version.jacoco>
 
-
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.6.2</extension.version.os-maven-plugin>
 
@@ -1319,7 +1318,10 @@
       This profile is used to add an explicit dependency to surefire-junit. To fix the race condition
       of https://github.com/zeebe-io/zeebe/issues/2379 we download all dependencies at the beginning
       with mvn dependency:go-offline and then run the tests in offline mode. But the plugin misses
-      to download the surefire-junit dependency, therefore define an explicit dependency while downloading
+      to download the surefire-junit dependency, therefore define an explicit dependency while downloading.
+
+      The dependency:go-offline is now replaced with go-offline-maven-plugin to better deal with dynamic
+      dependencies. Usage: mvn initialize -Pprepare-offline
     -->
     <profile>
       <id>prepare-offline</id>
@@ -1366,8 +1368,11 @@
                   <goal>go-offline</goal>
                 </goals>
               </execution>
+              
+              <!-- The analyze-only goal assumes that the test-compile phase has been executed -->
               <execution>
                 <id>analyze-dependencies</id>
+                <phase>verify</phase>
                 <goals>
                   <goal>analyze-only</goal>
                 </goals>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1328,7 +1328,7 @@
       with mvn dependency:go-offline and then run the tests in offline mode. But the plugin misses
       to download the surefire-junit dependency, therefore define an explicit dependency while downloading.
 
-      Usage: mvn initialize -Pprepare-offline
+      Usage: mvn install -Pprepare-offline
     -->
     <profile>
       <id>prepare-offline</id>


### PR DESCRIPTION
## Description

This PR uses Jenkins's stash and unstash to reuse build artifacts between different nodes. This way the `IT (Java)` stage (running on another node) does not have rebuild the same maven artifacts.

## Related issues

closes #5851

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
