### PR TITLE
feat(clients/java): add capability to change ZeebeObjectMapper

### DIFF
--- a/clients/java/ignored-changes.xml
+++ b/clients/java/ignored-changes.xml
@@ -7,4 +7,14 @@
     <className>io/zeebe/client/util/VersionUtil</className>
     <differenceType>8001</differenceType>
   </difference>
+  <difference>
+    <className>io/zeebe/client/ZeebeClientBuilder</className>
+    <method>io.zeebe.client.ZeebeClientBuilder withJsonMapper(io.zeebe.client.api.JsonMapper)</method>
+    <differenceType>7012</differenceType>
+  </difference>
+  <difference>
+    <className>io/zeebe/client/ZeebeClientConfiguration</className>
+    <method>io.zeebe.client.api.JsonMapper getJsonMapper()</method>
+    <differenceType>7012</differenceType>
+  </difference>
 </differences>

--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientBuilder.java
@@ -16,6 +16,7 @@
 package io.zeebe.client;
 
 import io.grpc.ClientInterceptor;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
 import java.time.Duration;
 import java.util.Properties;
@@ -97,6 +98,8 @@ public interface ZeebeClientBuilder {
   ZeebeClientBuilder keepAlive(Duration keepAlive);
 
   ZeebeClientBuilder withInterceptors(ClientInterceptor... interceptor);
+
+  ZeebeClientBuilder withJsonMapper(JsonMapper jsonMapper);
 
   /** @return a new {@link ZeebeClient} with the provided configuration options. */
   ZeebeClient build();

--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientConfiguration.java
@@ -16,6 +16,7 @@
 package io.zeebe.client;
 
 import io.grpc.ClientInterceptor;
+import io.zeebe.client.api.JsonMapper;
 import java.time.Duration;
 import java.util.List;
 
@@ -65,4 +66,7 @@ public interface ZeebeClientConfiguration {
   Duration getKeepAlive();
 
   List<ClientInterceptor> getInterceptors();
+
+  /** @see ZeebeClientBuilder#withJsonMapper(io.zeebe.client.api.JsonMapper) */
+  JsonMapper getJsonMapper();
 }

--- a/clients/java/src/main/java/io/zeebe/client/api/JsonMapper.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/JsonMapper.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.api;
+
+import java.io.InputStream;
+import java.util.Map;
+
+/**
+ * This interface is using to customize the way how objects will be serialized and deserialized in
+ * JSON format. The default implementation is {@link io.zeebe.client.impl.ZeebeObjectMapper}. This
+ * interface could be implemented to customize the way how variables in the commands
+ * serialized/deserialized. For example: there is such map with variables:
+ *
+ * <pre>
+ *   final Map<String, Object> variables = new HashMap<>();
+ *   variables.put("a", "b");
+ *   variables.put("c", null);
+ * </pre>
+ *
+ * And after doing this:
+ *
+ * <pre>
+ *   public class MyJsonMapper implements JsonMapper {
+ *
+ *     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().setSerializationInclusion(Include.NON_NULL);
+ *
+ *     public String toJson(final Object value) {
+ *       return OBJECT_MAPPER.writeValueAsString(value);
+ *     }
+ *     ...
+ *   }
+ *   ...
+ *   ZeebeClient.newClientBuilder().withJsonMapper(new MyJsonMapper());
+ * </pre>
+ *
+ * Null values won't pass in the JSON with variables: {@code { "a": "b" } }
+ *
+ * @see io.zeebe.client.impl.ZeebeObjectMapper
+ */
+public interface JsonMapper {
+
+  /**
+   * Deserializes a JSON string into an equivalent POJO of type {@code T}.
+   *
+   * @param json the JSON string to deserialize
+   * @param typeClass the Java type to deserialize into
+   * @param <T> the type of the returned object
+   * @return the POJO deserialized from the given JSON string
+   * @throws io.zeebe.client.api.command.InternalClientException on serialization/deserialization
+   *     error
+   */
+  <T> T fromJson(final String json, final Class<T> typeClass);
+
+  /**
+   * Deserializes a JSON string into a string to object map.
+   *
+   * @param json the JSON string to deserialize
+   * @return the map deserialized from the given JSON string
+   * @throws io.zeebe.client.api.command.InternalClientException on serialization/deserialization
+   *     error
+   */
+  Map<String, Object> fromJsonAsMap(final String json);
+
+  /**
+   * Deserializes a JSON string into a string to string map.
+   *
+   * @param json the JSON string to deserialize
+   * @return the map deserialized from the given JSON string
+   * @throws io.zeebe.client.api.command.InternalClientException on serialization/deserialization
+   *     error
+   */
+  Map<String, String> fromJsonAsStringMap(final String json);
+
+  /**
+   * Serializes an object (POJO, map, list, etc.) into an JSON string.
+   *
+   * @param value the object to serialize
+   * @return a JSON string serialized from the given object
+   * @throws io.zeebe.client.api.command.InternalClientException on serialization/deserialization
+   *     error
+   */
+  String toJson(final Object value);
+
+  /**
+   * Validates a JSON string. If it is not valid throws a {@link
+   * io.zeebe.client.api.command.InternalClientException}.
+   *
+   * @param propertyName the property name that contains the JSON string
+   * @param jsonInput the JSON string
+   * @return the same JSON string, that passed in
+   * @throws io.zeebe.client.api.command.InternalClientException on serialization/deserialization
+   *     error
+   */
+  String validateJson(final String propertyName, final String jsonInput);
+
+  /**
+   * Validates a stream that contains a JSON string. If it is not valid throws a {@link
+   * io.zeebe.client.api.command.InternalClientException}
+   *
+   * @param propertyName a property name that contains the stream
+   * @param jsonInput the stream that contains the JSON string
+   * @return the JSON string from the stream
+   * @throws io.zeebe.client.api.command.InternalClientException on serialization/deserialization
+   *     error
+   */
+  String validateJson(final String propertyName, final InputStream jsonInput);
+}

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -27,6 +27,7 @@ import io.zeebe.client.CredentialsProvider;
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.ZeebeClientConfiguration;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.zeebe.client.impl.util.Environment;
 import java.time.Duration;
@@ -59,6 +60,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private String certificatePath;
   private CredentialsProvider credentialsProvider;
   private Duration keepAlive = Duration.ofSeconds(45);
+  private JsonMapper jsonMapper = new ZeebeObjectMapper();
 
   @Override
   public String getBrokerContactPoint() {
@@ -128,6 +130,10 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   @Override
   public List<ClientInterceptor> getInterceptors() {
     return interceptors;
+  }
+
+  public JsonMapper getJsonMapper() {
+    return jsonMapper;
   }
 
   @Override
@@ -278,6 +284,12 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   @Override
   public ZeebeClientBuilder withInterceptors(final ClientInterceptor... interceptors) {
     this.interceptors.addAll(Arrays.asList(interceptors));
+    return this;
+  }
+
+  @Override
+  public ZeebeClientBuilder withJsonMapper(final JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
     return this;
   }
 

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientImpl.java
@@ -25,6 +25,7 @@ import io.netty.handler.ssl.SslContext;
 import io.zeebe.client.CredentialsProvider;
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.ZeebeClientConfiguration;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.command.ActivateJobsCommandStep1;
 import io.zeebe.client.api.command.CancelWorkflowInstanceCommandStep1;
 import io.zeebe.client.api.command.ClientException;
@@ -67,7 +68,7 @@ import java.util.concurrent.TimeUnit;
 
 public final class ZeebeClientImpl implements ZeebeClient {
   private final ZeebeClientConfiguration config;
-  private final ZeebeObjectMapper objectMapper;
+  private final JsonMapper jsonMapper;
   private final GatewayStub asyncStub;
   private final ManagedChannel channel;
   private final ScheduledExecutorService executorService;
@@ -97,7 +98,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
       final GatewayStub gatewayStub,
       final ScheduledExecutorService executorService) {
     this.config = config;
-    objectMapper = new ZeebeObjectMapper();
+    this.jsonMapper = config.getJsonMapper();
     this.channel = channel;
     asyncStub = gatewayStub;
     this.executorService = executorService;
@@ -238,7 +239,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
   public CreateWorkflowInstanceCommandStep1 newCreateInstanceCommand() {
     return new CreateWorkflowInstanceCommandImpl(
         asyncStub,
-        objectMapper,
+        jsonMapper,
         config.getDefaultRequestTimeout(),
         credentialsProvider::shouldRetryRequest);
   }
@@ -257,7 +258,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
   public SetVariablesCommandStep1 newSetVariablesCommand(final long elementInstanceKey) {
     return new SetVariablesCommandImpl(
         asyncStub,
-        objectMapper,
+        jsonMapper,
         elementInstanceKey,
         config.getDefaultRequestTimeout(),
         credentialsProvider::shouldRetryRequest);
@@ -266,7 +267,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
   @Override
   public PublishMessageCommandStep1 newPublishMessageCommand() {
     return new PublishMessageCommandImpl(
-        asyncStub, config, objectMapper, credentialsProvider::shouldRetryRequest);
+        asyncStub, config, jsonMapper, credentialsProvider::shouldRetryRequest);
   }
 
   @Override
@@ -293,7 +294,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
         config,
         asyncStub,
         jobClient,
-        objectMapper,
+        jsonMapper,
         executorService,
         closeables,
         credentialsProvider::shouldRetryRequest);
@@ -302,12 +303,12 @@ public final class ZeebeClientImpl implements ZeebeClient {
   @Override
   public ActivateJobsCommandStep1 newActivateJobsCommand() {
     return new ActivateJobsCommandImpl(
-        asyncStub, config, objectMapper, credentialsProvider::shouldRetryRequest);
+        asyncStub, config, jsonMapper, credentialsProvider::shouldRetryRequest);
   }
 
   private JobClient newJobClient() {
     return new JobClientImpl(
-        asyncStub, config, objectMapper, credentialsProvider::shouldRetryRequest);
+        asyncStub, config, jsonMapper, credentialsProvider::shouldRetryRequest);
   }
 
   @Override

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeObjectMapper.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeObjectMapper.java
@@ -19,12 +19,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.command.InternalClientException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 
-public final class ZeebeObjectMapper extends ObjectMapper {
+public final class ZeebeObjectMapper extends ObjectMapper implements JsonMapper {
 
   private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE =
       new TypeReference<Map<String, Object>>() {};

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/ActivateJobsCommandImpl.java
@@ -17,6 +17,7 @@ package io.zeebe.client.impl.command;
 
 import io.grpc.stub.StreamObserver;
 import io.zeebe.client.ZeebeClientConfiguration;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.ActivateJobsCommandStep1;
 import io.zeebe.client.api.command.ActivateJobsCommandStep1.ActivateJobsCommandStep2;
@@ -24,7 +25,6 @@ import io.zeebe.client.api.command.ActivateJobsCommandStep1.ActivateJobsCommandS
 import io.zeebe.client.api.command.FinalCommandStep;
 import io.zeebe.client.api.response.ActivateJobsResponse;
 import io.zeebe.client.impl.RetriableStreamingFutureImpl;
-import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.client.impl.response.ActivateJobsResponseImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.zeebe.gateway.protocol.GatewayOuterClass;
@@ -41,7 +41,7 @@ public final class ActivateJobsCommandImpl
 
   private static final Duration DEADLINE_OFFSET = Duration.ofSeconds(10);
   private final GatewayStub asyncStub;
-  private final ZeebeObjectMapper objectMapper;
+  private final JsonMapper jsonMapper;
   private final Predicate<Throwable> retryPredicate;
   private final Builder builder;
   private Duration requestTimeout;
@@ -49,10 +49,10 @@ public final class ActivateJobsCommandImpl
   public ActivateJobsCommandImpl(
       final GatewayStub asyncStub,
       final ZeebeClientConfiguration config,
-      final ZeebeObjectMapper objectMapper,
+      final JsonMapper jsonMapper,
       final Predicate<Throwable> retryPredicate) {
     this.asyncStub = asyncStub;
-    this.objectMapper = objectMapper;
+    this.jsonMapper = jsonMapper;
     this.retryPredicate = retryPredicate;
     builder = ActivateJobsRequest.newBuilder();
     requestTimeout(config.getDefaultRequestTimeout());
@@ -106,7 +106,7 @@ public final class ActivateJobsCommandImpl
   public ZeebeFuture<ActivateJobsResponse> send() {
     final ActivateJobsRequest request = builder.build();
 
-    final ActivateJobsResponseImpl response = new ActivateJobsResponseImpl(objectMapper);
+    final ActivateJobsResponseImpl response = new ActivateJobsResponseImpl(jsonMapper);
     final RetriableStreamingFutureImpl<ActivateJobsResponse, GatewayOuterClass.ActivateJobsResponse>
         future =
             new RetriableStreamingFutureImpl<>(

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/CommandWithVariables.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/CommandWithVariables.java
@@ -15,16 +15,16 @@
  */
 package io.zeebe.client.impl.command;
 
-import io.zeebe.client.impl.ZeebeObjectMapper;
+import io.zeebe.client.api.JsonMapper;
 import java.io.InputStream;
 import java.util.Map;
 
 public abstract class CommandWithVariables<T> {
 
-  protected final ZeebeObjectMapper objectMapper;
+  protected final JsonMapper objectMapper;
 
-  public CommandWithVariables(final ZeebeObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+  public CommandWithVariables(final JsonMapper jsonMapper) {
+    this.objectMapper = jsonMapper;
   }
 
   public T variables(final InputStream variables) {

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/CompleteJobCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/CompleteJobCommandImpl.java
@@ -16,12 +16,12 @@
 package io.zeebe.client.impl.command;
 
 import io.grpc.stub.StreamObserver;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.zeebe.client.api.command.FinalCommandStep;
 import io.zeebe.client.api.response.CompleteJobResponse;
 import io.zeebe.client.impl.RetriableClientFutureImpl;
-import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.zeebe.gateway.protocol.GatewayOuterClass;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
@@ -40,11 +40,11 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
 
   public CompleteJobCommandImpl(
       final GatewayStub asyncStub,
-      final ZeebeObjectMapper objectMapper,
+      final JsonMapper jsonMapper,
       final long key,
       final Duration requestTimeout,
       final Predicate<Throwable> retryPredicate) {
-    super(objectMapper);
+    super(jsonMapper);
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;
     this.retryPredicate = retryPredicate;

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/CreateWorkflowInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/CreateWorkflowInstanceCommandImpl.java
@@ -16,6 +16,7 @@
 package io.zeebe.client.impl.command;
 
 import io.grpc.stub.StreamObserver;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.CreateWorkflowInstanceCommandStep1;
 import io.zeebe.client.api.command.CreateWorkflowInstanceCommandStep1.CreateWorkflowInstanceCommandStep2;
@@ -23,7 +24,6 @@ import io.zeebe.client.api.command.CreateWorkflowInstanceCommandStep1.CreateWork
 import io.zeebe.client.api.command.FinalCommandStep;
 import io.zeebe.client.api.response.WorkflowInstanceEvent;
 import io.zeebe.client.impl.RetriableClientFutureImpl;
-import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.client.impl.response.CreateWorkflowInstanceResponseImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.zeebe.gateway.protocol.GatewayOuterClass;
@@ -40,35 +40,34 @@ public final class CreateWorkflowInstanceCommandImpl
         CreateWorkflowInstanceCommandStep2,
         CreateWorkflowInstanceCommandStep3 {
 
-  private final ZeebeObjectMapper objectMapper;
   private final GatewayStub asyncStub;
   private final Builder builder;
   private final Predicate<Throwable> retryPredicate;
+  private final JsonMapper jsonMapper;
   private Duration requestTimeout;
 
   public CreateWorkflowInstanceCommandImpl(
       final GatewayStub asyncStub,
-      final ZeebeObjectMapper objectMapper,
+      final JsonMapper jsonMapper,
       final Duration requestTimeout,
       final Predicate<Throwable> retryPredicate) {
     this.asyncStub = asyncStub;
-    this.objectMapper = objectMapper;
     this.requestTimeout = requestTimeout;
     this.retryPredicate = retryPredicate;
-
+    this.jsonMapper = jsonMapper;
     builder = CreateWorkflowInstanceRequest.newBuilder();
   }
 
   @Override
   public CreateWorkflowInstanceCommandStep3 variables(final InputStream variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return setVariables(objectMapper.validateJson("variables", variables));
+    return setVariables(jsonMapper.validateJson("variables", variables));
   }
 
   @Override
   public CreateWorkflowInstanceCommandStep3 variables(final String variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return setVariables(objectMapper.validateJson("variables", variables));
+    return setVariables(jsonMapper.validateJson("variables", variables));
   }
 
   @Override
@@ -79,13 +78,13 @@ public final class CreateWorkflowInstanceCommandImpl
   @Override
   public CreateWorkflowInstanceCommandStep3 variables(final Object variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return setVariables(objectMapper.toJson(variables));
+    return setVariables(jsonMapper.toJson(variables));
   }
 
   @Override
   public CreateWorkflowInstanceWithResultCommandStep1 withResult() {
     return new CreateWorkflowInstanceWithResultCommandImpl(
-        objectMapper, asyncStub, builder, retryPredicate, requestTimeout);
+        jsonMapper, asyncStub, builder, retryPredicate, requestTimeout);
   }
 
   @Override

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/CreateWorkflowInstanceWithResultCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/CreateWorkflowInstanceWithResultCommandImpl.java
@@ -16,12 +16,12 @@
 package io.zeebe.client.impl.command;
 
 import io.grpc.stub.StreamObserver;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.CreateWorkflowInstanceCommandStep1.CreateWorkflowInstanceWithResultCommandStep1;
 import io.zeebe.client.api.command.FinalCommandStep;
 import io.zeebe.client.api.response.WorkflowInstanceResult;
 import io.zeebe.client.impl.RetriableClientFutureImpl;
-import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.client.impl.response.CreateWorkflowInstanceWithResultResponseImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.zeebe.gateway.protocol.GatewayOuterClass;
@@ -38,7 +38,7 @@ public final class CreateWorkflowInstanceWithResultCommandImpl
     implements CreateWorkflowInstanceWithResultCommandStep1 {
 
   private static final Duration DEADLINE_OFFSET = Duration.ofSeconds(10);
-  private final ZeebeObjectMapper objectMapper;
+  private final JsonMapper jsonMapper;
   private final GatewayStub asyncStub;
   private final CreateWorkflowInstanceRequest.Builder createWorkflowInstanceRequestBuilder;
   private final Builder builder;
@@ -46,12 +46,12 @@ public final class CreateWorkflowInstanceWithResultCommandImpl
   private Duration requestTimeout;
 
   public CreateWorkflowInstanceWithResultCommandImpl(
-      final ZeebeObjectMapper objectMapper,
+      final JsonMapper jsonMapper,
       final GatewayStub asyncStub,
       final CreateWorkflowInstanceRequest.Builder builder,
       final Predicate<Throwable> retryPredicate,
       final Duration requestTimeout) {
-    this.objectMapper = objectMapper;
+    this.jsonMapper = jsonMapper;
     this.asyncStub = asyncStub;
     createWorkflowInstanceRequestBuilder = builder;
     this.retryPredicate = retryPredicate;
@@ -78,8 +78,7 @@ public final class CreateWorkflowInstanceWithResultCommandImpl
             WorkflowInstanceResult, GatewayOuterClass.CreateWorkflowInstanceWithResultResponse>
         future =
             new RetriableClientFutureImpl<>(
-                response ->
-                    new CreateWorkflowInstanceWithResultResponseImpl(objectMapper, response),
+                response -> new CreateWorkflowInstanceWithResultResponseImpl(jsonMapper, response),
                 retryPredicate,
                 streamObserver -> send(request, streamObserver));
 

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/PublishMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/PublishMessageCommandImpl.java
@@ -17,6 +17,7 @@ package io.zeebe.client.impl.command;
 
 import io.grpc.stub.StreamObserver;
 import io.zeebe.client.ZeebeClientConfiguration;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.FinalCommandStep;
 import io.zeebe.client.api.command.PublishMessageCommandStep1;
@@ -24,7 +25,6 @@ import io.zeebe.client.api.command.PublishMessageCommandStep1.PublishMessageComm
 import io.zeebe.client.api.command.PublishMessageCommandStep1.PublishMessageCommandStep3;
 import io.zeebe.client.api.response.PublishMessageResponse;
 import io.zeebe.client.impl.RetriableClientFutureImpl;
-import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.client.impl.response.PublishMessageResponseImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.zeebe.gateway.protocol.GatewayOuterClass;
@@ -44,9 +44,9 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
   public PublishMessageCommandImpl(
       final GatewayStub asyncStub,
       final ZeebeClientConfiguration configuration,
-      final ZeebeObjectMapper objectMapper,
+      final JsonMapper jsonMapper,
       final Predicate<Throwable> retryPredicate) {
-    super(objectMapper);
+    super(jsonMapper);
     this.asyncStub = asyncStub;
     this.retryPredicate = retryPredicate;
     builder = PublishMessageRequest.newBuilder();

--- a/clients/java/src/main/java/io/zeebe/client/impl/command/SetVariablesCommandImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/command/SetVariablesCommandImpl.java
@@ -16,13 +16,13 @@
 package io.zeebe.client.impl.command;
 
 import io.grpc.stub.StreamObserver;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.command.FinalCommandStep;
 import io.zeebe.client.api.command.SetVariablesCommandStep1;
 import io.zeebe.client.api.command.SetVariablesCommandStep1.SetVariablesCommandStep2;
 import io.zeebe.client.api.response.SetVariablesResponse;
 import io.zeebe.client.impl.RetriableClientFutureImpl;
-import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.client.impl.response.SetVariablesResponseImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.zeebe.gateway.protocol.GatewayOuterClass;
@@ -39,18 +39,18 @@ public final class SetVariablesCommandImpl
 
   private final GatewayStub asyncStub;
   private final Builder builder;
-  private final ZeebeObjectMapper objectMapper;
+  private final JsonMapper jsonMapper;
   private final Predicate<Throwable> retryPredicate;
   private Duration requestTimeout;
 
   public SetVariablesCommandImpl(
       final GatewayStub asyncStub,
-      final ZeebeObjectMapper objectMapper,
+      final JsonMapper jsonMapper,
       final long elementInstanceKey,
       final Duration requestTimeout,
       final Predicate<Throwable> retryPredicate) {
     this.asyncStub = asyncStub;
-    this.objectMapper = objectMapper;
+    this.jsonMapper = jsonMapper;
     this.requestTimeout = requestTimeout;
     this.retryPredicate = retryPredicate;
     builder = SetVariablesRequest.newBuilder();
@@ -95,13 +95,13 @@ public final class SetVariablesCommandImpl
   @Override
   public SetVariablesCommandStep2 variables(final InputStream variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return setVariables(objectMapper.validateJson("variables", variables));
+    return setVariables(jsonMapper.validateJson("variables", variables));
   }
 
   @Override
   public SetVariablesCommandStep2 variables(final String variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return setVariables(objectMapper.validateJson("variables", variables));
+    return setVariables(jsonMapper.validateJson("variables", variables));
   }
 
   @Override
@@ -112,7 +112,7 @@ public final class SetVariablesCommandImpl
   @Override
   public SetVariablesCommandStep2 variables(final Object variables) {
     ArgumentUtil.ensureNotNull("variables", variables);
-    return setVariables(objectMapper.toJson(variables));
+    return setVariables(jsonMapper.toJson(variables));
   }
 
   private SetVariablesCommandStep2 setVariables(final String jsonDocument) {

--- a/clients/java/src/main/java/io/zeebe/client/impl/response/ActivateJobsResponseImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/response/ActivateJobsResponseImpl.java
@@ -15,25 +15,25 @@
  */
 package io.zeebe.client.impl.response;
 
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.response.ActivateJobsResponse;
 import io.zeebe.client.api.response.ActivatedJob;
-import io.zeebe.client.impl.ZeebeObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
 
 public final class ActivateJobsResponseImpl implements ActivateJobsResponse {
 
-  private final ZeebeObjectMapper objectMapper;
+  private final JsonMapper jsonMapper;
   private final List<ActivatedJob> jobs = new ArrayList<>();
 
-  public ActivateJobsResponseImpl(final ZeebeObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+  public ActivateJobsResponseImpl(final JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
   }
 
   public void addResponse(
       final io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse activateJobsResponse) {
     activateJobsResponse.getJobsList().stream()
-        .map(r -> new ActivatedJobImpl(objectMapper, r))
+        .map(r -> new ActivatedJobImpl(jsonMapper, r))
         .forEach(jobs::add);
   }
 

--- a/clients/java/src/main/java/io/zeebe/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/response/ActivatedJobImpl.java
@@ -16,14 +16,14 @@
 package io.zeebe.client.impl.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.response.ActivatedJob;
-import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.gateway.protocol.GatewayOuterClass;
 import java.util.Map;
 
 public final class ActivatedJobImpl implements ActivatedJob {
 
-  @JsonIgnore private final ZeebeObjectMapper objectMapper;
+  @JsonIgnore private final JsonMapper jsonMapper;
 
   private final long key;
   private final String type;
@@ -39,13 +39,12 @@ public final class ActivatedJobImpl implements ActivatedJob {
   private final long deadline;
   private final String variables;
 
-  public ActivatedJobImpl(
-      final ZeebeObjectMapper objectMapper, final GatewayOuterClass.ActivatedJob job) {
-    this.objectMapper = objectMapper;
+  public ActivatedJobImpl(final JsonMapper jsonMapper, final GatewayOuterClass.ActivatedJob job) {
+    this.jsonMapper = jsonMapper;
 
     key = job.getKey();
     type = job.getType();
-    customHeaders = objectMapper.fromJsonAsStringMap(job.getCustomHeaders());
+    customHeaders = jsonMapper.fromJsonAsStringMap(job.getCustomHeaders());
     worker = job.getWorker();
     retries = job.getRetries();
     deadline = job.getDeadline();
@@ -125,17 +124,17 @@ public final class ActivatedJobImpl implements ActivatedJob {
 
   @Override
   public Map<String, Object> getVariablesAsMap() {
-    return objectMapper.fromJsonAsMap(variables);
+    return jsonMapper.fromJsonAsMap(variables);
   }
 
   @Override
   public <T> T getVariablesAsType(final Class<T> variableType) {
-    return objectMapper.fromJson(variables, variableType);
+    return jsonMapper.fromJson(variables, variableType);
   }
 
   @Override
   public String toJson() {
-    return objectMapper.toJson(this);
+    return jsonMapper.toJson(this);
   }
 
   @Override

--- a/clients/java/src/main/java/io/zeebe/client/impl/response/CreateWorkflowInstanceWithResultResponseImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/response/CreateWorkflowInstanceWithResultResponseImpl.java
@@ -15,14 +15,14 @@
  */
 package io.zeebe.client.impl.response;
 
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.response.WorkflowInstanceResult;
-import io.zeebe.client.impl.ZeebeObjectMapper;
-import io.zeebe.gateway.protocol.GatewayOuterClass;
+import io.zeebe.gateway.protocol.GatewayOuterClass.CreateWorkflowInstanceWithResultResponse;
 import java.util.Map;
 
 public final class CreateWorkflowInstanceWithResultResponseImpl implements WorkflowInstanceResult {
 
-  private final ZeebeObjectMapper objectMapper;
+  private final JsonMapper jsonMapper;
   private final long workflowKey;
   private final String bpmnProcessId;
   private final int version;
@@ -30,9 +30,8 @@ public final class CreateWorkflowInstanceWithResultResponseImpl implements Workf
   private final String variables;
 
   public CreateWorkflowInstanceWithResultResponseImpl(
-      final ZeebeObjectMapper objectMapper,
-      final GatewayOuterClass.CreateWorkflowInstanceWithResultResponse response) {
-    this.objectMapper = objectMapper;
+      final JsonMapper jsonMapper, final CreateWorkflowInstanceWithResultResponse response) {
+    this.jsonMapper = jsonMapper;
     workflowKey = response.getWorkflowKey();
     bpmnProcessId = response.getBpmnProcessId();
     version = response.getVersion();
@@ -67,12 +66,12 @@ public final class CreateWorkflowInstanceWithResultResponseImpl implements Workf
 
   @Override
   public Map<String, Object> getVariablesAsMap() {
-    return objectMapper.fromJsonAsMap(variables);
+    return jsonMapper.fromJsonAsMap(variables);
   }
 
   @Override
   public <T> T getVariablesAsType(final Class<T> variableType) {
-    return objectMapper.fromJson(variables, variableType);
+    return jsonMapper.fromJson(variables, variableType);
   }
 
   @Override

--- a/clients/java/src/main/java/io/zeebe/client/impl/worker/JobClientImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/worker/JobClientImpl.java
@@ -16,11 +16,11 @@
 package io.zeebe.client.impl.worker;
 
 import io.zeebe.client.ZeebeClientConfiguration;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.zeebe.client.api.command.FailJobCommandStep1;
 import io.zeebe.client.api.command.ThrowErrorCommandStep1;
 import io.zeebe.client.api.worker.JobClient;
-import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.client.impl.command.CompleteJobCommandImpl;
 import io.zeebe.client.impl.command.FailJobCommandImpl;
 import io.zeebe.client.impl.command.ThrowErrorCommandImpl;
@@ -31,24 +31,24 @@ public final class JobClientImpl implements JobClient {
 
   private final GatewayStub asyncStub;
   private final ZeebeClientConfiguration config;
-  private final ZeebeObjectMapper objectMapper;
+  private final JsonMapper jsonMapper;
   private final Predicate<Throwable> retryPredicate;
 
   public JobClientImpl(
       final GatewayStub asyncStub,
       final ZeebeClientConfiguration config,
-      final ZeebeObjectMapper objectMapper,
+      final JsonMapper jsonMapper,
       final Predicate<Throwable> retryPredicate) {
     this.asyncStub = asyncStub;
     this.config = config;
-    this.objectMapper = objectMapper;
+    this.jsonMapper = jsonMapper;
     this.retryPredicate = retryPredicate;
   }
 
   @Override
   public CompleteJobCommandStep1 newCompleteCommand(final long jobKey) {
     return new CompleteJobCommandImpl(
-        asyncStub, objectMapper, jobKey, config.getDefaultRequestTimeout(), retryPredicate);
+        asyncStub, jsonMapper, jobKey, config.getDefaultRequestTimeout(), retryPredicate);
   }
 
   @Override

--- a/clients/java/src/main/java/io/zeebe/client/impl/worker/JobPoller.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/worker/JobPoller.java
@@ -18,9 +18,9 @@ package io.zeebe.client.impl.worker;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.response.ActivatedJob;
 import io.zeebe.client.impl.Loggers;
-import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.client.impl.response.ActivatedJobImpl;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest.Builder;
@@ -39,7 +39,7 @@ public final class JobPoller implements StreamObserver<ActivateJobsResponse> {
 
   private final GatewayStub gatewayStub;
   private final Builder requestBuilder;
-  private final ZeebeObjectMapper objectMapper;
+  private final JsonMapper jsonMapper;
   private final long requestTimeout;
   private final Predicate<Throwable> retryPredicate;
 
@@ -52,12 +52,12 @@ public final class JobPoller implements StreamObserver<ActivateJobsResponse> {
   public JobPoller(
       final GatewayStub gatewayStub,
       final Builder requestBuilder,
-      final ZeebeObjectMapper objectMapper,
+      final JsonMapper jsonMapper,
       final Duration requestTimeout,
       final Predicate<Throwable> retryPredicate) {
     this.gatewayStub = gatewayStub;
     this.requestBuilder = requestBuilder;
-    this.objectMapper = objectMapper;
+    this.jsonMapper = jsonMapper;
     this.requestTimeout = requestTimeout.toMillis();
     this.retryPredicate = retryPredicate;
   }
@@ -96,7 +96,7 @@ public final class JobPoller implements StreamObserver<ActivateJobsResponse> {
   public void onNext(final ActivateJobsResponse activateJobsResponse) {
     activatedJobs += activateJobsResponse.getJobsCount();
     activateJobsResponse.getJobsList().stream()
-        .map(job -> new ActivatedJobImpl(objectMapper, job))
+        .map(job -> new ActivatedJobImpl(jsonMapper, job))
         .forEach(jobConsumer);
   }
 

--- a/clients/java/src/main/java/io/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
@@ -20,13 +20,13 @@ import static io.zeebe.client.impl.command.ArgumentUtil.ensureNotNull;
 import static io.zeebe.client.impl.command.ArgumentUtil.ensureNotNullNorEmpty;
 
 import io.zeebe.client.ZeebeClientConfiguration;
+import io.zeebe.client.api.JsonMapper;
 import io.zeebe.client.api.worker.JobClient;
 import io.zeebe.client.api.worker.JobHandler;
 import io.zeebe.client.api.worker.JobWorker;
 import io.zeebe.client.api.worker.JobWorkerBuilderStep1;
 import io.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep2;
 import io.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
-import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest.Builder;
@@ -44,7 +44,7 @@ public final class JobWorkerBuilderImpl
 
   private final GatewayStub gatewayStub;
   private final JobClient jobClient;
-  private final ZeebeObjectMapper objectMapper;
+  private final JsonMapper jsonMapper;
   private final ScheduledExecutorService executorService;
   private final List<Closeable> closeables;
   private final Predicate<Throwable> retryPredicate;
@@ -61,13 +61,13 @@ public final class JobWorkerBuilderImpl
       final ZeebeClientConfiguration configuration,
       final GatewayStub gatewayStub,
       final JobClient jobClient,
-      final ZeebeObjectMapper objectMapper,
+      final JsonMapper jsonMapper,
       final ScheduledExecutorService executorService,
       final List<Closeable> closeables,
       final Predicate<Throwable> retryPredicate) {
     this.gatewayStub = gatewayStub;
     this.jobClient = jobClient;
-    this.objectMapper = objectMapper;
+    this.jsonMapper = jsonMapper;
     this.executorService = executorService;
     this.closeables = closeables;
 
@@ -160,7 +160,7 @@ public final class JobWorkerBuilderImpl
 
     final JobRunnableFactory jobRunnableFactory = new JobRunnableFactory(jobClient, handler);
     final JobPoller jobPoller =
-        new JobPoller(gatewayStub, requestBuilder, objectMapper, deadline, retryPredicate);
+        new JobPoller(gatewayStub, requestBuilder, jsonMapper, deadline, retryPredicate);
 
     final JobWorkerImpl jobWorker =
         new JobWorkerImpl(

--- a/test/src/main/java/io/zeebe/test/WorkflowInstanceAssert.java
+++ b/test/src/main/java/io/zeebe/test/WorkflowInstanceAssert.java
@@ -16,7 +16,6 @@ import io.zeebe.test.util.record.RecordingExporter;
 import io.zeebe.test.util.record.WorkflowInstanceRecordStream;
 import io.zeebe.test.util.record.WorkflowInstances;
 import io.zeebe.test.util.stream.StreamWrapperException;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -164,12 +163,7 @@ public class WorkflowInstanceAssert
     }
 
     final Object value;
-    try {
-      value = OBJECT_MAPPER.readValue(variables.get(key), Object.class);
-    } catch (final IOException e) {
-      failWithMessage("Expected variable values to be JSON, but got <%s>", e.getMessage());
-      return this;
-    }
+    value = OBJECT_MAPPER.fromJson(variables.get(key), Object.class);
 
     if ((expectedValue == null && value != null)
         || (expectedValue != null && !expectedValue.equals(value))) {


### PR DESCRIPTION
## Description

I've added methods in the Java API that can change the usage of `io.zeebe.client.impl.ZeebeObjectMapper`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5578 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
