### PR TITLE
chore(broker): set log level on exporting exceptions as warn

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -140,7 +140,7 @@ final class ExporterContainer implements Controller {
       }
       return true;
     } catch (final Exception ex) {
-      context.getLogger().error("Error on exporting record with key {}", typedEvent.getKey(), ex);
+      context.getLogger().warn("Error on exporting record with key {}", typedEvent.getKey(), ex);
       return false;
     }
   }


### PR DESCRIPTION
## Description

I've set a warning log level for the exporter exceptions.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5564 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
