### PR TITLE
fix(engine): always accept Deployment CREATE command

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/state/deployment/WorkflowState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/deployment/WorkflowState.java
@@ -45,8 +45,8 @@ public final class WorkflowState {
     return (int) versionManager.getNextValue(bpmnProcessId);
   }
 
-  public boolean putDeployment(final long deploymentKey, final DeploymentRecord deploymentRecord) {
-    return workflowPersistenceCache.putDeployment(deploymentKey, deploymentRecord);
+  public void putDeployment(final DeploymentRecord deploymentRecord) {
+    workflowPersistenceCache.putDeployment(deploymentRecord);
   }
 
   public DeployedWorkflow getWorkflowByProcessIdAndVersion(

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStreamProcessorRule.java
@@ -129,8 +129,7 @@ public final class WorkflowInstanceStreamProcessorRule extends ExternalResource
         });
   }
 
-  public void deploy(
-      final BpmnModelInstance modelInstance, final int deploymentKey, final int version) {
+  public void deploy(final BpmnModelInstance modelInstance, final int version) {
     final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
     Bpmn.writeModelToStream(outStream, modelInstance);
     final DirectBuffer xmlBuffer = new UnsafeBuffer(outStream.toByteArray());
@@ -155,11 +154,11 @@ public final class WorkflowInstanceStreamProcessorRule extends ExternalResource
         .setBpmnProcessId(BufferUtil.wrapString(process.getId()))
         .setVersion(version);
 
-    actor.call(() -> workflowState.putDeployment(deploymentKey, record)).join();
+    actor.call(() -> workflowState.putDeployment(record)).join();
   }
 
   public void deploy(final BpmnModelInstance modelInstance) {
-    deploy(modelInstance, DEPLOYMENT_KEY, VERSION);
+    deploy(modelInstance, VERSION);
   }
 
   public Record<WorkflowInstanceRecord> createAndReceiveWorkflowInstance(

--- a/engine/src/test/java/io/zeebe/engine/processing/deployment/DeploymentCreateProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/deployment/DeploymentCreateProcessorTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 
 public final class DeploymentCreateProcessorTest {
+
   @Rule
   public final StreamProcessorRule rule =
       new StreamProcessorRule(Protocol.DEPLOYMENT_PARTITION + 1);
@@ -52,7 +53,7 @@ public final class DeploymentCreateProcessorTest {
   }
 
   @Test
-  public void shouldRejectTwoCreatingCommands() {
+  public void shouldNotRejectTwoCreateDeploymentCommands() {
     // given
     creatingDeployment();
 
@@ -73,12 +74,12 @@ public final class DeploymentCreateProcessorTest {
             DeploymentIntent.CREATE,
             DeploymentIntent.CREATED,
             DeploymentIntent.CREATE,
-            DeploymentIntent.CREATE);
+            DeploymentIntent.CREATED);
     //
     Assertions.assertThat(collect)
         .extracting(Record::getRecordType)
         .containsExactly(
-            RecordType.COMMAND, RecordType.EVENT, RecordType.COMMAND, RecordType.COMMAND_REJECTION);
+            RecordType.COMMAND, RecordType.EVENT, RecordType.COMMAND, RecordType.EVENT);
   }
 
   @Test

--- a/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
@@ -135,7 +135,7 @@ public final class IncidentStreamProcessorRule extends ExternalResource {
         .setBpmnProcessId(BufferUtil.wrapString(process.getId()))
         .setVersion(1);
 
-    workflowState.putDeployment(1, record);
+    workflowState.putDeployment(record);
   }
 
   public Record<WorkflowInstanceRecord> createWorkflowInstance(final String processId) {

--- a/engine/src/test/java/io/zeebe/engine/processing/workflowinstance/CreateWorkflowInstanceProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/workflowinstance/CreateWorkflowInstanceProcessorTest.java
@@ -317,7 +317,7 @@ public final class CreateWorkflowInstanceProcessorTest
     final long key = keyGenerator.nextKey();
     final DeploymentRecord deployment = newDeployment(model);
     final Workflow workflow = deployment.workflows().iterator().next();
-    workflowState.putDeployment(key, deployment);
+    workflowState.putDeployment(deployment);
 
     return workflowState.getLatestWorkflowVersionByProcessId(workflow.getBpmnProcessIdBuffer());
   }

--- a/engine/src/test/java/io/zeebe/engine/state/deployment/WorkflowStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/deployment/WorkflowStateTest.java
@@ -140,7 +140,7 @@ public final class WorkflowStateTest {
     final DeploymentRecord deploymentRecord = creatingDeploymentRecord(zeebeState);
 
     // when
-    workflowState.putDeployment(1, deploymentRecord);
+    workflowState.putDeployment(deploymentRecord);
 
     // then
     final DeployedWorkflow deployedWorkflow =
@@ -155,7 +155,7 @@ public final class WorkflowStateTest {
     final DeploymentRecord deploymentRecord = creatingDeploymentRecord(zeebeState);
 
     // when
-    workflowState.putDeployment(1, deploymentRecord);
+    workflowState.putDeployment(deploymentRecord);
     deploymentRecord.workflows().iterator().next().setKey(212).setBpmnProcessId("other");
 
     // then
@@ -175,8 +175,8 @@ public final class WorkflowStateTest {
     // given
 
     // when
-    workflowState.putDeployment(1, creatingDeploymentRecord(zeebeState));
-    workflowState.putDeployment(2, creatingDeploymentRecord(zeebeState));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState));
 
     // then
     final DeployedWorkflow deployedWorkflow =
@@ -201,10 +201,10 @@ public final class WorkflowStateTest {
   @Test
   public void shouldRestartVersionCountOnDifferentProcessId() {
     // given
-    workflowState.putDeployment(1, creatingDeploymentRecord(zeebeState));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState));
 
     // when
-    workflowState.putDeployment(2, creatingDeploymentRecord(zeebeState, "otherId"));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState, "otherId"));
 
     // then
     final DeployedWorkflow deployedWorkflow =
@@ -228,8 +228,8 @@ public final class WorkflowStateTest {
   @Test
   public void shouldGetLatestDeployedWorkflow() {
     // given
-    workflowState.putDeployment(1, creatingDeploymentRecord(zeebeState));
-    workflowState.putDeployment(2, creatingDeploymentRecord(zeebeState));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState));
 
     // when
     final DeployedWorkflow latestWorkflow =
@@ -263,12 +263,12 @@ public final class WorkflowStateTest {
   @Test
   public void shouldGetLatestDeployedWorkflowAfterDeploymentWasAdded() {
     // given
-    workflowState.putDeployment(1, creatingDeploymentRecord(zeebeState));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState));
     final DeployedWorkflow firstLatest =
         workflowState.getLatestWorkflowVersionByProcessId(wrapString("processId"));
 
     // when
-    workflowState.putDeployment(2, creatingDeploymentRecord(zeebeState));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState));
 
     // then
     final DeployedWorkflow latestWorkflow =
@@ -293,7 +293,7 @@ public final class WorkflowStateTest {
   public void shouldGetExecutableWorkflow() {
     // given
     final DeploymentRecord deploymentRecord = creatingDeploymentRecord(zeebeState);
-    workflowState.putDeployment(1, deploymentRecord);
+    workflowState.putDeployment(deploymentRecord);
 
     // when
     final DeployedWorkflow deployedWorkflow =
@@ -310,8 +310,7 @@ public final class WorkflowStateTest {
   public void shouldGetExecutableWorkflowByKey() {
     // given
     final DeploymentRecord deploymentRecord = creatingDeploymentRecord(zeebeState);
-    final long deploymentKey = FIRST_WORKFLOW_KEY;
-    workflowState.putDeployment(deploymentKey, deploymentRecord);
+    workflowState.putDeployment(deploymentRecord);
 
     // when
     final long workflowKey = FIRST_WORKFLOW_KEY;
@@ -328,8 +327,7 @@ public final class WorkflowStateTest {
   public void shouldGetExecutableWorkflowByLatestWorkflow() {
     // given
     final DeploymentRecord deploymentRecord = creatingDeploymentRecord(zeebeState);
-    final int deploymentKey = 1;
-    workflowState.putDeployment(deploymentKey, deploymentRecord);
+    workflowState.putDeployment(deploymentRecord);
 
     // when
     final DeployedWorkflow deployedWorkflow =
@@ -345,9 +343,9 @@ public final class WorkflowStateTest {
   @Test
   public void shouldGetAllWorkflows() {
     // given
-    workflowState.putDeployment(1, creatingDeploymentRecord(zeebeState));
-    workflowState.putDeployment(2, creatingDeploymentRecord(zeebeState));
-    workflowState.putDeployment(3, creatingDeploymentRecord(zeebeState, "otherId"));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState, "otherId"));
 
     // when
     final Collection<DeployedWorkflow> workflows = workflowState.getWorkflows();
@@ -367,8 +365,8 @@ public final class WorkflowStateTest {
   @Test
   public void shouldGetAllWorkflowsWithProcessId() {
     // given
-    workflowState.putDeployment(1, creatingDeploymentRecord(zeebeState));
-    workflowState.putDeployment(2, creatingDeploymentRecord(zeebeState));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState));
 
     // when
     final Collection<DeployedWorkflow> workflows =
@@ -388,8 +386,8 @@ public final class WorkflowStateTest {
   @Test
   public void shouldNotGetWorkflowsWithOtherProcessId() {
     // given
-    workflowState.putDeployment(1, creatingDeploymentRecord(zeebeState));
-    workflowState.putDeployment(2, creatingDeploymentRecord(zeebeState, "otherId"));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState, "otherId"));
 
     // when
     final Collection<DeployedWorkflow> workflows =
@@ -412,8 +410,8 @@ public final class WorkflowStateTest {
   public void shouldReturnHighestVersionInsteadOfMostRecent() {
     // given
     final String processId = "process";
-    workflowState.putDeployment(2, creatingDeploymentRecord(zeebeState, processId, 2));
-    workflowState.putDeployment(1, creatingDeploymentRecord(zeebeState, processId, 1));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState, processId, 2));
+    workflowState.putDeployment(creatingDeploymentRecord(zeebeState, processId, 1));
 
     // when
     final DeployedWorkflow latestWorkflow =


### PR DESCRIPTION
## Description

 * removes one of the in-memory deployment caches
 * always accept depmloyment create commands on other partitions, before it was rejected which can lead to inconsistency problems
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/5753
closes https://github.com/zeebe-io/zeebe/issues/5688

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
