### PR TITLE
Reprocessing detection feature flag

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -20,10 +20,12 @@ public class ExperimentalCfg {
   public static final int DEFAULT_MAX_APPENDS_PER_FOLLOWER = 2;
   public static final DataSize DEFAULT_MAX_APPEND_BATCH_SIZE = DataSize.ofKilobytes(32);
   public static final boolean DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH = false;
+  private static final boolean DEFAULT_DETECT_REPROCESSING_INCONSISTENCY = false;
 
   private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
   private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;
   private boolean disableExplicitRaftFlush = DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH;
+  private boolean detectReprocessingInconsistency = DEFAULT_DETECT_REPROCESSING_INCONSISTENCY;
 
   public int getMaxAppendsPerFollower() {
     return maxAppendsPerFollower;
@@ -53,6 +55,14 @@ public class ExperimentalCfg {
     this.disableExplicitRaftFlush = disableExplicitRaftFlush;
   }
 
+  public boolean isDetectReprocessingInconsistency() {
+    return detectReprocessingInconsistency;
+  }
+
+  public void setDetectReprocessingInconsistency(final boolean detectReprocessingInconsistency) {
+    this.detectReprocessingInconsistency = detectReprocessingInconsistency;
+  }
+
   @Override
   public String toString() {
     return "ExperimentalCfg{"
@@ -62,6 +72,8 @@ public class ExperimentalCfg {
         + maxAppendBatchSize
         + ", disableExplicitRaftFlush="
         + disableExplicitRaftFlush
+        + ", detectReprocessingInconsistency="
+        + detectReprocessingInconsistency
         + '}';
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
@@ -58,12 +58,15 @@ public class StreamProcessorPartitionStep implements PartitionStep {
   }
 
   private StreamProcessor createStreamProcessor(final PartitionContext state) {
+
     return StreamProcessor.builder()
         .logStream(state.getLogStream())
         .actorScheduler(state.getScheduler())
         .zeebeDb(state.getZeebeDb())
         .nodeId(state.getNodeId())
         .commandResponseWriter(state.getCommandApiService().newCommandResponseWriter())
+        .detectReprocessingInconsistency(
+            state.getBrokerCfg().getExperimental().isDetectReprocessingInconsistency())
         .onProcessedListener(
             state.getCommandApiService().getOnProcessedListener(state.getPartitionId()))
         .streamProcessorFactory(

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -524,3 +524,8 @@
       # Sets the maximum batch size, which is send per append request to a follower.
       # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_MAX_APPEND_BATCH_SIZE
       # maxAppendBatchSize = 32KB;
+
+      # Enables the detection of an inconsistency during reprocessing. If a inconsistency is detect the StreamProcessor is
+      # failed and the partition becomes unhealthy, no further progress will made on that specific partition.
+      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_DETECT_REPROCESSING_INCONSISTENCY
+      # detectReprocessingInconsistency = false;

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -35,6 +35,7 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
   private BooleanSupplier abortCondition;
   private Consumer<TypedRecord> onProcessedListener = record -> {};
   private int maxFragmentSize;
+  private boolean detectReprocessingInconsistency;
 
   public ProcessingContext actor(final ActorControl actor) {
     this.actor = actor;
@@ -102,6 +103,11 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return this;
   }
 
+  public ProcessingContext setDetectReprocessingInconsistency(final boolean detectReprocessingInconsistency) {
+    this.detectReprocessingInconsistency = detectReprocessingInconsistency;
+    return this;
+  }
+
   @Override
   public ActorControl getActor() {
     return actor;
@@ -164,5 +170,9 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
 
   public Consumer<TypedRecord> getOnProcessedListener() {
     return onProcessedListener;
+  }
+
+  public boolean isDetectReprocessingInconsistency() {
+    return detectReprocessingInconsistency;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -103,7 +103,8 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return this;
   }
 
-  public ProcessingContext setDetectReprocessingInconsistency(final boolean detectReprocessingInconsistency) {
+  public ProcessingContext setDetectReprocessingInconsistency(
+      final boolean detectReprocessingInconsistency) {
     this.detectReprocessingInconsistency = detectReprocessingInconsistency;
     return this;
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReProcessingStateMachine.java
@@ -273,7 +273,6 @@ public final class ReProcessingStateMachine {
       verifyRecordMatchesToReprocessing(typedEvent);
     }
 
-
     if (currentEvent.getPosition() <= lastSourceEventPosition) {
       // don't reprocess records after the last source event
       reprocessingStreamWriter.configureSourceContext(currentEvent.getPosition());

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
@@ -69,7 +69,8 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
-  public StreamProcessorBuilder detectReprocessingInconsistency(final boolean detectReprocessingInconsistency) {
+  public StreamProcessorBuilder detectReprocessingInconsistency(
+      final boolean detectReprocessingInconsistency) {
     this.processingContext.setDetectReprocessingInconsistency(detectReprocessingInconsistency);
     return this;
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
@@ -69,6 +69,11 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
+  public StreamProcessorBuilder detectReprocessingInconsistency(final boolean detectReprocessingInconsistency) {
+    this.processingContext.setDetectReprocessingInconsistency(detectReprocessingInconsistency);
+    return this;
+  }
+
   public TypedRecordProcessorFactory getTypedRecordProcessorFactory() {
     return typedRecordProcessorFactory;
   }

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
@@ -60,18 +60,21 @@ public class StreamProcessingComposite {
   }
 
   public StreamProcessor startTypedStreamProcessor(final TypedRecordProcessorFactory factory) {
-    return startTypedStreamProcessor(partitionId, factory);
+    return startTypedStreamProcessor(partitionId, factory, false);
   }
 
   public StreamProcessor startTypedStreamProcessor(
-      final int partitionId, final TypedRecordProcessorFactory factory) {
+      final int partitionId,
+      final TypedRecordProcessorFactory factory,
+      final boolean detectReprocessingInconsistency) {
     return streams.startStreamProcessor(
         getLogName(partitionId),
         zeebeDbFactory,
         (processingContext -> {
           zeebeState = processingContext.getZeebeState();
           return factory.createProcessors(processingContext);
-        }));
+        }),
+        detectReprocessingInconsistency);
   }
 
   public void pauseProcessing(final int partitionId) {

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -125,12 +125,15 @@ public final class StreamProcessorRule implements TestRule {
   }
 
   public StreamProcessor startTypedStreamProcessor(final TypedRecordProcessorFactory factory) {
-    return startTypedStreamProcessor(startPartitionId, factory);
+    return startTypedStreamProcessor(startPartitionId, factory, false);
   }
 
   public StreamProcessor startTypedStreamProcessor(
-      final int partitionId, final TypedRecordProcessorFactory factory) {
-    return streamProcessingComposite.startTypedStreamProcessor(partitionId, factory);
+      final int partitionId,
+      final TypedRecordProcessorFactory factory,
+      final boolean detectReprocessingInconsistency) {
+    return streamProcessingComposite.startTypedStreamProcessor(
+        partitionId, factory, detectReprocessingInconsistency);
   }
 
   public void pauseProcessing(final int partitionId) {

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -201,13 +201,24 @@ public final class TestStreams {
       final ZeebeDbFactory zeebeDbFactory,
       final TypedRecordProcessorFactory typedRecordProcessorFactory) {
     final SynchronousLogStream stream = getLogStream(log);
-    return buildStreamProcessor(stream, zeebeDbFactory, typedRecordProcessorFactory);
+    return buildStreamProcessor(stream, zeebeDbFactory, typedRecordProcessorFactory, false);
+  }
+
+  public StreamProcessor startStreamProcessor(
+      final String log,
+      final ZeebeDbFactory zeebeDbFactory,
+      final TypedRecordProcessorFactory typedRecordProcessorFactory,
+      final boolean detectReprocessingInconsistency) {
+    final SynchronousLogStream stream = getLogStream(log);
+    return buildStreamProcessor(
+        stream, zeebeDbFactory, typedRecordProcessorFactory, detectReprocessingInconsistency);
   }
 
   private StreamProcessor buildStreamProcessor(
       final SynchronousLogStream stream,
       final ZeebeDbFactory zeebeDbFactory,
-      final TypedRecordProcessorFactory factory) {
+      final TypedRecordProcessorFactory factory,
+      final boolean detectReprocessingInconsistency) {
     final var storage = createRuntimeFolder(stream);
     final var snapshot = storage.getParent().resolve(SNAPSHOT_FOLDER);
 
@@ -227,6 +238,7 @@ public final class TestStreams {
             .commandResponseWriter(mockCommandResponseWriter)
             .onProcessedListener(mockOnProcessedListener)
             .streamProcessorFactory(factory)
+            .detectReprocessingInconsistency(detectReprocessingInconsistency)
             .build();
     streamProcessor.openAsync().join(15, TimeUnit.SECONDS);
 


### PR DESCRIPTION
## Description

Introduces a new feature flag in the experimental config to enable the detection of reprocessing inconsistency. Per default it is now disabled.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/5759

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
