### PR TITLE
[BACKPORT 0.24] Add experimental configuration flag to control inconsistency detection

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
@@ -34,6 +34,7 @@ public final class BrokerCfg {
   private Map<String, ExporterCfg> exporters = new HashMap<>();
   private EmbeddedGatewayCfg gateway = new EmbeddedGatewayCfg();
   private BackpressureCfg backpressure = new BackpressureCfg();
+  private ExperimentalCfg experimental = new ExperimentalCfg();
 
   private Duration stepTimeout = Duration.ofMinutes(5);
   private boolean executionMetricsExporterEnabled;
@@ -142,6 +143,14 @@ public final class BrokerCfg {
     this.executionMetricsExporterEnabled = executionMetricsExporterEnabled;
   }
 
+  public ExperimentalCfg getExperimental() {
+    return experimental;
+  }
+
+  public void setExperimental(final ExperimentalCfg experimental) {
+    this.experimental = experimental;
+  }
+
   @Override
   public String toString() {
     return "BrokerCfg{"
@@ -159,6 +168,8 @@ public final class BrokerCfg {
         + gateway
         + ", backpressure="
         + backpressure
+        + ", experimental="
+        + experimental
         + ", stepTimeout="
         + stepTimeout
         + ", executionMetricsExporter="

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.configuration;
+
+/**
+ * Be aware that all configuration which are part of this class are experimental, which means they
+ * are subject to change and to drop. It might be that also some of them are actually dangerous so
+ * be aware when you change one of these!
+ */
+public class ExperimentalCfg {
+
+  private static final boolean DEFAULT_DETECT_REPROCESSING_INCONSISTENCY = false;
+
+  private boolean detectReprocessingInconsistency = DEFAULT_DETECT_REPROCESSING_INCONSISTENCY;
+
+  public boolean isDetectReprocessingInconsistency() {
+    return detectReprocessingInconsistency;
+  }
+
+  public void setDetectReprocessingInconsistency(final boolean detectReprocessingInconsistency) {
+    this.detectReprocessingInconsistency = detectReprocessingInconsistency;
+  }
+
+  @Override
+  public String toString() {
+    return "ExperimentalCfg{"
+        + ", detectReprocessingInconsistency="
+        + detectReprocessingInconsistency
+        + '}';
+  }
+}

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -518,6 +518,8 @@ public final class ZeebePartition extends Actor
         .zeebeDb(zeebeDb)
         .nodeId(localBroker.getNodeId())
         .commandResponseWriter(commandApiService.newCommandResponseWriter())
+        .detectReprocessingInconsistency(
+            brokerCfg.getExperimental().isDetectReprocessingInconsistency())
         .onProcessedListener(commandApiService.getOnProcessedListener(partitionId))
         .streamProcessorFactory(
             (processingContext) -> {

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -473,3 +473,20 @@
         #     workflowInstanceSubscription: false
         #
         #     ignoreVariablesAbove: 32677
+    # experimental
+      # Be aware that all configuration's which are part of the experimental section
+      # are subject to change and can be dropped at any time.
+      # It might be that also some of them are actually dangerous so be aware when you change one of these!
+
+      # Sets the maximum of appends which are send per follower.
+      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_MAX_APPENDS_PER_FOLLOWER
+      # maxAppendsPerFollower = 2
+
+      # Sets the maximum batch size, which is send per append request to a follower.
+      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_MAX_APPEND_BATCH_SIZE
+      # maxAppendBatchSize = 32KB;
+
+      # Enables the detection of an inconsistency during reprocessing. If a inconsistency is detect the StreamProcessor is
+      # failed and the partition becomes unhealthy, no further progress will made on that specific partition.
+      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_DETECT_REPROCESSING_INCONSISTENCY
+      # detectReprocessingInconsistency = false;

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -478,14 +478,6 @@
       # are subject to change and can be dropped at any time.
       # It might be that also some of them are actually dangerous so be aware when you change one of these!
 
-      # Sets the maximum of appends which are send per follower.
-      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_MAX_APPENDS_PER_FOLLOWER
-      # maxAppendsPerFollower = 2
-
-      # Sets the maximum batch size, which is send per append request to a follower.
-      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_MAX_APPEND_BATCH_SIZE
-      # maxAppendBatchSize = 32KB;
-
       # Enables the detection of an inconsistency during reprocessing. If a inconsistency is detect the StreamProcessor is
       # failed and the partition becomes unhealthy, no further progress will made on that specific partition.
       # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_DETECT_REPROCESSING_INCONSISTENCY

--- a/engine/src/main/java/io/zeebe/engine/processor/ProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ProcessingContext.java
@@ -100,7 +100,8 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return this;
   }
 
-  public ProcessingContext setDetectReprocessingInconsistency(final boolean detectReprocessingInconsistency) {
+  public ProcessingContext setDetectReprocessingInconsistency(
+      final boolean detectReprocessingInconsistency) {
     this.detectReprocessingInconsistency = detectReprocessingInconsistency;
     return this;
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/ProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ProcessingContext.java
@@ -32,6 +32,7 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
   private BooleanSupplier abortCondition;
   private Consumer<TypedRecord> onProcessedListener = record -> {};
   private int maxFragmentSize;
+  private boolean detectReprocessingInconsistency;
 
   public ProcessingContext actor(final ActorControl actor) {
     this.actor = actor;
@@ -99,6 +100,11 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return this;
   }
 
+  public ProcessingContext setDetectReprocessingInconsistency(final boolean detectReprocessingInconsistency) {
+    this.detectReprocessingInconsistency = detectReprocessingInconsistency;
+    return this;
+  }
+
   @Override
   public ActorControl getActor() {
     return actor;
@@ -161,5 +167,9 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
 
   public Consumer<TypedRecord> getOnProcessedListener() {
     return onProcessedListener;
+  }
+
+  public boolean isDetectReprocessingInconsistency() {
+    return detectReprocessingInconsistency;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
@@ -114,6 +114,7 @@ public final class ReProcessingStateMachine {
   private LoggedEvent currentEvent;
   private TypedRecordProcessor eventProcessor;
   private ZeebeDbTransaction zeebeDbTransaction;
+  private boolean detectReprocessingInconsistency;
 
   public ReProcessingStateMachine(final ProcessingContext context) {
     actor = context.getActor();
@@ -128,6 +129,7 @@ public final class ReProcessingStateMachine {
 
     updateStateRetryStrategy = new EndlessRetryStrategy(actor);
     processRetryStrategy = new EndlessRetryStrategy(actor);
+    detectReprocessingInconsistency = context.isDetectReprocessingInconsistency();
   }
 
   ActorFuture<Void> startRecover(final long snapshotPosition) {
@@ -255,7 +257,10 @@ public final class ReProcessingStateMachine {
         recordValues.readRecordValue(currentEvent, metadata.getValueType());
     typedEvent.wrap(currentEvent, metadata, value);
 
-    verifyRecordMatchesToReprocessing(typedEvent);
+    if (detectReprocessingInconsistency) {
+      verifyRecordMatchesToReprocessing(typedEvent);
+    }
+
 
     if (currentEvent.getPosition() <= lastSourceEventPosition) {
       // don't reprocess records after the last source event

--- a/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/ReProcessingStateMachine.java
@@ -261,7 +261,6 @@ public final class ReProcessingStateMachine {
       verifyRecordMatchesToReprocessing(typedEvent);
     }
 
-
     if (currentEvent.getPosition() <= lastSourceEventPosition) {
       // don't reprocess records after the last source event
       reprocessingStreamWriter.configureSourceContext(currentEvent.getPosition());

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorBuilder.java
@@ -68,7 +68,8 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
-  public StreamProcessorBuilder detectReprocessingInconsistency(final boolean detectReprocessingInconsistency) {
+  public StreamProcessorBuilder detectReprocessingInconsistency(
+      final boolean detectReprocessingInconsistency) {
     this.processingContext.setDetectReprocessingInconsistency(detectReprocessingInconsistency);
     return this;
   }

--- a/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/zeebe/engine/processor/StreamProcessorBuilder.java
@@ -68,6 +68,11 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
+  public StreamProcessorBuilder detectReprocessingInconsistency(final boolean detectReprocessingInconsistency) {
+    this.processingContext.setDetectReprocessingInconsistency(detectReprocessingInconsistency);
+    return this;
+  }
+
   public TypedRecordProcessorFactory getTypedRecordProcessorFactory() {
     return typedRecordProcessorFactory;
   }

--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -72,6 +73,7 @@ import org.junit.runners.model.Statement;
 public final class EngineRule extends ExternalResource {
 
   private static final int PARTITION_ID = Protocol.DEPLOYMENT_PARTITION;
+  private static final int REPROCESSING_TIMEOUT_SEC = 30;
   private static final RecordingExporter RECORDING_EXPORTER = new RecordingExporter();
   private final StreamProcessorRule environmentRule;
   private final RecordingExporterTestWatcher recordingExporterTestWatcher =
@@ -84,6 +86,8 @@ public final class EngineRule extends ExternalResource {
   private final Int2ObjectHashMap<SubscriptionCommandMessageHandler> subscriptionHandlers =
       new Int2ObjectHashMap<>();
   private ExecutorService subscriptionHandlerExecutor;
+  private final Map<Integer, ReprocessingCompletedListener> partitionReprocessingCompleteListeners =
+      new Int2ObjectHashMap<>();
 
   private EngineRule(final int partitionCount) {
     this(partitionCount, false);
@@ -129,10 +133,15 @@ public final class EngineRule extends ExternalResource {
   protected void after() {
     subscriptionHandlerExecutor.shutdown();
     subscriptionHandlers.clear();
+    partitionReprocessingCompleteListeners.clear();
   }
 
   public void start() {
     startProcessors();
+  }
+
+  public void startWithReprocessingDetection() {
+    startProcessors(true);
   }
 
   public void stop() {
@@ -150,6 +159,10 @@ public final class EngineRule extends ExternalResource {
   }
 
   private void startProcessors() {
+    startProcessors(false);
+  }
+
+  private void startProcessors(final boolean detectReprocessingInconsistency) {
     final DeploymentRecord deploymentRecord = new DeploymentRecord();
     final UnsafeBuffer deploymentBuffer = new UnsafeBuffer(new byte[deploymentRecord.getLength()]);
     deploymentRecord.write(deploymentBuffer, 0);
@@ -160,6 +173,8 @@ public final class EngineRule extends ExternalResource {
 
     forEachPartition(
         partitionId -> {
+          final var reprocessingCompletedListener = new ReprocessingCompletedListener();
+          partitionReprocessingCompleteListeners.put(partitionId, reprocessingCompletedListener);
           environmentRule.startTypedStreamProcessor(
               partitionId,
               (processingContext) ->
@@ -171,7 +186,9 @@ public final class EngineRule extends ExternalResource {
                           deploymentDistributor,
                           (key, partition) -> {},
                           jobsAvailableCallback)
-                      .withListener(new ProcessingExporterTransistor()));
+                      .withListener(new ProcessingExporterTransistor())
+                      .withListener(reprocessingCompletedListener),
+              detectReprocessingInconsistency);
 
           // sequenialize the commands to avoid concurrency
           subscriptionHandlers.put(
@@ -179,6 +196,12 @@ public final class EngineRule extends ExternalResource {
               new SubscriptionCommandMessageHandler(
                   subscriptionHandlerExecutor::submit, environmentRule::getLogStreamRecordWriter));
         });
+  }
+
+  public void awaitReprocessingCompleted() {
+    partitionReprocessingCompleteListeners
+        .values()
+        .forEach(ReprocessingCompletedListener::awaitReprocessingComplete);
   }
 
   public void forEachPartition(final Consumer<Integer> partitionIdConsumer) {
@@ -336,6 +359,19 @@ public final class EngineRule extends ExternalResource {
 
         RECORDING_EXPORTER.export(typedEvent);
       }
+    }
+  }
+
+  private final class ReprocessingCompletedListener implements StreamProcessorLifecycleAware {
+    private final ActorFuture<Void> reprocessingComplete = new CompletableActorFuture<>();
+
+    @Override
+    public void onRecovered(final ReadonlyProcessingContext context) {
+      reprocessingComplete.complete(null);
+    }
+
+    public void awaitReprocessingComplete() {
+      reprocessingComplete.join(REPROCESSING_TIMEOUT_SEC, TimeUnit.SECONDS);
     }
   }
 

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
@@ -60,18 +60,21 @@ public class StreamProcessingComposite {
   }
 
   public StreamProcessor startTypedStreamProcessor(final TypedRecordProcessorFactory factory) {
-    return startTypedStreamProcessor(partitionId, factory);
+    return startTypedStreamProcessor(partitionId, factory, false);
   }
 
   public StreamProcessor startTypedStreamProcessor(
-      final int partitionId, final TypedRecordProcessorFactory factory) {
+      final int partitionId,
+      final TypedRecordProcessorFactory factory,
+      final boolean detectReprocessingInconsistency) {
     return streams.startStreamProcessor(
         getLogName(partitionId),
         zeebeDbFactory,
         (processingContext -> {
           zeebeState = processingContext.getZeebeState();
           return factory.createProcessors(processingContext);
-        }));
+        }),
+        detectReprocessingInconsistency);
   }
 
   public void closeStreamProcessor(final int partitionId) {

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -125,12 +125,15 @@ public final class StreamProcessorRule implements TestRule {
   }
 
   public StreamProcessor startTypedStreamProcessor(final TypedRecordProcessorFactory factory) {
-    return startTypedStreamProcessor(startPartitionId, factory);
+    return startTypedStreamProcessor(startPartitionId, factory, false);
   }
 
   public StreamProcessor startTypedStreamProcessor(
-      final int partitionId, final TypedRecordProcessorFactory factory) {
-    return streamProcessingComposite.startTypedStreamProcessor(partitionId, factory);
+      final int partitionId,
+      final TypedRecordProcessorFactory factory,
+      final boolean detectReprocessingInconsistency) {
+    return streamProcessingComposite.startTypedStreamProcessor(
+        partitionId, factory, detectReprocessingInconsistency);
   }
 
   public void closeStreamProcessor(final int partitionId) {

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -200,15 +200,24 @@ public final class TestStreams {
       final ZeebeDbFactory zeebeDbFactory,
       final TypedRecordProcessorFactory typedRecordProcessorFactory) {
     final SynchronousLogStream stream = getLogStream(log);
+    return buildStreamProcessor(stream, zeebeDbFactory, typedRecordProcessorFactory, false);
+  }
+
+  public StreamProcessor startStreamProcessor(
+      final String log,
+      final ZeebeDbFactory zeebeDbFactory,
+      final TypedRecordProcessorFactory typedRecordProcessorFactory,
+      final boolean detectReprocessingInconsistency) {
+    final SynchronousLogStream stream = getLogStream(log);
     return buildStreamProcessor(
-        stream, zeebeDbFactory, typedRecordProcessorFactory, SNAPSHOT_INTERVAL);
+        stream, zeebeDbFactory, typedRecordProcessorFactory, detectReprocessingInconsistency);
   }
 
   private StreamProcessor buildStreamProcessor(
       final SynchronousLogStream stream,
       final ZeebeDbFactory zeebeDbFactory,
       final TypedRecordProcessorFactory factory,
-      final Duration snapshotInterval) {
+      final boolean detectReprocessingInconsistency) {
     final var storage = createRuntimeFolder(stream);
     final String logName = stream.getLogName();
 
@@ -221,6 +230,7 @@ public final class TestStreams {
             .commandResponseWriter(mockCommandResponseWriter)
             .onProcessedListener(mockOnProcessedListener)
             .streamProcessorFactory(factory)
+            .detectReprocessingInconsistency(detectReprocessingInconsistency)
             .build();
     streamProcessor.openAsync().join(15, TimeUnit.SECONDS);
 


### PR DESCRIPTION
## Description

This PR is a back port of #5761 to 0.24. It introduces the experimental configuration section to 0.24, but does not back port other experimental flags, only this one.

## Related issues

backports #5761
related to #5759 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
