### PR TITLE
5754 trigger testbench

### DIFF
--- a/.ci/scripts/distribution/qa-testbench.sh
+++ b/.ci/scripts/distribution/qa-testbench.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -eux
+
+chmod +x clients/go/cmd/zbctl/dist/zbctl
+
+alias zbctl="clients/go/cmd/zbctl/dist/zbctl"
+
+zbctl create instance qa-protocol --variables "${QA_RUN_VARIABLES}"

--- a/.ci/scripts/docker/upload-gcr.sh
+++ b/.ci/scripts/docker/upload-gcr.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -eux
+
+# this command is a little convoluted to avoid leaking of the secret;
+# it is unclear why the built-in Jenkins mechanism doesn't work out of the box
+echo "Authenticating with gcr.io and pushing image."
+set +x ; echo ${DOCKER_GCR} | docker login -u _json_key --password-stdin https://gcr.io ; set -x
+
+docker push ${IMAGE}:${TAG}
+
+

--- a/.ci/scripts/docker/upload-gcr.sh
+++ b/.ci/scripts/docker/upload-gcr.sh
@@ -3,8 +3,8 @@
 # this command is a little convoluted to avoid leaking of the secret;
 # it is unclear why the built-in Jenkins mechanism doesn't work out of the box
 echo "Authenticating with gcr.io and pushing image."
-set +x ; echo ${DOCKER_GCR} | docker login -u _json_key --password-stdin https://gcr.io ; set -x
+set +x ; echo "${DOCKER_GCR}" | docker login -u _json_key --password-stdin https://gcr.io ; set -x
 
-docker push ${IMAGE}:${TAG}
+docker push "${IMAGE}":"${TAG}"
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,15 +265,14 @@ pipeline {
                 IMAGE = "gcr.io/zeebe-io/zeebe"
                 VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
                 TAG = "${env.GIT_COMMIT}"
+                DOCKER_GCR = credentials("zeebe-gcr-serviceaccount-json")
             }
 
             steps {
-                container('maven') {
-                    sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
-                }
-
                 container('docker') {
+                    sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
                     sh '.ci/scripts/docker/build.sh'
+                    sh '.ci/scripts/docker/upload-gcr.sh'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -258,14 +258,22 @@ pipeline {
         }
 
         stage('QA') {
-            when {
-                expression { params.RUN_QA }
+            //when {
+            //    expression { params.RUN_QA }
+            //}
+            environment {
+                IMAGE = "gcr.io/zeebe-io/zeebe"
+                VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
+                TAG = "${env.GIT_COMMIT}"
             }
+
             steps {
                 container('maven') {
-                    configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-                        sh 'echo ${GIT_COMMIT}'
-                    }
+                    sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
+                }
+
+                container('docker') {
+                    sh '.ci/scripts/docker/build.sh'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,10 @@ pipeline {
         timeout(time: 45, unit: 'MINUTES')
     }
 
+    parameters {
+        booleanParam(name: 'RUN_QA', defaultValue: false, description: "Run QA Stage")
+    }
+
     stages {
         stage('Prepare') {
             steps {
@@ -254,10 +258,13 @@ pipeline {
         }
 
         stage('QA') {
+            when {
+                expression { params.RUN_QA }
+            }
             steps {
                 container('maven') {
                     configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-                        sh 'echo QA'
+                        sh 'echo ${GIT_COMMIT}'
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,6 +253,16 @@ pipeline {
             }
         }
 
+        stage('QA') {
+            steps {
+                container('maven') {
+                    configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                        sh 'echo QA'
+                    }
+                }
+            }
+        }
+
         stage('Upload') {
             when { allOf { branch developBranchName; not { triggeredBy 'TimerTrigger' } } }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,6 @@ pipeline {
     options {
         buildDiscarder(logRotator(daysToKeepStr: daysToKeep, numToKeepStr: numToKeep))
         timestamps()
-        timeout(time: 45, unit: 'MINUTES')
     }
 
     parameters {
@@ -48,6 +47,7 @@ pipeline {
 
     stages {
         stage('Prepare') {
+          timeout(2) {
             steps {
                 script {
                     commit_summary = sh([returnStdout: true, script: 'git show -s --format=%s']).trim()
@@ -71,9 +71,11 @@ pipeline {
                 }
 
             }
+          }
         }
 
         stage('Build (Java)') {
+          timeout(5) {
             steps {
                 container('maven') {
                     configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
@@ -81,9 +83,11 @@ pipeline {
                     }
                 }
             }
+          }
         }
 
         stage('Prepare Tests') {
+          timeout(3) {
             environment {
                 IMAGE = "camunda/zeebe"
                 VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
@@ -100,10 +104,12 @@ pipeline {
                     sh '.ci/scripts/docker/build_zeebe-hazelcast-exporter.sh'
                 }
             }
+          }
         }
 
 
         stage('Test') {
+          timeout(30) {
             parallel {
                 stage('Go') {
                     steps {
@@ -256,6 +262,7 @@ pipeline {
                     }
                 }
             }
+          }
         }
 
         stage('QA') {
@@ -300,20 +307,23 @@ pipeline {
 
         stage('Upload') {
             when { allOf { branch developBranchName; not { triggeredBy 'TimerTrigger' } } }
-            steps {
-                retry(3) {
-                    container('maven') {
-                        configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-                            sh '.ci/scripts/distribution/upload.sh'
-                        }
-                    }
-                }
+            timeout(15) {
+              steps {
+                  retry(3) {
+                      container('maven') {
+                          configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                              sh '.ci/scripts/distribution/upload.sh'
+                          }
+                      }
+                  }
+              }
             }
         }
 
         stage('Post') {
             when { not { triggeredBy 'TimerTrigger' } }
 
+          timeout(5) {
             parallel {
                 stage('Docker') {
                     when { branch developBranchName }
@@ -334,6 +344,7 @@ pipeline {
                     }
                 }
             }
+          }
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,8 +47,8 @@ pipeline {
 
     stages {
         stage('Prepare') {
-          timeout(2) {
             steps {
+              timeout(2) {
                 script {
                     commit_summary = sh([returnStdout: true, script: 'git show -s --format=%s']).trim()
                     displayNameFull = "#" + BUILD_NUMBER + ': ' + commit_summary
@@ -69,25 +69,23 @@ pipeline {
                 container('golang') {
                     sh '.ci/scripts/distribution/prepare-go.sh'
                 }
-
+              }
             }
-          }
         }
 
         stage('Build (Java)') {
-          timeout(5) {
             steps {
+              timeout(5) {
                 container('maven') {
                     configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
                         sh '.ci/scripts/distribution/build-java.sh'
                     }
                 }
+              }
             }
-          }
         }
 
         stage('Prepare Tests') {
-          timeout(3) {
             environment {
                 IMAGE = "camunda/zeebe"
                 VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
@@ -95,6 +93,7 @@ pipeline {
             }
 
             steps {
+              timeout(3) {
                 container('maven') {
                     sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
                 }
@@ -103,14 +102,14 @@ pipeline {
                     sh '.ci/scripts/docker/build.sh'
                     sh '.ci/scripts/docker/build_zeebe-hazelcast-exporter.sh'
                 }
+              }
             }
-          }
         }
 
 
         stage('Test') {
-          timeout(30) {
             parallel {
+              timeout(30) {
                 stage('Go') {
                     steps {
                         container('golang') {
@@ -236,6 +235,7 @@ pipeline {
                         }
                     }
                 }
+              }
             }
 
             post {
@@ -262,7 +262,7 @@ pipeline {
                     }
                 }
             }
-          }
+
         }
 
         stage('QA') {
@@ -307,8 +307,8 @@ pipeline {
 
         stage('Upload') {
             when { allOf { branch developBranchName; not { triggeredBy 'TimerTrigger' } } }
-            timeout(15) {
-              steps {
+            steps {
+              timeout(15) {
                   retry(3) {
                       container('maven') {
                           configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
@@ -323,8 +323,8 @@ pipeline {
         stage('Post') {
             when { not { triggeredBy 'TimerTrigger' } }
 
-          timeout(5) {
             parallel {
+              timeout(5) {
                 stage('Docker') {
                     when { branch developBranchName }
 
@@ -343,8 +343,8 @@ pipeline {
                         }
                     }
                 }
+              }
             }
-          }
         }
     }
 


### PR DESCRIPTION
## Description

Adds a QA stage that
* pushes a Zeebe image tagged with the current commit to gcr.io
* triggers a run of the testbench qa protocol with that image

## Related issues

closes #5754

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
