### PR TITLE
chore(broker): Use memory mapped log segments by default

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -41,7 +41,7 @@ public final class DataCfg implements ConfigurationEntry {
 
   private int logIndexDensity = 100;
 
-  private boolean useMmap = false;
+  private boolean useMmap = true;
   private boolean diskUsageMonitoringEnabled = DEFAULT_DISK_USAGE_MONITORING_ENABLED;
   private double diskUsageReplicationWatermark = DEFAULT_DISK_USAGE_REPLICATION_WATERMARK;
   private double diskUsageCommandWatermark = DEFAULT_DISK_USAGE_COMMAND_WATERMARK;

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
@@ -59,13 +59,13 @@ public class DataCfgTest {
   }
 
   @Test
-  public void shouldGetDiskAtomixStorageLevelAsDefault() {
+  public void shouldGetMappedAtomixStorageLevelAsDefault() {
     // given
     final var sutDataCfg = new DataCfg();
 
     // then
     final var actual = sutDataCfg.getAtomixStorageLevel();
-    assertThat(actual).isEqualTo(StorageLevel.DISK);
+    assertThat(actual).isEqualTo(StorageLevel.MAPPED);
   }
 
   @Test

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -132,14 +132,14 @@
       # logSegmentSize: 512MB
 
       # Configure whether data log segment file channels should be memory mapped.
-      # WARNING: This is an experimental setting. It is not yet as mature as direct file channels (default).
+      # WARNING: This setting has been deprecated. In future versions, log segment file channels will always be memory mapped.
       #
       # Zeebe reads the data log segment files using file channels.
       # Memory mapping these should generally allow for faster processing,
       # resulting in reduced cycle times (i.e. total duration of a single process instance).
       #
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_USEMMAP.
-      # useMmap: false
+      # useMmap: true
 
       # How often we take snapshots of streams (time unit)
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_SNAPSHOTPERIOD.

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/BrokerLeaderChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/BrokerLeaderChangeTest.java
@@ -15,8 +15,6 @@ import io.zeebe.broker.it.util.GrpcClientRule;
 import io.zeebe.client.api.response.BrokerInfo;
 import io.zeebe.client.api.response.PartitionInfo;
 import io.zeebe.client.api.worker.JobWorker;
-import io.zeebe.model.bpmn.Bpmn;
-import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.protocol.Protocol;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
@@ -30,14 +28,10 @@ import org.junit.rules.Timeout;
 
 // FIXME: rewrite tests now that leader election is not controllable
 public final class BrokerLeaderChangeTest {
-  public static final String NULL_VARIABLES = null;
   public static final String JOB_TYPE = "testTask";
-  private static final BpmnModelInstance WORKFLOW =
-      Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
 
   public final Timeout testTimeout = Timeout.seconds(120);
-  public final ClusteringRule clusteringRule =
-      new ClusteringRule(1, 3, 3, cfg -> cfg.getData().setUseMmap(false));
+  public final ClusteringRule clusteringRule = new ClusteringRule(1, 3, 3);
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 
   @Rule
@@ -64,7 +58,7 @@ public final class BrokerLeaderChangeTest {
             .filter(b -> b.getNodeId() == oldLeader)
             .flatMap(b -> b.getPartitions().stream().filter(p -> p.getPartitionId() == partition));
 
-    assertThat(partitionInfo.allMatch(p -> !p.isLeader())).isTrue();
+    assertThat(partitionInfo).noneMatch(PartitionInfo::isLeader);
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteredDataDeletionTest.java
@@ -66,7 +66,6 @@ public final class ClusteredDataDeletionTest {
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
     data.setLogSegmentSize(DataSize.ofKilobytes(8));
     data.setLogIndexDensity(50);
-    data.setUseMmap(false);
     brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(8));
 
     brokerCfg.setExporters(Collections.emptyMap());
@@ -77,7 +76,6 @@ public final class ClusteredDataDeletionTest {
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
     data.setLogSegmentSize(DataSize.ofKilobytes(8));
     data.setLogIndexDensity(50);
-    data.setUseMmap(false);
     brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(8));
 
     final ExporterCfg exporterCfg = new ExporterCfg();

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/DeploymentClusteredTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/DeploymentClusteredTest.java
@@ -27,8 +27,7 @@ public final class DeploymentClusteredTest {
       Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
 
   public final Timeout testTimeout = Timeout.seconds(120);
-  public final ClusteringRule clusteringRule =
-      new ClusteringRule(3, 3, 3, cfg -> cfg.getData().setUseMmap(false));
+  public final ClusteringRule clusteringRule = new ClusteringRule(3, 3, 3);
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 
   @Rule

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/FailOverReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/FailOverReplicationTest.java
@@ -227,7 +227,6 @@ public class FailOverReplicationTest {
   private static void configureBroker(final BrokerCfg brokerCfg) {
     final var data = brokerCfg.getData();
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
-    data.setUseMmap(false);
 
     data.setLogSegmentSize(DataSize.ofKilobytes(8));
     data.setLogIndexDensity(1);

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/GossipClusteringTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/GossipClusteringTest.java
@@ -21,8 +21,7 @@ import org.junit.rules.Timeout;
 public final class GossipClusteringTest {
 
   public final Timeout testTimeout = Timeout.seconds(120);
-  public final ClusteringRule clusteringRule =
-      new ClusteringRule(1, 3, 3, cfg -> cfg.getData().setUseMmap(false));
+  public final ClusteringRule clusteringRule = new ClusteringRule(1, 3, 3);
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
 
   @Rule

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/RestoreTest.java
@@ -41,7 +41,6 @@ public final class RestoreTest {
             cfg.getData().setLogSegmentSize(ATOMIX_SEGMENT_SIZE);
             cfg.getData().setLogIndexDensity(1);
             cfg.getNetwork().setMaxMessageSize(ATOMIX_SEGMENT_SIZE);
-            cfg.getData().setUseMmap(false);
           });
   private final GrpcClientRule clientRule =
       new GrpcClientRule(

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -217,6 +217,5 @@ public final class SnapshotReplicationTest {
   private static void configureBroker(final BrokerCfg brokerCfg) {
     brokerCfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD);
     brokerCfg.getData().setLogIndexDensity(1);
-    brokerCfg.getData().setUseMmap(false);
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/topology/TopologyClusterSmallerReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/topology/TopologyClusterSmallerReplicationTest.java
@@ -25,8 +25,7 @@ import org.junit.rules.Timeout;
 public final class TopologyClusterSmallerReplicationTest {
 
   private static final Timeout TEST_TIMEOUT = Timeout.seconds(120);
-  private static final ClusteringRule CLUSTERING_RULE =
-      new ClusteringRule(3, 2, 3, cfg -> cfg.getData().setUseMmap(false));
+  private static final ClusteringRule CLUSTERING_RULE = new ClusteringRule(3, 2, 3);
   private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(CLUSTERING_RULE);
 
   @ClassRule

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/topology/TopologyClusterTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/topology/TopologyClusterTest.java
@@ -27,8 +27,7 @@ import org.junit.rules.Timeout;
 public final class TopologyClusterTest {
 
   private static final Timeout TEST_TIMEOUT = Timeout.seconds(120);
-  private static final ClusteringRule CLUSTERING_RULE =
-      new ClusteringRule(3, 3, 3, cfg -> cfg.getData().setUseMmap(false));
+  private static final ClusteringRule CLUSTERING_RULE = new ClusteringRule(3, 3, 3);
   private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(CLUSTERING_RULE);
 
   @ClassRule


### PR DESCRIPTION
## Description

This PR flips the value of `zeebe.broker.data.useMmap` from `false` to `true`, enabling memory mapped log segments by default.

## Related issues

closes #5711

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
