### PR TITLE
Lower log level of broker errors in the gateway based on the error code

### DIFF
--- a/gateway/src/test/java/io/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -88,7 +88,7 @@ final class GrpcErrorMapperTest {
     assertThat(statusException.getStatus().getCode()).isEqualTo(Code.RESOURCE_EXHAUSTED);
     assertThat(recorder.getAppendedEvents()).hasSize(2);
     assertThat(recorder.getAppendedEvents().get(0).getLevel())
-        .isEqualTo(Level.ERROR); // partition leader mismatch
+        .isEqualTo(Level.TRACE); // partition leader mismatch
     assertThat(recorder.getAppendedEvents().get(1).getLevel())
         .isEqualTo(Level.TRACE); // resource exhausted
     assertThat(status.getDetailsCount()).isEqualTo(1);


### PR DESCRIPTION
## Description

This PR lowers the log level of broker errors in the gateway to trace for RESOURCE_EXHAUSTED and PARTITION_LEADER_MISMATCH, both of which are reported verbatim to the client and counted in our gateway metrics, such that logs are of little use.

## Related issues

closes #5638 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
