### PR TITLE
[BACKPORT 0.25] Return UNAVAILABLE on publish message and create workflow instance commands if no partitions are known

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -142,6 +142,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/gateway/src/main/java/io/zeebe/gateway/cmd/NoTopologyAvailableException.java
+++ b/gateway/src/main/java/io/zeebe/gateway/cmd/NoTopologyAvailableException.java
@@ -8,7 +8,14 @@
 package io.zeebe.gateway.cmd;
 
 public final class NoTopologyAvailableException extends ClientException {
+  private static final String DEFAULT_MESSAGE =
+      "Expected to send the request to a partition in the topology, but gateway does not know broker topology."
+          + " Please try again later. If the error persists contact your zeebe operator.";
   private static final long serialVersionUID = 7035483927294101779L;
+
+  public NoTopologyAvailableException() {
+    this(DEFAULT_MESSAGE);
+  }
 
   public NoTopologyAvailableException(final String message) {
     super(message);

--- a/gateway/src/main/java/io/zeebe/gateway/cmd/PartitionNotFoundException.java
+++ b/gateway/src/main/java/io/zeebe/gateway/cmd/PartitionNotFoundException.java
@@ -12,8 +12,26 @@ package io.zeebe.gateway.cmd;
  * can happen when the element instance key does not refer to a known partition.
  */
 public class PartitionNotFoundException extends ClientException {
+  private static final String DEFAULT_ERROR_MESSAGE =
+      "Expected to execute command on partition %d, but either it does not exist, or the gateway is not yet aware of it";
+  private final int partitionId;
 
-  public PartitionNotFoundException() {
-    super("Expected to execute command, but this command refers to an element that doesn't exist.");
+  public PartitionNotFoundException(final int partitionId) {
+    this(String.format(DEFAULT_ERROR_MESSAGE, partitionId), partitionId);
+  }
+
+  public PartitionNotFoundException(final String message, final int partitionId) {
+    super(message);
+    this.partitionId = partitionId;
+  }
+
+  public PartitionNotFoundException(
+      final String message, final Throwable cause, final int partitionId) {
+    super(message, cause);
+    this.partitionId = partitionId;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
   }
 }

--- a/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -17,6 +17,7 @@ import io.zeebe.gateway.Loggers;
 import io.zeebe.gateway.cmd.BrokerErrorException;
 import io.zeebe.gateway.cmd.BrokerRejectionException;
 import io.zeebe.gateway.cmd.InvalidBrokerRequestArgumentException;
+import io.zeebe.gateway.cmd.NoTopologyAvailableException;
 import io.zeebe.gateway.cmd.PartitionNotFoundException;
 import io.zeebe.gateway.impl.broker.RequestRetriesExhaustedException;
 import io.zeebe.gateway.impl.broker.response.BrokerError;
@@ -71,7 +72,7 @@ public final class GrpcErrorMapper {
       builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
       logger.debug("Expected to handle gRPC request, but messagepack property was invalid", error);
     } else if (error instanceof PartitionNotFoundException) {
-      builder.setCode(Code.NOT_FOUND_VALUE).setMessage(error.getMessage());
+      builder.setCode(Code.UNAVAILABLE_VALUE).setMessage(error.getMessage());
       logger.debug("Expected to handle gRPC request, but request could not be delivered", error);
     } else if (error instanceof RequestRetriesExhaustedException) {
       builder.setCode(Code.RESOURCE_EXHAUSTED_VALUE).setMessage(error.getMessage());
@@ -86,6 +87,11 @@ public final class GrpcErrorMapper {
       // partitions - it will then also occur when back pressure kicks in, leading to a large burst
       // of error logs that is, in fact, expected
       logger.trace("Expected to handle gRPC request, but all retries have been exhausted", error);
+    } else if (error instanceof NoTopologyAvailableException) {
+      builder.setCode(Code.UNAVAILABLE_VALUE).setMessage(error.getMessage());
+      logger.trace(
+          "Expected to handle gRPC request, but the gateway does not know any partitions yet",
+          error);
     } else {
       builder
           .setCode(Code.INTERNAL_VALUE)

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerRequestManager.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/BrokerRequestManager.java
@@ -120,6 +120,11 @@ final class BrokerRequestManager extends Actor {
       GatewayMetrics.registerFailedRequest(
           request.getPartitionId(), request.getType(), "PARTITION_NOT_FOUND");
       return;
+    } catch (final NoTopologyAvailableException e) {
+      returnFuture.completeExceptionally(e);
+      GatewayMetrics.registerFailedRequest(
+          request.getPartitionId(), request.getType(), "NO_TOPOLOGY");
+      return;
     }
 
     final ActorFuture<DirectBuffer> responseFuture =
@@ -203,7 +208,7 @@ final class BrokerRequestManager extends Actor {
     if (request.addressesSpecificPartition()) {
       final BrokerClusterState topology = topologyManager.getTopology();
       if (topology != null && !topology.getPartitions().contains(request.getPartitionId())) {
-        throw new PartitionNotFoundException();
+        throw new PartitionNotFoundException(request.getPartitionId());
       }
       // already know partition id
       return new BrokerAddressProvider(request.getPartitionId());
@@ -231,21 +236,17 @@ final class BrokerRequestManager extends Actor {
   private void determinePartitionIdForPublishMessageRequest(
       final BrokerPublishMessageRequest request) {
     final BrokerClusterState topology = topologyManager.getTopology();
-    if (topology != null) {
-      final int partitionsCount = topology.getPartitionsCount();
-
-      final int partitionId =
-          SubscriptionUtil.getSubscriptionPartitionId(request.getCorrelationKey(), partitionsCount);
-
-      request.setPartitionId(partitionId);
-    } else {
-      // should not happen as the the broker request manager fetches topology before publish message
-      // request if not present
+    if (topology == null || topology.getPartitionsCount() == 0) {
       throw new NoTopologyAvailableException(
           String.format(
               "Expected to pick partition for message with correlation key '%s', but no topology is available",
               request.getCorrelationKey()));
     }
+
+    final int partitionId =
+        SubscriptionUtil.getSubscriptionPartitionId(
+            request.getCorrelationKey(), topology.getPartitionsCount());
+    request.setPartitionId(partitionId);
   }
 
   private interface TransportRequestSender {

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/RequestRetryHandler.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/RequestRetryHandler.java
@@ -69,20 +69,18 @@ public final class RequestRetryHandler {
       final BrokerResponseConsumer<BrokerResponseT> responseConsumer,
       final Consumer<Throwable> throwableConsumer) {
     final var topology = topologyManager.getTopology();
-    if (topology != null) {
-      sendRequestWithRetry(
-          request,
-          requestSender,
-          partitionIdIteratorForType(topology.getPartitionsCount()),
-          responseConsumer,
-          throwableConsumer,
-          new ArrayList<>());
-    } else {
-      throwableConsumer.accept(
-          new NoTopologyAvailableException(
-              "Expected to send the request to a partition in the topology, but gateway does not know broker topology."
-                  + " Please try again later. If the error persists contact your zeebe operator."));
+    if (topology == null || topology.getPartitionsCount() == 0) {
+      throwableConsumer.accept(new NoTopologyAvailableException());
+      return;
     }
+
+    sendRequestWithRetry(
+        request,
+        requestSender,
+        partitionIdIteratorForType(topology.getPartitionsCount()),
+        responseConsumer,
+        throwableConsumer,
+        new ArrayList<>());
   }
 
   private <BrokerResponseT> void sendRequestWithRetry(

--- a/gateway/src/test/java/io/zeebe/gateway/api/UnavailableBrokersTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/api/UnavailableBrokersTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.gateway.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.atomix.cluster.AtomixCluster;
+import io.grpc.Status.Code;
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.api.ZeebeFuture;
+import io.zeebe.client.api.command.ClientStatusException;
+import io.zeebe.client.api.command.FinalCommandStep;
+import io.zeebe.gateway.Gateway;
+import io.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.zeebe.gateway.impl.configuration.NetworkCfg;
+import io.zeebe.test.util.asserts.grpc.ClientStatusExceptionAssert;
+import io.zeebe.test.util.socket.SocketUtil;
+import io.zeebe.util.sched.ActorScheduler;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Execution(ExecutionMode.CONCURRENT)
+class UnavailableBrokersTest {
+  static Gateway gateway;
+  static AtomixCluster cluster;
+  static ActorScheduler actorScheduler;
+  static ZeebeClient client;
+
+  @BeforeAll
+  static void setUp() throws IOException {
+    final NetworkCfg networkCfg = new NetworkCfg().setPort(SocketUtil.getNextAddress().getPort());
+    final GatewayCfg config = new GatewayCfg().setNetwork(networkCfg);
+    config.init(InetAddress.getLocalHost().getHostName());
+
+    cluster = AtomixCluster.builder().build();
+    cluster.start();
+
+    actorScheduler = ActorScheduler.newActorScheduler().build();
+    actorScheduler.start();
+
+    gateway = new Gateway(new GatewayCfg().setNetwork(networkCfg), cluster, actorScheduler);
+    gateway.start();
+
+    final String gatewayAddress =
+        io.zeebe.util.SocketUtil.toHostAndPortString(networkCfg.toSocketAddress());
+    client = ZeebeClient.newClientBuilder().gatewayAddress(gatewayAddress).usePlaintext().build();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    client.close();
+    gateway.stop();
+    actorScheduler.stop();
+    cluster.stop();
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("unavailableTestCases")
+  void shouldReturnUnavailableOnMissingTopology(
+      final String testName, final FinalCommandStep<?> command) {
+    // when
+    // setting a lower timeout than the time we wait on the future ensures we see a result from the
+    // gateway and not simply our future timing out
+    final ZeebeFuture<?> result = command.requestTimeout(Duration.ofSeconds(5)).send();
+
+    // then
+    assertThatCode(() -> result.join(10, TimeUnit.SECONDS))
+        .isInstanceOf(ClientStatusException.class)
+        .asInstanceOf(ClientStatusExceptionAssert.assertFactory())
+        .hasStatusSatisfying(s -> assertThat(s.getCode()).isEqualTo(Code.UNAVAILABLE));
+  }
+
+  /**
+   * Returns a list of test cases consisting primarily of commands which should return unavailable
+   * if the gateway has no topology.
+   */
+  static Stream<Object[]> unavailableTestCases() {
+    return Stream.of(
+            client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion(),
+            client.newPublishMessageCommand().messageName("message").correlationKey("key"))
+        .map(command -> new Object[] {command.getClass().getSimpleName(), command});
+  }
+}

--- a/gateway/src/test/java/io/zeebe/gateway/broker/BrokerClientTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/broker/BrokerClientTest.java
@@ -240,7 +240,7 @@ public final class BrokerClientTest {
 
     // then
     final String expected =
-        "Expected to execute command, but this command refers to an element that doesn't exist.";
+        "Expected to execute command on partition 0, but either it does not exist, or the gateway is not yet aware of it";
     assertThatThrownBy(async::join)
         .hasCauseInstanceOf(PartitionNotFoundException.class)
         .hasMessageContaining(expected);

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -100,6 +100,11 @@
       <artifactId>snakeyaml</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/test-util/src/main/java/io/zeebe/test/util/asserts/grpc/ClientStatusExceptionAssert.java
+++ b/test-util/src/main/java/io/zeebe/test/util/asserts/grpc/ClientStatusExceptionAssert.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.test.util.asserts.grpc;
+
+import io.grpc.Status;
+import io.zeebe.client.api.command.ClientStatusException;
+import java.util.function.Consumer;
+import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.InstanceOfAssertFactory;
+
+public final class ClientStatusExceptionAssert
+    extends AbstractThrowableAssert<ClientStatusExceptionAssert, ClientStatusException> {
+  private static final InstanceOfAssertFactory<ClientStatusException, ClientStatusExceptionAssert>
+      ASSERT_FACTORY =
+          new InstanceOfAssertFactory<>(
+              ClientStatusException.class, ClientStatusExceptionAssert::assertThat);
+
+  public ClientStatusExceptionAssert(final ClientStatusException e) {
+    super(e, ClientStatusExceptionAssert.class);
+  }
+
+  public static ClientStatusExceptionAssert assertThat(final ClientStatusException e) {
+    return new ClientStatusExceptionAssert(e);
+  }
+
+  public static InstanceOfAssertFactory<ClientStatusException, ClientStatusExceptionAssert>
+      assertFactory() {
+    return ASSERT_FACTORY;
+  }
+
+  public ClientStatusExceptionAssert hasStatusSatisfying(final Consumer<Status> statusAssertions) {
+    statusAssertions.accept(actual.getStatus());
+    return myself;
+  }
+}


### PR DESCRIPTION
## Description

This PR backports #5791 to the 0.25 branch. No merge conflicts or changes were needed.

## Related issues

related to #5783 
backports #5791 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
