### PR TITLE
[BACKPORT 0.24] Remove usage of Throwable#printStackTrace from production code

### DIFF
--- a/dist/src/main/java/io/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/zeebe/broker/StandaloneBroker.java
@@ -15,10 +15,12 @@ import io.zeebe.legacy.tomlconfig.LegacyConfigurationSupport.Scope;
 import io.zeebe.shared.EnvironmentHelper;
 import io.zeebe.util.FileUtil;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.concurrent.CountDownLatch;
 import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -30,6 +32,7 @@ import org.springframework.core.env.Environment;
 @SpringBootApplication(exclude = ElasticsearchRestClientAutoConfiguration.class)
 @ComponentScan({"io.zeebe.broker", "io.zeebe.shared"})
 public class StandaloneBroker implements CommandLineRunner {
+  private static final Logger LOG = Loggers.SYSTEM_LOGGER;
 
   @Autowired BrokerCfg configuration;
   @Autowired Environment springEnvironment;
@@ -96,7 +99,7 @@ public class StandaloneBroker implements CommandLineRunner {
       tempFolder = Files.createTempDirectory("zeebe").toAbsolutePath().normalize().toString();
       return new Broker(configuration, tempFolder, null, springBrokerBridge);
     } catch (final IOException e) {
-      throw new RuntimeException("Could not start broker", e);
+      throw new UncheckedIOException("Could not start broker", e);
     }
   }
 
@@ -105,7 +108,7 @@ public class StandaloneBroker implements CommandLineRunner {
       try {
         FileUtil.deleteFolder(tempFolder);
       } catch (final IOException e) {
-        e.printStackTrace();
+        LOG.error("Failed to delete temporary folder {}", tempFolder, e);
       }
     }
   }

--- a/util/src/main/java/io/zeebe/util/sched/ActorThread.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorThread.java
@@ -5,24 +5,10 @@
  * Licensed under the Zeebe Community License 1.0. You may not use this file
  * except in compliance with the Zeebe Community License 1.0.
  */
-/*
- * Copyright © 2017 camunda services GmbH (info@camunda.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.zeebe.util.sched;
 
 import io.zeebe.util.BoundedArrayQueue;
+import io.zeebe.util.Loggers;
 import io.zeebe.util.sched.clock.ActorClock;
 import io.zeebe.util.sched.clock.DefaultActorClock;
 import java.util.concurrent.CompletableFuture;
@@ -32,13 +18,14 @@ import java.util.function.Consumer;
 import org.agrona.UnsafeAccess;
 import org.agrona.concurrent.BackoffIdleStrategy;
 import org.agrona.concurrent.ManyToManyConcurrentArrayQueue;
+import org.slf4j.Logger;
 import org.slf4j.MDC;
 import sun.misc.Unsafe;
 
-@SuppressWarnings("restriction")
 public class ActorThread extends Thread implements Consumer<Runnable> {
   static final Unsafe UNSAFE = UnsafeAccess.UNSAFE;
   private static final long STATE_OFFSET;
+  private static final Logger LOG = Loggers.ACTOR_LOGGER;
 
   static {
     try {
@@ -108,7 +95,7 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
     } catch (final Exception e) {
       // TODO: check interrupt state?
       // TODO: Handle Exception
-      e.printStackTrace();
+      LOG.error("Unexpected error occurred in task {}", currentTask, e);
 
       // TODO: resubmit on exception?
       //                resubmit = true;
@@ -203,7 +190,7 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
       try {
         doWork();
       } catch (final Exception e) {
-        e.printStackTrace();
+        LOG.error("Unexpected error occurred while in the actor thread {}", getName(), e);
       }
     }
 


### PR DESCRIPTION
## Description

This PR backports #5792. No merge conflicts or anything were needed.

## Related issues

related to #4867 
backports #5792 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
