### PR TITLE
chore(clients/go): enable integration tests on Mac OS

### DIFF
--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -189,6 +189,8 @@ func (s *integrationTestSuite) runCommand(command string, envVars ...string) ([]
 func buildZbctl() ([]byte, error) {
 	if runtime.GOOS == "linux" {
 		zbctl = "zbctl"
+	} else if runtime.GOOS == "darwin" {
+		zbctl = "zbctl.darwin"
 	} else {
 		return nil, fmt.Errorf("can't run zbctl tests on unsupported OS '%s'", runtime.GOOS)
 	}


### PR DESCRIPTION
## Description

I've enabled integration tests of the go client on Mac OS. I tested it locally with MBP 2019, version: 10.15.7 (19H15).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5806 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
