### PR TITLE
chore(broker): persists streamprocessor pause state

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -46,6 +46,7 @@ import io.zeebe.broker.system.partitions.PartitionStep;
 import io.zeebe.broker.system.partitions.TypedRecordProcessorsFactory;
 import io.zeebe.broker.system.partitions.ZeebePartition;
 import io.zeebe.broker.system.partitions.impl.AtomixPartitionMessagingService;
+import io.zeebe.broker.system.partitions.impl.PartitionProcessingState;
 import io.zeebe.broker.system.partitions.impl.PartitionTransitionImpl;
 import io.zeebe.broker.system.partitions.impl.steps.ExporterDirectorPartitionStep;
 import io.zeebe.broker.system.partitions.impl.steps.FollowerPostStoragePartitionStep;
@@ -404,7 +405,8 @@ public final class Broker implements AutoCloseable {
                     partitionIndexes.get(partitionId),
                     snapshotStoreSupplier,
                     createFactory(topologyManager, clusterCfg, atomix, managementRequestHandler),
-                    buildExporterRepository(brokerCfg));
+                    buildExporterRepository(brokerCfg),
+                    new PartitionProcessingState(owningPartition));
             final PartitionTransitionImpl transitionBehavior =
                 new PartitionTransitionImpl(context, LEADER_STEPS, FOLLOWER_STEPS);
             final ZeebePartition zeebePartition = new ZeebePartition(context, transitionBehavior);

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/PartitionContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/PartitionContext.java
@@ -15,6 +15,7 @@ import io.zeebe.broker.exporter.stream.ExporterDirector;
 import io.zeebe.broker.logstreams.LogDeletionService;
 import io.zeebe.broker.system.configuration.BrokerCfg;
 import io.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
+import io.zeebe.broker.system.partitions.impl.PartitionProcessingState;
 import io.zeebe.broker.system.partitions.impl.StateControllerImpl;
 import io.zeebe.broker.transport.commandapi.CommandApiService;
 import io.zeebe.db.ZeebeDb;
@@ -27,6 +28,7 @@ import io.zeebe.util.health.HealthMonitor;
 import io.zeebe.util.sched.ActorControl;
 import io.zeebe.util.sched.ActorScheduler;
 import io.zeebe.util.sched.ScheduledTimer;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -46,6 +48,7 @@ public class PartitionContext {
   private final int maxFragmentSize;
   private final ZeebeIndexMapping zeebeIndexMapping;
   private final ExporterRepository exporterRepository;
+  private final PartitionProcessingState partitionProcessingState;
 
   private StreamProcessor streamProcessor;
   private LogStream logStream;
@@ -58,8 +61,6 @@ public class PartitionContext {
   private AsyncSnapshotDirector snapshotDirector;
   private HealthMonitor criticalComponentsHealthMonitor;
   private ZeebeDb zeebeDb;
-  private boolean diskSpaceAvailable;
-  private boolean isProcessingPaused;
   private ActorControl actor;
   private ScheduledTimer metricsTimer;
   private ExporterDirector exporterDirector;
@@ -75,7 +76,8 @@ public class PartitionContext {
       final ZeebeIndexMapping zeebeIndexMapping,
       final SnapshotStoreSupplier snapshotStoreSupplier,
       final TypedRecordProcessorsFactory typedRecordProcessorsFactory,
-      final ExporterRepository exporterRepository) {
+      final ExporterRepository exporterRepository,
+      final PartitionProcessingState partitionProcessingState) {
     this.nodeId = nodeId;
     this.raftPartition = raftPartition;
     this.messagingService = messagingService;
@@ -89,6 +91,7 @@ public class PartitionContext {
     maxFragmentSize = (int) brokerCfg.getNetwork().getMaxMessageSizeInBytes();
     this.zeebeIndexMapping = zeebeIndexMapping;
     this.exporterRepository = exporterRepository;
+    this.partitionProcessingState = partitionProcessingState;
   }
 
   public ExporterDirector getExporterDirector() {
@@ -152,7 +155,7 @@ public class PartitionContext {
   }
 
   public void setSnapshotController(final StateControllerImpl controller) {
-    this.stateController = controller;
+    stateController = controller;
   }
 
   public SnapshotReplication getSnapshotReplication() {
@@ -255,23 +258,19 @@ public class PartitionContext {
     return exporterRepository;
   }
 
-  public boolean isDiskSpaceAvailable() {
-    return diskSpaceAvailable;
-  }
-
   public void setDiskSpaceAvailable(final boolean diskSpaceAvailable) {
-    this.diskSpaceAvailable = diskSpaceAvailable;
-  }
-
-  public boolean isProcessingPaused() {
-    return isProcessingPaused;
-  }
-
-  public void setProcessingPaused(final boolean processingPaused) {
-    isProcessingPaused = processingPaused;
+    partitionProcessingState.setDiskSpaceAvailable(diskSpaceAvailable);
   }
 
   public boolean shouldProcess() {
-    return isDiskSpaceAvailable() && !isProcessingPaused();
+    return partitionProcessingState.shouldProcess();
+  }
+
+  public void pauseProcessing() throws IOException {
+    partitionProcessingState.pauseProcessing();
+  }
+
+  public void resumeProcessing() throws IOException {
+    partitionProcessingState.resumeProcessing();
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.partitions.impl;
+
+import io.atomix.raft.partition.RaftPartition;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class PartitionProcessingState {
+
+  private static final String PERSISTED_PAUSE_STATE_FILENAME = ".paused";
+  private boolean isProcessingPaused;
+  private final RaftPartition raftPartition;
+  private boolean diskSpaceAvailable;
+
+  public PartitionProcessingState(final RaftPartition raftPartition) {
+    this.raftPartition = raftPartition;
+    initProcessingStatus();
+  }
+
+  public boolean isDiskSpaceAvailable() {
+    return diskSpaceAvailable;
+  }
+
+  public void setDiskSpaceAvailable(final boolean diskSpaceAvailable) {
+    this.diskSpaceAvailable = diskSpaceAvailable;
+  }
+
+  public boolean isProcessingPaused() {
+    return isProcessingPaused;
+  }
+
+  public void resumeProcessing() throws IOException {
+    final File persistedPauseState = getPersistedPauseState();
+    Files.deleteIfExists(persistedPauseState.toPath());
+    if (!persistedPauseState.exists()) {
+      isProcessingPaused = false;
+    }
+  }
+
+  @SuppressWarnings({"squid:S899"})
+  public void pauseProcessing() throws IOException {
+    final File persistedPauseState = getPersistedPauseState();
+    persistedPauseState.createNewFile();
+    if (persistedPauseState.exists()) {
+      isProcessingPaused = true;
+    }
+  }
+
+  private File getPersistedPauseState() {
+    return raftPartition.dataDirectory().toPath().resolve(PERSISTED_PAUSE_STATE_FILENAME).toFile();
+  }
+
+  private void initProcessingStatus() {
+    isProcessingPaused = getPersistedPauseState().exists();
+  }
+
+  public boolean shouldProcess() {
+    return isDiskSpaceAvailable() && !isProcessingPaused();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/system/BrokerAdminServiceClusterTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/system/BrokerAdminServiceClusterTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.system;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.raft.RaftServer.Role;
+import io.zeebe.broker.Broker;
+import io.zeebe.broker.it.clustering.ClusteringRule;
+import io.zeebe.broker.it.util.GrpcClientRule;
+import io.zeebe.broker.system.management.BrokerAdminService;
+import io.zeebe.broker.system.management.PartitionStatus;
+import io.zeebe.engine.processing.streamprocessor.StreamProcessor.Phase;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+
+public class BrokerAdminServiceClusterTest {
+
+  private static final int PARTITION_ID = 1;
+  private final Timeout testTimeout = Timeout.seconds(60);
+  private final ClusteringRule clusteringRule =
+      new ClusteringRule(
+          1,
+          3,
+          3,
+          cfg -> {
+            cfg.getData().setLogIndexDensity(1);
+            cfg.getData().setSnapshotPeriod(Duration.ofMinutes(15));
+          });
+  private final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);
+
+  @Rule
+  public RuleChain ruleChain =
+      RuleChain.outerRule(testTimeout).around(clusteringRule).around(clientRule);
+
+  private BrokerAdminService leaderAdminService;
+  private Broker leader;
+
+  @Before
+  public void before() {
+    leader = clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId());
+    leaderAdminService = leader.getBrokerAdminService();
+  }
+
+  @Test
+  public void shouldReportPartitionStatusOnFollowersAndLeader() {
+    // given
+    final var followers =
+        clusteringRule.getOtherBrokerObjects(
+            clusteringRule.getLeaderForPartition(PARTITION_ID).getNodeId());
+
+    // when
+    final var followerStatus =
+        followers.stream()
+            .map(Broker::getBrokerAdminService)
+            .map(BrokerAdminService::getPartitionStatus)
+            .map(status -> status.get(1));
+
+    final var leaderStatus = leaderAdminService.getPartitionStatus().get(PARTITION_ID);
+
+    // then
+    followerStatus.forEach(
+        partitionStatus -> {
+          assertThat(partitionStatus.getRole()).isEqualTo(Role.FOLLOWER);
+          assertThat(partitionStatus.getProcessedPosition()).isNull();
+          assertThat(partitionStatus.getSnapshotId()).isNull();
+          assertThat(partitionStatus.getProcessedPositionInSnapshot()).isNull();
+          assertThat(partitionStatus.getStreamProcessorPhase()).isNull();
+        });
+
+    assertThat(leaderStatus.getRole()).isEqualTo(Role.LEADER);
+    assertThat(leaderStatus.getProcessedPosition()).isEqualTo(-1);
+    assertThat(leaderStatus.getSnapshotId()).isNull();
+    assertThat(leaderStatus.getProcessedPositionInSnapshot()).isNull();
+    assertThat(leaderStatus.getStreamProcessorPhase()).isEqualTo(Phase.PROCESSING);
+  }
+
+  @Test
+  public void shouldReportPartitionStatusWithSnapshotOnFollowers() {
+    // given
+    clientRule.createSingleJob("test");
+    leaderAdminService.takeSnapshot();
+
+    // when
+    waitForSnapshotAtBroker(leaderAdminService);
+
+    // then
+    final var leaderStatus = leaderAdminService.getPartitionStatus().get(PARTITION_ID);
+    clusteringRule.getBrokers().stream()
+        .map(Broker::getBrokerAdminService)
+        .forEach(
+            adminService ->
+                Awaitility.await()
+                    .untilAsserted(
+                        () -> assertFollowerSnapshotEqualToLeader(adminService, leaderStatus)));
+  }
+
+  @Test
+  public void shouldPauseAfterLeaderChange() {
+    // given
+    clusteringRule.getBrokers().stream()
+        .map(Broker::getBrokerAdminService)
+        .forEach(BrokerAdminService::pauseStreamProcessing);
+
+    // when
+    assertStreamProcessorPhase(leaderAdminService, Phase.PAUSED);
+    clusteringRule.stopBrokerAndAwaitNewLeader(leader.getConfig().getCluster().getNodeId());
+
+    // then
+    final var newLeaderAdminService =
+        clusteringRule
+            .getBroker(clusteringRule.getLeaderForPartition(1).getNodeId())
+            .getBrokerAdminService();
+    assertStreamProcessorPhase(newLeaderAdminService, Phase.PAUSED);
+  }
+
+  private void assertFollowerSnapshotEqualToLeader(
+      final BrokerAdminService followerService, final PartitionStatus leaderStatus) {
+    assertThat(followerService.getPartitionStatus().get(1).getSnapshotId())
+        .isEqualTo(leaderStatus.getSnapshotId());
+  }
+
+  private void waitForSnapshotAtBroker(final BrokerAdminService adminService) {
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                adminService
+                    .getPartitionStatus()
+                    .values()
+                    .forEach(
+                        status -> assertThat(status.getProcessedPositionInSnapshot()).isNotNull()));
+  }
+
+  private void assertStreamProcessorPhase(
+      final BrokerAdminService brokerAdminService, final Phase expected) {
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                brokerAdminService
+                    .getPartitionStatus()
+                    .forEach(
+                        (p, status) ->
+                            assertThat(status.getStreamProcessorPhase()).isEqualTo(expected)));
+  }
+}


### PR DESCRIPTION
## Description

Persists paused state of streamprocessor by creating a file. StreamProcessor should be paused if this file exists on restart.

## Related issues

closes #5770 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
