### PR TITLE
[BACKPORT 0.24] Lowers log level of RequestRetriesExhaustedException in the gateway

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.gateway.grpc;
 
+import com.google.protobuf.Any;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
 import com.google.rpc.Status.Builder;
@@ -27,25 +28,19 @@ import org.slf4j.Logger;
 
 /** Maps arbitrary {@link Throwable} to {@link StatusRuntimeException} and logs the exception. */
 public final class GrpcErrorMapper {
-  private final Logger logger;
-
-  public GrpcErrorMapper() {
-    this(Loggers.GATEWAY_LOGGER);
-  }
-
-  public GrpcErrorMapper(final Logger logger) {
-    this.logger = logger;
-  }
-
   public StatusRuntimeException mapError(final Throwable error) {
-    return StatusProto.toStatusRuntimeException(mapErrorToStatus(error));
+    return mapError(error, Loggers.GATEWAY_LOGGER);
   }
 
-  private Status mapErrorToStatus(final Throwable error) {
+  public StatusRuntimeException mapError(final Throwable error, final Logger logger) {
+    return StatusProto.toStatusRuntimeException(mapErrorToStatus(error, logger));
+  }
+
+  private Status mapErrorToStatus(final Throwable error, final Logger logger) {
     final Builder builder = Status.newBuilder();
 
     if (error instanceof ExecutionException) {
-      return mapErrorToStatus(error.getCause());
+      return mapErrorToStatus(error.getCause(), logger);
     } else if (error instanceof BrokerErrorException) {
       final Status status = mapBrokerErrorToStatus(((BrokerErrorException) error).getError());
       builder.mergeFrom(status);
@@ -81,11 +76,16 @@ public final class GrpcErrorMapper {
     } else if (error instanceof RequestRetriesExhaustedException) {
       builder.setCode(Code.RESOURCE_EXHAUSTED_VALUE).setMessage(error.getMessage());
 
+      // RequestRetriesExhaustedException will sometimes carry suppressed exceptions which can be
+      // added/mapped as error details to give more information to the user
+      for (final Throwable suppressed : error.getSuppressed()) {
+        builder.addDetails(Any.pack(mapErrorToStatus(suppressed, logger)));
+      }
+
       // this error occurs when all partitions have exhausted for requests which have no fixed
       // partitions - it will then also occur when back pressure kicks in, leading to a large burst
       // of error logs that is, in fact, expected
-      Loggers.GATEWAY_LOGGER.trace(
-          "Expected to handle gRPC request, but all retries have been exhausted", error);
+      logger.trace("Expected to handle gRPC request, but all retries have been exhausted", error);
     } else {
       builder
           .setCode(Code.INTERNAL_VALUE)

--- a/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -80,6 +80,10 @@ public final class GrpcErrorMapper {
       logger.debug("Expected to handle gRPC request, but request could not be delivered", error);
     } else if (error instanceof RequestRetriesExhaustedException) {
       builder.setCode(Code.RESOURCE_EXHAUSTED_VALUE).setMessage(error.getMessage());
+
+      // this error occurs when all partitions have exhausted for requests which have no fixed
+      // partitions - it will then also occur when back pressure kicks in, leading to a large burst
+      // of error logs that is, in fact, expected
       Loggers.GATEWAY_LOGGER.trace(
           "Expected to handle gRPC request, but all retries have been exhausted", error);
     } else {

--- a/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -17,6 +17,7 @@ import io.zeebe.gateway.cmd.BrokerErrorException;
 import io.zeebe.gateway.cmd.BrokerRejectionException;
 import io.zeebe.gateway.cmd.InvalidBrokerRequestArgumentException;
 import io.zeebe.gateway.cmd.PartitionNotFoundException;
+import io.zeebe.gateway.impl.broker.RequestRetriesExhaustedException;
 import io.zeebe.gateway.impl.broker.response.BrokerError;
 import io.zeebe.gateway.impl.broker.response.BrokerRejection;
 import io.zeebe.msgpack.MsgpackPropertyException;
@@ -77,6 +78,10 @@ public final class GrpcErrorMapper {
     } else if (error instanceof PartitionNotFoundException) {
       builder.setCode(Code.NOT_FOUND_VALUE).setMessage(error.getMessage());
       logger.debug("Expected to handle gRPC request, but request could not be delivered", error);
+    } else if (error instanceof RequestRetriesExhaustedException) {
+      builder.setCode(Code.RESOURCE_EXHAUSTED_VALUE).setMessage(error.getMessage());
+      Loggers.GATEWAY_LOGGER.trace(
+          "Expected to handle gRPC request, but all retries have been exhausted", error);
     } else {
       builder
           .setCode(Code.INTERNAL_VALUE)

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/RequestRetriesExhaustedException.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/RequestRetriesExhaustedException.java
@@ -11,7 +11,7 @@ import io.zeebe.gateway.cmd.ClientException;
 
 public final class RequestRetriesExhaustedException extends ClientException {
 
-  RequestRetriesExhaustedException() {
+  public RequestRetriesExhaustedException() {
     super(
         "Expected to execute the command on one of the partitions, but all failed; there are no more partitions available to retry. "
             + "Please try again. If the error persists contact your zeebe operator");

--- a/gateway/src/test/java/io/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -9,9 +9,13 @@ package io.zeebe.gateway.grpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.rpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.StatusProto;
 import io.zeebe.gateway.cmd.BrokerErrorException;
+import io.zeebe.gateway.impl.broker.RequestRetriesExhaustedException;
 import io.zeebe.gateway.impl.broker.response.BrokerError;
 import io.zeebe.protocol.record.ErrorCode;
 import io.zeebe.util.logging.RecordingAppender;
@@ -25,13 +29,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.slf4j.helpers.NOPLogger;
 
 @Execution(ExecutionMode.CONCURRENT)
 final class GrpcErrorMapperTest {
   private final RecordingAppender recorder = new RecordingAppender();
   private final Logger log = (Logger) LogManager.getLogger(GrpcErrorMapperTest.class);
-  private final GrpcErrorMapper errorMapper =
-      new GrpcErrorMapper(new Log4jLogger(log, log.getName()));
+  private final Log4jLogger logger = new Log4jLogger(log, log.getName());
+  private final GrpcErrorMapper errorMapper = new GrpcErrorMapper();
 
   @BeforeEach
   void setUp() {
@@ -54,12 +59,42 @@ final class GrpcErrorMapperTest {
 
     // when
     log.setLevel(Level.TRACE);
-    final StatusRuntimeException statusException = errorMapper.mapError(exception);
+    final StatusRuntimeException statusException = errorMapper.mapError(exception, logger);
 
     // then
     assertThat(statusException.getStatus().getCode()).isEqualTo(Code.RESOURCE_EXHAUSTED);
     assertThat(recorder.getAppendedEvents()).hasSize(1);
     final LogEvent event = recorder.getAppendedEvents().get(0);
     assertThat(event.getLevel()).isEqualTo(Level.TRACE);
+  }
+
+  @Test
+  void shouldAddDetailsForRequestRetriesExhaustedException() throws InvalidProtocolBufferException {
+    // given
+    final RequestRetriesExhaustedException exception = new RequestRetriesExhaustedException();
+    final BrokerError brokerError =
+        new BrokerError(ErrorCode.PARTITION_LEADER_MISMATCH, "Wrong partition");
+    final BrokerErrorException detailException = new BrokerErrorException(brokerError);
+    final Status expectedDetail =
+        StatusProto.fromThrowable(errorMapper.mapError(detailException, NOPLogger.NOP_LOGGER));
+
+    // when
+    exception.addSuppressed(detailException);
+    log.setLevel(Level.TRACE);
+    final StatusRuntimeException statusException = errorMapper.mapError(exception, logger);
+    final Status status = StatusProto.fromThrowable(statusException);
+
+    // then
+    assertThat(statusException.getStatus().getCode()).isEqualTo(Code.RESOURCE_EXHAUSTED);
+    assertThat(recorder.getAppendedEvents()).hasSize(2);
+    assertThat(recorder.getAppendedEvents().get(0).getLevel())
+        .isEqualTo(Level.ERROR); // partition leader mismatch
+    assertThat(recorder.getAppendedEvents().get(1).getLevel())
+        .isEqualTo(Level.TRACE); // resource exhausted
+    assertThat(status.getDetailsCount()).isEqualTo(1);
+
+    final Status statusDetail = status.getDetails(0).unpack(Status.class);
+    assertThat(statusDetail.getCode()).isEqualTo(expectedDetail.getCode());
+    assertThat(statusDetail.getMessage()).isEqualTo(expectedDetail.getMessage());
   }
 }


### PR DESCRIPTION
## Description

This PR backports #5454 to the 0.24 branch. No merge conflicts or changes were needed.

## Related issues
 
backports #5454

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
