### PR TITLE
[BACKPORT 0.24] Lower log level of broker errors in the gateway based on the error code

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -42,21 +42,13 @@ public final class GrpcErrorMapper {
     if (error instanceof ExecutionException) {
       return mapErrorToStatus(error.getCause(), logger);
     } else if (error instanceof BrokerErrorException) {
-      final Status status = mapBrokerErrorToStatus(((BrokerErrorException) error).getError());
+      final Status status =
+          mapBrokerErrorToStatus(((BrokerErrorException) error).getError(), logger);
       builder.mergeFrom(status);
-
-      // When there is back pressure, there will be a lot of `RESOURCE_EXHAUSTED` errors and the log
-      // can get flooded, so log them at the lowest level possible
-      if (status.getCode() != Code.RESOURCE_EXHAUSTED.getNumber()) {
-        logger.error("Expected to handle gRPC request, but received error from broker", error);
-      } else {
-        logger.trace("Expected to handle gRPC request, but broker is overloaded", error);
-      }
     } else if (error instanceof BrokerRejectionException) {
       final Status status = mapRejectionToStatus(((BrokerRejectionException) error).getRejection());
       builder.mergeFrom(status);
-
-      logger.debug("Expected to handle gRPC request, but broker rejected request", error);
+      logger.trace("Expected to handle gRPC request, but the broker rejected it", error);
     } else if (error instanceof TimeoutException) { // can be thrown by transport
       builder
           .setCode(Code.DEADLINE_EXCEEDED_VALUE)
@@ -97,7 +89,7 @@ public final class GrpcErrorMapper {
     return builder.build();
   }
 
-  private Status mapBrokerErrorToStatus(final BrokerError error) {
+  private Status mapBrokerErrorToStatus(final BrokerError error, final Logger logger) {
     final Builder builder = Status.newBuilder();
     String message = error.getMessage();
 
@@ -107,22 +99,20 @@ public final class GrpcErrorMapper {
         break;
       case RESOURCE_EXHAUSTED:
         builder.setCode(Code.RESOURCE_EXHAUSTED_VALUE);
+        logger.trace("Target broker is currently overloaded: {}", error);
         break;
       case PARTITION_LEADER_MISMATCH:
         // return UNAVAILABLE to indicate to the user that retrying might solve the issue, as this
         // is usually a transient issue
+        logger.trace("Target broker was not the leader of the partition: {}", error);
         builder.setCode(Code.UNAVAILABLE_VALUE);
         break;
-        // all the following are not errors which retrying (with the same gateway) will solve
-      case INVALID_MESSAGE_TEMPLATE:
-      case INVALID_DEPLOYMENT_PARTITION:
-      case MALFORMED_REQUEST:
-      case INVALID_CLIENT_VERSION:
-      case UNSUPPORTED_MESSAGE:
-      case INTERNAL_ERROR:
-      case SBE_UNKNOWN:
-      case NULL_VAL:
       default:
+        // all the following are for cases where retrying (with the same gateway) is not expected
+        // to solve anything
+        logger.error(
+            "Expected to handle gRPC request, but received an internal error from broker: {}",
+            error);
         builder.setCode(Code.INTERNAL_VALUE);
         message =
             String.format(

--- a/gateway/src/test/java/io/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -88,7 +88,7 @@ final class GrpcErrorMapperTest {
     assertThat(statusException.getStatus().getCode()).isEqualTo(Code.RESOURCE_EXHAUSTED);
     assertThat(recorder.getAppendedEvents()).hasSize(2);
     assertThat(recorder.getAppendedEvents().get(0).getLevel())
-        .isEqualTo(Level.ERROR); // partition leader mismatch
+        .isEqualTo(Level.TRACE); // partition leader mismatch
     assertThat(recorder.getAppendedEvents().get(1).getLevel())
         .isEqualTo(Level.TRACE); // resource exhausted
     assertThat(status.getDetailsCount()).isEqualTo(1);


### PR DESCRIPTION
## Description

This PR backports #5794. No merge conflicts or changes of any kind were necessary.

## Related issues

related to #5638 
backports #5794 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
