### PR TITLE
chore(broker): Add a capability to a broker to back off jobs.

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
@@ -84,7 +84,7 @@ public final class EngineProcessors {
 
     final JobErrorThrownProcessor jobErrorThrownProcessor =
         addJobProcessors(
-            zeebeState, typedRecordProcessors, onJobsAvailableCallback, maxFragmentSize);
+            zeebeState, actor, typedRecordProcessors, onJobsAvailableCallback, maxFragmentSize);
 
     addIncidentProcessors(
         zeebeState, bpmnStreamProcessor, typedRecordProcessors, jobErrorThrownProcessor);
@@ -156,11 +156,12 @@ public final class EngineProcessors {
 
   private static JobErrorThrownProcessor addJobProcessors(
       final ZeebeState zeebeState,
+      final ActorControl actorControl,
       final TypedRecordProcessors typedRecordProcessors,
       final Consumer<String> onJobsAvailableCallback,
       final int maxFragmentSize) {
     return JobEventProcessors.addJobProcessors(
-        typedRecordProcessors, zeebeState, onJobsAvailableCallback, maxFragmentSize);
+        typedRecordProcessors, actorControl, zeebeState, onJobsAvailableCallback, maxFragmentSize);
   }
 
   private static void addMessageProcessors(

--- a/engine/src/main/java/io/zeebe/engine/processing/job/FailProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/FailProcessor.java
@@ -43,13 +43,10 @@ public final class FailProcessor implements CommandProcessor<JobRecord> {
     failedJob.setRetries(retries);
     failedJob.setRetryBackOff(retryBackOff);
     failedJob.setErrorMessage(command.getValue().getErrorMessageBuffer());
-    if (retryBackOff != 0) {
+    if (retries > 0 && retryBackOff > 0) {
       state.failForBackoff(key, failedJob);
       actorControl.runDelayed(
-          Duration.ofMillis(retryBackOff),
-          () -> {
-            state.activable(key, failedJob);
-          });
+          Duration.ofMillis(retryBackOff), () -> state.activable(key, failedJob));
     } else {
       state.fail(key, failedJob);
     }

--- a/engine/src/main/java/io/zeebe/engine/processing/job/FailProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/FailProcessor.java
@@ -12,14 +12,19 @@ import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.state.instance.JobState;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.util.sched.ActorControl;
+import java.time.Duration;
 
 public final class FailProcessor implements CommandProcessor<JobRecord> {
 
   private final JobState state;
   private final DefaultJobCommandProcessor<JobRecord> defaultProcessor;
+  private final ActorControl actorControl;
 
-  public FailProcessor(final JobState state) {
+  public FailProcessor(final JobState state, final ActorControl actorControl) {
     this.state = state;
+    this.actorControl = actorControl;
+
     defaultProcessor = new DefaultJobCommandProcessor<>("fail", this.state, this::acceptCommand);
   }
 
@@ -33,9 +38,21 @@ public final class FailProcessor implements CommandProcessor<JobRecord> {
       final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
     final long key = command.getKey();
     final JobRecord failedJob = state.getJob(key);
-    failedJob.setRetries(command.getValue().getRetries());
+    final long retryBackOff = command.getValue().getRetryBackOff();
+    final int retries = command.getValue().getRetries();
+    failedJob.setRetries(retries);
+    failedJob.setRetryBackOff(retryBackOff);
     failedJob.setErrorMessage(command.getValue().getErrorMessageBuffer());
-    state.fail(key, failedJob);
+    if (retryBackOff != 0) {
+      state.failForBackoff(key, failedJob);
+      actorControl.runDelayed(
+          Duration.ofMillis(retryBackOff),
+          () -> {
+            state.activable(key, failedJob);
+          });
+    } else {
+      state.fail(key, failedJob);
+    }
     commandControl.accept(JobIntent.FAILED, failedJob);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
@@ -14,12 +14,14 @@ import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.JobBatchIntent;
 import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.util.sched.ActorControl;
 import java.util.function.Consumer;
 
 public final class JobEventProcessors {
 
   public static JobErrorThrownProcessor addJobProcessors(
       final TypedRecordProcessors typedRecordProcessors,
+      final ActorControl actorControl,
       final ZeebeState zeebeState,
       final Consumer<String> onJobsAvailableCallback,
       final int maxRecordSize) {
@@ -36,7 +38,7 @@ public final class JobEventProcessors {
         .onEvent(ValueType.JOB, JobIntent.COMPLETED, new JobCompletedEventProcessor(workflowState))
         .onCommand(ValueType.JOB, JobIntent.CREATE, new CreateProcessor(jobState))
         .onCommand(ValueType.JOB, JobIntent.COMPLETE, new CompleteProcessor(jobState))
-        .onCommand(ValueType.JOB, JobIntent.FAIL, new FailProcessor(jobState))
+        .onCommand(ValueType.JOB, JobIntent.FAIL, new FailProcessor(jobState, actorControl))
         .onEvent(ValueType.JOB, JobIntent.FAILED, new JobFailedProcessor())
         .onCommand(ValueType.JOB, JobIntent.THROW_ERROR, new JobThrowErrorProcessor(jobState))
         .onEvent(ValueType.JOB, JobIntent.ERROR_THROWN, jobErrorThrownProcessor)

--- a/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
@@ -117,6 +117,11 @@ public final class JobState {
     metrics.jobActivated(record.getType());
   }
 
+  public void activable(final long key, final JobRecord updatedValue) {
+    final State newState = updatedValue.getRetries() > 0 ? State.ACTIVATABLE : State.FAILED;
+    updateJob(key, updatedValue, newState);
+  }
+
   public void timeout(final long key, final JobRecord record) {
     final DirectBuffer type = record.getTypeBuffer();
     final long deadline = record.getDeadline();
@@ -170,6 +175,11 @@ public final class JobState {
     final State newState = updatedValue.getRetries() > 0 ? State.ACTIVATABLE : State.FAILED;
     updateJob(key, updatedValue, newState);
 
+    metrics.jobFailed(updatedValue.getType());
+  }
+
+  public void failForBackoff(final long key, final JobRecord updatedValue) {
+    updateJob(key, updatedValue, State.FAILED);
     metrics.jobFailed(updatedValue.getType());
   }
 

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStreamProcessorRule.java
@@ -123,7 +123,7 @@ public final class WorkflowInstanceStreamProcessorRule extends ExternalResource
               new DueDateTimerChecker(workflowState));
 
           JobEventProcessors.addJobProcessors(
-              typedRecordProcessors, zeebeState, type -> {}, Integer.MAX_VALUE);
+              typedRecordProcessors, actor, zeebeState, type -> {}, Integer.MAX_VALUE);
           typedRecordProcessors.withListener(this);
           return typedRecordProcessors;
         });

--- a/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
@@ -97,7 +97,11 @@ public final class IncidentStreamProcessorRule extends ExternalResource {
 
           final var jobErrorThrownProcessor =
               JobEventProcessors.addJobProcessors(
-                  typedRecordProcessors, zeebeState, type -> {}, Integer.MAX_VALUE);
+                  typedRecordProcessors,
+                  processingContext.getActor(),
+                  zeebeState,
+                  type -> {},
+                  Integer.MAX_VALUE);
 
           IncidentEventProcessors.addProcessors(
               typedRecordProcessors, zeebeState, stepProcessor, jobErrorThrownProcessor);

--- a/engine/src/test/java/io/zeebe/engine/util/client/JobClient.java
+++ b/engine/src/test/java/io/zeebe/engine/util/client/JobClient.java
@@ -87,6 +87,11 @@ public final class JobClient {
     return this;
   }
 
+  public JobClient withBackOff(final long backOff) {
+    jobRecord.setRetryBackOff(backOff);
+    return this;
+  }
+
   public JobClient withErrorMessage(final String errorMessage) {
     jobRecord.setErrorMessage(errorMessage);
     return this;

--- a/engine/src/test/java/io/zeebe/engine/util/client/JobClient.java
+++ b/engine/src/test/java/io/zeebe/engine/util/client/JobClient.java
@@ -17,6 +17,7 @@ import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.value.JobRecordValue;
 import io.zeebe.test.util.MsgPackUtil;
 import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
 import java.util.Map;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
@@ -87,8 +88,8 @@ public final class JobClient {
     return this;
   }
 
-  public JobClient withBackOff(final long backOff) {
-    jobRecord.setRetryBackOff(backOff);
+  public JobClient withBackOff(final Duration backOff) {
+    jobRecord.setRetryBackOff(backOff.toMillis());
     return this;
   }
 

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -39,7 +39,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final StringProperty workerProp = new StringProperty("worker", EMPTY_STRING);
   private final LongProperty deadlineProp = new LongProperty("deadline", -1);
   private final IntegerProperty retriesProp = new IntegerProperty(RETRIES, -1);
-  private final LongProperty retryBackoffProp = new LongProperty("retryBackoff", 0);
+  private final LongProperty retryBackoffProp = new LongProperty("retryBackoff", -1);
 
   private final PackedProperty customHeadersProp = new PackedProperty(CUSTOM_HEADERS, NO_HEADERS);
   private final DocumentProperty variableProp = new DocumentProperty(VARIABLES);

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -39,6 +39,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final StringProperty workerProp = new StringProperty("worker", EMPTY_STRING);
   private final LongProperty deadlineProp = new LongProperty("deadline", -1);
   private final IntegerProperty retriesProp = new IntegerProperty(RETRIES, -1);
+  private final LongProperty retryBackoffProp = new LongProperty("retryBackoff", 0);
 
   private final PackedProperty customHeadersProp = new PackedProperty(CUSTOM_HEADERS, NO_HEADERS);
   private final DocumentProperty variableProp = new DocumentProperty(VARIABLES);
@@ -60,6 +61,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     declareProperty(deadlineProp)
         .declareProperty(workerProp)
         .declareProperty(retriesProp)
+        .declareProperty(retryBackoffProp)
         .declareProperty(typeProp)
         .declareProperty(customHeadersProp)
         .declareProperty(variableProp)
@@ -77,6 +79,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     deadlineProp.setValue(record.getDeadline());
     workerProp.setValue(record.getWorkerBuffer());
     retriesProp.setValue(record.getRetries());
+    retryBackoffProp.setValue(record.getRetryBackOff());
     typeProp.setValue(record.getTypeBuffer());
     final DirectBuffer customHeaders = record.getCustomHeadersBuffer();
     customHeadersProp.setValue(customHeaders, 0, customHeaders.capacity());
@@ -129,6 +132,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   @Override
   public int getRetries() {
     return retriesProp.getValue();
+  }
+
+  @Override
+  public long getRetryBackOff() {
+    return retryBackoffProp.getValue();
   }
 
   @Override
@@ -226,6 +234,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setRetries(final int retries) {
     retriesProp.setValue(retries);
+    return this;
+  }
+
+  public JobRecord setRetryBackOff(final long retryBackOff) {
+    retryBackoffProp.setValue(retryBackOff);
     return this;
   }
 

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -123,6 +123,12 @@
               <method>*</method>
               <differenceType>7012</differenceType>
             </ignored>
+            <ignored>
+              <!-- ignore new methods in the JobRecordValue interface -->
+              <className>io/zeebe/protocol/record/value/JobRecordValue</className>
+              <method>*</method>
+              <differenceType>7012</differenceType>
+            </ignored>
           </ignored>
         </configuration>
       </plugin>

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/JobRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/JobRecordValue.java
@@ -39,6 +39,12 @@ public interface JobRecordValue extends RecordValueWithVariables, WorkflowInstan
   int getRetries();
 
   /**
+   * @return the time of backoff in milliseconds. If backoff is disabled this method returns 0
+   *     (default value).
+   */
+  long getRetryBackOff();
+
+  /**
    * @return the unix timestamp until when the job is exclusively assigned to this worker (time unit
    *     is milliseconds since unix epoch). If the deadline is exceeded, it can happen that the job
    *     is handed to another worker and the work is performed twice. If this property is not set it


### PR DESCRIPTION
## Description

A broker's process engine can delay jobs before reprocessing.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5626 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
