### PR TITLE
5754 trigger testbench

### DIFF
--- a/.ci/scripts/distribution/qa-testbench.sh
+++ b/.ci/scripts/distribution/qa-testbench.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -eux
+
+chmod +x clients/go/cmd/zbctl/dist/zbctl
+
+alias zbctl="clients/go/cmd/zbctl/dist/zbctl"
+
+zbctl create instance qa-protocol --variables "${QA_RUN_VARIABLES}"

--- a/.ci/scripts/docker/upload-gcr.sh
+++ b/.ci/scripts/docker/upload-gcr.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -eux
+
+# this command is a little convoluted to avoid leaking of the secret;
+# it is unclear why the built-in Jenkins mechanism doesn't work out of the box
+echo "Authenticating with gcr.io and pushing image."
+set +x ; echo ${DOCKER_GCR} | docker login -u _json_key --password-stdin https://gcr.io ; set -x
+
+docker push ${IMAGE}:${TAG}
+
+

--- a/.ci/scripts/docker/upload-gcr.sh
+++ b/.ci/scripts/docker/upload-gcr.sh
@@ -3,8 +3,8 @@
 # this command is a little convoluted to avoid leaking of the secret;
 # it is unclear why the built-in Jenkins mechanism doesn't work out of the box
 echo "Authenticating with gcr.io and pushing image."
-set +x ; echo ${DOCKER_GCR} | docker login -u _json_key --password-stdin https://gcr.io ; set -x
+set +x ; echo "${DOCKER_GCR}" | docker login -u _json_key --password-stdin https://gcr.io ; set -x
 
-docker push ${IMAGE}:${TAG}
+docker push "${IMAGE}":"${TAG}"
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,10 @@ pipeline {
         timeout(time: 45, unit: 'MINUTES')
     }
 
+    parameters {
+        booleanParam(name: 'RUN_QA', defaultValue: false, description: "Run QA Stage")
+    }
+
     stages {
         stage('Prepare') {
             steps {
@@ -248,6 +252,19 @@ pipeline {
                         if (fileExists('./target/FlakyTests.txt')) {
                             currentBuild.description = "Flaky Tests: <br>" + readFile('./target/FlakyTests.txt').split('\n').join('<br>')
                         }
+                    }
+                }
+            }
+        }
+
+        stage('QA') {
+            when {
+                expression { params.RUN_QA }
+            }
+            steps {
+                container('maven') {
+                    configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                        sh 'echo ${GIT_COMMIT}'
                     }
                 }
             }


### PR DESCRIPTION
## Description

Adds a QA stage to the build. The QA stage triggers testbench QA protocol and then waits for manual user confirmation.

The overall timeout has been removed from the build and split up into smaller timeout for individual steps.

The waiting for user input step has deliberately no timeout.

## Related issues

closes #5754

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
