### PR TITLE
[WIP] feat(clients/java): A Java client fails nicely when a broker is unavailable

### DIFF
--- a/clients/java/src/main/java/io/zeebe/client/api/command/GatewayConnectionException.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/command/GatewayConnectionException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.api.command;
+
+public class GatewayConnectionException extends ClientException {
+
+  private static final long serialVersionUID = -5195750018378722095L;
+
+  public GatewayConnectionException(Throwable cause) {
+    super(String.format("Cannot connect to the gateway. Because: %s", cause.getMessage()));
+  }
+}

--- a/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/ZeebeClientTest.java
@@ -22,6 +22,7 @@ import static io.zeebe.client.impl.ZeebeClientBuilderImpl.PLAINTEXT_CONNECTION_V
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.zeebe.client.api.command.GatewayConnectionException;
 import io.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.zeebe.client.util.ClientTest;
 import io.zeebe.client.util.Environment;
@@ -186,5 +187,12 @@ public final class ZeebeClientTest extends ClientTest {
           .isEqualTo(configuration.getBrokerContactPoint())
           .isEqualTo(gatewayAddress);
     }
+  }
+
+  @Test
+  public void shouldFailNicelyIfBrokerIsNotAvailable() {
+    assertThatThrownBy(() -> ZeebeClient.newClient().newTopologyRequest().send().join())
+        .isInstanceOf(GatewayConnectionException.class)
+        .hasMessageContaining("Connection refused: /0.0.0.0:26500");
   }
 }


### PR DESCRIPTION
## Description

When the specific status code occurs in the GRPC error, the exception with the single message will be thrown.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #462 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
