### PR TITLE
Move usage of maven plugins to profiles

### DIFF
--- a/.ci/scripts/distribution/build-java.sh
+++ b/.ci/scripts/distribution/build-java.sh
@@ -3,4 +3,4 @@
 
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
-mvn -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} -DskipTests clean com.mycila:license-maven-plugin:check com.coveo:fmt-maven-plugin:check install -Pspotbugs,prepare-offline
+mvn -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pchecks,spotbugs,prepare-offline

--- a/.ci/scripts/distribution/build-java.sh
+++ b/.ci/scripts/distribution/build-java.sh
@@ -3,4 +3,4 @@
 
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
-mvn -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} -DskipTests clean com.mycila:license-maven-plugin:check com.coveo:fmt-maven-plugin:check org.apache.maven.plugins:maven-dependency-plugin:3.1.1:go-offline install -Pspotbugs,prepare-offline
+mvn -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} -DskipTests clean com.mycila:license-maven-plugin:check com.coveo:fmt-maven-plugin:check install -Pspotbugs,prepare-offline

--- a/.ci/scripts/release/build-java.sh
+++ b/.ci/scripts/release/build-java.sh
@@ -12,4 +12,4 @@ else
   echo "Version $RELEASE_VERSION"
 fi
 
-mvn -B -s ${MAVEN_SETTINGS_XML} -DskipTests clean com.mycila:license-maven-plugin:check com.coveo:fmt-maven-plugin:check org.apache.maven.plugins:maven-dependency-plugin:3.1.1:go-offline install -Pprepare-offline
+mvn -B -s ${MAVEN_SETTINGS_XML} -DskipTests clean com.mycila:license-maven-plugin:check com.coveo:fmt-maven-plugin:check install -Pprepare-offline

--- a/.ci/scripts/release/build-java.sh
+++ b/.ci/scripts/release/build-java.sh
@@ -12,4 +12,4 @@ else
   echo "Version $RELEASE_VERSION"
 fi
 
-mvn -B -s ${MAVEN_SETTINGS_XML} -DskipTests clean com.mycila:license-maven-plugin:check com.coveo:fmt-maven-plugin:check install -Pprepare-offline
+mvn -B -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pchecks,prepare-offline

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -108,7 +108,7 @@
     <plugin.version.compiler>3.8.1</plugin.version.compiler>
     <plugin.version.exec>3.0.0</plugin.version.exec>
     <plugin.version.failsafe>3.0.0-M5</plugin.version.failsafe>
-    <plugin.version.fmt>2.9</plugin.version.fmt>
+    <plugin.version.fmt>2.10</plugin.version.fmt>
     <plugin.version.license>3.0</plugin.version.license>
     <plugin.version.protobuf-maven-plugin>0.6.1</plugin.version.protobuf-maven-plugin>
     <plugin.version.proto-backwards-compatibility>1.0.5

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1076,6 +1076,8 @@
           <version>${plugin.version.fmt}</version>
           <executions>
             <execution>
+              <id>format</id>
+              <phase>process-sources</phase>
               <goals>
                 <goal>format</goal>
               </goals>
@@ -1482,6 +1484,67 @@
                 <phase>verify</phase>
                 <goals>
                   <goal>sonar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- profile to disable the fmt-plugin on unsupported jdks -->
+    <profile>
+      <id>fmt-plugin</id>
+      <activation>
+        <jdk>[,9)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>fmt-maven-plugin</artifactId>
+            <groupId>com.coveo</groupId>
+            <executions>
+              <execution>
+                <id>format</id>
+                <phase>none</phase>
+                <goals>
+                  <goal>check</goal>
+                  <goal>format</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- profile to perform strict validation checks -->
+    <profile>
+      <id>checks</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>license-maven-plugin</artifactId>
+            <groupId>com.mycila</groupId>
+            <executions>
+              <execution>
+                <id>check-license</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>fmt-maven-plugin</artifactId>
+            <groupId>com.coveo</groupId>
+            <executions>
+              <execution>
+                <id>format</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>check</goal>
                 </goals>
               </execution>
             </executions>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1429,6 +1429,13 @@
             <artifactId>maven-dependency-plugin</artifactId>
             <executions>
               <execution>
+                <id>go-offline</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>go-offline</goal>
+                </goals>
+              </execution>
+              <execution>
                 <id>analyze-dependencies</id>
                 <goals>
                   <goal>analyze-only</goal>

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -552,7 +552,10 @@ public final class ClusteringRule extends ExternalResource {
     final MemberId nodeId = atomix.getMembershipService().getLocalMember().id();
 
     final var raftPartition =
-        atomix.getPartitionService().getPartitionGroup(AtomixFactory.GROUP_NAME).getPartitions()
+        atomix
+            .getPartitionService()
+            .getPartitionGroup(AtomixFactory.GROUP_NAME)
+            .getPartitions()
             .stream()
             .filter(partition -> partition.members().contains(nodeId))
             .filter(partition -> partition.id().id() == partitionId)


### PR DESCRIPTION
## Description

This PR moves the usage of maven plugins to profiles. This way dependency management of plugins (like version management) can be handled by the pom directly. 

This PR also disables the `fmt-plugin` on jdk 8 and lower, and updates the plugin to the latest version (2.10).

## Related issues

closes #4833

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
