### PR TITLE
chore(exporter): Return a cancellable ScheduledTask when creating a scheduled task.

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -14,6 +14,7 @@ import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.exporter.api.Exporter;
 import io.zeebe.exporter.api.context.Context;
 import io.zeebe.exporter.api.context.Controller;
+import io.zeebe.exporter.api.context.ScheduledTask;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.util.sched.ActorControl;
@@ -112,6 +113,12 @@ final class ExporterContainer implements Controller {
   @Override
   public void scheduleTask(final Duration delay, final Runnable task) {
     actor.runDelayed(delay, task);
+  }
+
+  @Override
+  public ScheduledTask scheduleCancellableTask(final Duration delay, final Runnable task) {
+    final var scheduledTimer = actor.runDelayed(delay, task);
+    return scheduledTimer::cancel;
   }
 
   public String getId() {

--- a/exporter-api/pom.xml
+++ b/exporter-api/pom.xml
@@ -22,12 +22,22 @@
   <properties>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
   </properties>
-  
+
   <build>
     <plugins>
-      <plugin> 
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <ignored>
+            <ignored>
+              <!-- ignore new methods in the Zeebe element instance interfaces -->
+              <className>io/zeebe/exporter/api/context/Controller</className>
+              <differenceType>7012</differenceType>
+              <method>*</method>
+            </ignored>
+          </ignored>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/exporter-api/src/main/java/io/zeebe/exporter/api/context/Controller.java
+++ b/exporter-api/src/main/java/io/zeebe/exporter/api/context/Controller.java
@@ -32,6 +32,17 @@ public interface Controller {
    *
    * @param delay time to wait until the task is ran
    * @param task the task to run
+   * @deprecated Consider to use {@link #scheduleCancellableTask(Duration, Runnable)}
    */
+  @Deprecated(since = "0.26.0", forRemoval = true)
   void scheduleTask(Duration delay, Runnable task);
+
+  /**
+   * Schedules a cancellable {@param task} to be ran after {@param delay} has expired.
+   *
+   * @param delay time to wait until the task is ran
+   * @param task the task to run
+   * @return cancellable task.
+   */
+  ScheduledTask scheduleCancellableTask(final Duration delay, final Runnable task);
 }

--- a/exporter-api/src/main/java/io/zeebe/exporter/api/context/ScheduledTask.java
+++ b/exporter-api/src/main/java/io/zeebe/exporter/api/context/ScheduledTask.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.exporter.api.context;
+
+import java.time.Duration;
+
+/**
+ * Represents a cancellable task.
+ *
+ * @see Controller#scheduleCancellableTask(Duration, Runnable)
+ */
+public interface ScheduledTask {
+  /** Cancel this task. */
+  void cancel();
+}

--- a/test/src/main/java/io/zeebe/test/exporter/MockController.java
+++ b/test/src/main/java/io/zeebe/test/exporter/MockController.java
@@ -8,6 +8,7 @@
 package io.zeebe.test.exporter;
 
 import io.zeebe.exporter.api.context.Controller;
+import io.zeebe.exporter.api.context.ScheduledTask;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -28,8 +29,15 @@ public class MockController implements Controller {
 
   @Override
   public void scheduleTask(final Duration delay, final Runnable task) {
-    final MockScheduledTask scheduledTask = new MockScheduledTask(delay, task);
+    final var scheduledTask = new MockScheduledTask(delay, task);
     scheduledTasks.add(scheduledTask);
+  }
+
+  @Override
+  public ScheduledTask scheduleCancellableTask(final Duration delay, final Runnable task) {
+    final var scheduledTask = new MockScheduledTask(delay, task);
+    scheduledTasks.add(scheduledTask);
+    return scheduledTask::cancel;
   }
 
   public void resetScheduler() {

--- a/test/src/main/java/io/zeebe/test/exporter/MockScheduledTask.java
+++ b/test/src/main/java/io/zeebe/test/exporter/MockScheduledTask.java
@@ -18,11 +18,13 @@ public class MockScheduledTask implements Runnable {
   private Duration delay;
   private Runnable task;
   private boolean executed;
+  private boolean canceled;
 
   MockScheduledTask(final Duration delay, final Runnable task) {
     this.delay = delay;
     this.task = task;
     executed = false;
+    canceled = false;
   }
 
   public Duration getDelay() {
@@ -43,7 +45,7 @@ public class MockScheduledTask implements Runnable {
 
   @Override
   public void run() {
-    if (!wasExecuted()) {
+    if (!wasExecuted() && !isCanceled()) {
       task.run();
       executed = true;
     }
@@ -51,5 +53,15 @@ public class MockScheduledTask implements Runnable {
 
   public boolean wasExecuted() {
     return executed;
+  }
+
+  public void cancel() {
+    if (!isCanceled()) {
+      canceled = true;
+    }
+  }
+
+  public boolean isCanceled() {
+    return canceled;
   }
 }


### PR DESCRIPTION
## Description

I've created a method that returns a cancellable version of the scheduled task.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2574 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
