### PR TITLE
chore(atomix): add checksum to append request

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractAppender.java
@@ -107,6 +107,7 @@ abstract class AbstractAppender implements AutoCloseable {
         .withTerm(raft.getTerm())
         .withLeader(leader.memberId())
         .withEntries(Collections.emptyList())
+        .withChecksums(Collections.emptyList())
         .withCommitIndex(raft.getCommitIndex())
         .build();
   }
@@ -146,6 +147,7 @@ abstract class AbstractAppender implements AutoCloseable {
 
     // Build a list of entries to send to the member.
     final List<RaftLogEntry> entries = new ArrayList<>();
+    final List<Long> checksums = new ArrayList<>();
 
     // Build a list of entries up to the MAX_BATCH_SIZE. Note that entries in the log may
     // be null if they've been compacted and the member to which we're sending entries is just
@@ -160,6 +162,7 @@ abstract class AbstractAppender implements AutoCloseable {
       // Otherwise, read the next entry and add it to the batch.
       final Indexed<RaftLogEntry> entry = reader.next();
       entries.add(entry.entry());
+      checksums.add(entry.checksum());
       size += entry.size();
       if (entry.index() == lastIndex || size >= maxBatchSizePerAppend) {
         break;
@@ -167,7 +170,7 @@ abstract class AbstractAppender implements AutoCloseable {
     }
 
     // Add the entries to the request builder and build the request.
-    return builder.withEntries(entries).build();
+    return builder.withEntries(entries).withChecksums(checksums).build();
   }
 
   /** Connects to the member and sends a commit message. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -437,9 +437,23 @@ public class PassiveRole extends InactiveRole {
       return future;
     }
 
+    if (!checkChecksums(request, future)) {
+      return future;
+    }
+
     // Append the entries to the log.
     appendEntries(request, future);
     return future;
+  }
+
+  private boolean checkChecksums(
+      final AppendRequest request, final CompletableFuture<AppendResponse> future) {
+    if (request.checksums() != null && request.entries().size() != request.checksums().size()) {
+      log.debug("Rejected {}: expected the same number of checksums as entries", request);
+      return failAppend(raft.getLogWriter().getLastIndex(), future);
+    }
+
+    return true;
   }
 
   /**
@@ -580,13 +594,16 @@ public class PassiveRole extends InactiveRole {
       }
 
       // Iterate through entries and append them.
-      for (final RaftLogEntry entry : request.entries()) {
+      for (int i = 0; i < request.entries().size(); ++i) {
         final long index = ++lastLogIndex;
+        final RaftLogEntry entry = request.entries().get(i);
+        final Long checksum = request.checksums() == null ? null : request.checksums().get(i);
 
         // Get the last entry written to the log by the writer.
         final Indexed<RaftLogEntry> lastEntry = writer.getLastEntry();
 
-        final boolean failedToAppend = tryToAppend(future, writer, reader, entry, index, lastEntry);
+        final boolean failedToAppend =
+            tryToAppend(future, writer, reader, entry, checksum, index, lastEntry);
         if (failedToAppend) {
           return;
         }
@@ -623,6 +640,7 @@ public class PassiveRole extends InactiveRole {
       final RaftLogWriter writer,
       final RaftLogReader reader,
       final RaftLogEntry entry,
+      final Long checksum,
       final long index,
       final Indexed<RaftLogEntry> lastEntry) {
     boolean failedToAppend = false;
@@ -630,7 +648,7 @@ public class PassiveRole extends InactiveRole {
       // If the last written entry index is greater than the next append entry index,
       // we need to validate that the entry that's already in the log matches this entry.
       if (lastEntry.index() > index) {
-        failedToAppend = !replaceExistingEntry(future, writer, reader, entry, index);
+        failedToAppend = !replaceExistingEntry(future, writer, reader, entry, checksum, index);
       } else if (lastEntry.index() == index) {
         // If the last written entry is equal to the append entry index, we don't need
         // to read the entry from disk and can just compare the last entry in the writer.
@@ -639,13 +657,13 @@ public class PassiveRole extends InactiveRole {
         // the log and append the leader's entry.
         if (lastEntry.entry().term() != entry.term()) {
           writer.truncate(index - 1);
-          failedToAppend = !appendEntry(index, entry, writer, future);
+          failedToAppend = !appendEntry(index, entry, checksum, writer, future);
         }
       } else { // Otherwise, this entry is being appended at the end of the log.
-        failedToAppend = !appendEntry(future, writer, entry, index, lastEntry);
+        failedToAppend = !appendEntry(future, writer, entry, checksum, index, lastEntry);
       }
     } else { // Otherwise, if the last entry is null just append the entry and log a message.
-      failedToAppend = !appendEntry(index, entry, writer, future);
+      failedToAppend = !appendEntry(index, entry, checksum, writer, future);
     }
     return failedToAppend;
   }
@@ -654,6 +672,7 @@ public class PassiveRole extends InactiveRole {
       final CompletableFuture<AppendResponse> future,
       final RaftLogWriter writer,
       final RaftLogEntry entry,
+      final Long checksum,
       final long index,
       final Indexed<RaftLogEntry> lastEntry) {
     // If the last entry index isn't the previous index, throw an exception because
@@ -664,7 +683,7 @@ public class PassiveRole extends InactiveRole {
     }
 
     // Append the entry and log a message.
-    return appendEntry(index, entry, writer, future);
+    return appendEntry(index, entry, checksum, writer, future);
   }
 
   private boolean replaceExistingEntry(
@@ -672,6 +691,7 @@ public class PassiveRole extends InactiveRole {
       final RaftLogWriter writer,
       final RaftLogReader reader,
       final RaftLogEntry entry,
+      final Long checksum,
       final long index) {
     // Reset the reader to the current entry index.
     if (reader.getNextIndex() != index) {
@@ -692,7 +712,7 @@ public class PassiveRole extends InactiveRole {
     // the log and append the leader's entry.
     if (existingEntry.entry().term() != entry.term()) {
       writer.truncate(index - 1);
-      if (!appendEntry(index, entry, writer, future)) {
+      if (!appendEntry(index, entry, checksum, writer, future)) {
         return false;
       }
     }
@@ -706,10 +726,17 @@ public class PassiveRole extends InactiveRole {
   private boolean appendEntry(
       final long index,
       final RaftLogEntry entry,
+      final Long checksum,
       final RaftLogWriter writer,
       final CompletableFuture<AppendResponse> future) {
     try {
-      final Indexed<RaftLogEntry> indexed = writer.append(entry);
+      final Indexed<RaftLogEntry> indexed;
+      if (checksum != null) {
+        indexed = writer.append(entry, checksum);
+      } else {
+        indexed = writer.append(entry);
+      }
+
       log.trace("Appended {}", indexed);
       raft.getReplicationMetrics().setAppendIndex(indexed.index());
     } catch (final StorageException.TooLarge e) {
@@ -717,8 +744,12 @@ public class PassiveRole extends InactiveRole {
           "Entry size exceeds maximum allowed bytes. Ensure Raft storage configuration is consistent on all nodes!");
       return false;
     } catch (final StorageException.OutOfDiskSpace e) {
-      log.trace("Append failed: {}", e);
+      log.trace("Append failed: ", e);
       raft.getLogCompactor().compact();
+      failAppend(index - 1, future);
+      return false;
+    } catch (final StorageException.InvalidChecksum e) {
+      log.debug("Entry checksum doesn't match entry data: ", e);
       failAppend(index - 1, future);
       return false;
     }

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -30,6 +30,7 @@ import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.metrics.RaftReplicationMetrics;
+import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.storage.log.RaftLogWriter;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
@@ -78,13 +79,14 @@ public class LeaderRoleTest {
         .then(
             i -> {
               final ZeebeEntry zeebeEntry = i.getArgument(0);
-              return new Indexed<>(1, zeebeEntry, 45);
+              return new Indexed<>(1, zeebeEntry, 45, -1);
             });
     when(context.getLogWriter()).thenReturn(writer);
 
     final ReceivableSnapshotStore persistedSnapshotStore = mock(ReceivableSnapshotStore.class);
     when(context.getPersistedSnapshotStore()).thenReturn(persistedSnapshotStore);
     when(context.getEntryValidator()).thenReturn((a, b) -> ValidationResult.success());
+    when(context.getStorage()).thenReturn(RaftStorage.builder().withMaxSegmentSize(1024).build());
 
     leaderRole = new LeaderRole(context);
     // since we mock RaftContext we should simulate leader close on transition
@@ -136,7 +138,7 @@ public class LeaderRoleTest {
         .then(
             i -> {
               final ZeebeEntry zeebeEntry = i.getArgument(0);
-              return new Indexed<>(1, zeebeEntry, 45);
+              return new Indexed<>(1, zeebeEntry, 45, -1);
             });
 
     final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
@@ -388,7 +390,7 @@ public class LeaderRoleTest {
         .then(
             i -> {
               final ZeebeEntry zeebeEntry = i.getArgument(0);
-              return new Indexed<>(1, zeebeEntry, 45);
+              return new Indexed<>(1, zeebeEntry, 45, -1);
             });
 
     final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
@@ -433,7 +435,7 @@ public class LeaderRoleTest {
         .then(
             i -> {
               final ZeebeEntry zeebeEntry = i.getArgument(0);
-              return new Indexed<>(1, zeebeEntry, 45);
+              return new Indexed<>(1, zeebeEntry, 45, -1);
             });
 
     final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.roles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.metrics.RaftReplicationMetrics;
+import io.atomix.raft.protocol.AppendRequest;
+import io.atomix.raft.protocol.AppendResponse;
+import io.atomix.raft.storage.RaftStorage;
+import io.atomix.raft.storage.log.RaftLog;
+import io.atomix.raft.storage.log.RaftLogWriter;
+import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.zeebe.ZeebeEntry;
+import io.atomix.storage.StorageException.InvalidChecksum;
+import io.atomix.storage.journal.Indexed;
+import io.atomix.utils.serializer.NamespaceImpl;
+import io.atomix.utils.serializer.NamespaceImpl.Builder;
+import io.atomix.utils.serializer.Namespaces;
+import io.zeebe.snapshots.raft.PersistedSnapshot;
+import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.CRC32;
+import java.util.zip.Checksum;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+public class PassiveRoleTest {
+
+  private static final NamespaceImpl NAMESPACE =
+      new Builder().register(Namespaces.BASIC).register(ZeebeEntry.class).build();
+  @Rule public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
+  private final ZeebeEntry entry = new ZeebeEntry(1, 1, 0, 1, ByteBuffer.allocate(0));
+  private RaftLogWriter writer;
+  private PassiveRole role;
+
+  @Before
+  public void setup() {
+    final RaftStorage storage = mock(RaftStorage.class);
+    when(storage.namespace()).thenReturn(NAMESPACE);
+
+    writer = mock(RaftLogWriter.class);
+    when(writer.getLastIndex()).thenReturn(1L);
+
+    final PersistedSnapshot snapshot = mock(PersistedSnapshot.class);
+    when(snapshot.getIndex()).thenReturn(1L);
+    when(snapshot.getTerm()).thenReturn(1L);
+
+    final ReceivableSnapshotStore store = mock(ReceivableSnapshotStore.class);
+    when(store.getLatestSnapshot()).thenReturn(Optional.of(snapshot));
+
+    final RaftContext ctx = mock(RaftContext.class);
+    when(ctx.getStorage()).thenReturn(storage);
+    when(ctx.getLogWriter()).thenReturn(writer);
+    when(ctx.getPersistedSnapshotStore()).thenReturn(store);
+    when(ctx.getTerm()).thenReturn(1L);
+    when(ctx.getReplicationMetrics()).thenReturn(mock(RaftReplicationMetrics.class));
+    when(ctx.getLog()).thenReturn(mock(RaftLog.class));
+
+    role = new PassiveRole(ctx);
+  }
+
+  @Test
+  public void shouldRejectRequestIfDifferentNumberEntriesAndChecksums() {
+    // given
+    final List<RaftLogEntry> entries = generateEntries(1);
+    final AppendRequest request = new AppendRequest(2, "", 1, 1, entries, List.of(1L, 2L), 1);
+
+    // when
+    final AppendResponse response = role.handleAppend(request).join();
+
+    // then
+    assertThat(response.succeeded()).isFalse();
+  }
+
+  @Test
+  public void shouldAppendEntryWithCorrectChecksum() {
+    // given
+    when(writer.append(any(), anyLong())).thenReturn(new Indexed<>(1, entry, 1, 1));
+    final List<RaftLogEntry> entries = generateEntries(1);
+    final List<Long> checksums = getChecksums(entries);
+    final AppendRequest request = new AppendRequest(2, "", 1, 1, entries, checksums, 1);
+
+    // when
+    final AppendResponse response = role.handleAppend(request).join();
+
+    // then
+    assertThat(response.succeeded()).isTrue();
+    verify(writer).append(any(ZeebeEntry.class), eq(checksums.get(0)));
+    verify(writer, never()).append(any(ZeebeEntry.class));
+  }
+
+  @Test
+  public void shouldNotValidateIfNoChecksum() {
+    // given
+    when(writer.append(any(ZeebeEntry.class))).thenReturn(new Indexed<>(1, entry, 1, 1));
+    final List<RaftLogEntry> entries = generateEntries(1);
+    final AppendRequest request = new AppendRequest(2, "", 1, 1, entries, null, 1);
+
+    // when
+    final AppendResponse response = role.handleAppend(request).join();
+
+    // then
+    assertThat(response.succeeded()).isTrue();
+    verify(writer).append(any(ZeebeEntry.class));
+    verify(writer, never()).append(any(ZeebeEntry.class), anyLong());
+  }
+
+  @Test
+  public void shouldFailAppendWithIncorrectChecksum() {
+    // given
+    when(writer.append(any(ZeebeEntry.class), anyLong()))
+        .thenReturn(new Indexed<>(1, entry, 1, 1))
+        .thenThrow(new InvalidChecksum("expected"));
+    final List<RaftLogEntry> entries = generateEntries(2);
+    final List<Long> checksums = getChecksums(entries);
+    checksums.set(1, 0L);
+    final AppendRequest request = new AppendRequest(2, "", 1, 1, entries, checksums, 1);
+
+    // when
+    final AppendResponse response = role.handleAppend(request).join();
+
+    // then
+    assertThat(response.succeeded()).isFalse();
+    assertThat(response.lastLogIndex()).isEqualTo(2);
+    verify(writer, times(2)).append(any(ZeebeEntry.class), anyLong());
+  }
+
+  private List<RaftLogEntry> generateEntries(final int numEntries) {
+    final List<RaftLogEntry> entries = new ArrayList<>();
+    for (int i = 0; i < numEntries; i++) {
+      entries.add(new ZeebeEntry(1, 1, i + 1, i + 1, ByteBuffer.allocate(0)));
+    }
+
+    return entries;
+  }
+
+  private List<Long> getChecksums(final List<RaftLogEntry> entries) {
+    final List<Long> checksums = new ArrayList<>();
+
+    for (final RaftLogEntry entry : entries) {
+      final byte[] serialized = NAMESPACE.serialize(entry);
+      final Checksum crc32 = new CRC32();
+      crc32.update(serialized, 0, serialized.length);
+
+      checksums.add(crc32.getValue());
+    }
+
+    return checksums;
+  }
+}

--- a/atomix/cluster/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/atomix/cluster/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/atomix/storage/pom.xml
+++ b/atomix/storage/pom.xml
@@ -59,6 +59,12 @@
       <groupId>junit</groupId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <parent>

--- a/atomix/storage/src/main/java/io/atomix/storage/StorageException.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/StorageException.java
@@ -50,4 +50,11 @@ public class StorageException extends RuntimeException {
       super(message);
     }
   }
+
+  /** Exception thrown when an entry has an invalid checksum. */
+  public static class InvalidChecksum extends StorageException {
+    public InvalidChecksum(final String message) {
+      super(message);
+    }
+  }
 }

--- a/atomix/storage/src/main/java/io/atomix/storage/journal/DelegatingJournalWriter.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/DelegatingJournalWriter.java
@@ -52,6 +52,11 @@ public class DelegatingJournalWriter<E> implements JournalWriter<E> {
   }
 
   @Override
+  public <T extends E> Indexed<T> append(final T entry, final long checksum) {
+    return delegate.append(entry, checksum);
+  }
+
+  @Override
   public void commit(final long index) {
     delegate.commit(index);
   }

--- a/atomix/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentReader.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentReader.java
@@ -143,7 +143,7 @@ class FileChannelJournalSegmentReader<E> implements JournalReader<E> {
 
     final Position position = this.index.lookup(index - 1);
     if (position != null && position.index() >= firstIndex && position.index() <= lastIndex) {
-      currentEntry = new Indexed<>(position.index() - 1, null, 0);
+      currentEntry = new Indexed<>(position.index() - 1, null, 0, -1);
       try {
         channel.position(position.position());
         memory.clear().flip();
@@ -209,7 +209,9 @@ class FileChannelJournalSegmentReader<E> implements JournalReader<E> {
   }
 
   private void readNextEntry(final long index, final int length) {
-    if (isChecksumInvalid(length)) {
+    final long checksum = memory.getInt() & 0xFFFFFFFFL;
+
+    if (isChecksumInvalid(checksum, length)) {
       resetReading();
       return;
     }
@@ -219,7 +221,7 @@ class FileChannelJournalSegmentReader<E> implements JournalReader<E> {
     memory.limit(memory.position() + length);
     final E entry = namespace.deserialize(memory);
     memory.limit(limit);
-    nextEntry = new Indexed<>(index, entry, length);
+    nextEntry = new Indexed<>(index, entry, length, checksum);
   }
 
   private void resetReading() {
@@ -227,10 +229,7 @@ class FileChannelJournalSegmentReader<E> implements JournalReader<E> {
     nextEntry = null;
   }
 
-  private boolean isChecksumInvalid(final int length) {
-    // Read the checksum of the entry.
-    final long checksum = memory.getInt() & 0xFFFFFFFFL;
-
+  private boolean isChecksumInvalid(final long checksum, final int length) {
     // Compute the checksum for the entry bytes.
     final Checksum crc32 = new CRC32();
     crc32.update(memory.array(), memory.position(), length);

--- a/atomix/storage/src/main/java/io/atomix/storage/journal/Indexed.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/Indexed.java
@@ -25,11 +25,13 @@ public class Indexed<E> {
   private final long index;
   private final E entry;
   private final int size;
+  private final long checksum;
 
-  public Indexed(final long index, final E entry, final int size) {
+  public Indexed(final long index, final E entry, final int size, final long checksum) {
     this.index = index;
     this.entry = entry;
     this.size = size;
+    this.checksum = checksum;
   }
 
   /**
@@ -57,6 +59,15 @@ public class Indexed<E> {
    */
   public int size() {
     return size;
+  }
+
+  /**
+   * Returns the entry checksum.
+   *
+   * @return The entry checksum.
+   */
+  public long checksum() {
+    return checksum;
   }
 
   /**
@@ -92,11 +103,18 @@ public class Indexed<E> {
       return false;
     }
     final Indexed<?> indexed = (Indexed<?>) o;
-    return index == indexed.index && size == indexed.size && Objects.equals(entry, indexed.entry);
+    return index == indexed.index
+        && size == indexed.size
+        && Objects.equals(entry, indexed.entry)
+        && checksum == indexed.checksum;
   }
 
   @Override
   public String toString() {
-    return toStringHelper(this).add("index", index).add("entry", entry).toString();
+    return toStringHelper(this)
+        .add("index", index)
+        .add("entry", entry)
+        .add("checksum", checksum)
+        .toString();
   }
 }

--- a/atomix/storage/src/main/java/io/atomix/storage/journal/JournalWriter.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/JournalWriter.java
@@ -53,6 +53,15 @@ public interface JournalWriter<E> extends AutoCloseable {
   <T extends E> Indexed<T> append(T entry);
 
   /**
+   * Validate the entry checksum and, if successful, appends the entry to the journal.
+   *
+   * @param entry The entry to append.
+   * @param checksum The entry checksum.
+   * @return The appended indexed entry.
+   */
+  <T extends E> Indexed<T> append(T entry, long checksum);
+
+  /**
    * Appends an indexed entry to the log.
    *
    * @param entry The indexed entry to append.

--- a/atomix/storage/src/main/java/io/atomix/storage/journal/MappedJournalSegmentReader.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/MappedJournalSegmentReader.java
@@ -132,7 +132,7 @@ class MappedJournalSegmentReader<E> implements JournalReader<E> {
 
     final Position position = this.index.lookup(index - 1);
     if (position != null && position.index() >= firstIndex && position.index() <= lastIndex) {
-      currentEntry = new Indexed<>(position.index() - 1, null, 0);
+      currentEntry = new Indexed<>(position.index() - 1, null, 0, -1);
       buffer.position(position.position());
 
       nextEntry = null;
@@ -182,7 +182,7 @@ class MappedJournalSegmentReader<E> implements JournalReader<E> {
       if (checksum == crc32.getValue()) {
         slice.rewind();
         final E entry = namespace.deserialize(slice);
-        nextEntry = new Indexed<>(index, entry, length);
+        nextEntry = new Indexed<>(index, entry, length, checksum);
         buffer.position(buffer.position() + length);
       } else {
         buffer.reset();

--- a/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournalWriter.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournalWriter.java
@@ -64,6 +64,21 @@ public class SegmentedJournalWriter<E> implements JournalWriter<E> {
   }
 
   @Override
+  public <T extends E> Indexed<T> append(final T entry, final long checksum) {
+    try {
+      return currentWriter.append(entry, checksum);
+    } catch (final BufferOverflowException e) {
+      if (currentSegment.index() == currentWriter.getNextIndex()) {
+        throw e;
+      }
+
+      journalMetrics.observeSegmentCreation(this::createNewSegment);
+
+      return currentWriter.append(entry, checksum);
+    }
+  }
+
+  @Override
   public void append(final Indexed<E> entry) {
     try {
       currentWriter.append(entry);

--- a/atomix/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
+++ b/atomix/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
@@ -63,12 +63,10 @@ public abstract class AbstractJournalTest {
   protected SegmentedJournal<TestEntry> journal;
 
   private final int maxSegmentSize;
-  private final int cacheSize;
   private File folder;
 
   protected AbstractJournalTest(final int maxSegmentSize, final int cacheSize) {
     this.maxSegmentSize = maxSegmentSize;
-    this.cacheSize = cacheSize;
     final int entryLength = (NAMESPACE.serialize(ENTRY).length + 8);
     entriesPerSegment = (maxSegmentSize - 64) / entryLength;
   }
@@ -175,7 +173,7 @@ public abstract class AbstractJournalTest {
     assertEquals(1, indexed.index());
 
     assertEquals(2, writer.getNextIndex());
-    writer.append(new Indexed<>(2, ENTRY, 0));
+    writer.append(new Indexed<>(2, ENTRY, 0, -1));
     reader.reset(2);
     indexed = reader.next();
     assertEquals(2, indexed.index());
@@ -239,7 +237,7 @@ public abstract class AbstractJournalTest {
     // Truncate the journal and write a different entry.
     writer.truncate(1);
     assertEquals(2, writer.getNextIndex());
-    writer.append(new Indexed<>(2, ENTRY, 0));
+    writer.append(new Indexed<>(2, ENTRY, 0, -1));
     reader.reset(2);
     indexed = reader.next();
     assertEquals(2, indexed.index());

--- a/atomix/storage/src/test/java/io/atomix/storage/journal/JournalSegmentWriterTest.java
+++ b/atomix/storage/src/test/java/io/atomix/storage/journal/JournalSegmentWriterTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.storage.journal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.storage.StorageException;
+import io.atomix.storage.journal.index.JournalIndex;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.NamespaceImpl.Builder;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.util.zip.CRC32;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.BeforeParam;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class JournalSegmentWriterTest {
+
+  @ClassRule public static TemporaryFolder temp = new TemporaryFolder();
+  public static final Namespace NAMESPACE = new Builder().register(Integer.class).build();
+  private static JournalWriter<Integer> writer;
+
+  @Parameter() public String testName;
+  private final CRC32 crc32 = new CRC32();
+
+  @Parameters(name = "{0}")
+  public static String[] data() {
+    return new String[] {"MappedJournal", "FileChannelJournal"};
+  }
+
+  @BeforeParam
+  public static void setup(final String journalType) throws IOException {
+    final FileChannel channel = mock(FileChannel.class);
+    final JournalSegmentFile journalFile = mock(JournalSegmentFile.class);
+    when(journalFile.openChannel(any())).thenReturn(channel);
+    when(journalFile.file()).thenReturn(temp.newFile());
+
+    final JournalSegmentDescriptor descriptor = mock(JournalSegmentDescriptor.class);
+    when(descriptor.maxSegmentSize()).thenReturn(1024);
+
+    final JournalSegment<Integer> segment = mock(JournalSegment.class);
+    when(segment.descriptor()).thenReturn(descriptor);
+
+    final JournalIndex index = mock(JournalIndex.class);
+    if ("FileChannelJournal".equals(journalType)) {
+      writer = new FileChannelJournalSegmentWriter<>(journalFile, segment, 1024, index, NAMESPACE);
+    } else if ("MappedJournal".equals(journalType)) {
+      writer = new MappedJournalSegmentWriter<>(journalFile, segment, 1024, index, NAMESPACE);
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Failed to setup due to unknown journal type '%s'", journalType));
+    }
+  }
+
+  @Test(expected = StorageException.InvalidChecksum.class)
+  public void shouldThrowExceptionOnFailedValidation() {
+    writer.append(0, -1);
+  }
+
+  @Test
+  public void shouldSucceedValidation() {
+    // given
+    final Integer entry = 0;
+    final byte[] serialized = NAMESPACE.serialize(entry);
+
+    crc32.reset();
+    crc32.update(serialized);
+    final int checksum = (int) crc32.getValue();
+
+    // when/then
+    writer.append(entry, checksum);
+  }
+}

--- a/atomix/storage/src/test/java/io/atomix/storage/journal/index/SparseJournalIndexTest.java
+++ b/atomix/storage/src/test/java/io/atomix/storage/journal/index/SparseJournalIndexTest.java
@@ -38,7 +38,7 @@ public class SparseJournalIndexTest {
   }
 
   public static Indexed asIndexedEntry(final long index) {
-    return new Indexed(index, null, 0);
+    return new Indexed(index, null, 0, -1);
   }
 
   @Test

--- a/atomix/storage/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/atomix/storage/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/atomix/utils/src/main/java/io/atomix/utils/serializer/FallbackNamespace.java
+++ b/atomix/utils/src/main/java/io/atomix/utils/serializer/FallbackNamespace.java
@@ -30,7 +30,7 @@ public class FallbackNamespace implements Namespace {
 
   private static final Logger LOG = getLogger(FallbackNamespace.class);
   private static final String DESERIALIZE_ERROR =
-      "Serialized bytes contained header with version but deserialization failed (will fallback to FieldSerializer):\n";
+      "Serialized bytes contained header with version but deserialization failed (will fallback to FieldSerializer): ";
   private static final String UNKNOWN_VERSION_ERROR =
       "Magic byte was encountered, signalling newer version of serializer, but version {} is unrecognized. Using FieldSerializer as fallback";
   private final NamespaceImpl fallback;
@@ -91,7 +91,7 @@ public class FallbackNamespace implements Namespace {
       try {
         return namespace.deserialize(bytes, VERSION_HEADER.length);
       } catch (final Exception e) {
-        LOG.debug(DESERIALIZE_ERROR, e);
+        LOG.warn(DESERIALIZE_ERROR, e);
       }
     } else {
       LOG.debug(UNKNOWN_VERSION_ERROR, (int) versionByte);
@@ -122,7 +122,7 @@ public class FallbackNamespace implements Namespace {
         buffer.position(position + VERSION_HEADER.length);
         return namespace.deserialize(buffer);
       } catch (final Exception e) {
-        LOG.debug(DESERIALIZE_ERROR, e);
+        LOG.warn(DESERIALIZE_ERROR, e);
       }
     } else {
       LOG.debug(UNKNOWN_VERSION_ERROR, (int) version);

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
@@ -84,7 +84,10 @@ public final class AsyncSnapshotingTest {
             l ->
                 Optional.of(
                     new Indexed(
-                        l + 100, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0)),
+                        l + 100,
+                        new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null),
+                        0,
+                        -1)),
             db -> Long.MAX_VALUE);
 
     snapshotController.openDb();

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
@@ -60,7 +60,8 @@ public final class FailingSnapshotChunkReplicationTest {
             replicator,
             l ->
                 Optional.of(
-                    new Indexed(l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0)),
+                    new Indexed(
+                        l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0, -1)),
             db -> Long.MAX_VALUE);
     senderStore.addSnapshotListener(replicatorSnapshotController);
 
@@ -74,7 +75,8 @@ public final class FailingSnapshotChunkReplicationTest {
             replicator,
             l ->
                 Optional.ofNullable(
-                    new Indexed(l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0)),
+                    new Indexed(
+                        l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0, -1)),
             db -> Long.MAX_VALUE);
     receiverStore.addSnapshotListener(receiverSnapshotController);
 

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
@@ -68,7 +68,8 @@ public final class ReplicateStateControllerTest {
             replicator,
             l ->
                 Optional.of(
-                    new Indexed(l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0)),
+                    new Indexed(
+                        l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0, -1)),
             db -> Long.MAX_VALUE);
     senderStore.addSnapshotListener(replicatorSnapshotController);
 
@@ -82,7 +83,8 @@ public final class ReplicateStateControllerTest {
             replicator,
             l ->
                 Optional.of(
-                    new Indexed(l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0)),
+                    new Indexed(
+                        l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0, -1)),
             db -> Long.MAX_VALUE);
     receiverStore.addSnapshotListener(receiverSnapshotController);
 

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -61,7 +61,8 @@ public final class StateControllerImplTest {
             new NoneSnapshotReplication(),
             l ->
                 Optional.ofNullable(
-                    new Indexed(l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0)),
+                    new Indexed(
+                        l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0, -1)),
             db -> exporterPosition.get());
 
     autoCloseableRule.manage(snapshotController);

--- a/logstreams/src/test/java/io/zeebe/logstreams/storage/atomix/AtomixIndexTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/storage/atomix/AtomixIndexTest.java
@@ -201,6 +201,6 @@ public class AtomixIndexTest {
   }
 
   private static Indexed asIndexedEntry(final long index) {
-    return new Indexed(index, new InitializeEntry(0, System.currentTimeMillis()), 0);
+    return new Indexed(index, new InitializeEntry(0, System.currentTimeMillis()), 0, -1);
   }
 }

--- a/logstreams/src/test/java/io/zeebe/logstreams/storage/atomix/ZeebeIndexTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/storage/atomix/ZeebeIndexTest.java
@@ -55,7 +55,7 @@ public class ZeebeIndexTest {
 
     // when
     zeebeIndexAdapter.index(
-        new Indexed<>(5, new InitializeEntry(0, System.currentTimeMillis()), 10), 10);
+        new Indexed<>(5, new InitializeEntry(0, System.currentTimeMillis()), 10, -1), 10);
 
     // then
     assertThat(zeebeIndexAdapter.lookupPosition(1)).isEqualTo(-1);
@@ -224,6 +224,7 @@ public class ZeebeIndexTest {
     return new Indexed(
         index,
         new ZeebeEntry(0, System.currentTimeMillis(), lowestPos, lowestPos, ByteBuffer.allocate(0)),
-        0);
+        0,
+        -1);
   }
 }


### PR DESCRIPTION
## Description

Adds a checksum to the AppendRequest that is replicated by the leader and then checked by the followers.

## Related issues

closes #4736

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
