### PR TITLE
Fix sccalabr PR

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -211,6 +211,12 @@
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-client-java</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -13,6 +13,7 @@ import com.google.rpc.Status;
 import com.google.rpc.Status.Builder;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
+import io.netty.channel.ConnectTimeoutException;
 import io.zeebe.gateway.Loggers;
 import io.zeebe.gateway.cmd.BrokerErrorException;
 import io.zeebe.gateway.cmd.BrokerRejectionException;
@@ -84,6 +85,10 @@ public final class GrpcErrorMapper {
       logger.trace(
           "Expected to handle gRPC request, but the gateway does not know any partitions yet",
           error);
+    } else if (error instanceof ConnectTimeoutException) {
+      builder.setCode(Code.UNAVAILABLE_VALUE).setMessage(error.getMessage());
+      logger.warn(
+          "Expected to handle gRPC request, but a connection timeout exception occurred", error);
     } else {
       builder
           .setCode(Code.INTERNAL_VALUE)


### PR DESCRIPTION
## Description

Cherry picks and fixes https://github.com/zeebe-io/zeebe/pull/5740 
> The log level was lowered from error to warn for connection time out exceptions.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->
closes #5397
closes https://github.com/zeebe-io/zeebe/pull/5740 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
