### PR TITLE
Show container logs on update test failure

### DIFF
--- a/update-tests/src/test/java/io/zeebe/test/ContainerStateExtension.java
+++ b/update-tests/src/test/java/io/zeebe/test/ContainerStateExtension.java
@@ -11,12 +11,11 @@ import io.zeebe.test.util.testcontainers.ManagedVolume;
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.TestWatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ContainerStateExtension
-    implements BeforeTestExecutionCallback, AfterTestExecutionCallback, TestWatcher {
+    implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
   private static final Logger LOG = LoggerFactory.getLogger(ContainerStateExtension.class);
 
   private final ContainerState state;
@@ -26,12 +25,12 @@ public class ContainerStateExtension
   }
 
   @Override
-  public void testFailed(final ExtensionContext context, final Throwable cause) {
-    state.onFailure();
-  }
-
-  @Override
   public void afterTestExecution(final ExtensionContext context) {
+    final boolean hasFailed = context.getExecutionException().isPresent();
+    if (hasFailed) {
+      state.onFailure();
+    }
+
     try {
       state.close();
     } catch (final Exception e) {


### PR DESCRIPTION
## Description

In the refactoring, it seems I broke showing the container logs when the test fails. This was because the `TestWatcher` extension is called after the resources have been closed, as a `TestWatcher` is supposed to only report on outcomes. I've moved the `onFailure` of the `ContainerState` now to the after test callback, and we can see if it failed by checking if an exception was thrown and not caught during the test.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
