### PR TITLE
Schedule clean up periodically

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -29,6 +29,8 @@ public class MetricsExporter implements Exporter {
   private final Long2LongHashMap jobKeyToCreationTimeMap;
   private final Long2LongHashMap workflowInstanceKeyToCreationTimeMap;
 
+  // only used to keep track of how long the entries are existing and to clean up the corresponding
+  // maps
   private final NavigableMap<Long, Long> creationTimeToJobKeyNavigableMap;
   private final NavigableMap<Long, Long> creationTimeToWorkflowInstanceKeyNavigableMap;
 
@@ -53,6 +55,8 @@ public class MetricsExporter implements Exporter {
   public void close() {
     jobKeyToCreationTimeMap.clear();
     workflowInstanceKeyToCreationTimeMap.clear();
+    creationTimeToJobKeyNavigableMap.clear();
+    creationTimeToWorkflowInstanceKeyNavigableMap.clear();
   }
 
   @Override
@@ -125,6 +129,8 @@ public class MetricsExporter implements Exporter {
         deadTime,
         creationTimeToWorkflowInstanceKeyNavigableMap,
         workflowInstanceKeyToCreationTimeMap);
+
+    controller.scheduleTask(TIME_TO_LIVE, this::cleanUp);
   }
 
   private void clearMaps(


### PR DESCRIPTION
## Description

Schedule clean up periodically (fixes memory leak) and add a comment why we have the maps.
<!-- Please explain the changes you made here. -->

Created a benchmark to see differences:

![metrics](https://user-images.githubusercontent.com/2758593/99791035-4cf76c80-2b25-11eb-90bd-05abdc42cf9c.png)

I think looks better but will run it for longer.

Heap dump via jmap on benchmarks shows that map gets cleared.

**General**
![general](https://user-images.githubusercontent.com/2758593/99791083-61d40000-2b25-11eb-9617-2921f2cdb035.png)

**MetricsExporter**
![metricsExporter](https://user-images.githubusercontent.com/2758593/99791084-626c9680-2b25-11eb-818d-7c4cb500423c.png)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/5882

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
