### PR TITLE
[BACKPORT 0.25] handle failures during transitions

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -450,6 +450,13 @@ public interface RaftServer {
   CompletableFuture<Void> shutdown();
 
   /**
+   * Transitions the server to INACTIVE without shutting down or leaving the cluster.
+   *
+   * @return A completable future to be completed once the server is inactive.
+   */
+  CompletableFuture<Void> goInactive();
+
+  /**
    * Leaves the Raft cluster.
    *
    * @return A completable future to be completed once the server has left the cluster.

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -143,6 +143,18 @@ public class DefaultRaftServer implements RaftServer {
     return future;
   }
 
+  @Override
+  public CompletableFuture<Void> goInactive() {
+    final CompletableFuture<Void> future = new AtomixFuture<>();
+    context
+        .getThreadContext()
+        .execute(
+            () -> {
+              context.transition(Role.INACTIVE);
+              future.complete(null);
+            });
+    return future;
+  }
   /**
    * Leaves the Raft cluster.
    *

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -228,6 +228,10 @@ public class RaftPartition implements Partition {
     return server.stepDown();
   }
 
+  public CompletableFuture<Void> goInactive() {
+    return server.goInactive();
+  }
+
   private void onFailure() {
     CompletableFuture.allOf(
             raftFailureListeners.stream()

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -190,6 +190,10 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
     return server.leave();
   }
 
+  public CompletableFuture<Void> goInactive() {
+    return server.goInactive();
+  }
+
   /**
    * Takes a snapshot of the partition server.
    *

--- a/broker/src/main/java/io/zeebe/broker/PartitionListener.java
+++ b/broker/src/main/java/io/zeebe/broker/PartitionListener.java
@@ -38,4 +38,14 @@ public interface PartitionListener {
    * @return future that should be completed by the listener
    */
   ActorFuture<Void> onBecomingLeader(int partitionId, long term, LogStream logStream);
+
+  /**
+   * Is called by the {@link io.zeebe.broker.system.partitions.ZeebePartition} on becoming inactive
+   * after a Raft role change or a failed transition.
+   *
+   * @param partitionId the corresponding partition id
+   * @param term the current term
+   * @return future that should be completed by the listener
+   */
+  ActorFuture<Void> onBecomingInactive(int partitionId, long term);
 }

--- a/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/topology/TopologyManagerImpl.java
@@ -70,6 +70,11 @@ public final class TopologyManagerImpl extends Actor
   }
 
   @Override
+  public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+    return setInactive(partitionId);
+  }
+
+  @Override
   public String getName() {
     return actorName;
   }
@@ -100,6 +105,15 @@ public final class TopologyManagerImpl extends Actor
         () -> {
           removeIfLeader(localBroker, partitionId);
           localBroker.setFollowerForPartition(partitionId);
+          publishTopologyChanges();
+        });
+  }
+
+  public ActorFuture<Void> setInactive(final int partitionId) {
+    return actor.call(
+        () -> {
+          removeIfLeader(localBroker, partitionId);
+          localBroker.setInactiveForPartition(partitionId);
           publishTopologyChanges();
         });
   }

--- a/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
+++ b/broker/src/main/java/io/zeebe/broker/engine/impl/SubscriptionApiCommandMessageHandlerService.java
@@ -84,6 +84,15 @@ public final class SubscriptionApiCommandMessageHandlerService extends Actor
   }
 
   @Override
+  public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+    return actor.call(
+        () -> {
+          leaderPartitions.remove(partitionId);
+          return null;
+        });
+  }
+
+  @Override
   public void onDiskSpaceNotAvailable() {
     actor.call(
         () -> {

--- a/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/LeaderManagementRequestHandler.java
@@ -84,6 +84,15 @@ public final class LeaderManagementRequestHandler extends Actor
   }
 
   @Override
+  public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+    return actor.call(
+        () -> {
+          leaderForPartitions.remove(partitionId);
+          return null;
+        });
+  }
+
+  @Override
   public String getName() {
     return actorName;
   }

--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -22,6 +22,7 @@ import io.zeebe.util.health.HealthMonitorable;
 import io.zeebe.util.health.HealthStatus;
 import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -129,6 +130,11 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
   public ActorFuture<Void> onBecomingLeader(
       final int partitionId, final long term, final LogStream logStream) {
     return updateBrokerReadyStatus(partitionId);
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+    return CompletableActorFuture.completed(null);
   }
 
   private ActorFuture<Void> updateBrokerReadyStatus(final int partitionId) {

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/RaftLogReaderPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/RaftLogReaderPartitionStep.java
@@ -8,6 +8,7 @@
 package io.zeebe.broker.system.partitions.impl.steps;
 
 import io.atomix.storage.journal.JournalReader.Mode;
+import io.zeebe.broker.Loggers;
 import io.zeebe.broker.system.partitions.PartitionContext;
 import io.zeebe.broker.system.partitions.PartitionStep;
 import io.zeebe.util.sched.future.ActorFuture;
@@ -24,8 +25,15 @@ public class RaftLogReaderPartitionStep implements PartitionStep {
 
   @Override
   public ActorFuture<Void> close(final PartitionContext context) {
-    context.getRaftLogReader().close();
-    context.setRaftLogReader(null);
+    try {
+      context.getRaftLogReader().close();
+    } catch (final Exception e) {
+      Loggers.SYSTEM_LOGGER.error(
+          "Unexpected error closing Raft log reader for partition {}", context.getPartitionId(), e);
+    } finally {
+      context.setRaftLogReader(null);
+    }
+
     return CompletableActorFuture.completed(null);
   }
 

--- a/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiService.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/commandapi/CommandApiService.java
@@ -59,11 +59,7 @@ public final class CommandApiService extends Actor
 
   @Override
   public ActorFuture<Void> onBecomingFollower(final int partitionId, final long term) {
-    return actor.call(
-        () -> {
-          requestHandler.removePartition(partitionId);
-          cleanLeadingPartition(partitionId);
-        });
+    return removeLeaderHandlersAsync(partitionId);
   }
 
   @Override
@@ -95,6 +91,19 @@ public final class CommandApiService extends Actor
                   });
         });
     return future;
+  }
+
+  @Override
+  public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+    return removeLeaderHandlersAsync(partitionId);
+  }
+
+  private ActorFuture<Void> removeLeaderHandlersAsync(final int partitionId) {
+    return actor.call(
+        () -> {
+          requestHandler.removePartition(partitionId);
+          cleanLeadingPartition(partitionId);
+        });
   }
 
   private void cleanLeadingPartition(final int partitionId) {

--- a/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
+++ b/broker/src/test/java/io/zeebe/broker/SimpleBrokerStartTest.java
@@ -96,6 +96,11 @@ public final class SimpleBrokerStartTest {
             leaderLatch.countDown();
             return CompletableActorFuture.completed(null);
           }
+
+          @Override
+          public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+            return CompletableActorFuture.completed(null);
+          }
         });
 
     // when

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -7,6 +7,8 @@
  */
 package io.zeebe.broker.system.partitions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -19,9 +21,13 @@ import io.zeebe.util.health.CriticalComponentsHealthMonitor;
 import io.zeebe.util.sched.future.ActorFuture;
 import io.zeebe.util.sched.future.CompletableActorFuture;
 import io.zeebe.util.sched.testing.ControlledActorSchedulerRule;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.InOrder;
 
 public class ZeebePartitionTest {
 
@@ -29,20 +35,21 @@ public class ZeebePartitionTest {
 
   private PartitionContext ctx;
   private PartitionTransition transition;
+  private RaftPartition raft;
 
   @Before
   public void setup() {
     ctx = mock(PartitionContext.class);
     transition = spy(new NoopTransition());
 
-    final RaftPartition raftPartition = mock(RaftPartition.class);
-    when(raftPartition.id()).thenReturn(new PartitionId("", 0));
-    when(raftPartition.getRole()).thenReturn(Role.INACTIVE);
+    raft = mock(RaftPartition.class);
+    when(raft.id()).thenReturn(new PartitionId("", 0));
+    when(raft.getRole()).thenReturn(Role.INACTIVE);
 
     final CriticalComponentsHealthMonitor healthMonitor =
         mock(CriticalComponentsHealthMonitor.class);
 
-    when(ctx.getRaftPartition()).thenReturn(raftPartition);
+    when(ctx.getRaftPartition()).thenReturn(raft);
     when(ctx.getComponentHealthMonitor()).thenReturn(healthMonitor);
   }
 
@@ -58,6 +65,76 @@ public class ZeebePartitionTest {
 
     // then
     verify(transition).toLeader();
+  }
+
+  @Test()
+  public void shouldStepDownAfterFailedLeaderTransition() throws InterruptedException {
+    // given
+    final ZeebePartition partition = new ZeebePartition(ctx, transition);
+    schedulerRule.submitActor(partition);
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    when(transition.toLeader())
+        .thenReturn(CompletableActorFuture.completedExceptionally(new Exception("expected")));
+    when(transition.toFollower())
+        .then(
+            invocation -> {
+              latch.countDown();
+              return CompletableActorFuture.completed(null);
+            });
+    when(raft.getRole()).thenReturn(Role.LEADER);
+    when(raft.stepDown())
+        .then(
+            invocation -> {
+              partition.onNewRole(Role.FOLLOWER, 2);
+              return CompletableFuture.completedFuture(null);
+            });
+
+    // when
+    partition.onNewRole(Role.LEADER, 1);
+    schedulerRule.workUntilDone();
+    assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+
+    // then
+    final InOrder order = inOrder(transition, raft);
+    order.verify(transition).toLeader();
+    order.verify(raft).stepDown();
+    order.verify(transition).toFollower();
+  }
+
+  @Test
+  public void shouldGoInactiveAfterFailedFollowerTransition() throws InterruptedException {
+    // given
+    final ZeebePartition partition = new ZeebePartition(ctx, transition);
+    schedulerRule.submitActor(partition);
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    when(transition.toFollower())
+        .thenReturn(CompletableActorFuture.completedExceptionally(new Exception("expected")));
+    when(transition.toInactive())
+        .then(
+            invocation -> {
+              latch.countDown();
+              return CompletableActorFuture.completed(null);
+            });
+    when(raft.getRole()).thenReturn(Role.FOLLOWER);
+    when(raft.goInactive())
+        .then(
+            invocation -> {
+              partition.onNewRole(Role.INACTIVE, 2);
+              return CompletableFuture.completedFuture(null);
+            });
+
+    // when
+    partition.onNewRole(Role.FOLLOWER, 1);
+    schedulerRule.workUntilDone();
+    assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+
+    // then
+    final InOrder order = inOrder(transition, raft);
+    order.verify(transition).toFollower();
+    order.verify(raft).goInactive();
+    order.verify(transition).toInactive();
   }
 
   private static class NoopTransition implements PartitionTransition {

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/ZeebePartitionTransitionIntegrationTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/ZeebePartitionTransitionIntegrationTest.java
@@ -15,9 +15,8 @@ import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.zeebe.broker.system.partitions.impl.PartitionTransitionImpl;
+import io.zeebe.broker.system.partitions.impl.TestPartitionStep;
 import io.zeebe.util.health.CriticalComponentsHealthMonitor;
-import io.zeebe.util.sched.future.ActorFuture;
-import io.zeebe.util.sched.future.CompletableActorFuture;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.util.List;
 import org.junit.Before;
@@ -36,8 +35,8 @@ public class ZeebePartitionTransitionIntegrationTest {
   @Before
   public void setup() {
     ctx = mock(PartitionContext.class);
-    final NoopPartitionStep firstComponent = spy(new NoopPartitionStep());
-    final NoopPartitionStep secondComponent = spy(new NoopPartitionStep());
+    final TestPartitionStep firstComponent = spy(TestPartitionStep.builder().build());
+    final TestPartitionStep secondComponent = spy(TestPartitionStep.builder().build());
     transition =
         spy(new PartitionTransitionImpl(ctx, List.of(firstComponent), List.of(secondComponent)));
 
@@ -69,23 +68,5 @@ public class ZeebePartitionTransitionIntegrationTest {
     inOrder.verify(transition).toLeader();
     inOrder.verify(transition).toFollower();
     inOrder.verify(transition).toInactive();
-  }
-
-  private static class NoopPartitionStep implements PartitionStep {
-
-    @Override
-    public ActorFuture<Void> open(final PartitionContext context) {
-      return CompletableActorFuture.completed(null);
-    }
-
-    @Override
-    public ActorFuture<Void> close(final PartitionContext context) {
-      return CompletableActorFuture.completed(null);
-    }
-
-    @Override
-    public String getName() {
-      return "NoopComponent";
-    }
   }
 }

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/TestPartitionStep.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/TestPartitionStep.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.partitions.impl;
+
+import io.zeebe.broker.system.partitions.PartitionContext;
+import io.zeebe.broker.system.partitions.PartitionStep;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
+
+public final class TestPartitionStep implements PartitionStep {
+  private final boolean failOpen;
+  private final boolean failClose;
+
+  private TestPartitionStep(final boolean failOpen, final boolean failClose) {
+    this.failOpen = failOpen;
+    this.failClose = failClose;
+  }
+
+  @Override
+  public ActorFuture<Void> open(final PartitionContext context) {
+    return failOpen
+        ? CompletableActorFuture.completedExceptionally(new Exception("expected"))
+        : CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public ActorFuture<Void> close(final PartitionContext context) {
+    return failClose
+        ? CompletableActorFuture.completedExceptionally(new Exception("expected"))
+        : CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public String getName() {
+    return "TestPartitionStep";
+  }
+
+  public static TestPartitionStepBuilder builder() {
+    return new TestPartitionStepBuilder();
+  }
+
+  public static class TestPartitionStepBuilder {
+    private boolean failOpen;
+    private boolean failClose;
+
+    public TestPartitionStepBuilder failOnOpen() {
+      failOpen = true;
+      return this;
+    }
+
+    public TestPartitionStepBuilder failOnClose() {
+      failClose = true;
+      return this;
+    }
+
+    public TestPartitionStep build() {
+      return new TestPartitionStep(failOpen, failClose);
+    }
+  }
+}

--- a/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -303,5 +303,10 @@ public final class EmbeddedBrokerRule extends ExternalResource {
       latch.countDown();
       return CompletableActorFuture.completed(null);
     }
+
+    @Override
+    public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+      return CompletableActorFuture.completed(null);
+    }
   }
 }

--- a/broker/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/broker/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/gateway/src/main/java/io/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicator.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicator.java
@@ -37,12 +37,9 @@ public class PartitionLeaderAwarenessHealthIndicator implements HealthIndicator 
     } else {
       final var clusterState = optClusterState.get();
       if (clusterState.getPartitions().stream()
-          .filter(
-              index -> {
-                return clusterState.getLeaderForPartition(index) != BrokerClusterState.NODE_ID_NULL;
-              })
-          .findAny()
-          .isPresent()) {
+          .anyMatch(
+              index ->
+                  clusterState.getLeaderForPartition(index) != BrokerClusterState.NODE_ID_NULL)) {
         return Health.up().build();
       } else {
         return Health.down().build();

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -222,6 +222,11 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
     return addPartitionRole(partitionId, PartitionRole.LEADER);
   }
 
+  public BrokerInfo setInactiveForPartition(final int partitionId) {
+    partitionLeaderTerms.remove(partitionId);
+    return addPartitionRole(partitionId, PartitionRole.INACTIVE);
+  }
+
   // TODO: This will be fixed in the https://github.com/zeebe-io/zeebe/issues/5640
   @SuppressWarnings("squid:S138")
   @Override

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -55,6 +55,7 @@
     <enum name="PartitionRole" encodingType="uint8">
       <validValue name="LEADER">0</validValue>
       <validValue name="FOLLOWER">1</validValue>
+      <validValue name="INACTIVE">2</validValue>
     </enum>
 
     <enum name="PartitionHealthStatus" encodingType="uint8">

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/BrokerFailedLeaderChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/BrokerFailedLeaderChangeTest.java
@@ -109,5 +109,10 @@ public class BrokerFailedLeaderChangeTest {
         final int partitionId, final long term, final LogStream logStream) {
       return new CompletableActorFuture<>();
     }
+
+    @Override
+    public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+      return CompletableActorFuture.completed(null);
+    }
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -763,5 +763,10 @@ public final class ClusteringRule extends ExternalResource {
       partitionLeader.put(partitionId, new Leader(nodeId, term, logStream));
       return CompletableActorFuture.completed(null);
     }
+
+    @Override
+    public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+      return CompletableActorFuture.completed(null);
+    }
   }
 }

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRestartTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerRestartTest.java
@@ -88,5 +88,10 @@ public class BrokerRestartTest {
       this.logStream = logStream;
       return CompletableActorFuture.completed(null);
     }
+
+    @Override
+    public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+      return CompletableActorFuture.completed(null);
+    }
   }
 }

--- a/test/src/main/java/io/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/zeebe/test/EmbeddedBrokerRule.java
@@ -296,5 +296,10 @@ public class EmbeddedBrokerRule extends ExternalResource {
       latch.countDown();
       return CompletableActorFuture.completed(null);
     }
+
+    @Override
+    public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
+      return CompletableActorFuture.completed(null);
+    }
   }
 }


### PR DESCRIPTION
## Description

We've seen nodes get stuck in invalid states because of errors during role transitions. This PR makes improves handling of these failures by:

ensuring that all steps are closed even if one of them fails (nothing is gained by leaving some pieces of state open)
partition listeners are notified if a transition fails or if the partition transitions to inactive (we want to close things like the commandApiService even if the follower wasn't successfully installed)
if an error occurs during the closing part of a transition, we still try to install the new partition (some closing failures are expected in which case we shouldn't prevent the install)
if an error occurs while trying to install the leader partition, we step down to follower
if an error occurs while trying to install the follower partition, we become inactive
## Related issues

<!-- Which issues are closed by this PR or are related -->
related #5117
related #5291

backports #5813

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
