### PR TITLE
Improve reliability of UpdateTest suite

### DIFF
--- a/update-tests/src/test/java/io/zeebe/test/UpdateTest.java
+++ b/update-tests/src/test/java/io/zeebe/test/UpdateTest.java
@@ -67,14 +67,14 @@ class UpdateTest {
   @Timeout(value = 5, unit = TimeUnit.MINUTES)
   @ParameterizedTest(name = "{0}")
   @ArgumentsSource(UpdateTestCaseProvider.class)
-  void upgradeWithSnapshot(final String name, final UpdateTestCase testCase) {
+  void updateWithSnapshot(final String name, final UpdateTestCase testCase) {
     updateZeebe(testCase, true);
   }
 
   @Timeout(value = 5, unit = TimeUnit.MINUTES)
   @ParameterizedTest(name = "{0}")
   @ArgumentsSource(UpdateTestCaseProvider.class)
-  void upgradeWithoutSnapshot(final String name, final UpdateTestCase testCase) {
+  void updateWithoutSnapshot(final String name, final UpdateTestCase testCase) {
     updateZeebe(testCase, false);
   }
 


### PR DESCRIPTION
## Description

This PR aims to improve the reliability of the `UpdateTest` suite by dropping the use of `TestUtil` in favour of `Awaitility`. I believe it will help as `TestUtil` is retry based - it will retry up to X amount of times, and fail. If your callable is fast, then this means it may wait for a very short amount of time before stopping. If you look at the past failures, this is essentially what was happening - we weren't waiting long enough for the logs to be printed out and consumed. Switching to Awaitility improves on this by allowing us to specify a time out, how often the callable should be called, and also helps provide more context when it fails (`TestUtil` essentially returns "true" or "false").

## Related issues

closes #5804
closes #5894 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
