### PR TITLE
Endpoint to pause and resume exporting

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -29,6 +29,7 @@ import io.zeebe.util.sched.ActorCondition;
 import io.zeebe.util.sched.ActorScheduler;
 import io.zeebe.util.sched.SchedulingHints;
 import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -62,8 +63,10 @@ public final class ExporterDirector extends Actor {
 
   private ActorCondition onCommitPositionUpdatedCondition;
   private boolean inExportingPhase;
+  private boolean isPaused;
+  private ExporterPhase exporterPhase;
 
-  public ExporterDirector(final ExporterDirectorContext context) {
+  public ExporterDirector(final ExporterDirectorContext context, final boolean shouldPauseOnStart) {
     name = context.getName();
     containers =
         context.getDescriptors().stream().map(ExporterContainer::new).collect(Collectors.toList());
@@ -75,6 +78,7 @@ public final class ExporterDirector extends Actor {
     exportingRetryStrategy = new BackOffRetryStrategy(actor, Duration.ofSeconds(10));
     recordWrapStrategy = new EndlessRetryStrategy(actor);
     zeebeDb = context.getZeebeDb();
+    isPaused = shouldPauseOnStart;
   }
 
   public ActorFuture<Void> startAsync(final ActorScheduler actorScheduler) {
@@ -83,6 +87,32 @@ public final class ExporterDirector extends Actor {
 
   public ActorFuture<Void> stopAsync() {
     return actor.close();
+  }
+
+  public ActorFuture<Void> pauseExporting() {
+    return actor.call(
+        () -> {
+          isPaused = true;
+          exporterPhase = ExporterPhase.PAUSED;
+          return;
+        });
+  }
+
+  public ActorFuture<Void> resumeExporting() {
+    return actor.call(
+        () -> {
+          isPaused = false;
+          exporterPhase = ExporterPhase.EXPORTING;
+          actor.submit(this::readNextEvent);
+          return;
+        });
+  }
+
+  public ActorFuture<ExporterPhase> getPhase() {
+    if (actor.isClosed()) {
+      return CompletableActorFuture.completed(ExporterPhase.CLOSED);
+    }
+    return actor.call(() -> exporterPhase);
   }
 
   @Override
@@ -146,6 +176,7 @@ public final class ExporterDirector extends Actor {
   @Override
   protected void onActorClosed() {
     LOG.debug("Closed exporter director '{}'.", getName());
+    exporterPhase = ExporterPhase.CLOSED;
   }
 
   @Override
@@ -212,7 +243,13 @@ public final class ExporterDirector extends Actor {
     clearExporterState();
 
     if (state.hasExporters()) {
-      actor.submit(this::readNextEvent);
+      if (!isPaused) {
+        exporterPhase = ExporterPhase.EXPORTING;
+        actor.submit(this::readNextEvent);
+      } else {
+        exporterPhase = ExporterPhase.PAUSED;
+      }
+
     } else {
       actor.close();
     }
@@ -235,7 +272,7 @@ public final class ExporterDirector extends Actor {
   }
 
   private void readNextEvent() {
-    if (isOpened.get() && logStreamReader.hasNext() && !inExportingPhase) {
+    if (shouldExport()) {
       final LoggedEvent currentEvent = logStreamReader.next();
       if (eventFilter == null || eventFilter.applies(currentEvent)) {
         inExportingPhase = true;
@@ -244,6 +281,10 @@ public final class ExporterDirector extends Actor {
         skipRecord(currentEvent);
       }
     }
+  }
+
+  private boolean shouldExport() {
+    return isOpened.get() && logStreamReader.hasNext() && !inExportingPhase && !isPaused;
   }
 
   private void exportEvent(final LoggedEvent event) {

--- a/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterPhase.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/stream/ExporterPhase.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.exporter.stream;
+
+public enum ExporterPhase {
+  EXPORTING,
+  PAUSED,
+  CLOSED
+}

--- a/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminService.java
@@ -17,6 +17,12 @@ public interface BrokerAdminService {
   /** Request a partition to resume its StreamProcessor */
   void resumeStreamProcessing();
 
+  /** Request a partition to pause exporting */
+  void pauseExporting();
+
+  /** Request a partition to resume exporting */
+  void resumeExporting();
+
   /**
    * Trigger a snapshot. Partition will attempt to take a snapshot instead of waiting for the
    * snapshot interval.

--- a/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminServiceEndpoint.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminServiceEndpoint.java
@@ -30,6 +30,8 @@ public class BrokerAdminServiceEndpoint {
     operations.put("resumeProcessing", this::resumeProcessing);
     operations.put("takeSnapshot", this::takeSnapshot);
     operations.put("prepareUpgrade", this::prepareUpgrade);
+    operations.put("pauseExporting", this::pauseExporting);
+    operations.put("resumeExporting", this::resumeExporting);
   }
 
   @WriteOperation
@@ -50,6 +52,16 @@ public class BrokerAdminServiceEndpoint {
 
   private Map<Integer, PartitionStatus> resumeProcessing() {
     springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::resumeStreamProcessing);
+    return partitionStatus();
+  }
+
+  private Map<Integer, PartitionStatus> pauseExporting() {
+    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::pauseExporting);
+    return partitionStatus();
+  }
+
+  private Map<Integer, PartitionStatus> resumeExporting() {
+    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::resumeExporting);
     return partitionStatus();
   }
 

--- a/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminServiceImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/BrokerAdminServiceImpl.java
@@ -8,18 +8,21 @@
 package io.zeebe.broker.system.management;
 
 import io.zeebe.broker.Loggers;
+import io.zeebe.broker.exporter.stream.ExporterDirector;
 import io.zeebe.broker.system.partitions.ZeebePartition;
 import io.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.zeebe.snapshots.broker.impl.FileBasedSnapshotMetadata;
 import io.zeebe.snapshots.raft.PersistedSnapshot;
 import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.future.ActorFuture;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 
 /**
@@ -44,7 +47,17 @@ public class BrokerAdminServiceImpl extends Actor implements BrokerAdminService 
 
   @Override
   public void resumeStreamProcessing() {
-    actor.call(this::unpauseStreamProcessingOnAllPartitions);
+    actor.call(this::resumeStreamProcessingOnAllPartitions);
+  }
+
+  @Override
+  public void pauseExporting() {
+    actor.call(this::pauseExportingOnAllPartitions);
+  }
+
+  @Override
+  public void resumeExporting() {
+    actor.call(this::resumeExportingOnAllPartitions);
   }
 
   @Override
@@ -83,17 +96,24 @@ public class BrokerAdminServiceImpl extends Actor implements BrokerAdminService 
 
   private CompletableFuture<PartitionStatus> getPartitionStatus(final ZeebePartition partition) {
     final CompletableFuture<PartitionStatus> partitionStatus = new CompletableFuture<>();
-    getStreamProcessor(partition)
-        .onComplete(
-            (streamProcessor, throwable) -> {
-              if (throwable != null) {
-                partitionStatus.completeExceptionally(throwable);
-                return;
-              }
-              streamProcessor.ifPresentOrElse(
-                  sp -> getLeaderPartitionStatus(partition, sp, partitionStatus),
-                  () -> getFollowerPartitionStatus(partition, partitionStatus));
-            });
+    final var streamProcessorFuture = partition.getStreamProcessor();
+    final var exporterDirectorFuture = partition.getExporterDirector();
+    actor.runOnCompletion(
+        List.of((ActorFuture) streamProcessorFuture, (ActorFuture) exporterDirectorFuture),
+        error -> {
+          if (error != null) {
+            partitionStatus.completeExceptionally(error);
+            return;
+          }
+          final var streamProcessor = streamProcessorFuture.join();
+          final var exporterDirector = exporterDirectorFuture.join();
+          if (streamProcessor.isPresent() && exporterDirector.isPresent()) {
+            getLeaderPartitionStatus(
+                partition, streamProcessor.get(), exporterDirector.get(), partitionStatus);
+          } else {
+            getFollowerPartitionStatus(partition, partitionStatus);
+          }
+        });
     return partitionStatus;
   }
 
@@ -107,38 +127,42 @@ public class BrokerAdminServiceImpl extends Actor implements BrokerAdminService 
   private void getLeaderPartitionStatus(
       final ZeebePartition partition,
       final StreamProcessor streamProcessor,
+      final ExporterDirector exporterDirector,
       final CompletableFuture<PartitionStatus> partitionStatus) {
+
     final var positionFuture = streamProcessor.getLastProcessedPositionAsync();
-    positionFuture.onComplete(
-        (processedPosition, positionRetrieveError) -> {
-          if (positionRetrieveError != null) {
-            partitionStatus.completeExceptionally(positionRetrieveError);
+    final var currentPhaseFuture = streamProcessor.getCurrentPhase();
+    final var exporterPhaseFuture = exporterDirector.getPhase();
+    final var exporterPosition = exporterDirector.getState().getLowestPosition();
+    final var snapshotId = getSnapshotId(partition);
+    final var processedPositionInSnapshot =
+        snapshotId
+            .flatMap(FileBasedSnapshotMetadata::ofFileName)
+            .map(FileBasedSnapshotMetadata::getProcessedPosition)
+            .orElse(null);
+
+    actor.runOnCompletion(
+        List.of(
+            (ActorFuture) positionFuture,
+            (ActorFuture) currentPhaseFuture,
+            (ActorFuture) exporterPhaseFuture),
+        error -> {
+          if (error != null) {
+            partitionStatus.completeExceptionally(error);
             return;
           }
-
-          streamProcessor
-              .getCurrentPhase()
-              .onComplete(
-                  (phase, phaseError) -> {
-                    if (phaseError != null) {
-                      partitionStatus.completeExceptionally(phaseError);
-                      return;
-                    }
-
-                    final var snapshotId = getSnapshotId(partition);
-                    final var processedPositionInSnapshot =
-                        snapshotId
-                            .flatMap(s -> FileBasedSnapshotMetadata.ofFileName(s))
-                            .map(FileBasedSnapshotMetadata::getProcessedPosition)
-                            .orElse(null);
-                    final var status =
-                        PartitionStatus.ofLeader(
-                            processedPosition,
-                            snapshotId.orElse(null),
-                            processedPositionInSnapshot,
-                            phase);
-                    partitionStatus.complete(status);
-                  });
+          final var processedPosition = positionFuture.join();
+          final var processorPhase = currentPhaseFuture.join();
+          final var exporterPhase = exporterPhaseFuture.join();
+          final var status =
+              PartitionStatus.ofLeader(
+                  processedPosition,
+                  snapshotId.orElse(null),
+                  processedPositionInSnapshot,
+                  processorPhase,
+                  exporterPhase,
+                  exporterPosition);
+          partitionStatus.complete(status);
         });
   }
 
@@ -146,17 +170,17 @@ public class BrokerAdminServiceImpl extends Actor implements BrokerAdminService 
     return partition.getSnapshotStore().getLatestSnapshot().map(PersistedSnapshot::getId);
   }
 
-  private ActorFuture<Optional<StreamProcessor>> getStreamProcessor(
-      final ZeebePartition partition) {
-    return partition.getStreamProcessor();
-  }
-
   private void prepareAllPartitionsForSafeUpgrade() {
     LOG.info("Preparing for safe upgrade.");
 
-    final var pauseCompleted = pauseStreamProcessingOnAllPartitions();
+    final var pauseProcessingCompleted = pauseStreamProcessingOnAllPartitions();
+    final var pauseExportingCompleted = pauseExportingOnAllPartitions();
+    final var pauseAll =
+        Stream.of(pauseProcessingCompleted, pauseExportingCompleted)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
 
-    actor.runOnCompletion(pauseCompleted, t -> takeSnapshotOnAllPartitions(partitions));
+    actor.runOnCompletion(pauseAll, t -> takeSnapshotOnAllPartitions(partitions));
   }
 
   private List<ActorFuture<Void>> pauseStreamProcessingOnAllPartitions() {
@@ -164,7 +188,7 @@ public class BrokerAdminServiceImpl extends Actor implements BrokerAdminService 
     return partitions.stream().map(ZeebePartition::pauseProcessing).collect(Collectors.toList());
   }
 
-  private void unpauseStreamProcessingOnAllPartitions() {
+  private void resumeStreamProcessingOnAllPartitions() {
     LOG.info("Resuming paused StreamProcessor on all partitions.");
     partitions.forEach(ZeebePartition::resumeProcessing);
   }
@@ -172,5 +196,15 @@ public class BrokerAdminServiceImpl extends Actor implements BrokerAdminService 
   private void takeSnapshotOnAllPartitions(final List<ZeebePartition> partitions) {
     LOG.info("Triggering Snapshots on all partitions.");
     partitions.forEach(ZeebePartition::triggerSnapshot);
+  }
+
+  private List<ActorFuture<Void>> pauseExportingOnAllPartitions() {
+    LOG.info("Pausing exporting on all partitions.");
+    return partitions.stream().map(ZeebePartition::pauseExporting).collect(Collectors.toList());
+  }
+
+  private void resumeExportingOnAllPartitions() {
+    LOG.info("Resuming exporting on all partitions.");
+    partitions.forEach(ZeebePartition::resumeExporting);
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/management/PartitionStatus.java
+++ b/broker/src/main/java/io/zeebe/broker/system/management/PartitionStatus.java
@@ -8,47 +8,55 @@
 package io.zeebe.broker.system.management;
 
 import io.atomix.raft.RaftServer.Role;
+import io.zeebe.broker.exporter.stream.ExporterPhase;
 import io.zeebe.engine.processing.streamprocessor.StreamProcessor.Phase;
 
 public final class PartitionStatus {
 
   private final Role role;
   private final String snapshotId;
-
   private final Long processedPosition;
-
   private final Long processedPositionInSnapshot;
-
   private final Phase streamProcessorPhase;
+  private final ExporterPhase exporterPhase;
+  private final Long exportedPosition;
 
   private PartitionStatus(
       final Role role,
       final Long processedPosition,
       final String snapshotId,
       final Long processedPositionInSnapshot,
-      final Phase streamProcessorPhase) {
+      final Phase streamProcessorPhase,
+      final ExporterPhase exporterPhase,
+      final Long exportedPosition) {
     this.role = role;
     this.processedPosition = processedPosition;
     this.snapshotId = snapshotId;
     this.processedPositionInSnapshot = processedPositionInSnapshot;
     this.streamProcessorPhase = streamProcessorPhase;
+    this.exporterPhase = exporterPhase;
+    this.exportedPosition = exportedPosition;
   }
 
   public static PartitionStatus ofLeader(
       final Long processedPosition,
       final String snapshotId,
       final Long processedPositionInSnapshot,
-      final Phase streamProcessorPhase) {
+      final Phase streamProcessorPhase,
+      final ExporterPhase exporterPhase,
+      final long exportedPosition) {
     return new PartitionStatus(
         Role.LEADER,
         processedPosition,
         snapshotId,
         processedPositionInSnapshot,
-        streamProcessorPhase);
+        streamProcessorPhase,
+        exporterPhase,
+        exportedPosition);
   }
 
   public static PartitionStatus ofFollower(final String snapshotId) {
-    return new PartitionStatus(Role.FOLLOWER, null, snapshotId, null, null);
+    return new PartitionStatus(Role.FOLLOWER, null, snapshotId, null, null, null, null);
   }
 
   public Role getRole() {
@@ -69,5 +77,13 @@ public final class PartitionStatus {
 
   public Phase getStreamProcessorPhase() {
     return streamProcessorPhase;
+  }
+
+  public ExporterPhase getExporterPhase() {
+    return exporterPhase;
+  }
+
+  public Long getExportedPosition() {
+    return exportedPosition;
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/PartitionContext.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/PartitionContext.java
@@ -266,11 +266,23 @@ public class PartitionContext {
     return partitionProcessingState.shouldProcess();
   }
 
+  public boolean shouldExport() {
+    return !partitionProcessingState.isExportingPaused();
+  }
+
   public void pauseProcessing() throws IOException {
     partitionProcessingState.pauseProcessing();
   }
 
   public void resumeProcessing() throws IOException {
     partitionProcessingState.resumeProcessing();
+  }
+
+  public boolean pauseExporting() throws IOException {
+    return partitionProcessingState.pauseExporting();
+  }
+
+  public boolean resumeExporting() throws IOException {
+    return partitionProcessingState.resumeExporting();
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
@@ -32,7 +32,7 @@ public class ExporterDirectorPartitionStep implements PartitionStep {
             .zeebeDb(context.getZeebeDb())
             .descriptors(exporterDescriptors);
 
-    final ExporterDirector director = new ExporterDirector(exporterCtx);
+    final ExporterDirector director = new ExporterDirector(exporterCtx, !context.shouldExport());
     context.setExporterDirector(director);
     return director.startAsync(context.getScheduler());
   }

--- a/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterRule.java
@@ -79,7 +79,7 @@ public final class ExporterRule implements TestRule {
             .zeebeDb(capturedZeebeDb)
             .descriptors(exporterDescriptors);
 
-    director = new ExporterDirector(context);
+    director = new ExporterDirector(context, false);
     director.startAsync(actorSchedulerRule.get()).join();
   }
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/system/BrokerAdminServiceWithOutExporterTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/system/BrokerAdminServiceWithOutExporterTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.system;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.raft.RaftServer.Role;
+import io.zeebe.broker.exporter.stream.ExporterPhase;
+import io.zeebe.broker.it.clustering.ClusteringRule;
+import io.zeebe.engine.processing.streamprocessor.StreamProcessor.Phase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+
+public class BrokerAdminServiceWithOutExporterTest {
+  private final Timeout testTimeout = Timeout.seconds(60);
+  private final ClusteringRule clusteringRule =
+      new ClusteringRule(1, 1, 1, cfg -> cfg.getExporters().clear());
+
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(testTimeout).around(clusteringRule);
+
+  @Test
+  public void shouldReportStatusWhenNoExporters() {
+    // given
+    final var leader =
+        clusteringRule.getBroker(clusteringRule.getLeaderForPartition(1).getNodeId());
+    final var leaderAdminService = leader.getBrokerAdminService();
+    // when there are no exporters configured
+    // then
+    final var partitionStatus = leaderAdminService.getPartitionStatus().get(1);
+    assertThat(partitionStatus.getRole()).isEqualTo(Role.LEADER);
+    assertThat(partitionStatus.getProcessedPosition()).isEqualTo(-1);
+    assertThat(partitionStatus.getSnapshotId()).isNull();
+    assertThat(partitionStatus.getProcessedPositionInSnapshot()).isNull();
+    assertThat(partitionStatus.getStreamProcessorPhase()).isEqualTo(Phase.PROCESSING);
+    assertThat(partitionStatus.getExporterPhase()).isEqualTo(ExporterPhase.CLOSED);
+    assertThat(partitionStatus.getExportedPosition()).isEqualTo(-1);
+  }
+}

--- a/update-tests/src/test/java/io/zeebe/test/PartitionsActuatorClient.java
+++ b/update-tests/src/test/java/io/zeebe/test/PartitionsActuatorClient.java
@@ -79,5 +79,7 @@ public final class PartitionsActuatorClient {
     public Long processedPosition;
     public Long processedPositionInSnapshot;
     public String streamProcessorPhase;
+    public Long exportedPosition;
+    public String exporterPhase;
   }
 }


### PR DESCRIPTION
## Description

* Pause/Resume exporter via admin endpoint
* Include exporter state in partition status returned by admin endpoint

## Related issues

closes #5902 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
