### PR TITLE
[Backport 0.25] Introduce new update test build agent

### DIFF
--- a/.ci/podSpecs/distribution.yml
+++ b/.ci/podSpecs/distribution.yml
@@ -26,10 +26,10 @@ spec:
       resources:
         limits:
           cpu: 12
-          memory: 24Gi
+          memory: 32Gi
         requests:
           cpu: 8
-          memory: 16Gi
+          memory: 24Gi
       securityContext:
         privileged: true
     - name: maven-jdk8
@@ -61,7 +61,7 @@ spec:
       tty: true
       resources:
         limits:
-          cpu: 6
+          cpu: 8
           memory: 12Gi
         requests:
           cpu: 4

--- a/.ci/podSpecs/distribution.yml
+++ b/.ci/podSpecs/distribution.yml
@@ -25,11 +25,11 @@ spec:
           value: tcp://localhost:2375
       resources:
         limits:
-          cpu: 12
+          cpu: 8
           memory: 32Gi
         requests:
           cpu: 8
-          memory: 24Gi
+          memory: 32Gi
       securityContext:
         privileged: true
     - name: maven-jdk8
@@ -48,8 +48,8 @@ spec:
           value: tcp://localhost:2375
       resources:
         limits:
-          cpu: 4
-          memory: 8Gi
+          cpu: 2
+          memory: 4Gi
         requests:
           cpu: 2
           memory: 4Gi
@@ -61,8 +61,8 @@ spec:
       tty: true
       resources:
         limits:
-          cpu: 8
-          memory: 12Gi
+          cpu: 4
+          memory: 8Gi
         requests:
           cpu: 4
           memory: 8Gi
@@ -86,8 +86,8 @@ spec:
       tty: true
       resources:
         limits:
-          cpu: 12
-          memory: 24Gi
+          cpu: 8
+          memory: 16Gi
         requests:
           cpu: 8
           memory: 16Gi

--- a/.ci/podSpecs/distribution.yml
+++ b/.ci/podSpecs/distribution.yml
@@ -25,11 +25,11 @@ spec:
           value: tcp://localhost:2375
       resources:
         limits:
-          cpu: 8
-          memory: 8Gi
+          cpu: 12
+          memory: 24Gi
         requests:
-          cpu: 8
-          memory: 8Gi
+          cpu: 10
+          memory: 16Gi
       securityContext:
         privileged: true
     - name: maven-jdk8
@@ -48,8 +48,8 @@ spec:
           value: tcp://localhost:2375
       resources:
         limits:
-          cpu: 2
-          memory: 4Gi
+          cpu: 4
+          memory: 8Gi
         requests:
           cpu: 2
           memory: 4Gi
@@ -61,11 +61,11 @@ spec:
       tty: true
       resources:
         limits:
-          cpu: 4
-          memory: 4Gi
+          cpu: 6
+          memory: 12Gi
         requests:
           cpu: 4
-          memory: 4Gi
+          memory: 8Gi
       env:
         - name: DOCKER_HOST
           value: tcp://localhost:2375
@@ -86,8 +86,8 @@ spec:
       tty: true
       resources:
         limits:
-          cpu: 8
-          memory: 8Gi
+          cpu: 12
+          memory: 24Gi
         requests:
           cpu: 8
-          memory: 8Gi
+          memory: 16Gi

--- a/.ci/podSpecs/distribution.yml
+++ b/.ci/podSpecs/distribution.yml
@@ -28,7 +28,7 @@ spec:
           cpu: 12
           memory: 24Gi
         requests:
-          cpu: 10
+          cpu: 8
           memory: 16Gi
       securityContext:
         privileged: true

--- a/.ci/podSpecs/integration-test.yml
+++ b/.ci/podSpecs/integration-test.yml
@@ -26,49 +26,10 @@ spec:
       resources:
         limits:
           cpu: 8
-          memory: 8Gi
+          memory: 16Gi
         requests:
           cpu: 8
-          memory: 8Gi
-      securityContext:
-        privileged: true
-    - name: maven-jdk8
-      image: maven:3.6.3-jdk-8
-      command: ["cat"]
-      tty: true
-      env:
-        - name: LIMITS_CPU
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: JAVA_TOOL_OPTIONS
-          value: |
-            -XX:+UseContainerSupport
-        - name: DOCKER_HOST
-          value: tcp://localhost:2375
-      resources:
-        limits:
-          cpu: 2
-          memory: 4Gi
-        requests:
-          cpu: 2
-          memory: 4Gi
-      securityContext:
-        privileged: true
-    - name: golang
-      image: golang:1.13.4
-      command: ["cat"]
-      tty: true
-      resources:
-        limits:
-          cpu: 4
-          memory: 4Gi
-        requests:
-          cpu: 4
-          memory: 4Gi
-      env:
-        - name: DOCKER_HOST
-          value: tcp://localhost:2375
+          memory: 16Gi
       securityContext:
         privileged: true
     - name: docker

--- a/.ci/podSpecs/integration-test.yml
+++ b/.ci/podSpecs/integration-test.yml
@@ -25,11 +25,11 @@ spec:
           value: tcp://localhost:2375
       resources:
         limits:
-          cpu: 12
+          cpu: 8
           memory: 32Gi
         requests:
           cpu: 8
-          memory: 24Gi
+          memory: 32Gi
       securityContext:
         privileged: true
     - name: docker
@@ -48,7 +48,7 @@ spec:
       resources:
         limits:
           cpu: 16
-          memory: 32Gi
+          memory: 24Gi
         requests:
-          cpu: 12
+          cpu: 16
           memory: 24Gi

--- a/.ci/podSpecs/integration-test.yml
+++ b/.ci/podSpecs/integration-test.yml
@@ -25,10 +25,10 @@ spec:
           value: tcp://localhost:2375
       resources:
         limits:
-          cpu: 8
-          memory: 16Gi
+          cpu: 16
+          memory: 32Gi
         requests:
-          cpu: 8
+          cpu: 10
           memory: 16Gi
       securityContext:
         privileged: true
@@ -47,8 +47,8 @@ spec:
       tty: true
       resources:
         limits:
-          cpu: 8
-          memory: 8Gi
+          cpu: 16
+          memory: 24Gi
         requests:
-          cpu: 8
-          memory: 8Gi
+          cpu: 10
+          memory: 12Gi

--- a/.ci/podSpecs/integration-test.yml
+++ b/.ci/podSpecs/integration-test.yml
@@ -28,7 +28,7 @@ spec:
           cpu: 16
           memory: 32Gi
         requests:
-          cpu: 10
+          cpu: 8
           memory: 16Gi
       securityContext:
         privileged: true

--- a/.ci/podSpecs/integration-test.yml
+++ b/.ci/podSpecs/integration-test.yml
@@ -25,11 +25,11 @@ spec:
           value: tcp://localhost:2375
       resources:
         limits:
-          cpu: 16
+          cpu: 12
           memory: 32Gi
         requests:
           cpu: 8
-          memory: 16Gi
+          memory: 24Gi
       securityContext:
         privileged: true
     - name: docker
@@ -48,7 +48,7 @@ spec:
       resources:
         limits:
           cpu: 16
-          memory: 24Gi
+          memory: 32Gi
         requests:
-          cpu: 10
-          memory: 12Gi
+          cpu: 12
+          memory: 24Gi

--- a/.ci/podSpecs/update-test.yml
+++ b/.ci/podSpecs/update-test.yml
@@ -30,11 +30,11 @@ spec:
           value: /home/shared
       resources:
         limits:
-          cpu: 4
-          memory: 4Gi
+          cpu: 8
+          memory: 16Gi
         requests:
           cpu: 4
-          memory: 4Gi
+          memory: 8Gi
       securityContext:
         privileged: true
       volumeMounts:
@@ -56,11 +56,11 @@ spec:
       tty: true
       resources:
         limits:
-          cpu: 8
-          memory: 8Gi
+          cpu: 16
+          memory: 32Gi
         requests:
-          cpu: 8
-          memory: 8Gi
+          cpu: 12
+          memory: 16Gi
       volumeMounts:
         - name: shared-data
           mountPath: /home/shared

--- a/.ci/podSpecs/update-test.yml
+++ b/.ci/podSpecs/update-test.yml
@@ -30,11 +30,11 @@ spec:
           value: /home/shared
       resources:
         limits:
-          cpu: 12
+          cpu: 8
           memory: 32Gi
         requests:
           cpu: 8
-          memory: 24Gi
+          memory: 32Gi
       securityContext:
         privileged: true
       volumeMounts:
@@ -57,9 +57,9 @@ spec:
       resources:
         limits:
           cpu: 16
-          memory: 32Gi
+          memory: 24Gi
         requests:
-          cpu: 12
+          cpu: 16
           memory: 24Gi
       volumeMounts:
         - name: shared-data

--- a/.ci/podSpecs/update-test.yml
+++ b/.ci/podSpecs/update-test.yml
@@ -8,6 +8,9 @@ spec:
     - key: "agents-n1-standard-32-netssd-preempt"
       operator: "Exists"
       effect: "NoSchedule"
+  volumes:
+    - name: shared-data
+      emptyDir: {}
   containers:
     - name: maven
       image: maven:3.6.3-jdk-11
@@ -23,42 +26,8 @@ spec:
             -XX:+UseContainerSupport
         - name: DOCKER_HOST
           value: tcp://localhost:2375
-      resources:
-        limits:
-          cpu: 8
-          memory: 8Gi
-        requests:
-          cpu: 8
-          memory: 8Gi
-      securityContext:
-        privileged: true
-    - name: maven-jdk8
-      image: maven:3.6.3-jdk-8
-      command: ["cat"]
-      tty: true
-      env:
-        - name: LIMITS_CPU
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: JAVA_TOOL_OPTIONS
-          value: |
-            -XX:+UseContainerSupport
-        - name: DOCKER_HOST
-          value: tcp://localhost:2375
-      resources:
-        limits:
-          cpu: 2
-          memory: 4Gi
-        requests:
-          cpu: 2
-          memory: 4Gi
-      securityContext:
-        privileged: true
-    - name: golang
-      image: golang:1.13.4
-      command: ["cat"]
-      tty: true
+        - name: ZEEBE_CI_SHARED_DATA
+          value: /home/shared
       resources:
         limits:
           cpu: 4
@@ -66,11 +35,12 @@ spec:
         requests:
           cpu: 4
           memory: 4Gi
-      env:
-        - name: DOCKER_HOST
-          value: tcp://localhost:2375
       securityContext:
         privileged: true
+      volumeMounts:
+        - name: shared-data
+          mountPath: /home/shared
+          mountPropagation: Bidirectional
     - name: docker
       image: docker:19.03.13-dind
       args:
@@ -91,3 +61,7 @@ spec:
         requests:
           cpu: 8
           memory: 8Gi
+      volumeMounts:
+        - name: shared-data
+          mountPath: /home/shared
+          mountPropagation: Bidirectional

--- a/.ci/podSpecs/update-test.yml
+++ b/.ci/podSpecs/update-test.yml
@@ -30,11 +30,11 @@ spec:
           value: /home/shared
       resources:
         limits:
-          cpu: 8
-          memory: 16Gi
+          cpu: 12
+          memory: 32Gi
         requests:
-          cpu: 4
-          memory: 8Gi
+          cpu: 8
+          memory: 24Gi
       securityContext:
         privileged: true
       volumeMounts:
@@ -60,7 +60,7 @@ spec:
           memory: 32Gi
         requests:
           cpu: 12
-          memory: 16Gi
+          memory: 24Gi
       volumeMounts:
         - name: shared-data
           mountPath: /home/shared

--- a/.ci/scripts/distribution/test-update-java.sh
+++ b/.ci/scripts/distribution/test-update-java.sh
@@ -1,13 +1,12 @@
 #!/bin/bash -eux
 
-
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
 tmpfile=$(mktemp)
 
-mvn -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} test-compile -Pprepare-offline -pl qa/integration-tests
+mvn -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} test-compile -Pprepare-offline -pl update-tests
 
-mvn -o -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl qa/integration-tests -DtestMavenId=2 -Dsurefire.rerunFailingTestsCount=7 | tee ${tmpfile}
+mvn -o -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl update-tests -DtestMavenId=3 -Dsurefire.rerunFailingTestsCount=7 | tee ${tmpfile}
 
 status=${PIPESTATUS[0]}
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,5 @@ indent_size = 2
 [*.md]
 indent_size = 2
 
+[{*.dsl,*.groovy,Jenkinsfile*}]
+indent_size = 4

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,21 +18,21 @@ def cronTrigger = isDevelopBranch ? '@hourly' : ''
 
 pipeline {
     agent {
-      kubernetes {
-        cloud 'zeebe-ci'
-        label "zeebe-ci-build_${buildName}"
-        defaultContainer 'jnlp'
-        yamlFile '.ci/podSpecs/distribution.yml'
-      }
+        kubernetes {
+            cloud 'zeebe-ci'
+            label "zeebe-ci-build_${buildName}"
+            defaultContainer 'jnlp'
+            yamlFile ".ci/podSpecs/distribution.yml"
+        }
     }
 
     environment {
-      NEXUS = credentials("camunda-nexus")
-      SONARCLOUD_TOKEN = credentials('zeebe-sonarcloud-token')
+        NEXUS = credentials("camunda-nexus")
+        SONARCLOUD_TOKEN = credentials('zeebe-sonarcloud-token')
     }
 
     triggers {
-      cron(cronTrigger)
+        cron(cronTrigger)
     }
 
     options {
@@ -42,42 +42,24 @@ pipeline {
     }
 
     stages {
-        stage('Prepare') {
+        stage('Prepare Distribution') {
             steps {
-                script {
-                    commit_summary = sh([returnStdout: true, script: 'git show -s --format=%s']).trim()
-                    displayNameFull = "#" + BUILD_NUMBER + ': ' + commit_summary
+                setHumanReadableBuildDisplayName()
 
-                    if (displayNameFull.length() <= 45) {
-                      currentBuild.displayName = displayNameFull
-                    } else {
-                      displayStringHardTruncate = displayNameFull.take(45)
-                      currentBuild.displayName = displayStringHardTruncate.take(displayStringHardTruncate.lastIndexOf(" "))
-                    }
-                }
-                container('maven') {
-                    sh '.ci/scripts/distribution/prepare.sh'
-                }
-                container('maven-jdk8') {
-                    sh '.ci/scripts/distribution/prepare.sh'
-                }
+                prepareMavenContainer()
+                prepareMavenContainer('jdk8')
                 container('golang') {
                     sh '.ci/scripts/distribution/prepare-go.sh'
                 }
-
             }
         }
 
-        stage('Build (Java)') {
+        stage('Build Distribution') {
             environment {
                 VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
             }
             steps {
-                container('maven') {
-                    configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
-                        sh '.ci/scripts/distribution/build-java.sh'
-                    }
-                }
+                runMavenContainerCommand('.ci/scripts/distribution/build-java.sh')
                 container('maven') {
                     sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
                 }
@@ -86,10 +68,10 @@ pipeline {
             }
         }
 
-        stage('Prepare Tests') {
+        stage('Build Docker Images') {
             environment {
+                DOCKER_BUILDKIT = "1"
                 IMAGE = "camunda/zeebe"
-                VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
                 TAG = 'current-test'
             }
 
@@ -100,11 +82,26 @@ pipeline {
             }
         }
 
-
-
-        stage('Test') {
+        stage('Verify') {
             parallel {
-                stage('Go') {
+                stage('Analyse') {
+                    steps {
+                        runMavenContainerCommand('.ci/scripts/distribution/analyse-java.sh')
+                    }
+                }
+
+                stage('Build Docs') {
+                    steps {
+                        retry(3) {
+                            container('maven') {
+                                sh '.ci/scripts/docs/prepare.sh'
+                                sh '.ci/scripts/docs/build.sh'
+                            }
+                        }
+                    }
+                }
+
+                stage('Test (Go)') {
                     steps {
                         container('golang') {
                             sh '.ci/scripts/distribution/build-go.sh'
@@ -122,19 +119,9 @@ pipeline {
                     }
                 }
 
-                stage('Analyse (Java)') {
-                    steps {
-                        container('maven') {
-                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
-                                sh '.ci/scripts/distribution/analyse-java.sh'
-                            }
-                        }
-                    }
-                }
-
-                stage('Unit (Java)') {
+                stage('Test (Java)') {
                     environment {
-                      SUREFIRE_REPORT_NAME_SUFFIX = 'java-testrun'
+                        SUREFIRE_REPORT_NAME_SUFFIX = 'java-testrun'
                     }
 
                     steps {
@@ -151,9 +138,10 @@ pipeline {
                         }
                     }
                 }
-                stage('Unit 8 (Java 8)') {
+
+                stage('Test (Java 8)') {
                     environment {
-                      SUREFIRE_REPORT_NAME_SUFFIX = 'java8-testrun'
+                        SUREFIRE_REPORT_NAME_SUFFIX = 'java8-testrun'
                     }
 
                     steps {
@@ -171,56 +159,105 @@ pipeline {
                     }
                 }
 
-                stage('IT (Java)') {
+                stage('IT') {
                     agent {
                         kubernetes {
                             cloud 'zeebe-ci'
                             label "zeebe-ci-build_${buildName}_it"
                             defaultContainer 'jnlp'
-                            yamlFile '.ci/podSpecs/distribution.yml'
+                            yamlFile '.ci/podSpecs/integration-test.yml'
                         }
                     }
 
-                    environment {
-                        SUREFIRE_REPORT_NAME_SUFFIX = 'it-testrun'
-                        IMAGE = "camunda/zeebe"
-                        VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
-                        TAG = 'current-test'
-                    }
-
-                    steps {
-                        container('maven') {
-                            sh '.ci/scripts/distribution/prepare.sh'
-                        }
-                        unstash name: "zeebe-build"
-                        unstash name: "zeebe-distro"
-                        container('docker') {
-                            sh '.ci/scripts/docker/build.sh'
-                        }
-                        container('maven') {
-                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
-                                sh '.ci/scripts/distribution/it-java.sh'
+                    stages {
+                        stage('Prepare') {
+                            steps {
+                                prepareMavenContainer()
                             }
                         }
-                    }
 
-                    post {
-                        always {
-                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
+                        stage('Build Docker Image') {
+                            environment {
+                                DOCKER_BUILDKIT = "1"
+                                IMAGE = "camunda/zeebe"
+                                TAG = 'current-test'
+                            }
+
+                            steps {
+                                unstash name: "zeebe-distro"
+                                container('docker') {
+                                    sh '.ci/scripts/docker/build.sh'
+                                }
+                            }
+                        }
+
+                        stage('Test') {
+                            environment {
+                                SUREFIRE_REPORT_NAME_SUFFIX = 'it-testrun'
+                            }
+
+                            steps {
+                                unstash name: "zeebe-build"
+                                runMavenContainerCommand('.ci/scripts/distribution/it-java.sh')
+                            }
+
+                            post {
+                                always {
+                                    junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
+                                }
+                            }
                         }
                     }
                 }
 
-                stage('Build Docs') {
-                    steps {
-                      retry(3) {
-                        container('maven') {
-                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
-                                sh '.ci/scripts/docs/prepare.sh'
-                                sh '.ci/scripts/docs/build.sh'
+                stage('Update') {
+                    agent {
+                        kubernetes {
+                            cloud 'zeebe-ci'
+                            label "zeebe-ci-build_${buildName}_update"
+                            defaultContainer 'jnlp'
+                            yamlFile '.ci/podSpecs/update-test.yml'
+                        }
+                    }
+
+                    stages {
+                        stage('Prepare') {
+                            steps {
+                                prepareMavenContainer()
                             }
                         }
-                      }
+
+                        stage('Build Docker Image') {
+                            environment {
+                                DOCKER_BUILDKIT = "1"
+                                IMAGE = "camunda/zeebe"
+                                TAG = 'current-test'
+                            }
+
+                            steps {
+                                unstash name: "zeebe-distro"
+                                container('docker') {
+                                    sh '.ci/scripts/docker/build.sh'
+                                }
+                            }
+                        }
+
+                        stage('Test') {
+                            environment {
+                                SUREFIRE_REPORT_NAME_SUFFIX = 'update-testrun'
+                            }
+
+                            steps {
+                                unstash name: "zeebe-build"
+                                runMavenContainerCommand('.ci/scripts/distribution/test-update-java.sh')
+                            }
+
+                            post {
+                                always {
+                                    junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -228,31 +265,32 @@ pipeline {
             post {
                 always {
                     jacoco(
-                          execPattern: '**/*.exec',
-                          classPattern: '**/target/classes',
-                          sourcePattern: '**/src/main/java,**/generated-sources/protobuf/java,**/generated-sources/assertj-assertions,**/generated-sources/sbe',
-                          exclusionPattern: '**/io/zeebe/gateway/protocol/**,'
-                                            + '**/*Encoder.class,**/*Decoder.class,**/MetaAttribute.class,'
-                                            + '**/io/zeebe/protocol/record/**/*Assert.class,**/io/zeebe/protocol/record/Assertions.class,', // classes from generated resources
-                          runAlways: true
+                        execPattern: '**/*.exec',
+                        classPattern: '**/target/classes',
+                        sourcePattern: '**/src/main/java,**/generated-sources/protobuf/java,**/generated-sources/assertj-assertions,**/generated-sources/sbe',
+                        exclusionPattern: '**/io/zeebe/gateway/protocol/**,'
+                            + '**/*Encoder.class,**/*Decoder.class,**/MetaAttribute.class,'
+                            + '**/io/zeebe/protocol/record/**/*Assert.class,**/io/zeebe/protocol/record/Assertions.class,', // classes from generated resources
+                        runAlways: true
                     )
                     zip zipFile: 'test-coverage-reports.zip', archive: true, glob: "**/target/site/jacoco/**"
                 }
+
                 failure {
                     zip zipFile: 'test-reports.zip', archive: true, glob: "**/*/surefire-reports/**"
                     archive "**/hs_err_*.log"
 
                     script {
-                      if (fileExists('./target/FlakyTests.txt')) {
-                          currentBuild.description = "Flaky Tests: <br>" + readFile('./target/FlakyTests.txt').split('\n').join('<br>')
-                      }
+                        if (fileExists('./target/FlakyTests.txt')) {
+                            currentBuild.description = "Flaky Tests: <br>" + readFile('./target/FlakyTests.txt').split('\n').join('<br>')
+                        }
                     }
                 }
             }
         }
 
         stage('Upload') {
-            when { allOf { branch developBranchName ; not {  triggeredBy 'TimerTrigger' } } }
+            when { allOf { branch developBranchName; not { triggeredBy 'TimerTrigger' } } }
             steps {
                 retry(3) {
                     container('maven') {
@@ -312,6 +350,20 @@ pipeline {
 
                     build job: currentBuild.projectName, propagate: false, quietPeriod: 60, wait: false
                 }
+
+                String userReason = null
+                if (currentBuild.description ==~ /.*Flaky Tests.*/) {
+                    userReason = 'flaky-tests'
+                }
+                org.camunda.helper.CIAnalytics.trackBuildStatus(this, userReason)
+            }
+        }
+        failure {
+            script {
+                if (env.BRANCH_NAME != 'develop' || agentDisconnected()) {
+                    return
+                }
+                sendZeebeSlackMessage()
             }
         }
         changed {
@@ -329,4 +381,47 @@ pipeline {
             }
         }
     }
+}
+
+//////////////////// Helper functions ////////////////////
+
+def getMavenContainerNameForJDK(String jdk = null) {
+    "maven${jdk ? '-' + jdk : ''}"
+}
+
+def prepareMavenContainer(String jdk = null) {
+    container(getMavenContainerNameForJDK(jdk)) {
+        sh '.ci/scripts/distribution/prepare.sh'
+    }
+}
+
+def runMavenContainerCommand(String shellCommand, String jdk = null) {
+    container(getMavenContainerNameForJDK(jdk)) {
+        configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
+            sh shellCommand
+        }
+    }
+}
+
+// TODO: can be extracted to zeebe-jenkins-shared-library
+def setHumanReadableBuildDisplayName(int maximumLength = 45) {
+    script {
+        commit_summary = sh([returnStdout: true, script: 'git show -s --format=%s']).trim()
+        displayNameFull = "#${env.BUILD_NUMBER}: ${commit_summary}"
+
+        if (displayNameFull.length() <= maximumLength) {
+            currentBuild.displayName = displayNameFull
+        } else {
+            displayStringHardTruncate = displayNameFull.take(maximumLength)
+            currentBuild.displayName = displayStringHardTruncate.take(displayStringHardTruncate.lastIndexOf(' '))
+        }
+    }
+}
+
+// TODO: can be extracted to zeebe-jenkins-shared-library
+def sendZeebeSlackMessage() {
+    echo "Send slack message"
+    slackSend(
+        channel: "#zeebe-ci${jenkins.model.JenkinsLocationConfiguration.get()?.getUrl()?.contains('stage') ? '-stage' : ''}",
+        message: "Zeebe ${env.BRANCH_NAME} build ${currentBuild.absoluteUrl} changed status to ${currentBuild.currentResult}")
 }


### PR DESCRIPTION
## Description

This PR backports #5908 to 0.25. There were some merge conflicts in the Jenkinsfile that had to be fixed, as we still build the docs on 0.25, so I guess it needs to be reviewed again, sorry.

## Related issues

related to #5873 
backports #5908 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
