### PR TITLE
5754 trigger testbench2

### DIFF
--- a/.ci/scripts/distribution/qa-testbench.sh
+++ b/.ci/scripts/distribution/qa-testbench.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -eux
+
+chmod +x clients/go/cmd/zbctl/dist/zbctl
+
+alias zbctl="clients/go/cmd/zbctl/dist/zbctl"
+
+zbctl create instance qa-protocol --variables "${QA_RUN_VARIABLES}"

--- a/.ci/scripts/docker/upload-gcr.sh
+++ b/.ci/scripts/docker/upload-gcr.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -eux
+
+# this command is a little convoluted to avoid leaking of the secret;
+# it is unclear why the built-in Jenkins mechanism doesn't work out of the box
+echo "Authenticating with gcr.io and pushing image."
+set +x ; echo "${DOCKER_GCR}" | docker login -u _json_key --password-stdin https://gcr.io ; set -x
+
+docker tag camunda/zeebe:current-test "${IMAGE}":"${TAG}"
+docker push "${IMAGE}":"${TAG}"
+
+


### PR DESCRIPTION
## Description

Adds a new QA stage to the build process, which
* pushes a docker image to gcr.io
* triggers the QA protocol in testbench

## Related issues

closes #5754

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
