### PR TITLE
Revert CI pod resource usages to pre-split

### DIFF
--- a/.ci/podSpecs/distribution.yml
+++ b/.ci/podSpecs/distribution.yml
@@ -26,10 +26,10 @@ spec:
       resources:
         limits:
           cpu: 8
-          memory: 8Gi
+          memory: 32Gi
         requests:
           cpu: 8
-          memory: 8Gi
+          memory: 32Gi
       securityContext:
         privileged: true
     - name: maven-jdk8
@@ -87,7 +87,7 @@ spec:
       resources:
         limits:
           cpu: 8
-          memory: 8Gi
+          memory: 16Gi
         requests:
           cpu: 8
-          memory: 8Gi
+          memory: 16Gi

--- a/.ci/podSpecs/integration-test.yml
+++ b/.ci/podSpecs/integration-test.yml
@@ -26,10 +26,10 @@ spec:
       resources:
         limits:
           cpu: 8
-          memory: 16Gi
+          memory: 32Gi
         requests:
           cpu: 8
-          memory: 16Gi
+          memory: 32Gi
       securityContext:
         privileged: true
     - name: docker
@@ -48,7 +48,7 @@ spec:
       resources:
         limits:
           cpu: 8
-          memory: 8Gi
+          memory: 16Gi
         requests:
           cpu: 8
-          memory: 8Gi
+          memory: 16Gi

--- a/.ci/podSpecs/update-test.yml
+++ b/.ci/podSpecs/update-test.yml
@@ -30,11 +30,11 @@ spec:
           value: /home/shared
       resources:
         limits:
-          cpu: 4
-          memory: 4Gi
+          cpu: 8
+          memory: 32Gi
         requests:
-          cpu: 4
-          memory: 4Gi
+          cpu: 8
+          memory: 32Gi
       securityContext:
         privileged: true
       volumeMounts:
@@ -57,10 +57,10 @@ spec:
       resources:
         limits:
           cpu: 8
-          memory: 8Gi
+          memory: 16Gi
         requests:
           cpu: 8
-          memory: 8Gi
+          memory: 16Gi
       volumeMounts:
         - name: shared-data
           mountPath: /home/shared


### PR DESCRIPTION
## Description

This PR attempts to fix new flakiness introduced when splitting the agents and reducing the resources. It now most likely overprovisions the resources, but seems to be more stable while still having split agents. I think to really reduce resources we would need to get metrics to have an idea of what are our peak loads and how much really is necessary.

## Related issues

related to #5873 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
