### PR TITLE
Scale CI agents vertically

### DIFF
--- a/.ci/podSpecs/integration-test.yml
+++ b/.ci/podSpecs/integration-test.yml
@@ -35,53 +35,16 @@ spec:
       resources:
         limits:
           cpu: 12
-          memory: 50Gi
+          memory: 48Gi
         requests:
           cpu: 12
-          memory: 50Gi
+          memory: 48Gi
       securityContext:
         privileged: true
       volumeMounts:
         - name: shared-data
           mountPath: /home/shared
           mountPropagation: Bidirectional
-    - name: maven-jdk8
-      image: maven:3.6.3-jdk-8
-      command: ["cat"]
-      tty: true
-      env:
-        - name: LIMITS_CPU
-          valueFrom:
-            resourceFieldRef:
-              resource: limits.cpu
-        - name: JAVA_TOOL_OPTIONS
-          value: |
-            -XX:+UseContainerSupport
-      resources:
-        limits:
-          cpu: 2
-          memory: 4Gi
-        requests:
-          cpu: 2
-          memory: 4Gi
-      securityContext:
-        privileged: true
-    - name: golang
-      image: golang:1.13.4
-      command: ["cat"]
-      tty: true
-      resources:
-        limits:
-          cpu: 4
-          memory: 4Gi
-        requests:
-          cpu: 4
-          memory: 4Gi
-      env:
-        - name: DOCKER_HOST
-          value: tcp://localhost:2375
-      securityContext:
-        privileged: true
     - name: docker
       image: docker:19.03.13-dind
       args:
@@ -97,11 +60,11 @@ spec:
       tty: true
       resources:
         limits:
-          cpu: 12
-          memory: 50Gi
+          cpu: 18
+          memory: 60Gi
         requests:
-          cpu: 12
-          memory: 50Gi
+          cpu: 18
+          memory: 60Gi
       volumeMounts:
         - name: shared-data
           mountPath: /home/shared

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,7 +182,7 @@ pipeline {
                             cloud 'zeebe-ci'
                             label "zeebe-ci-build_${buildName}_it"
                             defaultContainer 'jnlp'
-                            yamlFile '.ci/podSpecs/distribution.yml'
+                            yamlFile '.ci/podSpecs/integration-test.yml'
                         }
                     }
 


### PR DESCRIPTION
## Description

This PR scales CI agents vertically. It introduces a separate podSpec for the integration tests to remove the unnecessary JDK8 and golang containers. It also scales all podSpecs such that they use 30 CPUs and 108Gi. This based on n1-standard-32 node types which allow allocating 31.85 CPUs and 109Gi, with some buffer to allow for the Jenkins overhead (logging daemon, jnlp, etc.).

## Related issues

related to #5873 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
