### PR TITLE
feat(broker): a job worker is optional

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -79,8 +79,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private boolean isValid(final JobBatchRecord record) {
     return record.getMaxJobsToActivate() > 0
         && record.getTimeout() > 0
-        && record.getTypeBuffer().capacity() > 0
-        && record.getWorkerBuffer().capacity() > 0;
+        && record.getTypeBuffer().capacity() > 0;
   }
 
   private void activateJobs(
@@ -215,9 +214,6 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     } else if (value.getTypeBuffer().capacity() < 1) {
       rejectionType = RejectionType.INVALID_ARGUMENT;
       rejectionReason = String.format(format, "type", "present", "blank");
-    } else if (value.getWorkerBuffer().capacity() < 1) {
-      rejectionType = RejectionType.INVALID_ARGUMENT;
-      rejectionReason = String.format(format, "worker", "present", "blank");
     } else {
       throw new IllegalStateException(
           "Expected to reject an invalid activate job batch command, but it appears to be valid");

--- a/engine/src/test/java/io/zeebe/engine/processing/job/ActivateJobsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/job/ActivateJobsTest.java
@@ -112,16 +112,23 @@ public final class ActivateJobsTest {
   }
 
   @Test
-  public void shouldRejectInvalidWorker() {
+  public void shouldAcceptEmptyWorker() {
+    // given
+    ENGINE.deployment().withXmlResource(PROCESS_ID, MODEL_SUPPLIER.apply(taskType)).deploy();
+
+    final Duration timeout = Duration.ofMinutes(12);
+
     // when
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(taskType).byWorker("").expectRejection().activate();
+        ENGINE
+            .jobs()
+            .withType(taskType)
+            .withTimeout(timeout.toMillis())
+            .withMaxJobsToActivate(1)
+            .activate();
 
     // then
-    assertThat(batchRecord)
-        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
-        .hasRejectionReason(
-            "Expected to activate job batch with worker to be present, but it was blank");
+    assertThat(batchRecord.getIntent()).isEqualTo(JobBatchIntent.ACTIVATED);
   }
 
   @Test

--- a/engine/src/test/java/io/zeebe/engine/util/client/JobActivationClient.java
+++ b/engine/src/test/java/io/zeebe/engine/util/client/JobActivationClient.java
@@ -54,10 +54,7 @@ public final class JobActivationClient {
     this.environmentRule = environmentRule;
 
     jobBatchRecord = new JobBatchRecord();
-    jobBatchRecord
-        .setTimeout(DEFAULT_TIMEOUT)
-        .setWorker(DEFAULT_WORKER)
-        .setMaxJobsToActivate(DEFAULT_MAX_ACTIVATE);
+    jobBatchRecord.setTimeout(DEFAULT_TIMEOUT).setMaxJobsToActivate(DEFAULT_MAX_ACTIVATE);
     partitionId = DEFAULT_PARTITION;
   }
 


### PR DESCRIPTION
## Description

I remove the rejection of activation jobs if a job worker is absent.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #5819

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
