### PR TITLE
chore(ci): add template distribution podspec for stable agents on bors staging branch

### DIFF
--- a/.ci/podSpecs/distribution-template.yml
+++ b/.ci/podSpecs/distribution-template.yml
@@ -1,0 +1,93 @@
+metadata:
+  labels:
+    agent: zeebe-ci-build
+spec:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: "PODSPEC_TEMPLATE_NODE_POOL"
+  tolerations:
+    - key: "PODSPEC_TEMPLATE_NODE_POOL"
+      operator: "Exists"
+      effect: "NoSchedule"
+  containers:
+    - name: maven
+      image: maven:3.6.3-jdk-11
+      command: ["cat"]
+      tty: true
+      env:
+        - name: LIMITS_CPU
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: JAVA_TOOL_OPTIONS
+          value: |
+            -XX:+UseContainerSupport
+        - name: DOCKER_HOST
+          value: tcp://localhost:2375
+      resources:
+        limits:
+          cpu: 8
+          memory: 8Gi
+        requests:
+          cpu: 8
+          memory: 8Gi
+      securityContext:
+        privileged: true
+    - name: maven-jdk8
+      image: maven:3.6.3-jdk-8
+      command: ["cat"]
+      tty: true
+      env:
+        - name: LIMITS_CPU
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: JAVA_TOOL_OPTIONS
+          value: |
+            -XX:+UseContainerSupport
+        - name: DOCKER_HOST
+          value: tcp://localhost:2375
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
+      securityContext:
+        privileged: true
+    - name: golang
+      image: golang:1.13.4
+      command: ["cat"]
+      tty: true
+      resources:
+        limits:
+          cpu: 4
+          memory: 4Gi
+        requests:
+          cpu: 4
+          memory: 4Gi
+      env:
+        - name: DOCKER_HOST
+          value: tcp://localhost:2375
+      securityContext:
+        privileged: true
+    - name: docker
+      image: docker:19.03.13-dind
+      args:
+        - --storage-driver=overlay
+      env:
+        # The new dind versions expect secure access using cert
+        # Setting DOCKER_TLS_CERTDIR to empty string will disable the secure access
+        # (see https://hub.docker.com/_/docker?tab=description&page=1)
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
+      securityContext:
+        privileged: true
+      tty: true
+      resources:
+        limits:
+          cpu: 8
+          memory: 8Gi
+        requests:
+          cpu: 8
+          memory: 8Gi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
             cloud 'zeebe-ci'
             label "zeebe-ci-build_${buildName}"
             defaultContainer 'jnlp'
-            yamlFile ".ci/podSpecs/distribution.yml"
+            yaml templatePodspec('.ci/podSpecs/distribution-template.yml')
         }
     }
 
@@ -403,4 +403,30 @@ def sendZeebeSlackMessage() {
     slackSend(
         channel: "#zeebe-ci${jenkins.model.JenkinsLocationConfiguration.get()?.getUrl()?.contains('stage') ? '-stage' : ''}",
         message: "Zeebe ${env.BRANCH_NAME} build ${currentBuild.absoluteUrl} changed status to ${currentBuild.currentResult}")
+}
+
+def isBorsStagingBranch() {
+    env.BRANCH_NAME == 'staging'
+}
+
+def templatePodspec(String podspecPath, flags = [:]) {
+    def defaultFlags = [
+      useStableNodePool: isBorsStagingBranch()
+    ]
+    // will merge Maps by overwriting left Map with values of the right Map
+    def effectiveFlags = defaultFlags + flags
+
+    def nodePoolName = "agents-n1-standard-32-netssd-${effectiveFlags.useStableNodePool ? 'stable' : 'preempt'}"
+
+    // Needs no workspace, see:
+    // https://www.jenkins.io/doc/pipeline/steps/workflow-multibranch/#readtrusted-read-trusted-file-from-scm
+    String templateString = readTrusted(podspecPath)
+
+    // Note: Templating is currently done via simple string substitution as this
+    // is enough to solve all existing use cases. If need arises the templating
+    // can be transparently changed to a more sophisticated YAML-merge based
+    // approach as it is an implementation detail that the caller does not know.
+    templateString = templateString.replaceAll('PODSPEC_TEMPLATE_NODE_POOL', nodePoolName)
+
+    templateString
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -320,13 +320,16 @@ pipeline {
 
     post {
         always {
-            // Retrigger the build if there were connection issues
+            // Retrigger the build if there were connection issues (but not
+            // on bors staging branch as bors does not recognize this result)
             script {
                 if (agentDisconnected()) {
                     currentBuild.result = 'ABORTED'
                     currentBuild.description = "Aborted due to connection error"
 
-                    build job: currentBuild.projectName, propagate: false, quietPeriod: 60, wait: false
+                    if (!isBorsStagingBranch()) {
+                        build job: currentBuild.projectName, propagate: false, quietPeriod: 60, wait: false
+                    }
                 }
 
                 String userReason = null


### PR DESCRIPTION
## Description

Introduces a duplicated `distribution-template.yml` podspec as I didn't want to touch all usages yet.

Since bors cannot deal with the automated retriggering of Jenkins builds failed due to disconnected agents (due to e.g. https://issuetracker.google.com/issues/156556218), use a stable agent for these builds.