### PR TITLE
Enable opt-in junit5 parallel tests

### DIFF
--- a/.ci/scripts/distribution/it-java.sh
+++ b/.ci/scripts/distribution/it-java.sh
@@ -4,6 +4,7 @@
 LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
 MAVEN_PARALLELISM=${MAVEN_PARALLELISM:-$LIMITS_CPU}
 SUREFIRE_FORK_COUNT=${SUREFIRE_FORK_COUNT:-}
+JUNIT_THREAD_COUNT=${JUNIT_THREAD_COUNT:-}
 MAVEN_PROPERTIES=(
   -DtestMavenId=2
   -Dsurefire.rerunFailingTestsCount=7
@@ -14,6 +15,10 @@ if [ ! -z "$SUREFIRE_FORK_COUNT" ]; then
   MAVEN_PROPERTIES+=("-DforkCount=$SUREFIRE_FORK_COUNT")
   # if we know the fork count, we can limit the max heap for each fork to ensure we're not OOM killed
   JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -XX:MaxRAMPercentage=$((100 / (MAVEN_PARALLELISM * $SUREFIRE_FORK_COUNT)))"
+fi
+
+if [ ! -z "$JUNIT_THREAD_COUNT" ]; then
+  MAVEN_PROPERTIES+=("-DjunitThreadCount=$JUNIT_THREAD_COUNT")
 fi
 
 # make sure to specify the profiles used in the verify goal when running preparing to go offline, as

--- a/.ci/scripts/distribution/test-java.sh
+++ b/.ci/scripts/distribution/test-java.sh
@@ -4,6 +4,7 @@
 LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
 MAVEN_PARALLELISM=${MAVEN_PARALLELISM:-$LIMITS_CPU}
 SUREFIRE_FORK_COUNT=${SUREFIRE_FORK_COUNT:-}
+JUNIT_THREAD_COUNT=${JUNIT_THREAD_COUNT:-}
 MAVEN_PROPERTIES=(
   -Dzeebe.it.skip
   -DtestMavenId=1
@@ -15,6 +16,10 @@ if [ ! -z "$SUREFIRE_FORK_COUNT" ]; then
   MAVEN_PROPERTIES+=("-DforkCount=$SUREFIRE_FORK_COUNT")
   # if we know the fork count, we can limit the max heap for each fork to ensure we're not OOM killed
   JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -XX:MaxRAMPercentage=$((100 / ($MAVEN_PARALLELISM * $SUREFIRE_FORK_COUNT)))"
+fi
+
+if [ ! -z "$JUNIT_THREAD_COUNT" ]; then
+  MAVEN_PROPERTIES+=("-DjunitThreadCount=$JUNIT_THREAD_COUNT")
 fi
 
 mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests "${MAVEN_PROPERTIES[@]}" | tee ${tmpfile}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,6 +145,7 @@ pipeline {
                         SUREFIRE_REPORT_NAME_SUFFIX = 'java-testrun'
                         MAVEN_PARALLELISM = 2
                         SUREFIRE_FORK_COUNT = 6
+                        JUNIT_THREAD_COUNT = 6
                     }
 
                     steps {
@@ -219,6 +220,7 @@ pipeline {
                                 SUREFIRE_REPORT_NAME_SUFFIX = 'it-testrun'
                                 MAVEN_PARALLELISM = 2
                                 SUREFIRE_FORK_COUNT = 6
+                                JUNIT_THREAD_COUNT = 6
                             }
 
                             steps {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1267,6 +1267,7 @@
       <id>parallel-tests</id>
       <properties>
         <forkCount>0.5C</forkCount>
+        <junitThreadCount>0.5C</junitThreadCount>
       </properties>
       <build>
         <plugins>
@@ -1282,6 +1283,26 @@
                 and don't set the system property -->
                 <testForkNumber>$${surefire.forkNumber}</testForkNumber>
               </systemPropertyVariables>
+              <properties>
+                <!--
+                  allow junit5 parallel execution, configured on the number of cores
+                  note that this does not make tests parallel, this is still controlled in the tests
+                  themselves via the @Execution annotation. furthermore, child modules can define
+                  their own parallel configuration
+                -->
+                <junit.jupiter.execution.parallel.enabled>true
+                </junit.jupiter.execution.parallel.enabled>
+                <junit.jupiter.execution.parallel.mode.default>same_thread
+                </junit.jupiter.execution.parallel.mode.default>
+                <junit.jupiter.execution.parallel.mode.classes.default>same_thread
+                </junit.jupiter.execution.parallel.mode.classes.default>
+
+                <!-- will configure based on cpuCount * factor -->
+                <junit.jupiter.execution.parallel.config.strategy>dynamic
+                </junit.jupiter.execution.parallel.config.strategy>
+                <junit.jupiter.execution.parallel.config.dynamic.factor>${junitThreadCount}
+                </junit.jupiter.execution.parallel.config.dynamic.factor>
+              </properties>
             </configuration>
           </plugin>
           <plugin>
@@ -1296,6 +1317,26 @@
                 and don't set the system property -->
                 <testForkNumber>$${surefire.forkNumber}</testForkNumber>
               </systemPropertyVariables>
+              <properties>
+                <!--
+                  allow junit5 parallel execution, configured on the number of cores
+                  note that this does not make tests parallel, this is still controlled in the tests
+                  themselves via the @Execution annotation. furthermore, child modules can define
+                  their own parallel configuration
+                -->
+                <junit.jupiter.execution.parallel.enabled>true
+                </junit.jupiter.execution.parallel.enabled>
+                <junit.jupiter.execution.parallel.mode.default>same_thread
+                </junit.jupiter.execution.parallel.mode.default>
+                <junit.jupiter.execution.parallel.mode.classes.default>same_thread
+                </junit.jupiter.execution.parallel.mode.classes.default>
+
+                <!-- will configure based on cpuCount * factor -->
+                <junit.jupiter.execution.parallel.config.strategy>dynamic
+                </junit.jupiter.execution.parallel.config.strategy>
+                <junit.jupiter.execution.parallel.config.dynamic.factor>${junitThreadCount}
+                </junit.jupiter.execution.parallel.config.dynamic.factor>
+              </properties>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
## Description

This PR enables junit5 parallel tests for profile `parallel-tests`. Note that this is opt-in: by default, all tests within a class run sequentially. However, you can now annotate these classes with the `@Execution` annotation to opt-in and run your tests in parallel. Default configuration is to run up to half of the number of cores in parallel.

As such, this PR is more of a stepping stone to allow further options for parallel test execution.

## Related issues

related #5873

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
