### PR TITLE
Ignore DebugLogExporter if ZEEEB_DEBUG is false

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/exporter/debug/DebugLogExporter.java
+++ b/broker/src/main/java/io/zeebe/broker/exporter/debug/DebugLogExporter.java
@@ -17,7 +17,6 @@ import io.zeebe.exporter.api.context.Context;
 import io.zeebe.exporter.api.context.Controller;
 import io.zeebe.protocol.record.Record;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -79,10 +78,9 @@ public class DebugLogExporter implements Exporter {
     }
   }
 
-  public static ExporterCfg defaultConfig(final boolean prettyPrint) {
+  public static ExporterCfg defaultConfig() {
     final ExporterCfg exporterCfg = new ExporterCfg();
     exporterCfg.setClassName(DebugLogExporter.class.getName());
-    exporterCfg.setArgs(Collections.singletonMap("prettyPrint", prettyPrint));
     return exporterCfg;
   }
 

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
@@ -60,13 +60,9 @@ public final class BrokerCfg {
   }
 
   private void applyEnvironment(final Environment environment) {
-    environment
-        .get(ENV_DEBUG_EXPORTER)
-        .ifPresent(
-            value ->
-                exporters.put(
-                    DebugLogExporter.defaultExporterId(),
-                    DebugLogExporter.defaultConfig("pretty".equalsIgnoreCase(value))));
+    if (environment.getBool(ENV_DEBUG_EXPORTER).orElse(false)) {
+      exporters.put(DebugLogExporter.defaultExporterId(), DebugLogExporter.defaultConfig());
+    }
   }
 
   public NetworkCfg getNetwork() {

--- a/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerConfigurator.java
+++ b/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerConfigurator.java
@@ -20,7 +20,9 @@ import java.util.function.Consumer;
 public final class EmbeddedBrokerConfigurator {
 
   public static final Consumer<BrokerCfg> DEBUG_EXPORTER =
-      cfg -> cfg.getExporters().put("DebugLogExporter", DebugLogExporter.defaultConfig(false));
+      cfg ->
+          cfg.getExporters()
+              .put(DebugLogExporter.defaultExporterId(), DebugLogExporter.defaultConfig());
 
   public static final Consumer<BrokerCfg> HTTP_EXPORTER =
       cfg -> cfg.getExporters().put("DebugHttpExporter", DebugHttpExporter.defaultConfig());


### PR DESCRIPTION
## Description

This PR ensures the `DebugLogExporter` is only enabled iff `ZEEBE_DEBUG==true`.

## Related issues

closes #5695 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
