### PR TITLE
chore(broker): fix race condition between starting and pausing processor

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
@@ -34,7 +34,19 @@ public class ExporterDirectorPartitionStep implements PartitionStep {
 
     final ExporterDirector director = new ExporterDirector(exporterCtx, !context.shouldExport());
     context.setExporterDirector(director);
-    return director.startAsync(context.getScheduler());
+    final var startFuture = director.startAsync(context.getScheduler());
+    startFuture.onComplete(
+        (nothing, error) -> {
+          if (error == null) {
+            // Pause/Resume here in case the state was changed after the director was created
+            if (!context.shouldExport()) {
+              director.pauseExporting();
+            } else {
+              director.resumeExporting();
+            }
+          }
+        });
+    return startFuture;
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
@@ -20,7 +20,7 @@ public class StreamProcessorPartitionStep implements PartitionStep {
   @Override
   public ActorFuture<Void> open(final PartitionContext context) {
     final StreamProcessor streamProcessor = createStreamProcessor(context);
-    final ActorFuture<Void> openFuture = streamProcessor.openAsync();
+    final ActorFuture<Void> openFuture = streamProcessor.openAsync(!context.shouldProcess());
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
 
     openFuture.onComplete(
@@ -28,8 +28,12 @@ public class StreamProcessorPartitionStep implements PartitionStep {
           if (err == null) {
             context.setStreamProcessor(streamProcessor);
 
+            // Have to pause/resume it here in case the state changed after streamProcessor was
+            // created
             if (!context.shouldProcess()) {
               streamProcessor.pauseProcessing();
+            } else {
+              streamProcessor.resumeProcessing();
             }
 
             context

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -240,7 +240,7 @@ public final class TestStreams {
             .streamProcessorFactory(factory)
             .detectReprocessingInconsistency(detectReprocessingInconsistency)
             .build();
-    streamProcessor.openAsync().join(15, TimeUnit.SECONDS);
+    streamProcessor.openAsync(false).join(15, TimeUnit.SECONDS);
 
     final LogContext context = logContextMap.get(logName);
     final ProcessorContext processorContext =


### PR DESCRIPTION
## Description

Pass the flag on opening the StreamProcessor so that it can pause before any other task is executed.

## Related issues

closes #5941 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
