### PR TITLE
Tune port range configuration to reduce collision risks

### DIFF
--- a/test-util/src/main/java/io/zeebe/test/util/socket/SocketUtil.java
+++ b/test-util/src/main/java/io/zeebe/test/util/socket/SocketUtil.java
@@ -16,12 +16,24 @@ public final class SocketUtil {
   static final Logger LOG = LoggerFactory.getLogger("io.zeebe.test.util.SocketUtil");
 
   private static final String DEFAULT_HOST = "localhost";
-  private static final int BASE_PORT = 25600;
-  private static final int PORT_RANGE_PER_TEST_FORK = 100;
-  private static final int MAX_TEST_FORKS_PER_STAGE = 39;
-  private static final int PORT_RANGE_PER_TEST_STAGE =
-      PORT_RANGE_PER_TEST_FORK * MAX_TEST_FORKS_PER_STAGE; // 3900
+  // Docker maps exposed ports to random local ports, starting at 32768; this is undocumented, but
+  // observed empirically, and is aligned with Linux conventions, e.g. see
+  // https://tldp.org/LDP/solrhe/Securing-Optimizing-Linux-RH-Edition-v1.3/chap6sec70.html
+  private static final int DOCKER_BASE_PORT = 32768;
+  // most unix based systems reserve ports from 0-1024; picking 1025 as our base port gives us
+  // plenty of ports before we will collide with Docker's base port
+  private static final int BASE_PORT = 1025;
+  // defines the upper bound for how many separate maven processes (not forks or maven parallel
+  // build count) can be ran in parallel on the same machine, which is typically defined in the CI
+  // pipeline (e.g. Jenkinsfile)
   private static final int MAX_TEST_STAGES = 10;
+  // defines the upper bound for how many forks can be ran per stage; this should be the number of
+  // maven threads (-T option) times the configured surefire/failsafe forkCount (see the surefire
+  // or failsafe config in the pom)
+  private static final int MAX_TEST_FORKS_PER_STAGE = 30;
+  private static final int PORT_RANGE_PER_TEST_FORK = 100;
+  private static final int PORT_RANGE_PER_TEST_STAGE =
+      PORT_RANGE_PER_TEST_FORK * MAX_TEST_FORKS_PER_STAGE;
 
   private static final int TEST_FORK_NUMBER;
   private static final PortRange PORT_RANGE;
@@ -41,6 +53,15 @@ public final class SocketUtil {
         : "System property test fork number has to be smaller than " + MAX_TEST_FORKS_PER_STAGE;
     assert testMavenId < MAX_TEST_STAGES
         : "System property test maven id has to be smaller than " + MAX_TEST_STAGES;
+    final int absoluteMaxPort = BASE_PORT + MAX_TEST_STAGES * PORT_RANGE_PER_TEST_STAGE;
+    // this assert seems unnecessary but is there to prevent changes to the constants above from
+    // causing potential collisions with the base port that the Docker daemon uses
+    assert DOCKER_BASE_PORT > absoluteMaxPort
+        : "Maximum port "
+            + absoluteMaxPort
+            + " across all forks should be less than "
+            + DOCKER_BASE_PORT
+            + ", the minimum port of Docker";
 
     final int testOffset =
         testMavenId * PORT_RANGE_PER_TEST_STAGE + testForkNumber * PORT_RANGE_PER_TEST_FORK;


### PR DESCRIPTION
## Description

This PR tunes the configuration in `SocketUtil` relating to test port ranges. The primary goal here is to avoid any collisions with ports that are randomly chosen by the sibling Docker-in-Docker container. 

When it starts a new container, it will map the container's ports to a random port on the local machine, which is shared by the maven container. The Docker daemon, which is a nice tenant, will typically use the same port range as any ephemeral TCP-UDP connection, 32768-61000. 

As we cannot control this, in order to avoid collisions with it, it means we need to pick ports for our Java tests to be lower than 32768. So we need to lower the range in which we will pick ports. The lower bound here is 1024, as for most Unix systems, ports 0-1024 are reserved for the OS. This means have roughly 31k ports that we can pick from during our tests.

The PR lowers the base port to 1025, sets an upper bound of 10 max stages, 30 max forks per stages, and 100 ports per fork (which are reused in a round-robin fashion). This gives us a max absolute port of 31025, which should help us avoid any collision with Docker, though it does not prevent collisions from within the same fork, or any other test not using `SocketUtil`.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
