### PR TITLE
Use correct podSpec template for IT agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,7 @@ pipeline {
                             cloud 'zeebe-ci'
                             label "zeebe-ci-build_${buildName}_it"
                             defaultContainer 'jnlp'
-                            yaml templatePodspec('.ci/podSpecs/distribution-template.yml')
+                            yaml templatePodspec('.ci/podSpecs/integration-test-template.yml')
                         }
                     }
 


### PR DESCRIPTION
## Description

This PR corrects the podSpec template used by the IT agent. The template does not contain containers which are not necessary for the IT stage, e.g. golang and maven jdk8.

## Related issues

related to #5937

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
