### PR TITLE
[Backports stable/0.25] Backport CI improvements to stable/0.25

### DIFF
--- a/.ci/podSpecs/distribution-template.yml
+++ b/.ci/podSpecs/distribution-template.yml
@@ -3,17 +3,14 @@ metadata:
     agent: zeebe-ci-build
 spec:
   nodeSelector:
-    cloud.google.com/gke-nodepool: agents-n1-standard-32-netssd-preempt
+    cloud.google.com/gke-nodepool: "PODSPEC_TEMPLATE_NODE_POOL"
   tolerations:
-    - key: "agents-n1-standard-32-netssd-preempt"
+    - key: "PODSPEC_TEMPLATE_NODE_POOL"
       operator: "Exists"
       effect: "NoSchedule"
-  volumes:
-    - name: shared-data
-      emptyDir: {}
   containers:
     - name: maven
-      image: maven:3.6.0-jdk-11
+      image: maven:3.6.3-jdk-11
       command: ["cat"]
       tty: true
       env:
@@ -26,23 +23,17 @@ spec:
             -XX:+UseContainerSupport
         - name: DOCKER_HOST
           value: tcp://localhost:2375
-        - name: ZEEBE_CI_SHARED_DATA
-          value: /home/shared
       resources:
         limits:
-          cpu: 8
-          memory: 32Gi
+          cpu: 12
+          memory: 50Gi
         requests:
-          cpu: 8
-          memory: 32Gi
+          cpu: 12
+          memory: 50Gi
       securityContext:
         privileged: true
-      volumeMounts:
-        - name: shared-data
-          mountPath: /home/shared
-          mountPropagation: Bidirectional
     - name: maven-jdk8
-      image: maven:3.6.0-jdk-8
+      image: maven:3.6.3-jdk-8
       command: ["cat"]
       tty: true
       env:
@@ -53,10 +44,6 @@ spec:
         - name: JAVA_TOOL_OPTIONS
           value: |
             -XX:+UseContainerSupport
-        - name: DOCKER_HOST
-          value: tcp://localhost:2375
-        - name: ZEEBE_CI_SHARED_DATA
-          value: /home/shared
       resources:
         limits:
           cpu: 2
@@ -66,46 +53,39 @@ spec:
           memory: 4Gi
       securityContext:
         privileged: true
-      volumeMounts:
-        - name: shared-data
-          mountPath: /home/shared
-          mountPropagation: Bidirectional
     - name: golang
       image: golang:1.13.4
       command: ["cat"]
       tty: true
       resources:
         limits:
-          cpu: 3
-          memory: 2Gi
+          cpu: 4
+          memory: 4Gi
         requests:
-          cpu: 3
-          memory: 2Gi
+          cpu: 4
+          memory: 4Gi
       env:
         - name: DOCKER_HOST
           value: tcp://localhost:2375
-        - name: ZEEBE_CI_SHARED_DATA
-          value: /home/shared
       securityContext:
         privileged: true
-      volumeMounts:
-        - name: shared-data
-          mountPath: /home/shared
-          mountPropagation: Bidirectional
     - name: docker
-      image: docker:18.09.4-dind
-      args: ["--storage-driver=overlay2"]
+      image: docker:19.03.13-dind
+      args:
+        - --storage-driver=overlay
+      env:
+        # The new dind versions expect secure access using cert
+        # Setting DOCKER_TLS_CERTDIR to empty string will disable the secure access
+        # (see https://hub.docker.com/_/docker?tab=description&page=1)
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
       securityContext:
         privileged: true
       tty: true
       resources:
         limits:
-          cpu: 8
-          memory: 16Gi
+          cpu: 12
+          memory: 50Gi
         requests:
-          cpu: 8
-          memory: 16Gi
-      volumeMounts:
-        - name: shared-data
-          mountPath: /home/shared
-          mountPropagation: Bidirectional
+          cpu: 12
+          memory: 50Gi

--- a/.ci/podSpecs/integration-test-template.yml
+++ b/.ci/podSpecs/integration-test-template.yml
@@ -1,0 +1,58 @@
+# n1-standard-32 nodes have 31.85 and 109Gi allocatable CPU and memory
+# there is some overhead when scheduling a pod via jenkins (e.g. jnlp container), so let's aim to
+# keep resources to max 30 CPUs and 108Gi. before scaling horizontally (more agents), always scale
+# the nodes vertically.
+metadata:
+  labels:
+    agent: zeebe-ci-build
+spec:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: "PODSPEC_TEMPLATE_NODE_POOL"
+  tolerations:
+    - key: "PODSPEC_TEMPLATE_NODE_POOL"
+      operator: "Exists"
+      effect: "NoSchedule"
+  containers:
+    - name: maven
+      image: maven:3.6.3-jdk-11
+      command: ["cat"]
+      tty: true
+      env:
+        - name: LIMITS_CPU
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: JAVA_TOOL_OPTIONS
+          value: |
+            -XX:+UseContainerSupport
+        - name: DOCKER_HOST
+          value: tcp://localhost:2375
+      resources:
+        limits:
+          cpu: 12
+          memory: 48Gi
+        requests:
+          cpu: 12
+          memory: 48Gi
+      securityContext:
+        privileged: true
+    - name: docker
+      image: docker:19.03.13-dind
+      args:
+        - --storage-driver=overlay
+      env:
+        # The new dind versions expect secure access using cert
+        # Setting DOCKER_TLS_CERTDIR to empty string will disable the secure access
+        # (see https://hub.docker.com/_/docker?tab=description&page=1)
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
+      securityContext:
+        privileged: true
+      tty: true
+      resources:
+        limits:
+          cpu: 18
+          memory: 60Gi
+        requests:
+          cpu: 18
+          memory: 60Gi

--- a/.ci/scripts/distribution/it-java.sh
+++ b/.ci/scripts/distribution/it-java.sh
@@ -1,13 +1,25 @@
 #!/bin/bash -eux
 
-
-export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
-
+# getconf is a POSIX way to get the number of processors available which works on both Linux and macOS
+LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
+MAVEN_PARALLELISM=${MAVEN_PARALLELISM:-$LIMITS_CPU}
+SUREFIRE_FORK_COUNT=${SUREFIRE_FORK_COUNT:-}
+MAVEN_PROPERTIES=(
+  -DtestMavenId=2
+  -Dsurefire.rerunFailingTestsCount=7
+)
 tmpfile=$(mktemp)
 
-mvn -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} test-compile -Pprepare-offline -pl qa/integration-tests -pl update-tests
+if [ ! -z "$SUREFIRE_FORK_COUNT" ]; then
+  MAVEN_PROPERTIES+=("-DforkCount=$SUREFIRE_FORK_COUNT")
+  # if we know the fork count, we can limit the max heap for each fork to ensure we're not OOM killed
+  JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -XX:MaxRAMPercentage=$((100 / (MAVEN_PARALLELISM * $SUREFIRE_FORK_COUNT)))"
+fi
 
-mvn -o -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl qa/integration-tests -pl update-tests -DtestMavenId=2 -Dsurefire.rerunFailingTestsCount=7 | tee ${tmpfile}
+# make sure to specify the profiles used in the verify goal when running preparing to go offline, as
+# these may require some additional plugin dependencies
+mvn -B -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} test-compile -Pprepare-offline,skip-unstable-ci,parallel-tests -pl qa/integration-tests,update-tests
+mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl qa/integration-tests,update-tests "${MAVEN_PROPERTIES[@]}" | tee ${tmpfile}
 
 status=${PIPESTATUS[0]}
 
@@ -17,7 +29,7 @@ if grep -q "\[WARNING\] Flakes:" ${tmpfile}; then
 
   awk '/^\[WARNING\] Flakes:.*$/{flag=1}/^\[ERROR\] Tests run:.*Flakes: [0-9]*$/{print;flag=0}flag' ${tmpfile} > ${tmpfile2}
 
-  grep "\[ERROR\]   Run 1: " ${tmpfile} | awk '{print $4}' >> ./target/FlakyTests.txt
+  grep "\[ERROR\]   Run 1: " ${tmpfile2} | awk '{print $4}' >> ./FlakyTests.txt
 
   echo ERROR: Flaky Tests detected>&2
 

--- a/.ci/scripts/distribution/test-java.sh
+++ b/.ci/scripts/distribution/test-java.sh
@@ -1,10 +1,23 @@
 #!/bin/bash -eux
 
-export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
-
+# getconf is a POSIX way to get the number of processors available which works on both Linux and macOS
+LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
+MAVEN_PARALLELISM=${MAVEN_PARALLELISM:-$LIMITS_CPU}
+SUREFIRE_FORK_COUNT=${SUREFIRE_FORK_COUNT:-}
+MAVEN_PROPERTIES=(
+  -Dzeebe.it.skip
+  -DtestMavenId=1
+  -Dsurefire.rerunFailingTestsCount=7
+)
 tmpfile=$(mktemp)
 
-mvn -o -B --fail-never -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -Dzeebe.it.skip -DtestMavenId=1 -Dsurefire.rerunFailingTestsCount=7 | tee ${tmpfile}
+if [ ! -z "$SUREFIRE_FORK_COUNT" ]; then
+  MAVEN_PROPERTIES+=("-DforkCount=$SUREFIRE_FORK_COUNT")
+  # if we know the fork count, we can limit the max heap for each fork to ensure we're not OOM killed
+  JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -XX:MaxRAMPercentage=$((100 / ($MAVEN_PARALLELISM * $SUREFIRE_FORK_COUNT)))"
+fi
+
+mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests "${MAVEN_PROPERTIES[@]}" | tee ${tmpfile}
 
 status=${PIPESTATUS[0]}
 
@@ -14,7 +27,7 @@ if grep -q "\[WARNING\] Flakes:" ${tmpfile}; then
 
   awk '/^\[WARNING\] Flakes:.*$/{flag=1}/^\[ERROR\] Tests run:.*Flakes: [0-9]*$/{print;flag=0}flag' ${tmpfile} > ${tmpfile2}
 
-  grep "\[ERROR\]   Run 1: " ${tmpfile2} | awk '{print $4}' >> ./target/FlakyTests.txt
+  grep "\[ERROR\]   Run 1: " ${tmpfile2} | awk '{print $4}' >> ./FlakyTests.txt
 
   echo ERROR: Flaky Tests detected>&2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,5 @@ indent_size = 2
 [*.md]
 indent_size = 2
 
+[{*.dsl,*.groovy,Jenkinsfile*}]
+indent_size = 4

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,21 +18,21 @@ def cronTrigger = isDevelopBranch ? '@hourly' : ''
 
 pipeline {
     agent {
-      kubernetes {
-        cloud 'zeebe-ci'
-        label "zeebe-ci-build_${buildName}"
-        defaultContainer 'jnlp'
-        yamlFile '.ci/podSpecs/distribution.yml'
-      }
+        kubernetes {
+            cloud 'zeebe-ci'
+            label "zeebe-ci-build_${buildName}"
+            defaultContainer 'jnlp'
+            yaml templatePodspec('.ci/podSpecs/distribution-template.yml')
+        }
     }
 
     environment {
-      NEXUS = credentials("camunda-nexus")
-      SONARCLOUD_TOKEN = credentials('zeebe-sonarcloud-token')
+        NEXUS = credentials("camunda-nexus")
+        SONARCLOUD_TOKEN = credentials('zeebe-sonarcloud-token')
     }
 
     triggers {
-      cron(cronTrigger)
+        cron(cronTrigger)
     }
 
     options {
@@ -42,42 +42,24 @@ pipeline {
     }
 
     stages {
-        stage('Prepare') {
+        stage('Prepare Distribution') {
             steps {
-                script {
-                    commit_summary = sh([returnStdout: true, script: 'git show -s --format=%s']).trim()
-                    displayNameFull = "#" + BUILD_NUMBER + ': ' + commit_summary
+                setHumanReadableBuildDisplayName()
 
-                    if (displayNameFull.length() <= 45) {
-                      currentBuild.displayName = displayNameFull
-                    } else {
-                      displayStringHardTruncate = displayNameFull.take(45)
-                      currentBuild.displayName = displayStringHardTruncate.take(displayStringHardTruncate.lastIndexOf(" "))
-                    }
-                }
-                container('maven') {
-                    sh '.ci/scripts/distribution/prepare.sh'
-                }
-                container('maven-jdk8') {
-                    sh '.ci/scripts/distribution/prepare.sh'
-                }
+                prepareMavenContainer()
+                prepareMavenContainer('jdk8')
                 container('golang') {
                     sh '.ci/scripts/distribution/prepare-go.sh'
                 }
-
             }
         }
 
-        stage('Build (Java)') {
+        stage('Build Distribution') {
             environment {
                 VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
             }
             steps {
-                container('maven') {
-                    configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
-                        sh '.ci/scripts/distribution/build-java.sh'
-                    }
-                }
+                runMavenContainerCommand('.ci/scripts/distribution/build-java.sh')
                 container('maven') {
                     sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
                 }
@@ -86,10 +68,10 @@ pipeline {
             }
         }
 
-        stage('Prepare Tests') {
+        stage('Build Docker Images') {
             environment {
+                DOCKER_BUILDKIT = "1"
                 IMAGE = "camunda/zeebe"
-                VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
                 TAG = 'current-test'
             }
 
@@ -100,11 +82,15 @@ pipeline {
             }
         }
 
-
-
-        stage('Test') {
+        stage('Verify') {
             parallel {
-                stage('Go') {
+                stage('Analyse') {
+                    steps {
+                        runMavenContainerCommand('.ci/scripts/distribution/analyse-java.sh')
+                    }
+                }
+
+                stage('Test (Go)') {
                     steps {
                         container('golang') {
                             sh '.ci/scripts/distribution/build-go.sh'
@@ -122,46 +108,15 @@ pipeline {
                     }
                 }
 
-                stage('Analyse (Java)') {
-                    steps {
-                        container('maven') {
-                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
-                                sh '.ci/scripts/distribution/analyse-java.sh'
-                            }
-                        }
-                    }
-                }
-
-                stage('Unit (Java)') {
+                stage('Test (Java)') {
                     environment {
-                      SUREFIRE_REPORT_NAME_SUFFIX = 'java-testrun'
+                        SUREFIRE_REPORT_NAME_SUFFIX = 'java-testrun'
+                        MAVEN_PARALLELISM = 2
+                        SUREFIRE_FORK_COUNT = 6
                     }
 
                     steps {
-                        container('maven') {
-                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
-                                sh '.ci/scripts/distribution/test-java.sh'
-                            }
-                        }
-                    }
-
-                    post {
-                        always {
-                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
-                        }
-                    }
-                }
-                stage('Unit 8 (Java 8)') {
-                    environment {
-                      SUREFIRE_REPORT_NAME_SUFFIX = 'java8-testrun'
-                    }
-
-                    steps {
-                        container('maven-jdk8') {
-                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
-                                sh '.ci/scripts/distribution/test-java8.sh'
-                            }
-                        }
+                        runMavenContainerCommand('.ci/scripts/distribution/test-java.sh')
                     }
 
                     post {
@@ -171,56 +126,85 @@ pipeline {
                     }
                 }
 
-                stage('IT (Java)') {
+                stage('Test (Java 8)') {
+                    environment {
+                        SUREFIRE_REPORT_NAME_SUFFIX = 'java8-testrun'
+                    }
+
+                    steps {
+                        runMavenContainerCommand('.ci/scripts/distribution/test-java8.sh', 'jdk8')
+                    }
+
+                    post {
+                        always {
+                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
+                        }
+                    }
+                }
+
+                stage('IT') {
                     agent {
                         kubernetes {
                             cloud 'zeebe-ci'
                             label "zeebe-ci-build_${buildName}_it"
                             defaultContainer 'jnlp'
-                            yamlFile '.ci/podSpecs/distribution.yml'
+                            yaml templatePodspec('.ci/podSpecs/integration-test-template.yml')
                         }
                     }
 
-                    environment {
-                        SUREFIRE_REPORT_NAME_SUFFIX = 'it-testrun'
-                        IMAGE = "camunda/zeebe"
-                        VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
-                        TAG = 'current-test'
-                    }
-
-                    steps {
-                        container('maven') {
-                            sh '.ci/scripts/distribution/prepare.sh'
-                        }
-                        unstash name: "zeebe-build"
-                        unstash name: "zeebe-distro"
-                        container('docker') {
-                            sh '.ci/scripts/docker/build.sh'
-                        }
-                        container('maven') {
-                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
-                                sh '.ci/scripts/distribution/it-java.sh'
+                    stages {
+                        stage('Prepare') {
+                            steps {
+                                prepareMavenContainer()
                             }
                         }
-                    }
 
-                    post {
-                        always {
-                            junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
+                        stage('Build Docker Image') {
+                            environment {
+                                DOCKER_BUILDKIT = "1"
+                                IMAGE = "camunda/zeebe"
+                                TAG = 'current-test'
+                            }
+
+                            steps {
+                                unstash name: "zeebe-distro"
+                                container('docker') {
+                                    sh '.ci/scripts/docker/build.sh'
+                                }
+                            }
+                        }
+
+                        stage('Test') {
+                            environment {
+                                SUREFIRE_REPORT_NAME_SUFFIX = 'it-testrun'
+                                MAVEN_PARALLELISM = 2
+                                SUREFIRE_FORK_COUNT = 6
+                            }
+
+                            steps {
+                                unstash name: "zeebe-build"
+                                runMavenContainerCommand('.ci/scripts/distribution/it-java.sh')
+                            }
+
+                            post {
+                                always {
+                                    junit testResults: "**/*/TEST*${SUREFIRE_REPORT_NAME_SUFFIX}*.xml", keepLongStdio: true
+                                }
+                            }
                         }
                     }
                 }
 
                 stage('Build Docs') {
                     steps {
-                      retry(3) {
-                        container('maven') {
-                            configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
-                                sh '.ci/scripts/docs/prepare.sh'
-                                sh '.ci/scripts/docs/build.sh'
+                        retry(3) {
+                            container('maven') {
+                                configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
+                                    sh '.ci/scripts/docs/prepare.sh'
+                                    sh '.ci/scripts/docs/build.sh'
+                                }
                             }
                         }
-                      }
                     }
                 }
             }
@@ -228,38 +212,35 @@ pipeline {
             post {
                 always {
                     jacoco(
-                          execPattern: '**/*.exec',
-                          classPattern: '**/target/classes',
-                          sourcePattern: '**/src/main/java,**/generated-sources/protobuf/java,**/generated-sources/assertj-assertions,**/generated-sources/sbe',
-                          exclusionPattern: '**/io/zeebe/gateway/protocol/**,'
-                                            + '**/*Encoder.class,**/*Decoder.class,**/MetaAttribute.class,'
-                                            + '**/io/zeebe/protocol/record/**/*Assert.class,**/io/zeebe/protocol/record/Assertions.class,', // classes from generated resources
-                          runAlways: true
+                        execPattern: '**/*.exec',
+                        classPattern: '**/target/classes',
+                        sourcePattern: '**/src/main/java,**/generated-sources/protobuf/java,**/generated-sources/assertj-assertions,**/generated-sources/sbe',
+                        exclusionPattern: '**/io/zeebe/gateway/protocol/**,'
+                            + '**/*Encoder.class,**/*Decoder.class,**/MetaAttribute.class,'
+                            + '**/io/zeebe/protocol/record/**/*Assert.class,**/io/zeebe/protocol/record/Assertions.class,', // classes from generated resources
+                        runAlways: true
                     )
                     zip zipFile: 'test-coverage-reports.zip', archive: true, glob: "**/target/site/jacoco/**"
                 }
+
                 failure {
                     zip zipFile: 'test-reports.zip', archive: true, glob: "**/*/surefire-reports/**"
                     archive "**/hs_err_*.log"
 
                     script {
-                      if (fileExists('./target/FlakyTests.txt')) {
-                          currentBuild.description = "Flaky Tests: <br>" + readFile('./target/FlakyTests.txt').split('\n').join('<br>')
-                      }
+                        if (fileExists('./FlakyTests.txt')) {
+                            currentBuild.description = "Flaky Tests: <br>" + readFile('./FlakyTests.txt').split('\n').join('<br>')
+                        }
                     }
                 }
             }
         }
 
         stage('Upload') {
-            when { allOf { branch developBranchName ; not {  triggeredBy 'TimerTrigger' } } }
+            when { allOf { branch developBranchName; not { triggeredBy 'TimerTrigger' } } }
             steps {
                 retry(3) {
-                    container('maven') {
-                        configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
-                            sh '.ci/scripts/distribution/upload.sh'
-                        }
-                    }
+                    runMavenContainerCommand('.ci/scripts/distribution/upload.sh')
                 }
             }
         }
@@ -304,14 +285,31 @@ pipeline {
 
     post {
         always {
-            // Retrigger the build if there were connection issues
+            // Retrigger the build if there were connection issues (but not
+            // on bors staging branch as bors does not recognize this result)
             script {
                 if (agentDisconnected()) {
                     currentBuild.result = 'ABORTED'
                     currentBuild.description = "Aborted due to connection error"
 
-                    build job: currentBuild.projectName, propagate: false, quietPeriod: 60, wait: false
+                    if (!isBorsStagingBranch()) {
+                        build job: currentBuild.projectName, propagate: false, quietPeriod: 60, wait: false
+                    }
                 }
+
+                String userReason = null
+                if (currentBuild.description ==~ /.*Flaky Tests.*/) {
+                    userReason = 'flaky-tests'
+                }
+                org.camunda.helper.CIAnalytics.trackBuildStatus(this, userReason)
+            }
+        }
+        failure {
+            script {
+                if (env.BRANCH_NAME != 'develop' || agentDisconnected()) {
+                    return
+                }
+                sendZeebeSlackMessage()
             }
         }
         changed {
@@ -319,14 +317,83 @@ pipeline {
                 if (env.BRANCH_NAME != 'develop' || agentDisconnected()) {
                     return
                 }
-
-                if (hasBuildResultChanged()) {
-                    echo "Send slack message"
-                    slackSend(
-                        channel: "#zeebe-ci${jenkins.model.JenkinsLocationConfiguration.get()?.getUrl()?.contains('stage') ? '-stage' : ''}",
-                        message: "Zeebe ${env.BRANCH_NAME} build ${currentBuild.absoluteUrl} changed status to ${currentBuild.currentResult}")
+                if (currentBuild.currentResult == 'FAILURE') {
+                    return // already handled above
                 }
+                if (!hasBuildResultChanged()) {
+                    return
+                }
+
+                sendZeebeSlackMessage()
             }
         }
     }
+}
+//////////////////// Helper functions ////////////////////
+
+def getMavenContainerNameForJDK(String jdk = null) {
+    "maven${jdk ? '-' + jdk : ''}"
+}
+
+def prepareMavenContainer(String jdk = null) {
+    container(getMavenContainerNameForJDK(jdk)) {
+        sh '.ci/scripts/distribution/prepare.sh'
+    }
+}
+
+def runMavenContainerCommand(String shellCommand, String jdk = null) {
+    container(getMavenContainerNameForJDK(jdk)) {
+        configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe-local-repo', variable: 'MAVEN_SETTINGS_XML')]) {
+            sh shellCommand
+        }
+    }
+}
+
+// TODO: can be extracted to zeebe-jenkins-shared-library
+def setHumanReadableBuildDisplayName(int maximumLength = 45) {
+    script {
+        commit_summary = sh([returnStdout: true, script: 'git show -s --format=%s']).trim()
+        displayNameFull = "#${env.BUILD_NUMBER}: ${commit_summary}"
+
+        if (displayNameFull.length() <= maximumLength) {
+            currentBuild.displayName = displayNameFull
+        } else {
+            displayStringHardTruncate = displayNameFull.take(maximumLength)
+            currentBuild.displayName = displayStringHardTruncate.take(displayStringHardTruncate.lastIndexOf(' '))
+        }
+    }
+}
+
+// TODO: can be extracted to zeebe-jenkins-shared-library
+def sendZeebeSlackMessage() {
+    echo "Send slack message"
+    slackSend(
+        channel: "#zeebe-ci${jenkins.model.JenkinsLocationConfiguration.get()?.getUrl()?.contains('stage') ? '-stage' : ''}",
+        message: "Zeebe ${env.BRANCH_NAME} build ${currentBuild.absoluteUrl} changed status to ${currentBuild.currentResult}")
+}
+
+def isBorsStagingBranch() {
+    env.BRANCH_NAME == 'staging'
+}
+
+def templatePodspec(String podspecPath, flags = [:]) {
+    def defaultFlags = [
+        useStableNodePool: isBorsStagingBranch()
+    ]
+    // will merge Maps by overwriting left Map with values of the right Map
+    def effectiveFlags = defaultFlags + flags
+
+    def nodePoolName = "agents-n1-standard-32-netssd-${effectiveFlags.useStableNodePool ? 'stable' : 'preempt'}"
+
+    // Needs no workspace, see:
+    // https://www.jenkins.io/doc/pipeline/steps/workflow-multibranch/#readtrusted-read-trusted-file-from-scm
+    String templateString = readTrusted(podspecPath)
+
+    // Note: Templating is currently done via simple string substitution as this
+    // is enough to solve all existing use cases. If need arises the templating
+    // can be transparently changed to a more sophisticated YAML-merge based
+    // approach as it is an implementation detail that the caller does not know.
+    templateString = templateString.replaceAll('PODSPEC_TEMPLATE_NODE_POOL', nodePoolName)
+
+    templateString
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1291,13 +1291,30 @@
 
     <profile>
       <id>parallel-tests</id>
+      <properties>
+        <forkCount>0.5C</forkCount>
+      </properties>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <forkCount>0.5C</forkCount>
+              <forkCount>${forkCount}</forkCount>
+              <reuseForks>true</reuseForks>
+              <systemPropertyVariables>
+                <!-- use two dollar signs to prevent maven properties resolution, surefire will resolve
+                the property later. If only ${surefire.forkNumber} is used maven will fail to resolve it
+                and don't set the system property -->
+                <testForkNumber>$${surefire.forkNumber}</testForkNumber>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <forkCount>${forkCount}</forkCount>
               <reuseForks>true</reuseForks>
               <systemPropertyVariables>
                 <!-- use two dollar signs to prevent maven properties resolution, surefire will resolve

--- a/test-util/src/main/java/io/zeebe/test/util/TestEnvironment.java
+++ b/test-util/src/main/java/io/zeebe/test/util/TestEnvironment.java
@@ -7,14 +7,16 @@
  */
 package io.zeebe.test.util;
 
-import io.zeebe.util.ZbLogger;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class TestEnvironment {
-  private static final Logger LOG = new ZbLogger("io.zeebe.test.util");
+public final class TestEnvironment {
+  private static final Logger LOG = LoggerFactory.getLogger("io.zeebe.test.util");
 
   private static final String TEST_FORK_NUMBER_PROPERTY_NAME = "testForkNumber";
   private static final String TEST_MAVEN_ID_PROPERTY_NAME = "testMavenId";
+
+  private TestEnvironment() {}
 
   /**
    * Returns the test fork number
@@ -26,7 +28,7 @@ public class TestEnvironment {
     try {
       final String testForkNumberProperty = System.getProperty(TEST_FORK_NUMBER_PROPERTY_NAME);
       if (testForkNumberProperty != null) {
-        testForkNumber = Integer.valueOf(testForkNumberProperty);
+        testForkNumber = Integer.parseInt(testForkNumberProperty);
       } else {
         LOG.warn(
             "No system property '{}' set, using default value {}",
@@ -50,7 +52,7 @@ public class TestEnvironment {
     try {
       final String testMavenIdProperty = System.getProperty(TEST_MAVEN_ID_PROPERTY_NAME);
       if (testMavenIdProperty != null) {
-        testMavenId = Integer.valueOf(testMavenIdProperty);
+        testMavenId = Integer.parseInt(testMavenIdProperty);
       } else {
         LOG.warn(
             "No system property '{}' set, using default value {}",


### PR DESCRIPTION
## Description

This PR backports several CI improvements to the 0.25 branch. As we will be maintaining it for the next 3 months, having a more stable CI on this branch is equally important. The PR backports the following changes:

- templated podSpecs, allowing us to use the non-preemptible nodes for bors
- improved control over the Maven/Surefire/Failsafe parallelism
- fixes an error when using a separate IT agent where `./target` may not be there when appending to `FlakyTests.txt`
- synchronizes the CI files with develop so further backports can easily be made

## Related issues

related to #5937 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
