### PR TITLE
[Backports stable/0.25] Fix LGTM alerts

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -58,7 +58,12 @@ public final class DeploymentTransformer {
     validator = BpmnFactory.createValidator(expressionProcessor);
 
     try {
-      digestGenerator = MessageDigest.getInstance("MD5");
+      // We get an alert by LGTM, since MD5 is a weak cryptographic hash function,
+      // but it is not easy to exchange this weak algorithm without getting compatibility issues
+      // with previous versions. Furthermore it is very unlikely that we get problems on checking
+      // the deployments hashes.
+      digestGenerator =
+          MessageDigest.getInstance("MD5"); // lgtm [java/weak-cryptographic-algorithm]
     } catch (final NoSuchAlgorithmException e) {
       throw new IllegalStateException(e);
     }

--- a/util/src/main/java/io/zeebe/util/sched/ActorThread.java
+++ b/util/src/main/java/io/zeebe/util/sched/ActorThread.java
@@ -173,7 +173,7 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
   }
 
   @Override
-  public void start() {
+  public synchronized void start() {
     if (UNSAFE.compareAndSwapObject(
         this, STATE_OFFSET, ActorThreadState.NEW, ActorThreadState.RUNNING)) {
       super.start();


### PR DESCRIPTION
## Description

This PR backports #5928, which fixes LGTM and SonarCloud alerts. I'm backporting because right now SonarCloud checks are failing on 0.25 and 0.24, which causes additional toil for reviewers when backporting.

## Related issues

closes #5647
backports #5928 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
