### PR TITLE
Configure junit5 parallel only once for both surefire and failsafe

### DIFF
--- a/gateway/src/test/java/io/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -27,11 +27,8 @@ import org.apache.logging.slf4j.Log4jLogger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.helpers.NOPLogger;
 
-@Execution(ExecutionMode.CONCURRENT)
 final class GrpcErrorMapperTest {
   private final RecordingAppender recorder = new RecordingAppender();
   private final Logger log = (Logger) LogManager.getLogger(GrpcErrorMapperTest.class);

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1267,7 +1267,16 @@
       <id>parallel-tests</id>
       <properties>
         <forkCount>0.5C</forkCount>
-        <junitThreadCount>0.5C</junitThreadCount>
+        <junitThreadCount>2</junitThreadCount>
+        <junitConfigurationParameters>
+          <!-- allow junit5 parallel execution, configured on the number of cores
+               note that this does not make tests parallel, this is still controlled in the tests
+               themselves via the @Execution annotation. furthermore, child modules can define
+               their own parallel configuration -->
+          junit.jupiter.execution.parallel.enabled = true
+          junit.jupiter.execution.parallel.config.strategy = fixed
+          junit.jupiter.execution.parallel.config.fixed.parallelism = ${junitThreadCount}
+        </junitConfigurationParameters>
       </properties>
       <build>
         <plugins>
@@ -1284,24 +1293,7 @@
                 <testForkNumber>$${surefire.forkNumber}</testForkNumber>
               </systemPropertyVariables>
               <properties>
-                <!--
-                  allow junit5 parallel execution, configured on the number of cores
-                  note that this does not make tests parallel, this is still controlled in the tests
-                  themselves via the @Execution annotation. furthermore, child modules can define
-                  their own parallel configuration
-                -->
-                <junit.jupiter.execution.parallel.enabled>true
-                </junit.jupiter.execution.parallel.enabled>
-                <junit.jupiter.execution.parallel.mode.default>same_thread
-                </junit.jupiter.execution.parallel.mode.default>
-                <junit.jupiter.execution.parallel.mode.classes.default>same_thread
-                </junit.jupiter.execution.parallel.mode.classes.default>
-
-                <!-- will configure based on cpuCount * factor -->
-                <junit.jupiter.execution.parallel.config.strategy>dynamic
-                </junit.jupiter.execution.parallel.config.strategy>
-                <junit.jupiter.execution.parallel.config.dynamic.factor>${junitThreadCount}
-                </junit.jupiter.execution.parallel.config.dynamic.factor>
+                <configurationParameters>${junitConfigurationParameters}</configurationParameters>
               </properties>
             </configuration>
           </plugin>
@@ -1318,24 +1310,7 @@
                 <testForkNumber>$${surefire.forkNumber}</testForkNumber>
               </systemPropertyVariables>
               <properties>
-                <!--
-                  allow junit5 parallel execution, configured on the number of cores
-                  note that this does not make tests parallel, this is still controlled in the tests
-                  themselves via the @Execution annotation. furthermore, child modules can define
-                  their own parallel configuration
-                -->
-                <junit.jupiter.execution.parallel.enabled>true
-                </junit.jupiter.execution.parallel.enabled>
-                <junit.jupiter.execution.parallel.mode.default>same_thread
-                </junit.jupiter.execution.parallel.mode.default>
-                <junit.jupiter.execution.parallel.mode.classes.default>same_thread
-                </junit.jupiter.execution.parallel.mode.classes.default>
-
-                <!-- will configure based on cpuCount * factor -->
-                <junit.jupiter.execution.parallel.config.strategy>dynamic
-                </junit.jupiter.execution.parallel.config.strategy>
-                <junit.jupiter.execution.parallel.config.dynamic.factor>${junitThreadCount}
-                </junit.jupiter.execution.parallel.config.dynamic.factor>
+                <configurationParameters>${junitConfigurationParameters}</configurationParameters>
               </properties>
             </configuration>
           </plugin>


### PR DESCRIPTION
## Description

This PR extracts the junit5 configuration into a single property, allowing reuse for both failsafe and surefire. This reduces the risk of errors due to having to change it in two places. It was switched to use `configurationParameters` - this is a single string property which expects a `Properties`-string like format, making the configuration easily shared between failsafe and surefire. We also switch from dynamic to fixed strategy, as that's easier to reason about, especially when configuring it from the CI.

This PR also removes unnecessary concurrency which causes a test to be flaky due to shared state.

## Related issues

related to #5938 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
