### PR TITLE
chore(atomix): add more logs in the join process

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -443,11 +443,14 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
                   } else {
                     // If the response error was non-null, attempt to join via the next server in
                     // the members list.
-                    log.debug("Failed to join {}", member.getMember().memberId());
+                    log.debug(
+                        "Failed to join {}. Received error {}",
+                        member.getMember().memberId(),
+                        response.error());
                     join(iterator);
                   }
                 } else {
-                  log.debug("Failed to join {}", member.getMember().memberId());
+                  log.debug("Failed to join {}", member.getMember().memberId(), error);
                   join(iterator);
                 }
               },

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -123,6 +123,11 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     // Configuration changes should not be allowed until the leader has committed a no-op entry.
     // See https://groups.google.com/forum/#!topic/raft-dev/t4xj6dJTP6E
     if (configuring() || initializing()) {
+      log.debug(
+          "Cannot accept join request {}. Another configuration change ongoing (configuring = {}) or the leader has not committed its first entry (initializing = {})",
+          request,
+          configuring(),
+          initializing());
       return CompletableFuture.completedFuture(
           logResponse(JoinResponse.builder().withStatus(RaftResponse.Status.ERROR).build()));
     }


### PR DESCRIPTION
## Description

Add more logs to help debug #5292 

## Related issues

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
