### PR TITLE
Add more metrics for processing latency

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/metrics/StreamProcessorMetrics.java
+++ b/engine/src/main/java/io/zeebe/engine/metrics/StreamProcessorMetrics.java
@@ -35,7 +35,14 @@ public final class StreamProcessorMetrics {
       Histogram.build()
           .namespace(NAMESPACE)
           .name("stream_processor_latency")
-          .help("Latency of processing in seconds")
+          .help("Time between a record is written until it is picked up for processing (in seconds)")
+          .labelNames("recordType", "partition")
+          .register();
+  private static final Histogram PROCESSING_DURATION =
+      Histogram.build()
+          .namespace(NAMESPACE)
+          .name("stream_processor_processing_duration")
+          .help("Time for processing a record (in seconds)")
           .labelNames("recordType", "partition")
           .register();
 
@@ -62,6 +69,13 @@ public final class StreamProcessorMetrics {
     PROCESSING_LATENCY
         .labels(recordType.name(), partitionIdLabel)
         .observe((processed - written) / 1000f);
+  }
+
+  public void processingDuration(
+      final RecordType recordType, final long started, final long processed) {
+    PROCESSING_DURATION
+        .labels(recordType.name(), partitionIdLabel)
+        .observe((processed - started) / 1000f);
   }
 
   public void eventProcessed() {

--- a/engine/src/main/java/io/zeebe/engine/metrics/StreamProcessorMetrics.java
+++ b/engine/src/main/java/io/zeebe/engine/metrics/StreamProcessorMetrics.java
@@ -35,7 +35,8 @@ public final class StreamProcessorMetrics {
       Histogram.build()
           .namespace(NAMESPACE)
           .name("stream_processor_latency")
-          .help("Time between a record is written until it is picked up for processing (in seconds)")
+          .help(
+              "Time between a record is written until it is picked up for processing (in seconds)")
           .labelNames("recordType", "partition")
           .register();
   private static final Histogram PROCESSING_DURATION =

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -136,6 +136,8 @@ public final class ProcessingStateMachine {
   private long errorRecordPosition = StreamProcessor.UNSET_POSITION;
   private volatile boolean onErrorHandlingLoop;
   private int onErrorRetries;
+  // Used for processing duration metrics
+  private long processingStartTime;
 
   public ProcessingStateMachine(
       final ProcessingContext context, final BooleanSupplier shouldProcessNext) {
@@ -217,8 +219,8 @@ public final class ProcessingStateMachine {
       return;
     }
 
-    metrics.processingLatency(
-        metadata.getRecordType(), event.getTimestamp(), ActorClock.currentTimeMillis());
+    processingStartTime = ActorClock.currentTimeMillis();
+    metrics.processingLatency(metadata.getRecordType(), event.getTimestamp(), processingStartTime);
 
     try {
       final UnifiedRecordValue value = recordValues.readRecordValue(event, metadata.getValueType());
@@ -426,6 +428,8 @@ public final class ProcessingStateMachine {
 
           notifyListener();
 
+          metrics.processingDuration(
+              metadata.getRecordType(), processingStartTime, ActorClock.currentTimeMillis());
           // continue with next event
           currentProcessor = null;
           actor.submit(this::readNextEvent);

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/AppenderMetrics.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/AppenderMetrics.java
@@ -8,6 +8,7 @@
 package io.zeebe.logstreams.impl.log;
 
 import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
 
 public class AppenderMetrics {
 
@@ -27,6 +28,21 @@ public class AppenderMetrics {
           .labelNames("partition")
           .register();
 
+  private static final Histogram WRITE_LATENCY =
+      Histogram.build()
+          .namespace("zeebe")
+          .name("log_appender_append_latency")
+          .help("Latency to append an event to the log in seconds")
+          .labelNames("partition")
+          .register();
+  private static final Histogram COMMIT_LATENCY =
+      Histogram.build()
+          .namespace("zeebe")
+          .name("log_appender_commit_latency")
+          .help("Latency to commit an event to the log in seconds")
+          .labelNames("partition")
+          .register();
+
   private final String partitionLabel;
 
   public AppenderMetrics(final String partitionLabel) {
@@ -39,5 +55,13 @@ public class AppenderMetrics {
 
   public void setLastAppendedPosition(final long position) {
     LAST_APPENDED_POSITION.labels(partitionLabel).set(position);
+  }
+
+  public void appendLatency(final long startTime, final long currentTime) {
+    WRITE_LATENCY.labels(partitionLabel).observe((currentTime - startTime) / 1000f);
+  }
+
+  public void commitLatency(final long startTime, final long currentTime) {
+    COMMIT_LATENCY.labels(partitionLabel).observe((currentTime - startTime) / 1000f);
   }
 }

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/Listener.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/Listener.java
@@ -12,18 +12,20 @@ import io.zeebe.logstreams.spi.LogStorage.AppendListener;
 import java.util.NoSuchElementException;
 
 public final class Listener implements AppendListener {
-
   private final LogStorageAppender appender;
   private final long highestPosition;
+  private final long startTime;
 
-  public Listener(final LogStorageAppender appender, final long highestPosition) {
+  public Listener(
+      final LogStorageAppender appender, final long highestPosition, final long startTime) {
     this.appender = appender;
     this.highestPosition = highestPosition;
+    this.startTime = startTime;
   }
 
   @Override
   public void onWrite(final long address) {
-    appender.notifyWritePosition(highestPosition);
+    appender.notifyWritePosition(highestPosition, startTime);
   }
 
   @Override
@@ -45,7 +47,7 @@ public final class Listener implements AppendListener {
   @Override
   public void onCommit(final long address) {
     releaseBackPressure();
-    appender.notifyCommitPosition(highestPosition);
+    appender.notifyCommitPosition(highestPosition, startTime);
   }
 
   @Override

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -83,7 +83,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1604053043635,
+  "iteration": 1607335080870,
   "links": [],
   "panels": [
     {
@@ -5054,6 +5054,198 @@
           "yBucketBound": "auto",
           "yBucketNumber": null,
           "yBucketSize": null
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#ef843c",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "$DS_PROMETHEUS",
+          "description": "Time taken to process a record",
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 38
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 233,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "sum(increase(zeebe_stream_processor_processing_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[30s])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Processing Duration",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "dtdurations",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#ef843c",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "$DS_PROMETHEUS",
+          "description": "Time taken to append a record to the log",
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 38
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 234,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "sum(increase(zeebe_log_appender_append_latency_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[30s])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Record write latency",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "dtdurations",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#ef843c",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateSpectral",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "$DS_PROMETHEUS",
+          "description": "Time taken to commit a record to the log (includes write latency)",
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 45
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 235,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "sum(increase(zeebe_log_appender_commit_latency_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[30s])) by (le)",
+              "format": "heatmap",
+              "interval": "30s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Commit latency",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "dtdurations",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
         }
       ],
       "title": "Processing Latency",
@@ -9321,7 +9513,7 @@
       "type": "row"
     }
   ],
-  "refresh": "",
+  "refresh": "10s",
   "schemaVersion": 22,
   "style": "dark",
   "tags": [],
@@ -9451,5 +9643,5 @@
   "variables": {
     "list": []
   },
-  "version": 23
+  "version": 24
 }

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -4667,7 +4667,7 @@
           "reverseYBuckets": false,
           "targets": [
             {
-              "expr": "sum(increase(zeebe_stream_processor_latency_bucket{namespace=~\"$namespace\",partition=~\"$partition\", recordType=\"COMMAND\"}[30s])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_latency_bucket{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\",recordType=\"COMMAND\"}[30s])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -4731,7 +4731,7 @@
           "reverseYBuckets": false,
           "targets": [
             {
-              "expr": "sum(increase(zeebe_stream_processor_latency_bucket{namespace=~\"$namespace\",partition=~\"$partition\", recordType=\"EVENT\"}[30s])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_latency_bucket{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\", recordType=\"EVENT\"}[30s])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -4795,7 +4795,7 @@
           "reverseYBuckets": false,
           "targets": [
             {
-              "expr": "sum(increase(zeebe_workflow_instance_execution_time_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[30s])) by (le)",
+              "expr": "sum(increase(zeebe_workflow_instance_execution_time_bucket{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[30s])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -5087,7 +5087,7 @@
           "reverseYBuckets": false,
           "targets": [
             {
-              "expr": "sum(increase(zeebe_stream_processor_processing_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[30s])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_processing_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[30s])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -5151,7 +5151,7 @@
           "reverseYBuckets": false,
           "targets": [
             {
-              "expr": "sum(increase(zeebe_log_appender_append_latency_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[30s])) by (le)",
+              "expr": "sum(increase(zeebe_log_appender_append_latency_bucket{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[30s])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -5215,7 +5215,7 @@
           "reverseYBuckets": false,
           "targets": [
             {
-              "expr": "sum(increase(zeebe_log_appender_commit_latency_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[30s])) by (le)",
+              "expr": "sum(increase(zeebe_log_appender_commit_latency_bucket{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[30s])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,


### PR DESCRIPTION
## Description

Since we have been speculating about several root causes/solutions for performance bottlenecks, I thought it would be good to added following metrics:
* Time taken for processing a record
* Latency to write a record to the log
* Latency to commit a record

## Related issues

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
