### PR TITLE
[Backport stable/0.24] Reusable junit5 parallelism configuration

### DIFF
--- a/gateway/src/test/java/io/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -27,11 +27,8 @@ import org.apache.logging.slf4j.Log4jLogger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.helpers.NOPLogger;
 
-@Execution(ExecutionMode.CONCURRENT)
 final class GrpcErrorMapperTest {
   private final RecordingAppender recorder = new RecordingAppender();
   private final Logger log = (Logger) LogManager.getLogger(GrpcErrorMapperTest.class);

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1251,6 +1251,16 @@
       <id>parallel-tests</id>
       <properties>
         <forkCount>0.5C</forkCount>
+        <junitThreadCount>2</junitThreadCount>
+        <junitConfigurationParameters>
+          <!-- allow junit5 parallel execution, configured on the number of cores
+               note that this does not make tests parallel, this is still controlled in the tests
+               themselves via the @Execution annotation. furthermore, child modules can define
+               their own parallel configuration -->
+          junit.jupiter.execution.parallel.enabled = true
+          junit.jupiter.execution.parallel.config.strategy = fixed
+          junit.jupiter.execution.parallel.config.fixed.parallelism = ${junitThreadCount}
+        </junitConfigurationParameters>
       </properties>
       <build>
         <plugins>
@@ -1266,6 +1276,9 @@
                 and don't set the system property -->
                 <testForkNumber>$${surefire.forkNumber}</testForkNumber>
               </systemPropertyVariables>
+              <properties>
+                <configurationParameters>${junitConfigurationParameters}</configurationParameters>
+              </properties>
             </configuration>
           </plugin>
           <plugin>
@@ -1280,6 +1293,9 @@
                 and don't set the system property -->
                 <testForkNumber>$${surefire.forkNumber}</testForkNumber>
               </systemPropertyVariables>
+              <properties>
+                <configurationParameters>${junitConfigurationParameters}</configurationParameters>
+              </properties>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
## Description

This PR backports #5966 to 0.24. There were some merge conflicts as one backport was skipped (#5963), but keep in mind that this PR refactored those changes to streamline them, so there's no need to backport them (however please challenge this).

## Related issues

related to #5963 
backports #5966

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
