### PR TITLE
5964 wait for end of qa run

### DIFF
--- a/.ci/scripts/distribution/qa-testbench.sh
+++ b/.ci/scripts/distribution/qa-testbench.sh
@@ -1,7 +1,48 @@
-#!/bin/sh -eux
+#!/bin/bash -eux
 
 chmod +x clients/go/cmd/zbctl/dist/zbctl
 
-alias zbctl="clients/go/cmd/zbctl/dist/zbctl"
+zbctl="clients/go/cmd/zbctl/dist/zbctl"
 
-zbctl create instance qa-protocol --variables "${QA_RUN_VARIABLES}"
+"${zbctl}" create instance external-tool-integration --variables "${QA_RUN_VARIABLES}"
+
+businessKey="${BUSINESS_KEY}"
+
+echo "Waiting for result of $businessKey"
+
+while true; do
+
+    "${zbctl}"  activate jobs "$businessKey" > activationresponse.txt 2>/dev/null
+
+    key=$(jq -r '.key' < activationresponse.txt)
+
+    if [ -z "$key" ]; then
+        echo "Still waiting"
+        sleep 5m
+    else
+        echo "QA run completed"
+        break
+    fi
+done
+
+key=$(jq -r '.key' < activationresponse.txt)
+
+echo "Job key is: $key"
+
+variables=$(jq -r '.variables' < activationresponse.txt)
+
+echo "Job variables are: $variables"
+
+testResult=$(echo "$variables" | jq -r '.aggregatedTestResult')
+
+echo "Test result is: $testResult"
+
+"${zbctl}"  complete job "$key"
+
+if [ "$testResult" == "FAILED" ]; then
+  echo "Test failed"
+  exit 1
+else
+  echo "Test passed or skipped"
+  exit 0
+fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -278,33 +278,41 @@ pipeline {
                 DOCKER_GCR = credentials("zeebe-gcr-serviceaccount-json")
                 ZEEBE_AUTHORIZATION_SERVER_URL = 'https://login.cloud.ultrawombat.com/oauth/token'
                 ZEEBE_CLIENT_ID = 'W5a4JUc3I1NIetNnodo3YTvdsRIFb12w'
-                QA_RUN_VARIABLES = "{\"zeebeImage\": \"${env.IMAGE}:${env.TAG}\", \"generationTemplate\": \"${params.GENERATION_TEMPLATE}\", \"channel\": \"Internal Dev\", " +
-                    "\"branch\": \"${env.BRANCH_NAME}\", \"build\": \"${currentBuild.absoluteUrl}\"}"
+                QA_RUN_VARIABLES = "{\"zeebeImage\": \"${env.IMAGE}:${env.TAG}\", \"generationTemplate\": \"${params.GENERATION_TEMPLATE}\", " +
+                                    "\"channel\": \"Internal Dev\", \"branch\": \"${env.BRANCH_NAME}\", \"build\": \"${currentBuild.absoluteUrl}\", " +
+                                    "\"businessKey\": \"${currentBuild.absoluteUrl}\", \"processId\": \"qa-protocol\"}"
+                BUSINESS_KEY = "${currentBuild.absoluteUrl}"
             }
 
             steps {
-                timeout(time: shortTimeoutMinutes, unit: 'MINUTES') {
-                    container('docker') {
-                        sh '.ci/scripts/docker/upload-gcr.sh'
-                        withVault(
-                            [vaultSecrets:
-                                 [
-                                     [path        : 'secret/common/ci-zeebe/testbench-secrets-int',
-                                      secretValues:
-                                          [
-                                              [envVar: 'ZEEBE_CLIENT_SECRET', vaultKey: 'clientSecret'],
-                                              [envVar: 'ZEEBE_ADDRESS', vaultKey: 'contactPoint'],
-                                          ]
-                                     ],
-                                 ]
-                            ]
-                        ) {
-                            sh '.ci/scripts/distribution/qa-testbench.sh'
-                        }
+                container('docker') {
+                    sh '.ci/scripts/docker/upload-gcr.sh'
+                }
+                container('maven') {
+                    withVault(
+                        [vaultSecrets:
+                             [
+                                 [path        : 'secret/common/ci-zeebe/testbench-secrets-int',
+                                  secretValues:
+                                      [
+                                          [envVar: 'ZEEBE_CLIENT_SECRET', vaultKey: 'clientSecret'],
+                                          [envVar: 'ZEEBE_ADDRESS', vaultKey: 'contactPoint'],
+                                      ]
+                                 ],
+                             ]
+                        ]
+                    ) {
+                        sh '.ci/scripts/distribution/qa-testbench.sh'
                     }
                 }
+            }
 
-                input message: 'Were all QA tests successful?', ok: 'Yes'
+            post {
+                failure {
+                    script {
+                        currentBuild.description = 'Failure in QA Stage'
+                    }
+                }
             }
         }
 
@@ -441,9 +449,13 @@ def isBorsStagingBranch() {
     env.BRANCH_NAME == 'staging'
 }
 
+def runsQA() {
+    return params.RUN_QA
+}
+
 def templatePodspec(String podspecPath, flags = [:]) {
     def defaultFlags = [
-        useStableNodePool: isBorsStagingBranch()
+        useStableNodePool: isBorsStagingBranch() || runsQA()
     ]
     // will merge Maps by overwriting left Map with values of the right Map
     def effectiveFlags = defaultFlags + flags


### PR DESCRIPTION
## Description

* Extends the QA script to wait for the result of the execution
* Changes node pool to stable nodes when QA tests are being run

## Related issues

closes #5964
closes #5935 

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
