### PR TITLE
Fixes outdated topology when no new leader is assigned

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -217,6 +217,12 @@
       <artifactId>netty-transport</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerClusterStateImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerClusterStateImpl.java
@@ -94,6 +94,7 @@ public final class BrokerClusterStateImpl implements BrokerClusterState {
 
   public void addPartitionFollower(final int partitionId, final int followerId) {
     partitionFollowers.computeIfAbsent(partitionId, ArrayList::new).add(followerId);
+    partitionLeaders.remove(partitionId, followerId);
   }
 
   public void addPartitionIfAbsent(final int partitionId) {

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/topology/TopologyFaultToleranceTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/topology/TopologyFaultToleranceTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.clustering.topology;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.it.clustering.ClusteringRule;
+import io.zeebe.broker.it.util.GrpcClientRule;
+import io.zeebe.broker.system.configuration.BrokerCfg;
+import io.zeebe.client.api.response.PartitionInfo;
+import io.zeebe.test.util.asserts.TopologyAssert;
+import java.time.Duration;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+/**
+ * Checks that even with brokers connecting/disconnecting, the topology is eventually consistent.
+ *
+ * <p>NOTE: this could be a good candidate for randomized testing.
+ */
+public final class TopologyFaultToleranceTest {
+  private final int clusterSize = 3;
+  private final int partitionsCount = 3;
+  private final int replicationFactor = 3;
+
+  private final ClusteringRule clusterRule =
+      new ClusteringRule(
+          partitionsCount, replicationFactor, clusterSize, this::configureFastGossip);
+  private final GrpcClientRule clientRule = new GrpcClientRule(clusterRule);
+
+  @Rule public final RuleChain ruleChain = RuleChain.outerRule(clusterRule).around(clientRule);
+
+  @Test
+  public void shouldDetectTopologyChanges() {
+    for (int nodeId = 0; nodeId < clusterSize; nodeId++) {
+      // when
+      disconnect(nodeId);
+      awaitBrokerIsRemovedFromTopology(nodeId);
+      connect(nodeId);
+
+      // then
+      awaitTopologyIsComplete();
+    }
+  }
+
+  @Test
+  public void shouldDetectIncompleteTopology() {
+    // when - disconnect two nodes
+    IntStream.range(0, clusterSize - 1)
+        .parallel()
+        .forEach(
+            nodeId -> {
+              disconnect(nodeId);
+              awaitBrokerIsRemovedFromTopology(nodeId);
+            });
+
+    // then
+    Awaitility.await("topology is a single node, follower for all partitions")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(250))
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(clusterRule.getTopologyFromClient())
+                    .hasBrokersCount(1)
+                    .hasBrokerSatisfying(
+                        broker -> {
+                          assertThat(broker.getNodeId()).isEqualTo(clusterSize - 1);
+                          assertThat(broker.getPartitions())
+                              .describedAs("has %d follower partitions", partitionsCount)
+                              .hasSize(partitionsCount)
+                              .allMatch(Predicate.not(PartitionInfo::isLeader));
+                        }));
+  }
+
+  private void disconnect(final int nodeId) {
+    clusterRule.disconnect(clusterRule.getBroker(nodeId));
+  }
+
+  private void connect(final int nodeId) {
+    clusterRule.connect(clusterRule.getBroker(nodeId));
+  }
+
+  private void awaitTopologyIsComplete() {
+    Awaitility.await("fail over occurs and topology is complete")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(clusterRule.getTopologyFromClient())
+                    .isComplete(clusterRule.getClusterSize(), clusterRule.getPartitionCount()));
+  }
+
+  private void awaitBrokerIsRemovedFromTopology(final int nodeId) {
+    Awaitility.await("broker " + nodeId + " is removed from topology")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(clusterRule.getTopologyFromClient())
+                    .doesNotContainBroker(nodeId));
+  }
+
+  private void configureFastGossip(final BrokerCfg config) {
+    config
+        .getCluster()
+        .getMembership()
+        .setSyncInterval(Duration.ofSeconds(1))
+        .setFailureTimeout(Duration.ofSeconds(1))
+        .setBroadcastUpdates(true)
+        .setProbeTimeout(Duration.ofMillis(100))
+        .setProbeInterval(Duration.ofMillis(250))
+        .setGossipInterval(Duration.ofMillis(250));
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes a bug in the gateway topology. The topology manager keeps track of who is leader and follower for each partition. This information is gossiped by all nodes in the cluster. Normally, when a node which was leader for partition 1 sends that it is now follower, another node will send that it is leader. There's an edge case, however, when no other node sends that it is the leader. In this case, we end up with a topology where a node is both leader and follower. This means that we report the wrong topology and that the gateway will keep trying to route requests to the node. The case where no new node becomes leader can happen due to network partitioning, for example, and is an expected case we should be able to tolerate.

This PR adds more test coverage and fixes the issue by removing the old partition leader if, when adding a new follower, they have the same ID.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2501 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
