### PR TITLE
Introduce single data directory configuration field

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -78,7 +78,7 @@ public final class AtomixFactory {
             .withMembershipProvider(discoveryProvider);
 
     final DataCfg dataConfiguration = configuration.getData();
-    final String rootDirectory = dataConfiguration.getDirectories().get(0);
+    final String rootDirectory = dataConfiguration.getDirectory();
     IoUtil.ensureDirectoryExists(new File(rootDirectory), "Zeebe data directory");
 
     final RaftPartitionGroup partitionGroup =

--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/DiskSpaceUsageMonitor.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/DiskSpaceUsageMonitor.java
@@ -28,7 +28,7 @@ public class DiskSpaceUsageMonitor extends Actor {
   public DiskSpaceUsageMonitor(final DataCfg dataCfg) {
     monitoringDelay = dataCfg.getDiskUsageMonitoringInterval();
     minFreeDiskSpaceRequired = dataCfg.getFreeDiskSpaceCommandWatermark();
-    final var directory = new File(dataCfg.getDirectories().get(0));
+    final var directory = new File(dataCfg.getDirectory());
     freeDiskSpaceSupplier = directory::getUsableSpace;
   }
 

--- a/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
+++ b/broker/src/test/java/io/zeebe/broker/test/EmbeddedBrokerRule.java
@@ -40,7 +40,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -71,7 +70,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
   protected final SpringBrokerBridge springBrokerBridge = new SpringBrokerBridge();
   protected long startTime;
   private File newTemporaryFolder;
-  private List<String> dataDirectories;
+  private String dataDirectory;
 
   @SafeVarargs
   public EmbeddedBrokerRule(final Consumer<BrokerCfg>... configurators) {
@@ -244,7 +243,7 @@ public final class EmbeddedBrokerRule extends ExternalResource {
           });
     }
 
-    dataDirectories = broker.getBrokerContext().getBrokerConfiguration().getData().getDirectories();
+    dataDirectory = broker.getBrokerContext().getBrokerConfiguration().getData().getDirectory();
   }
 
   public void configureBroker(final BrokerCfg brokerCfg) {
@@ -269,17 +268,17 @@ public final class EmbeddedBrokerRule extends ExternalResource {
   }
 
   public void purgeSnapshots() {
-    for (final String dataDirectoryName : dataDirectories) {
-      final File dataDirectory = new File(dataDirectoryName);
+    final File directory = new File(dataDirectory);
 
-      final File[] partitionDirectories =
-          dataDirectory.listFiles((d, f) -> new File(d, f).isDirectory());
+    final File[] partitionDirectories = directory.listFiles((d, f) -> new File(d, f).isDirectory());
+    if (partitionDirectories == null) {
+      return;
+    }
 
-      for (final File partitionDirectory : partitionDirectories) {
-        final File stateDirectory = new File(partitionDirectory, STATE_DIRECTORY);
-        if (stateDirectory.exists()) {
-          deleteSnapshots(stateDirectory);
-        }
+    for (final File partitionDirectory : partitionDirectories) {
+      final File stateDirectory = new File(partitionDirectory, STATE_DIRECTORY);
+      if (stateDirectory.exists()) {
+        deleteSnapshots(stateDirectory);
       }
     }
   }

--- a/broker/src/test/resources/system/default.yaml
+++ b/broker/src/test/resources/system/default.yaml
@@ -49,9 +49,9 @@ zeebe:
       host: 0.0.0.0
 
     data:
-      # Specify a list of directories in which data is stored.
-      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORIES.
-      directories: [ data ]
+      # Specify the directory in which data is stored.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORY.
+      directory: data
       # The size of data log segment files.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_LOGSEGMENTSIZE.
       logSegmentSize: 512MB

--- a/broker/src/test/resources/system/directories.yaml
+++ b/broker/src/test/resources/system/directories.yaml
@@ -1,4 +1,0 @@
-zeebe:
-  broker:
-    data:
-      directories: [ data1, data2, data3 ]

--- a/broker/src/test/resources/system/directory.yaml
+++ b/broker/src/test/resources/system/directory.yaml
@@ -1,0 +1,4 @@
+zeebe:
+  broker:
+    data:
+      directory: foo

--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -49,9 +49,9 @@ zeebe:
       host: 0.0.0.0
 
     data:
-      # Specify a list of directories in which data is stored.
-      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORIES.
-      directories: [ data ]
+      # Specify a directory in which data is stored.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORY.
+      directory: data
       # The size of data log segment files.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_LOGSEGMENTSIZE.
       logSegmentSize: 512MB

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -166,14 +166,9 @@
       #		  ├── runtime
       #		  └── snapshots
 
-      # Specify a list of directories in which data is stored. Using multiple
-      # directories makes sense in case the machine which is running Zeebe has
-      # multiple disks which are used in a JBOD (just a bunch of disks) manner. This
-      # allows to get greater throughput in combination with a higher io thread count
-      # since writes to different disks can potentially be done in parallel.
-      #
-      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORIES.
-      # directories: [ data ]
+      # Specify the directory in which data is stored.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORY.
+      # directory: data
 
       # The size of data log segment files.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_LOGSEGMENTSIZE.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -118,14 +118,9 @@
       #		  ├── runtime
       #		  └── snapshots
 
-      # Specify a list of directories in which data is stored. Using multiple
-      # directories makes sense in case the machine which is running Zeebe has
-      # multiple disks which are used in a JBOD (just a bunch of disks) manner. This
-      # allows to get greater throughput in combination with a higher io thread count
-      # since writes to different disks can potentially be done in parallel.
-      #
-      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORIES.
-      # directories: [ data ]
+      # Specify the directory in which data is stored.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DIRECTORY.
+      # directory: data
 
       # The size of data log segment files.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_LOGSEGMENTSIZE.

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -699,12 +699,12 @@ public final class ClusteringRule extends ExternalResource {
   }
 
   public Path getSegmentsDirectory(final Broker broker) {
-    final String dataDir = broker.getConfig().getData().getDirectories().get(0);
+    final String dataDir = broker.getConfig().getData().getDirectory();
     return Paths.get(dataDir).resolve(RAFT_PARTITION_PATH);
   }
 
   public File getSnapshotsDirectory(final Broker broker) {
-    final String dataDir = broker.getConfig().getData().getDirectories().get(0);
+    final String dataDir = broker.getConfig().getData().getDirectory();
     return new File(dataDir, RAFT_PARTITION_PATH + "/snapshots");
   }
 

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerReprocessingTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/startup/BrokerReprocessingTest.java
@@ -680,8 +680,6 @@ public final class BrokerReprocessingTest {
   }
 
   protected void deleteSnapshotsAndRestart() {
-    brokerRule.getBroker().getBrokerContext().getBrokerConfiguration().getData().getDirectories();
-
     brokerRule.stopBroker();
 
     // delete snapshot files to trigger recovery

--- a/test/src/main/java/io/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/zeebe/test/EmbeddedBrokerRule.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.time.Duration;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -66,7 +65,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
   protected long startTime;
   private final Duration timeout;
   private final File newTemporaryFolder;
-  private List<String> dataDirectories;
+  private String dataDirectory;
 
   @SafeVarargs
   public EmbeddedBrokerRule(final Consumer<BrokerCfg>... configurators) {
@@ -243,7 +242,7 @@ public class EmbeddedBrokerRule extends ExternalResource {
           });
     }
 
-    dataDirectories = broker.getBrokerContext().getBrokerConfiguration().getData().getDirectories();
+    dataDirectory = broker.getBrokerContext().getBrokerConfiguration().getData().getDirectory();
   }
 
   public void configureBroker(final BrokerCfg brokerCfg) {
@@ -262,17 +261,17 @@ public class EmbeddedBrokerRule extends ExternalResource {
   }
 
   public void purgeSnapshots() {
-    for (final String dataDirectoryName : dataDirectories) {
-      final File dataDirectory = new File(dataDirectoryName);
+    final File directory = new File(dataDirectory);
 
-      final File[] partitionDirectories =
-          dataDirectory.listFiles((d, f) -> new File(d, f).isDirectory());
+    final File[] partitionDirectories = directory.listFiles((d, f) -> new File(d, f).isDirectory());
+    if (partitionDirectories == null) {
+      return;
+    }
 
-      for (final File partitionDirectory : partitionDirectories) {
-        final File stateDirectory = new File(partitionDirectory, STATE_DIRECTORY);
-        if (stateDirectory.exists()) {
-          deleteSnapshots(stateDirectory);
-        }
+    for (final File partitionDirectory : partitionDirectories) {
+      final File stateDirectory = new File(partitionDirectory, STATE_DIRECTORY);
+      if (stateDirectory.exists()) {
+        deleteSnapshots(stateDirectory);
       }
     }
   }


### PR DESCRIPTION
## Description

This PR deprecates `zeebe.broker.data.directories` configuration setting - a comma separated list of paths - in favour of `zeebe.broker.data.directory`, a single string. This is to avoid confusion on the user's end, as we don't support multiple directories since a long time, and configuring multiple ones simply does nothing. The old setting is deprecated as of 0.26, and marked for removal in 0.27.0.

## Related issues

closes #2789 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
