### PR TITLE
Don't write Job activated record

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -26,7 +26,6 @@ import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.IncidentIntent;
 import io.zeebe.protocol.record.intent.JobBatchIntent;
-import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.value.ErrorType;
 import io.zeebe.util.ByteValue;
 import java.util.Collection;
@@ -174,17 +173,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final JobRecord jobRecord = iterator.next();
       final LongValue next1 = keyIt.next();
       final long key = next1.getValue();
-
-      // update state and write follow up event for job record
-      // we have to copy the job record because #write will reset the iterator state
-      final ExpandableArrayBuffer copy = new ExpandableArrayBuffer();
-      jobRecord.write(copy, 0);
-      final JobRecord copiedJob = new JobRecord();
-      copiedJob.wrap(copy, 0, jobRecord.getLength());
-
-      // first write follow up event as state.activate will clear the variables
-      streamWriter.appendFollowUpEvent(key, JobIntent.ACTIVATED, copiedJob);
-      jobState.activate(key, copiedJob);
+      jobState.activate(key, jobRecord);
     }
   }
 

--- a/engine/src/main/java/io/zeebe/engine/state/instance/JobRecordValue.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/JobRecordValue.java
@@ -25,7 +25,7 @@ public class JobRecordValue extends UnpackedObject implements DbValue {
     return recordProp.getValue();
   }
 
-  public void setRecord(final JobRecord record) {
-    recordProp.getValue().wrap(record);
+  public void setRecordWithoutVariables(final JobRecord record) {
+    recordProp.getValue().wrapWithoutVariables(record);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/JobState.java
@@ -289,8 +289,7 @@ public final class JobState {
   private void resetVariablesAndUpdateJobRecord(final long key, final JobRecord updatedValue) {
     jobKey.wrapLong(key);
     // do not persist variables in job state
-    updatedValue.resetVariables();
-    jobRecordToWrite.setRecord(updatedValue);
+    jobRecordToWrite.setRecordWithoutVariables(updatedValue);
     jobsColumnFamily.put(jobKey, jobRecordToWrite);
   }
 

--- a/engine/src/test/java/io/zeebe/engine/processing/job/ActivateJobsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/job/ActivateJobsTest.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.processing.job;
 
 import static io.zeebe.protocol.record.Assertions.assertThat;
 import static io.zeebe.test.util.TestUtil.waitUntil;
+import static io.zeebe.test.util.record.RecordingExporter.jobBatchRecords;
 import static io.zeebe.test.util.record.RecordingExporter.jobRecords;
 import static io.zeebe.test.util.record.RecordingExporter.workflowInstanceRecords;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -162,13 +163,11 @@ public final class ActivateJobsTest {
 
     assertThat(jobs.get(0).getVariables()).containsExactly(entry("foo", "bar"));
 
-    final Record<JobRecordValue> jobRecord =
-        jobRecords(JobIntent.ACTIVATED)
-            .withWorkflowInstanceKey(firstInstanceKey)
-            .withType(taskType)
-            .getFirst();
-    assertThat(jobRecord).hasKey(expectedJobKey);
-    assertThat(jobRecord.getValue()).hasRetries(3).hasWorker(worker);
+    final var activatedJobBatch = getActivatedJobBatch();
+    final var jobRecordValue = activatedJobBatch.getJobs().get(0);
+    final var jobKey = activatedJobBatch.getJobKeys().get(0);
+    assertThat(jobKey).isEqualTo(expectedJobKey);
+    assertThat(jobRecordValue).hasRetries(3).hasWorker(worker);
   }
 
   @Test
@@ -239,16 +238,14 @@ public final class ActivateJobsTest {
     final List<Long> jobs = activateJobs(taskType, 7);
 
     // then
-    assertThat(jobs).containsOnlyElementsOf(jobKeys);
+    assertThat(jobs).containsExactly(jobKeys.toArray(new Long[0]));
 
-    final List<Record<JobRecordValue>> records =
-        jobRecords(JobIntent.ACTIVATED)
-            .withType(taskType)
-            .limit(jobKeys.size())
-            .collect(Collectors.toList());
+    final var activatedJobBatch = getActivatedJobBatch();
+    assertThat(activatedJobBatch).hasJobKeys(jobKeys);
 
-    assertThat(records).extracting(Record::getKey).containsOnlyElementsOf(jobKeys);
-    assertThat(records).extracting("value.type").containsOnly(taskType);
+    assertThat(activatedJobBatch.getJobs())
+        .extracting(JobRecordValue::getType)
+        .containsOnly(taskType);
   }
 
   @Test
@@ -310,13 +307,8 @@ public final class ActivateJobsTest {
     ENGINE.job().ofInstance(workflowInstanceKey).withType(taskType).complete();
 
     // then
-    final JobRecordValue jobRecord =
-        jobRecords(JobIntent.ACTIVATED)
-            .withWorkflowInstanceKey(workflowInstanceKey)
-            .withType(taskType)
-            .getFirst()
-            .getValue();
-    assertThat(jobRecord.getCustomHeaders().get("foo")).isEqualTo(LONG_CUSTOM_HEADER_VALUE);
+    final var jobRecordValue = getActivatedJobBatch().getJobs().get(0);
+    assertThat(jobRecordValue.getCustomHeaders()).containsEntry("foo", LONG_CUSTOM_HEADER_VALUE);
   }
 
   @Test
@@ -461,5 +453,9 @@ public final class ActivateJobsTest {
                     .limit(jobAmount)
                     .count()
                 == jobAmount);
+  }
+
+  private JobBatchRecordValue getActivatedJobBatch() {
+    return jobBatchRecords(JobBatchIntent.ACTIVATED).withType(taskType).getFirst().getValue();
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/job/JobEventSequenceTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/job/JobEventSequenceTest.java
@@ -10,7 +10,7 @@ package io.zeebe.engine.processing.job;
 import static io.zeebe.engine.util.RecordToWrite.command;
 import static io.zeebe.engine.util.RecordToWrite.event;
 import static io.zeebe.protocol.record.intent.JobBatchIntent.ACTIVATE;
-import static io.zeebe.protocol.record.intent.JobIntent.ACTIVATED;
+import static io.zeebe.protocol.record.intent.JobBatchIntent.ACTIVATED;
 import static io.zeebe.protocol.record.intent.JobIntent.CANCEL;
 import static io.zeebe.protocol.record.intent.JobIntent.CANCELED;
 import static io.zeebe.protocol.record.intent.JobIntent.CREATE;
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.zeebe.engine.util.EngineRule;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.RecordValue;
-import io.zeebe.protocol.record.intent.JobBatchIntent;
 import io.zeebe.protocol.record.value.JobRecordValue;
 import io.zeebe.test.util.record.RecordingExporter;
 import java.util.List;
@@ -48,10 +47,10 @@ public final class JobEventSequenceTest {
     final Record<JobRecordValue> canceled =
         RecordingExporter.jobRecords().withIntent(CANCELED).getFirst();
 
-    final Record<JobRecordValue> activated =
-        RecordingExporter.jobRecords().withIntent(ACTIVATED).getFirst();
+    final var activated =
+        RecordingExporter.jobBatchRecords(ACTIVATED).getFirst().getValue().getJobs().get(0);
 
-    assertThat(activated.getValue().getDeadline()).isEqualTo(canceled.getValue().getDeadline());
+    assertThat(activated.getDeadline()).isEqualTo(canceled.getValue().getDeadline());
 
     final List<Record<RecordValue>> records =
         RecordingExporter.records()
@@ -59,7 +58,6 @@ public final class JobEventSequenceTest {
             .collect(Collectors.toList());
     assertThat(records)
         .extracting(Record::getIntent)
-        .containsExactly(
-            CREATE, CREATED, ACTIVATE, CANCEL, ACTIVATED, JobBatchIntent.ACTIVATED, CANCELED);
+        .containsExactly(CREATE, CREATED, ACTIVATE, CANCEL, ACTIVATED, CANCELED);
   }
 }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -73,14 +73,13 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(elementInstanceKeyProp);
   }
 
-  public void wrap(final JobRecord record) {
+  public void wrapWithoutVariables(final JobRecord record) {
     deadlineProp.setValue(record.getDeadline());
     workerProp.setValue(record.getWorkerBuffer());
     retriesProp.setValue(record.getRetries());
     typeProp.setValue(record.getTypeBuffer());
     final DirectBuffer customHeaders = record.getCustomHeadersBuffer();
     customHeadersProp.setValue(customHeaders, 0, customHeaders.capacity());
-    variableProp.setValue(record.getVariablesBuffer());
     errorMessageProp.setValue(record.getErrorMessageBuffer());
     errorCodeProp.setValue(record.getErrorCodeBuffer());
     bpmnProcessIdProp.setValue(record.getBpmnProcessIdBuffer());


### PR DESCRIPTION
## Description
 * The job activated record is no longer written to the log. It is already present in JobBatchRecord.
 * Job record is also not copied multiple times just wrapped without variables for state updates.
 * Fixed MetricExporter, since it relied on the Job.ACTIVATED event.
  * Fix several engine tests

<!-- Please explain the changes you made here. -->

I run a benchmark and saw no problems, only with the Job activation metrics, which I have fixed afterwards.

### Base

#### General

![general](https://user-images.githubusercontent.com/2758593/101642534-6a886980-3a33-11eb-929c-7c3ed996959e.png)
![general2](https://user-images.githubusercontent.com/2758593/101642542-6bb99680-3a33-11eb-94de-e8049a3127e5.png)

#### Resources
![res](https://user-images.githubusercontent.com/2758593/101642548-6ceac380-3a33-11eb-8451-6b5bb7b10154.png)

#### Latency
![latency](https://user-images.githubusercontent.com/2758593/101642543-6c522d00-3a33-11eb-891d-8195347971be.png)
![latency2](https://user-images.githubusercontent.com/2758593/101642545-6ceac380-3a33-11eb-967b-b313d953cbaa.png)


### No activated job event

#### General

![no-general](https://user-images.githubusercontent.com/2758593/101642702-94419080-3a33-11eb-9cc8-b100563a659c.png)
![no-general2](https://user-images.githubusercontent.com/2758593/101642704-9572bd80-3a33-11eb-9e44-d621201efd44.png)

#### Resources

![no-res](https://user-images.githubusercontent.com/2758593/101642715-986dae00-3a33-11eb-9d7b-0b053b7b8e72.png)


#### Latency

![no-latency](https://user-images.githubusercontent.com/2758593/101642730-9e638f00-3a33-11eb-980b-3990f848c610.png)
![no-latency2](https://user-images.githubusercontent.com/2758593/101642732-9e638f00-3a33-11eb-8fdf-c5c322d2a8b6.png)


I set up a new benchmark with the metrics fix.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/2182

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [X] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
