### PR TITLE
chore(ci): build go always in distribution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,6 +69,9 @@ pipeline {
             }
             steps {
                 timeout(time: shortTimeoutMinutes, unit: 'MINUTES') {
+                    container('golang') {
+                        sh '.ci/scripts/distribution/build-go.sh'
+                    }
                     runMavenContainerCommand('.ci/scripts/distribution/build-java.sh')
                     container('maven') {
                         sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
@@ -123,10 +126,6 @@ pipeline {
                 stage('Test (Go)') {
                     steps {
                         timeout(time: longTimeoutMinutes, unit: 'MINUTES') {
-                            container('golang') {
-                                sh '.ci/scripts/distribution/build-go.sh'
-                            }
-
                             container('golang') {
                                 sh '.ci/scripts/distribution/test-go.sh'
                             }


### PR DESCRIPTION
## Description

- Build go always
- this should fix the missing zbctl in QA run images
- this should fix the failing chaos test

## Related issues


## Definition of Done

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
