### PR TITLE
[backport 0.24] chore(ci): build go always in distribution

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,9 @@ pipeline {
                 VERSION = readMavenPom(file: 'parent/pom.xml').getVersion()
             }
             steps {
+                container('golang') {
+                    sh '.ci/scripts/distribution/build-go.sh'
+                }
                 runMavenContainerCommand('.ci/scripts/distribution/build-java.sh')
                 container('maven') {
                     sh 'cp dist/target/zeebe-distribution-*.tar.gz zeebe-distribution.tar.gz'
@@ -80,10 +83,6 @@ pipeline {
 
                 stage('Test (Go)') {
                     steps {
-                        container('golang') {
-                            sh '.ci/scripts/distribution/build-go.sh'
-                        }
-
                         container('golang') {
                             sh '.ci/scripts/distribution/test-go.sh'
                         }


### PR DESCRIPTION
## Description

backport of #5994 to stable/0.24


## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
