### PR TITLE
chore(broker): lower default swim probe timeout

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/MembershipCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/MembershipCfg.java
@@ -17,7 +17,7 @@ public final class MembershipCfg implements ConfigurationEntry {
   private static final Duration DEFAULT_GOSSIP_INTERVAL = Duration.ofMillis(250);
   private static final int DEFAULT_GOSSIP_FANOUT = 2;
   private static final Duration DEFAULT_PROBE_INTERVAL = Duration.ofMillis(1000);
-  private static final Duration DEFAULT_PROBE_TIMEOUT = Duration.ofMillis(2000);
+  private static final Duration DEFAULT_PROBE_TIMEOUT = Duration.ofMillis(100);
   private static final int DEFAULT_SUSPECT_PROBES = 3;
   private static final Duration DEFAULT_FAILURE_TIMEOUT = Duration.ofMillis(10_000);
   private static final Duration DEFAULT_SYNC_INTERVAL = Duration.ofMillis(10_000);

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -300,7 +300,7 @@
 
         # Sets the timeout for a probe response
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBETIMEOUT
-        # probeTimeout: 2s
+        # probeTimeout: 100ms
 
         # Sets the number of probes failed before declaring a member is suspect
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SUSPECTPROBES

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -260,7 +260,7 @@
 
         # Sets the timeout for a probe response
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBETIMEOUT
-        # probeTimeout: 2s
+        # probeTimeout: 100ms
 
         # Sets the number of probes failed before declaring a member is suspect
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SUSPECTPROBES

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -105,7 +105,7 @@
 
         # Sets the timeout for a probe response
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_PROBETIMEOUT
-        # probeTimeout: 2s
+        # probeTimeout: 100ms
 
         # Sets the number of probes failed before declaring a member is suspect
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SUSPECTPROBES

--- a/gateway/src/main/java/io/zeebe/gateway/impl/configuration/MembershipCfg.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/configuration/MembershipCfg.java
@@ -17,7 +17,7 @@ public final class MembershipCfg {
   private static final Duration DEFAULT_GOSSIP_INTERVAL = Duration.ofMillis(250);
   private static final int DEFAULT_GOSSIP_FANOUT = 2;
   private static final Duration DEFAULT_PROBE_INTERVAL = Duration.ofMillis(1000);
-  private static final Duration DEFAULT_PROBE_TIMEOUT = Duration.ofMillis(2000);
+  private static final Duration DEFAULT_PROBE_TIMEOUT = Duration.ofMillis(100);
   private static final int DEFAULT_SUSPECT_PROBES = 3;
   private static final Duration DEFAULT_FAILURE_TIMEOUT = Duration.ofMillis(10_000);
   private static final Duration DEFAULT_SYNC_INTERVAL = Duration.ofMillis(10_000);


### PR DESCRIPTION
## Description

Set default probeTimeout for swim to 100ms.

## Related issues

closes #4827 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
