### PR TITLE
Use array access when extracting job properties from ActivateJobsResponse

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,7 @@ pipeline {
     }
 
     parameters {
+        booleanParam(name: 'SKIP_VERIFY', defaultValue: false, description: "Skip 'Verify' Stage")
         booleanParam(name: 'RUN_QA', defaultValue: false, description: "Run QA Stage")
         string(name: 'GENERATION_TEMPLATE', defaultValue: 'Zeebe 0.x.0', description: "Generation template for QA tests (the QA test will be run with this Zeebe version and Operate/Elasticsearch version from the generation template)")
     }
@@ -100,6 +101,7 @@ pipeline {
         }
 
         stage('Verify') {
+            when { not { expression { params.SKIP_VERIFY } } }
             parallel {
                 stage('Analyse') {
                     steps {


### PR DESCRIPTION
## Description

This PR fixes an issue in the QA script which was introduced after #5972, where the output of zbctl's `ActivateJobsResponse` was changed to be standard JSON and always return an array.

It also introduces a new flag which allows skipping the verify stage if you only want to run the QA stage, which can be quite useful for you're testing that in particular.

## Related issues

closes #6008 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
