### PR TITLE
[Backport stable/0.25] Fixes outdated topology when no new leader is assigned

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -211,6 +211,11 @@
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-client-java</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerClusterStateImpl.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/broker/cluster/BrokerClusterStateImpl.java
@@ -70,6 +70,7 @@ public final class BrokerClusterStateImpl implements BrokerClusterState {
 
   public void addPartitionFollower(final int partitionId, final int followerId) {
     partitionFollowers.computeIfAbsent(partitionId, ArrayList::new).add(followerId);
+    partitionLeaders.remove(partitionId, followerId);
   }
 
   public void addPartitionIfAbsent(final int partitionId) {

--- a/gateway/src/test/java/io/zeebe/gateway/topology/TopologyUpdateTest.java
+++ b/gateway/src/test/java/io/zeebe/gateway/topology/TopologyUpdateTest.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.gateway.topology;
 
+import static io.zeebe.gateway.impl.broker.cluster.BrokerClusterState.NODE_ID_NULL;
 import static io.zeebe.test.util.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,6 +22,7 @@ import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -110,7 +112,8 @@ public final class TopologyUpdateTest {
     topologyManager.event(createMemberAddedEvent(broker));
     waitUntil(() -> !topologyManager.getTopology().getBrokers().isEmpty());
 
-    assertThat(topologyManager.getTopology().getFollowersForPartition(1).contains(0)).isFalse();
+    assertThat(topologyManager.getTopology().getFollowersForPartition(1)).doesNotContain(0);
+    assertThat(topologyManager.getTopology().getLeaderForPartition(1)).isEqualTo(NODE_ID_NULL);
   }
 
   @Test
@@ -172,6 +175,35 @@ public final class TopologyUpdateTest {
     // then
     waitUntil(() -> topologyManager.getTopology().getBrokers().contains(leaderId));
     assertThat(topologyManager.getTopology().getLeaderForPartition(1)).isEqualTo(leaderId);
+  }
+
+  @Test
+  public void shouldUpdateTopologyOnLeaderRemoval() {
+    // given
+    final BrokerInfo broker = createBroker(0).setLeaderForPartition(1, 1);
+
+    // when
+    topologyManager.event(createMemberUpdateEvent(broker));
+    Awaitility.await("broker 0 is leader of partition 1")
+        .atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(100))
+        .untilAsserted(
+            () -> assertThat(topologyManager.getTopology().getLeaderForPartition(1)).isZero());
+
+    broker.setFollowerForPartition(1);
+    topologyManager.event(createMemberUpdateEvent(broker));
+
+    // then
+    Awaitility.await("broker 0 is follower of partition 1")
+        .atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofMillis(100))
+        .untilAsserted(
+            () -> {
+              assertThat(topologyManager.getTopology().getFollowersForPartition(1))
+                  .containsExactlyInAnyOrder(0);
+              assertThat(topologyManager.getTopology().getLeaderForPartition(1))
+                  .isEqualTo(NODE_ID_NULL);
+            });
   }
 
   private BrokerInfo createBroker(final int brokerId) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -37,7 +37,7 @@
     <!-- EXTERNAL LIBS -->
     <version.agrona>1.8.0</version.agrona>
     <version.animal-sniffer>1.19</version.animal-sniffer>
-    <version.assertj>3.17.2</version.assertj>
+    <version.assertj>3.18.1</version.assertj>
     <version.awaitility>4.0.3</version.awaitility>
     <version.camunda>7.14.0</version.camunda>
     <version.commons-lang>3.11</version.commons-lang>

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/topology/TopologyFaultToleranceTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/topology/TopologyFaultToleranceTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.clustering.topology;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.broker.it.clustering.ClusteringRule;
+import io.zeebe.broker.it.util.GrpcClientRule;
+import io.zeebe.broker.system.configuration.BrokerCfg;
+import io.zeebe.client.api.response.PartitionInfo;
+import io.zeebe.test.util.asserts.TopologyAssert;
+import java.time.Duration;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+/**
+ * Checks that even with brokers connecting/disconnecting, the topology is eventually consistent.
+ *
+ * <p>NOTE: this could be a good candidate for randomized testing.
+ */
+public final class TopologyFaultToleranceTest {
+  private final int clusterSize = 3;
+  private final int partitionsCount = 3;
+  private final int replicationFactor = 3;
+
+  private final ClusteringRule clusterRule =
+      new ClusteringRule(
+          partitionsCount, replicationFactor, clusterSize, this::configureFastGossip);
+  private final GrpcClientRule clientRule = new GrpcClientRule(clusterRule);
+
+  @Rule public final RuleChain ruleChain = RuleChain.outerRule(clusterRule).around(clientRule);
+
+  @Test
+  public void shouldDetectTopologyChanges() {
+    for (int nodeId = 0; nodeId < clusterSize; nodeId++) {
+      // when
+      disconnect(nodeId);
+      awaitBrokerIsRemovedFromTopology(nodeId);
+      connect(nodeId);
+
+      // then
+      awaitTopologyIsComplete();
+    }
+  }
+
+  @Test
+  public void shouldDetectIncompleteTopology() {
+    // when - disconnect two nodes
+    IntStream.range(0, clusterSize - 1)
+        .parallel()
+        .forEach(
+            nodeId -> {
+              disconnect(nodeId);
+              awaitBrokerIsRemovedFromTopology(nodeId);
+            });
+
+    // then
+    Awaitility.await("topology is a single node, follower for all partitions")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(250))
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(clusterRule.getTopologyFromClient())
+                    .hasBrokersCount(1)
+                    .hasBrokerSatisfying(
+                        broker -> {
+                          assertThat(broker.getNodeId()).isEqualTo(clusterSize - 1);
+                          assertThat(broker.getPartitions())
+                              .describedAs("has %d follower partitions", partitionsCount)
+                              .hasSize(partitionsCount)
+                              .allMatch(Predicate.not(PartitionInfo::isLeader));
+                        }));
+  }
+
+  private void disconnect(final int nodeId) {
+    clusterRule.disconnect(clusterRule.getBroker(nodeId));
+  }
+
+  private void connect(final int nodeId) {
+    clusterRule.connect(clusterRule.getBroker(nodeId));
+  }
+
+  private void awaitTopologyIsComplete() {
+    Awaitility.await("fail over occurs and topology is complete")
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(clusterRule.getTopologyFromClient())
+                    .isComplete(clusterRule.getClusterSize(), clusterRule.getPartitionCount()));
+  }
+
+  private void awaitBrokerIsRemovedFromTopology(final int nodeId) {
+    Awaitility.await("broker " + nodeId + " is removed from topology")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofMillis(500))
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(clusterRule.getTopologyFromClient())
+                    .doesNotContainBroker(nodeId));
+  }
+
+  private void configureFastGossip(final BrokerCfg config) {
+    config
+        .getCluster()
+        .getMembership()
+        .setSyncInterval(Duration.ofSeconds(1))
+        .setFailureTimeout(Duration.ofSeconds(1))
+        .setBroadcastUpdates(true)
+        .setProbeTimeout(Duration.ofMillis(100))
+        .setProbeInterval(Duration.ofMillis(250))
+        .setGossipInterval(Duration.ofMillis(250));
+  }
+}


### PR DESCRIPTION
# Description
Backport of #5979 to `stable/0.25`. There was some minor conflicts, where I had to bump the AssertJ version as `failure` did not exist in 3.17.