### PR TITLE
chore(uptdate-tests): disable update tests

### DIFF
--- a/update-tests/src/test/java/io/zeebe/test/NoSnapshotTest.java
+++ b/update-tests/src/test/java/io/zeebe/test/NoSnapshotTest.java
@@ -15,12 +15,14 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.testcontainers.containers.Network;
 
+@Disabled("https://github.com/zeebe-io/zeebe/issues/6007")
 @ExtendWith(ContainerStateExtension.class)
 final class NoSnapshotTest {
 

--- a/update-tests/src/test/java/io/zeebe/test/OldGatewayTest.java
+++ b/update-tests/src/test/java/io/zeebe/test/OldGatewayTest.java
@@ -15,12 +15,14 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.testcontainers.containers.Network;
 
+@Disabled("https://github.com/zeebe-io/zeebe/issues/6007")
 @ExtendWith(ContainerStateExtension.class)
 final class OldGatewayTest {
 

--- a/update-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
+++ b/update-tests/src/test/java/io/zeebe/test/RollingUpdateTest.java
@@ -38,11 +38,13 @@ import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Network;
 import org.testcontainers.lifecycle.Startables;
 
+@Ignore("https://github.com/zeebe-io/zeebe/issues/6007")
 public class RollingUpdateTest {
   private static final String OLD_VERSION = VersionUtil.getPreviousVersion();
   private static final String NEW_VERSION = VersionUtil.getVersion();

--- a/update-tests/src/test/java/io/zeebe/test/SnapshotTest.java
+++ b/update-tests/src/test/java/io/zeebe/test/SnapshotTest.java
@@ -16,12 +16,14 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.testcontainers.containers.Network;
 
+@Disabled("https://github.com/zeebe-io/zeebe/issues/6007")
 @ExtendWith(ContainerStateExtension.class)
 final class SnapshotTest {
 


### PR DESCRIPTION
## Description

Disables the update tests since 0.27 will be a breaking change.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
