### PR TITLE
Fixes multi agent post verification analysis

### DIFF
--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -223,6 +223,14 @@
           <argLine>-Xmx2048m -XX:MaxDirectMemorySize=4g</argLine>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
 
   </build>


### PR DESCRIPTION
## Description

This PR fixes post verification analysis results involving work done on multiple agents. It appears the `post` step of the `Verify` stage is run on the main agent only, meaning it only has access to build artefacts produced on that agent. Any results (e.g. `FlakyTests.txt`, JaCoCo `.exec` files) produced in the `IT` stage are ignored in the post analysis.

The solution is to stash and un-stash the artefacts produced by the IT agents. As they have share the same names (since those are coming from the POM/plugins), a new directory is created as `.tmp/it` in the main agent, where the files are un-stashed.

## Related issues

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
