### PR TITLE
CI scripts/pipeline clean up

### DIFF
--- a/.ci/scripts/distribution/build-java.sh
+++ b/.ci/scripts/distribution/build-java.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -eux
 
+# getconf is a POSIX way to get the number of processors available which works on both Linux and macOS
+LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
+MAVEN_PARALLELISM=${MAVEN_PARALLELISM:-$LIMITS_CPU}
 
-export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
-
-mvn -B -T$LIMITS_CPU -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pchecks,spotbugs,prepare-offline
+mvn -B -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pchecks,spotbugs,prepare-offline

--- a/.ci/scripts/distribution/it-java.sh
+++ b/.ci/scripts/distribution/it-java.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -eux
 
+source "${BASH_SOURCE%/*}/../lib/flaky-tests.sh"
+
 # getconf is a POSIX way to get the number of processors available which works on both Linux and macOS
 LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
 MAVEN_PARALLELISM=${MAVEN_PARALLELISM:-$LIMITS_CPU}
@@ -14,32 +16,18 @@ tmpfile=$(mktemp)
 if [ ! -z "$SUREFIRE_FORK_COUNT" ]; then
   MAVEN_PROPERTIES+=("-DforkCount=$SUREFIRE_FORK_COUNT")
   # if we know the fork count, we can limit the max heap for each fork to ensure we're not OOM killed
-  JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -XX:MaxRAMPercentage=$((100 / (MAVEN_PARALLELISM * $SUREFIRE_FORK_COUNT)))"
+  export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -XX:MaxRAMPercentage=$((100 / (MAVEN_PARALLELISM * $SUREFIRE_FORK_COUNT)))"
 fi
 
 if [ ! -z "$JUNIT_THREAD_COUNT" ]; then
   MAVEN_PROPERTIES+=("-DjunitThreadCount=$JUNIT_THREAD_COUNT")
 fi
 
-# make sure to specify the profiles used in the verify goal when running preparing to go offline, as
-# these may require some additional plugin dependencies
-mvn -B -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} test-compile -Pprepare-offline,skip-unstable-ci,parallel-tests -pl qa/integration-tests,update-tests
 mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests -pl qa/integration-tests,update-tests "${MAVEN_PROPERTIES[@]}" | tee ${tmpfile}
-
 status=${PIPESTATUS[0]}
 
-if grep -q "\[WARNING\] Flakes:" ${tmpfile}; then
-
-  tmpfile2=$(mktemp)
-
-  awk '/^\[WARNING\] Flakes:.*$/{flag=1}/^\[ERROR\] Tests run:.*Flakes: [0-9]*$/{print;flag=0}flag' ${tmpfile} > ${tmpfile2}
-
-  grep "\[ERROR\]   Run 1: " ${tmpfile2} | awk '{print $4}' >> ./FlakyTests.txt
-
-  echo ERROR: Flaky Tests detected>&2
-
-  exit 1
-fi
+# delay checking the maven status after we've analysed flaky tests
+analyseFlakyTests "${tmpfile}" "./FlakyTests.txt" || exit $?
 
 if [[ $status != 0 ]]; then
   exit $status;

--- a/.ci/scripts/distribution/it-prepare.sh
+++ b/.ci/scripts/distribution/it-prepare.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eux
+
+# getconf is a POSIX way to get the number of processors available which works on both Linux and macOS
+LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
+MAVEN_PARALLELISM=${MAVEN_PARALLELISM:-$LIMITS_CPU}
+MAVEN_OPTIONS=()
+
+# make sure to specify the profiles used in the verify goal when running preparing to go offline, as
+# these may require some additional plugin dependencies
+mvn -B -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} test-compile -Pprepare-offline,skip-unstable-ci,parallel-tests -pl qa/integration-tests,update-tests

--- a/.ci/scripts/distribution/test-java.sh
+++ b/.ci/scripts/distribution/test-java.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -eux
 
+source "${BASH_SOURCE%/*}/../lib/flaky-tests.sh"
+
 # getconf is a POSIX way to get the number of processors available which works on both Linux and macOS
 LIMITS_CPU=${LIMITS_CPU:-$(getconf _NPROCESSORS_ONLN)}
 MAVEN_PARALLELISM=${MAVEN_PARALLELISM:-$LIMITS_CPU}
@@ -15,7 +17,7 @@ tmpfile=$(mktemp)
 if [ ! -z "$SUREFIRE_FORK_COUNT" ]; then
   MAVEN_PROPERTIES+=("-DforkCount=$SUREFIRE_FORK_COUNT")
   # if we know the fork count, we can limit the max heap for each fork to ensure we're not OOM killed
-  JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -XX:MaxRAMPercentage=$((100 / ($MAVEN_PARALLELISM * $SUREFIRE_FORK_COUNT)))"
+  export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -XX:MaxRAMPercentage=$((100 / ($MAVEN_PARALLELISM * $SUREFIRE_FORK_COUNT)))"
 fi
 
 if [ ! -z "$JUNIT_THREAD_COUNT" ]; then
@@ -23,21 +25,10 @@ if [ ! -z "$JUNIT_THREAD_COUNT" ]; then
 fi
 
 mvn -o -B --fail-never -T${MAVEN_PARALLELISM} -s ${MAVEN_SETTINGS_XML} verify -P skip-unstable-ci,parallel-tests "${MAVEN_PROPERTIES[@]}" | tee ${tmpfile}
-
 status=${PIPESTATUS[0]}
 
-if grep -q "\[WARNING\] Flakes:" ${tmpfile}; then
-
-  tmpfile2=$(mktemp)
-
-  awk '/^\[WARNING\] Flakes:.*$/{flag=1}/^\[ERROR\] Tests run:.*Flakes: [0-9]*$/{print;flag=0}flag' ${tmpfile} > ${tmpfile2}
-
-  grep "\[ERROR\]   Run 1: " ${tmpfile2} | awk '{print $4}' >> ./FlakyTests.txt
-
-  echo ERROR: Flaky Tests detected>&2
-
-  exit 1
-fi
+# delay checking the maven status after we've analysed flaky tests
+analyseFlakyTests "${tmpfile}" "./FlakyTests.txt" || exit $?
 
 if [[ $status != 0 ]]; then
   exit $status;

--- a/.ci/scripts/lib/flaky-tests.sh
+++ b/.ci/scripts/lib/flaky-tests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#######################################
+# Analyses flaky tests produced by flaky-test-extractor-maven-plugin
+# Globals:
+#   None
+# Arguments:
+#   1 - file containing the test outputs
+#   2 - file to which the flaky tests should be appended
+# Outputs:
+#   Error message on STDERR if flaky tests are detected
+# Returns:
+#   0 if no flaky tests detected
+#   1 if flaky tests were detected
+#######################################
+function analyseFlakyTests() {
+  local -r testInputFile="$1"
+  local -r testOutputFile="$2"
+  local -r irOutputFile=$(mktemp)
+
+  if grep -q "\[WARNING\] Flakes:" ${testInputFile}; then
+    tmpfile2=$(mktemp)
+    awk '/^\[WARNING\] Flakes:.*$/{flag=1}/^\[ERROR\] Tests run:.*Flakes: [0-9]*$/{print;flag=0}flag' ${testInputFile} > ${irOutputFile}
+    grep "\[ERROR\]   Run 1: " ${irOutputFile} | awk '{print $4}' >> ${testOutputFile}
+    echo 'ERROR: Flaky Tests detected'>&2
+    return 1
+  fi
+
+  return 0
+}


### PR DESCRIPTION
## Description

This PR is a clean up effort after the various changes made in the past 3 months. It reuses the new helper functions in the Jenkinsfile as much as possible, introduces a first script library to centralize how flaky tests are analysed for easier maintainability, moves the `test-compile` phase of the IT agent into its prepare stage so the test stage logs are only about testing, and makes sure the way we configure Maven in built/test scripts is consistent across all scripts.

## Related issues

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
