### PR TITLE
chore(samples): adjust examples to support connecting to cloud

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,3 +1,8 @@
 # Zeebe Java Client Examples
 
-This Maven project contains a number of examples each performing a specific task using the Zeebe Java client. For an overview and context have a look at the Zeebe documentation: https://docs.zeebe.io/java-client-examples/README.html
+This Maven project contains a number of examples each performing a specific task using the Zeebe
+Java client.
+
+For an overview and context have a look at
+the [Zeebe documentation](https://docs.camunda.io/docs/product-manuals/clients/java-client-examples/index)
+;

--- a/samples/src/main/java/io/zeebe/example/cluster/TopologyViewer.java
+++ b/samples/src/main/java/io/zeebe/example/cluster/TopologyViewer.java
@@ -12,7 +12,7 @@ import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.api.response.Topology;
 
 /**
- * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ * Example application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
  *
  * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
  * environment variables are set:

--- a/samples/src/main/java/io/zeebe/example/cluster/TopologyViewer.java
+++ b/samples/src/main/java/io/zeebe/example/cluster/TopologyViewer.java
@@ -11,16 +11,47 @@ import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.api.response.Topology;
 
+/**
+ * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ *
+ * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
+ * environment variables are set:
+ *
+ * <ul>
+ *   <li>ZEEBE_ADDRESS
+ *   <li>ZEEBE_CLIENT_ID
+ *   <li>ZEEBE_CLIENT_SECRET
+ *   <li>ZEEBE_AUTHORIZATION_SERVER_URL
+ * </ul>
+ *
+ * <p><strong>Hint:</strong> When you create client credentials in Camunda Cloud you have the option
+ * to download a file with above lines filled out for you.
+ *
+ * <p>When {@code ZEEBE_ADDRESS} is not set, it connects to a broker running on localhost with
+ * default ports
+ */
 public final class TopologyViewer {
 
   public static void main(final String[] args) {
-    final String broker = "127.0.0.1:26500";
+    final String defaultAddress = "localhost:26500";
+    final String envVarAddress = System.getenv("ZEEBE_ADDRESS");
 
-    final ZeebeClientBuilder builder =
-        ZeebeClient.newClientBuilder().gatewayAddress(broker).usePlaintext();
+    final ZeebeClientBuilder clientBuilder;
+    final String contactPoint;
+    if (envVarAddress != null) {
+      /* Connect to Camunda Cloud Cluster, assumes that credentials are set in environment variables.
+       * See JavaDoc on class level for details
+       */
+      contactPoint = envVarAddress;
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(envVarAddress);
+    } else {
+      // connect to local deployment; assumes that authentication is disabled
+      contactPoint = defaultAddress;
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(defaultAddress).usePlaintext();
+    }
 
-    try (final ZeebeClient client = builder.build()) {
-      System.out.println("Requesting topology with initial contact point " + broker);
+    try (final ZeebeClient client = clientBuilder.build()) {
+      System.out.println("Requesting topology with initial contact point " + contactPoint);
 
       final Topology topology = client.newTopologyRequest().send().join();
 

--- a/samples/src/main/java/io/zeebe/example/data/HandleVariablesAsPojo.java
+++ b/samples/src/main/java/io/zeebe/example/data/HandleVariablesAsPojo.java
@@ -14,14 +14,42 @@ import io.zeebe.client.api.worker.JobClient;
 import io.zeebe.client.api.worker.JobHandler;
 import java.util.Scanner;
 
+/**
+ * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ *
+ * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
+ * environment variables are set:
+ *
+ * <ul>
+ *   <li>ZEEBE_ADDRESS
+ *   <li>ZEEBE_CLIENT_ID
+ *   <li>ZEEBE_CLIENT_SECRET
+ *   <li>ZEEBE_AUTHORIZATION_SERVER_URL
+ * </ul>
+ *
+ * <p><strong>Hint:</strong> When you create client credentials in Camunda Cloud you have the option
+ * to download a file with above lines filled out for you.
+ *
+ * <p>When {@code ZEEBE_ADDRESS} is not set, it connects to a broker running on localhost with
+ * default ports
+ */
 public final class HandleVariablesAsPojo {
   public static void main(final String[] args) {
-    final String broker = "127.0.0.1:26500";
+    final String defaultAddress = "localhost:26500";
+    final String envVarAddress = System.getenv("ZEEBE_ADDRESS");
 
-    final ZeebeClientBuilder builder =
-        ZeebeClient.newClientBuilder().gatewayAddress(broker).usePlaintext();
+    final ZeebeClientBuilder clientBuilder;
+    if (envVarAddress != null) {
+      /* Connect to Camunda Cloud Cluster, assumes that credentials are set in environment variables.
+       * See JavaDoc on class level for details
+       */
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(envVarAddress);
+    } else {
+      // connect to local deployment; assumes that authentication is disabled
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(defaultAddress).usePlaintext();
+    }
 
-    try (final ZeebeClient client = builder.build()) {
+    try (final ZeebeClient client = clientBuilder.build()) {
       final Order order = new Order();
       order.setOrderId(31243);
 

--- a/samples/src/main/java/io/zeebe/example/data/HandleVariablesAsPojo.java
+++ b/samples/src/main/java/io/zeebe/example/data/HandleVariablesAsPojo.java
@@ -15,7 +15,7 @@ import io.zeebe.client.api.worker.JobHandler;
 import java.util.Scanner;
 
 /**
- * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ * Example application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
  *
  * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
  * environment variables are set:

--- a/samples/src/main/java/io/zeebe/example/job/JobWorkerCreator.java
+++ b/samples/src/main/java/io/zeebe/example/job/JobWorkerCreator.java
@@ -16,16 +16,44 @@ import io.zeebe.client.api.worker.JobWorker;
 import java.time.Duration;
 import java.util.Scanner;
 
+/**
+ * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ *
+ * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
+ * environment variables are set:
+ *
+ * <ul>
+ *   <li>ZEEBE_ADDRESS
+ *   <li>ZEEBE_CLIENT_ID
+ *   <li>ZEEBE_CLIENT_SECRET
+ *   <li>ZEEBE_AUTHORIZATION_SERVER_URL
+ * </ul>
+ *
+ * <p><strong>Hint:</strong> When you create client credentials in Camunda Cloud you have the option
+ * to download a file with above lines filled out for you.
+ *
+ * <p>When {@code ZEEBE_ADDRESS} is not set, it connects to a broker running on localhost with
+ * default ports
+ */
 public final class JobWorkerCreator {
   public static void main(final String[] args) {
-    final String broker = "127.0.0.1:26500";
+    final String defaultAddress = "localhost:26500";
+    final String envVarAddress = System.getenv("ZEEBE_ADDRESS");
+
+    final ZeebeClientBuilder clientBuilder;
+    if (envVarAddress != null) {
+      /* Connect to Camunda Cloud Cluster, assumes that credentials are set in environment variables.
+       * See JavaDoc on class level for details
+       */
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(envVarAddress);
+    } else {
+      // connect to local deployment; assumes that authentication is disabled
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(defaultAddress).usePlaintext();
+    }
 
     final String jobType = "foo";
 
-    final ZeebeClientBuilder builder =
-        ZeebeClient.newClientBuilder().gatewayAddress(broker).usePlaintext();
-
-    try (final ZeebeClient client = builder.build()) {
+    try (final ZeebeClient client = clientBuilder.build()) {
 
       System.out.println("Opening job worker.");
 

--- a/samples/src/main/java/io/zeebe/example/job/JobWorkerCreator.java
+++ b/samples/src/main/java/io/zeebe/example/job/JobWorkerCreator.java
@@ -17,7 +17,7 @@ import java.time.Duration;
 import java.util.Scanner;
 
 /**
- * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ * Example application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
  *
  * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
  * environment variables are set:

--- a/samples/src/main/java/io/zeebe/example/workflow/NonBlockingWorkflowInstanceCreator.java
+++ b/samples/src/main/java/io/zeebe/example/workflow/NonBlockingWorkflowInstanceCreator.java
@@ -13,7 +13,7 @@ import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.response.WorkflowInstanceEvent;
 
 /**
- * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ * Example application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
  *
  * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
  * environment variables are set:

--- a/samples/src/main/java/io/zeebe/example/workflow/NonBlockingWorkflowInstanceCreator.java
+++ b/samples/src/main/java/io/zeebe/example/workflow/NonBlockingWorkflowInstanceCreator.java
@@ -12,16 +12,45 @@ import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.api.ZeebeFuture;
 import io.zeebe.client.api.response.WorkflowInstanceEvent;
 
+/**
+ * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ *
+ * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
+ * environment variables are set:
+ *
+ * <ul>
+ *   <li>ZEEBE_ADDRESS
+ *   <li>ZEEBE_CLIENT_ID
+ *   <li>ZEEBE_CLIENT_SECRET
+ *   <li>ZEEBE_AUTHORIZATION_SERVER_URL
+ * </ul>
+ *
+ * <p><strong>Hint:</strong> When you create client credentials in Camunda Cloud you have the option
+ * to download a file with above lines filled out for you.
+ *
+ * <p>When {@code ZEEBE_ADDRESS} is not set, it connects to a broker running on localhost with
+ * default ports
+ */
 public final class NonBlockingWorkflowInstanceCreator {
   public static void main(final String[] args) {
-    final String broker = "127.0.0.1:26500";
+    final String defaultAddress = "localhost:26500";
+    final String envVarAddress = System.getenv("ZEEBE_ADDRESS");
+
+    final ZeebeClientBuilder clientBuilder;
+    if (envVarAddress != null) {
+      /* Connect to Camunda Cloud Cluster, assumes that credentials are set in environment variables.
+       * See JavaDoc on class level for details
+       */
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(envVarAddress);
+    } else {
+      // connect to local deployment; assumes that authentication is disabled
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(defaultAddress).usePlaintext();
+    }
+
     final int numberOfInstances = 100_000;
     final String bpmnProcessId = "demoProcess";
 
-    final ZeebeClientBuilder builder =
-        ZeebeClient.newClientBuilder().gatewayAddress(broker).usePlaintext();
-
-    try (final ZeebeClient client = builder.build()) {
+    try (final ZeebeClient client = clientBuilder.build()) {
       System.out.println("Creating " + numberOfInstances + " workflow instances");
 
       final long startTime = System.currentTimeMillis();

--- a/samples/src/main/java/io/zeebe/example/workflow/WorkflowDeployer.java
+++ b/samples/src/main/java/io/zeebe/example/workflow/WorkflowDeployer.java
@@ -12,7 +12,7 @@ import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.api.response.DeploymentEvent;
 
 /**
- * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ * Example application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
  *
  * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
  * environment variables are set:

--- a/samples/src/main/java/io/zeebe/example/workflow/WorkflowDeployer.java
+++ b/samples/src/main/java/io/zeebe/example/workflow/WorkflowDeployer.java
@@ -11,13 +11,41 @@ import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.api.response.DeploymentEvent;
 
+/**
+ * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ *
+ * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
+ * environment variables are set:
+ *
+ * <ul>
+ *   <li>ZEEBE_ADDRESS
+ *   <li>ZEEBE_CLIENT_ID
+ *   <li>ZEEBE_CLIENT_SECRET
+ *   <li>ZEEBE_AUTHORIZATION_SERVER_URL
+ * </ul>
+ *
+ * <p><strong>Hint:</strong> When you create client credentials in Camunda Cloud you have the option
+ * to download a file with above lines filled out for you.
+ *
+ * <p>When {@code ZEEBE_ADDRESS} is not set, it connects to a broker running on localhost with
+ * default ports
+ */
 public final class WorkflowDeployer {
 
   public static void main(final String[] args) {
-    final String broker = "localhost:26500";
+    final String defaultAddress = "localhost:26500";
+    final String envVarAddress = System.getenv("ZEEBE_ADDRESS");
 
-    final ZeebeClientBuilder clientBuilder =
-        ZeebeClient.newClientBuilder().gatewayAddress(broker).usePlaintext();
+    final ZeebeClientBuilder clientBuilder;
+    if (envVarAddress != null) {
+      /* Connect to Camunda Cloud Cluster, assumes that credentials are set in environment variables.
+       * See JavaDoc on class level for details
+       */
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(envVarAddress);
+    } else {
+      // connect to local deployment; assumes that authentication is disabled
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(defaultAddress).usePlaintext();
+    }
 
     try (final ZeebeClient client = clientBuilder.build()) {
 

--- a/samples/src/main/java/io/zeebe/example/workflow/WorkflowInstanceCreator.java
+++ b/samples/src/main/java/io/zeebe/example/workflow/WorkflowInstanceCreator.java
@@ -12,7 +12,7 @@ import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.api.response.WorkflowInstanceEvent;
 
 /**
- * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ * Example application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
  *
  * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
  * environment variables are set:

--- a/samples/src/main/java/io/zeebe/example/workflow/WorkflowInstanceCreator.java
+++ b/samples/src/main/java/io/zeebe/example/workflow/WorkflowInstanceCreator.java
@@ -11,17 +11,45 @@ import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.api.response.WorkflowInstanceEvent;
 
+/**
+ * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ *
+ * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
+ * environment variables are set:
+ *
+ * <ul>
+ *   <li>ZEEBE_ADDRESS
+ *   <li>ZEEBE_CLIENT_ID
+ *   <li>ZEEBE_CLIENT_SECRET
+ *   <li>ZEEBE_AUTHORIZATION_SERVER_URL
+ * </ul>
+ *
+ * <p><strong>Hint:</strong> When you create client credentials in Camunda Cloud you have the option
+ * to download a file with above lines filled out for you.
+ *
+ * <p>When {@code ZEEBE_ADDRESS} is not set, it connects to a broker running on localhost with
+ * default ports
+ */
 public final class WorkflowInstanceCreator {
 
   public static void main(final String[] args) {
-    final String broker = "127.0.0.1:26500";
+    final String defaultAddress = "localhost:26500";
+    final String envVarAddress = System.getenv("ZEEBE_ADDRESS");
+
+    final ZeebeClientBuilder clientBuilder;
+    if (envVarAddress != null) {
+      /* Connect to Camunda Cloud Cluster, assumes that credentials are set in environment variables.
+       * See JavaDoc on class level for details
+       */
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(envVarAddress);
+    } else {
+      // connect to local deployment; assumes that authentication is disabled
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(defaultAddress).usePlaintext();
+    }
 
     final String bpmnProcessId = "demoProcess";
 
-    final ZeebeClientBuilder builder =
-        ZeebeClient.newClientBuilder().gatewayAddress(broker).usePlaintext();
-
-    try (final ZeebeClient client = builder.build()) {
+    try (final ZeebeClient client = clientBuilder.build()) {
 
       System.out.println("Creating workflow instance");
 

--- a/samples/src/main/java/io/zeebe/example/workflow/WorkflowInstanceWithResultCreator.java
+++ b/samples/src/main/java/io/zeebe/example/workflow/WorkflowInstanceWithResultCreator.java
@@ -14,7 +14,7 @@ import java.time.Duration;
 import java.util.Map;
 
 /**
- * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ * Example application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
  *
  * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
  * environment variables are set:

--- a/samples/src/main/java/io/zeebe/example/workflow/WorkflowInstanceWithResultCreator.java
+++ b/samples/src/main/java/io/zeebe/example/workflow/WorkflowInstanceWithResultCreator.java
@@ -13,16 +13,44 @@ import io.zeebe.client.api.response.WorkflowInstanceResult;
 import java.time.Duration;
 import java.util.Map;
 
+/**
+ * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ *
+ * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
+ * environment variables are set:
+ *
+ * <ul>
+ *   <li>ZEEBE_ADDRESS
+ *   <li>ZEEBE_CLIENT_ID
+ *   <li>ZEEBE_CLIENT_SECRET
+ *   <li>ZEEBE_AUTHORIZATION_SERVER_URL
+ * </ul>
+ *
+ * <p><strong>Hint:</strong> When you create client credentials in Camunda Cloud you have the option
+ * to download a file with above lines filled out for you.
+ *
+ * <p>When {@code ZEEBE_ADDRESS} is not set, it connects to a broker running on localhost with
+ * default ports
+ */
 public class WorkflowInstanceWithResultCreator {
   public static void main(final String[] args) {
-    final String broker = "127.0.0.1:26500";
+    final String defaultAddress = "localhost:26500";
+    final String envVarAddress = System.getenv("ZEEBE_ADDRESS");
+
+    final ZeebeClientBuilder clientBuilder;
+    if (envVarAddress != null) {
+      /* Connect to Camunda Cloud Cluster, assumes that credentials are set in environment variables.
+       * See JavaDoc on class level for details
+       */
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(envVarAddress);
+    } else {
+      // connect to local deployment; assumes that authentication is disabled
+      clientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(defaultAddress).usePlaintext();
+    }
 
     final String bpmnProcessId = "demoProcessSingleTask";
 
-    final ZeebeClientBuilder builder =
-        ZeebeClient.newClientBuilder().gatewayAddress(broker).usePlaintext();
-
-    try (final ZeebeClient client = builder.build()) {
+    try (final ZeebeClient client = clientBuilder.build()) {
 
       openJobWorker(client); // open job workers so that task are executed and workflow is completed
       System.out.println("Creating workflow instance");


### PR DESCRIPTION
## Description

Adjusts examples so that they can be used with cluster in Camunda Cloud.

Change set:
- add JavaDocs explaining which environment variables need to be set to connect to Camunda Cloud
- add logic to support both local deployments and cloud deployments

## Related issues

https://github.com/camunda-cloud/camunda-cloud-documentation/issues/88

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
