### PR TITLE
Lower log level to debug in benchmarks

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -29,6 +29,8 @@ gateway:
           fieldPath: metadata.namespace
     - name: ATOMIX_LOG_LEVEL
       value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
     - name: ZEEBE_GATEWAY_MONITORING_ENABLED
       value: "true"
     - name: ZEEBE_GATEWAY_THREADS_MANAGEMENTTHREADS
@@ -74,6 +76,8 @@ env:
     value: "true"
   - name: ATOMIX_LOG_LEVEL
     value: INFO
+  - name: ZEEBE_LOG_LEVEL
+    value: DEBUG
   - name: ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK
     value: "0.8"
   - name: ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK


### PR DESCRIPTION
## Description

This PR ensures we output debug logging for all benchmarks. If you look at the latest (e.g. release-0.26.0-rc1), log level was INFO. That makes sense for normal runs, but here we usually want to see what happened after an error occurred, and for this we need debugging information.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
