### PR TITLE
[Backport stable/0.25] test zbctl JSON output as JSON

### DIFF
--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -45,13 +46,16 @@ type integrationTestSuite struct {
 	*containersuite.ContainerSuite
 }
 
-var tests = []struct {
+type testCase struct {
 	name       string
 	setupCmds  []string
 	envVars    []string
 	cmd        string
 	goldenFile string
-}{
+	jsonOutput bool
+}
+
+var tests = []testCase{
 	{
 		name:       "print help",
 		cmd:        "help",
@@ -81,12 +85,14 @@ var tests = []struct {
 		name:       "deploy workflow",
 		cmd:        "--insecure deploy testdata/model.bpmn testdata/job_model.bpmn --resourceNames=model.bpmn,job.bpmn",
 		goldenFile: "testdata/deploy.golden",
+		jsonOutput: true,
 	},
 	{
 		name:       "create instance",
 		setupCmds:  []string{"--insecure deploy testdata/model.bpmn"},
 		cmd:        "--insecure create instance process",
 		goldenFile: "testdata/create_instance.golden",
+		jsonOutput: true,
 	},
 	{
 		name:       "create worker",
@@ -127,6 +133,11 @@ func (s *integrationTestSuite) TestCommonCommands() {
 				}
 			}
 
+			if len(test.setupCmds) > 0 {
+				// mitigates race condition between setup commands and test command
+				<-time.After(time.Second)
+			}
+
 			cmdOut, err := s.runCommand(test.cmd, test.envVars...)
 			if errors.Is(err, context.DeadlineExceeded) {
 				t.Fatal(fmt.Errorf("timed out while executing command '%s': %w", test.cmd, err))
@@ -136,14 +147,40 @@ func (s *integrationTestSuite) TestCommonCommands() {
 			if err != nil {
 				t.Fatal(err)
 			}
-			want := strings.Split(string(goldenOut), "\n")
-			got := strings.Split(string(cmdOut), "\n")
 
-			if diff := cmp.Diff(want, got, cmp.Comparer(composeComparer(cmpIgnoreNums, cmpIgnoreVersion))); diff != "" {
-				t.Fatalf("%s: diff (-want +got):\n%s", test.name, diff)
+			if test.jsonOutput {
+				assertEqJSON(t, test, goldenOut, cmdOut)
+			} else {
+				assertEqText(t, test, goldenOut, cmdOut)
 			}
 		})
 	}
+}
+
+func assertEqText(t *testing.T, test testCase, golden, cmdOut []byte) {
+	wantLines := strings.Split(string(golden), "\n")
+	gotLines := strings.Split(string(cmdOut), "\n")
+
+	if diff := cmp.Diff(wantLines, gotLines, cmp.Comparer(composeComparer(cmpIgnoreNums, cmpIgnoreVersion))); diff != "" {
+		t.Fatalf("%s: diff (-want +got):\n%s", test.name, diff)
+	}
+}
+
+func assertEqJSON(t *testing.T, test testCase, golden, cmdOut []byte) {
+	want := string(golden)
+	got := string(cmdOut)
+
+	// remove versions
+	ignorePattern := regexp.MustCompile(semVer)
+	want = ignorePattern.ReplaceAllString(want, "")
+	got = ignorePattern.ReplaceAllString(got, "")
+
+	// remove numbers
+	ignorePattern = regexp.MustCompile(`\d`)
+	want = ignorePattern.ReplaceAllString(want, "1")
+	got = ignorePattern.ReplaceAllString(got, "1")
+
+	require.JSONEqf(t, want, got, "expected JSON output from '%s' to match golden file '%s'", test.cmd, test.goldenFile)
 }
 
 func composeComparer(cmpFuncs ...func(x, y string) bool) func(x, y string) bool {


### PR DESCRIPTION
## Description

Backports #6063. The merge conflicts were caused by the absence of some tests in stable/0.25.

## Related issues

closes #6037 
backports #6063 

## Definition of Done
_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
