### PR TITLE
Use process_files_* for file descriptor graph

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -3970,19 +3970,15 @@
         },
         {
           "aliasColors": {},
-          "bars": false,
           "dashLength": 10,
-          "dashes": false,
           "datasource": "$DS_PROMETHEUS",
           "fill": 1,
-          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
             "y": 21
           },
-          "hiddenSeries": false,
           "id": 37,
           "legend": {
             "avg": false,
@@ -4000,29 +3996,37 @@
           "options": {
             "dataLinks": []
           },
-          "percentage": false,
           "pointradius": 5,
-          "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "$$hashKey": "object:407",
+              "alias": "/.*limit.*/",
+              "fill": 0,
+              "linewidth": 2,
+              "color": "#C4162A"
+            }
+          ],
           "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
           "targets": [
             {
-              "expr": "container_file_descriptors{namespace=~\"$namespace\",pod=~\"$pod\", container=~\"zeebe.*\"}",
+              "expr": "process_files_open_files{namespace=~\"$namespace\",pod=~\"$pod\"}",
+              "legendFormat": "{{pod}} use fds",
+              "interval": "",
               "format": "time_series",
               "hide": false,
-              "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}} use fds",
               "refId": "B"
+            },
+            {
+              "expr": "process_files_max_files{namespace=~\"$namespace\",pod=~\"$pod\"}",
+              "legendFormat": "{{pod}} limit",
+              "interval": "",
+              "refId": "A"
             }
           ],
           "thresholds": [],
-          "timeFrom": null,
           "timeRegions": [],
-          "timeShift": null,
           "title": "File descriptors",
           "tooltip": {
             "shared": true,
@@ -4060,7 +4064,23 @@
           "yaxis": {
             "align": false,
             "alignLevel": null
-          }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "bars": false,
+          "dashes": false,
+          "fillGradient": 0,
+          "hiddenSeries": false,
+          "percentage": false,
+          "points": false,
+          "stack": false,
+          "steppedLine": false,
+          "timeFrom": null,
+          "timeShift": null
         },
         {
           "aliasColors": {},


### PR DESCRIPTION
## Description

This PR updates the `File descriptors` graph of our Grafana dashboard such that it shows the maximum and current number of open file descriptors in our test environment __and__ in Camunda Cloud.

Camunda Cloud dashboard:
![camunda-cloud-fds](https://user-images.githubusercontent.com/43373/103901451-72eac780-50f9-11eb-9f31-03eaa1ff3ee5.png)

Test environment dashboard:
![test-fds](https://user-images.githubusercontent.com/43373/103901455-754d2180-50f9-11eb-8d1b-0b8843807c5a.png)


## Related issues

closes #6079

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
