### PR TITLE
fix(gateway): not remove stacktraces

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -34,73 +34,83 @@ public final class GrpcErrorMapper {
     return mapError(error, Loggers.GATEWAY_LOGGER);
   }
 
-  public StatusRuntimeException mapError(final Throwable error, final Logger logger) {
+  StatusRuntimeException mapError(final Throwable error, final Logger logger) {
     return StatusProto.toStatusRuntimeException(mapErrorToStatus(error, logger));
   }
 
   private Status mapErrorToStatus(final Throwable error, final Logger logger) {
+    return mapErrorToStatus(error, error, logger);
+  }
+
+  private Status mapErrorToStatus(
+      final Throwable rootError, final Throwable error, final Logger logger) {
     final Builder builder = Status.newBuilder();
 
     if (error instanceof ExecutionException) {
-      return mapErrorToStatus(error.getCause(), logger);
+      return mapErrorToStatus(rootError, error.getCause(), logger);
     } else if (error instanceof BrokerErrorException) {
       final Status status =
-          mapBrokerErrorToStatus(((BrokerErrorException) error).getError(), logger);
+          mapBrokerErrorToStatus(rootError, ((BrokerErrorException) error).getError(), logger);
       builder.mergeFrom(status);
     } else if (error instanceof BrokerRejectionException) {
       final Status status = mapRejectionToStatus(((BrokerRejectionException) error).getRejection());
       builder.mergeFrom(status);
-      logger.trace("Expected to handle gRPC request, but the broker rejected it", error);
+      logger.trace("Expected to handle gRPC request, but the broker rejected it", rootError);
     } else if (error instanceof TimeoutException) { // can be thrown by transport
       builder
           .setCode(Code.DEADLINE_EXCEEDED_VALUE)
           .setMessage("Time out between gateway and broker: " + error.getMessage());
       logger.debug(
           "Expected to handle gRPC request, but request timed out between gateway and broker",
-          error);
+          rootError);
     } else if (error instanceof InvalidBrokerRequestArgumentException) {
       builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
-      logger.debug("Expected to handle gRPC request, but broker argument was invalid", error);
+      logger.debug("Expected to handle gRPC request, but broker argument was invalid", rootError);
     } else if (error instanceof MsgpackPropertyException) {
       builder.setCode(Code.INVALID_ARGUMENT_VALUE).setMessage(error.getMessage());
-      logger.debug("Expected to handle gRPC request, but messagepack property was invalid", error);
+      logger.debug(
+          "Expected to handle gRPC request, but messagepack property was invalid", rootError);
     } else if (error instanceof PartitionNotFoundException) {
       builder.setCode(Code.UNAVAILABLE_VALUE).setMessage(error.getMessage());
-      logger.debug("Expected to handle gRPC request, but request could not be delivered", error);
+      logger.debug(
+          "Expected to handle gRPC request, but request could not be delivered", rootError);
     } else if (error instanceof RequestRetriesExhaustedException) {
       builder.setCode(Code.RESOURCE_EXHAUSTED_VALUE).setMessage(error.getMessage());
 
       // RequestRetriesExhaustedException will sometimes carry suppressed exceptions which can be
       // added/mapped as error details to give more information to the user
       for (final Throwable suppressed : error.getSuppressed()) {
-        builder.addDetails(Any.pack(mapErrorToStatus(suppressed, logger)));
+        builder.addDetails(Any.pack(mapErrorToStatus(rootError, suppressed, logger)));
       }
 
       // this error occurs when all partitions have exhausted for requests which have no fixed
       // partitions - it will then also occur when back pressure kicks in, leading to a large burst
       // of error logs that is, in fact, expected
-      logger.trace("Expected to handle gRPC request, but all retries have been exhausted", error);
+      logger.trace(
+          "Expected to handle gRPC request, but all retries have been exhausted", rootError);
     } else if (error instanceof NoTopologyAvailableException) {
       builder.setCode(Code.UNAVAILABLE_VALUE).setMessage(error.getMessage());
       logger.trace(
           "Expected to handle gRPC request, but the gateway does not know any partitions yet",
-          error);
+          rootError);
     } else if (error instanceof ConnectTimeoutException) {
       builder.setCode(Code.UNAVAILABLE_VALUE).setMessage(error.getMessage());
       logger.warn(
-          "Expected to handle gRPC request, but a connection timeout exception occurred", error);
+          "Expected to handle gRPC request, but a connection timeout exception occurred",
+          rootError);
     } else {
       builder
           .setCode(Code.INTERNAL_VALUE)
           .setMessage(
               "Unexpected error occurred during the request processing: " + error.getMessage());
-      logger.error("Expected to handle gRPC request, but an unexpected error occurred", error);
+      logger.error("Expected to handle gRPC request, but an unexpected error occurred", rootError);
     }
 
     return builder.build();
   }
 
-  private Status mapBrokerErrorToStatus(final BrokerError error, final Logger logger) {
+  private Status mapBrokerErrorToStatus(
+      final Throwable rootError, final BrokerError error, final Logger logger) {
     final Builder builder = Status.newBuilder();
     String message = error.getMessage();
 
@@ -110,12 +120,12 @@ public final class GrpcErrorMapper {
         break;
       case RESOURCE_EXHAUSTED:
         builder.setCode(Code.RESOURCE_EXHAUSTED_VALUE);
-        logger.trace("Target broker is currently overloaded: {}", error);
+        logger.trace("Target broker is currently overloaded: {}", error, rootError);
         break;
       case PARTITION_LEADER_MISMATCH:
         // return UNAVAILABLE to indicate to the user that retrying might solve the issue, as this
         // is usually a transient issue
-        logger.trace("Target broker was not the leader of the partition: {}", error);
+        logger.trace("Target broker was not the leader of the partition: {}", error, rootError);
         builder.setCode(Code.UNAVAILABLE_VALUE);
         break;
       default:
@@ -123,7 +133,8 @@ public final class GrpcErrorMapper {
         // to solve anything
         logger.error(
             "Expected to handle gRPC request, but received an internal error from broker: {}",
-            error);
+            error,
+            rootError);
         builder.setCode(Code.INTERNAL_VALUE);
         message =
             String.format(


### PR DESCRIPTION
## Description

Introduces a new parameter (rootError) to pass it through the recursion. Added a new test which verifies the logged error.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/6076

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
