### PR TITLE
fix(broker): detect out of cluster messages received in NettyUnicastService 

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
@@ -351,7 +351,7 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
   /** Builds a default unicast service. */
   protected static ManagedUnicastService buildUnicastService(final ClusterConfig config) {
     return new NettyUnicastService(
-        config.getNodeConfig().getAddress(), config.getMessagingConfig());
+        config.getClusterId(), config.getNodeConfig().getAddress(), config.getMessagingConfig());
   }
 
   /** Builds a member location provider. */

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -73,10 +73,13 @@ public class NettyUnicastService implements ManagedUnicastService {
   private final AtomicBoolean started = new AtomicBoolean();
   private EventLoopGroup group;
   private DatagramChannel channel;
+  private final int preamble;
 
-  public NettyUnicastService(final Address address, final MessagingConfig config) {
+  public NettyUnicastService(
+      final String clusterId, final Address address, final MessagingConfig config) {
     this.address = address;
     this.config = config;
+    preamble = clusterId.hashCode();
   }
 
   @Override
@@ -95,7 +98,8 @@ public class NettyUnicastService implements ManagedUnicastService {
 
     final Message message = new Message(this.address, subject, payload);
     final byte[] bytes = SERIALIZER.encode(message);
-    final ByteBuf buf = channel.alloc().buffer(4 + bytes.length);
+    final ByteBuf buf = channel.alloc().buffer(Integer.BYTES + Integer.BYTES + bytes.length);
+    buf.writeInt(preamble);
     buf.writeInt(bytes.length).writeBytes(bytes);
     channel.writeAndFlush(
         new DatagramPacket(buf, new InetSocketAddress(resolvedAddress, address.port())));
@@ -130,17 +134,7 @@ public class NettyUnicastService implements ManagedUnicastService {
                   protected void channelRead0(
                       final ChannelHandlerContext context, final DatagramPacket packet)
                       throws Exception {
-                    final byte[] payload = new byte[packet.content().readInt()];
-                    packet.content().readBytes(payload);
-                    final Message message = SERIALIZER.decode(payload);
-                    final Map<BiConsumer<Address, byte[]>, Executor> listeners =
-                        NettyUnicastService.this.listeners.get(message.subject());
-                    if (listeners != null) {
-                      listeners.forEach(
-                          (consumer, executor) ->
-                              executor.execute(
-                                  () -> consumer.accept(message.source(), message.payload())));
-                    }
+                    handleReceivedPacket(packet);
                   }
                 })
             .option(ChannelOption.RCVBUF_ALLOCATOR, new DefaultMaxBytesRecvByteBufAllocator())
@@ -148,6 +142,26 @@ public class NettyUnicastService implements ManagedUnicastService {
             .option(ChannelOption.SO_REUSEADDR, true);
 
     return bind(serverBootstrap);
+  }
+
+  private void handleReceivedPacket(final DatagramPacket packet) {
+    final int preambleReceived = packet.content().readInt();
+    if (preambleReceived != preamble) {
+      log.warn(
+          "Received unicast message from {} which is outside of the cluster. Ignoring the message.",
+          packet.sender());
+      return;
+    }
+    final byte[] payload = new byte[packet.content().readInt()];
+    packet.content().readBytes(payload);
+    final Message message = SERIALIZER.decode(payload);
+    final Map<BiConsumer<Address, byte[]>, Executor> subjectListeners =
+        listeners.get(message.subject());
+    if (subjectListeners != null) {
+      subjectListeners.forEach(
+          (consumer, executor) ->
+              executor.execute(() -> consumer.accept(message.source(), message.payload())));
+    }
   }
 
   /**

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyUnicastServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyUnicastServiceTest.java
@@ -71,10 +71,11 @@ public class NettyUnicastServiceTest extends ConcurrentTestCase {
     address1 = Address.from("127.0.0.1", SocketUtil.getNextAddress().getPort());
     address2 = Address.from("127.0.0.1", SocketUtil.getNextAddress().getPort());
 
-    service1 = new NettyUnicastService(address1, new MessagingConfig());
+    final String clusterId = "testClusterId";
+    service1 = new NettyUnicastService(clusterId, address1, new MessagingConfig());
     service1.start().join();
 
-    service2 = new NettyUnicastService(address2, new MessagingConfig());
+    service2 = new NettyUnicastService(clusterId, address2, new MessagingConfig());
     service2.start().join();
   }
 


### PR DESCRIPTION
## Description

BREAKING CHANGE

* Use a preamble in every message send by NettyUnicastService
* If the preamble of the received message does not match the preamble of this cluster, it simply ignores the message

Preamble is generated from the clusterIds. The assumption here is that clusterIds are unique.

## Related issues

closes #5641

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
