### PR TITLE
java-client: Job worker polling backoff mechanism

### DIFF
--- a/clients/java/ignored-changes.xml
+++ b/clients/java/ignored-changes.xml
@@ -17,4 +17,19 @@
     <method>io.zeebe.client.api.JsonMapper getJsonMapper()</method>
     <differenceType>7012</differenceType>
   </difference>
+  <difference>
+    <className>io/zeebe/client/api/worker/JobWorkerBuilderStep1$JobWorkerBuilderStep3</className>
+    <differenceType>7012</differenceType>
+    <method>io.zeebe.client.api.worker.JobWorkerBuilderStep1$JobWorkerBuilderStep3 backoffSupplier(io.zeebe.client.api.worker.BackoffSupplier)</method>
+  </difference>
+  <difference>
+    <className>io/zeebe/client/impl/worker/JobPoller</className>
+    <differenceType>7004</differenceType>
+    <method>void poll(int, java.util.function.Consumer, java.util.function.IntConsumer, java.util.function.BooleanSupplier)</method>
+  </difference>
+  <difference>
+    <className>io/zeebe/client/impl/worker/JobWorkerImpl</className>
+    <differenceType>7004</differenceType>
+    <method>JobWorkerImpl(int, java.util.concurrent.ScheduledExecutorService, java.time.Duration, io.zeebe.client.impl.worker.JobRunnableFactory, io.zeebe.client.impl.worker.JobPoller)</method>
+  </difference>
 </differences>

--- a/clients/java/ignored-changes.xml
+++ b/clients/java/ignored-changes.xml
@@ -22,14 +22,4 @@
     <differenceType>7012</differenceType>
     <method>io.zeebe.client.api.worker.JobWorkerBuilderStep1$JobWorkerBuilderStep3 backoffSupplier(io.zeebe.client.api.worker.BackoffSupplier)</method>
   </difference>
-  <difference>
-    <className>io/zeebe/client/impl/worker/JobPoller</className>
-    <differenceType>7004</differenceType>
-    <method>void poll(int, java.util.function.Consumer, java.util.function.IntConsumer, java.util.function.BooleanSupplier)</method>
-  </difference>
-  <difference>
-    <className>io/zeebe/client/impl/worker/JobWorkerImpl</className>
-    <differenceType>7004</differenceType>
-    <method>JobWorkerImpl(int, java.util.concurrent.ScheduledExecutorService, java.time.Duration, io.zeebe.client.impl.worker.JobRunnableFactory, io.zeebe.client.impl.worker.JobPoller)</method>
-  </difference>
 </differences>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -106,6 +106,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <scope>runtime</scope>

--- a/clients/java/src/main/java/io/zeebe/client/api/worker/BackoffSupplier.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/worker/BackoffSupplier.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.api.worker;
+
+import io.zeebe.client.impl.worker.ExponentialBackoffBuilderImpl;
+import java.time.Duration;
+
+/**
+ * The {@link JobWorker} uses this interface to determine the retry delay after each failed request.
+ * After a successful request, or if no requests have been sent yet, the delay is reset to the job
+ * worker's polling interval (see {@link
+ * io.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3#pollInterval(Duration)}).
+ *
+ * <p>The supplier is called after a failed request. The worker will then await the supplied delay
+ * before sending the next request.
+ */
+@FunctionalInterface
+public interface BackoffSupplier {
+
+  /**
+   * @return a builder to configure and create a new exponential backoff {@link
+   *     io.zeebe.client.impl.worker.ExponentialBackoff}.
+   */
+  static ExponentialBackoffBuilder newBackoffBuilder() {
+    return new ExponentialBackoffBuilderImpl();
+  }
+
+  /**
+   * Returns the delay before the next retry. The delay should be specified in milliseconds.
+   *
+   * @param currentRetryDelay the last used retry delay
+   * @return the new retry delay
+   */
+  long supplyRetryDelay(final long currentRetryDelay);
+}

--- a/clients/java/src/main/java/io/zeebe/client/api/worker/ExponentialBackoffBuilder.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/worker/ExponentialBackoffBuilder.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.api.worker;
+
+import java.util.Random;
+
+public interface ExponentialBackoffBuilder {
+
+  /**
+   * Sets the maximum retry delay.
+   *
+   * <p>Note that the jitter may push the retry delay over this maximum.
+   *
+   * <p>Default is 5000ms.
+   *
+   * @param maxDelay the maximum delay before retrying in ms
+   * @return the builder for this exponential backoff
+   */
+  ExponentialBackoffBuilder maxDelay(long maxDelay);
+
+  /**
+   * Sets the minimum retry delay.
+   *
+   * <p>Note that the jitter may push the retry delay below this minimum.
+   *
+   * <p>Default is 50ms.
+   *
+   * @param minDelay the minimum delay before retrying is ms
+   * @return the builder for this exponential backoff
+   */
+  ExponentialBackoffBuilder minDelay(long minDelay);
+
+  /**
+   * Sets the backoff multiplication factor. The previous delay is multiplied by this factor.
+   * Default is 1.6.
+   *
+   * @param backoffFactor the factor to multiply with the previous delay to determine the next delay
+   * @return the builder for this exponential backoff
+   */
+  ExponentialBackoffBuilder backoffFactor(double backoffFactor);
+
+  /**
+   * Sets the jitter factor. The next delay is changed randomly within a range of +/- this factor.
+   *
+   * <p>For example, if the next delay is calculated to be 1s and the jitterFactor is 0.1 then the
+   * actual next delay can be somewhere between 0.9 and 1.1s.
+   *
+   * <p>Default is 0.1
+   *
+   * @param jitterFactor the range of possible jitter defined as a factor
+   * @return the builder for this exponential backoff
+   */
+  ExponentialBackoffBuilder jitterFactor(double jitterFactor);
+
+  /**
+   * Sets the random number generator used to add jitter to the next delay.
+   *
+   * <p>Default is {@code new java.util.Random()}.
+   *
+   * @param random the random to use for jitter
+   * @return the builder for this exponential backoff
+   */
+  ExponentialBackoffBuilder random(Random random);
+
+  /** @return a new {@link BackoffSupplier} with the provided configuration options. */
+  BackoffSupplier build();
+}

--- a/clients/java/src/main/java/io/zeebe/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/zeebe/client/api/worker/JobWorkerBuilderStep1.java
@@ -177,6 +177,21 @@ public interface JobWorkerBuilderStep1 {
     JobWorkerBuilderStep3 fetchVariables(String... fetchVariables);
 
     /**
+     * Sets the backoff supplier. The supplier is called to determine the retry delay after each
+     * failed request; the worker then waits until the returned delay has elapsed before sending the
+     * next request. Note that this is used <strong>only</strong> for the polling mechanism -
+     * failures in the {@link JobHandler} should be handled there, and retried there if need be.
+     *
+     * <p>By default, the supplier uses exponential back off, with an upper bound of 5 seconds. The
+     * exponential backoff can be easily configured using {@link
+     * BackoffSupplier#newBackoffBuilder()}.
+     *
+     * @param backoffSupplier supplies the retry delay after a failed request
+     * @return the builder for this worker
+     */
+    JobWorkerBuilderStep3 backoffSupplier(BackoffSupplier backoffSupplier);
+
+    /**
      * Open the worker and start to work on available tasks.
      *
      * @return the worker

--- a/clients/java/src/main/java/io/zeebe/client/impl/worker/ExponentialBackoff.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/worker/ExponentialBackoff.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl.worker;
+
+import io.zeebe.client.api.worker.BackoffSupplier;
+import java.util.Random;
+
+/**
+ * An implementation of {@link BackoffSupplier} which uses a simple formula, multiplying the
+ * previous delay with an increasing multiplier and adding some jitter to avoid multiple clients
+ * polling at the same time even with back off.
+ *
+ * <p>The next delay is calculated as:
+ *
+ * <pre> max(min(maxDelay, currentDelay * backoffFactor), minDelay) + (rand(0.0, 1.0) *
+ * (currentDelay * jitterFactor) + (currentDelay * -jitterFactor)) </pre>
+ */
+public final class ExponentialBackoff implements BackoffSupplier {
+
+  private final long maxDelay;
+  private final long minDelay;
+  private final double backoffFactor;
+  private final double jitterFactor;
+  private final Random random;
+
+  public ExponentialBackoff(
+      final long maxDelay,
+      final long minDelay,
+      final double backoffFactor,
+      final double jitterFactor,
+      final Random random) {
+    this.maxDelay = maxDelay;
+    this.minDelay = minDelay;
+    this.backoffFactor = backoffFactor;
+    this.jitterFactor = jitterFactor;
+    this.random = random;
+  }
+
+  @Override
+  public long supplyRetryDelay(final long currentRetryDelay) {
+    final double delay = Math.max(Math.min(maxDelay, currentRetryDelay * backoffFactor), minDelay);
+    final double jitter = computeJitter(delay);
+    return Math.round(delay + jitter);
+  }
+
+  private double computeJitter(final double value) {
+    final double minFactor = value * -jitterFactor;
+    final double maxFactor = value * jitterFactor;
+
+    return (random.nextDouble() * (maxFactor - minFactor)) + minFactor;
+  }
+}

--- a/clients/java/src/main/java/io/zeebe/client/impl/worker/ExponentialBackoffBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/worker/ExponentialBackoffBuilderImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl.worker;
+
+import io.zeebe.client.api.worker.BackoffSupplier;
+import io.zeebe.client.api.worker.ExponentialBackoffBuilder;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+public final class ExponentialBackoffBuilderImpl implements ExponentialBackoffBuilder {
+
+  private static final long DEFAULT_MAX_DELAY = TimeUnit.SECONDS.toMillis(5);
+  private static final long DEFAULT_MIN_DELAY = TimeUnit.MILLISECONDS.toMillis(50);
+  private static final double DEFAULT_MULTIPLIER = 1.6;
+  private static final double DEFAULT_JITTER = 0.1;
+  private static final Random DEFAULT_RANDOM = new Random();
+
+  private long maxDelay;
+  private long minDelay;
+  private double backoffFactor;
+  private double jitterFactor;
+  private Random random;
+
+  public ExponentialBackoffBuilderImpl() {
+    maxDelay = DEFAULT_MAX_DELAY;
+    minDelay = DEFAULT_MIN_DELAY;
+    backoffFactor = DEFAULT_MULTIPLIER;
+    jitterFactor = DEFAULT_JITTER;
+    random = DEFAULT_RANDOM;
+  }
+
+  @Override
+  public ExponentialBackoffBuilder maxDelay(final long maxDelay) {
+    this.maxDelay = maxDelay;
+    return this;
+  }
+
+  @Override
+  public ExponentialBackoffBuilder minDelay(final long minDelay) {
+    this.minDelay = minDelay;
+    return this;
+  }
+
+  @Override
+  public ExponentialBackoffBuilder backoffFactor(final double backoffFactor) {
+    this.backoffFactor = backoffFactor;
+    return this;
+  }
+
+  @Override
+  public ExponentialBackoffBuilder jitterFactor(final double jitterFactor) {
+    this.jitterFactor = jitterFactor;
+    return this;
+  }
+
+  @Override
+  public ExponentialBackoffBuilder random(final Random random) {
+    this.random = random;
+    return this;
+  }
+
+  @Override
+  public BackoffSupplier build() {
+    return new ExponentialBackoff(maxDelay, minDelay, backoffFactor, jitterFactor, random);
+  }
+}

--- a/clients/java/src/main/java/io/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
@@ -41,10 +41,9 @@ import java.util.function.Predicate;
 public final class JobWorkerBuilderImpl
     implements JobWorkerBuilderStep1, JobWorkerBuilderStep2, JobWorkerBuilderStep3 {
 
-  private static final Duration DEADLINE_OFFSET = Duration.ofSeconds(10);
-  private static final BackoffSupplier DEFAULT_BACKOFF_SUPPLIER =
+  public static final BackoffSupplier DEFAULT_BACKOFF_SUPPLIER =
       BackoffSupplier.newBackoffBuilder().build();
-
+  private static final Duration DEADLINE_OFFSET = Duration.ofSeconds(10);
   private final GatewayStub gatewayStub;
   private final JobClient jobClient;
   private final JsonMapper jsonMapper;

--- a/clients/java/src/test/java/io/zeebe/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/impl/worker/JobWorkerImplTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.api.worker.JobHandler;
+import io.zeebe.client.impl.ZeebeClientBuilderImpl;
+import io.zeebe.client.impl.ZeebeClientImpl;
+import io.zeebe.gateway.protocol.GatewayGrpc;
+import io.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
+import io.zeebe.gateway.protocol.GatewayOuterClass;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import io.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class JobWorkerImplTest {
+
+  private static final JobHandler NOOP_JOB_HANDLER = (client, job) -> {};
+  private static final long SLOW_POLL_DELAY_IN_MS = 1_000L;
+  private static final Duration SLOW_POLL_THRESHOLD = Duration.ofMillis(SLOW_POLL_DELAY_IN_MS / 2);
+
+  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+  private MockedGateway gateway;
+  private ZeebeClient client;
+
+  @Before
+  public void setup() throws IOException {
+    // Generate a unique in-process server name.
+    final String serverName = InProcessServerBuilder.generateName();
+
+    // Create a server, add service, start, and register for automatic graceful shutdown.
+    gateway = new MockedGateway();
+    grpcCleanup.register(
+        InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(gateway)
+            .build()
+            .start());
+
+    // Create a client channel and register for automatic graceful shutdown.
+    final ManagedChannel channel =
+        grpcCleanup.register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+
+    // Create the Zeebe Client
+    client =
+        new ZeebeClientImpl(new ZeebeClientBuilderImpl(), channel, GatewayGrpc.newStub(channel));
+  }
+
+  @Test
+  public void shouldBackoffWhenGatewayRespondsWithResourceExhausted() {
+    // given a gateway that responds with some jobs
+    gateway.respondWith(TestData.jobs(10));
+
+    // and a client with retry delay supplier that is slowing down polling
+    client
+        .newWorker()
+        .jobType("test")
+        .handler(NOOP_JOB_HANDLER)
+        .backoffSupplier(prev -> SLOW_POLL_DELAY_IN_MS)
+        .open();
+
+    // and assuming that the gateway responded multiple times successfully with jobs
+    gateway.startMeasuring();
+    Awaitility.await()
+        .pollInterval(Duration.ofMillis(10))
+        .atMost(Duration.ofSeconds(1))
+        .until(() -> gateway.getCountedPolls() > 3);
+    gateway.stopMeasuring();
+
+    // then polling is fast
+    assertThat(gateway.getTimeBetweenLatestPolls()).isLessThan(SLOW_POLL_THRESHOLD);
+
+    // when the gateway responds with errors
+    gateway.respondWith(new StatusRuntimeException(Status.RESOURCE_EXHAUSTED));
+
+    // then polling is slowed down
+    gateway.startMeasuring();
+    Awaitility.await()
+        .pollInterval(Duration.ofMillis(100))
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                assertThat(gateway.getTimeBetweenLatestPolls()).isGreaterThan(SLOW_POLL_THRESHOLD));
+  }
+
+  /**
+   * This mocked gateway is able to record metrics on polling for new jobs and easily switch how it
+   * responds to polling.
+   *
+   * <ul>
+   *   Due to the concurrent nature of the test setup and the job worker, 2 lock objects are used:
+   *   <li>responsesLock to lock access to the mocking of responses objects for test setup;
+   *   <li>metricsLock to lock access to the polling metrics objects.
+   * </ul>
+   */
+  private static final class MockedGateway extends GatewayImplBase {
+
+    // mocking of poll responses
+    private final Object responsesLock = new Object();
+    private boolean isInErrorMode = false;
+    private ActivateJobsResponse pollSuccessResponse = ActivateJobsResponse.newBuilder().build();
+    private StatusRuntimeException pollErrorResponse = new StatusRuntimeException(Status.UNKNOWN);
+
+    // polling metrics
+    private final Object metricsLock = new Object();
+    private boolean isMeasuring = false;
+    private long countedPolls = 0;
+    private Instant lastPoll = null;
+    private Duration timeBetweenLatestPolls = null;
+
+    @Override
+    public void activateJobs(
+        final ActivateJobsRequest request,
+        final StreamObserver<ActivateJobsResponse> responseObserver) {
+      synchronized (metricsLock) {
+        if (isMeasuring) {
+          final Instant now = Instant.now();
+          countedPolls++;
+          if (lastPoll != null) {
+            timeBetweenLatestPolls = Duration.between(lastPoll, now);
+          }
+          lastPoll = now;
+        }
+      }
+      synchronized (responsesLock) {
+        if (isInErrorMode) {
+          responseObserver.onError(pollErrorResponse);
+        } else {
+          responseObserver.onNext(pollSuccessResponse);
+          responseObserver.onCompleted();
+        }
+      }
+    }
+
+    public void respondWith(final List<ActivatedJob> jobs) {
+      synchronized (responsesLock) {
+        System.out.println("Now responding with jobs");
+        isInErrorMode = false;
+        pollSuccessResponse = ActivateJobsResponse.newBuilder().addAllJobs(jobs).build();
+      }
+    }
+
+    public void respondWith(final StatusRuntimeException throwable) {
+      synchronized (responsesLock) {
+        System.out.println("Now responding exceptionally");
+        isInErrorMode = true;
+        pollErrorResponse = throwable;
+      }
+    }
+
+    public void startMeasuring() {
+      synchronized (metricsLock) {
+        countedPolls = 0;
+        lastPoll = null;
+        timeBetweenLatestPolls = null;
+        isMeasuring = true;
+      }
+    }
+
+    public void stopMeasuring() {
+      synchronized (metricsLock) {
+        isMeasuring = false;
+      }
+    }
+
+    public Duration getTimeBetweenLatestPolls() {
+      synchronized (metricsLock) {
+        return timeBetweenLatestPolls;
+      }
+    }
+
+    public long getCountedPolls() {
+      synchronized (metricsLock) {
+        return countedPolls;
+      }
+    }
+  }
+
+  private static final class TestData {
+    private static GatewayOuterClass.ActivatedJob job() {
+      return GatewayOuterClass.ActivatedJob.newBuilder()
+          .setKey(12)
+          .setType("foo")
+          .setWorkflowInstanceKey(123)
+          .setBpmnProcessId("test1")
+          .setWorkflowDefinitionVersion(2)
+          .setWorkflowKey(23)
+          .setElementId("foo")
+          .setElementInstanceKey(23213)
+          .setCustomHeaders("{\"version\": \"1\"}")
+          .setWorker("worker1")
+          .setRetries(34)
+          .setDeadline(1231)
+          .setVariables("{\"key\": \"val\"}")
+          .build();
+    }
+
+    public static List<ActivatedJob> jobs(final int numberOfJobs) {
+      return IntStream.range(0, numberOfJobs).mapToObj(i -> job()).collect(Collectors.toList());
+    }
+  }
+}

--- a/clients/java/src/test/java/io/zeebe/client/job/ExponentialBackoffTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/job/ExponentialBackoffTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.client.api.worker.BackoffSupplier;
+import io.zeebe.client.impl.worker.ExponentialBackoff;
+import io.zeebe.client.impl.worker.ExponentialBackoffBuilderImpl;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.Test;
+
+public final class ExponentialBackoffTest {
+  @Test
+  public void plotIt() {
+    final ExponentialBackoff defaultSupplier =
+        (ExponentialBackoff) BackoffSupplier.newBackoffBuilder().jitterFactor(0.15).build();
+
+    final List<String> list = new ArrayList<>();
+    long delay = 0L;
+    for (int i = 0; i < 100; i++) {
+      delay = defaultSupplier.supplyRetryDelay(delay);
+      list.add("" + i + ".0, " + delay + ".0");
+    }
+
+    System.out.println(String.join("\n", list));
+  }
+
+  @Test
+  public void shouldReturnDelayWithinBounds() {
+    // given
+    final long maxDelay = 1_000L;
+    final long minDelay = 50L;
+    final BackoffSupplier supplier =
+        new ExponentialBackoffBuilderImpl()
+            .maxDelay(maxDelay)
+            .minDelay(minDelay)
+            .backoffFactor(1.6)
+            .jitterFactor(0)
+            .build();
+    final LongStream delayGenerator =
+        LongStream.iterate(supplier.supplyRetryDelay(0), supplier::supplyRetryDelay);
+
+    // when
+    final ArrayList<Long> delays = collectLongStream(delayGenerator, 100);
+
+    // then - as we used 0 for jitter factor, we can guarantee all are sorted
+    final long previousDelay = -1L;
+    assertThat(delays).startsWith(minDelay).endsWith(maxDelay).isNotEmpty();
+    assertIsStrictlyIncreasing(maxDelay, delays, previousDelay);
+  }
+
+  @Test
+  public void shouldBeRandomizedWithJitter() {
+    // given
+    final long maxDelay = 1_000L;
+    final long minDelay = 50L;
+    final double jitterFactor = 0.2;
+    final BackoffSupplier supplier =
+        new ExponentialBackoffBuilderImpl()
+            .maxDelay(maxDelay)
+            .minDelay(minDelay)
+            .backoffFactor(1.5)
+            .jitterFactor(jitterFactor)
+            .build();
+    final long lowerMaxBound = Math.round(maxDelay + maxDelay * -jitterFactor);
+    final long upperMaxBound = Math.round(maxDelay + maxDelay * jitterFactor);
+    final LongStream delayGenerator =
+        LongStream.iterate(maxDelay, delay -> supplier.supplyRetryDelay(maxDelay));
+
+    // when
+    final ArrayList<Long> delays = collectLongStream(delayGenerator, 10);
+
+    // then - note that we don't test how uniform the distribution is, just that we get different
+    // values
+    assertThat(delays)
+        .isNotEmpty()
+        .allSatisfy(delay -> assertThat(delay).isBetween(lowerMaxBound, upperMaxBound));
+    assertThat(delays.stream().distinct()).hasSizeGreaterThan(1);
+  }
+
+  // ignore for the sake of readability
+  private void assertIsStrictlyIncreasing(
+      final long maxDelay, final ArrayList<Long> delays, long previousDelay) {
+    for (final long delay : delays) {
+      if (delay != maxDelay) {
+        assertThat(delay).isGreaterThan(previousDelay);
+      }
+
+      previousDelay = delay;
+    }
+  }
+
+  private ArrayList<Long> collectLongStream(final LongStream stream, final int maxCount) {
+    return stream
+        .limit(maxCount)
+        .collect(
+            ArrayList::new, ArrayList::add, (head, tail) -> new ArrayList<>(head).addAll(tail));
+  }
+}

--- a/clients/java/src/test/java/io/zeebe/client/job/ExponentialBackoffTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/job/ExponentialBackoffTest.java
@@ -18,28 +18,12 @@ package io.zeebe.client.job;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.zeebe.client.api.worker.BackoffSupplier;
-import io.zeebe.client.impl.worker.ExponentialBackoff;
 import io.zeebe.client.impl.worker.ExponentialBackoffBuilderImpl;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.LongStream;
 import org.junit.Test;
 
 public final class ExponentialBackoffTest {
-  @Test
-  public void plotIt() {
-    final ExponentialBackoff defaultSupplier =
-        (ExponentialBackoff) BackoffSupplier.newBackoffBuilder().jitterFactor(0.15).build();
-
-    final List<String> list = new ArrayList<>();
-    long delay = 0L;
-    for (int i = 0; i < 100; i++) {
-      delay = defaultSupplier.supplyRetryDelay(delay);
-      list.add("" + i + ".0, " + delay + ".0");
-    }
-
-    System.out.println(String.join("\n", list));
-  }
 
   @Test
   public void shouldReturnDelayWithinBounds() {
@@ -95,6 +79,7 @@ public final class ExponentialBackoffTest {
   }
 
   // ignore for the sake of readability
+  @SuppressWarnings("SameParameterValue")
   private void assertIsStrictlyIncreasing(
       final long maxDelay, final ArrayList<Long> delays, long previousDelay) {
     for (final long delay : delays) {

--- a/clients/java/src/test/java/io/zeebe/client/job/JobPollerTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/job/JobPollerTest.java
@@ -15,31 +15,122 @@
  */
 package io.zeebe.client.job;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.zeebe.client.api.response.ActivatedJob;
 import io.zeebe.client.impl.ZeebeObjectMapper;
 import io.zeebe.client.impl.worker.JobPoller;
 import io.zeebe.client.util.ClientTest;
+import io.zeebe.gateway.protocol.GatewayOuterClass;
 import io.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import java.time.Duration;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
+import org.awaitility.Awaitility;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public final class JobPollerTest extends ClientTest {
+
+  private Consumer<ActivatedJob> jobConsumer;
+  private IntConsumer doneCallback;
+  private Consumer<Throwable> errorCallback;
+
+  @Before
+  public void setup() {
+    jobConsumer = Mockito.spy(Consumer.class);
+    doneCallback = Mockito.spy(IntConsumer.class);
+    errorCallback = Mockito.spy(Consumer.class);
+  }
 
   @Test
   public void shouldSetRequestTimeout() {
     // given
     final Duration requestTimeout = Duration.ofHours(123);
-    final JobPoller jobPoller =
-        new JobPoller(
-            rule.getGatewayStub(),
-            ActivateJobsRequest.newBuilder(),
-            new ZeebeObjectMapper(),
-            requestTimeout,
-            (t) -> false);
+    final JobPoller jobPoller = getJobPoller(requestTimeout);
 
     // when
-    jobPoller.poll(123, job -> {}, integer -> {}, () -> true);
+    jobPoller.poll(123, jobConsumer, doneCallback, errorCallback, () -> true);
 
     // then
     rule.verifyRequestTimeout(requestTimeout);
+  }
+
+  @Test
+  public void shouldCallbackWhenPollComplete() {
+    // given
+    gatewayService.onActivateJobsRequest(TestData.job(), TestData.job());
+
+    // when
+    getJobPoller().poll(123, jobConsumer, doneCallback, errorCallback, () -> true);
+
+    // then
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              verify(jobConsumer, times(2)).accept(any(ActivatedJob.class));
+              verify(doneCallback).accept(eq(2));
+              verify(errorCallback, never()).accept(any(Throwable.class));
+            });
+  }
+
+  @Test
+  public void shouldCallbackWhenPollFailed() {
+    // given
+    gatewayService.onActivateJobsRequest(new StatusRuntimeException(Status.RESOURCE_EXHAUSTED));
+
+    // when
+    getJobPoller().poll(123, jobConsumer, doneCallback, errorCallback, () -> true);
+
+    // then
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              verify(jobConsumer, never()).accept(any(ActivatedJob.class));
+              verify(doneCallback, never()).accept(any(Integer.class));
+              verify(errorCallback).accept(any(StatusRuntimeException.class));
+            });
+  }
+
+  private JobPoller getJobPoller() {
+    return getJobPoller(Duration.ofSeconds(10));
+  }
+
+  private JobPoller getJobPoller(final Duration requestTimeout) {
+    return new JobPoller(
+        rule.getGatewayStub(),
+        ActivateJobsRequest.newBuilder(),
+        new ZeebeObjectMapper(),
+        requestTimeout,
+        (t) -> false);
+  }
+
+  private static final class TestData {
+    private static GatewayOuterClass.ActivatedJob job() {
+      return GatewayOuterClass.ActivatedJob.newBuilder()
+          .setKey(12)
+          .setType("foo")
+          .setWorkflowInstanceKey(123)
+          .setBpmnProcessId("test1")
+          .setWorkflowDefinitionVersion(2)
+          .setWorkflowKey(23)
+          .setElementId("foo")
+          .setElementInstanceKey(23213)
+          .setCustomHeaders("{\"version\": \"1\"}")
+          .setWorker("worker1")
+          .setRetries(34)
+          .setDeadline(1231)
+          .setVariables("{\"key\": \"val\"}")
+          .build();
+    }
   }
 }


### PR DESCRIPTION
## Description

This PR adds the ability for the Job Worker to backoff when receiving an error from the gateway during polling for available jobs.

> Failed to activate jobs, delay retry for 256 ms

Using the `JobWorkerBuilder`, a `BackoffSupplier` can be provided by the user. This supplies the job worker with a retry delay when a failure occurred during polling for jobs. A default `ExponentialBackoff` is used that increases the retry delay up until some predefined maximum (5s) and also adds jitter for improved usability in real error scenarios. This exponential backoff can also be configured using `BackoffSupplier.newBackoffBuilder()`.

This makes sure the logs don't get flooded with resource exhausted warnings, since we can now backoff. So this warning is now logged again to deal with #6046.

This PR also extends the capabilities of the `RecordingGatewayService` test utility to handle requests with exceptionally.

## Related issues

closes #4443
closes #6046

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
