### PR TITLE
fix(broker): improve logging in broker and atomix

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -201,7 +201,7 @@ public class NettyMessagingService implements ManagedMessagingService {
                   try {
                     responsePayload = handler.apply(message.sender(), message.payload());
                   } catch (final Exception e) {
-                    log.warn("An error occurred in a message handler: {}", e);
+                    log.warn("An error occurred in a message handler:", e);
                     status = ProtocolReply.Status.ERROR_HANDLER_EXCEPTION;
                   }
                   connection.reply(message, status, Optional.ofNullable(responsePayload));
@@ -213,21 +213,20 @@ public class NettyMessagingService implements ManagedMessagingService {
       final String type, final BiFunction<Address, byte[], CompletableFuture<byte[]>> handler) {
     handlers.register(
         type,
-        (message, connection) -> {
-          handler
-              .apply(message.sender(), message.payload())
-              .whenComplete(
-                  (result, error) -> {
-                    final ProtocolReply.Status status;
-                    if (error == null) {
-                      status = ProtocolReply.Status.OK;
-                    } else {
-                      log.warn("An error occurred in a message handler: {}", error);
-                      status = ProtocolReply.Status.ERROR_HANDLER_EXCEPTION;
-                    }
-                    connection.reply(message, status, Optional.ofNullable(result));
-                  });
-        });
+        (message, connection) ->
+            handler
+                .apply(message.sender(), message.payload())
+                .whenComplete(
+                    (result, error) -> {
+                      final ProtocolReply.Status status;
+                      if (error == null) {
+                        status = ProtocolReply.Status.OK;
+                      } else {
+                        log.warn("An error occurred in a message handler:", error);
+                        status = ProtocolReply.Status.ERROR_HANDLER_EXCEPTION;
+                      }
+                      connection.reply(message, status, Optional.ofNullable(result));
+                    }));
   }
 
   @Override
@@ -321,7 +320,7 @@ public class NettyMessagingService implements ManagedMessagingService {
       serverChannelClass = EpollServerSocketChannel.class;
       clientChannelClass = EpollSocketChannel.class;
       return;
-    } catch (final Throwable e) {
+    } catch (final Exception e) {
       log.debug(
           "Failed to initialize native (epoll) transport. " + "Reason: {}. Proceeding with nio.",
           e.getMessage(),
@@ -350,7 +349,7 @@ public class NettyMessagingService implements ManagedMessagingService {
       final String type,
       final Function<ClientConnection, CompletableFuture<T>> callback,
       final Executor executor) {
-    final CompletableFuture<T> future = new CompletableFuture<T>();
+    final CompletableFuture<T> future = new CompletableFuture<>();
     executeOnPooledConnection(address, type, callback, executor, future);
     return future;
   }

--- a/broker/src/main/java/io/zeebe/broker/bootstrap/StartProcess.java
+++ b/broker/src/main/java/io/zeebe/broker/bootstrap/StartProcess.java
@@ -72,7 +72,7 @@ public final class StartProcess {
             step.getName(),
             durationStepStarting);
       } catch (final Exception startException) {
-        LOG.info(
+        LOG.error(
             "Bootstrap {} [{}/{}]: {} failed with unexpected exception.",
             name,
             index,


### PR DESCRIPTION
## Description

Raises the log level when logging an exceptions during a starting step to error and fixes some linter warnings in NettyMessagingService.

## Related issues
closes #6109

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
