### PR TITLE
chore(broker): set new defaults

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -24,7 +24,7 @@ public final class DataCfg implements ConfigurationEntry {
 
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
 
-  private static final DataSize DEFAULT_DATA_SIZE = DataSize.ofMegabytes(512);
+  private static final DataSize DEFAULT_DATA_SIZE = DataSize.ofMegabytes(128);
   private static final boolean DEFAULT_DISK_USAGE_MONITORING_ENABLED = true;
   private static final double DEFAULT_DISK_USAGE_REPLICATION_WATERMARK = 0.99;
   private static final double DEFAULT_DISK_USAGE_COMMAND_WATERMARK = 0.97;
@@ -42,7 +42,7 @@ public final class DataCfg implements ConfigurationEntry {
 
   private DataSize logSegmentSize = DEFAULT_DATA_SIZE;
 
-  private Duration snapshotPeriod = Duration.ofMinutes(15);
+  private Duration snapshotPeriod = Duration.ofMinutes(5);
 
   private int logIndexDensity = 100;
 

--- a/broker/src/test/resources/system/default.yaml
+++ b/broker/src/test/resources/system/default.yaml
@@ -54,7 +54,7 @@ zeebe:
       directory: data
       # The size of data log segment files.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_LOGSEGMENTSIZE.
-      logSegmentSize: 512MB
+      logSegmentSize: 128MB
       # How often we take snapshots of streams (time unit)
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_SNAPSHOTPERIOD.
       snapshotPeriod: 15m

--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -54,7 +54,7 @@ zeebe:
       directory: data
       # The size of data log segment files.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_LOGSEGMENTSIZE.
-      logSegmentSize: 512MB
+      logSegmentSize: 128MB
       # How often we take snapshots of streams (time unit)
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_SNAPSHOTPERIOD.
       snapshotPeriod: 15m

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -172,7 +172,7 @@
 
       # The size of data log segment files.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_LOGSEGMENTSIZE.
-      # logSegmentSize: 512MB
+      # logSegmentSize: 128MB
 
       # Configure whether data log segment file channels should be memory mapped.
       # WARNING: This is an experimental setting. It is not yet as mature as direct file channels (default).

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -124,7 +124,7 @@
 
       # The size of data log segment files.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_LOGSEGMENTSIZE.
-      # logSegmentSize: 512MB
+      # logSegmentSize: 128MB
 
       # Configure whether data log segment file channels should be memory mapped.
       # WARNING: This setting has been deprecated. In future versions, log segment file channels will always be memory mapped.


### PR DESCRIPTION
## Description

Sets new defaults for:
 * log segment size to 128 MB
 * snapshot interval to 5

Setting these values will improve the performance (related https://github.com/zeebe-io/zeebe/issues/4249) and makes possible that we can compact more in shorter time. Related also to https://github.com/zeebe-io/zeebe/issues/3014

|| **New Defaults** | **Base** |Comment|
|---|-----------------------|------------|--|
|general|![general](https://user-images.githubusercontent.com/2758593/104877471-35d4cf80-595a-11eb-92fe-17fceea9e7d4.png)|![base-general](https://user-images.githubusercontent.com/2758593/104877475-366d6600-595a-11eb-90fc-71cb77ca658b.png)|The FNI's are almost doubled.|
|general2|![general2](https://user-images.githubusercontent.com/2758593/104877529-53a23480-595a-11eb-9243-9e6fe129190f.png)|![base-general2](https://user-images.githubusercontent.com/2758593/104877531-54d36180-595a-11eb-9db8-629a4a627e7e.png)|50 Workflow instance completion per second more over the avg of 3 days.|
|Throughput|![throughput](https://user-images.githubusercontent.com/2758593/104877608-80564c00-595a-11eb-976d-17b00091df24.png)|![base-throughput](https://user-images.githubusercontent.com/2758593/104877611-81877900-595a-11eb-8a8e-55b00c28371d.png)|Here we can see again that the avg has almost doubled.|
|Snapshots|![snapshots](https://user-images.githubusercontent.com/2758593/104877803-f490ef80-595a-11eb-8fc1-e2970943af33.png)|![base-snapshot](https://user-images.githubusercontent.com/2758593/104877805-f5298600-595a-11eb-8539-27658bc21f1c.png)|Looks like that we sometimes take no snapshots?|
|Resources|![res](https://user-images.githubusercontent.com/2758593/104877896-2609bb00-595b-11eb-96eb-3c46582edf69.png)|![base-res](https://user-images.githubusercontent.com/2758593/104877897-26a25180-595b-11eb-96e5-4ad7429530d0.png)| We had some restarts because we reached the memory limit.|
|Resources 2|![res2](https://user-images.githubusercontent.com/2758593/104877933-3d48a880-595b-11eb-9ebf-b1d6e52c183a.png)|![base-res2](https://user-images.githubusercontent.com/2758593/104877936-3de13f00-595b-11eb-99a2-3a13b496a4da.png)|The disk usage is by factor ~2 lower.|
|Atomix|![atomix](https://user-images.githubusercontent.com/2758593/104877993-56e9f000-595b-11eb-9df5-5613af38ce8d.png)|![base-atomix](https://user-images.githubusercontent.com/2758593/104877992-56515980-595b-11eb-9d2e-2c7e2eae2aa0.png)||
|Atomix|![atomix2](https://user-images.githubusercontent.com/2758593/104878037-76811880-595b-11eb-9db2-5738752d5956.png)|![base-atomix2](https://user-images.githubusercontent.com/2758593/104878031-75e88200-595b-11eb-8500-f32f736cb191.png)|We can see that we use more segments|
|Processing|![processing](https://user-images.githubusercontent.com/2758593/104878107-99133180-595b-11eb-89bb-ca39fdc8088c.png)|![base-processing](https://user-images.githubusercontent.com/2758593/104878109-99abc800-595b-11eb-960c-43b383f06105.png)|Looks like we had some problems on exporting or the metric is broken.|
|Latency|![latency](https://user-images.githubusercontent.com/2758593/104878135-acbe9800-595b-11eb-966a-0db0df9dde5b.png)|![base-latency](https://user-images.githubusercontent.com/2758593/104878137-ad572e80-595b-11eb-98c8-7d162303723b.png)|Latency has also improved here by factor ~2.|




















<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3622 
closes https://github.com/zeebe-io/zeebe/issues/3014

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [x] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
