### PR TITLE
chore(clients/java): remove unnecessary guava dependency

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -77,11 +77,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>

--- a/clients/java/src/main/java/io/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
@@ -20,7 +20,6 @@ import static java.lang.Math.toIntExact;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.google.common.io.CharStreams;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
 import io.grpc.Status;
@@ -188,9 +187,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
 
     try (final InputStream in = connection.getInputStream();
         final InputStreamReader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
-
-      final ZeebeClientCredentials fetchedCredentials =
-          CREDENTIALS_READER.readValue(CharStreams.toString(reader));
+      final ZeebeClientCredentials fetchedCredentials = CREDENTIALS_READER.readValue(reader);
 
       if (fetchedCredentials == null) {
         throw new IOException("Expected valid credentials but got null instead.");

--- a/clients/java/src/test/java/io/zeebe/client/workflow/CreateWorkflowInstanceTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/workflow/CreateWorkflowInstanceTest.java
@@ -21,13 +21,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
-import com.google.common.base.Charsets;
 import io.zeebe.client.api.command.ClientException;
 import io.zeebe.client.api.response.WorkflowInstanceEvent;
 import io.zeebe.client.util.ClientTest;
 import io.zeebe.gateway.protocol.GatewayOuterClass.CreateWorkflowInstanceRequest;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
 import org.junit.Test;
@@ -96,7 +96,8 @@ public final class CreateWorkflowInstanceTest extends ClientTest {
   public void shouldCreateWorkflowInstanceWithInputStreamVariables() {
     // given
     final String variables = "{\"foo\": \"bar\"}";
-    final InputStream inputStream = new ByteArrayInputStream(variables.getBytes(Charsets.UTF_8));
+    final InputStream inputStream =
+        new ByteArrayInputStream(variables.getBytes(StandardCharsets.UTF_8));
 
     // when
     client.newCreateInstanceCommand().workflowKey(123).variables(inputStream).send().join();

--- a/clients/java/src/test/java/io/zeebe/client/workflow/DeployWorkflowTest.java
+++ b/clients/java/src/test/java/io/zeebe/client/workflow/DeployWorkflowTest.java
@@ -19,7 +19,6 @@ import static io.zeebe.client.util.RecordingGatewayService.deployedWorkflow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.google.common.base.Charsets;
 import io.zeebe.client.api.command.ClientException;
 import io.zeebe.client.api.response.DeploymentEvent;
 import io.zeebe.client.api.response.Workflow;
@@ -33,6 +32,7 @@ import io.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import org.junit.Test;
@@ -127,7 +127,11 @@ public final class DeployWorkflowTest extends ClientTest {
     final String xml = new String(getBytes(filename));
 
     // when
-    client.newDeployCommand().addResourceString(xml, Charsets.UTF_8, filename).send().join();
+    client
+        .newDeployCommand()
+        .addResourceString(xml, StandardCharsets.UTF_8, filename)
+        .send()
+        .join();
 
     // then
     final DeployWorkflowRequest request = gatewayService.getLastRequest();
@@ -141,7 +145,7 @@ public final class DeployWorkflowTest extends ClientTest {
   public void shouldDeployWorkflowFromUtf8String() {
     // given
     final String filename = BPMN_1_FILENAME;
-    final String xml = new String(getBytes(filename), Charsets.UTF_8);
+    final String xml = new String(getBytes(filename), StandardCharsets.UTF_8);
 
     // when
     client.newDeployCommand().addResourceStringUtf8(xml, filename).send().join();


### PR DESCRIPTION
## Description

Removes the Guava dependency and replaces its usages with something simpler and equivalent.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
