### PR TITLE
Fix overwrite last written position to zero

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -351,8 +351,14 @@ public final class ProcessingStateMachine {
     final ActorFuture<Boolean> retryFuture =
         writeRetryStrategy.runWithRetry(
             () -> {
-              writtenEventPosition = logStreamWriter.flush();
-              return writtenEventPosition >= 0;
+              final long position = logStreamWriter.flush();
+
+              // only overwrite position if events were flushed
+              if (position > 0) {
+                writtenEventPosition = position;
+              }
+
+              return position >= 0;
             },
             abortCondition);
 

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
@@ -41,7 +41,6 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -281,7 +280,7 @@ public final class StreamProcessorTest {
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 WorkflowInstanceIntent.ELEMENT_ACTIVATING,
-                new TypedRecordProcessor<UnifiedRecordValue>() {
+                new TypedRecordProcessor<>() {
                   @Override
                   public void processRecord(
                       final long position,
@@ -313,7 +312,7 @@ public final class StreamProcessorTest {
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 WorkflowInstanceIntent.ELEMENT_ACTIVATING,
-                new TypedRecordProcessor<UnifiedRecordValue>() {
+                new TypedRecordProcessor<>() {
                   @Override
                   public void processRecord(
                       final long position,
@@ -345,7 +344,7 @@ public final class StreamProcessorTest {
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 WorkflowInstanceIntent.ELEMENT_ACTIVATING,
-                new TypedRecordProcessor<UnifiedRecordValue>() {
+                new TypedRecordProcessor<>() {
                   @Override
                   public void processRecord(
                       final long position,
@@ -492,7 +491,7 @@ public final class StreamProcessorTest {
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 WorkflowInstanceIntent.ELEMENT_ACTIVATING,
-                new TypedRecordProcessor<UnifiedRecordValue>() {
+                new TypedRecordProcessor<>() {
                   @Override
                   public void processRecord(
                       final long position,
@@ -531,7 +530,7 @@ public final class StreamProcessorTest {
             processors.onEvent(
                 ValueType.WORKFLOW_INSTANCE,
                 WorkflowInstanceIntent.ELEMENT_ACTIVATING,
-                new TypedRecordProcessor<UnifiedRecordValue>() {
+                new TypedRecordProcessor<>() {
                   @Override
                   public void processRecord(
                       final long position,
@@ -564,7 +563,7 @@ public final class StreamProcessorTest {
   }
 
   @Test
-  public void shouldInvokeOnProcessedListener() throws InterruptedException, TimeoutException {
+  public void shouldInvokeOnProcessedListener() throws InterruptedException {
     // given
     final var onProcessedListener = new AwaitableProcessedListener();
     streamProcessorRule.startTypedStreamProcessor(
@@ -750,7 +749,7 @@ public final class StreamProcessorTest {
     }
 
     private boolean await() throws InterruptedException {
-      return getLatch().await(TIMEOUT.toMillis(), TimeUnit.SECONDS);
+      return getLatch().await(TIMEOUT.toSeconds(), TimeUnit.SECONDS);
     }
 
     private CountDownLatch getLatch() {


### PR DESCRIPTION
## Description

Fixes an issue where events with no follow-up would overwrite the `lastWrittenEventPosition` to zero which would cause snapshots to be marked as ready before they actually are.

## Related issues

closes #6049 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
