### PR TITLE
Use one column family with RocksDB

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/state/DefaultZeebeDbFactory.java
+++ b/engine/src/main/java/io/zeebe/engine/state/DefaultZeebeDbFactory.java
@@ -17,9 +17,7 @@ import java.util.function.BiFunction;
 public final class DefaultZeebeDbFactory {
 
   public static final BiFunction<String, ZeebeDb<ZbColumnFamilies>, ZeebeRocksDBMetricExporter>
-      DEFAULT_DB_METRIC_EXPORTER_FACTORY =
-          (partitionId, database) ->
-              new ZeebeRocksDBMetricExporter<>(partitionId, database, ZbColumnFamilies.class);
+      DEFAULT_DB_METRIC_EXPORTER_FACTORY = ZeebeRocksDBMetricExporter::new;
 
   /**
    * Returns the default zeebe database factory, which is used in most of the places except for the

--- a/engine/src/main/java/io/zeebe/engine/state/instance/VariablesState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/VariablesState.java
@@ -429,7 +429,6 @@ public class VariablesState {
   /**
    * Provides all variables of a scope to the given consumer until a condition is met.
    *
-   * @param scopeKey
    * @param variableFilter evaluated with the name of each variable; the variable is consumed only
    *     if the filter returns true
    * @param variableConsumer a consumer that receives variable name and value
@@ -469,7 +468,8 @@ public class VariablesState {
 
     removeAllVariables(scopeKey);
 
-    childParentColumnFamily.delete(this.scopeKey);
+    childKey.wrapLong(scopeKey);
+    childParentColumnFamily.delete(childKey);
   }
 
   public void removeAllVariables(final long scopeKey) {
@@ -527,6 +527,7 @@ public class VariablesState {
   }
 
   public interface VariableListener {
+
     void onCreate(
         long key,
         long workflowKey,
@@ -545,6 +546,7 @@ public class VariablesState {
   }
 
   private class IndexedDocument implements Iterable<Void> {
+
     // variable name offset -> variable value offset
     private final Int2IntHashMap entries = new Int2IntHashMap(-1);
     private final DocumentEntryIterator iterator = new DocumentEntryIterator();
@@ -581,6 +583,7 @@ public class VariablesState {
   }
 
   private class DocumentEntryIterator implements Iterator<Void> {
+
     private EntryIterator iterator;
     private DirectBuffer document;
     private int documentLength;

--- a/zb-db/src/main/java/io/zeebe/db/ZeebeDb.java
+++ b/zb-db/src/main/java/io/zeebe/db/ZeebeDb.java
@@ -18,8 +18,6 @@ import java.util.Optional;
  * ColumnFamily instance via {@link #createColumnFamily(Enum, DbContext, DbKey, DbValue)}. If the
  * column family instances are created they are type save, which makes it possible that only the
  * defined key and value types are stored in the column family.
- *
- * @param <ColumnFamilyType>
  */
 public interface ZeebeDb<ColumnFamilyType extends Enum<ColumnFamilyType>> extends AutoCloseable {
 
@@ -33,7 +31,6 @@ public interface ZeebeDb<ColumnFamilyType extends Enum<ColumnFamilyType>> extend
    * @param <KeyType> the key type of the column family
    * @param <ValueType> the value type of the column family
    * @param columnFamily the enum instance of the column family
-   * @param context
    * @param keyInstance this instance defines the type of the column family key type
    * @param valueInstance this instance defines the type of the column family value type
    * @return the created column family instance
@@ -52,7 +49,7 @@ public interface ZeebeDb<ColumnFamilyType extends Enum<ColumnFamilyType>> extend
    */
   void createSnapshot(File snapshotDir);
 
-  Optional<String> getProperty(ColumnFamilyType columnFamilyName, String propertyName);
+  Optional<String> getProperty(String propertyName);
 
   DbContext createContext();
 

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -10,17 +10,28 @@ package io.zeebe.db.impl.rocksdb;
 import io.zeebe.db.ZeebeDbFactory;
 import io.zeebe.db.impl.rocksdb.transaction.ZeebeTransactionDb;
 import java.io.File;
+import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.stream.Collectors;
-import org.rocksdb.ColumnFamilyDescriptor;
+import org.agrona.CloseHelper;
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.BloomFilter;
 import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.CompactionPriority;
+import org.rocksdb.CompactionStyle;
+import org.rocksdb.CompressionType;
 import org.rocksdb.DBOptions;
+import org.rocksdb.DataBlockIndexType;
+import org.rocksdb.IndexType;
+import org.rocksdb.LRUCache;
+import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
+import org.rocksdb.Statistics;
+import org.rocksdb.StatsLevel;
+import org.rocksdb.TableFormatConfig;
 
 public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamilyType>>
     implements ZeebeDbFactory<ColumnFamilyType> {
@@ -55,84 +66,200 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
 
   @Override
   public ZeebeTransactionDb<ColumnFamilyType> createDb(final File pathName) {
-    return open(
-        pathName,
-        Arrays.stream(columnFamilyTypeClass.getEnumConstants())
-            .map(c -> c.name().toLowerCase().getBytes())
-            .collect(Collectors.toList()));
-  }
-
-  private ZeebeTransactionDb<ColumnFamilyType> open(
-      final File dbDirectory, final List<byte[]> columnFamilyNames) {
-
     final ZeebeTransactionDb<ColumnFamilyType> db;
+    final List<AutoCloseable> closeables = new ArrayList<>();
     try {
-      final List<AutoCloseable> closeables = new ArrayList<>();
-
       // column family options have to be closed as last
-      final ColumnFamilyOptions columnFamilyOptions = createColumnFamilyOptions();
+      final var columnFamilyOptions = createColumnFamilyOptions(closeables);
       closeables.add(columnFamilyOptions);
-
-      final List<ColumnFamilyDescriptor> columnFamilyDescriptors =
-          createFamilyDescriptors(columnFamilyNames, columnFamilyOptions);
-      final DBOptions dbOptions =
-          new DBOptions()
-              .setCreateMissingColumnFamilies(true)
-              .setErrorIfExists(false)
-              .setCreateIfMissing(true)
-              .setParanoidChecks(true);
+      final var dbOptions = createDefaultDbOptions(closeables);
       closeables.add(dbOptions);
 
-      db =
-          ZeebeTransactionDb.openTransactionalDb(
-              dbOptions,
-              dbDirectory.getAbsolutePath(),
-              columnFamilyDescriptors,
-              closeables,
-              columnFamilyTypeClass);
+      final var options = new Options(dbOptions, columnFamilyOptions);
+      closeables.add(options);
+
+      db = ZeebeTransactionDb.openTransactionalDb(options, pathName.getAbsolutePath(), closeables);
 
     } catch (final RocksDBException e) {
-      throw new RuntimeException("Unexpected error occurred trying to open the database", e);
+      CloseHelper.quietCloseAll(closeables);
+      throw new IllegalStateException("Unexpected error occurred trying to open the database", e);
     }
     return db;
   }
 
-  private List<ColumnFamilyDescriptor> createFamilyDescriptors(
-      final List<byte[]> columnFamilyNames, final ColumnFamilyOptions columnFamilyOptions) {
-    final List<ColumnFamilyDescriptor> columnFamilyDescriptors = new ArrayList<>();
+  private DBOptions createDefaultDbOptions(final List<AutoCloseable> closeables) {
+    final var statistics = new Statistics();
+    closeables.add(statistics);
+    statistics.setStatsLevel(StatsLevel.ALL);
 
-    if (columnFamilyNames != null && !columnFamilyNames.isEmpty()) {
-      for (final byte[] name : columnFamilyNames) {
-        final ColumnFamilyDescriptor columnFamilyDescriptor =
-            new ColumnFamilyDescriptor(name, columnFamilyOptions);
-        columnFamilyDescriptors.add(columnFamilyDescriptor);
-      }
-    }
-    return columnFamilyDescriptors;
+    return new DBOptions()
+        .setErrorIfExists(false)
+        .setCreateIfMissing(true)
+        .setParanoidChecks(true)
+        // 1 flush, 1 compaction
+        .setMaxBackgroundJobs(2)
+        // we only use the default CF
+        .setCreateMissingColumnFamilies(false)
+        // may not be necessary when WAL is disabled, but nevertheless recommended to avoid
+        // many small SST files
+        .setAvoidFlushDuringRecovery(true)
+        // fsync is called asynchronously once we have at least 4Mb
+        .setBytesPerSync(4 * 1024 * 1024L)
+        // limit the size of the manifest (logs all operations), otherwise it will grow
+        // unbounded
+        .setMaxManifestFileSize(256 * 1024 * 1024L)
+        // speeds up opening the DB
+        .setSkipStatsUpdateOnDbOpen(true)
+        // keep 1 hour of logs - completely arbitrary. we should keep what we think would be
+        // a good balance between useful for performance and small for replication
+        .setLogFileTimeToRoll(Duration.ofMinutes(30).toSeconds())
+        .setKeepLogFileNum(2)
+        // can be disabled when not profiling
+        .setStatsDumpPeriodSec(20)
+        .setStatistics(statistics);
   }
 
   /** @return Options which are used on all column families */
-  public ColumnFamilyOptions createColumnFamilyOptions() {
-    // start with some defaults
-    final var columnFamilyOptionProps = new Properties();
-    // look for cf_options.h to find available keys
-    // look for options_helper.cc to find available values
-    columnFamilyOptionProps.put("compaction_pri", "kOldestSmallestSeqFirst");
+  ColumnFamilyOptions createColumnFamilyOptions(final List<AutoCloseable> closeables) {
 
-    // apply custom options
-    columnFamilyOptionProps.putAll(userProvidedColumnFamilyOptions);
+    final var hasUserOptions = !userProvidedColumnFamilyOptions.isEmpty();
 
+    if (hasUserOptions) {
+      return createFromUserOptions(userProvidedColumnFamilyOptions);
+    }
+
+    return createDefaultColumnFamilyOptions(closeables);
+  }
+
+  private ColumnFamilyOptions createFromUserOptions(
+      final Properties userProvidedColumnFamilyOptions) {
     final var columnFamilyOptions =
-        ColumnFamilyOptions.getColumnFamilyOptionsFromProps(columnFamilyOptionProps);
+        ColumnFamilyOptions.getColumnFamilyOptionsFromProps(userProvidedColumnFamilyOptions);
     if (columnFamilyOptions == null) {
       throw new IllegalStateException(
           String.format(
               "Expected to create column family options for RocksDB, "
                   + "but one or many values are undefined in the context of RocksDB "
-                  + "[Compiled ColumnFamilyOptions: %s; User-provided ColumnFamilyOptions: %s]. "
+                  + "[User-provided ColumnFamilyOptions: %s]. "
                   + "See RocksDB's cf_options.h and options_helper.cc for available keys and values.",
-              columnFamilyOptionProps, userProvidedColumnFamilyOptions));
+              userProvidedColumnFamilyOptions));
     }
     return columnFamilyOptions;
+  }
+
+  private ColumnFamilyOptions createDefaultColumnFamilyOptions(
+      final List<AutoCloseable> closeables) {
+    final var columnFamilyOptions = new ColumnFamilyOptions();
+
+    final var totalMemoryBudget =
+        512 * 1024
+            * 1024L; // TODO: make this configurable https://github.com/zeebe-io/zeebe/issues/6159
+    // recommended by RocksDB, but we could tweak it; keep in mind we're also caching the indexes
+    // and filters into the block cache, so we don't need to account for more memory there
+    final var blockCacheMemory = totalMemoryBudget / 3;
+    // flushing the memtables is done asynchronously, so there may be multiple memtables in memory,
+    // although only a single one is writable. once we have too many memtables, writes will stop.
+    // since prefix iteration is our bread n butter, we will build an additional filter for each
+    // memtable which takes a bit of memory which must be accounted for from the memtable's memory
+    final var maxConcurrentMemtableCount = 6;
+    // this is a current guess and candidate for further tuning
+    // values can be between 0 and 0.25 (anything higher gets clamped to 0.25), we randomly picked
+    // 0.15
+    // prefix seek must be fast, so we allocate some extra memory of a single memtable budget to
+    // create
+    // a filter for each memtable, allowing us to skip the prefixes if possible
+    final var memtablePrefixFilterMemory = 0.15;
+    final var memtableMemory =
+        Math.round(
+            ((totalMemoryBudget - blockCacheMemory) / (double) maxConcurrentMemtableCount)
+                * (1 - memtablePrefixFilterMemory));
+
+    final var tableConfig = createTableFormatConfig(closeables, blockCacheMemory);
+
+    return columnFamilyOptions
+        // to extract our column family type (used as prefix) and seek faster
+        .useFixedLengthPrefixExtractor(Long.BYTES)
+        .setMemtablePrefixBloomSizeRatio(memtablePrefixFilterMemory)
+        // memtables
+        // merge at least 3 memtables per L0 file, otherwise all memtables are flushed as individual
+        // files
+        // this is also a candidate for tuning, it was a rough guess
+        .setMinWriteBufferNumberToMerge(Math.min(3, maxConcurrentMemtableCount))
+        .setMaxWriteBufferNumberToMaintain(maxConcurrentMemtableCount)
+        .setMaxWriteBufferNumber(maxConcurrentMemtableCount)
+        .setWriteBufferSize(memtableMemory)
+        // compaction
+        .setLevelCompactionDynamicLevelBytes(true)
+        .setCompactionPriority(CompactionPriority.OldestSmallestSeqFirst)
+        .setCompactionStyle(CompactionStyle.LEVEL)
+        // L-0 means immediately flushed memtables
+        .setLevel0FileNumCompactionTrigger(maxConcurrentMemtableCount)
+        .setLevel0SlowdownWritesTrigger(
+            maxConcurrentMemtableCount + (maxConcurrentMemtableCount / 2))
+        .setLevel0StopWritesTrigger(maxConcurrentMemtableCount * 2)
+        // configure 4 levels: L1 = 32mb, L2 = 320mb, L3 = 3.2Gb, L4 >= 3.2Gb
+        // level 1 and 2 are uncompressed, level 3 and above are compressed using a CPU-cheap
+        // compression algo. compressed blocks are stored in the OS page cache, and uncompressed in
+        // the LRUCache created above. note L0 is always uncompressed
+        .setNumLevels(4)
+        .setMaxBytesForLevelBase(32 * 1024 * 1024L)
+        .setMaxBytesForLevelMultiplier(10)
+        .setCompressionPerLevel(
+            List.of(
+                CompressionType.NO_COMPRESSION,
+                CompressionType.NO_COMPRESSION,
+                CompressionType.LZ4_COMPRESSION,
+                CompressionType.LZ4_COMPRESSION))
+        // Target file size for compaction.
+        // Defines the desired SST file size for different levels (but not guaranteed, it is usually
+        // lower)
+        // L0 is what gets merged and flushed, e.g. 3 memtables to X, and target file size and
+        // multiplier is for L1 and other levels.
+        // L1 => 8Mb, L2 => 16Mb, L3 => 32Mb
+        // As levels get bigger, we want to have a good balance between the number of files and the
+        // individual file sizes
+        // https://github.com/facebook/rocksdb/blob/fd0d35d390e212b617e90d7567102d3e5fd1c706/include/rocksdb/advanced_options.h#L417-L429
+        .setTargetFileSizeBase(8 * 1024 * 1024L)
+        .setTargetFileSizeMultiplier(2)
+        // misc
+        .setTableFormatConfig(tableConfig);
+  }
+
+  private TableFormatConfig createTableFormatConfig(
+      final List<AutoCloseable> closeables, final long blockCacheMemory) {
+    // you can use the perf context to check if we're often blocked on the block cache mutex, in
+    // which case we want to increase the number of shards (shard count == 2^shardBits)
+    final var cache = new LRUCache(blockCacheMemory, 8, false, 0.15);
+    closeables.add(cache);
+
+    final var filter = new BloomFilter(10, false);
+    closeables.add(filter);
+
+    return new BlockBasedTableConfig()
+        .setBlockCache(cache)
+        // increasing block size means reducing memory usage, but increasing read iops
+        .setBlockSize(32 * 1024L)
+        // full and partitioned filters use a more efficient bloom filter implementation when
+        // using format 5
+        .setFormatVersion(5)
+        .setFilterPolicy(filter)
+        // caching and pinning indexes and filters is important to keep reads/seeks fast when we
+        // have many memtables, and pinning them ensures they are never evicted from the block
+        // cache
+        .setCacheIndexAndFilterBlocks(true)
+        .setPinL0FilterAndIndexBlocksInCache(true)
+        .setCacheIndexAndFilterBlocksWithHighPriority(true)
+        // default is binary search, but all of our scans are prefix based which is a good use
+        // case for efficient hashing
+        .setIndexType(IndexType.kHashSearch)
+        .setDataBlockIndexType(DataBlockIndexType.kDataBlockBinaryAndHash)
+        // RocksDB dev benchmarks show improvements when this is between 0.5 and 1, so let's
+        // start with the middle and optimize later from there
+        .setDataBlockHashTableUtilRatio(0.75)
+        // while we mostly care about the prefixes, these are covered below by the
+        // setMemtablePrefixBloomSizeRatio which will create a separate index for prefixes, so
+        // keeping the whole keys in the prefixes is still useful for efficient gets. think of
+        // it as a two-tiered index
+        .setWholeKeyFiltering(true);
   }
 }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/DefaultDbContext.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/DefaultDbContext.java
@@ -29,6 +29,7 @@ import org.rocksdb.RocksIterator;
 import org.rocksdb.Status;
 
 public final class DefaultDbContext implements DbContext {
+
   private static final byte[] ZERO_SIZE_ARRAY = new byte[0];
 
   private final ZeebeTransaction transaction;
@@ -72,7 +73,8 @@ public final class DefaultDbContext implements DbContext {
   @Override
   public void wrapKeyView(final byte[] key) {
     if (key != null) {
-      keyViewBuffer.wrap(key);
+      // wrap without the column family key
+      keyViewBuffer.wrap(key, Long.BYTES, key.length - Long.BYTES);
     } else {
       keyViewBuffer.wrap(ZERO_SIZE_ARRAY);
     }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -12,6 +12,9 @@ import io.zeebe.db.DbContext;
 import io.zeebe.db.DbKey;
 import io.zeebe.db.DbValue;
 import io.zeebe.db.KeyValuePairVisitor;
+import io.zeebe.db.impl.DbCompositeKey;
+import io.zeebe.db.impl.DbLong;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
@@ -27,8 +30,10 @@ class TransactionalColumnFamily<
 
   private final DbContext context;
 
+  private final DbCompositeKey<DbLong, KeyType> compositeKey;
   private final ValueType valueInstance;
   private final KeyType keyInstance;
+  private final DbLong columnFamilyKey;
 
   TransactionalColumnFamily(
       final ZeebeTransactionDb<ColumnFamilyNames> transactionDb,
@@ -41,6 +46,9 @@ class TransactionalColumnFamily<
     this.context = context;
     this.keyInstance = keyInstance;
     this.valueInstance = valueInstance;
+    columnFamilyKey = new DbLong();
+    columnFamilyKey.wrapLong(columnFamily.ordinal());
+    compositeKey = new DbCompositeKey<>(columnFamilyKey, keyInstance);
   }
 
   @Override
@@ -50,7 +58,7 @@ class TransactionalColumnFamily<
 
   @Override
   public void put(final DbContext context, final KeyType key, final ValueType value) {
-    transactionDb.put(handle, context, key, value);
+    transactionDb.put(handle, context, compositeKey, value);
   }
 
   @Override
@@ -60,7 +68,7 @@ class TransactionalColumnFamily<
 
   @Override
   public ValueType get(final DbContext context, final KeyType key, final ValueType value) {
-    final DirectBuffer valueBuffer = transactionDb.get(handle, context, key);
+    final DirectBuffer valueBuffer = transactionDb.get(handle, context, compositeKey);
     if (valueBuffer != null) {
 
       value.wrap(valueBuffer, 0, valueBuffer.capacity());
@@ -90,7 +98,7 @@ class TransactionalColumnFamily<
       final KeyValuePairVisitor<KeyType, ValueType> visitor,
       final KeyType key,
       final ValueType value) {
-    transactionDb.whileTrue(handle, context, key, value, visitor);
+    transactionDb.whileEqualPrefix(columnFamilyKey, handle, context, key, value, visitor);
   }
 
   @Override
@@ -112,7 +120,7 @@ class TransactionalColumnFamily<
 
   @Override
   public void delete(final DbContext context, final KeyType key) {
-    transactionDb.delete(handle, context, key);
+    transactionDb.delete(handle, context, compositeKey);
   }
 
   @Override
@@ -127,7 +135,18 @@ class TransactionalColumnFamily<
 
   @Override
   public boolean isEmpty(final DbContext context) {
-    return transactionDb.isEmpty(handle, context);
+    final AtomicBoolean isEmpty = new AtomicBoolean(true);
+    transactionDb.whileEqualPrefix(
+        columnFamilyKey,
+        handle,
+        context,
+        keyInstance,
+        valueInstance,
+        (key, value) -> {
+          isEmpty.set(false);
+          return false;
+        });
+    return isEmpty.get();
   }
 
   public ValueType get(final DbContext context, final KeyType key) {
@@ -135,33 +154,43 @@ class TransactionalColumnFamily<
   }
 
   public void forEach(final DbContext context, final Consumer<ValueType> consumer) {
-    transactionDb.foreach(handle, context, valueInstance, consumer);
+    transactionDb.whileEqualPrefix(
+        columnFamilyKey,
+        handle,
+        context,
+        keyInstance,
+        valueInstance,
+        (BiConsumer<KeyType, ValueType>) (ignore, value) -> consumer.accept(value));
   }
 
   public void forEach(final DbContext context, final BiConsumer<KeyType, ValueType> consumer) {
-    transactionDb.foreach(handle, context, keyInstance, valueInstance, consumer);
+    transactionDb.whileEqualPrefix(
+        columnFamilyKey, handle, context, keyInstance, valueInstance, consumer);
   }
 
   public void whileTrue(
       final DbContext context, final KeyValuePairVisitor<KeyType, ValueType> visitor) {
-    whileTrue(context, visitor, keyInstance, valueInstance);
+    transactionDb.whileEqualPrefix(
+        columnFamilyKey, handle, context, keyInstance, valueInstance, visitor);
   }
 
   public void whileEqualPrefix(
       final DbContext context,
       final DbKey keyPrefix,
       final BiConsumer<KeyType, ValueType> visitor) {
-    transactionDb.whileEqualPrefix(handle, context, keyPrefix, keyInstance, valueInstance, visitor);
+    transactionDb.whileEqualPrefix(
+        columnFamilyKey, handle, context, keyPrefix, keyInstance, valueInstance, visitor);
   }
 
   public void whileEqualPrefix(
       final DbContext context,
       final DbKey keyPrefix,
       final KeyValuePairVisitor<KeyType, ValueType> visitor) {
-    transactionDb.whileEqualPrefix(handle, context, keyPrefix, keyInstance, valueInstance, visitor);
+    transactionDb.whileEqualPrefix(
+        columnFamilyKey, handle, context, keyPrefix, keyInstance, valueInstance, visitor);
   }
 
   public boolean exists(final DbContext context, final KeyType key) {
-    return transactionDb.exists(handle, context, key);
+    return transactionDb.exists(handle, context, compositeKey);
   }
 }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -42,7 +42,7 @@ class TransactionalColumnFamily<
       final KeyType keyInstance,
       final ValueType valueInstance) {
     this.transactionDb = transactionDb;
-    handle = this.transactionDb.getColumnFamilyHandle(columnFamily);
+    handle = this.transactionDb.getColumnFamilyHandle();
     this.context = context;
     this.keyInstance = keyInstance;
     this.valueInstance = valueInstance;

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -16,6 +16,8 @@ import io.zeebe.db.DbValue;
 import io.zeebe.db.KeyValuePairVisitor;
 import io.zeebe.db.ZeebeDb;
 import io.zeebe.db.ZeebeDbException;
+import io.zeebe.db.impl.DbLong;
+import io.zeebe.db.impl.DbNil;
 import io.zeebe.db.impl.rocksdb.Loggers;
 import java.io.File;
 import java.util.ArrayList;
@@ -25,8 +27,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.rocksdb.Checkpoint;
 import org.rocksdb.ColumnFamilyDescriptor;
@@ -54,12 +56,15 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
   private final ReadOptions prefixReadOptions;
   private final ReadOptions defaultReadOptions;
   private final WriteOptions defaultWriteOptions;
+  private final ColumnFamilyHandle defaultHandle;
 
   protected ZeebeTransactionDb(
+      final ColumnFamilyHandle defaultHandle,
       final OptimisticTransactionDB optimisticTransactionDB,
       final EnumMap<ColumnFamilyNames, Long> columnFamilyMap,
       final Long2ObjectHashMap<ColumnFamilyHandle> handelToEnumMap,
       final List<AutoCloseable> closables) {
+    this.defaultHandle = defaultHandle;
     this.optimisticTransactionDB = optimisticTransactionDB;
     this.columnFamilyMap = columnFamilyMap;
     this.handelToEnumMap = handelToEnumMap;
@@ -85,8 +90,10 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
 
     final List<ColumnFamilyHandle> handles = new ArrayList<>();
     final OptimisticTransactionDB optimisticTransactionDB =
-        OptimisticTransactionDB.open(options, path, columnFamilyDescriptors, handles);
+        OptimisticTransactionDB.open(
+            options, path, List.of(columnFamilyDescriptors.get(0)), handles);
     closables.add(optimisticTransactionDB);
+    final var defaultHandle = handles.get(0);
 
     final ColumnFamilyNames[] enumConstants = columnFamilyTypeClass.getEnumConstants();
     final Long2ObjectHashMap<ColumnFamilyHandle> handleToEnumMap = new Long2ObjectHashMap<>();
@@ -98,7 +105,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
     }
 
     return new ZeebeTransactionDb<>(
-        optimisticTransactionDB, columnFamilyMap, handleToEnumMap, closables);
+        defaultHandle, optimisticTransactionDB, columnFamilyMap, handleToEnumMap, closables);
   }
 
   private static long getNativeHandle(final RocksObject object) {
@@ -111,7 +118,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
   }
 
   long getColumnFamilyHandle(final ColumnFamilyNames columnFamily) {
-    return columnFamilyMap.get(columnFamily);
+    return getNativeHandle(defaultHandle);
   }
 
   @Override
@@ -247,74 +254,8 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
     return context.newIterator(options, handle);
   }
 
-  public <ValueType extends DbValue> void foreach(
-      final long columnFamilyHandle,
-      final DbContext context,
-      final ValueType iteratorValue,
-      final Consumer<ValueType> consumer) {
-    foreach(
-        columnFamilyHandle,
-        context,
-        (keyBuffer, valueBuffer) -> {
-          iteratorValue.wrap(valueBuffer, 0, valueBuffer.capacity());
-          consumer.accept(iteratorValue);
-        });
-  }
-
-  public <KeyType extends DbKey, ValueType extends DbValue> void foreach(
-      final long columnFamilyHandle,
-      final DbContext context,
-      final KeyType iteratorKey,
-      final ValueType iteratorValue,
-      final BiConsumer<KeyType, ValueType> consumer) {
-    foreach(
-        columnFamilyHandle,
-        context,
-        (keyBuffer, valueBuffer) -> {
-          iteratorKey.wrap(keyBuffer, 0, keyBuffer.capacity());
-          iteratorValue.wrap(valueBuffer, 0, valueBuffer.capacity());
-          consumer.accept(iteratorKey, iteratorValue);
-        });
-  }
-
-  private void foreach(
-      final long columnFamilyHandle,
-      final DbContext context,
-      final BiConsumer<DirectBuffer, DirectBuffer> keyValuePairConsumer) {
-    ensureInOpenTransaction(
-        context,
-        transaction -> {
-          try (final RocksIterator iterator =
-              newIterator(columnFamilyHandle, context, defaultReadOptions)) {
-            for (iterator.seekToFirst(); iterator.isValid(); iterator.next()) {
-              context.wrapKeyView(iterator.key());
-              context.wrapValueView(iterator.value());
-              keyValuePairConsumer.accept(context.getKeyView(), context.getValueView());
-            }
-          }
-        });
-  }
-
-  public <KeyType extends DbKey, ValueType extends DbValue> void whileTrue(
-      final long columnFamilyHandle,
-      final DbContext context,
-      final KeyType keyInstance,
-      final ValueType valueInstance,
-      final KeyValuePairVisitor<KeyType, ValueType> visitor) {
-    ensureInOpenTransaction(
-        context,
-        transaction -> {
-          try (final RocksIterator iterator =
-              newIterator(columnFamilyHandle, context, defaultReadOptions)) {
-            boolean shouldVisitNext = true;
-            for (iterator.seekToFirst(); iterator.isValid() && shouldVisitNext; iterator.next()) {
-              shouldVisitNext = visit(context, keyInstance, valueInstance, visitor, iterator);
-            }
-          }
-        });
-  }
-
   protected <KeyType extends DbKey, ValueType extends DbValue> void whileEqualPrefix(
+      final DbLong columnFamilyKey,
       final long columnFamilyHandle,
       final DbContext context,
       final DbKey prefix,
@@ -322,6 +263,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
       final ValueType valueInstance,
       final BiConsumer<KeyType, ValueType> visitor) {
     whileEqualPrefix(
+        columnFamilyKey,
         columnFamilyHandle,
         context,
         prefix,
@@ -331,6 +273,47 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
           visitor.accept(k, v);
           return true;
         });
+  }
+
+  // This method is used mainly from other iterator methods to iterate over column family entries,
+  // which are prefixed with column family key.
+  protected <KeyType extends DbKey, ValueType extends DbValue> void whileEqualPrefix(
+      final DbLong columnFamilyKey,
+      final long columnFamilyHandle,
+      final DbContext context,
+      final KeyType keyInstance,
+      final ValueType valueInstance,
+      final BiConsumer<KeyType, ValueType> visitor) {
+    whileEqualPrefix(
+        columnFamilyKey,
+        columnFamilyHandle,
+        context,
+        new DbNullKey(),
+        keyInstance,
+        valueInstance,
+        (k, v) -> {
+          visitor.accept(k, v);
+          return true;
+        });
+  }
+
+  // This method is used mainly from other iterator methods to iterate over column family entries,
+  // which are prefixed with column family key.
+  protected <KeyType extends DbKey, ValueType extends DbValue> void whileEqualPrefix(
+      final DbLong columnFamilyKey,
+      final long columnFamilyHandle,
+      final DbContext context,
+      final KeyType keyInstance,
+      final ValueType valueInstance,
+      final KeyValuePairVisitor<KeyType, ValueType> visitor) {
+    whileEqualPrefix(
+        columnFamilyKey,
+        columnFamilyHandle,
+        context,
+        new DbNullKey(),
+        keyInstance,
+        valueInstance,
+        visitor);
   }
 
   /**
@@ -343,6 +326,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
    * <p>While iterating over subsequent keys we have to validate it.
    */
   protected <KeyType extends DbKey, ValueType extends DbValue> void whileEqualPrefix(
+      final DbLong columnFamilyKey,
       final long columnFamilyHandle,
       final DbContext context,
       final DbKey prefix,
@@ -356,8 +340,10 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
                 transaction -> {
                   try (final RocksIterator iterator =
                       newIterator(columnFamilyHandle, context, prefixReadOptions)) {
-                    prefix.write(prefixKeyBuffer, 0);
-                    final int prefixLength = prefix.getLength();
+
+                    columnFamilyKey.write(prefixKeyBuffer, 0);
+                    prefix.write(prefixKeyBuffer, Long.BYTES);
+                    final int prefixLength = Long.BYTES + prefix.getLength();
 
                     boolean shouldVisitNext = true;
 
@@ -372,7 +358,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
                       if (!startsWith(
                           prefixKeyBuffer.byteArray(),
                           0,
-                          prefix.getLength(),
+                          prefixLength,
                           keyBytes,
                           0,
                           keyBytes.length)) {
@@ -392,7 +378,9 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
       final ValueType valueInstance,
       final KeyValuePairVisitor<KeyType, ValueType> iteratorConsumer,
       final RocksIterator iterator) {
-    context.wrapKeyView(iterator.key());
+    final var keyBytes = iterator.key();
+
+    context.wrapKeyView(keyBytes);
     context.wrapValueView(iterator.value());
 
     final DirectBuffer keyViewBuffer = context.getKeyView();
@@ -403,25 +391,27 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
     return iteratorConsumer.visit(keyInstance, valueInstance);
   }
 
-  public boolean isEmpty(final long columnFamilyHandle, final DbContext context) {
-    final AtomicBoolean isEmpty = new AtomicBoolean(false);
-    ensureInOpenTransaction(
+  public boolean isEmpty(
+      final long columnFamilyKey, final long columnFamilyHandle, final DbContext context) {
+    final var columnKey = new DbLong();
+    columnKey.wrapLong(columnFamilyKey);
+    final AtomicBoolean isEmpty = new AtomicBoolean(true);
+    whileEqualPrefix(
+        columnKey,
+        columnFamilyHandle,
         context,
-        transaction -> {
-          try (final RocksIterator iterator =
-              newIterator(columnFamilyHandle, context, defaultReadOptions)) {
-            iterator.seekToFirst();
-            final boolean hasEntry = iterator.isValid();
-            isEmpty.set(!hasEntry);
-          }
+        DbNullKey.INSTANCE,
+        DbNil.INSTANCE,
+        (key, value) -> {
+          isEmpty.set(false);
+          return false;
         });
     return isEmpty.get();
   }
 
   @Override
   public boolean isEmpty(final ColumnFamilyNames columnFamilyName, final DbContext context) {
-    final var columnFamilyHandle = columnFamilyMap.get(columnFamilyName);
-    return isEmpty(columnFamilyHandle, context);
+    return isEmpty(columnFamilyName.ordinal(), getNativeHandle(defaultHandle), context);
   }
 
   @Override
@@ -447,6 +437,33 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
 
   @FunctionalInterface
   interface TransactionConsumer {
+
     void run(ZeebeTransaction transaction) throws Exception;
+  }
+
+  /**
+   * This class is used only internally by #whileEqualPrefix to search for same column family
+   * prefix.
+   */
+  private static final class DbNullKey implements DbKey {
+
+    public static final DbNullKey INSTANCE = new DbNullKey();
+
+    private DbNullKey() {}
+
+    @Override
+    public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+      // do nothing
+    }
+
+    @Override
+    public void write(final MutableDirectBuffer buffer, final int offset) {
+      // do nothing
+    }
+
+    @Override
+    public int getLength() {
+      return 0;
+    }
   }
 }

--- a/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbIterationTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbIterationTest.java
@@ -60,8 +60,7 @@ public final class ZeebeRocksDbIterationTest {
               return spy;
             })
         .when(zeebeDb)
-        .newIterator(
-            Mockito.anyLong(), Mockito.any(DbContext.class), Mockito.any(ReadOptions.class));
+        .newIterator(Mockito.any(DbContext.class), Mockito.any(ReadOptions.class));
 
     final long prefixes = 3;
     final long suffixes = 5;


### PR DESCRIPTION
## Description

Migrates the RocksDB multiple column family usage to one column family. 

Acceptance criteria:

 * Tests running :heavy_check_mark: 
 * QA runs :heavy_check_mark: 
 * Zeebe Benchmark :heavy_check_mark: 
 * Low Load Benchmark :heavy_check_mark: 
 * Big State Benchmark :heavy_check_mark: 

For further insights check the related issue and the documented observations https://github.com/zeebe-io/zeebe/issues/4002.

### Benchmarks

Based on our normal benchmarks (three nodes, three partitions and replication factor three) the following impact has been observed

|Impact | Base | One Column |Description|
|---------|---------|-------------------|---------------|
|Memory |![base-res](https://user-images.githubusercontent.com/2758593/105804859-1a447700-5fa1-11eb-95cb-c010a072b02f.png)|![res](https://user-images.githubusercontent.com/2758593/105804862-1add0d80-5fa1-11eb-8372-a550273192bc.png)| Reduces the memory consumption by factor ~4.|
| Snapshots|![base-snapshot](https://user-images.githubusercontent.com/2758593/105804944-3f38ea00-5fa1-11eb-8141-44e1d1e005e3.png)|![snapshot](https://user-images.githubusercontent.com/2758593/105804946-3fd18080-5fa1-11eb-8e68-f408e1312f7b.png)| Reduces snapshot size by factor 4-5 and reduces file count by factor 10.|
| Throughput | ![base-general-2](https://user-images.githubusercontent.com/2758593/105805043-7ad3b400-5fa1-11eb-897f-41d8b5e51aed.png)|![general-2](https://user-images.githubusercontent.com/2758593/105805044-7b6c4a80-5fa1-11eb-9a9c-0388658f7979.png)| throughput is improved by ~15% | 
| Latency |![base-latency](https://user-images.githubusercontent.com/2758593/105805081-8c1cc080-5fa1-11eb-88ae-2c303d6b6f37.png)|![latency](https://user-images.githubusercontent.com/2758593/105805082-8cb55700-5fa1-11eb-9fce-dbe2fc1886c0.png)| Latency is improved by ~50%|
|RocksDB|![base-rocks1](https://user-images.githubusercontent.com/2758593/105805137-b1113380-5fa1-11eb-9a42-6f7ab08b9bb8.png)|![rocks1](https://user-images.githubusercontent.com/2758593/105805138-b1a9ca00-5fa1-11eb-86f8-9692d6e425b6.png)|RocksDb stays in his bounds.|
|RocksDB 2|![base-rocks2](https://user-images.githubusercontent.com/2758593/105805247-e453c280-5fa1-11eb-84e0-ea812302b1f0.png)|![rocks2](https://user-images.githubusercontent.com/2758593/105805249-e4ec5900-5fa1-11eb-9253-f2938a24aa4e.png)|SST file size usage is reduced by factor 4, correlates to the snapshot size reduction.|

Based on the results we can see in the benchmarks I would say the solution fulfills our needs.

#### Big State Benchmark

As part of the acceptance criteria we wanted to investigate how it now behaves on big state and determine whether it changes something in our current support of long running workflows etc.

|Section | Base | One Column |Description|
|---------|---------|-------------------|---------------|
|General|![base-big-state-general](https://user-images.githubusercontent.com/2758593/105805704-e5392400-5fa2-11eb-8c9a-ec48379a38fd.png)|![big-state-general](https://user-images.githubusercontent.com/2758593/105805706-e5d1ba80-5fa2-11eb-994a-083624a9af70.png)|We can see that in the base the processing has already stopped.|
|General 2|![base-big-state-general-2](https://user-images.githubusercontent.com/2758593/105805745-fb46e480-5fa2-11eb-9730-c8f3327623a8.png)|![big-state-general-2](https://user-images.githubusercontent.com/2758593/105805746-fbdf7b00-5fa2-11eb-8f8f-d3c8bee57e27.png)|The one col benchmark is still processing|
|Running workflows|![base-big-state-proc](https://user-images.githubusercontent.com/2758593/105805781-0dc11e00-5fa3-11eb-9e80-7ca54c5791dd.png)|![big-state-proc](https://user-images.githubusercontent.com/2758593/105805783-0e59b480-5fa3-11eb-8439-da023efc66b0.png)|In the base we have half of the running workflow instances|
|Resources|![base-big-state-res](https://user-images.githubusercontent.com/2758593/105805852-27fafc00-5fa3-11eb-947c-20644a44623b.png)|![big-state-res](https://user-images.githubusercontent.com/2758593/105805854-28939280-5fa3-11eb-9751-b82b31ff3f20.png)| The resource consumption looks similar, except that the one col. uses more java heap. It might be related to the processing stop of the base benchmark.|
|Disk|![base-big-state-disk](https://user-images.githubusercontent.com/2758593/105806039-858f4880-5fa3-11eb-9398-a4e4c2c59c34.png)|![big-state-disk](https://user-images.githubusercontent.com/2758593/105806040-8627df00-5fa3-11eb-9d92-bb22c4af20d1.png)|The base has a higher disk usage, by factor 2.|
|Snapshots|![base-big-state-snap](https://user-images.githubusercontent.com/2758593/105806136-b8d1d780-5fa3-11eb-95a8-453837c947ce.png)|![big-state-snap](https://user-images.githubusercontent.com/2758593/105806139-b96a6e00-5fa3-11eb-999b-44251c2e7e43.png)|The snapshot size is on the base also doubled, which is very likely that this causes to fail the benchmark|
|RocksDB|![base-big-state-rocks](https://user-images.githubusercontent.com/2758593/105806224-d737d300-5fa3-11eb-9ccb-9d4fa27b5bc4.png)|![big-state-rocks](https://user-images.githubusercontent.com/2758593/105806226-d7d06980-5fa3-11eb-9569-cc05b9978806.png)|The one col RocksDB stays pretty well in his bounds.|
|RocksDB 2|![base-big-state-rocks2](https://user-images.githubusercontent.com/2758593/105806301-fd5d7300-5fa3-11eb-8e52-58bf7318b0b3.png)|![big-state-rocks2](https://user-images.githubusercontent.com/2758593/105806302-fdf60980-5fa3-11eb-89b4-83772d7bed4d.png)|SST file size usage is much less on the one column benchmark|
|Latency|![base-big-state-lat](https://user-images.githubusercontent.com/2758593/105806380-2b42b780-5fa4-11eb-878d-59bf49483858.png)|![big-state-lat](https://user-images.githubusercontent.com/2758593/105806382-2bdb4e00-5fa4-11eb-81c7-3d93f317b605.png)|Interesting is the latency, which degrades overtime in the one column benchmark.|

I think the results are quite interesting and promising. It seems that we are now more likely to support long running workflows and big states, still we need to fix our current snapshot replication approach but this is a good first step I would say. Furthermore It seems that we trade latency for availability which is totally fine for me.

closes https://github.com/zeebe-io/zeebe/issues/4560

#### Low Load Benchmark

Another acceptance criteria was that low load shouldn't cause more incidents, since earlier this caused defragmentation of RocksDB and there snapshots.

|Section | Base | One Column |Description|
|---------|---------|-------------------|---------------|
|General|![base-low-load-general-1](https://user-images.githubusercontent.com/2758593/105807004-62fe2f00-5fa5-11eb-8011-9ab6e0dbbe62.png)|![low-load-general-1](https://user-images.githubusercontent.com/2758593/105807006-6396c580-5fa5-11eb-82a0-2268c82e4418.png)|We can see that on one col. one node is leader for all partition, which causes higher memory usage on that node|
|General 2|![base-low-load-general](https://user-images.githubusercontent.com/2758593/105806958-46fa8d80-5fa5-11eb-95ea-7ea6c81a1098.png)|![low-load-general](https://user-images.githubusercontent.com/2758593/105806959-47932400-5fa5-11eb-938a-810614bf70f4.png)|Both benchmarks were still running|
|Resources|![base-low-load-res](https://user-images.githubusercontent.com/2758593/105807077-8b862900-5fa5-11eb-975d-e6119edf8ff0.png)|![low-load-res](https://user-images.githubusercontent.com/2758593/105807078-8c1ebf80-5fa5-11eb-87fd-715137e153fd.png)|The process memory usage of one col. is much less then for the base|
|Snapshot|![base-low-load-snap](https://user-images.githubusercontent.com/2758593/105807127-af496f00-5fa5-11eb-97dd-7c98d42cff90.png)|![low-load-snap](https://user-images.githubusercontent.com/2758593/105807129-b07a9c00-5fa5-11eb-9152-082cf75fe0ca.png)|The snapshot size and file count has been reduced a lot at the one col. benchmark|
|Latency|![base-low-load-lat](https://user-images.githubusercontent.com/2758593/105807313-064f4400-5fa6-11eb-975b-e12bc711a185.png)|![low-load-lat](https://user-images.githubusercontent.com/2758593/105807314-06e7da80-5fa6-11eb-84a3-6308d9a20791.png)|Looks similar|

As we can see, with this change we can solve our low load problem.

closes https://github.com/zeebe-io/zeebe/issues/5137

## Further Work

We will run another benchmark to see whether the memory issues with frequent snapshots have been mitigated, but 
I think we can already review and merge it as first increment. The results we see above and in the related issue are quite promising and a big improvement.

I created several follow up issues regarding exposing configuration, making things optional etc.

**Follow up issues:**

 * https://github.com/zeebe-io/zeebe/issues/6157
 * https://github.com/zeebe-io/zeebe/issues/6158
 * https://github.com/zeebe-io/zeebe/issues/6159

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/4002 _drop multi column families usage_
closes https://github.com/zeebe-io/zeebe/issues/5137 _low load causes defragmentation_
https://github.com/zeebe-io/zeebe/issues/5185 _investigate high snapshot rate_
closes https://github.com/zeebe-io/zeebe/issues/4560 _unstable cluster on bigger state_
closes https://github.com/zeebe-io/zeebe/issues/5810 _Log file to big_
closes https://github.com/zeebe-io/zeebe/issues/6038 _Out of Disk: to many inodes in use_

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [x] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
