### PR TITLE
fix(gateway): propagate rejections to clients without retrying

### DIFF
--- a/gateway/src/main/java/io/zeebe/gateway/impl/job/LongPollingActivateJobsRequest.java
+++ b/gateway/src/main/java/io/zeebe/gateway/impl/job/LongPollingActivateJobsRequest.java
@@ -88,6 +88,18 @@ public final class LongPollingActivateJobsRequest {
     }
   }
 
+  public void onError(final Throwable error) {
+    if (isCompleted() || isCanceled()) {
+      return;
+    }
+
+    try {
+      responseObserver.onError(error);
+    } catch (final Exception e) {
+      LOG.warn("Failed to send response to client.", e);
+    }
+  }
+
   public void timeout() {
     complete();
     isTimedOut = true;


### PR DESCRIPTION
## Description

Previously, a rejected job activate request would be ignore and retried in the remaining partitions. In the end, the rejection would be suppressed and a response with zero jobs would be returned. Since rejections are most likely not transient errors, there's not point in retrying. Furthermore, returning zero jobs will cause the clients to eventually retry. This PR changes the gateway to not retry on rejections and actually return the rejection as an error. This will allow the clients to detect this and react accordingly (issues camunda/camunda#6167 camunda/issue-migration-go-client#14).

## Related issues

closes camunda/camunda#6166 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
