### PR TITLE
chore(benchmarks): portable distribution script

### DIFF
--- a/benchmarks/docs/scripts/partitionDistribution.sh
+++ b/benchmarks/docs/scripts/partitionDistribution.sh
@@ -1,4 +1,4 @@
-#!/bin/java --source 11
+#!/usr/bin/env -S java --source 11
 package io.zeebe.broker.it.util;
 
 import static java.lang.System.exit;


### PR DESCRIPTION
## Description

Makes the `partitionDistribution.sh` script usable for those of us which don't have `java` in `/bin` :slightly_smiling_face: Should work on most Unix distribution.

## Related issues

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
