### PR TITLE
Omit creating an event subscription if no event can be triggered

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -120,8 +120,10 @@ public final class CatchEventBehavior {
       }
     }
 
-    eventScopeInstanceState.createIfNotExists(
-        context.getElementInstanceKey(), supplier.getInterruptingElementIds());
+    if (!events.isEmpty()) {
+      eventScopeInstanceState.createIfNotExists(
+          context.getElementInstanceKey(), supplier.getInterruptingElementIds());
+    }
   }
 
   public void subscribeToTimerEvent(


### PR DESCRIPTION
## Description

* don't create an event subscription (i.e. an event trigger) for an activity if no event can be triggered (i.e. no boundary events)
* it is a preparation for #6200
* there is no test to verify that the subscription is not created because
  * currently, we don't have stream processor tests that verify the state directly
  * the impact is very low  
  * it will be tested indirectly later when verifying the replay 

## Related issues

closes #6201 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
