### PR TITLE
chore(journal): add a new module for journal

### DIFF
--- a/journal/pom.xml
+++ b/journal/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <name>Zeebe Journal</name>
+  <artifactId>zeebe-journal</artifactId>
+  <version>0.27.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>io.zeebe</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>0.27.0-SNAPSHOT</version>
+    <relativePath>../parent</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>atomix-utils</artifactId>
+    </dependency>
+  </dependencies>
+
+
+  <build>
+    <plugins>
+      <!-- LICENSE PLUGIN -->
+      <plugin>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <!--
+             Will only add license headers if file has none, to only add our copyright
+             to new added files. We need to make sure that the old ONF copyrights are saved
+             and not replaced accidentally.
+          -->
+          <skipExistingHeaders>true</skipExistingHeaders>
+        </configuration>
+        <groupId>com.mycila</groupId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+  </properties>
+
+</project>

--- a/journal/src/main/java/io/zeebe/journal/Journal.java
+++ b/journal/src/main/java/io/zeebe/journal/Journal.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal;
+
+import io.zeebe.journal.StorageException.InvalidChecksum;
+import io.zeebe.journal.StorageException.InvalidIndex;
+import org.agrona.DirectBuffer;
+
+public interface Journal extends AutoCloseable {
+
+  /**
+   * Appends a new {@link JournalRecord} that contains the given data. asqn refers to Application
+   * Sequence Number. It is a sequence number provided by the application. The given asqn must be
+   * positive and, it must be greater than the asqn of the previous record.
+   *
+   * @param asqn A sequence number provided by the application.
+   * @param data The data to be appended
+   * @return the journal record that was appended
+   */
+  JournalRecord append(long asqn, DirectBuffer data);
+
+  /**
+   * Appends a new {@link JournalRecord} that contains the given data. The asqn of this record could
+   * not be used to seek. Use this for records that do not have a specific applicationSqNum.
+   * Examples for such record is raft record that indicates a leader change.
+   *
+   * @param data The data to be appended
+   * @return the journal record that was appended
+   */
+  JournalRecord append(DirectBuffer data);
+
+  /**
+   * Appends a {@link JournalRecord}. If the index of the record is not the next expected index, the
+   * append will fail.
+   *
+   * @param record the record to be appended
+   * @exception InvalidIndex if the index of record is not the next expected index
+   * @exception InvalidChecksum if the checksum in record does not match the checksum of the data
+   */
+  void append(JournalRecord record);
+
+  /**
+   * Delete all records after indexExclusive. After a call to this method, {@link
+   * Journal#getLastIndex()} should return indexExclusive.
+   *
+   * @param indexExclusive the index after which the records will be deleted.
+   */
+  void deleteAfter(long indexExclusive);
+
+  /**
+   * Attempts to delete all records until indexExclusive. The records may be immediately deleted or
+   * marked to be deleted later depending on the implementation.
+   *
+   * @param indexExclusive the index until which will be deleted. The record at this index is not
+   *     deleted.
+   */
+  void deleteUntil(long indexExclusive);
+
+  /**
+   * Delete all records in the journal and reset the next index to nextIndex. The following calls to
+   * {@link Journal#append(long, DirectBuffer)} will append at index nextIndex.
+   *
+   * @param nextIndex the next index of the journal.
+   */
+  void reset(long nextIndex);
+
+  /**
+   * Returns the index of last record in the journal
+   *
+   * @return the last index
+   */
+  long getLastIndex();
+
+  /**
+   * Returns the index of the first record.
+   *
+   * @return the first index
+   */
+  long getFirstIndex();
+
+  /**
+   * Check if the journal is empty.
+   *
+   * @return true if empty, false otherwise.
+   */
+  boolean isEmpty();
+
+  /**
+   * Depending on the implementation, appends to the journal may not be immediately flushed to the
+   * persistent storage. A call to this method guarantees that all records written are safely
+   * flushed to the persistent storage.
+   */
+  void flush();
+
+  /**
+   * Opens a new {@link JournalReader}
+   *
+   * @return a journal reader
+   */
+  JournalReader openReader();
+
+  /**
+   * Check if the journal is open
+   *
+   * @return true if open, false otherwise
+   */
+  boolean isOpen();
+}

--- a/journal/src/main/java/io/zeebe/journal/JournalReader.java
+++ b/journal/src/main/java/io/zeebe/journal/JournalReader.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal;
+
+import java.util.Iterator;
+
+public interface JournalReader extends Iterator<JournalRecord>, AutoCloseable {
+
+  /**
+   * Seek to a record at the given index. if seek(index) return true, {@link JournalReader#next()}
+   * should return a record at index.
+   *
+   * <p>if the index is less than {@link Journal#getFirstIndex()}, {@link JournalReader#next()}
+   * should return a record at index {@link Journal#getFirstIndex()}. If the index is greater than
+   * {@link Journal#getLastIndex()}, then it seeks to lastIndex + 1, and {@link
+   * JournalReader#hasNext()} returns false.
+   *
+   * @param index the index to seek to.
+   * @return true if a record at the index exists, false otherwise.
+   */
+  boolean seek(long index);
+
+  /**
+   * Seek to the first index of the journal. Equivalent to calling seek(journal.getFirstIndex()).
+   */
+  void seekToFirst();
+
+  /** Seek to the last index of the journal. Equivalent to calling seek(journal.getLastIndex()). */
+  void seekToLast();
+
+  /**
+   * Seek to a record with the highest asqn less than or equal to the given asqn.
+   *
+   * @param asqn application sequence number to seek
+   * @return true if such a record exists, false if there are no records with asqn less than or
+   *     equal to the given asqn.
+   */
+  boolean seekToAsqn(long asqn);
+}

--- a/journal/src/main/java/io/zeebe/journal/JournalRecord.java
+++ b/journal/src/main/java/io/zeebe/journal/JournalRecord.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal;
+
+import org.agrona.DirectBuffer;
+
+public interface JournalRecord {
+
+  /**
+   * Index of the record
+   *
+   * @return index
+   */
+  long index();
+
+  /**
+   * Application sequence number for the record
+   *
+   * @return asqn
+   */
+  long asqn();
+
+  /**
+   * Checksum of the data
+   *
+   * @return checksum
+   */
+  int checksum();
+
+  /**
+   * Application provided data of the record
+   *
+   * @return data
+   */
+  DirectBuffer data();
+}

--- a/journal/src/main/java/io/zeebe/journal/StorageException.java
+++ b/journal/src/main/java/io/zeebe/journal/StorageException.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal;
+
+/** Defines exceptions thrown by the Journal */
+public class StorageException extends RuntimeException {
+
+  public StorageException() {}
+
+  public StorageException(final String message) {
+    super(message);
+  }
+
+  public StorageException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public StorageException(final Throwable cause) {
+    super(cause);
+  }
+
+  /** Exception thrown when an entry being stored is too large. */
+  public static class TooLarge extends StorageException {
+    public TooLarge(final String message) {
+      super(message);
+    }
+  }
+
+  /** Exception thrown when storage runs out of disk space. */
+  public static class OutOfDiskSpace extends StorageException {
+    public OutOfDiskSpace(final String message) {
+      super(message);
+    }
+  }
+
+  /** Exception thrown when an entry has an invalid checksum. */
+  public static class InvalidChecksum extends StorageException {
+    public InvalidChecksum(final String message) {
+      super(message);
+    }
+  }
+
+  /** Exception thrown when an entry's index is not the expected one. */
+  public static class InvalidIndex extends StorageException {
+    public InvalidIndex(final String message) {
+      super(message);
+    }
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/IndexInfo.java
+++ b/journal/src/main/java/io/zeebe/journal/file/IndexInfo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+/** Indexing info stored by JournalIndex */
+class IndexInfo {
+  private final long index;
+  private final int position;
+
+  public IndexInfo(final long index, final int position) {
+    this.index = index;
+    this.position = position;
+  }
+
+  public long index() {
+    return index;
+  }
+
+  public int position() {
+    return position;
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/JournalIndex.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalIndex.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import io.zeebe.journal.JournalRecord;
+
+/**
+ * JournalIndex that indexes record's index, position and asqn. JournalReader may use this to
+ * optimize seek.
+ */
+interface JournalIndex {
+
+  /**
+   * Indexes the record and its position with in a segment
+   *
+   * @param record the record that should be indexed
+   * @param position the position of the given index
+   */
+  void index(JournalRecord record, int position);
+
+  /**
+   * Looks up the position of the given index.
+   *
+   * @param index the index to lookup
+   * @return the position of the given index or a lesser index
+   */
+  IndexInfo lookup(long index);
+
+  /**
+   * Look up the index for the given application sequence number.
+   *
+   * @param asqn
+   * @return the index of a record with asqn less than or equal to the given asqn.
+   */
+  Long lookupAsqn(long asqn);
+
+  /**
+   * Delete all entries after the given index.
+   *
+   * @param indexExclusive the index after which to be deleted
+   */
+  void deleteAfter(long indexExclusive);
+
+  /**
+   * Compacts the index until the next stored index (exclusively), which means everything lower then
+   * the stored index will be removed.
+   *
+   * <p>Example Index: {5 -> 10; 10 -> 20; 15 -> 30}, when compact is called with index 11. The next
+   * lower stored index is 15, everything lower then this index will be removed.
+   *
+   * @param indexExclusive the index to which to compact the index
+   */
+  void deleteUntil(long indexExclusive);
+}

--- a/journal/src/main/java/io/zeebe/journal/file/JournalMetrics.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalMetrics.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+
+class JournalMetrics {
+  private static final String NAMESPACE = "atomix";
+  private static final String PARTITION_LABEL = "partition";
+  private static final Histogram SEGMENT_CREATION_TIME =
+      Histogram.build()
+          .namespace(NAMESPACE)
+          .name("segment_creation_time")
+          .help("Time spend to create a new segment")
+          .labelNames(PARTITION_LABEL)
+          .register();
+
+  private static final Histogram SEGMENT_TRUNCATE_TIME =
+      Histogram.build()
+          .namespace(NAMESPACE)
+          .name("segment_truncate_time")
+          .help("Time spend to truncate a segment")
+          .labelNames(PARTITION_LABEL)
+          .register();
+
+  private static final Histogram SEGMENT_FLUSH_TIME =
+      Histogram.build()
+          .namespace(NAMESPACE)
+          .name("segment_flush_time")
+          .help("Time spend to flush segment to disk")
+          .labelNames(PARTITION_LABEL)
+          .register();
+
+  private static final Gauge SEGMENT_COUNT =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("segment_count")
+          .help("Number of segments")
+          .labelNames(PARTITION_LABEL)
+          .register();
+  private static final Gauge JOURNAL_OPEN_DURATION =
+      Gauge.build()
+          .namespace(NAMESPACE)
+          .name("journal_open_time")
+          .help("Time taken to open the journal")
+          .labelNames(PARTITION_LABEL)
+          .register();
+
+  private final String logName;
+
+  public JournalMetrics(final String logName) {
+    this.logName = logName;
+  }
+
+  public void observeSegmentCreation(final Runnable segmentCreation) {
+    SEGMENT_CREATION_TIME.labels(logName).time(segmentCreation);
+  }
+
+  public void observeSegmentFlush(final Runnable segmentFlush) {
+    SEGMENT_FLUSH_TIME.labels(logName).time(segmentFlush);
+  }
+
+  public void observeSegmentTruncation(final Runnable segmentTruncation) {
+    SEGMENT_TRUNCATE_TIME.labels(logName).time(segmentTruncation);
+  }
+
+  public void observeJournalOpenDuration(final long durationMillis) {
+    JOURNAL_OPEN_DURATION.labels(logName).set(durationMillis / 1000f);
+  }
+
+  public void incSegmentCount() {
+    SEGMENT_COUNT.labels(logName).inc();
+  }
+
+  public void decSegmentCount() {
+    SEGMENT_COUNT.labels(logName).dec();
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/JournalSegment.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalSegment.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.Sets;
+import io.zeebe.journal.StorageException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Set;
+
+/**
+ * Log segment.
+ *
+ * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
+ */
+class JournalSegment implements AutoCloseable {
+
+  private final JournalSegmentFile file;
+  private final JournalSegmentDescriptor descriptor;
+  private final int maxEntrySize;
+  private final JournalIndex index;
+  private final MappedJournalSegmentWriter writer;
+  private final Set<MappedJournalSegmentReader> readers = Sets.newConcurrentHashSet();
+  private boolean open = true;
+
+  public JournalSegment(
+      final JournalSegmentFile file,
+      final JournalSegmentDescriptor descriptor,
+      final int maxEntrySize,
+      final JournalIndex journalIndex) {
+    this.file = file;
+    this.descriptor = descriptor;
+    this.maxEntrySize = maxEntrySize;
+    index = journalIndex;
+    writer = createWriter(file, maxEntrySize);
+  }
+
+  /**
+   * Returns the segment ID.
+   *
+   * @return The segment ID.
+   */
+  public long id() {
+    return descriptor.id();
+  }
+
+  /**
+   * Returns the segment version.
+   *
+   * @return The segment version.
+   */
+  public long version() {
+    return descriptor.version();
+  }
+
+  /**
+   * Returns the segment's starting index.
+   *
+   * @return The segment's starting index.
+   */
+  public long index() {
+    return descriptor.index();
+  }
+
+  /**
+   * Returns the last index in the segment.
+   *
+   * @return The last index in the segment.
+   */
+  public long lastIndex() {
+    return writer.getLastIndex();
+  }
+
+  /**
+   * Returns the segment file.
+   *
+   * @return The segment file.
+   */
+  public JournalSegmentFile file() {
+    return file;
+  }
+
+  /**
+   * Returns the segment descriptor.
+   *
+   * @return The segment descriptor.
+   */
+  public JournalSegmentDescriptor descriptor() {
+    return descriptor;
+  }
+
+  /**
+   * Returns a boolean value indicating whether the segment is empty.
+   *
+   * @return Indicates whether the segment is empty.
+   */
+  public boolean isEmpty() {
+    return length() == 0;
+  }
+
+  /**
+   * Returns the segment length.
+   *
+   * @return The segment length.
+   */
+  public long length() {
+    return writer.getNextIndex() - index();
+  }
+
+  /**
+   * Returns the segment writer.
+   *
+   * @return The segment writer.
+   */
+  public MappedJournalSegmentWriter writer() {
+    checkOpen();
+    return writer;
+  }
+
+  /**
+   * Creates a new segment reader.
+   *
+   * @return A new segment reader.
+   */
+  MappedJournalSegmentReader createReader() {
+    checkOpen();
+    return new MappedJournalSegmentReader(file, this, maxEntrySize, index);
+  }
+
+  private MappedJournalSegmentWriter createWriter(
+      final JournalSegmentFile file, final int maxEntrySize) {
+    return new MappedJournalSegmentWriter(file, this, maxEntrySize, index);
+  }
+
+  /**
+   * Removes the reader from this segment.
+   *
+   * @param reader the closed reader
+   */
+  void onReaderClosed(final MappedJournalSegmentReader reader) {
+    readers.remove(reader);
+  }
+
+  /** Checks whether the segment is open. */
+  private void checkOpen() {
+    checkState(open, "Segment not open");
+  }
+
+  /**
+   * Returns a boolean indicating whether the segment is open.
+   *
+   * @return indicates whether the segment is open
+   */
+  public boolean isOpen() {
+    return open;
+  }
+
+  /** Closes the segment. */
+  @Override
+  public void close() {
+    writer.close();
+    readers.forEach(MappedJournalSegmentReader::close);
+    open = false;
+  }
+
+  void compactIndex(final long index) {
+    this.index.deleteUntil(index);
+  }
+
+  /** Deletes the segment. */
+  public void delete() {
+    try {
+      Files.deleteIfExists(file.file().toPath());
+    } catch (final IOException e) {
+      throw new StorageException(e);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("id", id())
+        .add("version", version())
+        .add("index", index())
+        .toString();
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/JournalSegmentDescriptor.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalSegmentDescriptor.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.nio.ByteBuffer;
+
+/**
+ * Stores information about a {@link JournalSegment} of the log.
+ *
+ * <p>The segment descriptor manages metadata related to a single segment of the log. Descriptors
+ * are stored within the first {@code 64} bytes of each segment in the following order:
+ *
+ * <ul>
+ *   <li>{@code id} (64-bit signed integer) - A unique segment identifier. This is a monotonically
+ *       increasing number within each log. Segments with in-sequence identifiers should contain
+ *       in-sequence indexes.
+ *   <li>{@code index} (64-bit signed integer) - The effective first index of the segment. This
+ *       indicates the index at which the first entry should be written to the segment. Indexes are
+ *       monotonically increasing thereafter.
+ *   <li>{@code version} (64-bit signed integer) - The version of the segment. Versions are
+ *       monotonically increasing starting at {@code 1}. Versions will only be incremented whenever
+ *       the segment is rewritten to another memory/disk space, e.g. after log compaction.
+ *   <li>{@code maxSegmentSize} (32-bit unsigned integer) - The maximum number of bytes allowed in
+ *       the segment.
+ *   <li>{@code maxEntries} (32-bit signed integer) - The total number of expected entries in the
+ *       segment. This is the final number of entries allowed within the segment both before and
+ *       after compaction. This entry count is used to determine the count of internal indexing and
+ *       deduplication facilities.
+ *   <li>{@code updated} (64-bit signed integer) - The last update to the segment in terms of
+ *       milliseconds since the epoch. When the segment is first constructed, the {@code updated}
+ *       time is {@code 0}. Once all entries in the segment have been committed, the {@code updated}
+ *       time should be set to the current time. Log compaction should not result in a change to
+ *       {@code updated}.
+ *   <li>{@code locked} (8-bit boolean) - A boolean indicating whether the segment is locked.
+ *       Segments will be locked once all entries have been committed to the segment. The lock state
+ *       of each segment is used to determine log compaction and recovery behavior.
+ * </ul>
+ *
+ * The remainder of the 64 segment header bytes are reserved for future metadata.
+ *
+ * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
+ */
+final class JournalSegmentDescriptor {
+  public static final int BYTES = 64;
+
+  // Current segment version.
+  @VisibleForTesting static final int VERSION = 1;
+
+  // The lengths of each field in the header.
+  private static final int VERSION_LENGTH = Integer.BYTES; // 32-bit signed integer
+  private static final int ID_LENGTH = Long.BYTES; // 64-bit signed integer
+  private static final int INDEX_LENGTH = Long.BYTES; // 64-bit signed integer
+  private static final int MAX_SIZE_LENGTH = Integer.BYTES; // 32-bit signed integer
+  private static final int MAX_ENTRIES_LENGTH = Integer.BYTES; // 32-bit signed integer
+  private static final int UPDATED_LENGTH = Long.BYTES; // 64-bit signed integer
+
+  // The positions of each field in the header.
+  private static final int VERSION_POSITION = 0; // 0
+  private static final int ID_POSITION = VERSION_POSITION + VERSION_LENGTH; // 4
+  private static final int INDEX_POSITION = ID_POSITION + ID_LENGTH; // 12
+  private static final int MAX_SIZE_POSITION = INDEX_POSITION + INDEX_LENGTH; // 20
+  private static final int MAX_ENTRIES_POSITION = MAX_SIZE_POSITION + MAX_SIZE_LENGTH; // 24
+  private static final int UPDATED_POSITION = MAX_ENTRIES_POSITION + MAX_ENTRIES_LENGTH; // 28
+  private final ByteBuffer buffer;
+  private final int version;
+  private final long id;
+  private final long index;
+  private final int maxSegmentSize;
+  private volatile long updated;
+  private final boolean locked;
+  /** @throws NullPointerException if {@code buffer} is null */
+  public JournalSegmentDescriptor(final ByteBuffer buffer) {
+    this.buffer = buffer;
+    version = buffer.getInt();
+    id = buffer.getLong();
+    index = buffer.getLong();
+    maxSegmentSize = buffer.getInt();
+    updated = buffer.getLong();
+    locked = buffer.get() == 1;
+  }
+
+  /**
+   * Returns a descriptor builder.
+   *
+   * <p>The descriptor builder will write segment metadata to a {@code 48} byte in-memory buffer.
+   *
+   * @return The descriptor builder.
+   */
+  public static Builder builder() {
+    return new Builder(ByteBuffer.allocate(BYTES));
+  }
+
+  /**
+   * Returns a descriptor builder for the given descriptor buffer.
+   *
+   * @param buffer The descriptor buffer.
+   * @return The descriptor builder.
+   * @throws NullPointerException if {@code buffer} is null
+   */
+  public static Builder builder(final ByteBuffer buffer) {
+    return new Builder(buffer);
+  }
+
+  /**
+   * Returns the segment version.
+   *
+   * <p>Versions are monotonically increasing starting at {@code 1}.
+   *
+   * @return The segment version.
+   */
+  public int version() {
+    return version;
+  }
+
+  /**
+   * Returns the segment identifier.
+   *
+   * <p>The segment ID is a monotonically increasing number within each log. Segments with
+   * in-sequence identifiers should contain in-sequence indexes.
+   *
+   * @return The segment identifier.
+   */
+  public long id() {
+    return id;
+  }
+
+  /**
+   * Returns the segment index.
+   *
+   * <p>The index indicates the index at which the first entry should be written to the segment.
+   * Indexes are monotonically increasing thereafter.
+   *
+   * @return The segment index.
+   */
+  public long index() {
+    return index;
+  }
+
+  /**
+   * Returns the maximum count of the segment.
+   *
+   * @return The maximum allowed count of the segment.
+   */
+  public int maxSegmentSize() {
+    return maxSegmentSize;
+  }
+
+  /**
+   * Returns last time the segment was updated.
+   *
+   * <p>When the segment is first constructed, the {@code updated} time is {@code 0}. Once all
+   * entries in the segment have been committed, the {@code updated} time should be set to the
+   * current time. Log compaction should not result in a change to {@code updated}.
+   *
+   * @return The last time the segment was updated in terms of milliseconds since the epoch.
+   */
+  public long updated() {
+    return updated;
+  }
+
+  /** Writes an update to the descriptor. */
+  public void update(final long timestamp) {
+    if (!locked) {
+      buffer.putLong(UPDATED_POSITION, timestamp);
+      updated = timestamp;
+    }
+  }
+
+  /** Copies the segment to a new buffer. */
+  JournalSegmentDescriptor copyTo(final ByteBuffer buffer) {
+    buffer.putInt(version);
+    buffer.putLong(id);
+    buffer.putLong(index);
+    buffer.putInt(maxSegmentSize);
+    buffer.putLong(updated);
+    buffer.put(locked ? (byte) 1 : (byte) 0);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("version", version)
+        .add("id", id)
+        .add("index", index)
+        .add("updated", updated)
+        .toString();
+  }
+
+  /** Segment descriptor builder. */
+  public static final class Builder {
+    private final ByteBuffer buffer;
+
+    private Builder(final ByteBuffer buffer) {
+      this.buffer = checkNotNull(buffer, "buffer cannot be null");
+      buffer.putInt(VERSION_POSITION, VERSION);
+    }
+
+    /**
+     * Sets the segment identifier.
+     *
+     * @param id The segment identifier.
+     * @return The segment descriptor builder.
+     */
+    public Builder withId(final long id) {
+      buffer.putLong(ID_POSITION, id);
+      return this;
+    }
+
+    /**
+     * Sets the segment index.
+     *
+     * @param index The segment starting index.
+     * @return The segment descriptor builder.
+     */
+    public Builder withIndex(final long index) {
+      buffer.putLong(INDEX_POSITION, index);
+      return this;
+    }
+
+    /**
+     * Sets maximum count of the segment.
+     *
+     * @param maxSegmentSize The maximum count of the segment.
+     * @return The segment descriptor builder.
+     */
+    public Builder withMaxSegmentSize(final int maxSegmentSize) {
+      buffer.putInt(MAX_SIZE_POSITION, maxSegmentSize);
+      return this;
+    }
+
+    /**
+     * Builds the segment descriptor.
+     *
+     * @return The built segment descriptor.
+     */
+    public JournalSegmentDescriptor build() {
+      buffer.rewind();
+      return new JournalSegmentDescriptor(buffer);
+    }
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/JournalSegmentFile.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalSegmentFile.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.zeebe.journal.StorageException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Segment file utility.
+ *
+ * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
+ */
+final class JournalSegmentFile {
+  private static final char PART_SEPARATOR = '-';
+  private static final char EXTENSION_SEPARATOR = '.';
+  private static final String EXTENSION = "log";
+  private final File file;
+
+  /** @throws IllegalArgumentException if {@code file} is not a valid segment file */
+  JournalSegmentFile(final File file) {
+    this.file = file;
+  }
+
+  /**
+   * Returns a boolean value indicating whether the given file appears to be a parsable segment
+   * file.
+   *
+   * @throws NullPointerException if {@code file} is null
+   */
+  public static boolean isSegmentFile(final String name, final File file) {
+    return isSegmentFile(name, file.getName());
+  }
+
+  /**
+   * Returns a boolean value indicating whether the given file appears to be a parsable segment
+   * file.
+   *
+   * @param journalName the name of the journal
+   * @param fileName the name of the file to check
+   * @throws NullPointerException if {@code file} is null
+   */
+  public static boolean isSegmentFile(final String journalName, final String fileName) {
+    checkNotNull(journalName, "journalName cannot be null");
+    checkNotNull(fileName, "fileName cannot be null");
+
+    final int partSeparator = fileName.lastIndexOf(PART_SEPARATOR);
+    final int extensionSeparator = fileName.lastIndexOf(EXTENSION_SEPARATOR);
+
+    if (extensionSeparator == -1
+        || partSeparator == -1
+        || extensionSeparator < partSeparator
+        || !fileName.endsWith(EXTENSION)) {
+      return false;
+    }
+
+    for (int i = partSeparator + 1; i < extensionSeparator; i++) {
+      if (!Character.isDigit(fileName.charAt(i))) {
+        return false;
+      }
+    }
+
+    return fileName.startsWith(journalName);
+  }
+
+  /** Creates a segment file for the given directory, log name, segment ID, and segment version. */
+  static File createSegmentFile(final String name, final File directory, final long id) {
+    return new File(
+        directory, String.format("%s-%d.log", checkNotNull(name, "name cannot be null"), id));
+  }
+
+  /**
+   * Returns the segment file.
+   *
+   * @return The segment file.
+   */
+  public File file() {
+    return file;
+  }
+
+  FileChannel openChannel(final StandardOpenOption... options) {
+    try {
+      return FileChannel.open(file.toPath(), options);
+    } catch (final IOException e) {
+      throw new StorageException(e);
+    }
+  }
+
+  public String name() {
+    return file.getName();
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.Namespaces;
+import io.zeebe.journal.JournalRecord;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel.MapMode;
+import java.util.NoSuchElementException;
+import java.util.zip.CRC32;
+import org.agrona.DirectBuffer;
+import org.agrona.IoUtil;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/** Log segment reader. */
+class MappedJournalSegmentReader {
+
+  private static final Namespace NAMESPACE =
+      new Namespace.Builder()
+          .register(Namespaces.BASIC)
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+          .register(PersistedJournalRecord.class)
+          .register(UnsafeBuffer.class)
+          .name("Journal")
+          .build();
+  private final MappedByteBuffer buffer;
+  private final int maxEntrySize;
+  private final JournalIndex index;
+  private final JournalSegment segment;
+  private JournalRecord currentEntry;
+  private JournalRecord nextEntry;
+  private final CRC32 crc32 = new CRC32();
+
+  MappedJournalSegmentReader(
+      final JournalSegmentFile file,
+      final JournalSegment segment,
+      final int maxEntrySize,
+      final JournalIndex index) {
+    this.maxEntrySize = maxEntrySize;
+    this.index = index;
+    this.segment = segment;
+    buffer =
+        IoUtil.mapExistingFile(
+            file.file(), MapMode.READ_ONLY, file.name(), 0, segment.descriptor().maxSegmentSize());
+    reset();
+  }
+
+  public JournalRecord getCurrentEntry() {
+    return currentEntry;
+  }
+
+  public JournalRecord getNextEntry() {
+    return nextEntry;
+  }
+
+  public boolean hasNext() {
+    // If the next entry is null, check whether a next entry exists.
+    if (nextEntry == null) {
+      readNext(getNextIndex());
+    }
+    return nextEntry != null;
+  }
+
+  public JournalRecord next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    // Set the current entry to the next entry.
+    currentEntry = nextEntry;
+
+    // Reset the next entry to null.
+    nextEntry = null;
+
+    // Read the next entry in the segment.
+    readNext(getNextIndex());
+
+    // Return the current entry.
+    return currentEntry;
+  }
+
+  public void reset() {
+    buffer.position(JournalSegmentDescriptor.BYTES);
+    currentEntry = null;
+    nextEntry = null;
+    readNext(getNextIndex());
+  }
+
+  public boolean seek(final long index) {
+    final long firstIndex = segment.index();
+    final long lastIndex = segment.lastIndex();
+
+    reset();
+
+    final var position = this.index.lookup(index - 1);
+    if (position != null && position.index() >= firstIndex && position.index() <= lastIndex) {
+      currentEntry = null;
+      buffer.position(position.position());
+
+      nextEntry = null;
+      readNext(position.index());
+    }
+
+    while (getNextIndex() < index && hasNext()) {
+      next();
+    }
+
+    return nextEntry != null && nextEntry.index() == index;
+  }
+
+  public void close() {
+    IoUtil.unmap(buffer);
+    segment.onReaderClosed(this);
+  }
+
+  long getNextIndex() {
+    return currentEntry == null ? segment.index() : currentEntry.index() + 1;
+  }
+
+  /** Reads the next entry in the segment. */
+  private void readNext(final long expectedIndex) {
+
+    // Mark the buffer so it can be reset if necessary.
+    buffer.mark();
+
+    try {
+      // Read the length of the record.
+      final int length = buffer.getInt();
+
+      // If the buffer length is zero then return.
+      if (length <= 0 || length > maxEntrySize) {
+        buffer.reset();
+        nextEntry = null;
+        return;
+      }
+
+      final ByteBuffer slice = buffer.slice();
+      slice.limit(length);
+
+      // If the stored checksum equals the computed checksum, return the record.
+      slice.rewind();
+      final PersistedJournalRecord record = NAMESPACE.deserialize(slice);
+      final var checksum = record.checksum();
+      // TODO: checksum should also include asqn.
+      // TODO: It is now copying the data to calculate the checksum. This should be fixed.
+      final var expectedChecksum = computeChecksum(record.data());
+      if (checksum != expectedChecksum || expectedIndex != record.index()) {
+        nextEntry = null;
+        buffer.reset();
+        return;
+      }
+      nextEntry = record;
+      buffer.position(buffer.position() + length);
+
+    } catch (final BufferUnderflowException e) {
+      buffer.reset();
+      nextEntry = null;
+    }
+  }
+
+  private int computeChecksum(final DirectBuffer data) {
+    final byte[] slice = new byte[data.capacity()];
+    data.getBytes(0, slice);
+    crc32.reset();
+    crc32.update(slice);
+    return (int) crc32.getValue();
+  }
+
+  long getCurrentIndex() {
+    return currentEntry != null ? currentEntry.index() : 0;
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import com.esotericsoftware.kryo.KryoException;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.Namespaces;
+import io.zeebe.journal.JournalRecord;
+import io.zeebe.journal.StorageException;
+import io.zeebe.journal.StorageException.InvalidChecksum;
+import io.zeebe.journal.StorageException.InvalidIndex;
+import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.util.zip.CRC32;
+import org.agrona.DirectBuffer;
+import org.agrona.IoUtil;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/** Segment writer. */
+class MappedJournalSegmentWriter {
+
+  private static final Namespace NAMESPACE =
+      new Namespace.Builder()
+          .register(Namespaces.BASIC)
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+          .register(PersistedJournalRecord.class)
+          .register(UnsafeBuffer.class)
+          .name("Journal")
+          .build();
+  private final MappedByteBuffer buffer;
+  private final JournalSegment segment;
+  private final int maxEntrySize;
+  private final JournalIndex index;
+  private final long firstIndex;
+  private final CRC32 crc32 = new CRC32();
+  private JournalRecord lastEntry;
+  private boolean isOpen = true;
+
+  MappedJournalSegmentWriter(
+      final JournalSegmentFile file,
+      final JournalSegment segment,
+      final int maxEntrySize,
+      final JournalIndex index) {
+    this.segment = segment;
+    this.maxEntrySize = maxEntrySize;
+    this.index = index;
+    firstIndex = segment.index();
+    buffer = mapFile(file, segment);
+    reset(0);
+  }
+
+  private static MappedByteBuffer mapFile(
+      final JournalSegmentFile file, final JournalSegment segment) {
+    // map existing file, because file is already created by SegmentedJournal
+    return IoUtil.mapExistingFile(
+        file.file(), file.name(), 0, segment.descriptor().maxSegmentSize());
+  }
+
+  public long getLastIndex() {
+    return lastEntry != null ? lastEntry.index() : segment.index() - 1;
+  }
+
+  public JournalRecord getLastEntry() {
+    return lastEntry;
+  }
+
+  public long getNextIndex() {
+    if (lastEntry != null) {
+      return lastEntry.index() + 1;
+    } else {
+      return firstIndex;
+    }
+  }
+
+  public JournalRecord append(final long asqn, final DirectBuffer data) {
+    // Store the entry index.
+    final long index = getNextIndex();
+
+    // TODO: Should reject append if the asqn is not greater than the previous record
+
+    // Serialize the entry.
+    final int recordStartPosition = buffer.position();
+    if (recordStartPosition + Integer.BYTES > buffer.limit()) {
+      throw new BufferOverflowException();
+    }
+
+    buffer.position(recordStartPosition + Integer.BYTES);
+
+    // compute checksum and construct the record
+    // TODO: checksum should also include asqn. https://github.com/zeebe-io/zeebe/issues/6218
+    // TODO: It is now copying the data to calculate the checksum. This should be fixed when
+    // we change the serialization format. https://github.com/zeebe-io/zeebe/issues/6219
+    final var checksum = computeChecksum(data);
+    final var recordToWrite = new PersistedJournalRecord(index, asqn, checksum, data);
+
+    try {
+      NAMESPACE.serialize(recordToWrite, buffer);
+    } catch (final KryoException e) {
+      throw new BufferOverflowException();
+    }
+
+    final int length = buffer.position() - (recordStartPosition + Integer.BYTES);
+
+    // If the entry length exceeds the maximum entry size then throw an exception.
+    if (length > maxEntrySize) {
+      // Just reset the buffer. There's no need to zero the bytes since we haven't written the
+      // length or checksum.
+      buffer.position(recordStartPosition);
+      throw new StorageException.TooLarge(
+          "Entry size " + length + " exceeds maximum allowed bytes (" + maxEntrySize + ")");
+    }
+
+    buffer.position(recordStartPosition);
+    buffer.putInt(length);
+    buffer.position(recordStartPosition + Integer.BYTES + length);
+
+    lastEntry = recordToWrite;
+    this.index.index(lastEntry, recordStartPosition);
+    return lastEntry;
+  }
+
+  private int computeChecksum(final DirectBuffer data) {
+    final byte[] slice = new byte[data.capacity()];
+    data.getBytes(0, slice);
+    crc32.reset();
+    crc32.update(slice);
+    return (int) crc32.getValue();
+  }
+
+  public void append(final JournalRecord record) {
+    final long nextIndex = getNextIndex();
+
+    // If the entry's index is not the expected next index in the segment, fail the append.
+    if (record.index() != nextIndex) {
+      throw new InvalidIndex(
+          String.format(
+              "The record index is not sequential. Expected the next index to be %d, but the record to append has index %d",
+              nextIndex, record.index()));
+    }
+
+    final int recordStartPosition = buffer.position();
+    if (recordStartPosition + Integer.BYTES > buffer.limit()) {
+      throw new BufferOverflowException();
+    }
+
+    buffer.position(recordStartPosition + Integer.BYTES);
+    final var checksum = computeChecksum(record.data());
+
+    if (checksum != record.checksum()) {
+      throw new InvalidChecksum("Checksum invalid for record " + record);
+    }
+    try {
+      NAMESPACE.serialize(record, buffer);
+    } catch (final KryoException e) {
+      throw new BufferOverflowException();
+    }
+
+    final int length = buffer.position() - (recordStartPosition + Integer.BYTES);
+
+    // If the entry length exceeds the maximum entry size then throw an exception.
+    if (length > maxEntrySize) {
+      // Just reset the buffer. There's no need to zero the bytes since we haven't written the
+      // length or checksum.
+      buffer.position(recordStartPosition);
+      throw new StorageException.TooLarge(
+          "Entry size " + length + " exceeds maximum allowed bytes (" + maxEntrySize + ")");
+    }
+
+    buffer.position(recordStartPosition);
+    buffer.putInt(length);
+    buffer.position(recordStartPosition + Integer.BYTES + length);
+
+    lastEntry = record;
+    index.index(lastEntry, recordStartPosition);
+  }
+
+  private void reset(final long index) {
+    long nextIndex = firstIndex;
+
+    // Clear the buffer indexes.
+    buffer.position(JournalSegmentDescriptor.BYTES);
+
+    // Read the entry length.
+    buffer.mark();
+
+    try {
+      var recordPosition = buffer.position();
+      int length = buffer.getInt();
+
+      // If the length is non-zero, read the entry.
+      while (length > 0 && length <= maxEntrySize && (index == 0 || nextIndex <= index)) {
+
+        final ByteBuffer slice = buffer.slice();
+        slice.limit(length);
+
+        // If the stored checksum equals the computed checksum, return the record.
+        slice.rewind();
+        final PersistedJournalRecord record = NAMESPACE.deserialize(slice);
+        final var checksum = record.checksum();
+        final var expectedChecksum = computeChecksum(record.data());
+        if (checksum != expectedChecksum || nextIndex != record.index()) {
+          buffer.reset();
+          return;
+        }
+        lastEntry = record;
+        this.index.index(record, recordPosition);
+        nextIndex++;
+        buffer.position(recordPosition + Integer.BYTES + length);
+
+        recordPosition = buffer.position();
+        buffer.mark();
+        length = buffer.getInt();
+      }
+
+    } catch (final BufferUnderflowException e) {
+      // Reached end of the segment
+    } finally {
+      buffer.reset();
+    }
+  }
+
+  public void truncate(final long index) {
+    // If the index is greater than or equal to the last index, skip the truncate.
+    if (index >= getLastIndex()) {
+      return;
+    }
+
+    // Reset the last entry.
+    lastEntry = null;
+
+    // Truncate the index.
+    this.index.deleteAfter(index);
+
+    if (index < segment.index()) {
+      buffer.position(JournalSegmentDescriptor.BYTES);
+      buffer.putInt(0);
+      buffer.putInt(0);
+      buffer.position(JournalSegmentDescriptor.BYTES);
+    } else {
+      // Reset the writer to the given index.
+      reset(index);
+
+      // Zero entries after the given index.
+      final int position = buffer.position();
+      buffer.putInt(0);
+      buffer.putInt(0);
+      buffer.position(position);
+    }
+  }
+
+  public void flush() {
+    buffer.force();
+  }
+
+  public void close() {
+    if (isOpen) {
+      isOpen = false;
+      flush();
+      IoUtil.unmap(buffer);
+    }
+  }
+
+  /**
+   * Returns a boolean indicating whether the segment is empty.
+   *
+   * @return Indicates whether the segment is empty.
+   */
+  public boolean isEmpty() {
+    return lastEntry == null;
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/PersistedJournalRecord.java
+++ b/journal/src/main/java/io/zeebe/journal/file/PersistedJournalRecord.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import io.zeebe.journal.JournalRecord;
+import org.agrona.DirectBuffer;
+
+/** Journal Record */
+class PersistedJournalRecord implements JournalRecord {
+
+  private final DirectBuffer data;
+  private final long index;
+  private final long asqn;
+  private final int checksum;
+
+  public PersistedJournalRecord(
+      final long index, final long asqn, final int checksum, final DirectBuffer data) {
+    this.index = index;
+    this.asqn = asqn;
+    this.checksum = checksum;
+    this.data = data;
+  }
+
+  @Override
+  public long index() {
+    return index;
+  }
+
+  @Override
+  public long asqn() {
+    return asqn;
+  }
+
+  @Override
+  public int checksum() {
+    return checksum;
+  }
+
+  @Override
+  public DirectBuffer data() {
+    return data;
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournal.java
@@ -1,0 +1,559 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.Sets;
+import io.zeebe.journal.Journal;
+import io.zeebe.journal.JournalReader;
+import io.zeebe.journal.JournalRecord;
+import io.zeebe.journal.StorageException;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import org.agrona.DirectBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** A file based journal. The journal is split into multiple segments files. */
+public class SegmentedJournal implements Journal {
+
+  public static final long ASQN_IGNORE = -1;
+  private static final int SEGMENT_BUFFER_FACTOR = 3;
+  private static final int FIRST_SEGMENT_ID = 1;
+  private static final int INITIAL_INDEX = 1;
+  private final JournalMetrics journalMetrics;
+  private final Logger log = LoggerFactory.getLogger(getClass());
+  private final String name;
+  private final File directory;
+  private final int maxSegmentSize;
+  private final int maxEntrySize;
+  private final NavigableMap<Long, JournalSegment> segments = new ConcurrentSkipListMap<>();
+  private final Collection<SegmentedJournalReader> readers = Sets.newConcurrentHashSet();
+  private volatile JournalSegment currentSegment;
+  private volatile boolean open = true;
+  private final long minFreeDiskSpace;
+  private final JournalIndex journalIndex;
+  private final SegmentedJournalWriter writer;
+
+  public SegmentedJournal(
+      final String name,
+      final File directory,
+      final int maxSegmentSize,
+      final int maxEntrySize,
+      final long minFreeSpace,
+      final JournalIndex journalIndex) {
+    this.name = checkNotNull(name, "name cannot be null");
+    this.directory = checkNotNull(directory, "directory cannot be null");
+    this.maxSegmentSize = maxSegmentSize;
+    this.maxEntrySize = maxEntrySize;
+    journalMetrics = new JournalMetrics(name);
+    minFreeDiskSpace = minFreeSpace;
+    this.journalIndex = journalIndex;
+    open();
+    writer = new SegmentedJournalWriter(this);
+  }
+
+  /**
+   * Returns a new SegmentedJournal builder.
+   *
+   * @return A new Segmented journal builder.
+   */
+  public static SegmentedJournalBuilder builder() {
+    return new SegmentedJournalBuilder();
+  }
+
+  @Override
+  public JournalRecord append(final long asqn, final DirectBuffer data) {
+    return writer.append(asqn, data);
+  }
+
+  @Override
+  public JournalRecord append(final DirectBuffer data) {
+    return writer.append(ASQN_IGNORE, data);
+  }
+
+  @Override
+  public void append(final JournalRecord record) {
+    writer.append(record);
+  }
+
+  @Override
+  public void deleteAfter(final long indexExclusive) {
+    writer.deleteAfter(indexExclusive);
+  }
+
+  @Override
+  public void deleteUntil(final long index) {
+    final Map.Entry<Long, JournalSegment> segmentEntry = segments.floorEntry(index);
+    if (segmentEntry != null) {
+      final SortedMap<Long, JournalSegment> compactSegments =
+          segments.headMap(segmentEntry.getValue().index());
+      if (!compactSegments.isEmpty()) {
+        log.debug("{} - Compacting {} segment(s)", name, compactSegments.size());
+        for (final JournalSegment segment : compactSegments.values()) {
+          log.trace("Deleting segment: {}", segment);
+          segment.compactIndex(index);
+          segment.close();
+          segment.delete();
+          journalMetrics.decSegmentCount();
+        }
+        compactSegments.clear();
+      }
+      resetHead(getFirstSegment().index());
+    }
+  }
+
+  @Override
+  public void reset(final long nextIndex) {
+    writer.reset(nextIndex);
+  }
+
+  @Override
+  public long getLastIndex() {
+    return writer.getLastIndex();
+  }
+
+  @Override
+  public long getFirstIndex() {
+    if (!isEmpty()) {
+      return segments.firstEntry().getValue().index();
+    } else {
+      return 0;
+    }
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return writer.getNextIndex() - getFirstSegment().index() == 0;
+  }
+
+  @Override
+  public void flush() {
+    writer.flush();
+  }
+
+  @Override
+  public JournalReader openReader() {
+    final SegmentedJournalReader reader = new SegmentedJournalReader(this);
+    readers.add(reader);
+    return reader;
+  }
+
+  @Override
+  public boolean isOpen() {
+    return open;
+  }
+
+  @Override
+  public void close() {
+    segments
+        .values()
+        .forEach(
+            segment -> {
+              log.debug("Closing segment: {}", segment);
+              segment.close();
+            });
+    currentSegment = null;
+    open = false;
+  }
+
+  /** Opens the segments. */
+  private synchronized void open() {
+    final long startTime = System.currentTimeMillis();
+    // Load existing log segments from disk.
+    for (final JournalSegment segment : loadSegments()) {
+      segments.put(segment.descriptor().index(), segment);
+      journalMetrics.incSegmentCount();
+    }
+
+    // If a segment doesn't already exist, create an initial segment starting at index 1.
+    if (!segments.isEmpty()) {
+      currentSegment = segments.lastEntry().getValue();
+    } else {
+      final JournalSegmentDescriptor descriptor =
+          JournalSegmentDescriptor.builder()
+              .withId(FIRST_SEGMENT_ID)
+              .withIndex(INITIAL_INDEX)
+              .withMaxSegmentSize(maxSegmentSize)
+              .build();
+
+      currentSegment = createSegment(descriptor);
+      currentSegment.descriptor().update(System.currentTimeMillis());
+
+      segments.put(1L, currentSegment);
+      journalMetrics.incSegmentCount();
+    }
+    journalMetrics.observeJournalOpenDuration(System.currentTimeMillis() - startTime);
+  }
+
+  /**
+   * Asserts that the journal is open.
+   *
+   * @throws IllegalStateException if the journal is not open
+   */
+  private void assertOpen() {
+    checkState(currentSegment != null, "journal not open");
+  }
+
+  /** Asserts that enough disk space is available to allocate a new segment. */
+  private void assertDiskSpace() {
+    if (directory().getUsableSpace()
+        < Math.max(maxSegmentSize() * SEGMENT_BUFFER_FACTOR, minFreeDiskSpace)) {
+      throw new StorageException.OutOfDiskSpace(
+          "Not enough space to allocate a new journal segment");
+    }
+  }
+
+  private long maxSegmentSize() {
+    return maxSegmentSize;
+  }
+
+  private File directory() {
+    return directory;
+  }
+
+  /** Resets the current segment, creating a new segment if necessary. */
+  private synchronized void resetCurrentSegment() {
+    final JournalSegment lastSegment = getLastSegment();
+    if (lastSegment != null) {
+      currentSegment = lastSegment;
+    } else {
+      final JournalSegmentDescriptor descriptor =
+          JournalSegmentDescriptor.builder()
+              .withId(1)
+              .withIndex(1)
+              .withMaxSegmentSize(maxSegmentSize)
+              .build();
+
+      currentSegment = createSegment(descriptor);
+
+      segments.put(1L, currentSegment);
+      journalMetrics.incSegmentCount();
+    }
+  }
+
+  /**
+   * Resets and returns the first segment in the journal.
+   *
+   * @param index the starting index of the journal
+   * @return the first segment
+   */
+  JournalSegment resetSegments(final long index) {
+    assertOpen();
+
+    for (final JournalSegment segment : segments.values()) {
+      segment.close();
+      segment.delete();
+      journalMetrics.decSegmentCount();
+    }
+    segments.clear();
+
+    final JournalSegmentDescriptor descriptor =
+        JournalSegmentDescriptor.builder()
+            .withId(1)
+            .withIndex(index)
+            .withMaxSegmentSize(maxSegmentSize)
+            .build();
+    currentSegment = createSegment(descriptor);
+    segments.put(index, currentSegment);
+    journalMetrics.incSegmentCount();
+    return currentSegment;
+  }
+
+  /**
+   * Returns the first segment in the log.
+   *
+   * @throws IllegalStateException if the segment manager is not open
+   */
+  JournalSegment getFirstSegment() {
+    assertOpen();
+    final Map.Entry<Long, JournalSegment> segment = segments.firstEntry();
+    return segment != null ? segment.getValue() : null;
+  }
+
+  /**
+   * Returns the last segment in the log.
+   *
+   * @throws IllegalStateException if the segment manager is not open
+   */
+  JournalSegment getLastSegment() {
+    assertOpen();
+    final Map.Entry<Long, JournalSegment> segment = segments.lastEntry();
+    return segment != null ? segment.getValue() : null;
+  }
+
+  /**
+   * Creates and returns the next segment.
+   *
+   * @return The next segment.
+   * @throws IllegalStateException if the segment manager is not open
+   */
+  synchronized JournalSegment getNextSegment() {
+    assertOpen();
+    assertDiskSpace();
+
+    final JournalSegment lastSegment = getLastSegment();
+    final JournalSegmentDescriptor descriptor =
+        JournalSegmentDescriptor.builder()
+            .withId(lastSegment != null ? lastSegment.descriptor().id() + 1 : 1)
+            .withIndex(currentSegment.lastIndex() + 1)
+            .withMaxSegmentSize(maxSegmentSize)
+            .build();
+
+    currentSegment = createSegment(descriptor);
+
+    segments.put(descriptor.index(), currentSegment);
+    journalMetrics.incSegmentCount();
+    return currentSegment;
+  }
+
+  /**
+   * Returns the segment following the segment with the given ID.
+   *
+   * @param index The segment index with which to look up the next segment.
+   * @return The next segment for the given index.
+   */
+  JournalSegment getNextSegment(final long index) {
+    final Map.Entry<Long, JournalSegment> nextSegment = segments.higherEntry(index);
+    return nextSegment != null ? nextSegment.getValue() : null;
+  }
+
+  /**
+   * Returns the segment for the given index.
+   *
+   * @param index The index for which to return the segment.
+   * @throws IllegalStateException if the segment manager is not open
+   */
+  synchronized JournalSegment getSegment(final long index) {
+    assertOpen();
+    // Check if the current segment contains the given index first in order to prevent an
+    // unnecessary map lookup.
+    if (currentSegment != null && index > currentSegment.index()) {
+      return currentSegment;
+    }
+
+    // If the index is in another segment, get the entry with the next lowest first index.
+    final Map.Entry<Long, JournalSegment> segment = segments.floorEntry(index);
+    if (segment != null) {
+      return segment.getValue();
+    }
+    return getFirstSegment();
+  }
+
+  /**
+   * Removes a segment.
+   *
+   * @param segment The segment to remove.
+   */
+  synchronized void removeSegment(final JournalSegment segment) {
+    segments.remove(segment.index());
+    journalMetrics.decSegmentCount();
+    segment.close();
+    segment.delete();
+    resetCurrentSegment();
+  }
+
+  /** Creates a new segment. */
+  JournalSegment createSegment(final JournalSegmentDescriptor descriptor) {
+    final File segmentFile = JournalSegmentFile.createSegmentFile(name, directory, descriptor.id());
+
+    final RandomAccessFile raf;
+    final FileChannel channel;
+    try {
+      raf = new RandomAccessFile(segmentFile, "rw");
+      raf.setLength(descriptor.maxSegmentSize());
+      channel = raf.getChannel();
+    } catch (final IOException e) {
+      throw new StorageException(e);
+    }
+
+    final ByteBuffer buffer = ByteBuffer.allocate(JournalSegmentDescriptor.BYTES);
+    descriptor.copyTo(buffer);
+    buffer.flip();
+    try {
+      channel.write(buffer);
+    } catch (final IOException e) {
+      throw new StorageException(e);
+    } finally {
+      try {
+        channel.close();
+        raf.close();
+      } catch (final IOException e) {
+        log.warn("Unexpected IOException on closing", e);
+      }
+    }
+    final JournalSegment segment = newSegment(new JournalSegmentFile(segmentFile), descriptor);
+    log.debug("Created segment: {}", segment);
+    return segment;
+  }
+
+  /**
+   * Creates a new segment instance.
+   *
+   * @param segmentFile The segment file.
+   * @param descriptor The segment descriptor.
+   * @return The segment instance.
+   */
+  protected JournalSegment newSegment(
+      final JournalSegmentFile segmentFile, final JournalSegmentDescriptor descriptor) {
+    return new JournalSegment(segmentFile, descriptor, maxEntrySize, journalIndex);
+  }
+
+  /** Loads a segment. */
+  private JournalSegment loadSegment(final long segmentId) {
+    final File segmentFile = JournalSegmentFile.createSegmentFile(name, directory, segmentId);
+    final ByteBuffer buffer = ByteBuffer.allocate(JournalSegmentDescriptor.BYTES);
+    try (final FileChannel channel = openChannel(segmentFile)) {
+      channel.read(buffer);
+      buffer.flip();
+      final JournalSegmentDescriptor descriptor = new JournalSegmentDescriptor(buffer);
+      final JournalSegment segment = newSegment(new JournalSegmentFile(segmentFile), descriptor);
+      log.debug("Loaded disk segment: {} ({})", descriptor.id(), segmentFile.getName());
+      return segment;
+    } catch (final IOException e) {
+      throw new StorageException(e);
+    }
+  }
+
+  private FileChannel openChannel(final File file) {
+    try {
+      return FileChannel.open(
+          file.toPath(),
+          StandardOpenOption.CREATE,
+          StandardOpenOption.READ,
+          StandardOpenOption.WRITE);
+    } catch (final IOException e) {
+      throw new StorageException(e);
+    }
+  }
+
+  /**
+   * Loads all segments from disk.
+   *
+   * @return A collection of segments for the log.
+   */
+  protected Collection<JournalSegment> loadSegments() {
+    // Ensure log directories are created.
+    directory.mkdirs();
+
+    final TreeMap<Long, JournalSegment> segments = new TreeMap<>();
+
+    // Iterate through all files in the log directory.
+    for (final File file : directory.listFiles(File::isFile)) {
+
+      // If the file looks like a segment file, attempt to load the segment.
+      if (JournalSegmentFile.isSegmentFile(name, file)) {
+        final JournalSegmentFile segmentFile = new JournalSegmentFile(file);
+        final ByteBuffer buffer = ByteBuffer.allocate(JournalSegmentDescriptor.BYTES);
+        try (final FileChannel channel = openChannel(file)) {
+          channel.read(buffer);
+          buffer.flip();
+        } catch (final IOException e) {
+          throw new StorageException(e);
+        }
+
+        final JournalSegmentDescriptor descriptor = new JournalSegmentDescriptor(buffer);
+
+        // Load the segment.
+        final JournalSegment segment = loadSegment(descriptor.id());
+
+        // Add the segment to the segments list.
+        log.debug(
+            "Found segment: {} ({})", segment.descriptor().id(), segmentFile.file().getName());
+        segments.put(segment.index(), segment);
+      }
+    }
+
+    // Verify that all the segments in the log align with one another.
+    JournalSegment previousSegment = null;
+    boolean corrupted = false;
+    final Iterator<Entry<Long, JournalSegment>> iterator = segments.entrySet().iterator();
+    while (iterator.hasNext()) {
+      final JournalSegment segment = iterator.next().getValue();
+      if (previousSegment != null && previousSegment.lastIndex() != segment.index() - 1) {
+        log.warn(
+            "Journal is inconsistent. {} is not aligned with prior segment {}",
+            segment.file().file(),
+            previousSegment.file().file());
+        corrupted = true;
+      }
+      if (corrupted) {
+        segment.close();
+        segment.delete();
+        iterator.remove();
+      }
+      previousSegment = segment;
+    }
+
+    return segments.values();
+  }
+
+  public void closeReader(final SegmentedJournalReader segmentedJournalReader) {
+    readers.remove(segmentedJournalReader);
+  }
+
+  /**
+   * Resets journal readers to the given head.
+   *
+   * @param index The index at which to reset readers.
+   */
+  void resetHead(final long index) {
+    for (final SegmentedJournalReader reader : readers) {
+      if (reader.getNextIndex() <= index) {
+        reader.seek(index);
+      }
+    }
+  }
+
+  /**
+   * Resets journal readers to the given tail.
+   *
+   * @param index The index at which to reset readers.
+   */
+  void resetTail(final long index) {
+    for (final SegmentedJournalReader reader : readers) {
+      if (reader.getNextIndex() >= index) {
+        reader.seek(index);
+      } else {
+        // This is not thread safe https://github.com/zeebe-io/zeebe/issues/4198
+        reader.seek(reader.getNextIndex());
+      }
+    }
+  }
+
+  public JournalMetrics getJournalMetrics() {
+    return journalMetrics;
+  }
+
+  public JournalIndex getJournalIndex() {
+    return journalIndex;
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.File;
+
+/** Raft log builder. */
+public class SegmentedJournalBuilder {
+
+  private static final String DEFAULT_NAME = "journal";
+  private static final String DEFAULT_DIRECTORY = System.getProperty("user.dir");
+  private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
+  private static final int DEFAULT_MAX_ENTRY_SIZE = 1024 * 1024;
+  private static final long DEFAULT_MIN_FREE_DISK_SPACE = 1024L * 1024 * 1024 * 1;
+  protected String name = DEFAULT_NAME;
+  protected File directory = new File(DEFAULT_DIRECTORY);
+  protected int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
+  protected int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
+
+  private long freeDiskSpace = DEFAULT_MIN_FREE_DISK_SPACE;
+  private int journalIndexDensity = 100;
+
+  protected SegmentedJournalBuilder() {}
+
+  /**
+   * Sets the storage name.
+   *
+   * @param name The storage name.
+   * @return The storage builder.
+   */
+  public SegmentedJournalBuilder withName(final String name) {
+    this.name = checkNotNull(name, "name cannot be null");
+    return this;
+  }
+
+  /**
+   * Sets the journal directory, returning the builder for method chaining.
+   *
+   * <p>The journal will write segment files into the provided directory.
+   *
+   * @param directory The log directory.
+   * @return The storage builder.
+   * @throws NullPointerException If the {@code directory} is {@code null}
+   */
+  public SegmentedJournalBuilder withDirectory(final String directory) {
+    return withDirectory(new File(checkNotNull(directory, "directory cannot be null")));
+  }
+
+  /**
+   * Sets the journal directory, returning the builder for method chaining.
+   *
+   * <p>The journal will write segment files into the provided directory.
+   *
+   * @param directory The journal directory.
+   * @return The journal builder.
+   * @throws NullPointerException If the {@code directory} is {@code null}
+   */
+  public SegmentedJournalBuilder withDirectory(final File directory) {
+    this.directory = checkNotNull(directory, "directory cannot be null");
+    return this;
+  }
+
+  /**
+   * Sets the maximum segment size in bytes, returning the builder for method chaining.
+   *
+   * <p>The maximum segment size dictates when logs should roll over to new segments. As entries are
+   * written to a segment of the log, once the size of the segment surpasses the configured maximum
+   * segment size, the log will create a new segment and append new entries to that segment.
+   *
+   * <p>By default, the maximum segment size is {@code 1024 * 1024 * 32}.
+   *
+   * @param maxSegmentSize The maximum segment size in bytes.
+   * @return The journal builder.
+   * @throws IllegalArgumentException If the {@code maxSegmentSize} is not positive
+   */
+  public SegmentedJournalBuilder withMaxSegmentSize(final int maxSegmentSize) {
+    checkArgument(
+        maxSegmentSize > JournalSegmentDescriptor.BYTES,
+        "maxSegmentSize must be greater than " + JournalSegmentDescriptor.BYTES);
+    this.maxSegmentSize = maxSegmentSize;
+    return this;
+  }
+
+  /**
+   * Sets the maximum entry size in bytes, returning the builder for method chaining.
+   *
+   * @param maxEntrySize the maximum entry size in bytes
+   * @return the storage builder
+   * @throws IllegalArgumentException if the {@code maxEntrySize} is not positive
+   */
+  public SegmentedJournalBuilder withMaxEntrySize(final int maxEntrySize) {
+    checkArgument(maxEntrySize > 0, "maxEntrySize must be positive");
+    this.maxEntrySize = maxEntrySize;
+    return this;
+  }
+
+  /**
+   * Sets the minimum free disk space to leave when allocating a new segment
+   *
+   * @param freeDiskSpace free disk space in bytes
+   * @return the storage builder
+   * @throws IllegalArgumentException if the {@code freeDiskSpace} is not positive
+   */
+  public SegmentedJournalBuilder withFreeDiskSpace(final long freeDiskSpace) {
+    checkArgument(freeDiskSpace >= 0, "minFreeDiskSpace must be positive");
+    this.freeDiskSpace = freeDiskSpace;
+    return this;
+  }
+
+  public SegmentedJournalBuilder withJournalIndexDensity(final int journalIndexDensity) {
+    this.journalIndexDensity = journalIndexDensity;
+    return this;
+  }
+
+  public SegmentedJournal build() {
+    return new SegmentedJournal(
+        name,
+        directory,
+        maxSegmentSize,
+        maxEntrySize,
+        freeDiskSpace,
+        new SparseJournalIndex(journalIndexDensity));
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalReader.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalReader.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import io.zeebe.journal.JournalReader;
+import io.zeebe.journal.JournalRecord;
+import java.util.NoSuchElementException;
+
+class SegmentedJournalReader implements JournalReader {
+
+  private final SegmentedJournal journal;
+  private JournalSegment currentSegment;
+  private JournalRecord previousEntry;
+  private MappedJournalSegmentReader currentReader;
+
+  SegmentedJournalReader(final SegmentedJournal journal) {
+    this.journal = journal;
+    initialize();
+  }
+
+  /** Initializes the reader to the given index. */
+  private void initialize() {
+    currentSegment = journal.getFirstSegment();
+    currentReader = currentSegment.createReader();
+    final long nextIndex = journal.getFirstIndex();
+  }
+
+  public long getCurrentIndex() {
+    final long currentIndex = currentReader.getCurrentIndex();
+    if (currentIndex != 0) {
+      return currentIndex;
+    }
+    if (previousEntry != null) {
+      return previousEntry.index();
+    }
+    return 0;
+  }
+
+  public JournalRecord getCurrentEntry() {
+    final var currentEntry = currentReader.getCurrentEntry();
+    if (currentEntry != null) {
+      return currentEntry;
+    }
+    return previousEntry;
+  }
+
+  public long getNextIndex() {
+    return currentReader.getNextIndex();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return hasNextEntry();
+  }
+
+  @Override
+  public JournalRecord next() {
+    if (!currentReader.hasNext()) {
+      final JournalSegment nextSegment = journal.getNextSegment(currentSegment.index());
+      if (nextSegment != null && nextSegment.index() == getNextIndex()) {
+        previousEntry = currentReader.getCurrentEntry();
+        replaceCurrentSegment(nextSegment);
+        return currentReader.next();
+      } else {
+        throw new NoSuchElementException();
+      }
+    } else {
+      previousEntry = currentReader.getCurrentEntry();
+      return currentReader.next();
+    }
+  }
+
+  @Override
+  public boolean seek(final long index) {
+    // If the current segment is not open, it has been replaced. Reset the segments.
+    if (!currentSegment.isOpen()) {
+      seekToFirst();
+    }
+
+    if (index < currentReader.getNextIndex()) {
+      rewind(index);
+    } else if (index > currentReader.getNextIndex()) {
+      forward(index);
+    } else {
+      currentReader.seek(index);
+    }
+    return getNextIndex() == index;
+  }
+
+  @Override
+  public void seekToFirst() {
+    replaceCurrentSegment(journal.getFirstSegment());
+    previousEntry = null;
+  }
+
+  @Override
+  public void seekToLast() {
+    replaceCurrentSegment(journal.getLastSegment());
+    seek(journal.getLastIndex());
+  }
+
+  @Override
+  public boolean seekToAsqn(final long asqn) {
+    final var journalIndex = journal.getJournalIndex();
+    final var index = journalIndex.lookupAsqn(asqn);
+    if (index == null) {
+      // No index found - so seek to first
+      seekToFirst();
+    } else {
+      seek(index);
+    }
+
+    JournalRecord record = null;
+    while (hasNext()) {
+      final var currentRecord = next();
+      if (currentRecord.asqn() <= asqn) {
+        record = currentRecord;
+      } else if (currentRecord.asqn() >= asqn) {
+        break;
+      }
+    }
+    if (record != null && record.asqn() <= asqn) {
+      // This is needed so that the next() returns the correct record
+      // TODO: Remove the duplicate seek. https://github.com/zeebe-io/zeebe/issues/6223
+      return seek(record.index());
+    }
+    return false;
+  }
+
+  @Override
+  public void close() {
+    currentReader.close();
+    journal.closeReader(this);
+  }
+
+  /** Rewinds the journal to the given index. */
+  private void rewind(final long index) {
+    if (currentSegment.index() >= index) {
+      final JournalSegment segment = journal.getSegment(index - 1);
+      if (segment != null) {
+        replaceCurrentSegment(segment);
+      }
+    }
+
+    currentReader.seek(index);
+    previousEntry = currentReader.getCurrentEntry();
+  }
+
+  /** Fast forwards the journal to the given index. */
+  private void forward(final long index) {
+    // skip to the correct segment if there is one
+    if (!currentSegment.equals(journal.getLastSegment())) {
+      final JournalSegment segment = journal.getSegment(index);
+      if (segment != null && !segment.equals(currentSegment)) {
+        replaceCurrentSegment(segment);
+      }
+    }
+
+    while (getNextIndex() < index && hasNext()) {
+      next();
+    }
+  }
+
+  private boolean hasNextEntry() {
+    if (!currentReader.hasNext()) {
+      final JournalSegment nextSegment = journal.getNextSegment(currentSegment.index());
+      if (nextSegment != null && nextSegment.index() == getNextIndex()) {
+        previousEntry = currentReader.getCurrentEntry();
+        replaceCurrentSegment(nextSegment);
+        return currentReader.hasNext();
+      }
+      return false;
+    }
+    return true;
+  }
+
+  private void replaceCurrentSegment(final JournalSegment nextSegment) {
+    currentReader.close();
+    currentSegment = nextSegment;
+    currentReader = currentSegment.createReader();
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalWriter.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import io.zeebe.journal.JournalRecord;
+import java.nio.BufferOverflowException;
+import org.agrona.DirectBuffer;
+
+class SegmentedJournalWriter {
+  private final SegmentedJournal journal;
+  private final JournalMetrics journalMetrics;
+  private JournalSegment currentSegment;
+  private MappedJournalSegmentWriter currentWriter;
+
+  public SegmentedJournalWriter(final SegmentedJournal journal) {
+    this.journal = journal;
+    journalMetrics = journal.getJournalMetrics();
+    currentSegment = journal.getLastSegment();
+    currentWriter = currentSegment.writer();
+  }
+
+  public long getLastIndex() {
+    return currentWriter.getLastIndex();
+  }
+
+  public JournalRecord getLastEntry() {
+    return currentWriter.getLastEntry();
+  }
+
+  public long getNextIndex() {
+    return currentWriter.getNextIndex();
+  }
+
+  public JournalRecord append(final long asqn, final DirectBuffer data) {
+    try {
+      return currentWriter.append(asqn, data);
+    } catch (final BufferOverflowException e) {
+      if (currentSegment.index() == currentWriter.getNextIndex()) {
+        throw e;
+      }
+
+      journalMetrics.observeSegmentCreation(this::createNewSegment);
+
+      return currentWriter.append(asqn, data);
+    }
+  }
+
+  public void append(final JournalRecord record) {
+    try {
+      currentWriter.append(record);
+    } catch (final BufferOverflowException e) {
+      if (currentSegment.index() == currentWriter.getNextIndex()) {
+        throw e;
+      }
+
+      journalMetrics.observeSegmentCreation(this::createNewSegment);
+      currentWriter.append(record);
+    }
+  }
+
+  public void reset(final long index) {
+    currentSegment = journal.resetSegments(index);
+    currentWriter = currentSegment.writer();
+    journal.resetHead(index);
+  }
+
+  public void deleteAfter(final long index) {
+    journalMetrics.observeSegmentTruncation(
+        () -> {
+          // Delete all segments with first indexes greater than the given index.
+          while (index < currentSegment.index() && currentSegment != journal.getFirstSegment()) {
+            journal.removeSegment(currentSegment);
+            currentSegment = journal.getLastSegment();
+            currentWriter = currentSegment.writer();
+          }
+
+          // Truncate the current index.
+          currentWriter.truncate(index);
+
+          // Reset segment readers.
+          journal.resetTail(index + 1);
+        });
+  }
+
+  public void flush() {
+    journalMetrics.observeSegmentFlush(currentWriter::flush);
+  }
+
+  public void close() {
+    currentWriter.close();
+  }
+
+  private void createNewSegment() {
+    currentWriter.flush();
+    currentSegment = journal.getNextSegment();
+    currentWriter = currentSegment.writer();
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/SparseJournalIndex.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SparseJournalIndex.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import io.zeebe.journal.JournalRecord;
+import java.util.Map;
+import java.util.TreeMap;
+
+class SparseJournalIndex implements JournalIndex {
+
+  private final int density;
+  private final TreeMap<Long, Integer> indexToPosition = new TreeMap<>();
+  private final TreeMap<Long, Long> asqnToIndex = new TreeMap<>();
+  // This is added to make deleteAfter and deleteUntil easier.
+  // TODO: Check if this can be improved. https://github.com/zeebe-io/zeebe/issues/6220
+  private final TreeMap<Long, Long> indexToAsqn = new TreeMap<>();
+
+  public SparseJournalIndex(final int density) {
+    this.density = density;
+  }
+
+  @Override
+  public void index(final JournalRecord indexedEntry, final int position) {
+    final long index = indexedEntry.index();
+    if (index % density == 0) {
+      indexToPosition.put(index, position);
+      final long asqn = indexedEntry.asqn();
+      if (asqn != SegmentedJournal.ASQN_IGNORE) {
+        asqnToIndex.put(asqn, index);
+        indexToAsqn.put(index, asqn);
+      }
+    }
+  }
+
+  @Override
+  public IndexInfo lookup(final long index) {
+    final Map.Entry<Long, Integer> entry = indexToPosition.floorEntry(index);
+    return entry != null ? new IndexInfo(entry.getKey(), entry.getValue()) : null;
+  }
+
+  @Override
+  public Long lookupAsqn(final long asqn) {
+    final Map.Entry<Long, Long> entry = asqnToIndex.floorEntry(asqn);
+    return entry != null ? entry.getValue() : null;
+  }
+
+  @Override
+  public void deleteAfter(final long index) {
+    indexToPosition.tailMap(index, false).clear();
+    final var asqnEntryToDelete = indexToAsqn.ceilingEntry(index);
+    if (asqnEntryToDelete != null) {
+      final var asqnToDelete = asqnEntryToDelete.getValue();
+      indexToAsqn.tailMap(index, false).clear();
+      final boolean include = asqnEntryToDelete.getKey() > index;
+      asqnToIndex.tailMap(asqnToDelete, include).clear();
+    }
+  }
+
+  @Override
+  public void deleteUntil(final long index) {
+    indexToPosition.headMap(index, false).clear();
+
+    final var asqnEntryToDelete = indexToAsqn.floorEntry(index);
+    if (asqnEntryToDelete != null) {
+      final var asqnToDelete = asqnEntryToDelete.getValue();
+      indexToAsqn.headMap(index, false).clear();
+      asqnToIndex.headMap(asqnToDelete, false).clear();
+    }
+  }
+}

--- a/journal/src/test/java/io/zeebe/journal/file/JournalSegmentDescriptorTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/JournalSegmentDescriptorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.ByteBuffer;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Segment descriptor test.
+ *
+ * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
+ */
+public class JournalSegmentDescriptorTest {
+
+  /** Tests the segment descriptor builder. */
+  @Test
+  public void shouldBuildDescriptor() {
+    final JournalSegmentDescriptor descriptor =
+        JournalSegmentDescriptor.builder(ByteBuffer.allocate(JournalSegmentDescriptor.BYTES))
+            .withId(2)
+            .withIndex(1025)
+            .withMaxSegmentSize(1024 * 1024)
+            .build();
+
+    assertEquals(2, descriptor.id());
+    assertEquals(JournalSegmentDescriptor.VERSION, descriptor.version());
+    assertEquals(1025, descriptor.index());
+    assertEquals(1024 * 1024, descriptor.maxSegmentSize());
+
+    assertEquals(0, descriptor.updated());
+    final long time = System.currentTimeMillis();
+    descriptor.update(time);
+    assertEquals(time, descriptor.updated());
+  }
+
+  /** Tests copying the segment descriptor. */
+  @Test
+  public void shouldCopyDescriptor() {
+    JournalSegmentDescriptor descriptor =
+        JournalSegmentDescriptor.builder()
+            .withId(2)
+            .withIndex(1025)
+            .withMaxSegmentSize(1024 * 1024)
+            .build();
+
+    final long time = System.currentTimeMillis();
+    descriptor.update(time);
+
+    descriptor = descriptor.copyTo(ByteBuffer.allocate(JournalSegmentDescriptor.BYTES));
+
+    assertEquals(2, descriptor.id());
+    assertEquals(JournalSegmentDescriptor.VERSION, descriptor.version());
+    assertEquals(1025, descriptor.index());
+    assertEquals(1024 * 1024, descriptor.maxSegmentSize());
+    assertEquals(time, descriptor.updated());
+  }
+}

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.Namespaces;
+import io.zeebe.journal.JournalRecord;
+import io.zeebe.journal.StorageException.InvalidChecksum;
+import io.zeebe.journal.StorageException.InvalidIndex;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class SegmentedJournalTest {
+
+  @TempDir Path directory;
+  final DirectBuffer data = new UnsafeBuffer();
+  private SegmentedJournal journal;
+  private byte[] entry;
+  private int entriesPerSegment;
+
+  @BeforeEach
+  public void setup() {
+    final var namespace =
+        new Namespace.Builder()
+            .register(Namespaces.BASIC)
+            .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+            .register(PersistedJournalRecord.class)
+            .register(UnsafeBuffer.class)
+            .name("Journal")
+            .build();
+
+    entry = "TestData".getBytes();
+    data.wrap(entry);
+
+    final var entrySize =
+        namespace.serialize(new PersistedJournalRecord(1, 1, Integer.MAX_VALUE, data)).length
+            + Integer.BYTES;
+    entriesPerSegment = 10;
+
+    journal =
+        SegmentedJournal.builder()
+            .withDirectory(directory.resolve("data").toFile())
+            .withMaxSegmentSize(entriesPerSegment * entrySize + JournalSegmentDescriptor.BYTES)
+            .withJournalIndexDensity(5)
+            .build();
+  }
+
+  @Test
+  public void shouldBeEmpty() {
+    // when-then
+    assertThat(journal.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void shouldNotBeEmpty() {
+    // given
+    journal.append(1, data);
+
+    // when-then
+    assertThat(journal.isEmpty()).isFalse();
+  }
+
+  @Test
+  public void shouldAppendData() {
+    // when
+    final var recordAppended = journal.append(1, data);
+    assertThat(recordAppended.index()).isEqualTo(1);
+    assertThat(recordAppended.asqn()).isEqualTo(1);
+
+    // then
+    final var recordRead = journal.openReader().next();
+    assertThat(recordAppended.index()).isEqualTo(recordRead.index());
+    assertThat(recordAppended.asqn()).isEqualTo(recordRead.asqn());
+    assertThat(recordAppended.checksum()).isEqualTo(recordRead.checksum());
+  }
+
+  @Test
+  public void shouldAppendMultipleRecords() {
+    // when
+    for (int i = 0; i < 10; i++) {
+      final var recordAppended = journal.append(i + 10, data);
+      assertThat(recordAppended.index()).isEqualTo(i + 1);
+    }
+
+    // then
+    final var reader = journal.openReader();
+    for (int i = 0; i < 10; i++) {
+      assertThat(reader.hasNext()).isTrue();
+      final var recordRead = reader.next();
+      assertThat(recordRead.index()).isEqualTo(i + 1);
+      final byte[] data = new byte[recordRead.data().capacity()];
+      recordRead.data().getBytes(0, data);
+      assertThat(recordRead.asqn()).isEqualTo(i + 10);
+      assertThat(data).containsExactly(entry);
+    }
+  }
+
+  @Test
+  public void shouldAppendAndReadMultipleRecords() {
+    final var reader = journal.openReader();
+    for (int i = 0; i < 10; i++) {
+      // given
+      entry = ("TestData" + i).getBytes();
+      data.wrap(entry);
+
+      // when
+      final var recordAppended = journal.append(i + 10, data);
+      assertThat(recordAppended.index()).isEqualTo(i + 1);
+
+      // then
+      assertThat(reader.hasNext()).isTrue();
+      final var recordRead = reader.next();
+      assertThat(recordRead.index()).isEqualTo(i + 1);
+      final byte[] data = new byte[recordRead.data().capacity()];
+      recordRead.data().getBytes(0, data);
+      assertThat(recordRead.asqn()).isEqualTo(i + 10);
+      assertThat(data).containsExactly(entry);
+    }
+  }
+
+  @Test
+  public void shouldReset() {
+    // given
+    long asqn = 1;
+    assertThat(journal.getLastIndex()).isEqualTo(0);
+    journal.append(asqn++, data);
+    journal.append(asqn++, data);
+
+    // when
+    journal.reset(2);
+
+    // then
+    assertThat(journal.getLastIndex()).isEqualTo(1);
+    final var record = journal.append(asqn++, data);
+    assertThat(record.index()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldResetWhileReading() {
+    // given
+    final var reader = journal.openReader();
+    long asqn = 1;
+    assertThat(journal.getLastIndex()).isEqualTo(0);
+    journal.append(asqn++, data);
+    journal.append(asqn++, data);
+    final var record1 = reader.next();
+    assertThat(record1.index()).isEqualTo(1);
+
+    // when
+    journal.reset(2);
+
+    // then
+    assertThat(journal.getLastIndex()).isEqualTo(1);
+    final var record = journal.append(asqn++, data);
+    assertThat(record.index()).isEqualTo(2);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    final var record2 = reader.next();
+    assertThat(record2.index()).isEqualTo(2);
+    assertThat(record2.asqn()).isEqualTo(record.asqn());
+  }
+
+  @Test
+  public void shouldTruncate() {
+    // given
+    final var reader = journal.openReader();
+    assertThat(journal.getLastIndex()).isEqualTo(0);
+    journal.append(1, data);
+    journal.append(2, data);
+    journal.append(3, data);
+    final var record1 = reader.next();
+    assertThat(record1.index()).isEqualTo(1);
+
+    // when
+    journal.deleteAfter(2);
+
+    // then - should write after the truncated index
+    assertThat(journal.getLastIndex()).isEqualTo(2);
+    final var record = journal.append(4, data);
+    assertThat(record.index()).isEqualTo(3);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    final var record2 = reader.next();
+    assertThat(record2.index()).isEqualTo(2);
+    assertThat(record2.asqn()).isEqualTo(2);
+    assertThat(reader.hasNext()).isTrue();
+
+    // then - should not read truncated entry
+    final var record3 = reader.next();
+    assertThat(record3.index()).isEqualTo(3);
+    assertThat(record3.asqn()).isEqualTo(4);
+  }
+
+  @Test
+  public void shouldNotReadTruncatedEntries() {
+    // given
+    final int totalWrites = 10;
+    final int truncateIndex = 5;
+    int asqn = 1;
+    final Map<Integer, JournalRecord> written = new HashMap<>();
+
+    final var reader = journal.openReader();
+
+    int writerIndex;
+    for (writerIndex = 1; writerIndex <= totalWrites; writerIndex++) {
+      final var record = journal.append(asqn++, data);
+      assertThat(record.index()).isEqualTo(writerIndex);
+      written.put(writerIndex, record);
+    }
+
+    int readerIndex;
+    for (readerIndex = 1; readerIndex <= truncateIndex; readerIndex++) {
+      assertThat(reader.hasNext()).isTrue();
+      final var record = reader.next();
+      assertThat(record.index()).isEqualTo(readerIndex);
+      assertThat(record.asqn()).isEqualTo(written.get(readerIndex).asqn());
+    }
+
+    // when
+    journal.deleteAfter(truncateIndex);
+
+    for (writerIndex = truncateIndex + 1; writerIndex <= totalWrites; writerIndex++) {
+      final var record = journal.append(asqn++, data);
+      assertThat(record.index()).isEqualTo(writerIndex);
+      written.put(writerIndex, record);
+    }
+
+    for (; readerIndex <= totalWrites; readerIndex++) {
+      assertThat(reader.hasNext()).isTrue();
+      final var record = reader.next();
+      assertThat(record.index()).isEqualTo(readerIndex);
+      assertThat(record.asqn()).isEqualTo(written.get(readerIndex).asqn());
+    }
+  }
+
+  @Test
+  public void shouldReadAfterCompact() {
+    // given
+    final var reader = journal.openReader();
+    long asqn = 1;
+
+    for (int i = 1; i <= entriesPerSegment * 5; i++) {
+      assertThat(journal.append(asqn++, data).index()).isEqualTo(i);
+    }
+    assertThat(reader.hasNext()).isTrue();
+
+    // when - compact up to the first index of segment 3
+    final int indexToCompact = entriesPerSegment * 2 + 1;
+    journal.deleteUntil(indexToCompact);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    assertThat(reader.next().index()).isEqualTo(indexToCompact);
+  }
+
+  @Test
+  public void shouldSeekToIndex() {
+    // given
+    final var reader = journal.openReader();
+    long asqn = 1;
+    JournalRecord lastRecordWritten = null;
+    for (int i = 1; i <= entriesPerSegment * 2; i++) {
+      final JournalRecord record = journal.append(asqn++, data);
+      assertThat(record.index()).isEqualTo(i);
+      lastRecordWritten = record;
+    }
+    assertThat(reader.hasNext()).isTrue();
+
+    // when - compact up to the first index of segment 3
+    reader.seek(lastRecordWritten.index() - 1);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    assertThat(reader.next().index()).isEqualTo(lastRecordWritten.index() - 1);
+  }
+
+  @Test
+  public void shouldSeekToAsqn() {
+    // given
+    final var reader = journal.openReader();
+    long asqn = 10;
+    JournalRecord lastRecordWritten = null;
+    for (int i = 1; i <= entriesPerSegment * 2; i++) {
+      final JournalRecord record = journal.append(asqn++, data);
+      assertThat(record.index()).isEqualTo(i);
+      lastRecordWritten = record;
+    }
+    assertThat(reader.hasNext()).isTrue();
+
+    // when
+    reader.seekToAsqn(lastRecordWritten.asqn() - 2);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    assertThat(reader.next().asqn()).isEqualTo(lastRecordWritten.asqn() - 2);
+  }
+
+  @Test
+  public void shouldAppendJournalRecord() {
+    // given
+    final var receiverJournal =
+        SegmentedJournal.builder()
+            .withDirectory(directory.resolve("data-2").toFile())
+            .withJournalIndexDensity(5)
+            .build();
+    final var record = journal.append(10, data);
+
+    // when
+    receiverJournal.append(record);
+
+    // then
+    final var reader = receiverJournal.openReader();
+    assertThat(reader.hasNext()).isTrue();
+    assertThat(reader.next().asqn()).isEqualTo(10);
+  }
+
+  @Test
+  public void shouldNotAppendRecordWithInvalidIndex() {
+    // given
+    final var receiverJournal =
+        SegmentedJournal.builder()
+            .withDirectory(directory.resolve("data-2").toFile())
+            .withJournalIndexDensity(5)
+            .build();
+    final var record = journal.append(1, data);
+    receiverJournal.append(record);
+
+    // when
+    final var invalidIndexRecord = record;
+
+    // then
+    assertThatThrownBy(() -> receiverJournal.append(invalidIndexRecord))
+        .isInstanceOf(InvalidIndex.class);
+  }
+
+  @Test
+  public void shouldNotAppendRecordWithInvalidChecksum() {
+    // given
+    final var receiverJournal =
+        SegmentedJournal.builder()
+            .withDirectory(directory.resolve("data-2").toFile())
+            .withJournalIndexDensity(5)
+            .build();
+    final var record = journal.append(1, data);
+
+    // when
+    final var invalidChecksumRecord =
+        new PersistedJournalRecord(record.index(), record.asqn(), -1, record.data());
+
+    // then
+    assertThatThrownBy(() -> receiverJournal.append(invalidChecksumRecord))
+        .isInstanceOf(InvalidChecksum.class);
+  }
+}

--- a/journal/src/test/java/io/zeebe/journal/file/SparseJournalIndexTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SparseJournalIndexTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.zeebe.journal.JournalRecord;
+import org.junit.jupiter.api.Test;
+
+/** Sparse journal index test. */
+public class SparseJournalIndexTest {
+
+  @Test
+  public void shouldNotFindIndexWhenNotReachedDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+
+    // when
+    final IndexInfo position = index.lookup(1);
+
+    // then
+    assertNull(position);
+  }
+
+  public static JournalRecord asJournalRecord(final long index, final long asqn) {
+    return new PersistedJournalRecord(index, asqn, 0, null);
+  }
+
+  @Test
+  public void shouldFindIndexWhenReachedDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+
+    // when
+    index.index(asJournalRecord(1, 1), 2);
+    index.index(asJournalRecord(2, 2), 4);
+    index.index(asJournalRecord(3, 3), 6);
+    index.index(asJournalRecord(4, 4), 8);
+    index.index(asJournalRecord(5, 5), 10);
+
+    // then
+    assertEquals(5, index.lookup(5).index());
+    assertEquals(10, index.lookup(5).position());
+  }
+
+  @Test
+  public void shouldFindLowerIndexWhenNotReachedDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    // index entries
+    index.index(asJournalRecord(1, 1), 2);
+    index.index(asJournalRecord(2, 2), 4);
+    index.index(asJournalRecord(3, 3), 6);
+    index.index(asJournalRecord(4, 4), 8);
+    index.index(asJournalRecord(5, 5), 10);
+
+    // when
+    index.index(asJournalRecord(6, 6), 12);
+    index.index(asJournalRecord(7, 7), 14);
+    index.index(asJournalRecord(8, 8), 16);
+
+    // then
+    assertEquals(5, index.lookup(8).index());
+    assertEquals(10, index.lookup(8).position());
+  }
+
+  @Test
+  public void shouldFindNextIndexWhenReachedDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    // index entries
+    index.index(asJournalRecord(1, 1), 2);
+    index.index(asJournalRecord(2, 2), 4);
+    index.index(asJournalRecord(3, 3), 6);
+    index.index(asJournalRecord(4, 4), 8);
+    index.index(asJournalRecord(5, 5), 10);
+    index.index(asJournalRecord(6, 6), 12);
+    index.index(asJournalRecord(7, 7), 14);
+    index.index(asJournalRecord(8, 8), 16);
+
+    // when
+    index.index(asJournalRecord(9, 9), 18);
+    index.index(asJournalRecord(10, 10), 20);
+
+    // then
+    assertEquals(10, index.lookup(10).index());
+    assertEquals(20, index.lookup(10).position());
+  }
+
+  @Test
+  public void shouldTruncateIndex() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    // index entries
+    index.index(asJournalRecord(1, 10), 2);
+    index.index(asJournalRecord(2, 20), 4);
+    index.index(asJournalRecord(3, 30), 6);
+    index.index(asJournalRecord(4, 40), 8);
+    index.index(asJournalRecord(5, 50), 10);
+    index.index(asJournalRecord(6, 60), 12);
+    index.index(asJournalRecord(7, 70), 14);
+    index.index(asJournalRecord(8, 80), 16);
+    index.index(asJournalRecord(9, 90), 18);
+    index.index(asJournalRecord(10, 100), 20);
+
+    // when
+    index.deleteAfter(8);
+
+    // then
+    assertEquals(5, index.lookup(8).index());
+    assertEquals(10, index.lookup(8).position());
+    assertEquals(5, index.lookup(10).index());
+    assertEquals(10, index.lookup(10).position());
+    assertEquals(5, index.lookupAsqn(80));
+    assertEquals(5, index.lookupAsqn(90));
+  }
+
+  @Test
+  public void shouldTruncateCompleteIndex() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    // index entries
+    index.index(asJournalRecord(1, 10), 2);
+    index.index(asJournalRecord(2, 20), 4);
+    index.index(asJournalRecord(3, 30), 6);
+    index.index(asJournalRecord(4, 40), 8);
+    index.index(asJournalRecord(5, 50), 10);
+    index.index(asJournalRecord(6, 60), 12);
+    index.index(asJournalRecord(7, 70), 14);
+    index.index(asJournalRecord(8, 80), 16);
+    index.index(asJournalRecord(9, 90), 18);
+    index.index(asJournalRecord(10, 100), 20);
+    index.deleteAfter(8);
+
+    // when
+    index.deleteAfter(4);
+
+    // then
+    assertNull(index.lookup(4));
+    assertNull(index.lookup(5));
+    assertNull(index.lookup(8));
+    assertNull(index.lookup(10));
+    assertNull(index.lookupAsqn(40));
+    assertNull(index.lookupAsqn(50));
+    assertNull(index.lookupAsqn(80));
+    assertNull(index.lookupAsqn(100));
+  }
+
+  @Test
+  public void shouldNotCompactIndex() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    // index entries
+    index.index(asJournalRecord(1, 10), 2);
+    index.index(asJournalRecord(2, 20), 4);
+    index.index(asJournalRecord(3, 30), 6);
+    index.index(asJournalRecord(4, 40), 8);
+    index.index(asJournalRecord(5, 50), 10);
+    index.index(asJournalRecord(6, 60), 12);
+    index.index(asJournalRecord(7, 70), 14);
+    index.index(asJournalRecord(8, 80), 16);
+    index.index(asJournalRecord(9, 90), 18);
+    index.index(asJournalRecord(10, 100), 20);
+
+    // when
+    index.deleteUntil(8);
+
+    // then
+    assertNull(index.lookup(8));
+    assertEquals(10, index.lookup(10).index());
+    assertEquals(20, index.lookup(10).position());
+  }
+
+  @Test
+  public void shouldCompactIndex() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    // index entries
+    index.index(asJournalRecord(1, 10), 2);
+    index.index(asJournalRecord(2, 20), 4);
+    index.index(asJournalRecord(3, 30), 6);
+    index.index(asJournalRecord(4, 40), 8);
+    index.index(asJournalRecord(5, 50), 10);
+    index.index(asJournalRecord(6, 60), 12);
+    index.index(asJournalRecord(7, 70), 14);
+    index.index(asJournalRecord(8, 80), 16);
+    index.index(asJournalRecord(9, 90), 18);
+    index.index(asJournalRecord(10, 100), 20);
+    // when
+    index.deleteUntil(11);
+
+    // then
+    assertNull(index.lookup(4));
+    assertNull(index.lookup(5));
+    assertNull(index.lookup(8));
+    assertNull(index.lookupAsqn(40));
+    assertNull(index.lookupAsqn(50));
+    assertNull(index.lookupAsqn(80));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <module>expression-language</module>
     <module>snapshot</module>
     <module>benchmarks/project</module>
+    <module>journal</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
## Description

A new module for journal is added. It introduces a new API.
The module also includes a file based journal implementation. It is mostly the existing implementation from io.atomix.storage.journal.SegmentedJournal. Some changes necessary to incorporate the new API is done. The new changes are not always the optimal way of implementing them. Follow up issues are created to improve the new implementation.

PS:- This new module is not yet used by Raft.

## Related issues

closes #6146 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
