### PR TITLE
fix(broker): use correct address for binding and advertising

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingService.java
@@ -18,6 +18,7 @@ package io.atomix.cluster.messaging;
 
 import io.atomix.utils.net.Address;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
@@ -27,11 +28,19 @@ import java.util.function.BiFunction;
 public interface MessagingService {
 
   /**
-   * Returns the local messaging service address.
+   * Returns the local messaging service address. This is the address used by other nodes to
+   * communicate to this service.
    *
-   * @return the local address
+   * @return the address remote nodes use to communicate to this node
    */
   Address address();
+
+  /**
+   * Returns the interfaces to which the local messaging service is bind.
+   *
+   * @return the address the messaging service is bound to
+   */
+  Collection<Address> bindingAddresses();
 
   /**
    * Sends a message asynchronously to the specified communication address. The message is specified

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -19,7 +19,6 @@ package io.atomix.cluster.messaging.impl;
 import static io.atomix.utils.concurrent.Threads.namedThreads;
 
 import com.google.common.base.Throwables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.atomix.cluster.messaging.ManagedMessagingService;
@@ -52,6 +51,8 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.Future;
 import java.net.InetAddress;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +70,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,9 +78,9 @@ import org.slf4j.LoggerFactory;
 public class NettyMessagingService implements ManagedMessagingService {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
-  private final Address returnAddress;
+  private final Address advertisedAddress;
+  private final Collection<Address> bindingAddresses = new ArrayList<>();
   private final int preamble;
-  private final MessagingConfig config;
   private final ProtocolVersion protocolVersion;
   private final AtomicBoolean started = new AtomicBoolean(false);
   private final HandlerRegistry handlers = new HandlerRegistry();
@@ -95,33 +97,52 @@ public class NettyMessagingService implements ManagedMessagingService {
   private final List<CompletableFuture> openFutures;
 
   public NettyMessagingService(
-      final String cluster, final Address address, final MessagingConfig config) {
-    this(cluster, address, config, ProtocolVersion.latest());
+      final String cluster, final Address advertisedAddress, final MessagingConfig config) {
+    this(cluster, advertisedAddress, config, ProtocolVersion.latest());
   }
 
   NettyMessagingService(
       final String cluster,
-      final Address address,
+      final Address advertisedAddress,
       final MessagingConfig config,
       final ProtocolVersion protocolVersion) {
     preamble = cluster.hashCode();
-    returnAddress = address;
-    this.config = config;
+    this.advertisedAddress = advertisedAddress;
     this.protocolVersion = protocolVersion;
     openFutures = new CopyOnWriteArrayList<>();
     channelPool = new ChannelPool(this::openChannel, config.getConnectionPoolSize());
+    initAddresses(config);
+  }
+
+  private void initAddresses(final MessagingConfig config) {
+    final int port = config.getPort() != null ? config.getPort() : advertisedAddress.port();
+    if (config.getInterfaces().isEmpty()) {
+      bindingAddresses.add(Address.from(advertisedAddress.host(), port));
+    } else {
+      final List<Address> addresses =
+          config.getInterfaces().stream()
+              .map(iface -> Address.from(iface, port))
+              .collect(Collectors.toList());
+      bindingAddresses.addAll(addresses);
+    }
   }
 
   @Override
   public Address address() {
-    return returnAddress;
+    return advertisedAddress;
+  }
+
+  @Override
+  public Collection<Address> bindingAddresses() {
+    return bindingAddresses;
   }
 
   @Override
   public CompletableFuture<Void> sendAsync(
       final Address address, final String type, final byte[] payload, final boolean keepAlive) {
     final long messageId = messageIdGenerator.incrementAndGet();
-    final ProtocolRequest message = new ProtocolRequest(messageId, returnAddress, type, payload);
+    final ProtocolRequest message =
+        new ProtocolRequest(messageId, advertisedAddress, type, payload);
     return executeOnPooledConnection(
         address, type, c -> c.sendAsync(message), MoreExecutors.directExecutor());
   }
@@ -167,7 +188,8 @@ public class NettyMessagingService implements ManagedMessagingService {
     }
 
     final long messageId = messageIdGenerator.incrementAndGet();
-    final ProtocolRequest message = new ProtocolRequest(messageId, returnAddress, type, payload);
+    final ProtocolRequest message =
+        new ProtocolRequest(messageId, advertisedAddress, type, payload);
     if (keepAlive) {
       return executeOnPooledConnection(
           address, type, c -> c.sendAndReceive(message, timeout), executor);
@@ -237,7 +259,7 @@ public class NettyMessagingService implements ManagedMessagingService {
   @Override
   public CompletableFuture<MessagingService> start() {
     if (started.get()) {
-      log.warn("Already running at local address: {}", returnAddress);
+      log.warn("Already running at local address: {}", advertisedAddress);
       return CompletableFuture.completedFuture(this);
     }
 
@@ -370,7 +392,7 @@ public class NettyMessagingService implements ManagedMessagingService {
       final Function<ClientConnection, CompletableFuture<T>> callback,
       final Executor executor,
       final CompletableFuture<T> future) {
-    if (address.equals(returnAddress)) {
+    if (address.equals(advertisedAddress)) {
       callback
           .apply(localConnection)
           .whenComplete(
@@ -435,7 +457,7 @@ public class NettyMessagingService implements ManagedMessagingService {
       final Function<ClientConnection, CompletableFuture<T>> callback,
       final Executor executor) {
     final CompletableFuture<T> future = new CompletableFuture<>();
-    if (address.equals(returnAddress)) {
+    if (address.equals(advertisedAddress)) {
       callback
           .apply(localConnection)
           .whenComplete(
@@ -574,12 +596,9 @@ public class NettyMessagingService implements ManagedMessagingService {
    */
   private CompletableFuture<Void> bind(final ServerBootstrap bootstrap) {
     final CompletableFuture<Void> future = new CompletableFuture<>();
-    final int port = config.getPort() != null ? config.getPort() : returnAddress.port();
-    if (config.getInterfaces().isEmpty()) {
-      bind(bootstrap, Lists.newArrayList("0.0.0.0").iterator(), port, future);
-    } else {
-      bind(bootstrap, config.getInterfaces().iterator(), port, future);
-    }
+
+    bind(bootstrap, bindingAddresses.iterator(), future);
+
     return future;
   }
 
@@ -587,33 +606,28 @@ public class NettyMessagingService implements ManagedMessagingService {
    * Recursively binds the given bootstrap to the given interfaces.
    *
    * @param bootstrap the bootstrap to bind
-   * @param ifaces an iterator of interfaces to which to bind
-   * @param port the port to which to bind
+   * @param addressIterator an iterator of Addresses to which to bind
    * @param future the future to completed once the bootstrap has been bound to all provided
    *     interfaces
    */
   private void bind(
       final ServerBootstrap bootstrap,
-      final Iterator<String> ifaces,
-      final int port,
+      final Iterator<Address> addressIterator,
       final CompletableFuture<Void> future) {
-    if (ifaces.hasNext()) {
-      final String iface = ifaces.next();
+    if (addressIterator.hasNext()) {
+      final Address address = addressIterator.next();
       bootstrap
-          .bind(iface, port)
+          .bind(address.host(), address.port())
           .addListener(
               (ChannelFutureListener)
                   f -> {
                     if (f.isSuccess()) {
-                      log.info("TCP server listening for connections on {}:{}", iface, port);
+                      log.info("TCP server listening for connections on {}", address);
                       serverChannel = f.channel();
-                      bind(bootstrap, ifaces, port, future);
+                      bind(bootstrap, addressIterator, future);
                     } else {
                       log.warn(
-                          "Failed to bind TCP server to port {}:{} due to {}",
-                          iface,
-                          port,
-                          f.cause());
+                          "Failed to bind TCP server to port {} due to {}", address, f.cause());
                       future.completeExceptionally(f.cause());
                     }
                   });
@@ -695,7 +709,7 @@ public class NettyMessagingService implements ManagedMessagingService {
         final ChannelHandlerContext context,
         final Connection<M> connection,
         final ProtocolVersion protocolVersion) {
-      final MessagingProtocol protocol = protocolVersion.createProtocol(returnAddress);
+      final MessagingProtocol protocol = protocolVersion.createProtocol(advertisedAddress);
       context.pipeline().remove(this);
       context.pipeline().addLast("encoder", protocol.newEncoder());
       context.pipeline().addLast("decoder", protocol.newDecoder());

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -29,11 +29,13 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.atomix.cluster.messaging.MessagingConfig;
+import io.atomix.cluster.messaging.MessagingService;
 import io.atomix.utils.net.Address;
 import io.zeebe.test.util.socket.SocketUtil;
 import java.net.ConnectException;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -69,6 +71,7 @@ public class NettyMessagingServiceTest {
   Address addressv21;
   Address addressv22;
   Address invalidAddress;
+  private MessagingService messagingService;
 
   @Before
   public void setUp() throws Exception {
@@ -423,5 +426,23 @@ public class NettyMessagingServiceTest {
     nettyv22.registerHandler(subject, (address, bytes) -> CompletableFuture.completedFuture(bytes));
     response = nettyv12.sendAndReceive(addressv22, subject, payload).get(10, TimeUnit.SECONDS);
     assertArrayEquals(payload, response);
+  }
+
+  @Test
+  public void shouldNotBindToAdvertisedAddress() {
+    // given
+    final var bindingAddress = Address.from(SocketUtil.getNextAddress().getPort());
+    final MessagingConfig config = new MessagingConfig();
+    config.setInterfaces(List.of(bindingAddress.host()));
+    config.setPort(bindingAddress.port());
+
+    // when
+    final Address nonBindableAddress = new Address("invalid.host", 1);
+    final var startFuture = new NettyMessagingService("test", nonBindableAddress, config).start();
+
+    // then - should not fail by using advertisedAddress for binding
+    messagingService = startFuture.join();
+    assertThat(messagingService.bindingAddresses()).contains(bindingAddress);
+    assertThat(messagingService.address()).isEqualTo(nonBindableAddress);
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestMessagingService.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestMessagingService.java
@@ -27,6 +27,8 @@ import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.net.Address;
 import java.net.ConnectException;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -96,6 +98,11 @@ public class TestMessagingService implements ManagedMessagingService {
   @Override
   public Address address() {
     return address;
+  }
+
+  @Override
+  public Collection<Address> bindingAddresses() {
+    return List.of(address);
   }
 
   @Override

--- a/atomix/core/src/test/java/io/atomix/core/test/messaging/TestMessagingService.java
+++ b/atomix/core/src/test/java/io/atomix/core/test/messaging/TestMessagingService.java
@@ -27,6 +27,8 @@ import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.net.Address;
 import java.net.ConnectException;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -96,6 +98,11 @@ public class TestMessagingService implements ManagedMessagingService {
   @Override
   public Address address() {
     return address;
+  }
+
+  @Override
+  public Collection<Address> bindingAddresses() {
+    return List.of(address);
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -8,6 +8,7 @@
 package io.zeebe.broker;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.messaging.impl.NettyMessagingService;
 import io.atomix.core.Atomix;
@@ -32,6 +33,7 @@ import io.zeebe.broker.system.configuration.BrokerCfg;
 import io.zeebe.broker.system.configuration.ClusterCfg;
 import io.zeebe.broker.system.configuration.DataCfg;
 import io.zeebe.broker.system.configuration.NetworkCfg;
+import io.zeebe.broker.system.configuration.SocketBindingCfg;
 import io.zeebe.broker.system.configuration.backpressure.BackpressureCfg;
 import io.zeebe.broker.system.management.BrokerAdminService;
 import io.zeebe.broker.system.management.BrokerAdminServiceImpl;
@@ -206,7 +208,10 @@ public final class Broker implements AutoCloseable {
     startContext.addStep("actor scheduler", this::actorSchedulerStep);
     startContext.addStep("membership and replication protocol", () -> atomixCreateStep(brokerCfg));
     startContext.addStep(
-        "command api transport", () -> commandApiTransportStep(clusterCfg, localBroker));
+        "command api transport",
+        () ->
+            commandApiTransportStep(
+                clusterCfg, brokerCfg.getNetwork().getCommandApi(), localBroker));
     startContext.addStep(
         "command api handler", () -> commandApiHandlerStep(brokerCfg, localBroker));
     startContext.addStep("subscription api", () -> subscriptionAPIStep(localBroker));
@@ -273,25 +278,35 @@ public final class Broker implements AutoCloseable {
   }
 
   private AutoCloseable commandApiTransportStep(
-      final ClusterCfg clusterCfg, final BrokerInfo localBroker) {
-
-    final var nettyMessagingService =
-        new NettyMessagingService(
-            clusterCfg.getClusterName(),
-            Address.from(localBroker.getCommandApiAddress()),
-            new MessagingConfig());
-
-    nettyMessagingService.start().join();
-    LOG.debug("Bound command API to {} ", nettyMessagingService.address());
+      final ClusterCfg clusterCfg,
+      final SocketBindingCfg commpandApiConfig,
+      final BrokerInfo localBroker) {
+    final var messagingService = createMessagingService(clusterCfg, commpandApiConfig);
+    messagingService.start().join();
+    LOG.debug(
+        "Bound command API to {}, using advertised address {} ",
+        messagingService.bindingAddresses(),
+        messagingService.address());
 
     final var transportFactory = new TransportFactory(scheduler);
     serverTransport =
-        transportFactory.createServerTransport(localBroker.getNodeId(), nettyMessagingService);
+        transportFactory.createServerTransport(localBroker.getNodeId(), messagingService);
 
     return () -> {
       serverTransport.close();
-      nettyMessagingService.stop().join();
+      messagingService.stop().join();
     };
+  }
+
+  private ManagedMessagingService createMessagingService(
+      final ClusterCfg clusterCfg, final SocketBindingCfg socketCfg) {
+    final var messagingConfig = new MessagingConfig();
+    messagingConfig.setInterfaces(List.of(socketCfg.getHost()));
+    messagingConfig.setPort(socketCfg.getPort());
+    return new NettyMessagingService(
+        clusterCfg.getClusterName(),
+        Address.from(socketCfg.getAdvertisedHost(), socketCfg.getAdvertisedPort()),
+        messagingConfig);
   }
 
   private AutoCloseable commandApiHandlerStep(

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -71,6 +71,8 @@ public final class AtomixFactory {
             .withClusterId(clusterCfg.getClusterName())
             .withMemberId(localMemberId)
             .withMembershipProtocol(membershipProtocol)
+            .withMessagingInterface(networkCfg.getInternalApi().getHost())
+            .withMessagingPort(networkCfg.getInternalApi().getPort())
             .withAddress(
                 Address.from(
                     networkCfg.getInternalApi().getAdvertisedHost(),

--- a/dist/src/main/config/log4j2.xml
+++ b/dist/src/main/config/log4j2.xml
@@ -3,9 +3,13 @@
 
   <Properties>
     <Property name="log.path">${sys:app.home}/logs</Property>
-    <Property name="log.pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n</Property>
-    <Property name="log.stackdriver.serviceName">${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-}</Property>
-    <Property name="log.stackdriver.serviceVersion">${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-}</Property>
+    <Property name="log.pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{actor-name}] [%t] %-5level
+      %logger{36} - %msg%n
+    </Property>
+    <Property name="log.stackdriver.serviceName">${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-}
+    </Property>
+    <Property name="log.stackdriver.serviceVersion">${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-}
+    </Property>
   </Properties>
 
   <Appenders>
@@ -16,7 +20,7 @@
 
     <Console name="Stackdriver" target="SYSTEM_OUT">
       <StackdriverLayout serviceName="${log.stackdriver.serviceName}"
-        serviceVersion="${log.stackdriver.serviceVersion}" />
+        serviceVersion="${log.stackdriver.serviceVersion}"/>
     </Console>
 
     <RollingFile name="RollingFile" fileName="${log.path}/zeebe.log"

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -574,6 +574,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>toxiproxy</artifactId>
+        <version>${version.testcontainers}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.github.docker-java</groupId>
         <artifactId>docker-java-api</artifactId>
         <version>${version.docker-java-api}</version>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -130,6 +130,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>toxiproxy</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-protocol-asserts</artifactId>
       <scope>test</scope>

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/network/AdvertisedAddressTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/network/AdvertisedAddressTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.it.network;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.ZeebeClientBuilder;
+import io.zeebe.client.api.response.Topology;
+import io.zeebe.containers.ZeebeBrokerContainer;
+import io.zeebe.containers.ZeebeGatewayContainer;
+import io.zeebe.containers.ZeebePort;
+import io.zeebe.containers.ZeebeTopologyWaitStrategy;
+import io.zeebe.test.util.asserts.TopologyAssert;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Use ToxiProxy. Even though it does not support UDP, we can still use ToxiProxy because only
+ * "gossip" messages use UDP. SWIM has other messages to probe and sync that uses TCP. So the
+ * brokers can still find each other.
+ */
+public class AdvertisedAddressTest {
+  private static final String TOXIPROXY_NETWORK_ALIAS = "toxiproxy";
+  private static final String TOXIPROXY_IMAGE = "shopify/toxiproxy:2.1.0";
+  private static final int CLUSTER_SIZE = 3;
+  private static final int PARTITION_COUNT = 1;
+  private static final int REPLICATION_FACTOR = 3;
+  private static final String ZEEBE_IMAGE_VERSION = "camunda/zeebe:current-test";
+  @Rule public final Network network = Network.newNetwork();
+
+  @Rule
+  public final ToxiproxyContainer toxiproxy =
+      new ToxiproxyContainer(DockerImageName.parse(TOXIPROXY_IMAGE))
+          .withNetwork(network)
+          .withNetworkAliases(TOXIPROXY_NETWORK_ALIAS);
+
+  private List<ZeebeBrokerContainer> containers;
+  private List<String> initialContactPoints;
+  private ZeebeGatewayContainer gateway;
+
+  @Before
+  public void setup() {
+    initialContactPoints = new ArrayList<>();
+    containers =
+        IntStream.range(0, CLUSTER_SIZE)
+            .mapToObj(i -> new ZeebeBrokerContainer(ZEEBE_IMAGE_VERSION))
+            .collect(Collectors.toList());
+
+    gateway = new ZeebeGatewayContainer(ZEEBE_IMAGE_VERSION);
+    IntStream.range(0, CLUSTER_SIZE).forEach(i -> configureBrokerContainer(i, containers));
+    configureGatewayContainer(gateway, initialContactPoints.get(0));
+  }
+
+  @After
+  public void tearDown() {
+    containers.parallelStream().forEach(GenericContainer::stop);
+  }
+
+  @Test
+  public void shouldCommunicateOverProxy() {
+    // given
+    containers.parallelStream().forEach(GenericContainer::start);
+    gateway.start();
+
+    // when
+    final ZeebeClientBuilder zeebeClientBuilder =
+        ZeebeClient.newClientBuilder()
+            .usePlaintext()
+            .gatewayAddress(gateway.getExternalGatewayAddress());
+    final Topology topology;
+    try (final var client = zeebeClientBuilder.build()) {
+      topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
+      // then - can find each other
+      TopologyAssert.assertThat(topology).isComplete(3, 1);
+
+      // when
+      final var messageSend =
+          client
+              .newPublishMessageCommand()
+              .messageName("test")
+              .correlationKey("test")
+              .send()
+              .join(5, TimeUnit.SECONDS);
+      // then - gateway can talk to the broker
+      assertThat(messageSend.getMessageKey()).isPositive();
+    }
+  }
+
+  private void configureBrokerContainer(final int index, final List<ZeebeBrokerContainer> brokers) {
+    final int clusterSize = brokers.size();
+    final var broker = brokers.get(index);
+    final var hostName = "broker-" + index;
+    final var commandApiProxy = toxiproxy.getProxy(hostName, ZeebePort.COMMAND.getPort());
+    final var internalApiProxy = toxiproxy.getProxy(hostName, ZeebePort.INTERNAL.getPort());
+    final var monitoringApiProxy = toxiproxy.getProxy(hostName, ZeebePort.MONITORING.getPort());
+
+    initialContactPoints.add(
+        TOXIPROXY_NETWORK_ALIAS + ":" + internalApiProxy.getOriginalProxyPort());
+
+    LoggerFactory.getLogger("Test")
+        .info("Configuring broker with initial contactpoints {}", initialContactPoints);
+
+    broker
+        .withNetwork(network)
+        .withNetworkAliases(hostName)
+        .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "128KB")
+        .withEnv("ZEEBE_BROKER_CLUSTER_NODEID", String.valueOf(index))
+        .withEnv("ZEEBE_BROKER_CLUSTER_CLUSTERSIZE", String.valueOf(clusterSize))
+        .withEnv("ZEEBE_BROKER_CLUSTER_REPLICATIONFACTOR", String.valueOf(REPLICATION_FACTOR))
+        .withEnv("ZEEBE_BROKER_CLUSTER_PARTITIONCOUNT", String.valueOf(PARTITION_COUNT))
+        .withEnv(
+            "ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS", String.join(",", initialContactPoints))
+        .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
+        .withEnv("ATOMIX_LOG_LEVEL", "INFO")
+        .withEnv("ZEEBE_BROKER_NETWORK_COMMANDAPI_ADVERTISEDHOST", TOXIPROXY_NETWORK_ALIAS)
+        .withEnv(
+            "ZEEBE_BROKER_NETWORK_COMMANDAPI_ADVERTISEDPORT",
+            String.valueOf(commandApiProxy.getOriginalProxyPort()))
+        .withEnv("ZEEBE_BROKER_NETWORK_INTERNALAPI_ADVERTISEDHOST", TOXIPROXY_NETWORK_ALIAS)
+        .withEnv(
+            "ZEEBE_BROKER_NETWORK_INTERNALAPI_ADVERTISEDPORT",
+            String.valueOf(internalApiProxy.getOriginalProxyPort()))
+        .withEnv("ZEEBE_BROKER_NETWORK_MONITORINGAPI_ADVERTISEDHOST", TOXIPROXY_NETWORK_ALIAS)
+        .withEnv(
+            "ZEEBE_BROKER_NETWORK_MONITORINGAPI_ADVERTISEDPORT",
+            String.valueOf(monitoringApiProxy.getOriginalProxyPort()))
+        // Since gossip does not work with ToxiProxy, increase the sync interval so changes are
+        // propagated faster
+        .withEnv("ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SYNCINTERVAL", "100ms");
+  }
+
+  private void configureGatewayContainer(
+      final ZeebeGatewayContainer gateway, final String initialContactPoint) {
+    // gateway is not behind proxy
+    gateway
+        .withEnv("ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT", initialContactPoint)
+        .withTopologyCheck(
+            new ZeebeTopologyWaitStrategy()
+                .forBrokersCount(CLUSTER_SIZE)
+                .forPartitionsCount(PARTITION_COUNT)
+                .forReplicationFactor(REPLICATION_FACTOR))
+        .withNetwork(network)
+        .withNetworkAliases("gateway");
+  }
+}


### PR DESCRIPTION
## Description

* Fix Atomix and CommandAPI so that it uses configured host and port to bind and use advertisedHost and advertisedPort for advertising to other nodes

## Related issue

closes #5426

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
