### PR TITLE
The stream processor processes only commands

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MetadataEventFilter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MetadataEventFilter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.streamprocessor;
+
+import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+
+public class MetadataEventFilter implements EventFilter {
+
+  protected final RecordMetadata metadata = new RecordMetadata();
+  protected final MetadataFilter metadataFilter;
+
+  public MetadataEventFilter(final MetadataFilter metadataFilter) {
+    this.metadataFilter = metadataFilter;
+  }
+
+  @Override
+  public boolean applies(final LoggedEvent event) {
+    event.readMetadata(metadata);
+    return metadataFilter.applies(metadata);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.streamprocessor;
+
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class MigratedStreamProcessors {
+
+  private static final List<BpmnElementType> MIGRATED_BPMN_PROCESSORS = new ArrayList<>();
+
+  private static final Function<TypedRecord<?>, Boolean> NOT_MIGRATED = record -> false;
+  private static final Function<TypedRecord<?>, Boolean> MIGRATED = record -> true;
+
+  private static final Map<ValueType, Function<TypedRecord<?>, Boolean>> MIGRATED_VALUE_TYPES =
+      new EnumMap<>(ValueType.class);
+
+  private MigratedStreamProcessors() {
+    MIGRATED_VALUE_TYPES.put(
+        ValueType.WORKFLOW_INSTANCE,
+        record -> {
+          final var recordValue = (WorkflowInstanceRecord) record.getValue();
+          final var bpmnElementType = recordValue.getBpmnElementType();
+          return MIGRATED_BPMN_PROCESSORS.contains(bpmnElementType);
+        });
+    MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.TESTING_ONLY);
+
+    MIGRATED_VALUE_TYPES.put(ValueType.ERROR, MIGRATED);
+  }
+
+  public static boolean isMigrated(final TypedRecord<?> record) {
+    final var valueType = record.getValueType();
+    return MIGRATED_VALUE_TYPES.getOrDefault(valueType, NOT_MIGRATED).apply(record);
+  }
+
+  public static boolean isMigrated(final ValueType valueType) {
+    return MIGRATED_VALUE_TYPES.get(valueType) == MIGRATED;
+  }
+
+  public static boolean isMigrated(final BpmnElementType bpmnElementType) {
+    return MIGRATED_BPMN_PROCESSORS.contains(bpmnElementType);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -21,7 +21,6 @@ import java.util.function.Consumer;
 public final class ProcessingContext implements ReadonlyProcessingContext {
 
   private ActorControl actor;
-  private EventFilter eventFilter;
   private LogStream logStream;
   private LogStreamReader logStreamReader;
   private TypedStreamWriter logStreamWriter = new NoopTypedStreamWriter();
@@ -39,11 +38,6 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
 
   public ProcessingContext actor(final ActorControl actor) {
     this.actor = actor;
-    return this;
-  }
-
-  public ProcessingContext eventFilter(final EventFilter eventFilter) {
-    this.eventFilter = eventFilter;
     return this;
   }
 
@@ -112,11 +106,6 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
   @Override
   public ActorControl getActor() {
     return actor;
-  }
-
-  @Override
-  public EventFilter getEventFilter() {
-    return eventFilter;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReProcessingStateMachine.java
@@ -96,7 +96,9 @@ public final class ReProcessingStateMachine {
   private final RecordValues recordValues;
   private final RecordProcessorMap recordProcessorMap;
 
-  private final EventFilter eventFilter;
+  private final EventFilter eventFilter =
+      new MetadataEventFilter(new RecordProtocolVersionFilter());
+
   private final LogStreamReader logStreamReader;
   private final ReprocessingStreamWriter reprocessingStreamWriter = new ReprocessingStreamWriter();
   private final TypedResponseWriter noopResponseWriter = new NoopResponseWriter();
@@ -116,11 +118,10 @@ public final class ReProcessingStateMachine {
   private LoggedEvent currentEvent;
   private TypedRecordProcessor eventProcessor;
   private ZeebeDbTransaction zeebeDbTransaction;
-  private boolean detectReprocessingInconsistency;
+  private final boolean detectReprocessingInconsistency;
 
   public ReProcessingStateMachine(final ProcessingContext context) {
     actor = context.getActor();
-    eventFilter = context.getEventFilter();
     logStreamReader = context.getLogStreamReader();
     recordValues = context.getRecordValues();
     recordProcessorMap = context.getRecordProcessorMap();
@@ -235,7 +236,7 @@ public final class ReProcessingStateMachine {
     try {
       readNextEvent();
 
-      if (eventFilter == null || eventFilter.applies(currentEvent)) {
+      if (eventFilter.applies(currentEvent)) {
         reprocessEvent(currentEvent);
       } else {
         onRecordReprocessed(currentEvent);

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReadonlyProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReadonlyProcessingContext.java
@@ -21,9 +21,6 @@ public interface ReadonlyProcessingContext {
   /** @return the actor on which the processing runs */
   ActorControl getActor();
 
-  /** @return the filter, which is used to filter for events */
-  EventFilter getEventFilter();
-
   /** @return the logstream, on which the processor runs */
   LogStream getLogStream();
 

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/RecordProtocolVersionFilter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/RecordProtocolVersionFilter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.streamprocessor;
+
+import io.zeebe.protocol.Protocol;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+
+public final class RecordProtocolVersionFilter implements MetadataFilter {
+
+  @Override
+  public boolean applies(final RecordMetadata m) {
+    if (m.getProtocolVersion() > Protocol.PROTOCOL_VERSION) {
+      throw new RuntimeException(
+          String.format(
+              "Cannot handle event with version newer "
+                  + "than what is implemented by broker (%d > %d)",
+              m.getProtocolVersion(), Protocol.PROTOCOL_VERSION));
+    }
+
+    return true;
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
@@ -33,6 +33,7 @@ import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.DeploymentIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.test.util.TestUtil;
 import io.zeebe.util.exception.RecoverableException;
 import io.zeebe.util.sched.ActorControl;
@@ -229,6 +230,57 @@ public final class StreamProcessorTest {
     inOrder
         .verify(typedRecordProcessor, never())
         .processRecord(eq(secondPosition), any(), any(), any(), any());
+
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldProcessOnlyCommands() {
+    // given
+    final TypedRecordProcessor<?> typedRecordProcessor = mock(TypedRecordProcessor.class);
+    streamProcessorRule.startTypedStreamProcessor(
+        (processors, state) ->
+            processors
+                .onCommand(
+                    ValueType.WORKFLOW_INSTANCE,
+                    WorkflowInstanceIntent.ACTIVATE_ELEMENT,
+                    typedRecordProcessor)
+                .onEvent(
+                    ValueType.WORKFLOW_INSTANCE,
+                    WorkflowInstanceIntent.ELEMENT_ACTIVATING,
+                    typedRecordProcessor));
+
+    final var record =
+        new WorkflowInstanceRecord().setBpmnElementType(BpmnElementType.TESTING_ONLY);
+
+    // when
+    final long commandPosition =
+        streamProcessorRule.writeCommand(WorkflowInstanceIntent.ACTIVATE_ELEMENT, record);
+
+    final long eventPosition =
+        streamProcessorRule.writeEvent(WorkflowInstanceIntent.ACTIVATE_ELEMENT, record);
+
+    final var rejectionPosition =
+        streamProcessorRule.writeCommandRejection(WorkflowInstanceIntent.ACTIVATE_ELEMENT, record);
+
+    final var nextCommandPosition =
+        streamProcessorRule.writeCommand(WorkflowInstanceIntent.ACTIVATE_ELEMENT, record);
+
+    // then
+    final InOrder inOrder = inOrder(typedRecordProcessor);
+    inOrder.verify(typedRecordProcessor, TIMEOUT.times(2)).onRecovered(any());
+    inOrder
+        .verify(typedRecordProcessor, TIMEOUT)
+        .processRecord(eq(commandPosition), any(), any(), any(), any());
+    inOrder
+        .verify(typedRecordProcessor, never())
+        .processRecord(eq(eventPosition), any(), any(), any(), any());
+    inOrder
+        .verify(typedRecordProcessor, never())
+        .processRecord(eq(rejectionPosition), any(), any(), any(), any());
+    inOrder
+        .verify(typedRecordProcessor, TIMEOUT)
+        .processRecord(eq(nextCommandPosition), any(), any(), any(), any());
 
     inOrder.verifyNoMoreInteractions();
   }

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
@@ -212,6 +212,15 @@ public class StreamProcessingComposite {
         .write();
   }
 
+  public long writeCommandRejection(final Intent intent, final UnpackedObject value) {
+    return streams
+        .newRecord(getLogName(partitionId))
+        .recordType(RecordType.COMMAND_REJECTION)
+        .intent(intent)
+        .event(value)
+        .write();
+  }
+
   public static String getLogName(final int partitionId) {
     return STREAM_NAME + partitionId;
   }

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -237,6 +237,10 @@ public final class StreamProcessorRule implements TestRule {
     return streamProcessingComposite.writeCommand(requestStreamId, requestId, intent, value);
   }
 
+  public long writeCommandRejection(final Intent intent, final UnpackedObject value) {
+    return streamProcessingComposite.writeCommandRejection(intent, value);
+  }
+
   public void snapshot() {
     final var partitionId = startPartitionId;
     streamProcessingComposite.snapshot(partitionId);

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/WorkflowInstanceIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/WorkflowInstanceIntent.java
@@ -27,7 +27,11 @@ public enum WorkflowInstanceIntent implements WorkflowInstanceRelatedIntent {
   ELEMENT_TERMINATING((short) 6),
   ELEMENT_TERMINATED((short) 7),
 
-  EVENT_OCCURRED((short) 8);
+  EVENT_OCCURRED((short) 8),
+
+  ACTIVATE_ELEMENT((short) 9),
+  COMPLETE_ELEMENT((short) 10),
+  TERMINATE_ELEMENT((short) 11);
 
   private final short value;
   private final boolean shouldBlacklist;
@@ -65,6 +69,12 @@ public enum WorkflowInstanceIntent implements WorkflowInstanceRelatedIntent {
         return ELEMENT_TERMINATED;
       case 8:
         return EVENT_OCCURRED;
+      case 9:
+        return ACTIVATE_ELEMENT;
+      case 10:
+        return COMPLETE_ELEMENT;
+      case 11:
+        return TERMINATE_ELEMENT;
       default:
         return Intent.UNKNOWN;
     }

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/BpmnElementType.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/BpmnElementType.java
@@ -42,7 +42,10 @@ public enum BpmnElementType {
   // Other
   SEQUENCE_FLOW,
   MULTI_INSTANCE_BODY,
-  CALL_ACTIVITY;
+  CALL_ACTIVITY,
+
+  // TODO (saig0): remove element type for testing - #6202
+  TESTING_ONLY;
 
   public static BpmnElementType bpmnElementTypeFor(final String elementTypeName) {
     switch (elementTypeName) {


### PR DESCRIPTION
## Description

* add event filter to process only commands for migrated stream processors
  * extract the existing event filters into separate classes
  * instantiate the event filters in the state machines themselves to define different filters
  * after all processors are migrated, only the event filter is required     
* add a feature toggle to determine the migrated stream processors
* add new workflow instance intents for the commands 
* add new workflow instance intent to verify the behavior of the stream processor
  * should be used for testing only
  * should be removed after all processors are migrated
  * seems to be the easiest way to test the behavior - alternatives: new value type, more refactoring 

## Related issues

closes #6160 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
