### PR TITLE
chore(broker): move RocksDB to experimental cfg

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/BrokerCfg.java
@@ -57,6 +57,7 @@ public final class BrokerCfg {
     exporters.values().forEach(e -> e.init(this, brokerBase));
     gateway.init(this, brokerBase);
     backpressure.init(this, brokerBase);
+    experimental.init(this, brokerBase);
   }
 
   private void applyEnvironment(final Environment environment) {

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -51,7 +51,6 @@ public final class DataCfg implements ConfigurationEntry {
   private double diskUsageReplicationWatermark = DEFAULT_DISK_USAGE_REPLICATION_WATERMARK;
   private double diskUsageCommandWatermark = DEFAULT_DISK_USAGE_COMMAND_WATERMARK;
   private Duration diskUsageMonitoringInterval = DEFAULT_DISK_USAGE_MONITORING_DELAY;
-  private RocksdbCfg rocksdb = new RocksdbCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -73,7 +72,6 @@ public final class DataCfg implements ConfigurationEntry {
       diskUsageReplicationWatermark = DISABLED_DISK_USAGE_WATERMARK;
       diskUsageCommandWatermark = DISABLED_DISK_USAGE_WATERMARK;
     }
-    rocksdb.init(globalConfig, brokerBase);
   }
 
   /**
@@ -187,14 +185,6 @@ public final class DataCfg implements ConfigurationEntry {
     this.diskUsageMonitoringInterval = diskUsageMonitoringInterval;
   }
 
-  public RocksdbCfg getRocksdb() {
-    return rocksdb;
-  }
-
-  public void setRocksdb(final RocksdbCfg rocksdb) {
-    this.rocksdb = rocksdb;
-  }
-
   @Override
   public String toString() {
     return "DataCfg{"
@@ -216,8 +206,6 @@ public final class DataCfg implements ConfigurationEntry {
         + diskUsageCommandWatermark
         + ", diskUsageMonitoringInterval="
         + diskUsageMonitoringInterval
-        + ", rocksdb="
-        + rocksdb
         + '}';
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -15,7 +15,7 @@ import org.springframework.util.unit.DataSize;
  * are subject to change and to drop. It might be that also some of them are actually dangerous so
  * be aware when you change one of these!
  */
-public class ExperimentalCfg {
+public class ExperimentalCfg implements ConfigurationEntry {
 
   public static final int DEFAULT_MAX_APPENDS_PER_FOLLOWER = 2;
   public static final DataSize DEFAULT_MAX_APPEND_BATCH_SIZE = DataSize.ofKilobytes(32);
@@ -26,6 +26,12 @@ public class ExperimentalCfg {
   private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;
   private boolean disableExplicitRaftFlush = DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH;
   private boolean detectReprocessingInconsistency = DEFAULT_DETECT_REPROCESSING_INCONSISTENCY;
+  private RocksdbCfg rocksdb = new RocksdbCfg();
+
+  @Override
+  public void init(final BrokerCfg globalConfig, final String brokerBase) {
+    rocksdb.init(globalConfig, brokerBase);
+  }
 
   public int getMaxAppendsPerFollower() {
     return maxAppendsPerFollower;
@@ -63,6 +69,14 @@ public class ExperimentalCfg {
     this.detectReprocessingInconsistency = detectReprocessingInconsistency;
   }
 
+  public RocksdbCfg getRocksdb() {
+    return rocksdb;
+  }
+
+  public void setRocksdb(final RocksdbCfg rocksdb) {
+    this.rocksdb = rocksdb;
+  }
+
   @Override
   public String toString() {
     return "ExperimentalCfg{"
@@ -74,6 +88,8 @@ public class ExperimentalCfg {
         + disableExplicitRaftFlush
         + ", detectReprocessingInconsistency="
         + detectReprocessingInconsistency
+        + ", rocksdb="
+        + rocksdb
         + '}';
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -55,7 +55,8 @@ public final class RocksdbCfg implements ConfigurationEntry {
       Objects.requireNonNull(entry.getKey());
       // The key of the entry may contain dot chars when provided as an Environment Variable.
       // These should always be replaced with underscores to match the available property names.
-      // For example: `ZEEBE_BROKER_DATA_ROCKSDB_COLUMNFAMILYOPTIONS_WRITE_BUFFER_SIZE=8388608`
+      // For example:
+      // `ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_COLUMNFAMILYOPTIONS_WRITE_BUFFER_SIZE=8388608`
       // would result in a key with name `write.buffer.size`, but should be `write_buffer_size`.
       key = replaceAllDotCharsWithUnderscore(entry.getKey().toString());
       value = entry.getValue(); // the value can stay the same

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
@@ -23,7 +23,7 @@ public class StateControllerPartitionStep implements PartitionStep {
   public ActorFuture<Void> open(final PartitionContext context) {
     final var runtimeDirectory =
         context.getRaftPartition().dataDirectory().toPath().resolve("runtime");
-    final var databaseCfg = context.getBrokerCfg().getData().getRocksdb();
+    final var databaseCfg = context.getBrokerCfg().getExperimental().getRocksdb();
 
     final var stateController =
         new StateControllerImpl(

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/RocksdbCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/RocksdbCfgTest.java
@@ -21,7 +21,7 @@ public final class RocksdbCfgTest {
   public void shouldSetColumnFamilyOptionsConfig() {
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
-    final var rocksdb = cfg.getData().getRocksdb();
+    final var rocksdb = cfg.getExperimental().getRocksdb();
 
     // then
     final var columnFamilyOptions = rocksdb.getColumnFamilyOptions();
@@ -32,11 +32,12 @@ public final class RocksdbCfgTest {
   @Test
   public void shouldSetColumnFamilyOptionsConfigFromEnvironmentVariables() {
     // given
-    environment.put("zeebe.broker.data.rocksdb.columnFamilyOptions.arena.block.size", "16777216");
+    environment.put(
+        "zeebe.broker.experimental.rocksdb.columnFamilyOptions.arena.block.size", "16777216");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
-    final var rocksdb = cfg.getData().getRocksdb();
+    final var rocksdb = cfg.getExperimental().getRocksdb();
 
     // then keys should contain underscores
     final var columnFamilyOptions = rocksdb.getColumnFamilyOptions();

--- a/broker/src/test/resources/system/rocksdb-cfg.yaml
+++ b/broker/src/test/resources/system/rocksdb-cfg.yaml
@@ -1,6 +1,6 @@
 zeebe:
   broker:
-    data:
+    experimental:
       rocksdb:
         columnFamilyOptions:
           compaction_pri: "kOldestSmallestSeqFirst"

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -205,17 +205,6 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGINTERVAL
       # diskUsageMonitoringInterval = 1s
 
-      # rocksdb:
-        # Specify custom column family options overwriting Zeebe's own defaults.
-        # WARNING: This setting requires in-depth knowledge of Zeebe's embedded database: RocksDB.
-        # The expected property key names and values are derived from RocksDB's C implementation,
-        # and are not limited to the provided examples below. Please look in RocksDB's SCM repo
-        # for the files: `cf_options.h` and `options_helper.cc`. This setting can also be overridden
-        # using the environment variable ZEEBE_BROKER_DATA_ROCKSDB_COLUMNFAMILYOPTIONS_{PROPERTY_KEY_NAME}
-        # For example, `write_buffer_size` can be set using `ZEEBE_BROKER_DATA_ROCKSDB_COLUMNFAMILYOPTIONS_WRITE_BUFFER_SIZE`.
-        # columnFamilyOptions:
-          # compaction_pri: "kOldestSmallestSeqFirst"
-          # write_buffer_size: 67108864
 
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
@@ -524,3 +513,15 @@
       # failed and the partition becomes unhealthy, no further progress will made on that specific partition.
       # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_DETECT_REPROCESSING_INCONSISTENCY
       # detectReprocessingInconsistency = false;
+
+      # rocksdb:
+        # Specify custom column family options overwriting Zeebe's own defaults.
+        # WARNING: This setting requires in-depth knowledge of Zeebe's embedded database: RocksDB.
+        # The expected property key names and values are derived from RocksDB's C implementation,
+        # and are not limited to the provided examples below. Please look in RocksDB's SCM repo
+        # for the files: `cf_options.h` and `options_helper.cc`. This setting can also be overridden
+        # using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_COLUMNFAMILYOPTIONS_{PROPERTY_KEY_NAME}
+        # For example, `write_buffer_size` can be set using `ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_COLUMNFAMILYOPTIONS_WRITE_BUFFER_SIZE`.
+        # columnFamilyOptions:
+          # compaction_pri: "kOldestSmallestSeqFirst"
+          # write_buffer_size: 67108864

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -165,18 +165,6 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_DISKUSAGEMONITORINGINTERVAL
       # diskUsageMonitoringInterval = 1s
 
-      # rocksdb:
-        # Specify custom column family options overwriting Zeebe's own defaults.
-        # WARNING: This setting requires in-depth knowledge of Zeebe's embedded database: RocksDB.
-        # The expected property key names and values are derived from RocksDB's C implementation,
-        # and are not limited to the provided examples below. Please look in RocksDB's SCM repo
-        # for the files: `cf_options.h` and `options_helper.cc`. This setting can also be overridden
-        # using the environment variable ZEEBE_BROKER_DATA_ROCKSDB_COLUMNFAMILYOPTIONS_{PROPERTY_KEY_NAME}
-        # For example, `write_buffer_size` can be set using `ZEEBE_BROKER_DATA_ROCKSDB_COLUMNFAMILYOPTIONS_WRITE_BUFFER_SIZE`.
-        # columnFamilyOptions:
-          # compaction_pri: "kOldestSmallestSeqFirst"
-          # write_buffer_size: 67108864
-
     # cluster:
       # This section contains all cluster related configurations, to setup a zeebe cluster
 
@@ -467,3 +455,34 @@
         #     workflowInstanceSubscription: false
         #
         #     ignoreVariablesAbove: 32677
+
+
+    # experimental
+      # Be aware that all configuration's which are part of the experimental section
+      # are subject to change and can be dropped at any time.
+      # It might be that also some of them are actually dangerous so be aware when you change one of these!
+
+      # Sets the maximum of appends which are send per follower.
+      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_MAX_APPENDS_PER_FOLLOWER
+      # maxAppendsPerFollower = 2
+
+      # Sets the maximum batch size, which is send per append request to a follower.
+      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_MAX_APPEND_BATCH_SIZE
+      # maxAppendBatchSize = 32KB;
+
+      # Enables the detection of an inconsistency during reprocessing. If a inconsistency is detect the StreamProcessor is
+      # failed and the partition becomes unhealthy, no further progress will made on that specific partition.
+      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_DETECT_REPROCESSING_INCONSISTENCY
+      # detectReprocessingInconsistency = false;
+
+      # rocksdb:
+        # Specify custom column family options overwriting Zeebe's own defaults.
+        # WARNING: This setting requires in-depth knowledge of Zeebe's embedded database: RocksDB.
+        # The expected property key names and values are derived from RocksDB's C implementation,
+        # and are not limited to the provided examples below. Please look in RocksDB's SCM repo
+        # for the files: `cf_options.h` and `options_helper.cc`. This setting can also be overridden
+        # using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_COLUMNFAMILYOPTIONS_{PROPERTY_KEY_NAME}
+        # For example, `write_buffer_size` can be set using `ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_COLUMNFAMILYOPTIONS_WRITE_BUFFER_SIZE`.
+        # columnFamilyOptions:
+          # compaction_pri: "kOldestSmallestSeqFirst"
+          # write_buffer_size: 67108864


### PR DESCRIPTION
## Description

Moves the RocksDB configuration to the experimental section. I will adjust the docs after this PR is merged.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6158 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
