### PR TITLE
chore(zb-db): introduce RocksDBConfig and made statistics optional

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.broker.system.configuration;
 
+import io.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Properties;
@@ -15,6 +16,7 @@ import java.util.regex.Pattern;
 public final class RocksdbCfg implements ConfigurationEntry {
 
   private Properties columnFamilyOptions;
+  private boolean statisticsEnabled;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -42,6 +44,18 @@ public final class RocksdbCfg implements ConfigurationEntry {
 
   public void setColumnFamilyOptions(final Properties columnFamilyOptions) {
     this.columnFamilyOptions = columnFamilyOptions;
+  }
+
+  public boolean isStatisticsEnabled() {
+    return statisticsEnabled;
+  }
+
+  public void setStatisticsEnabled(final boolean statisticsEnabled) {
+    this.statisticsEnabled = statisticsEnabled;
+  }
+
+  public RocksDbConfiguration createRocksDbConfiguration() {
+    return RocksDbConfiguration.of(columnFamilyOptions, statisticsEnabled);
   }
 
   private static final class RocksDBColumnFamilyOption {

--- a/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 import io.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.state.DefaultZeebeDbFactory;
-import io.zeebe.engine.state.ZbColumnFamilies;
 import io.zeebe.exporter.api.Exporter;
 import io.zeebe.exporter.api.context.Context;
 import io.zeebe.exporter.api.context.Controller;
@@ -45,7 +44,7 @@ public class ExporterContainerTest {
   public void setup() throws IOException {
     testActor = new TestActor();
     actorSchedulerRule.submitActor(testActor).join();
-    final var dbFactory = DefaultZeebeDbFactory.defaultFactory(ZbColumnFamilies.class);
+    final var dbFactory = DefaultZeebeDbFactory.defaultFactory();
     final var db = dbFactory.createDb(tempFolder.newFolder());
     exportersState = new ExportersState(db, db.createContext());
     final ExporterMetrics exporterMetrics = new ExporterMetrics(1);

--- a/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterRule.java
@@ -49,7 +49,7 @@ public final class ExporterRule implements TestRule {
   private ExporterDirector director;
 
   public ExporterRule(final int partitionId) {
-    this(partitionId, DefaultZeebeDbFactory.defaultFactory(ZbColumnFamilies.class));
+    this(partitionId, DefaultZeebeDbFactory.defaultFactory());
   }
 
   public ExporterRule(final int partitionId, final ZeebeDbFactory dbFactory) {

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
@@ -22,7 +22,6 @@ import io.atomix.storage.journal.Indexed;
 import io.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.zeebe.broker.system.partitions.impl.NoneSnapshotReplication;
 import io.zeebe.broker.system.partitions.impl.StateControllerImpl;
-import io.zeebe.db.impl.DefaultColumnFamily;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.zeebe.logstreams.log.LogStream;
@@ -76,7 +75,7 @@ public final class AsyncSnapshotingTest {
     snapshotController =
         new StateControllerImpl(
             1,
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class),
+            ZeebeRocksDbFactory.newFactory(),
             persistedSnapshotStore,
             factory.getReceivableSnapshotStore(partitionName),
             rootDirectory.resolve("runtime"),

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.raft.zeebe.ZeebeEntry;
 import io.atomix.storage.journal.Indexed;
 import io.zeebe.broker.system.partitions.SnapshotReplication;
-import io.zeebe.db.impl.DefaultColumnFamily;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.zeebe.snapshots.broker.ConstructableSnapshotStore;
 import io.zeebe.snapshots.broker.impl.FileBasedSnapshotStoreFactory;
@@ -53,7 +52,7 @@ public final class FailingSnapshotChunkReplicationTest {
     replicatorSnapshotController =
         new StateControllerImpl(
             1,
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class),
+            ZeebeRocksDbFactory.newFactory(),
             senderStore,
             senderFactory.getReceivableSnapshotStore("1"),
             senderRoot.resolve("runtime"),
@@ -68,7 +67,7 @@ public final class FailingSnapshotChunkReplicationTest {
     receiverSnapshotController =
         new StateControllerImpl(
             1,
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class),
+            ZeebeRocksDbFactory.newFactory(),
             receiverFactory.getConstructableSnapshotStore("1"),
             receiverFactory.getReceivableSnapshotStore("1"),
             receiverRoot.resolve("runtime"),

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.raft.zeebe.ZeebeEntry;
 import io.atomix.storage.journal.Indexed;
 import io.zeebe.broker.system.partitions.SnapshotReplication;
-import io.zeebe.db.impl.DefaultColumnFamily;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.zeebe.logstreams.util.RocksDBWrapper;
 import io.zeebe.snapshots.broker.ConstructableSnapshotStore;
@@ -61,7 +60,7 @@ public final class ReplicateStateControllerTest {
     replicatorSnapshotController =
         new StateControllerImpl(
             1,
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class),
+            ZeebeRocksDbFactory.newFactory(),
             senderStore,
             senderFactory.getReceivableSnapshotStore("1"),
             senderRoot.resolve("runtime"),
@@ -76,7 +75,7 @@ public final class ReplicateStateControllerTest {
     receiverSnapshotController =
         new StateControllerImpl(
             1,
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class),
+            ZeebeRocksDbFactory.newFactory(),
             receiverFactory.getConstructableSnapshotStore("1"),
             receiverStore,
             receiverRoot.resolve("runtime"),

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.raft.zeebe.ZeebeEntry;
 import io.atomix.storage.journal.Indexed;
-import io.zeebe.db.impl.DefaultColumnFamily;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.zeebe.logstreams.util.RocksDBWrapper;
 import io.zeebe.snapshots.broker.ConstructableSnapshotStore;
@@ -36,6 +35,7 @@ import org.junit.rules.TemporaryFolder;
 
 @SuppressWarnings("unchecked")
 public final class StateControllerImplTest {
+
   @Rule public final TemporaryFolder tempFolderRule = new TemporaryFolder();
   @Rule public final AutoCloseableRule autoCloseableRule = new AutoCloseableRule();
 
@@ -54,7 +54,7 @@ public final class StateControllerImplTest {
     snapshotController =
         new StateControllerImpl(
             1,
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class),
+            ZeebeRocksDbFactory.newFactory(),
             store,
             factory.getReceivableSnapshotStore("1"),
             rootDirectory.resolve("runtime"),

--- a/broker/src/test/resources/system/rocksdb-cfg.yaml
+++ b/broker/src/test/resources/system/rocksdb-cfg.yaml
@@ -5,3 +5,4 @@ zeebe:
         columnFamilyOptions:
           compaction_pri: "kOldestSmallestSeqFirst"
           write_buffer_size: 67108864
+        statisticsEnabled: true

--- a/engine/src/main/java/io/zeebe/engine/state/DefaultZeebeDbFactory.java
+++ b/engine/src/main/java/io/zeebe/engine/state/DefaultZeebeDbFactory.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.state;
 
 import io.zeebe.db.ZeebeDb;
 import io.zeebe.db.ZeebeDbFactory;
+import io.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDBMetricExporter;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import java.util.Properties;
@@ -38,35 +39,20 @@ public final class DefaultZeebeDbFactory {
    */
   public static ZeebeDbFactory<ZbColumnFamilies> defaultFactory(
       final Properties userProvidedColumnFamilyOptions) {
-    return defaultFactory(ZbColumnFamilies.class, userProvidedColumnFamilyOptions);
+    return defaultFactory(RocksDbConfiguration.of(userProvidedColumnFamilyOptions));
   }
 
   /**
    * Returns the default zeebe database factory which is used in the broker.
    *
    * @param <ColumnFamilyNames> the type of the enum
-   * @param columnFamilyNamesClass the enum class, which contains the column family names
+   * @param rocksDbConfiguration user provided rocks db configuration
    * @return the created zeebe database factory
    */
   public static <ColumnFamilyNames extends Enum<ColumnFamilyNames>>
       ZeebeDbFactory<ColumnFamilyNames> defaultFactory(
-          final Class<ColumnFamilyNames> columnFamilyNamesClass) {
-    return defaultFactory(columnFamilyNamesClass, new Properties());
-  }
-
-  /**
-   * Returns the default zeebe database factory which is used in the broker.
-   *
-   * @param <ColumnFamilyNames> the type of the enum
-   * @param columnFamilyNamesClass the enum class, which contains the column family names
-   * @param userProvidedColumnFamilyOptions additional column family options
-   * @return the created zeebe database factory
-   */
-  public static <ColumnFamilyNames extends Enum<ColumnFamilyNames>>
-      ZeebeDbFactory<ColumnFamilyNames> defaultFactory(
-          final Class<ColumnFamilyNames> columnFamilyNamesClass,
-          final Properties userProvidedColumnFamilyOptions) {
+          final RocksDbConfiguration rocksDbConfiguration) {
     // one place to replace the zeebe database implementation
-    return ZeebeRocksDbFactory.newFactory(columnFamilyNamesClass, userProvidedColumnFamilyOptions);
+    return ZeebeRocksDbFactory.newFactory(rocksDbConfiguration);
   }
 }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.db.impl.rocksdb;
+
+import java.util.Properties;
+
+public final class RocksDbConfiguration {
+
+  private final Properties columnFamilyOptions;
+  private final boolean statisticsEnabled;
+
+  private RocksDbConfiguration(
+      final Properties columnFamilyOptions, final boolean statisticsEnabled) {
+    this.columnFamilyOptions = columnFamilyOptions;
+    this.statisticsEnabled = statisticsEnabled;
+  }
+
+  public static RocksDbConfiguration empty() {
+    return new RocksDbConfiguration(new Properties(), false);
+  }
+
+  public static RocksDbConfiguration of(final Properties properties) {
+    return new RocksDbConfiguration(properties, false);
+  }
+
+  public static RocksDbConfiguration of(
+      final Properties properties, final boolean statisticsEnabled) {
+    return new RocksDbConfiguration(properties, statisticsEnabled);
+  }
+
+  public Properties getColumnFamilyOptions() {
+    return columnFamilyOptions;
+  }
+
+  public boolean isStatisticsEnabled() {
+    return statisticsEnabled;
+  }
+}

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -97,20 +97,21 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
             // limit the size of the manifest (logs all operations), otherwise it will grow
             // unbounded
             .setMaxManifestFileSize(256 * 1024 * 1024L)
-            // speeds up opening the DB
-            .setSkipStatsUpdateOnDbOpen(true)
             // keep 1 hour of logs - completely arbitrary. we should keep what we think would be
             // a good balance between useful for performance and small for replication
             .setLogFileTimeToRoll(Duration.ofMinutes(30).toSeconds())
-            .setKeepLogFileNum(2)
-            // can be disabled when not profiling
-            .setStatsDumpPeriodSec(20);
+            .setKeepLogFileNum(2);
 
     if (rocksDbConfiguration.isStatisticsEnabled()) {
       final var statistics = new Statistics();
       closeables.add(statistics);
       statistics.setStatsLevel(StatsLevel.ALL);
-      dbOptions.setStatistics(statistics);
+      dbOptions
+          .setStatistics(statistics)
+          // speeds up opening the DB
+          .setSkipStatsUpdateOnDbOpen(true)
+          // can be disabled when not profiling
+          .setStatsDumpPeriodSec(20);
     }
 
     return dbOptions;

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -40,28 +40,20 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
     RocksDB.loadLibrary();
   }
 
-  private final Class<ColumnFamilyType> columnFamilyTypeClass;
-  private final Properties userProvidedColumnFamilyOptions;
+  private final RocksDbConfiguration rocksDbConfiguration;
 
-  private ZeebeRocksDbFactory(
-      final Class<ColumnFamilyType> columnFamilyTypeClass,
-      final Properties userProvidedColumnFamilyOptions) {
-    this.columnFamilyTypeClass = columnFamilyTypeClass;
-    this.userProvidedColumnFamilyOptions = Objects.requireNonNull(userProvidedColumnFamilyOptions);
+  private ZeebeRocksDbFactory(final RocksDbConfiguration rocksDbConfiguration) {
+    this.rocksDbConfiguration = Objects.requireNonNull(rocksDbConfiguration);
   }
 
   public static <ColumnFamilyType extends Enum<ColumnFamilyType>>
-      ZeebeDbFactory<ColumnFamilyType> newFactory(
-          final Class<ColumnFamilyType> columnFamilyTypeClass) {
-    final var columnFamilyOptions = new Properties();
-    return new ZeebeRocksDbFactory<>(columnFamilyTypeClass, columnFamilyOptions);
+      ZeebeDbFactory<ColumnFamilyType> newFactory() {
+    return new ZeebeRocksDbFactory<>(RocksDbConfiguration.empty());
   }
 
   public static <ColumnFamilyType extends Enum<ColumnFamilyType>>
-      ZeebeDbFactory<ColumnFamilyType> newFactory(
-          final Class<ColumnFamilyType> columnFamilyTypeClass,
-          final Properties userProvidedColumnFamilyOptions) {
-    return new ZeebeRocksDbFactory<>(columnFamilyTypeClass, userProvidedColumnFamilyOptions);
+      ZeebeDbFactory<ColumnFamilyType> newFactory(final RocksDbConfiguration rocksDbConfiguration) {
+    return new ZeebeRocksDbFactory<>(rocksDbConfiguration);
   }
 
   @Override
@@ -88,40 +80,45 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
   }
 
   private DBOptions createDefaultDbOptions(final List<AutoCloseable> closeables) {
-    final var statistics = new Statistics();
-    closeables.add(statistics);
-    statistics.setStatsLevel(StatsLevel.ALL);
+    final var dbOptions =
+        new DBOptions()
+            .setErrorIfExists(false)
+            .setCreateIfMissing(true)
+            .setParanoidChecks(true)
+            // 1 flush, 1 compaction
+            .setMaxBackgroundJobs(2)
+            // we only use the default CF
+            .setCreateMissingColumnFamilies(false)
+            // may not be necessary when WAL is disabled, but nevertheless recommended to avoid
+            // many small SST files
+            .setAvoidFlushDuringRecovery(true)
+            // fsync is called asynchronously once we have at least 4Mb
+            .setBytesPerSync(4 * 1024 * 1024L)
+            // limit the size of the manifest (logs all operations), otherwise it will grow
+            // unbounded
+            .setMaxManifestFileSize(256 * 1024 * 1024L)
+            // speeds up opening the DB
+            .setSkipStatsUpdateOnDbOpen(true)
+            // keep 1 hour of logs - completely arbitrary. we should keep what we think would be
+            // a good balance between useful for performance and small for replication
+            .setLogFileTimeToRoll(Duration.ofMinutes(30).toSeconds())
+            .setKeepLogFileNum(2)
+            // can be disabled when not profiling
+            .setStatsDumpPeriodSec(20);
 
-    return new DBOptions()
-        .setErrorIfExists(false)
-        .setCreateIfMissing(true)
-        .setParanoidChecks(true)
-        // 1 flush, 1 compaction
-        .setMaxBackgroundJobs(2)
-        // we only use the default CF
-        .setCreateMissingColumnFamilies(false)
-        // may not be necessary when WAL is disabled, but nevertheless recommended to avoid
-        // many small SST files
-        .setAvoidFlushDuringRecovery(true)
-        // fsync is called asynchronously once we have at least 4Mb
-        .setBytesPerSync(4 * 1024 * 1024L)
-        // limit the size of the manifest (logs all operations), otherwise it will grow
-        // unbounded
-        .setMaxManifestFileSize(256 * 1024 * 1024L)
-        // speeds up opening the DB
-        .setSkipStatsUpdateOnDbOpen(true)
-        // keep 1 hour of logs - completely arbitrary. we should keep what we think would be
-        // a good balance between useful for performance and small for replication
-        .setLogFileTimeToRoll(Duration.ofMinutes(30).toSeconds())
-        .setKeepLogFileNum(2)
-        // can be disabled when not profiling
-        .setStatsDumpPeriodSec(20)
-        .setStatistics(statistics);
+    if (rocksDbConfiguration.isStatisticsEnabled()) {
+      final var statistics = new Statistics();
+      closeables.add(statistics);
+      statistics.setStatsLevel(StatsLevel.ALL);
+      dbOptions.setStatistics(statistics);
+    }
+
+    return dbOptions;
   }
 
   /** @return Options which are used on all column families */
   ColumnFamilyOptions createColumnFamilyOptions(final List<AutoCloseable> closeables) {
-
+    final var userProvidedColumnFamilyOptions = rocksDbConfiguration.getColumnFamilyOptions();
     final var hasUserOptions = !userProvidedColumnFamilyOptions.isEmpty();
 
     if (hasUserOptions) {

--- a/zb-db/src/test/java/io/zeebe/db/impl/ColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/ColumnFamilyTest.java
@@ -24,7 +24,7 @@ public final class ColumnFamilyTest {
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
   private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
-      DefaultZeebeDbFactory.getDefaultFactory(DefaultColumnFamily.class);
+      DefaultZeebeDbFactory.getDefaultFactory();
   private ZeebeDb<DefaultColumnFamily> zeebeDb;
   private ColumnFamily<DbLong, DbLong> columnFamily;
   private DbLong key;

--- a/zb-db/src/test/java/io/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/DbCompositeKeyColumnFamilyTest.java
@@ -24,7 +24,7 @@ public final class DbCompositeKeyColumnFamilyTest {
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
   private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
-      DefaultZeebeDbFactory.getDefaultFactory(DefaultColumnFamily.class);
+      DefaultZeebeDbFactory.getDefaultFactory();
   private ZeebeDb<DefaultColumnFamily> zeebeDb;
   private ColumnFamily<DbCompositeKey<DbString, DbLong>, DbString> columnFamily;
   private DbString firstKey;

--- a/zb-db/src/test/java/io/zeebe/db/impl/DbStringColumnFamilyTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/DbStringColumnFamilyTest.java
@@ -25,7 +25,7 @@ public final class DbStringColumnFamilyTest {
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
   private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
-      DefaultZeebeDbFactory.getDefaultFactory(DefaultColumnFamily.class);
+      DefaultZeebeDbFactory.getDefaultFactory();
   private ZeebeDb<DefaultColumnFamily> zeebeDb;
   private ColumnFamily<DbString, DbString> columnFamily;
   private DbString key;

--- a/zb-db/src/test/java/io/zeebe/db/impl/DbTransactionTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/DbTransactionTest.java
@@ -27,7 +27,7 @@ public final class DbTransactionTest {
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
   private final ZeebeDbFactory<ColumnFamilies> dbFactory =
-      DefaultZeebeDbFactory.getDefaultFactory(ColumnFamilies.class);
+      DefaultZeebeDbFactory.getDefaultFactory();
   private DbContext dbContext;
 
   private ColumnFamily<DbLong, DbLong> oneColumnFamily;

--- a/zb-db/src/test/java/io/zeebe/db/impl/DefaultZeebeDbFactory.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/DefaultZeebeDbFactory.java
@@ -9,20 +9,11 @@ package io.zeebe.db.impl;
 
 import io.zeebe.db.ZeebeDbFactory;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
-import java.util.Properties;
 
 public final class DefaultZeebeDbFactory {
 
   public static <ColumnFamilyType extends Enum<ColumnFamilyType>>
-      ZeebeDbFactory<ColumnFamilyType> getDefaultFactory(
-          final Class<ColumnFamilyType> columnFamilyTypeClass) {
-    return ZeebeRocksDbFactory.newFactory(columnFamilyTypeClass);
-  }
-
-  public static <ColumnFamilyType extends Enum<ColumnFamilyType>>
-      ZeebeDbFactory<ColumnFamilyType> getDefaultFactory(
-          final Class<ColumnFamilyType> columnFamilyTypeClass,
-          final Properties columnFamilyOptions) {
-    return ZeebeRocksDbFactory.newFactory(columnFamilyTypeClass, columnFamilyOptions);
+      ZeebeDbFactory<ColumnFamilyType> getDefaultFactory() {
+    return ZeebeRocksDbFactory.newFactory();
   }
 }

--- a/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -30,8 +30,7 @@ public final class ZeebeRocksDbFactoryTest {
   @Test
   public void shouldCreateNewDb() throws Exception {
     // given
-    final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
-        ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class);
+    final ZeebeDbFactory<DefaultColumnFamily> dbFactory = ZeebeRocksDbFactory.newFactory();
 
     final File pathName = temporaryFolder.newFolder();
 
@@ -46,8 +45,7 @@ public final class ZeebeRocksDbFactoryTest {
   @Test
   public void shouldCreateTwoNewDbs() throws Exception {
     // given
-    final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
-        ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class);
+    final ZeebeDbFactory<DefaultColumnFamily> dbFactory = ZeebeRocksDbFactory.newFactory();
     final File firstPath = temporaryFolder.newFolder();
     final File secondPath = temporaryFolder.newFolder();
 
@@ -73,11 +71,10 @@ public final class ZeebeRocksDbFactoryTest {
     customProperties.put("compaction_pri", "kByCompensatedSize");
 
     final var factoryWithDefaults =
-        (ZeebeRocksDbFactory<DefaultColumnFamily>)
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class);
+        (ZeebeRocksDbFactory<DefaultColumnFamily>) ZeebeRocksDbFactory.newFactory();
     final var factoryWithCustomOptions =
         (ZeebeRocksDbFactory<DefaultColumnFamily>)
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class, customProperties);
+            ZeebeRocksDbFactory.newFactory(RocksDbConfiguration.of(customProperties));
 
     // when
     final var defaults = factoryWithDefaults.createColumnFamilyOptions(new ArrayList<>());
@@ -109,7 +106,7 @@ public final class ZeebeRocksDbFactoryTest {
 
     final var factoryWithCustomOptions =
         (ZeebeRocksDbFactory<DefaultColumnFamily>)
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class, customProperties);
+            ZeebeRocksDbFactory.newFactory(RocksDbConfiguration.of(customProperties));
 
     // expect
     assertThatThrownBy(

--- a/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbTest.java
@@ -26,8 +26,7 @@ public final class ZeebeRocksDbTest {
   @Test
   public void shouldCreateSnapshot() throws Exception {
     // given
-    final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
-        ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class);
+    final ZeebeDbFactory<DefaultColumnFamily> dbFactory = ZeebeRocksDbFactory.newFactory();
 
     final File pathName = temporaryFolder.newFolder();
     final ZeebeDb<DefaultColumnFamily> db = dbFactory.createDb(pathName);
@@ -52,8 +51,7 @@ public final class ZeebeRocksDbTest {
   @Test
   public void shouldReopenDb() throws Exception {
     // given
-    final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
-        ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class);
+    final ZeebeDbFactory<DefaultColumnFamily> dbFactory = ZeebeRocksDbFactory.newFactory();
     final File pathName = temporaryFolder.newFolder();
     ZeebeDb<DefaultColumnFamily> db = dbFactory.createDb(pathName);
 
@@ -82,8 +80,7 @@ public final class ZeebeRocksDbTest {
   @Test
   public void shouldRecoverFromSnapshot() throws Exception {
     // given
-    final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
-        ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class);
+    final ZeebeDbFactory<DefaultColumnFamily> dbFactory = ZeebeRocksDbFactory.newFactory();
     final File pathName = temporaryFolder.newFolder();
     ZeebeDb<DefaultColumnFamily> db = dbFactory.createDb(pathName);
 

--- a/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbIterationTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbIterationTest.java
@@ -29,7 +29,7 @@ public final class ZeebeRocksDbIterationTest {
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
   private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
-      DefaultZeebeDbFactory.getDefaultFactory(DefaultColumnFamily.class);
+      DefaultZeebeDbFactory.getDefaultFactory();
   private ZeebeTransactionDb<DefaultColumnFamily> zeebeDb;
   private ColumnFamily<DbCompositeKey<DbLong, DbLong>, DbNil> columnFamily;
   private DbLong firstKey;

--- a/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbTransactionTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeRocksDbTransactionTest.java
@@ -33,7 +33,7 @@ public final class ZeebeRocksDbTransactionTest {
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
   private final ZeebeDbFactory<DefaultColumnFamily> dbFactory =
-      DefaultZeebeDbFactory.getDefaultFactory(DefaultColumnFamily.class);
+      DefaultZeebeDbFactory.getDefaultFactory();
   private DbContext dbContext;
 
   @Before


### PR DESCRIPTION
## Description

* Introduce the RocksDbConfiguration class which can be used with the ZeebeDbFactory. 
* Made Statistics optional
* Remove unused Enum class object
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6157 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
