### PR TITLE
Verify that replay restores the state

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/RandomWorkflowExecutionPropertyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/RandomWorkflowExecutionPropertyTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.streamprocessor;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.engine.util.WorkflowExecutor;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.test.util.bpmn.random.ExecutionPath;
+import io.zeebe.test.util.bpmn.random.TestDataGenerator;
+import io.zeebe.test.util.bpmn.random.TestDataGenerator.TestDataRecord;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.util.Collection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class RandomWorkflowExecutionPropertyTest {
+
+  /*
+   * Some notes on scaling of these tests:
+   * With 10 workflows and 100 paths there is a theoretical maximum of 1000 records.
+   * However, in tests the number of actual records was around 300, which can execute in about 1 m.
+   *
+   * Having a high number of random execution paths has only a small effect as there are rarely 100
+   * different execution paths for any given workflow. Having a high number of paths gives us a good
+   * chance to exhaust all possible paths within a given workflow.
+   *
+   * This is only true if the complexity of the workflows stays constant.
+   * Increasing the maximum number of blocks, depth or branches could increase the number of
+   * possible paths exponentially
+   */
+  private static final int WORKFLOW_COUNT = 10;
+  private static final int EXECUTION_PATH_COUNT = 100;
+
+  @Rule public final EngineRule engineRule = EngineRule.singlePartition();
+
+  @Parameter public TestDataRecord record;
+
+  private final WorkflowExecutor workflowExecutor = new WorkflowExecutor(engineRule);
+
+  /**
+   * This test takes a random workflow and execution path in that workflow. A process instance is
+   * started and the workflow is executed according to the random execution path. The test passes if
+   * it reaches the end of the workflow.
+   */
+  @Test
+  public void shouldExecuteWorkflowToEnd() {
+    final BpmnModelInstance model = record.getBpmnModel();
+    engineRule.deployment().withXmlResource(model).deploy();
+
+    final ExecutionPath path = record.getExecutionPath();
+
+    path.getSteps().forEach(workflowExecutor::applyStep);
+
+    // wait for the completion of the process
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+        .withElementType(BpmnElementType.PROCESS)
+        .withBpmnProcessId(path.getProcessId())
+        .await();
+  }
+
+  @Parameters(name = "{0}")
+  public static Collection<TestDataGenerator.TestDataRecord> getTestRecords() {
+    return TestDataGenerator.generateTestRecords(WORKFLOW_COUNT, EXECUTION_PATH_COUNT);
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStatePropertyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStatePropertyTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.streamprocessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.engine.processing.streamprocessor.StreamProcessor.Phase;
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.engine.util.WorkflowExecutor;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.test.util.bpmn.random.AbstractExecutionStep;
+import io.zeebe.test.util.bpmn.random.ExecutionPath;
+import io.zeebe.test.util.bpmn.random.TestDataGenerator;
+import io.zeebe.test.util.bpmn.random.TestDataGenerator.TestDataRecord;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.util.Collection;
+import org.assertj.core.api.SoftAssertions;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class ReplayStatePropertyTest {
+
+  private static final int WORKFLOW_COUNT = 5;
+  private static final int EXECUTION_PATH_COUNT = 5;
+
+  @Rule public final EngineRule engineRule = EngineRule.singlePartition();
+
+  @Parameter public TestDataRecord record;
+
+  private final WorkflowExecutor workflowExecutor = new WorkflowExecutor(engineRule);
+
+  /**
+   * This test takes a random workflow and execution path in that workflow. A process instance is
+   * started and the workflow is executed step by step according to the random execution path. After
+   * each step, the current database state is captured and the engine is restarted. After restart
+   * the database state is captured and compared to the database state before the restart. After all
+   * steps are executed, a final comparison is performed.
+   *
+   * <p>The test passes if at any step in time the database states before and after the restart of
+   * the engine are identical.
+   */
+  @Test
+  public void shouldRestoreStateAtEachStepInExecution() {
+    final BpmnModelInstance model = record.getBpmnModel();
+    engineRule.deployment().withXmlResource(model).deploy();
+
+    final ExecutionPath path = record.getExecutionPath();
+
+    for (final AbstractExecutionStep step : path.getSteps()) {
+
+      workflowExecutor.applyStep(step);
+
+      stopAndRestartEngineAndCompareStates();
+    }
+
+    // wait for termination of the process
+    final var result =
+        RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_COMPLETED)
+            .withElementType(BpmnElementType.PROCESS)
+            .withBpmnProcessId(path.getProcessId())
+            .getFirst();
+
+    final var position = result.getPosition();
+
+    Awaitility.await()
+        .until(
+            () ->
+                engineRule.getStreamProcessor(1).getLastProcessedPositionAsync().join()
+                    == position);
+
+    stopAndRestartEngineAndCompareStates();
+  }
+
+  private void stopAndRestartEngineAndCompareStates() {
+    // given
+    waitForProcessingToStop();
+
+    final var processingState = engineRule.collectState();
+    engineRule.stop();
+
+    // when
+    engineRule.start();
+
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(engineRule.getStreamProcessor(1).getCurrentPhase().join())
+                    .isEqualTo(Phase.PROCESSING));
+
+    // then
+    final var replayState = engineRule.collectState();
+
+    final var softly = new SoftAssertions();
+
+    processingState.forEach(
+        (column, processingEntries) -> {
+          final var replayEntries = replayState.get(column);
+
+          if (processingEntries.isEmpty()) {
+            softly
+                .assertThat(replayEntries)
+                .describedAs("The state column '%s' should be empty after replay", column)
+                .isEmpty();
+          } else {
+            softly
+                .assertThat(replayEntries)
+                .describedAs("The state column '%s' has different entries after replay", column)
+                .containsExactlyInAnyOrderEntriesOf(processingEntries);
+          }
+        });
+
+    softly.assertAll();
+  }
+
+  private void waitForProcessingToStop() {
+    final var lastWrittenPosition =
+        engineRule.getStreamProcessor(1).getLastWrittenPositionAsync().join();
+
+    /* the last written position is -1 directly after a replay and before new records are being
+     * written. In this state we don't need to wait at all. In all other states we wait until the
+     * processed position has advanced to the last written position */
+    if (lastWrittenPosition != -1) {
+      Awaitility.await()
+          .untilAsserted(
+              () -> {
+                final var processed =
+                    engineRule.getStreamProcessor(1).getLastProcessedPositionAsync().join();
+                final var written =
+                    engineRule.getStreamProcessor(1).getLastWrittenPositionAsync().join();
+
+                assertThat(written).isEqualTo(processed);
+              });
+    }
+  }
+
+  @Parameters(name = "{0}")
+  public static Collection<TestDataRecord> getTestRecords() {
+    return TestDataGenerator.generateTestRecords(WORKFLOW_COUNT, EXECUTION_PATH_COUNT);
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.streamprocessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.engine.processing.streamprocessor.StreamProcessor.Phase;
+import io.zeebe.engine.state.ZbColumnFamilies;
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import org.assertj.core.api.SoftAssertions;
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class ReplayStateTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private long workflowInstanceKey;
+  private Map<ZbColumnFamilies, Map<Object, Object>> processingState;
+
+  @Before
+  public void setup() {
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .done())
+        .deploy();
+
+    workflowInstanceKey = engine.workflowInstance().ofBpmnProcessId("process").create();
+
+    RecordingExporter.workflowInstanceRecords(WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .await();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED).await();
+
+    processingState = engine.collectState();
+    engine.stop();
+  }
+
+  @Test
+  public void shouldContinueAfterRestart() {
+    // given
+    engine.start();
+
+    // when
+    engine
+        .jobs()
+        .withType("test")
+        .activate()
+        .getValue()
+        .getJobKeys()
+        .forEach(jobKey -> engine.job().withKey(jobKey).complete());
+
+    // then
+    assertThat(
+            RecordingExporter.workflowInstanceRecords()
+                .withWorkflowInstanceKey(workflowInstanceKey)
+                .filterRootScope()
+                .limitToWorkflowInstanceCompleted())
+        .extracting(Record::getIntent)
+        .contains(WorkflowInstanceIntent.ELEMENT_COMPLETED);
+  }
+
+  @Test
+  public void shouldRestoreState() {
+    // when
+    engine.start();
+
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              assertThat(engine.getStreamProcessor(1).getCurrentPhase().join())
+                  .isEqualTo(Phase.PROCESSING);
+            });
+
+    // then
+    final var replayState = engine.collectState();
+
+    final var softly = new SoftAssertions();
+
+    processingState.forEach(
+        (column, processingEntries) -> {
+          final var replayEntries = replayState.get(column);
+
+          softly
+              .assertThat(replayEntries)
+              .describedAs("The state column '%s' has different entries after replay", column)
+              .containsExactlyInAnyOrderEntriesOf(processingEntries);
+        });
+
+    softly.assertAll();
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/WorkflowExecutor.java
+++ b/engine/src/test/java/io/zeebe/engine/util/WorkflowExecutor.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.util;
+
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.test.util.bpmn.random.AbstractExecutionStep;
+import io.zeebe.test.util.bpmn.random.blocks.ExclusiveGatewayBlockBuilder.StepPickConditionCase;
+import io.zeebe.test.util.bpmn.random.blocks.ExclusiveGatewayBlockBuilder.StepPickDefaultCase;
+import io.zeebe.test.util.bpmn.random.blocks.IntermediateMessageCatchEventBlockBuilder;
+import io.zeebe.test.util.bpmn.random.blocks.IntermediateMessageCatchEventBlockBuilder.StepPublishMessage;
+import io.zeebe.test.util.bpmn.random.blocks.ServiceTaskBlockBuilder.StepActivateAndCompleteJob;
+import io.zeebe.test.util.bpmn.random.blocks.ServiceTaskBlockBuilder.StepActivateAndFailJob;
+import io.zeebe.test.util.bpmn.random.blocks.StepStartProcessInstance;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+
+/** This class executes individual {@link AbstractExecutionStep} for a given workflow */
+public class WorkflowExecutor {
+
+  private final EngineRule engineRule;
+
+  public WorkflowExecutor(final EngineRule engineRule) {
+    this.engineRule = engineRule;
+  }
+
+  public void applyStep(final AbstractExecutionStep step) {
+
+    if (step instanceof StepStartProcessInstance) {
+      final StepStartProcessInstance startProcess = (StepStartProcessInstance) step;
+      createWorkflowInstance(startProcess);
+    } else if (step instanceof StepPublishMessage) {
+      final StepPublishMessage publishMessage = (StepPublishMessage) step;
+      publicMessage(publishMessage);
+    } else if (step instanceof StepActivateAndCompleteJob) {
+      final StepActivateAndCompleteJob activateAndCompleteJob = (StepActivateAndCompleteJob) step;
+      activateAndCompleteJob(activateAndCompleteJob);
+    } else if (step instanceof StepActivateAndFailJob) {
+      final StepActivateAndFailJob activateAndFailJob = (StepActivateAndFailJob) step;
+      activateAndFailJob(activateAndFailJob);
+    } else if ((step instanceof StepPickDefaultCase) || (step instanceof StepPickConditionCase)) {
+      /*
+       * Nothing to do here, as the choice is made by the engine. The default case is for debugging
+       * purposes only The condition case is implemented by starting the workflow with the right
+       * variables;
+       *
+       * One thing that might be a useful addition here is to wait until a certain path was taken to improve debugging
+       */
+    } else {
+      throw new IllegalStateException("Not yet implemented: " + step);
+    }
+  }
+
+  private void activateAndCompleteJob(final StepActivateAndCompleteJob activateAndCompleteJob) {
+    waitForJobToBeCreated(activateAndCompleteJob.getJobType());
+
+    engineRule
+        .jobs()
+        .withType(activateAndCompleteJob.getJobType())
+        .activate()
+        .getValue()
+        .getJobKeys()
+        .forEach(jobKey -> engineRule.job().withKey(jobKey).complete());
+  }
+
+  private void activateAndFailJob(final StepActivateAndFailJob activateAndFailJob) {
+    waitForJobToBeCreated(activateAndFailJob.getJobType());
+
+    engineRule
+        .jobs()
+        .withType(activateAndFailJob.getJobType())
+        .activate()
+        .getValue()
+        .getJobKeys()
+        .forEach(jobKey -> engineRule.job().withKey(jobKey).withRetries(2).fail());
+  }
+
+  private void waitForJobToBeCreated(final String jobType) {
+    RecordingExporter.jobRecords(JobIntent.CREATED).withType(jobType).await();
+  }
+
+  private void publicMessage(final StepPublishMessage publishMessage) {
+    engineRule
+        .message()
+        .withName(publishMessage.getMessageName())
+        .withCorrelationKey(IntermediateMessageCatchEventBlockBuilder.CORRELATION_KEY_VALUE)
+        .withTimeToLive(Duration.ofSeconds(10))
+        .publish();
+
+    // TODO Wait for message being correlated
+    /*
+     * If we don't wait for the message to be correlated, then this will happen asynchronously.
+     * Especially in ReplayStatePropertyTest this prevents us from capturing database
+     * state at precise points where we know that the system is idle.
+     */
+  }
+
+  private void createWorkflowInstance(final StepStartProcessInstance startProcess) {
+    engineRule
+        .workflowInstance()
+        .ofBpmnProcessId(startProcess.getProcessId())
+        .withVariables(startProcess.getVariables())
+        .create();
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/ZeebeStateRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/ZeebeStateRule.java
@@ -59,10 +59,8 @@ public final class ZeebeStateRule extends ExternalResource {
 
   public ZeebeDb<ZbColumnFamilies> createNewDb() {
     try {
-      final ZeebeDb<ZbColumnFamilies> db =
-          DefaultZeebeDbFactory.defaultFactory().createDb(tempFolder.newFolder());
 
-      return db;
+      return DefaultZeebeDbFactory.defaultFactory().createDb(tempFolder.newFolder());
     } catch (final Exception e) {
       throw new RuntimeException(e);
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Parent</name>
@@ -851,6 +853,15 @@
               </property>
             </properties>
             <reportNameSuffix>${env.SUREFIRE_REPORT_NAME_SUFFIX}</reportNameSuffix>
+            <statelessTestsetReporter
+              implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+              <disable>false</disable>
+              <version>3.0</version>
+              <usePhrasedFileName>false</usePhrasedFileName>
+              <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+              <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+              <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+            </statelessTestsetReporter>
           </configuration>
         </plugin>
 
@@ -981,7 +992,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -1076,7 +1087,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <dependencyConvergence />
+                  <dependencyConvergence/>
                 </rules>
               </configuration>
             </execution>
@@ -1087,7 +1098,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <banDuplicatePomDependencyVersions />
+                  <banDuplicatePomDependencyVersions/>
                 </rules>
               </configuration>
             </execution>

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/AbstractExecutionStep.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/AbstractExecutionStep.java
@@ -18,6 +18,9 @@ import org.apache.commons.lang3.builder.ToStringStyle;
  * variables need to be set before the execution step can be executed (e.g. setting the variables
  * when process is created)
  *
+ * <p>New implementations should also extends the execution logic in {@link
+ * io.zeebe.engine.util.WorkflowExecutor}
+ *
  * <p>Contract: each implementing class must implement {@code equals(...)/hashCode()} This is mostly
  * in order to be able to compare two randomly generated execution paths to see if they are the same
  */

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ExecutionPath.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ExecutionPath.java
@@ -11,8 +11,6 @@ import io.zeebe.test.util.bpmn.random.blocks.StepStartProcessInstance;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -45,18 +43,22 @@ public final class ExecutionPath {
     if (this == o) {
       return true;
     }
-
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
 
     final ExecutionPath that = (ExecutionPath) o;
 
-    return new EqualsBuilder().append(steps, that.steps).isEquals();
+    if (!steps.equals(that.steps)) {
+      return false;
+    }
+    return processId.equals(that.processId);
   }
 
   @Override
   public int hashCode() {
-    return new HashCodeBuilder(17, 37).append(steps).toHashCode();
+    int result = steps.hashCode();
+    result = 31 * result + processId.hashCode();
+    return result;
   }
 }

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ExecutionPath.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ExecutionPath.java
@@ -19,10 +19,16 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 /** Execution path to execute a random workflow from start to finish. This class is immutable. */
 public final class ExecutionPath {
   private final List<AbstractExecutionStep> steps = new ArrayList<>();
+  private final String processId;
 
-  public ExecutionPath(final ExecutionPathSegment pathSegment) {
-    steps.add(new StepStartProcessInstance(pathSegment));
+  public ExecutionPath(final String processId, final ExecutionPathSegment pathSegment) {
+    this.processId = processId;
+    steps.add(new StepStartProcessInstance(processId, pathSegment));
     steps.addAll(pathSegment.getSteps());
+  }
+
+  public String getProcessId() {
+    return processId;
   }
 
   public List<AbstractExecutionStep> getSteps() {

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ExecutionPathSegment.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ExecutionPathSegment.java
@@ -12,8 +12,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -57,18 +55,17 @@ public final class ExecutionPathSegment {
     if (this == o) {
       return true;
     }
-
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
 
     final ExecutionPathSegment that = (ExecutionPathSegment) o;
 
-    return new EqualsBuilder().append(steps, that.steps).isEquals();
+    return steps.equals(that.steps);
   }
 
   @Override
   public int hashCode() {
-    return new HashCodeBuilder(17, 37).append(steps).toHashCode();
+    return steps.hashCode();
   }
 }

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/RandomWorkflowGenerator.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/RandomWorkflowGenerator.java
@@ -69,7 +69,7 @@ public final class RandomWorkflowGenerator {
   }
 
   public ExecutionPath findRandomExecutionPath(final long seed) {
-    return new ExecutionPath(blockBuilder.findRandomExecutionPath(new Random(seed)));
+    return new ExecutionPath(processId, blockBuilder.findRandomExecutionPath(new Random(seed)));
   }
 
   // main method to test and debug this class

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/TestDataGenerator.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/TestDataGenerator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.test.util.bpmn.random;
+
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+public class TestDataGenerator {
+
+  static final Random RANDOM = new Random();
+
+  public static Collection<TestDataRecord> generateTestRecords(
+      final int workflows, final int pathsPerWorkflow) {
+    final List<TestDataRecord> records = new ArrayList<>();
+
+    for (int workflowIndex = 0; workflowIndex < workflows; workflowIndex++) {
+      final long workflowSeed = RANDOM.nextLong();
+
+      final RandomWorkflowGenerator generator =
+          new RandomWorkflowGenerator(workflowSeed, null, null, null);
+
+      final BpmnModelInstance bpmnModelInstance = generator.buildWorkflow();
+
+      final Set<ExecutionPath> paths = new HashSet<>();
+      for (int pathIndex = 0; pathIndex < pathsPerWorkflow; pathIndex++) {
+        final long pathSeed = RANDOM.nextLong();
+
+        final ExecutionPath path = generator.findRandomExecutionPath(pathSeed);
+
+        final boolean isDifferentPath = paths.add(path);
+
+        if (isDifferentPath) {
+          records.add(new TestDataRecord(workflowSeed, pathSeed, bpmnModelInstance, path));
+        }
+      }
+    }
+
+    return records;
+  }
+
+  public static TestDataRecord regenerateTestRecord(
+      final int workflowSeed, final int executionPathSeed) {
+    final RandomWorkflowGenerator generator =
+        new RandomWorkflowGenerator(workflowSeed, null, null, null);
+
+    final BpmnModelInstance bpmnModelInstance = generator.buildWorkflow();
+
+    final ExecutionPath path = generator.findRandomExecutionPath(executionPathSeed);
+
+    return new TestDataRecord(workflowSeed, executionPathSeed, bpmnModelInstance, path);
+  }
+
+  public static final class TestDataRecord {
+    private final long workFlowSeed;
+    private final long executionPathSeed;
+
+    private final BpmnModelInstance bpmnModel;
+    private final ExecutionPath executionPath;
+
+    private TestDataRecord(
+        final long workFlowSeed,
+        final long executionPathSeed,
+        final BpmnModelInstance bpmnModel,
+        final ExecutionPath executionPath) {
+      this.workFlowSeed = workFlowSeed;
+      this.executionPathSeed = executionPathSeed;
+      this.bpmnModel = bpmnModel;
+      this.executionPath = executionPath;
+    }
+
+    public BpmnModelInstance getBpmnModel() {
+      return bpmnModel;
+    }
+
+    public ExecutionPath getExecutionPath() {
+      return executionPath;
+    }
+
+    @Override
+    public String toString() {
+      return "TestDataRecord{"
+          + "workFlowSeed="
+          + workFlowSeed
+          + ", executionPathSeed="
+          + executionPathSeed
+          + '}';
+    }
+  }
+}

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -28,7 +28,13 @@ public class BlockSequenceBuilder implements BlockBuilder {
   private static final List<BlockBuilderFactory> BLOCK_BUILDER_FACTORIES =
       Arrays.asList(
           new ServiceTaskBlockBuilder.Factory(),
-          new IntermediateMessageCatchEventBlockBuilder.Factory(),
+          // new IntermediateMessageCatchEventBlockBuilder.Factory(),
+          /* The logic for IntermediateMessageCatchEventBlockBuilder is not fully implemented yet.
+           * the logic to generate a workflow and execution path is sound. What is incomplete
+           * is the execution logic of the corresponding execution step. What is missing there is
+           * that after publishing the message, the process should wait until the message has been
+           * correlated.
+           */
           new SubProcessBlockBuilder.Factory(),
           new ExclusiveGatewayBlockBuilder.Factory(),
           new ParallelGatewayBlockBuilder.Factory());

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ExclusiveGatewayBlockBuilder.java
@@ -18,8 +18,6 @@ import io.zeebe.test.util.bpmn.random.IDGenerator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Generates a block with a forking exclusive gateway, a default case, a random number of
@@ -127,22 +125,23 @@ public class ExclusiveGatewayBlockBuilder implements BlockBuilder {
       if (this == o) {
         return true;
       }
-
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
 
       final StepPickConditionCase that = (StepPickConditionCase) o;
 
-      return new EqualsBuilder()
-          .append(forkingGatewayId, that.forkingGatewayId)
-          .append(edgeId, that.edgeId)
-          .isEquals();
+      if (!forkingGatewayId.equals(that.forkingGatewayId)) {
+        return false;
+      }
+      return edgeId.equals(that.edgeId);
     }
 
     @Override
     public int hashCode() {
-      return new HashCodeBuilder(17, 37).append(forkingGatewayId).append(edgeId).toHashCode();
+      int result = forkingGatewayId.hashCode();
+      result = 31 * result + edgeId.hashCode();
+      return result;
     }
   }
 
@@ -161,19 +160,18 @@ public class ExclusiveGatewayBlockBuilder implements BlockBuilder {
       if (this == o) {
         return true;
       }
-
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
 
       final StepPickDefaultCase that = (StepPickDefaultCase) o;
 
-      return new EqualsBuilder().append(forkingGatewayId, that.forkingGatewayId).isEquals();
+      return forkingGatewayId.equals(that.forkingGatewayId);
     }
 
     @Override
     public int hashCode() {
-      return new HashCodeBuilder(17, 37).append(forkingGatewayId).toHashCode();
+      return forkingGatewayId.hashCode();
     }
   }
 

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/IntermediateMessageCatchEventBlockBuilder.java
@@ -16,8 +16,6 @@ import io.zeebe.test.util.bpmn.random.ConstructionContext;
 import io.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.zeebe.test.util.bpmn.random.IDGenerator;
 import java.util.Random;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Generates an intermediate message catch event. It waits for a message with name {@code
@@ -78,19 +76,18 @@ public class IntermediateMessageCatchEventBlockBuilder implements BlockBuilder {
       if (this == o) {
         return true;
       }
-
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
 
       final StepPublishMessage that = (StepPublishMessage) o;
 
-      return new EqualsBuilder().append(messageName, that.messageName).isEquals();
+      return messageName.equals(that.messageName);
     }
 
     @Override
     public int hashCode() {
-      return new HashCodeBuilder(17, 37).append(messageName).toHashCode();
+      return messageName.hashCode();
     }
   }
 

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ServiceTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ServiceTaskBlockBuilder.java
@@ -49,16 +49,21 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
     if (random.nextBoolean()) {
       result.append(new StepActivateAndFailJob(jobTypeId));
     }
+
     result.append(new StepActivateAndCompleteJob(jobTypeId));
 
     return result;
   }
 
   public static final class StepActivateAndCompleteJob extends AbstractExecutionStep {
-    private final String jobTypeId;
+    private final String jobType;
 
-    public StepActivateAndCompleteJob(final String jobTypeId) {
-      this.jobTypeId = jobTypeId;
+    public StepActivateAndCompleteJob(final String jobType) {
+      this.jobType = jobType;
+    }
+
+    public String getJobType() {
+      return jobType;
     }
 
     @Override
@@ -73,20 +78,24 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
 
       final StepActivateAndCompleteJob that = (StepActivateAndCompleteJob) o;
 
-      return new EqualsBuilder().append(jobTypeId, that.jobTypeId).isEquals();
+      return new EqualsBuilder().append(jobType, that.jobType).isEquals();
     }
 
     @Override
     public int hashCode() {
-      return new HashCodeBuilder(17, 37).append(jobTypeId).toHashCode();
+      return new HashCodeBuilder(17, 37).append(jobType).toHashCode();
     }
   }
 
   public static final class StepActivateAndFailJob extends AbstractExecutionStep {
-    private final String jobTypeId;
+    private final String jobType;
 
-    public StepActivateAndFailJob(final String jobTypeId) {
-      this.jobTypeId = jobTypeId;
+    public StepActivateAndFailJob(final String jobType) {
+      this.jobType = jobType;
+    }
+
+    public String getJobType() {
+      return jobType;
     }
 
     @Override
@@ -101,12 +110,12 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
 
       final StepActivateAndFailJob that = (StepActivateAndFailJob) o;
 
-      return new EqualsBuilder().append(jobTypeId, that.jobTypeId).isEquals();
+      return new EqualsBuilder().append(jobType, that.jobType).isEquals();
     }
 
     @Override
     public int hashCode() {
-      return new HashCodeBuilder(17, 37).append(jobTypeId).toHashCode();
+      return new HashCodeBuilder(17, 37).append(jobType).toHashCode();
     }
   }
 

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ServiceTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ServiceTaskBlockBuilder.java
@@ -16,8 +16,6 @@ import io.zeebe.test.util.bpmn.random.ConstructionContext;
 import io.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.zeebe.test.util.bpmn.random.IDGenerator;
 import java.util.Random;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /** Generates a service task * */
 public class ServiceTaskBlockBuilder implements BlockBuilder {
@@ -71,19 +69,18 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
       if (this == o) {
         return true;
       }
-
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
 
       final StepActivateAndCompleteJob that = (StepActivateAndCompleteJob) o;
 
-      return new EqualsBuilder().append(jobType, that.jobType).isEquals();
+      return jobType.equals(that.jobType);
     }
 
     @Override
     public int hashCode() {
-      return new HashCodeBuilder(17, 37).append(jobType).toHashCode();
+      return jobType.hashCode();
     }
   }
 
@@ -103,19 +100,18 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
       if (this == o) {
         return true;
       }
-
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
 
       final StepActivateAndFailJob that = (StepActivateAndFailJob) o;
 
-      return new EqualsBuilder().append(jobType, that.jobType).isEquals();
+      return jobType.equals(that.jobType);
     }
 
     @Override
     public int hashCode() {
-      return new HashCodeBuilder(17, 37).append(jobType).toHashCode();
+      return jobType.hashCode();
     }
   }
 

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/StepStartProcessInstance.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/StepStartProcessInstance.java
@@ -14,8 +14,15 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public final class StepStartProcessInstance extends AbstractExecutionStep {
 
-  public StepStartProcessInstance(final ExecutionPathSegment pathSegment) {
+  private final String processId;
+
+  public StepStartProcessInstance(final String processId, final ExecutionPathSegment pathSegment) {
+    this.processId = processId;
     variables.putAll(pathSegment.collectVariables());
+  }
+
+  public String getProcessId() {
+    return processId;
   }
 
   @Override
@@ -30,11 +37,14 @@ public final class StepStartProcessInstance extends AbstractExecutionStep {
 
     final StepStartProcessInstance that = (StepStartProcessInstance) o;
 
-    return new EqualsBuilder().append(variables, that.variables).isEquals();
+    return new EqualsBuilder()
+        .append(processId, that.processId)
+        .append(variables, that.variables)
+        .isEquals();
   }
 
   @Override
   public int hashCode() {
-    return new HashCodeBuilder(17, 37).append(variables).toHashCode();
+    return new HashCodeBuilder(17, 37).append(processId).append(variables).toHashCode();
   }
 }

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/StepStartProcessInstance.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/StepStartProcessInstance.java
@@ -9,8 +9,6 @@ package io.zeebe.test.util.bpmn.random.blocks;
 
 import io.zeebe.test.util.bpmn.random.AbstractExecutionStep;
 import io.zeebe.test.util.bpmn.random.ExecutionPathSegment;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public final class StepStartProcessInstance extends AbstractExecutionStep {
 
@@ -30,21 +28,17 @@ public final class StepStartProcessInstance extends AbstractExecutionStep {
     if (this == o) {
       return true;
     }
-
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
 
     final StepStartProcessInstance that = (StepStartProcessInstance) o;
 
-    return new EqualsBuilder()
-        .append(processId, that.processId)
-        .append(variables, that.variables)
-        .isEquals();
+    return processId.equals(that.processId);
   }
 
   @Override
   public int hashCode() {
-    return new HashCodeBuilder(17, 37).append(processId).append(variables).toHashCode();
+    return processId.hashCode();
   }
 }


### PR DESCRIPTION
## Description

Adds property-based test that takes a random process and execution path. It verifies at each step if the state before and after replay is the same.

## Related issues

closes #6203 

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
