### PR TITLE
fix(journal): clear index mapping on reset

### DIFF
--- a/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournalWriter.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournalWriter.java
@@ -102,6 +102,9 @@ public class SegmentedJournalWriter<E> implements JournalWriter<E> {
   @Override
   public void reset(final long index) {
     if (index > currentSegment.index()) {
+      // delete all index mapping
+      currentSegment.compactIndex(index + 1);
+      // delete all segments and create an empty one
       currentSegment = journal.resetSegments(index);
       currentWriter = currentSegment.writer();
     } else {

--- a/journal/src/main/java/io/zeebe/journal/file/JournalIndex.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalIndex.java
@@ -64,4 +64,7 @@ interface JournalIndex {
    * @param indexExclusive the index to which to compact the index
    */
   void deleteUntil(long indexExclusive);
+
+  /** Delete all index mappings */
+  void clear();
 }

--- a/journal/src/main/java/io/zeebe/journal/file/JournalSegment.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalSegment.java
@@ -180,10 +180,6 @@ class JournalSegment implements AutoCloseable {
     open = false;
   }
 
-  void compactIndex(final long index) {
-    this.index.deleteUntil(index);
-  }
-
   /** Deletes the segment. */
   public void delete() {
     try {

--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournal.java
@@ -120,19 +120,20 @@ public class SegmentedJournal implements Journal {
         log.debug("{} - Compacting {} segment(s)", name, compactSegments.size());
         for (final JournalSegment segment : compactSegments.values()) {
           log.trace("Deleting segment: {}", segment);
-          segment.compactIndex(index);
           segment.close();
           segment.delete();
           journalMetrics.decSegmentCount();
         }
         compactSegments.clear();
       }
+      journalIndex.deleteUntil(index);
       resetHead(getFirstSegment().index());
     }
   }
 
   @Override
   public void reset(final long nextIndex) {
+    journalIndex.clear();
     writer.reset(nextIndex);
   }
 

--- a/journal/src/main/java/io/zeebe/journal/file/SparseJournalIndex.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SparseJournalIndex.java
@@ -80,4 +80,11 @@ class SparseJournalIndex implements JournalIndex {
       asqnToIndex.headMap(asqnToDelete, false).clear();
     }
   }
+
+  @Override
+  public void clear() {
+    indexToPosition.clear();
+    indexToAsqn.clear();
+    asqnToIndex.clear();
+  }
 }


### PR DESCRIPTION
## Description

## Related issues

closes #6237 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
