### PR TITLE
Made RocksDB memory limit configurable

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -12,11 +12,13 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.regex.Pattern;
+import org.springframework.util.unit.DataSize;
 
 public final class RocksdbCfg implements ConfigurationEntry {
 
   private Properties columnFamilyOptions;
   private boolean statisticsEnabled;
+  private DataSize memoryLimit = DataSize.ofBytes(RocksDbConfiguration.DEFAULT_MEMORY_LIMIT);
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -54,8 +56,28 @@ public final class RocksdbCfg implements ConfigurationEntry {
     this.statisticsEnabled = statisticsEnabled;
   }
 
+  public DataSize getMemoryLimit() {
+    return memoryLimit;
+  }
+
+  public void setMemoryLimit(final DataSize memoryLimit) {
+    this.memoryLimit = memoryLimit;
+  }
+
   public RocksDbConfiguration createRocksDbConfiguration() {
-    return RocksDbConfiguration.of(columnFamilyOptions, statisticsEnabled);
+    return RocksDbConfiguration.of(columnFamilyOptions, statisticsEnabled, memoryLimit.toBytes());
+  }
+
+  @Override
+  public String toString() {
+    return "RocksdbCfg{"
+        + "columnFamilyOptions="
+        + columnFamilyOptions
+        + ", statisticsEnabled="
+        + statisticsEnabled
+        + ", memoryLimit="
+        + memoryLimit
+        + '}';
   }
 
   private static final class RocksDBColumnFamilyOption {

--- a/broker/src/test/resources/system/rocksdb-cfg.yaml
+++ b/broker/src/test/resources/system/rocksdb-cfg.yaml
@@ -6,3 +6,4 @@ zeebe:
           compaction_pri: "kOldestSmallestSeqFirst"
           write_buffer_size: 67108864
         statisticsEnabled: true
+        memoryLimit: 32MB

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -514,6 +514,7 @@
       # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_DETECT_REPROCESSING_INCONSISTENCY
       # detectReprocessingInconsistency = false;
 
+      # Allows to configure RocksDB properties, which is used for state management.
       # rocksdb:
         # Specify custom column family options overwriting Zeebe's own defaults.
         # WARNING: This setting requires in-depth knowledge of Zeebe's embedded database: RocksDB.
@@ -525,3 +526,12 @@
         # columnFamilyOptions:
           # compaction_pri: "kOldestSmallestSeqFirst"
           # write_buffer_size: 67108864
+
+        # Enables RocksDB statistics, which will be written to the RocksDB log file.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_STATISTICS_ENABLED
+        # statisticsEnabled: false
+
+        # Configures the memory limit, which can be used by RocksDB. Be aware that this setting only applies to RocksDB, which is used by the Zeebe's state management and that
+        # an RocksDB instance is used per partition.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORY_LIMIT
+        # memoryLimit: 512MB

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -475,6 +475,7 @@
       # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_DETECT_REPROCESSING_INCONSISTENCY
       # detectReprocessingInconsistency = false;
 
+      # Allows to configure RocksDB properties, which is used for state management.
       # rocksdb:
         # Specify custom column family options overwriting Zeebe's own defaults.
         # WARNING: This setting requires in-depth knowledge of Zeebe's embedded database: RocksDB.
@@ -486,3 +487,12 @@
         # columnFamilyOptions:
           # compaction_pri: "kOldestSmallestSeqFirst"
           # write_buffer_size: 67108864
+
+        # Enables RocksDB statistics, which will be written to the RocksDB log file.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_STATISTICS_ENABLED
+        # statisticsEnabled: false
+
+        # Configures the memory limit, which can be used by RocksDB. Be aware that this setting only applies to RocksDB, which is used by the Zeebe's state management and that
+        # an RocksDB instance is used per partition.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORY_LIMIT
+        # memoryLimit: 512MB

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -11,26 +11,37 @@ import java.util.Properties;
 
 public final class RocksDbConfiguration {
 
+  public static final long DEFAULT_MEMORY_LIMIT = 512 * 1024 * 1024L;
+
   private final Properties columnFamilyOptions;
   private final boolean statisticsEnabled;
+  private final long memoryLimit;
 
   private RocksDbConfiguration(
-      final Properties columnFamilyOptions, final boolean statisticsEnabled) {
+      final Properties columnFamilyOptions,
+      final boolean statisticsEnabled,
+      final long memoryLimit) {
     this.columnFamilyOptions = columnFamilyOptions;
     this.statisticsEnabled = statisticsEnabled;
+    this.memoryLimit = memoryLimit;
   }
 
   public static RocksDbConfiguration empty() {
-    return new RocksDbConfiguration(new Properties(), false);
+    return new RocksDbConfiguration(new Properties(), false, DEFAULT_MEMORY_LIMIT);
   }
 
   public static RocksDbConfiguration of(final Properties properties) {
-    return new RocksDbConfiguration(properties, false);
+    return new RocksDbConfiguration(properties, false, DEFAULT_MEMORY_LIMIT);
   }
 
   public static RocksDbConfiguration of(
       final Properties properties, final boolean statisticsEnabled) {
-    return new RocksDbConfiguration(properties, statisticsEnabled);
+    return new RocksDbConfiguration(properties, statisticsEnabled, DEFAULT_MEMORY_LIMIT);
+  }
+
+  public static RocksDbConfiguration of(
+      final Properties properties, final boolean statisticsEnabled, final long memoryLimit) {
+    return new RocksDbConfiguration(properties, statisticsEnabled, memoryLimit);
   }
 
   public Properties getColumnFamilyOptions() {
@@ -39,5 +50,9 @@ public final class RocksDbConfiguration {
 
   public boolean isStatisticsEnabled() {
     return statisticsEnabled;
+  }
+
+  public long getMemoryLimit() {
+    return memoryLimit;
   }
 }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -149,9 +149,7 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
       final List<AutoCloseable> closeables) {
     final var columnFamilyOptions = new ColumnFamilyOptions();
 
-    final var totalMemoryBudget =
-        512 * 1024
-            * 1024L; // TODO: make this configurable https://github.com/zeebe-io/zeebe/issues/6159
+    final var totalMemoryBudget = rocksDbConfiguration.getMemoryLimit();
     // recommended by RocksDB, but we could tweak it; keep in mind we're also caching the indexes
     // and filters into the block cache, so we don't need to account for more memory there
     final var blockCacheMemory = totalMemoryBudget / 3;


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6159 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
