### PR TITLE
The stream processor replays only events

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
@@ -11,6 +11,7 @@ import io.zeebe.broker.system.partitions.PartitionContext;
 import io.zeebe.broker.system.partitions.PartitionStep;
 import io.zeebe.engine.processing.streamprocessor.StreamProcessor;
 import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.appliers.EventAppliers;
 import io.zeebe.util.sched.ActorControl;
 import io.zeebe.util.sched.future.ActorFuture;
 import io.zeebe.util.sched.future.CompletableActorFuture;
@@ -67,6 +68,7 @@ public class StreamProcessorPartitionStep implements PartitionStep {
         .logStream(state.getLogStream())
         .actorScheduler(state.getScheduler())
         .zeebeDb(state.getZeebeDb())
+        .eventApplierFactory(EventAppliers::new)
         .nodeId(state.getNodeId())
         .commandResponseWriter(state.getCommandApiService().newCommandResponseWriter())
         .detectReprocessingInconsistency(

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/TypedStreamWriterProxy.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/TypedStreamWriterProxy.java
@@ -9,8 +9,8 @@ package io.zeebe.engine.processing.bpmn.behavior;
 
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
-import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.Intent;
 import java.util.function.UnaryOperator;
@@ -25,7 +25,7 @@ public final class TypedStreamWriterProxy implements TypedStreamWriter {
 
   @Override
   public void appendRejection(
-      final TypedRecord<? extends UnpackedObject> command,
+      final TypedRecord<? extends RecordValue> command,
       final RejectionType type,
       final String reason) {
     writer.appendRejection(command, type, reason);
@@ -33,7 +33,7 @@ public final class TypedStreamWriterProxy implements TypedStreamWriter {
 
   @Override
   public void appendRejection(
-      final TypedRecord<? extends UnpackedObject> command,
+      final TypedRecord<? extends RecordValue> command,
       final RejectionType type,
       final String reason,
       final UnaryOperator<RecordMetadata> modifier) {
@@ -46,12 +46,12 @@ public final class TypedStreamWriterProxy implements TypedStreamWriter {
   }
 
   @Override
-  public void appendNewEvent(final long key, final Intent intent, final UnpackedObject value) {
+  public void appendNewEvent(final long key, final Intent intent, final RecordValue value) {
     writer.appendNewEvent(key, intent, value);
   }
 
   @Override
-  public void appendFollowUpEvent(final long key, final Intent intent, final UnpackedObject value) {
+  public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     writer.appendFollowUpEvent(key, intent, value);
   }
 
@@ -59,19 +59,18 @@ public final class TypedStreamWriterProxy implements TypedStreamWriter {
   public void appendFollowUpEvent(
       final long key,
       final Intent intent,
-      final UnpackedObject value,
+      final RecordValue value,
       final UnaryOperator<RecordMetadata> modifier) {
     writer.appendFollowUpEvent(key, intent, value, modifier);
   }
 
   @Override
-  public void appendNewCommand(final Intent intent, final UnpackedObject value) {
+  public void appendNewCommand(final Intent intent, final RecordValue value) {
     writer.appendNewCommand(intent, value);
   }
 
   @Override
-  public void appendFollowUpCommand(
-      final long key, final Intent intent, final UnpackedObject value) {
+  public void appendFollowUpCommand(final long key, final Intent intent, final RecordValue value) {
     writer.appendFollowUpCommand(key, intent, value);
   }
 
@@ -79,7 +78,7 @@ public final class TypedStreamWriterProxy implements TypedStreamWriter {
   public void appendFollowUpCommand(
       final long key,
       final Intent intent,
-      final UnpackedObject value,
+      final RecordValue value,
       final UnaryOperator<RecordMetadata> modifier) {
     writer.appendFollowUpCommand(key, intent, value, modifier);
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -26,7 +26,7 @@ public final class MigratedStreamProcessors {
   private static final Map<ValueType, Function<TypedRecord<?>, Boolean>> MIGRATED_VALUE_TYPES =
       new EnumMap<>(ValueType.class);
 
-  private MigratedStreamProcessors() {
+  static {
     MIGRATED_VALUE_TYPES.put(
         ValueType.WORKFLOW_INSTANCE,
         record -> {
@@ -38,6 +38,8 @@ public final class MigratedStreamProcessors {
 
     MIGRATED_VALUE_TYPES.put(ValueType.ERROR, MIGRATED);
   }
+
+  private MigratedStreamProcessors() {}
 
   public static boolean isMigrated(final TypedRecord<?> record) {
     final var valueType = record.getValueType();

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -11,6 +11,7 @@ import io.zeebe.db.TransactionContext;
 import io.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.NoopTypedStreamWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.zeebe.engine.state.EventApplier;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
@@ -30,6 +31,7 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
   private RecordProcessorMap recordProcessorMap;
   private ZeebeState zeebeState;
   private TransactionContext transactionContext;
+  private EventApplier eventApplier;
 
   private BooleanSupplier abortCondition;
   private Consumer<TypedRecord> onProcessedListener = record -> {};
@@ -103,6 +105,11 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return this;
   }
 
+  public ProcessingContext eventApplier(final EventApplier eventApplier) {
+    this.eventApplier = eventApplier;
+    return this;
+  }
+
   @Override
   public ActorControl getActor() {
     return actor;
@@ -164,5 +171,10 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
 
   public boolean isDetectReprocessingInconsistency() {
     return detectReprocessingInconsistency;
+  }
+
+  @Override
+  public EventApplier getEventApplier() {
+    return eventApplier;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReadonlyProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReadonlyProcessingContext.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.processing.streamprocessor;
 import io.zeebe.db.TransactionContext;
 import io.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.zeebe.engine.state.EventApplier;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
@@ -53,4 +54,7 @@ public interface ReadonlyProcessingContext {
 
   /** @return condition which indicates, whether the processing should stop or not */
   BooleanSupplier getAbortCondition();
+
+  /** @return the consumer of events to apply their state changes */
+  EventApplier getEventApplier();
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
@@ -9,12 +9,15 @@ package io.zeebe.engine.processing.streamprocessor;
 
 import io.zeebe.db.ZeebeDb;
 import io.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.zeebe.engine.state.EventApplier;
+import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.util.sched.ActorScheduler;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 public final class StreamProcessorBuilder {
 
@@ -23,6 +26,7 @@ public final class StreamProcessorBuilder {
   private TypedRecordProcessorFactory typedRecordProcessorFactory;
   private ActorScheduler actorScheduler;
   private ZeebeDb zeebeDb;
+  private Function<ZeebeState, EventApplier> eventApplierFactory;
   private int nodeId;
 
   public StreamProcessorBuilder() {
@@ -72,6 +76,12 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
+  public StreamProcessorBuilder eventApplierFactory(
+      final Function<ZeebeState, EventApplier> eventApplierFactory) {
+    this.eventApplierFactory = eventApplierFactory;
+    return this;
+  }
+
   public TypedRecordProcessorFactory getTypedRecordProcessorFactory() {
     return typedRecordProcessorFactory;
   }
@@ -96,6 +106,10 @@ public final class StreamProcessorBuilder {
     return nodeId;
   }
 
+  public Function<ZeebeState, EventApplier> getEventApplierFactory() {
+    return eventApplierFactory;
+  }
+
   public StreamProcessor build() {
     validate();
 
@@ -109,5 +123,6 @@ public final class StreamProcessorBuilder {
     Objects.requireNonNull(
         processingContext.getCommandResponseWriter(), "No command response writer provided.");
     Objects.requireNonNull(zeebeDb, "No database provided.");
+    Objects.requireNonNull(eventApplierFactory, "No factory for the event supplier provided.");
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/NoopTypedStreamWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/NoopTypedStreamWriter.java
@@ -8,8 +8,8 @@
 package io.zeebe.engine.processing.streamprocessor.writers;
 
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
-import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.Intent;
 import java.util.function.UnaryOperator;
@@ -18,7 +18,7 @@ public final class NoopTypedStreamWriter implements TypedStreamWriter {
 
   @Override
   public void appendRejection(
-      final TypedRecord<? extends UnpackedObject> command,
+      final TypedRecord<? extends RecordValue> command,
       final RejectionType type,
       final String reason) {
     // no op implementation
@@ -26,7 +26,7 @@ public final class NoopTypedStreamWriter implements TypedStreamWriter {
 
   @Override
   public void appendRejection(
-      final TypedRecord<? extends UnpackedObject> command,
+      final TypedRecord<? extends RecordValue> command,
       final RejectionType type,
       final String reason,
       final UnaryOperator<RecordMetadata> modifier) {
@@ -39,12 +39,12 @@ public final class NoopTypedStreamWriter implements TypedStreamWriter {
   }
 
   @Override
-  public void appendNewEvent(final long key, final Intent intent, final UnpackedObject value) {
+  public void appendNewEvent(final long key, final Intent intent, final RecordValue value) {
     // no op implementation
   }
 
   @Override
-  public void appendFollowUpEvent(final long key, final Intent intent, final UnpackedObject value) {
+  public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     // no op implementation
   }
 
@@ -52,19 +52,18 @@ public final class NoopTypedStreamWriter implements TypedStreamWriter {
   public void appendFollowUpEvent(
       final long key,
       final Intent intent,
-      final UnpackedObject value,
+      final RecordValue value,
       final UnaryOperator<RecordMetadata> modifier) {
     // no op implementation
   }
 
   @Override
-  public void appendNewCommand(final Intent intent, final UnpackedObject value) {
+  public void appendNewCommand(final Intent intent, final RecordValue value) {
     // no op implementation
   }
 
   @Override
-  public void appendFollowUpCommand(
-      final long key, final Intent intent, final UnpackedObject value) {
+  public void appendFollowUpCommand(final long key, final Intent intent, final RecordValue value) {
     // no op implementation
   }
 
@@ -72,7 +71,7 @@ public final class NoopTypedStreamWriter implements TypedStreamWriter {
   public void appendFollowUpCommand(
       final long key,
       final Intent intent,
-      final UnpackedObject value,
+      final RecordValue value,
       final UnaryOperator<RecordMetadata> modifier) {
     // no op implementation
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/ReprocessingStreamWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/ReprocessingStreamWriter.java
@@ -8,9 +8,9 @@
 package io.zeebe.engine.processing.streamprocessor.writers;
 
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
-import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.Intent;
 import java.util.ArrayList;
@@ -25,7 +25,7 @@ public final class ReprocessingStreamWriter implements TypedStreamWriter {
 
   @Override
   public void appendRejection(
-      final TypedRecord<? extends UnpackedObject> command,
+      final TypedRecord<? extends RecordValue> command,
       final RejectionType type,
       final String reason) {
 
@@ -40,7 +40,7 @@ public final class ReprocessingStreamWriter implements TypedStreamWriter {
 
   @Override
   public void appendRejection(
-      final TypedRecord<? extends UnpackedObject> command,
+      final TypedRecord<? extends RecordValue> command,
       final RejectionType type,
       final String reason,
       final UnaryOperator<RecordMetadata> modifier) {
@@ -60,14 +60,14 @@ public final class ReprocessingStreamWriter implements TypedStreamWriter {
   }
 
   @Override
-  public void appendNewEvent(final long key, final Intent intent, final UnpackedObject value) {
+  public void appendNewEvent(final long key, final Intent intent, final RecordValue value) {
 
     final var record = new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.EVENT);
     records.add(record);
   }
 
   @Override
-  public void appendFollowUpEvent(final long key, final Intent intent, final UnpackedObject value) {
+  public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
 
     final var record = new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.EVENT);
     records.add(record);
@@ -77,7 +77,7 @@ public final class ReprocessingStreamWriter implements TypedStreamWriter {
   public void appendFollowUpEvent(
       final long key,
       final Intent intent,
-      final UnpackedObject value,
+      final RecordValue value,
       final UnaryOperator<RecordMetadata> modifier) {
 
     final var record = new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.EVENT);
@@ -85,7 +85,7 @@ public final class ReprocessingStreamWriter implements TypedStreamWriter {
   }
 
   @Override
-  public void appendNewCommand(final Intent intent, final UnpackedObject value) {
+  public void appendNewCommand(final Intent intent, final RecordValue value) {
 
     final var record =
         new ReprocessingRecord(-1L, sourceRecordPosition, intent, RecordType.COMMAND);
@@ -93,8 +93,7 @@ public final class ReprocessingStreamWriter implements TypedStreamWriter {
   }
 
   @Override
-  public void appendFollowUpCommand(
-      final long key, final Intent intent, final UnpackedObject value) {
+  public void appendFollowUpCommand(final long key, final Intent intent, final RecordValue value) {
 
     final var record =
         new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.COMMAND);
@@ -105,7 +104,7 @@ public final class ReprocessingStreamWriter implements TypedStreamWriter {
   public void appendFollowUpCommand(
       final long key,
       final Intent intent,
-      final UnpackedObject value,
+      final RecordValue value,
       final UnaryOperator<RecordMetadata> modifier) {
 
     final var record =

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/StateWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/StateWriter.java
@@ -8,8 +8,8 @@
 package io.zeebe.engine.processing.streamprocessor.writers;
 
 import io.zeebe.engine.state.appliers.EventAppliers;
-import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.intent.Intent;
 import java.util.function.UnaryOperator;
 
@@ -35,12 +35,12 @@ public final class StateWriter implements TypedEventWriter {
   }
 
   @Override
-  public void appendNewEvent(final long key, final Intent intent, final UnpackedObject value) {
+  public void appendNewEvent(final long key, final Intent intent, final RecordValue value) {
     appendFollowUpEvent(key, intent, value, NO_MODIFIER);
   }
 
   @Override
-  public void appendFollowUpEvent(final long key, final Intent intent, final UnpackedObject value) {
+  public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     appendFollowUpEvent(key, intent, value, NO_MODIFIER);
   }
 
@@ -48,7 +48,7 @@ public final class StateWriter implements TypedEventWriter {
   public void appendFollowUpEvent(
       final long key,
       final Intent intent,
-      final UnpackedObject value,
+      final RecordValue value,
       final UnaryOperator<RecordMetadata> modifier) {
     streamWriter.appendFollowUpEvent(key, intent, value, modifier);
     eventAppliers.applyState(key, intent, value);

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriter.java
@@ -7,17 +7,17 @@
  */
 package io.zeebe.engine.processing.streamprocessor.writers;
 
-import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.intent.Intent;
 import java.util.function.UnaryOperator;
 
 /** Things that any actor can write to a partition. */
 public interface TypedCommandWriter {
 
-  void appendNewCommand(Intent intent, UnpackedObject value);
+  void appendNewCommand(Intent intent, RecordValue value);
 
-  void appendFollowUpCommand(long key, Intent intent, UnpackedObject value);
+  void appendFollowUpCommand(long key, Intent intent, RecordValue value);
 
   /**
    * @deprecated The modifier parameter is used, but at the time of writing unnecessarily by {@link
@@ -25,7 +25,7 @@ public interface TypedCommandWriter {
    */
   @Deprecated
   void appendFollowUpCommand(
-      long key, Intent intent, UnpackedObject value, UnaryOperator<RecordMetadata> modifier);
+      long key, Intent intent, RecordValue value, UnaryOperator<RecordMetadata> modifier);
 
   void reset();
 

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -7,19 +7,19 @@
  */
 package io.zeebe.engine.processing.streamprocessor.writers;
 
-import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.intent.Intent;
 import java.util.function.UnaryOperator;
 
 public interface TypedEventWriter {
 
-  void appendNewEvent(long key, Intent intent, UnpackedObject value);
+  void appendNewEvent(long key, Intent intent, RecordValue value);
 
-  void appendFollowUpEvent(long key, Intent intent, UnpackedObject value);
+  void appendFollowUpEvent(long key, Intent intent, RecordValue value);
 
   /** @deprecated The modifier parameter is not used at the time of writing */
   @Deprecated
   void appendFollowUpEvent(
-      long key, Intent intent, UnpackedObject value, UnaryOperator<RecordMetadata> modifier);
+      long key, Intent intent, RecordValue value, UnaryOperator<RecordMetadata> modifier);
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriter.java
@@ -8,8 +8,8 @@
 package io.zeebe.engine.processing.streamprocessor.writers;
 
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
-import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.RejectionType;
 import java.util.function.UnaryOperator;
 
@@ -17,12 +17,12 @@ import java.util.function.UnaryOperator;
 public interface TypedStreamWriter extends TypedCommandWriter, TypedEventWriter {
 
   void appendRejection(
-      TypedRecord<? extends UnpackedObject> command, RejectionType type, String reason);
+      TypedRecord<? extends RecordValue> command, RejectionType type, String reason);
 
   /** @deprecated The modifier parameter is not used at the time of writing */
   @Deprecated
   void appendRejection(
-      TypedRecord<? extends UnpackedObject> command,
+      TypedRecord<? extends RecordValue> command,
       RejectionType type,
       String reason,
       UnaryOperator<RecordMetadata> modifier);

--- a/engine/src/main/java/io/zeebe/engine/state/TypedEventApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/TypedEventApplier.java
@@ -10,15 +10,8 @@ package io.zeebe.engine.state;
 import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.intent.Intent;
 
-/** Applies the state changes for a specific event. */
-public interface EventApplier {
+/** Applies state changes for a specific event to the {@link io.zeebe.engine.state.ZeebeState}. */
+public interface TypedEventApplier<I extends Intent, V extends RecordValue> {
 
-  /**
-   * Apply the state changes of the given event.
-   *
-   * @param key the key of the event
-   * @param intent the intent of the event
-   * @param recordValue the value of the event
-   */
-  void applyState(long key, Intent intent, RecordValue recordValue);
+  void applyState(final long key, final V value);
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementActivatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementActivatedApplier.java
@@ -7,7 +7,7 @@
  */
 package io.zeebe.engine.state.appliers;
 
-import io.zeebe.engine.state.EventApplier;
+import io.zeebe.engine.state.TypedEventApplier;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
@@ -16,7 +16,7 @@ import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
  * This class represents an example to apply state changes for `WorkflowInstance:Element_Activated`
  */
 final class WorkflowInstanceElementActivatedApplier
-    implements EventApplier<WorkflowInstanceIntent, WorkflowInstanceRecord> {
+    implements TypedEventApplier<WorkflowInstanceIntent, WorkflowInstanceRecord> {
 
   WorkflowInstanceElementActivatedApplier(final ZeebeState state) {}
 

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -19,9 +19,9 @@ import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.util.StreamProcessorRule;
-import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.Intent;
@@ -240,7 +240,7 @@ public class StreamProcessorHealthTest {
 
     @Override
     public void appendRejection(
-        final TypedRecord<? extends UnpackedObject> command,
+        final TypedRecord<? extends RecordValue> command,
         final RejectionType type,
         final String reason) {
       wrappedWriter.appendRejection(command, type, reason);
@@ -248,7 +248,7 @@ public class StreamProcessorHealthTest {
 
     @Override
     public void appendRejection(
-        final TypedRecord<? extends UnpackedObject> command,
+        final TypedRecord<? extends RecordValue> command,
         final RejectionType type,
         final String reason,
         final UnaryOperator<RecordMetadata> modifier) {
@@ -261,13 +261,12 @@ public class StreamProcessorHealthTest {
     }
 
     @Override
-    public void appendNewEvent(final long key, final Intent intent, final UnpackedObject value) {
+    public void appendNewEvent(final long key, final Intent intent, final RecordValue value) {
       wrappedWriter.appendNewEvent(key, intent, value);
     }
 
     @Override
-    public void appendFollowUpEvent(
-        final long key, final Intent intent, final UnpackedObject value) {
+    public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
       if (shouldFailErrorHandlingInTransaction.get()) {
         throw new RuntimeException("Expected failure on append followup event");
       }
@@ -278,7 +277,7 @@ public class StreamProcessorHealthTest {
     public void appendFollowUpEvent(
         final long key,
         final Intent intent,
-        final UnpackedObject value,
+        final RecordValue value,
         final UnaryOperator<RecordMetadata> modifier) {
       if (shouldFailErrorHandlingInTransaction.get()) {
         throw new RuntimeException("Expected failure on append followup event");
@@ -287,13 +286,13 @@ public class StreamProcessorHealthTest {
     }
 
     @Override
-    public void appendNewCommand(final Intent intent, final UnpackedObject value) {
+    public void appendNewCommand(final Intent intent, final RecordValue value) {
       wrappedWriter.appendNewCommand(intent, value);
     }
 
     @Override
     public void appendFollowUpCommand(
-        final long key, final Intent intent, final UnpackedObject value) {
+        final long key, final Intent intent, final RecordValue value) {
       wrappedWriter.appendFollowUpCommand(key, intent, value);
     }
 
@@ -301,7 +300,7 @@ public class StreamProcessorHealthTest {
     public void appendFollowUpCommand(
         final long key,
         final Intent intent,
-        final UnpackedObject value,
+        final RecordValue value,
         final UnaryOperator<RecordMetadata> modifier) {
       wrappedWriter.appendFollowUpCommand(key, intent, value, modifier);
     }

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorReplayTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorReplayTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.streamprocessor;
+
+import static io.zeebe.protocol.record.intent.WorkflowInstanceIntent.ELEMENT_ACTIVATING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+
+import io.zeebe.engine.state.EventApplier;
+import io.zeebe.engine.util.StreamProcessorRule;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.verification.VerificationWithTimeout;
+
+public final class StreamProcessorReplayTest {
+
+  private static final long TIMEOUT_MILLIS = 2_000L;
+  private static final VerificationWithTimeout TIMEOUT = timeout(TIMEOUT_MILLIS);
+
+  private static final int EXPECTED_ON_RECOVERED_INVOCATIONS = 2;
+
+  private static final WorkflowInstanceRecord RECORD =
+      new WorkflowInstanceRecord().setBpmnElementType(BpmnElementType.TESTING_ONLY);
+
+  @Rule public final StreamProcessorRule streamProcessorRule = new StreamProcessorRule();
+
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock private TypedRecordProcessor<?> typedRecordProcessor;
+  @Mock private EventApplier eventApplier;
+
+  @Test
+  public void shouldReplayEvents() {
+    // given
+    final long commandPosition =
+        streamProcessorRule.writeCommand(WorkflowInstanceIntent.ACTIVATE_ELEMENT, RECORD);
+
+    streamProcessorRule.writeEvent(
+        WorkflowInstanceIntent.ELEMENT_ACTIVATING,
+        RECORD,
+        writer -> writer.sourceRecordPosition(commandPosition));
+
+    // when
+    startStreamProcessor(typedRecordProcessor, eventApplier);
+
+    // then
+    final InOrder inOrder = inOrder(typedRecordProcessor, eventApplier);
+    inOrder.verify(eventApplier, TIMEOUT).applyState(anyLong(), eq(ELEMENT_ACTIVATING), any());
+    inOrder
+        .verify(typedRecordProcessor, never())
+        .processRecord(anyLong(), any(), any(), any(), any());
+    inOrder
+        .verify(typedRecordProcessor, TIMEOUT.times(EXPECTED_ON_RECOVERED_INVOCATIONS))
+        .onRecovered(any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldSkipCommands() {
+    // given
+    final var commandPosition =
+        streamProcessorRule.writeCommand(WorkflowInstanceIntent.ACTIVATE_ELEMENT, RECORD);
+
+    streamProcessorRule.writeEvent(
+        WorkflowInstanceIntent.ELEMENT_ACTIVATING,
+        RECORD,
+        writer -> writer.sourceRecordPosition(commandPosition));
+
+    // when
+    startStreamProcessor(typedRecordProcessor, eventApplier);
+
+    // then
+    final InOrder inOrder = inOrder(typedRecordProcessor, eventApplier);
+    inOrder
+        .verify(typedRecordProcessor, never())
+        .processRecord(anyLong(), any(), any(), any(), any());
+    inOrder
+        .verify(eventApplier, never())
+        .applyState(anyLong(), eq(WorkflowInstanceIntent.ACTIVATE_ELEMENT), any());
+    inOrder
+        .verify(typedRecordProcessor, TIMEOUT.times(EXPECTED_ON_RECOVERED_INVOCATIONS))
+        .onRecovered(any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldSkipRejections() {
+    // given
+    final var commandPosition =
+        streamProcessorRule.writeCommand(WorkflowInstanceIntent.ACTIVATE_ELEMENT, RECORD);
+
+    streamProcessorRule.writeCommandRejection(
+        WorkflowInstanceIntent.ACTIVATE_ELEMENT,
+        RECORD,
+        writer -> writer.sourceRecordPosition(commandPosition));
+
+    // when
+    startStreamProcessor(typedRecordProcessor, eventApplier);
+
+    // then
+    final InOrder inOrder = inOrder(typedRecordProcessor, eventApplier);
+    inOrder
+        .verify(typedRecordProcessor, never())
+        .processRecord(anyLong(), any(), any(), any(), any());
+    inOrder
+        .verify(eventApplier, never())
+        .applyState(anyLong(), eq(WorkflowInstanceIntent.ACTIVATE_ELEMENT), any());
+    inOrder
+        .verify(typedRecordProcessor, TIMEOUT.times(EXPECTED_ON_RECOVERED_INVOCATIONS))
+        .onRecovered(any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldNotReplayEventIfAlreadyApplied() {
+    // given
+    final var eventKeyBeforeSnapshot = 1L;
+    final var eventKeyAfterSnapshot = 2L;
+
+    startStreamProcessor(typedRecordProcessor, eventApplier);
+
+    final long commandPositionBeforeSnapshot =
+        streamProcessorRule.writeCommand(WorkflowInstanceIntent.ACTIVATE_ELEMENT, RECORD);
+
+    streamProcessorRule.writeEvent(
+        WorkflowInstanceIntent.ELEMENT_ACTIVATING,
+        RECORD,
+        writer ->
+            writer.key(eventKeyBeforeSnapshot).sourceRecordPosition(commandPositionBeforeSnapshot));
+
+    awaitUntilProcessed(commandPositionBeforeSnapshot);
+
+    streamProcessorRule.snapshot();
+    streamProcessorRule.closeStreamProcessor();
+
+    // when
+    final long commandPositionAfterSnapshot =
+        streamProcessorRule.writeCommand(WorkflowInstanceIntent.ACTIVATE_ELEMENT, RECORD);
+
+    streamProcessorRule.writeEvent(
+        WorkflowInstanceIntent.ELEMENT_ACTIVATING,
+        RECORD,
+        writer ->
+            writer.key(eventKeyAfterSnapshot).sourceRecordPosition(commandPositionAfterSnapshot));
+
+    startStreamProcessor(typedRecordProcessor, eventApplier);
+
+    // then
+    final InOrder inOrder = inOrder(eventApplier);
+    inOrder.verify(eventApplier, never()).applyState(eq(eventKeyBeforeSnapshot), any(), any());
+    inOrder.verify(eventApplier, TIMEOUT).applyState(eq(eventKeyAfterSnapshot), any(), any());
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  private void startStreamProcessor(
+      final TypedRecordProcessor<?> typedRecordProcessor, final EventApplier eventApplier) {
+    streamProcessorRule
+        .withEventApplierFactory(zeebeState -> eventApplier)
+        .startTypedStreamProcessor(
+            (processors, context) ->
+                processors
+                    .onCommand(
+                        ValueType.WORKFLOW_INSTANCE,
+                        WorkflowInstanceIntent.ACTIVATE_ELEMENT,
+                        typedRecordProcessor)
+                    .onEvent(
+                        ValueType.WORKFLOW_INSTANCE, ELEMENT_ACTIVATING, typedRecordProcessor));
+  }
+
+  private void awaitUntilProcessed(final long position) {
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final var processedPosition =
+                  streamProcessorRule.getStreamProcessor(0).getLastProcessedPositionAsync().join();
+              assertThat(processedPosition).isEqualTo(position);
+            });
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -15,11 +15,14 @@ import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.zeebe.engine.state.DefaultZeebeDbFactory;
+import io.zeebe.engine.state.EventApplier;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.util.StreamProcessingComposite.StreamProcessorTestFactory;
+import io.zeebe.engine.util.TestStreams.FluentLogWriter;
 import io.zeebe.logstreams.log.LogStreamRecordWriter;
 import io.zeebe.logstreams.util.SynchronousLogStream;
 import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import io.zeebe.test.util.AutoCloseableRule;
@@ -30,7 +33,9 @@ import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.File;
 import java.io.IOException;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
@@ -109,6 +114,12 @@ public final class StreamProcessorRule implements TestRule {
   @Override
   public Statement apply(final Statement base, final Description description) {
     return chain.apply(base, description);
+  }
+
+  public StreamProcessorRule withEventApplierFactory(
+      final Function<ZeebeState, EventApplier> eventApplierFactory) {
+    streams.withEventApplierFactory(eventApplierFactory);
+    return this;
   }
 
   public LogStreamRecordWriter getLogStreamRecordWriter(final int partitionId) {
@@ -239,6 +250,34 @@ public final class StreamProcessorRule implements TestRule {
 
   public long writeCommandRejection(final Intent intent, final UnpackedObject value) {
     return streamProcessingComposite.writeCommandRejection(intent, value);
+  }
+
+  public long writeEvent(
+      final Intent intent,
+      final UnpackedObject value,
+      final UnaryOperator<FluentLogWriter> writer) {
+    return writeRecord(intent, value, w -> writer.apply(w.recordType(RecordType.EVENT)));
+  }
+
+  public long writeCommandRejection(
+      final Intent intent,
+      final UnpackedObject value,
+      final UnaryOperator<FluentLogWriter> writer) {
+    return writeRecord(
+        intent, value, w -> writer.apply(w.recordType(RecordType.COMMAND_REJECTION)));
+  }
+
+  private long writeRecord(
+      final Intent intent,
+      final UnpackedObject value,
+      final UnaryOperator<FluentLogWriter> writer) {
+    final var recordWriter =
+        streams
+            .newRecord(getLogName(startPartitionId))
+            .recordType(RecordType.EVENT)
+            .intent(intent)
+            .event(value);
+    return writer.apply(recordWriter).write();
   }
 
   public void snapshot() {


### PR DESCRIPTION
## Description

* replay events for migrated processors (i.e. apply the state changes)
* don't replay or reprocess commands or rejections of migrated processors
* don't replay event if the state change is already applied in the snapshot
* replay all events of the stream (i.e. don't stop on the last processed command)

Hints for the reviewer:
* postponed a bigger refactoring since the reprocessing part will be removed soon. We should refactor the whole stream processor after the refactoring.

## Related issues

closes #6163 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
