### PR TITLE
chore(zb-db): expose maxOpenFiles

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -19,6 +19,7 @@ public final class RocksdbCfg implements ConfigurationEntry {
   private Properties columnFamilyOptions;
   private boolean statisticsEnabled;
   private DataSize memoryLimit = DataSize.ofBytes(RocksDbConfiguration.DEFAULT_MEMORY_LIMIT);
+  private int maxOpenFiles = RocksDbConfiguration.DEFAULT_UNLIMITED_MAX_OPEN_FILES;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -64,8 +65,17 @@ public final class RocksdbCfg implements ConfigurationEntry {
     this.memoryLimit = memoryLimit;
   }
 
+  public int getMaxOpenFiles() {
+    return maxOpenFiles;
+  }
+
+  public void setMaxOpenFiles(final int maxOpenFiles) {
+    this.maxOpenFiles = maxOpenFiles;
+  }
+
   public RocksDbConfiguration createRocksDbConfiguration() {
-    return RocksDbConfiguration.of(columnFamilyOptions, statisticsEnabled, memoryLimit.toBytes());
+    return RocksDbConfiguration.of(
+        columnFamilyOptions, statisticsEnabled, memoryLimit.toBytes(), maxOpenFiles);
   }
 
   @Override
@@ -77,6 +87,8 @@ public final class RocksdbCfg implements ConfigurationEntry {
         + statisticsEnabled
         + ", memoryLimit="
         + memoryLimit
+        + ", maxOpenFiles="
+        + maxOpenFiles
         + '}';
   }
 

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/RocksdbCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/RocksdbCfgTest.java
@@ -49,6 +49,16 @@ public final class RocksdbCfgTest {
   }
 
   @Test
+  public void shouldUseDefaultMaxOpenFiles() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getMaxOpenFiles()).isEqualTo(-1);
+  }
+
+  @Test
   public void shouldCreateRocksDbConfigurationFromDefault() {
     // given
     final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
@@ -62,6 +72,7 @@ public final class RocksdbCfgTest {
     assertThat(rocksDbConfiguration.isStatisticsEnabled()).isFalse();
     assertThat(rocksDbConfiguration.getMemoryLimit())
         .isEqualTo(DataSize.ofMegabytes(512).toBytes());
+    assertThat(rocksDbConfiguration.getMaxOpenFiles()).isEqualTo(-1);
   }
 
   @Test
@@ -79,6 +90,7 @@ public final class RocksdbCfgTest {
         .containsEntry("write_buffer_size", "67108864");
     assertThat(rocksDbConfiguration.isStatisticsEnabled()).isTrue();
     assertThat(rocksDbConfiguration.getMemoryLimit()).isEqualTo(DataSize.ofMegabytes(32).toBytes());
+    assertThat(rocksDbConfiguration.getMaxOpenFiles()).isEqualTo(3);
   }
 
   @Test
@@ -111,6 +123,16 @@ public final class RocksdbCfgTest {
 
     // then
     assertThat(rocksdb.getMemoryLimit()).isEqualTo(DataSize.ofMegabytes(32));
+  }
+
+  @Test
+  public void shouldSetMaxOpenFilesViaConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getMaxOpenFiles()).isEqualTo(3);
   }
 
   @Test
@@ -152,5 +174,18 @@ public final class RocksdbCfgTest {
 
     // then
     assertThat(rocksdb.getMemoryLimit()).isEqualTo(DataSize.ofKilobytes(16));
+  }
+
+  @Test
+  public void shouldSetMaxOpenFilesViaEnvironmentVariables() {
+    // given
+    environment.put("zeebe.broker.experimental.rocksdb.maxOpenFiles", "5");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getMaxOpenFiles()).isEqualTo(5);
   }
 }

--- a/broker/src/test/resources/system/rocksdb-cfg.yaml
+++ b/broker/src/test/resources/system/rocksdb-cfg.yaml
@@ -7,3 +7,4 @@ zeebe:
           write_buffer_size: 67108864
         statisticsEnabled: true
         memoryLimit: 32MB
+        maxOpenFiles: 3

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -535,3 +535,10 @@
         # an RocksDB instance is used per partition.
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORY_LIMIT
         # memoryLimit: 512MB
+
+        # Configures how many files are kept open by RocksDB, per default it is unlimited (-1).
+        # This is a performance optimization: if you set a value greater than zero, it will keep track and cap the number of open
+        # files in the TableCache. On accessing the files it needs to look them up in the cache.
+        # You should configure this property if the maximum open files are limited on your system, or if you have thousands of files in your RocksDB state as there is a memory overhead to keeping all of them open, and setting maxOpenFiles will bound that.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MAX_OPEN_FILES
+        # maxOpenFiles: -1

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -496,3 +496,10 @@
         # an RocksDB instance is used per partition.
         # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORY_LIMIT
         # memoryLimit: 512MB
+
+        # Configures how many files are kept open by RocksDB, per default it is unlimited (-1).
+        # This is a performance optimization: if you set a value greater than zero, it will keep track and cap the number of open
+        # files in the TableCache. On accessing the files it needs to look them up in the cache.
+        # You should configure this property if the maximum open files are limited on your system, or if you have thousands of files in your RocksDB state as there is a memory overhead to keeping all of them open, and setting maxOpenFiles will bound that.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MAX_OPEN_FILES
+        # maxOpenFiles: -1

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -12,36 +12,56 @@ import java.util.Properties;
 public final class RocksDbConfiguration {
 
   public static final long DEFAULT_MEMORY_LIMIT = 512 * 1024 * 1024L;
+  public static final int DEFAULT_UNLIMITED_MAX_OPEN_FILES = -1;
 
   private final Properties columnFamilyOptions;
   private final boolean statisticsEnabled;
   private final long memoryLimit;
 
+  /**
+   * Defines how many files are kept open by RocksDB, per default it is unlimited (-1). This is done
+   * for performance reasons, if we set a value higher then zero it needs to keep track of open
+   * files in the TableCache and look up on accessing them.
+   *
+   * <p>https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide#general-options
+   */
+  private final int maxOpenFiles;
+
   private RocksDbConfiguration(
       final Properties columnFamilyOptions,
       final boolean statisticsEnabled,
-      final long memoryLimit) {
+      final long memoryLimit,
+      final int maxOpenFiles) {
     this.columnFamilyOptions = columnFamilyOptions;
     this.statisticsEnabled = statisticsEnabled;
     this.memoryLimit = memoryLimit;
+    this.maxOpenFiles = maxOpenFiles;
   }
 
   public static RocksDbConfiguration empty() {
-    return new RocksDbConfiguration(new Properties(), false, DEFAULT_MEMORY_LIMIT);
+    return of(new Properties());
   }
 
   public static RocksDbConfiguration of(final Properties properties) {
-    return new RocksDbConfiguration(properties, false, DEFAULT_MEMORY_LIMIT);
+    return of(properties, false);
   }
 
   public static RocksDbConfiguration of(
       final Properties properties, final boolean statisticsEnabled) {
-    return new RocksDbConfiguration(properties, statisticsEnabled, DEFAULT_MEMORY_LIMIT);
+    return of(properties, statisticsEnabled, DEFAULT_MEMORY_LIMIT);
   }
 
   public static RocksDbConfiguration of(
       final Properties properties, final boolean statisticsEnabled, final long memoryLimit) {
-    return new RocksDbConfiguration(properties, statisticsEnabled, memoryLimit);
+    return of(properties, statisticsEnabled, memoryLimit, DEFAULT_UNLIMITED_MAX_OPEN_FILES);
+  }
+
+  public static RocksDbConfiguration of(
+      final Properties properties,
+      final boolean statisticsEnabled,
+      final long memoryLimit,
+      final int maxOpenFiles) {
+    return new RocksDbConfiguration(properties, statisticsEnabled, memoryLimit, maxOpenFiles);
   }
 
   public Properties getColumnFamilyOptions() {
@@ -54,5 +74,9 @@ public final class RocksDbConfiguration {
 
   public long getMemoryLimit() {
     return memoryLimit;
+  }
+
+  public int getMaxOpenFiles() {
+    return maxOpenFiles;
   }
 }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -85,6 +85,7 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
             .setErrorIfExists(false)
             .setCreateIfMissing(true)
             .setParanoidChecks(true)
+            .setMaxOpenFiles(rocksDbConfiguration.getMaxOpenFiles())
             // 1 flush, 1 compaction
             .setMaxBackgroundJobs(2)
             // we only use the default CF


### PR DESCRIPTION
## Description
Exposes the max open file setting from RocksDB.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6213 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
