### PR TITLE
Reuse transaction

### DIFF
--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/TransactionRenovator.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/TransactionRenovator.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.db.impl.rocksdb.transaction;
+
+import org.rocksdb.Transaction;
+
+@FunctionalInterface
+public interface TransactionRenovator {
+
+  /**
+   * Renews the given oldTransaction such that it can reused.
+   *
+   * @param oldTransaction the old transaction which becomes new
+   * @return the renewed transaction
+   */
+  Transaction renewTransaction(Transaction oldTransaction);
+}

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
@@ -20,11 +20,15 @@ import org.rocksdb.Transaction;
 
 public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
 
-  private final Transaction transaction;
   private final long nativeHandle;
-  private boolean inCurrentTransaction;
+  private final TransactionRenovator transactionRenovator;
 
-  public ZeebeTransaction(final Transaction transaction) {
+  private boolean inCurrentTransaction;
+  private Transaction transaction;
+
+  public ZeebeTransaction(
+      final Transaction transaction, final TransactionRenovator transactionRenovator) {
+    this.transactionRenovator = transactionRenovator;
     this.transaction = transaction;
     try {
       nativeHandle = RocksDbInternal.nativeHandle.getLong(transaction);
@@ -66,6 +70,7 @@ public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
   }
 
   void resetTransaction() {
+    transaction = transactionRenovator.renewTransaction(transaction);
     inCurrentTransaction = true;
   }
 

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -31,7 +31,7 @@ import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 
 public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames>>
-    implements ZeebeDb<ColumnFamilyNames> {
+    implements ZeebeDb<ColumnFamilyNames>, TransactionRenovator {
 
   private static final Logger LOG = Loggers.DB_LOGGER;
   private static final String ERROR_MESSAGE_CLOSE_RESOURCE =
@@ -128,9 +128,14 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
   }
 
   @Override
+  public Transaction renewTransaction(final Transaction oldTransaction) {
+    return optimisticTransactionDB.beginTransaction(defaultWriteOptions, oldTransaction);
+  }
+
+  @Override
   public TransactionContext createContext() {
     final Transaction transaction = optimisticTransactionDB.beginTransaction(defaultWriteOptions);
-    final ZeebeTransaction zeebeTransaction = new ZeebeTransaction(transaction);
+    final ZeebeTransaction zeebeTransaction = new ZeebeTransaction(transaction, this);
     closables.add(zeebeTransaction);
     return new DefaultTransactionContext(zeebeTransaction);
   }


### PR DESCRIPTION
## Description

Instead of relying of the implementation that it resets the transaction on rollback or commit, we renew the transaction via #beginTransaction . 
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #2397 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
