### PR TITLE
Disable WAL of RocksDB

### DIFF
--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -64,7 +64,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<ColumnFamilyNames
     closables.add(prefixReadOptions);
     defaultReadOptions = new ReadOptions();
     closables.add(defaultReadOptions);
-    defaultWriteOptions = new WriteOptions();
+    defaultWriteOptions = new WriteOptions().setDisableWAL(true);
     closables.add(defaultWriteOptions);
   }
 


### PR DESCRIPTION
## Description
Disabled WAL (write ahead log) on the write options. This makes RocksDB less fault tolerant, but this is not used anyway by us since we restoring always an snapshot. 
<!-- Please explain the changes you made here. -->

## Benchmark

In order to compare the performance I run a benchmark with 3 nodes, one partition, replication factor 3 and the normal starter/worker setup.

|Impact | Base | One Column |Description|
|---------|---------|-------------------|---------------|
| General | ![base-general](https://user-images.githubusercontent.com/2758593/106999093-e4b04280-6785-11eb-82dc-22d842f579c8.png) | ![wal-general](https://user-images.githubusercontent.com/2758593/106999094-e548d900-6785-11eb-85c7-236e7cd7bb1f.png) | FNI's look quite similar | 
| General 2 | ![base-general2](https://user-images.githubusercontent.com/2758593/106999173-06112e80-6786-11eb-82d3-1b8d2c729371.png) | ![wal-general2](https://user-images.githubusercontent.com/2758593/106999176-06a9c500-6786-11eb-8155-8949e5125e37.png) | Throughput looks similar |
| Snapshots|![base-snap](https://user-images.githubusercontent.com/2758593/106998989-aca8ff80-6785-11eb-9429-46c88fa3aaae.png)|![wal-snap](https://user-images.githubusercontent.com/2758593/106998991-ad419600-6785-11eb-8de8-584ee320199b.png)| Looks like it reduced the snapshot size by 33% |
|Memory |![base-res](https://user-images.githubusercontent.com/2758593/106998729-41f7c400-6785-11eb-9a85-d2e45bea2f8d.png)|![wal-res](https://user-images.githubusercontent.com/2758593/106998731-42905a80-6785-11eb-885b-49aab109db05.png)| Not really a difference. |
| Disk | ![base-disk](https://user-images.githubusercontent.com/2758593/106999292-38229080-6786-11eb-9b50-96fa9219125b.png) | ![wal-disk](https://user-images.githubusercontent.com/2758593/106999295-38bb2700-6786-11eb-9741-121a628b3fc1.png) | No difference here |
| IO | ![base-io](https://user-images.githubusercontent.com/2758593/106999341-4f617e00-6786-11eb-85ec-16948762eac0.png) | ![wal-io](https://user-images.githubusercontent.com/2758593/106999342-4ffa1480-6786-11eb-9da2-73b4fa53e5ea.png) | Not a difference.
| Latency | ![base-latency](https://user-images.githubusercontent.com/2758593/106999417-728c2d80-6786-11eb-8820-36c3de6f4006.png) | ![wal-latency](https://user-images.githubusercontent.com/2758593/106999420-7324c400-6786-11eb-9874-208711a633b5.png) | Looks like we get better latency, without wal. |
| RocksDB | ![base-rocksdb](https://user-images.githubusercontent.com/2758593/106999675-e8909480-6786-11eb-867d-51a09d1ecf8b.png) | ![wal-rocksdb](https://user-images.githubusercontent.com/2758593/106999676-e9c1c180-6786-11eb-9011-69e5910c6ca9.png) | Estimate live data seems to be lower without WAL |
| RocksDB 2 | ![base-rocksdb2](https://user-images.githubusercontent.com/2758593/106999698-f47c5680-6786-11eb-8e85-f24026886929.png) | ![wal-rocksdb2](https://user-images.githubusercontent.com/2758593/106999701-f47c5680-6786-11eb-94c3-48b3ecc4c66f.png) | SST file size looks more stable | 
| RocksDB 3 | ![base-rocksdb3](https://user-images.githubusercontent.com/2758593/106999754-078f2680-6787-11eb-8936-2a8347fd621e.png) | ![wal-rocksdb3](https://user-images.githubusercontent.com/2758593/106999756-0827bd00-6787-11eb-8945-ea5d0b470483.png) | See not really a difference |

Based on the benchmark I see not really a difference, except for the latency and snapshot size. You guys can decide whether we want to turn it of or not.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6161 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
