### PR TITLE
BPMN element processors support new commands

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -14,6 +14,7 @@ import io.zeebe.engine.processing.bpmn.behavior.TypedStreamWriterProxy;
 import io.zeebe.engine.processing.common.CatchEventBehavior;
 import io.zeebe.engine.processing.common.ExpressionProcessor;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.zeebe.engine.processing.streamprocessor.MigratedStreamProcessors;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
@@ -102,6 +103,28 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<WorkflowI
       final ExecutableFlowElement element) {
 
     switch (intent) {
+      case ACTIVATE_ELEMENT:
+        if (MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
+          // TODO (saig0): invoke the migrated processor to activate the element
+        } else {
+          processor.onActivating(element, context);
+        }
+        break;
+      case COMPLETE_ELEMENT:
+        if (MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
+          // TODO (saig0): invoke the migrated processor to complete the element
+        } else {
+          processor.onCompleting(element, context);
+        }
+        break;
+      case TERMINATE_ELEMENT:
+        if (MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
+          // TODO (saig0): invoke the migrated processor to terminate the element
+        } else {
+          processor.onTerminating(element, context);
+        }
+        break;
+        // legacy behavior for not migrated processors
       case ELEMENT_ACTIVATING:
         processor.onActivating(element, context);
         break;


### PR DESCRIPTION
## Description

* allow migrating stream processors and writing the new commands for BPMN elements
* delegate to the existing legacy behavior if the element processor is not migrated yet
* no support for already migrated element processors. this can be part of the migration of the first element processor.  

## Related issues


## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
