### PR TITLE
chore(client/go): update go.mod and docker deps

### DIFF
--- a/clients/go/go.mod
+++ b/clients/go/go.mod
@@ -2,8 +2,6 @@ module github.com/zeebe-io/zeebe/clients/go
 
 go 1.15
 
-replace github.com/docker/docker => github.com/docker/engine v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
-
 require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 // indirect

--- a/clients/go/go.sum
+++ b/clients/go/go.sum
@@ -82,8 +82,8 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/engine v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible h1:hx8H7MbcmXUXAmphQuA/XB7CfSzX4DRrNuHFvfK9aIQ=
-github.com/docker/engine v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible/go.mod h1:3CPr2caMgTHxxIAZgEMd3uLYPDlRvPqCpyeRf6ncPcY=
+github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible h1:SiUATuP//KecDjpOK2tvZJgeScYAklvyjfK8JZlU6fo=
+github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -145,10 +145,8 @@ github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
-github.com/golang/protobuf v1.4.0 h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
-github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
@@ -157,7 +155,6 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -315,7 +312,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -405,7 +401,6 @@ golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -413,7 +408,6 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210201163806-010130855d6c h1:HiAZXo96zOhVhtFHchj/ojzoxCFiPrp9/j0GtS38V3g=
 golang.org/x/oauth2 v0.0.0-20210201163806-010130855d6c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
@@ -422,7 +416,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
@@ -453,14 +446,12 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200803210538-64077c9b5642 h1:B6caxRw+hozq68X2MY7jEpZh/cr4/aHLv9xU8Kkadrw=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -468,12 +459,10 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -525,7 +514,6 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -546,7 +534,6 @@ google.golang.org/api v0.28.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0M
 google.golang.org/api v0.29.0/go.mod h1:Lcubydp8VUV7KeIHD9z2Bys/sm/vGKnG1UHuDBSrHWM=
 google.golang.org/api v0.30.0/go.mod h1:QGmEvQ87FHZNiUVJkT14jQNYJ4ZJjdRF23ZXz5138Fc=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
-google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
@@ -602,10 +589,8 @@ google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLY
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
-google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zimw=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
@@ -626,9 +611,7 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/clients/go/vendor/github.com/docker/docker/api/swagger.yaml
+++ b/clients/go/vendor/github.com/docker/docker/api/swagger.yaml
@@ -26,13 +26,19 @@ info:
   x-logo:
     url: "https://docs.docker.com/images/logo-docker-main.png"
   description: |
-    The Engine API is an HTTP API served by Docker Engine. It is the API the Docker client uses to communicate with the Engine, so everything the Docker client can do can be done with the API.
+    The Engine API is an HTTP API served by Docker Engine. It is the API the
+    Docker client uses to communicate with the Engine, so everything the Docker
+    client can do can be done with the API.
 
-    Most of the client's commands map directly to API endpoints (e.g. `docker ps` is `GET /containers/json`). The notable exception is running containers, which consists of several API calls.
+    Most of the client's commands map directly to API endpoints (e.g. `docker ps`
+    is `GET /containers/json`). The notable exception is running containers,
+    which consists of several API calls.
 
     # Errors
 
-    The API uses standard HTTP status codes to indicate the success or failure of the API call. The body of the response will be JSON in the following format:
+    The API uses standard HTTP status codes to indicate the success or failure
+    of the API call. The body of the response will be JSON in the following
+    format:
 
     ```
     {
@@ -65,7 +71,11 @@ info:
 
     # Authentication
 
-    Authentication for registries is handled client side. The client has to send authentication details to various endpoints that need to communicate with registries, such as `POST /images/(name)/push`. These are sent as `X-Registry-Auth` header as a [base64url encoded](https://tools.ietf.org/html/rfc4648#section-5) (JSON) string with the following structure:
+    Authentication for registries is handled client side. The client has to send
+    authentication details to various endpoints that need to communicate with
+    registries, such as `POST /images/(name)/push`. These are sent as
+    `X-Registry-Auth` header as a [base64url encoded](https://tools.ietf.org/html/rfc4648#section-5)
+    (JSON) string with the following structure:
 
     ```
     {
@@ -76,9 +86,11 @@ info:
     }
     ```
 
-    The `serveraddress` is a domain/IP without a protocol. Throughout this structure, double quotes are required.
+    The `serveraddress` is a domain/IP without a protocol. Throughout this
+    structure, double quotes are required.
 
-    If you have already got an identity token from the [`/auth` endpoint](#operation/SystemAuth), you can just pass this instead of credentials:
+    If you have already got an identity token from the [`/auth` endpoint](#operation/SystemAuth),
+    you can just pass this instead of credentials:
 
     ```
     {
@@ -104,7 +116,9 @@ tags:
   - name: "Network"
     x-displayName: "Networks"
     description: |
-      Networks are user-defined networks that containers can be attached to. See the [networking documentation](https://docs.docker.com/engine/userguide/networking/) for more information.
+      Networks are user-defined networks that containers can be attached to.
+      See the [networking documentation](https://docs.docker.com/network/)
+      for more information.
   - name: "Volume"
     x-displayName: "Volumes"
     description: |
@@ -112,34 +126,46 @@ tags:
   - name: "Exec"
     x-displayName: "Exec"
     description: |
-      Run new commands inside running containers. See the [command-line reference](https://docs.docker.com/engine/reference/commandline/exec/) for more information.
+      Run new commands inside running containers. Refer to the
+      [command-line reference](https://docs.docker.com/engine/reference/commandline/exec/)
+      for more information.
 
-      To exec a command in a container, you first need to create an exec instance, then start it. These two API endpoints are wrapped up in a single command-line command, `docker exec`.
+      To exec a command in a container, you first need to create an exec instance,
+      then start it. These two API endpoints are wrapped up in a single command-line
+      command, `docker exec`.
+
   # Swarm things
   - name: "Swarm"
     x-displayName: "Swarm"
     description: |
-      Engines can be clustered together in a swarm. See [the swarm mode documentation](https://docs.docker.com/engine/swarm/) for more information.
+      Engines can be clustered together in a swarm. Refer to the
+      [swarm mode documentation](https://docs.docker.com/engine/swarm/)
+      for more information.
   - name: "Node"
     x-displayName: "Nodes"
     description: |
-      Nodes are instances of the Engine participating in a swarm. Swarm mode must be enabled for these endpoints to work.
+      Nodes are instances of the Engine participating in a swarm. Swarm mode
+      must be enabled for these endpoints to work.
   - name: "Service"
     x-displayName: "Services"
     description: |
-      Services are the definitions of tasks to run on a swarm. Swarm mode must be enabled for these endpoints to work.
+      Services are the definitions of tasks to run on a swarm. Swarm mode must
+      be enabled for these endpoints to work.
   - name: "Task"
     x-displayName: "Tasks"
     description: |
-      A task is a container running on a swarm. It is the atomic scheduling unit of swarm. Swarm mode must be enabled for these endpoints to work.
+      A task is a container running on a swarm. It is the atomic scheduling unit
+      of swarm. Swarm mode must be enabled for these endpoints to work.
   - name: "Secret"
     x-displayName: "Secrets"
     description: |
-      Secrets are sensitive data that can be used by services. Swarm mode must be enabled for these endpoints to work.
+      Secrets are sensitive data that can be used by services. Swarm mode must
+      be enabled for these endpoints to work.
   - name: "Config"
     x-displayName: "Configs"
     description: |
-      Configs are application configurations that can be used by services. Swarm mode must be enabled for these endpoints to work.
+      Configs are application configurations that can be used by services. Swarm
+      mode must be enabled for these endpoints to work.
   # System things
   - name: "Plugin"
     x-displayName: "Plugins"
@@ -345,9 +371,11 @@ definitions:
 
   RestartPolicy:
     description: |
-      The behavior to apply when the container exits. The default is not to restart.
+      The behavior to apply when the container exits. The default is not to
+      restart.
 
-      An ever increasing delay (double the previous delay, starting at 100ms) is added before each restart to prevent flooding the server.
+      An ever increasing delay (double the previous delay, starting at 100ms) is
+      added before each restart to prevent flooding the server.
     type: "object"
     properties:
       Name:
@@ -364,7 +392,8 @@ definitions:
           - "on-failure"
       MaximumRetryCount:
         type: "integer"
-        description: "If `on-failure` is used, the number of times to retry before giving up"
+        description: |
+          If `on-failure` is used, the number of times to retry before giving up.
 
   Resources:
     description: "A container's resources (cgroups config, ulimits, etc)"
@@ -372,7 +401,9 @@ definitions:
     properties:
       # Applicable to all platforms
       CpuShares:
-        description: "An integer value representing this container's relative CPU weight versus other containers."
+        description: |
+          An integer value representing this container's relative CPU weight
+          versus other containers.
         type: "integer"
       Memory:
         description: "Memory limit in bytes."
@@ -381,7 +412,11 @@ definitions:
         default: 0
       # Applicable to UNIX platforms
       CgroupParent:
-        description: "Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist."
+        description: |
+          Path to `cgroups` under which the container's `cgroup` is created. If
+          the path is not absolute, the path is considered to be relative to the
+          `cgroups` path of the init process. Cgroups are created if they do not
+          already exist.
         type: "string"
       BlkioWeight:
         description: "Block IO weight (relative weight)."
@@ -390,7 +425,11 @@ definitions:
         maximum: 1000
       BlkioWeightDevice:
         description: |
-          Block IO weight (relative device weight) in the form `[{"Path": "device_path", "Weight": weight}]`.
+          Block IO weight (relative device weight) in the form:
+
+          ```
+          [{"Path": "device_path", "Weight": weight}]
+          ```
         type: "array"
         items:
           type: "object"
@@ -402,25 +441,41 @@ definitions:
               minimum: 0
       BlkioDeviceReadBps:
         description: |
-          Limit read rate (bytes per second) from a device, in the form `[{"Path": "device_path", "Rate": rate}]`.
+          Limit read rate (bytes per second) from a device, in the form:
+
+          ```
+          [{"Path": "device_path", "Rate": rate}]
+          ```
         type: "array"
         items:
           $ref: "#/definitions/ThrottleDevice"
       BlkioDeviceWriteBps:
         description: |
-          Limit write rate (bytes per second) to a device, in the form `[{"Path": "device_path", "Rate": rate}]`.
+          Limit write rate (bytes per second) to a device, in the form:
+
+          ```
+          [{"Path": "device_path", "Rate": rate}]
+          ```
         type: "array"
         items:
           $ref: "#/definitions/ThrottleDevice"
       BlkioDeviceReadIOps:
         description: |
-          Limit read rate (IO per second) from a device, in the form `[{"Path": "device_path", "Rate": rate}]`.
+          Limit read rate (IO per second) from a device, in the form:
+
+          ```
+          [{"Path": "device_path", "Rate": rate}]
+          ```
         type: "array"
         items:
           $ref: "#/definitions/ThrottleDevice"
       BlkioDeviceWriteIOps:
         description: |
-          Limit write rate (IO per second) to a device, in the form `[{"Path": "device_path", "Rate": rate}]`.
+          Limit write rate (IO per second) to a device, in the form:
+
+          ```
+          [{"Path": "device_path", "Rate": rate}]
+          ```
         type: "array"
         items:
           $ref: "#/definitions/ThrottleDevice"
@@ -429,23 +484,31 @@ definitions:
         type: "integer"
         format: "int64"
       CpuQuota:
-        description: "Microseconds of CPU time that the container can get in a CPU period."
+        description: |
+          Microseconds of CPU time that the container can get in a CPU period.
         type: "integer"
         format: "int64"
       CpuRealtimePeriod:
-        description: "The length of a CPU real-time period in microseconds. Set to 0 to allocate no time allocated to real-time tasks."
+        description: |
+          The length of a CPU real-time period in microseconds. Set to 0 to
+          allocate no time allocated to real-time tasks.
         type: "integer"
         format: "int64"
       CpuRealtimeRuntime:
-        description: "The length of a CPU real-time runtime in microseconds. Set to 0 to allocate no time allocated to real-time tasks."
+        description: |
+          The length of a CPU real-time runtime in microseconds. Set to 0 to
+          allocate no time allocated to real-time tasks.
         type: "integer"
         format: "int64"
       CpusetCpus:
-        description: "CPUs in which to allow execution (e.g., `0-3`, `0,1`)"
+        description: |
+          CPUs in which to allow execution (e.g., `0-3`, `0,1`).
         type: "string"
         example: "0-3"
       CpusetMems:
-        description: "Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems."
+        description: |
+          Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only
+          effective on NUMA systems.
         type: "string"
       Devices:
         description: "A list of devices to add to the container."
@@ -459,7 +522,8 @@ definitions:
           type: "string"
           example: "c 13:* rwm"
       DeviceRequests:
-        description: "a list of requests for devices to be sent to device drivers"
+        description: |
+          A list of requests for devices to be sent to device drivers.
         type: "array"
         items:
           $ref: "#/definitions/DeviceRequest"
@@ -477,11 +541,15 @@ definitions:
         type: "integer"
         format: "int64"
       MemorySwap:
-        description: "Total memory limit (memory + swap). Set as `-1` to enable unlimited swap."
+        description: |
+          Total memory limit (memory + swap). Set as `-1` to enable unlimited
+          swap.
         type: "integer"
         format: "int64"
       MemorySwappiness:
-        description: "Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100."
+        description: |
+          Tune a container's memory swappiness behavior. Accepts an integer
+          between 0 and 100.
         type: "integer"
         format: "int64"
         minimum: 0
@@ -494,18 +562,26 @@ definitions:
         description: "Disable OOM Killer for the container."
         type: "boolean"
       Init:
-        description: "Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used."
+        description: |
+          Run an init inside the container that forwards signals and reaps
+          processes. This field is omitted if empty, and the default (as
+          configured on the daemon) is used.
         type: "boolean"
         x-nullable: true
       PidsLimit:
         description: |
-          Tune a container's PIDs limit. Set `0` or `-1` for unlimited, or `null` to not change.
+          Tune a container's PIDs limit. Set `0` or `-1` for unlimited, or `null`
+          to not change.
         type: "integer"
         format: "int64"
         x-nullable: true
       Ulimits:
         description: |
-          A list of resource limits to set in the container. For example: `{"Name": "nofile", "Soft": 1024, "Hard": 2048}`"
+          A list of resource limits to set in the container. For example:
+
+          ```
+          {"Name": "nofile", "Soft": 1024, "Hard": 2048}
+          ```
         type: "array"
         items:
           type: "object"
@@ -524,14 +600,18 @@ definitions:
         description: |
           The number of usable CPUs (Windows only).
 
-          On Windows Server containers, the processor resource controls are mutually exclusive. The order of precedence is `CPUCount` first, then `CPUShares`, and `CPUPercent` last.
+          On Windows Server containers, the processor resource controls are
+          mutually exclusive. The order of precedence is `CPUCount` first, then
+          `CPUShares`, and `CPUPercent` last.
         type: "integer"
         format: "int64"
       CpuPercent:
         description: |
           The usable percentage of the available CPUs (Windows only).
 
-          On Windows Server containers, the processor resource controls are mutually exclusive. The order of precedence is `CPUCount` first, then `CPUShares`, and `CPUPercent` last.
+          On Windows Server containers, the processor resource controls are
+          mutually exclusive. The order of precedence is `CPUCount` first, then
+          `CPUShares`, and `CPUPercent` last.
         type: "integer"
         format: "int64"
       IOMaximumIOps:
@@ -539,12 +619,16 @@ definitions:
         type: "integer"
         format: "int64"
       IOMaximumBandwidth:
-        description: "Maximum IO in bytes per second for the container system drive (Windows only)"
+        description: |
+          Maximum IO in bytes per second for the container system drive
+          (Windows only).
         type: "integer"
         format: "int64"
 
   ResourceObject:
-    description: "An object describing the resources which can be advertised by a node and requested by a task"
+    description: |
+      An object describing the resources which can be advertised by a node and
+      requested by a task.
     type: "object"
     properties:
       NanoCPUs:
@@ -559,7 +643,9 @@ definitions:
         $ref: "#/definitions/GenericResources"
 
   GenericResources:
-    description: "User-defined resources can be either Integer resources (e.g, `SSD=3`) or String resources (e.g, `GPU=UUID1`)"
+    description: |
+      User-defined resources can be either Integer resources (e.g, `SSD=3`) or
+      String resources (e.g, `GPU=UUID1`).
     type: "array"
     items:
       type: "object"
@@ -606,16 +692,25 @@ definitions:
         items:
           type: "string"
       Interval:
-        description: "The time to wait between checks in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit."
+        description: |
+          The time to wait between checks in nanoseconds. It should be 0 or at
+          least 1000000 (1 ms). 0 means inherit.
         type: "integer"
       Timeout:
-        description: "The time to wait before considering the check to have hung. It should be 0 or at least 1000000 (1 ms). 0 means inherit."
+        description: |
+          The time to wait before considering the check to have hung. It should
+          be 0 or at least 1000000 (1 ms). 0 means inherit.
         type: "integer"
       Retries:
-        description: "The number of consecutive failures needed to consider a container as unhealthy. 0 means inherit."
+        description: |
+          The number of consecutive failures needed to consider a container as
+          unhealthy. 0 means inherit.
         type: "integer"
       StartPeriod:
-        description: "Start period for the container to initialize before starting health-retries countdown in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit."
+        description: |
+          Start period for the container to initialize before starting
+          health-retries countdown in nanoseconds. It should be 0 or at least
+          1000000 (1 ms). 0 means inherit.
         type: "integer"
 
   Health:
@@ -758,25 +853,33 @@ definitions:
                   type: "string"
           NetworkMode:
             type: "string"
-            description: "Network mode to use for this container. Supported standard values are: `bridge`, `host`, `none`, and `container:<name|id>`. Any other value is taken
-              as a custom network's name to which this container should connect to."
+            description: |
+              Network mode to use for this container. Supported standard values
+              are: `bridge`, `host`, `none`, and `container:<name|id>`. Any
+              other value is taken as a custom network's name to which this
+              container should connect to.
           PortBindings:
             $ref: "#/definitions/PortMap"
           RestartPolicy:
             $ref: "#/definitions/RestartPolicy"
           AutoRemove:
             type: "boolean"
-            description: "Automatically remove the container when the container's process exits. This has no effect if `RestartPolicy` is set."
+            description: |
+              Automatically remove the container when the container's process
+              exits. This has no effect if `RestartPolicy` is set.
           VolumeDriver:
             type: "string"
             description: "Driver that this container uses to mount volumes."
           VolumesFrom:
             type: "array"
-            description: "A list of volumes to inherit from another container, specified in the form `<container name>[:<ro|rw>]`."
+            description: |
+              A list of volumes to inherit from another container, specified in
+              the form `<container name>[:<ro|rw>]`.
             items:
               type: "string"
           Mounts:
-            description: "Specification for mounts to be added to the container."
+            description: |
+              Specification for mounts to be added to the container.
             type: "array"
             items:
               $ref: "#/definitions/Mount"
@@ -785,19 +888,24 @@ definitions:
           Capabilities:
             type: "array"
             description: |
-              A list of kernel capabilities to be available for container (this overrides the default set).
+              A list of kernel capabilities to be available for container (this
+              overrides the default set).
 
               Conflicts with options 'CapAdd' and 'CapDrop'"
             items:
               type: "string"
           CapAdd:
             type: "array"
-            description: "A list of kernel capabilities to add to the container. Conflicts with option 'Capabilities'"
+            description: |
+              A list of kernel capabilities to add to the container. Conflicts
+              with option 'Capabilities'.
             items:
               type: "string"
           CapDrop:
             type: "array"
-            description: "A list of kernel capabilities to drop from the container. Conflicts with option 'Capabilities'"
+            description: |
+              A list of kernel capabilities to drop from the container. Conflicts
+              with option 'Capabilities'.
             items:
               type: "string"
           Dns:
@@ -818,43 +926,49 @@ definitions:
           ExtraHosts:
             type: "array"
             description: |
-              A list of hostnames/IP mappings to add to the container's `/etc/hosts` file. Specified in the form `["hostname:IP"]`.
+              A list of hostnames/IP mappings to add to the container's `/etc/hosts`
+              file. Specified in the form `["hostname:IP"]`.
             items:
               type: "string"
           GroupAdd:
             type: "array"
-            description: "A list of additional groups that the container process will run as."
+            description: |
+              A list of additional groups that the container process will run as.
             items:
               type: "string"
           IpcMode:
             type: "string"
             description: |
-                    IPC sharing mode for the container. Possible values are:
+              IPC sharing mode for the container. Possible values are:
 
-                    - `"none"`: own private IPC namespace, with /dev/shm not mounted
-                    - `"private"`: own private IPC namespace
-                    - `"shareable"`: own private IPC namespace, with a possibility to share it with other containers
-                    - `"container:<name|id>"`: join another (shareable) container's IPC namespace
-                    - `"host"`: use the host system's IPC namespace
+              - `"none"`: own private IPC namespace, with /dev/shm not mounted
+              - `"private"`: own private IPC namespace
+              - `"shareable"`: own private IPC namespace, with a possibility to share it with other containers
+              - `"container:<name|id>"`: join another (shareable) container's IPC namespace
+              - `"host"`: use the host system's IPC namespace
 
-                    If not specified, daemon default is used, which can either be `"private"`
-                    or `"shareable"`, depending on daemon version and configuration.
+              If not specified, daemon default is used, which can either be `"private"`
+              or `"shareable"`, depending on daemon version and configuration.
           Cgroup:
             type: "string"
             description: "Cgroup to use for the container."
           Links:
             type: "array"
-            description: "A list of links for the container in the form `container_name:alias`."
+            description: |
+              A list of links for the container in the form `container_name:alias`.
             items:
               type: "string"
           OomScoreAdj:
             type: "integer"
-            description: "An integer value containing the score given to the container in order to tune OOM killer preferences."
+            description: |
+              An integer value containing the score given to the container in
+              order to tune OOM killer preferences.
             example: 500
           PidMode:
             type: "string"
             description: |
-              Set the PID (Process) Namespace mode for the container. It can be either:
+              Set the PID (Process) Namespace mode for the container. It can be
+              either:
 
               - `"container:<name|id>"`: joins another container's PID namespace
               - `"host"`: use the host's PID namespace inside the container
@@ -867,11 +981,13 @@ definitions:
               Allocates an ephemeral host port for all of a container's
               exposed ports.
 
-              Ports are de-allocated when the container stops and allocated when the container starts.
-              The allocated port might be changed when restarting the container.
+              Ports are de-allocated when the container stops and allocated when
+              the container starts. The allocated port might be changed when
+              restarting the container.
 
-              The port is selected from the ephemeral port range that depends on the kernel.
-              For example, on Linux the range is defined by `/proc/sys/net/ipv4/ip_local_port_range`.
+              The port is selected from the ephemeral port range that depends on
+              the kernel. For example, on Linux the range is defined by
+              `/proc/sys/net/ipv4/ip_local_port_range`.
           ReadonlyRootfs:
             type: "boolean"
             description: "Mount the container's root filesystem as read only."
@@ -890,7 +1006,12 @@ definitions:
           Tmpfs:
             type: "object"
             description: |
-              A map of container directories which should be replaced by tmpfs mounts, and their corresponding mount options. For example: `{ "/run": "rw,noexec,nosuid,size=65536k" }`.
+              A map of container directories which should be replaced by tmpfs
+              mounts, and their corresponding mount options. For example:
+
+              ```
+              { "/run": "rw,noexec,nosuid,size=65536k" }
+              ```
             additionalProperties:
               type: "string"
           UTSMode:
@@ -898,15 +1019,23 @@ definitions:
             description: "UTS namespace to use for the container."
           UsernsMode:
             type: "string"
-            description: "Sets the usernamespace mode for the container when usernamespace remapping option is enabled."
+            description: |
+              Sets the usernamespace mode for the container when usernamespace
+              remapping option is enabled.
           ShmSize:
             type: "integer"
-            description: "Size of `/dev/shm` in bytes. If omitted, the system uses 64MB."
+            description: |
+              Size of `/dev/shm` in bytes. If omitted, the system uses 64MB.
             minimum: 0
           Sysctls:
             type: "object"
             description: |
-              A list of kernel parameters (sysctls) to set in the container. For example: `{"net.ipv4.ip_forward": "1"}`
+              A list of kernel parameters (sysctls) to set in the container.
+              For example:
+
+              ```
+              {"net.ipv4.ip_forward": "1"}
+              ```
             additionalProperties:
               type: "string"
           Runtime:
@@ -915,7 +1044,8 @@ definitions:
           # Applicable to Windows
           ConsoleSize:
             type: "array"
-            description: "Initial console size, as an `[height, width]` array. (Windows only)"
+            description: |
+              Initial console size, as an `[height, width]` array. (Windows only)
             minItems: 2
             maxItems: 2
             items:
@@ -923,19 +1053,24 @@ definitions:
               minimum: 0
           Isolation:
             type: "string"
-            description: "Isolation technology of the container. (Windows only)"
+            description: |
+              Isolation technology of the container. (Windows only)
             enum:
               - "default"
               - "process"
               - "hyperv"
           MaskedPaths:
             type: "array"
-            description: "The list of paths to be masked inside the container (this overrides the default set of paths)"
+            description: |
+              The list of paths to be masked inside the container (this overrides
+              the default set of paths).
             items:
               type: "string"
           ReadonlyPaths:
             type: "array"
-            description: "The list of paths to be set as read-only inside the container (this overrides the default set of paths)"
+            description: |
+              The list of paths to be set as read-only inside the container
+              (this overrides the default set of paths).
             items:
               type: "string"
 
@@ -976,7 +1111,8 @@ definitions:
             - {}
           default: {}
       Tty:
-        description: "Attach standard streams to a TTY, including `stdin` if it is not closed."
+        description: |
+          Attach standard streams to a TTY, including `stdin` if it is not closed.
         type: "boolean"
         default: false
       OpenStdin:
@@ -989,12 +1125,15 @@ definitions:
         default: false
       Env:
         description: |
-          A list of environment variables to set inside the container in the form `["VAR=value", ...]`. A variable without `=` is removed from the environment, rather than to have an empty value.
+          A list of environment variables to set inside the container in the
+          form `["VAR=value", ...]`. A variable without `=` is removed from the
+          environment, rather than to have an empty value.
         type: "array"
         items:
           type: "string"
       Cmd:
-        description: "Command to run specified as a string or an array of strings."
+        description: |
+          Command to run specified as a string or an array of strings.
         type: "array"
         items:
           type: "string"
@@ -1004,10 +1143,13 @@ definitions:
         description: "Command is already escaped (Windows only)"
         type: "boolean"
       Image:
-        description: "The name of the image to use when creating the container"
+        description: |
+          The name of the image to use when creating the container/
         type: "string"
       Volumes:
-        description: "An object mapping mount point paths inside the container to empty objects."
+        description: |
+          An object mapping mount point paths inside the container to empty
+          objects.
         type: "object"
         additionalProperties:
           type: "object"
@@ -1021,7 +1163,9 @@ definitions:
         description: |
           The entry point for the container as a string or an array of strings.
 
-          If the array consists of exactly one empty string (`[""]`) then the entry point is reset to system default (i.e., the entry point used by docker when there is no `ENTRYPOINT` instruction in the `Dockerfile`).
+          If the array consists of exactly one empty string (`[""]`) then the
+          entry point is reset to system default (i.e., the entry point used by
+          docker when there is no `ENTRYPOINT` instruction in the `Dockerfile`).
         type: "array"
         items:
           type: "string"
@@ -1032,7 +1176,8 @@ definitions:
         description: "MAC address of the container."
         type: "string"
       OnBuild:
-        description: "`ONBUILD` metadata that were defined in the image's `Dockerfile`."
+        description: |
+          `ONBUILD` metadata that were defined in the image's `Dockerfile`.
         type: "array"
         items:
           type: "string"
@@ -1042,7 +1187,8 @@ definitions:
         additionalProperties:
           type: "string"
       StopSignal:
-        description: "Signal to stop a container as a string or unsigned integer."
+        description: |
+          Signal to stop a container as a string or unsigned integer.
         type: "string"
         default: "SIGTERM"
       StopTimeout:
@@ -1050,10 +1196,47 @@ definitions:
         type: "integer"
         default: 10
       Shell:
-        description: "Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell."
+        description: |
+          Shell for when `RUN`, `CMD`, and `ENTRYPOINT` uses a shell.
         type: "array"
         items:
           type: "string"
+
+  NetworkingConfig:
+    description: |
+      NetworkingConfig represents the container's networking configuration for
+      each of its interfaces.
+      It is used for the networking configs specified in the `docker create`
+      and `docker network connect` commands.
+    type: "object"
+    properties:
+      EndpointsConfig:
+        description: |
+          A mapping of network name to endpoint configuration for that network.
+        type: "object"
+        additionalProperties:
+          $ref: "#/definitions/EndpointSettings"
+    example:
+      # putting an example here, instead of using the example values from
+      # /definitions/EndpointSettings, because containers/create currently
+      # does not support attaching to multiple networks, so the example request
+      # would be confusing if it showed that multiple networks can be contained
+      # in the EndpointsConfig.
+      # TODO remove once we support multiple networks on container create (see https://github.com/moby/moby/blob/07e6b843594e061f82baa5fa23c2ff7d536c2a05/daemon/create.go#L323)
+      EndpointsConfig:
+        isolated_nw:
+          IPAMConfig:
+            IPv4Address: "172.20.30.33"
+            IPv6Address: "2001:db8:abcd::3033"
+            LinkLocalIPs:
+              - "169.254.34.68"
+              - "fe80::3468"
+          Links:
+            - "container_1"
+            - "container_2"
+          Aliases:
+            - "server_x"
+            - "server_y"
 
   NetworkSettings:
     description: "NetworkSettings exposes the network settings in the API"
@@ -1497,13 +1680,16 @@ definitions:
           type: "string"
       Scope:
         type: "string"
-        description: "The level at which the volume exists. Either `global` for cluster-wide, or `local` for machine level."
+        description: |
+          The level at which the volume exists. Either `global` for cluster-wide,
+          or `local` for machine level.
         default: "local"
         x-nullable: false
         enum: ["local", "global"]
       Options:
         type: "object"
-        description: "The driver specific options used when creating the volume."
+        description: |
+          The driver specific options used when creating the volume.
         additionalProperties:
           type: "string"
       UsageData:
@@ -1621,7 +1807,12 @@ definitions:
         type: "string"
         default: "default"
       Config:
-        description: "List of IPAM configuration options, specified as a map: `{\"Subnet\": <CIDR>, \"IPRange\": <CIDR>, \"Gateway\": <IP address>, \"AuxAddress\": <device_name:IP address>}`"
+        description: |
+          List of IPAM configuration options, specified as a map:
+
+          ```
+          {"Subnet": <CIDR>, "IPRange": <CIDR>, "Gateway": <IP address>, "AuxAddress": <device_name:IP address>}
+          ```
         type: "array"
         items:
           type: "object"
@@ -1683,12 +1874,24 @@ definitions:
       Shared:
         type: "boolean"
       Size:
+        description: |
+          Amount of disk space used by the build cache (in bytes).
         type: "integer"
       CreatedAt:
-        type: "integer"
+        description: |
+          Date and time at which the build cache was created in
+          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+        type: "string"
+        format: "dateTime"
+        example: "2016-08-18T10:44:24.496525531Z"
       LastUsedAt:
-        type: "integer"
+        description: |
+          Date and time at which the build cache was last used in
+          [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format with nano-seconds.
+        type: "string"
+        format: "dateTime"
         x-nullable: true
+        example: "2017-08-09T07:09:37.632105588Z"
       UsageCount:
         type: "integer"
 
@@ -1967,7 +2170,9 @@ definitions:
         x-nullable: false
         example: "tiborvass/sample-volume-plugin"
       Enabled:
-        description: "True if the plugin is running. False if the plugin is not running, only installed."
+        description:
+          True if the plugin is running. False if the plugin is not running,
+          only installed.
         type: "boolean"
         x-nullable: false
         example: true
@@ -2169,13 +2374,16 @@ definitions:
 
   ObjectVersion:
     description: |
-      The version number of the object such as node, service, etc. This is needed to avoid conflicting writes.
-      The client must send the version number along with the modified specification when updating these objects.
-      This approach ensures safe concurrency and determinism in that the change on the object
-      may not be applied if the version number has changed from the last read. In other words,
-      if two update requests specify the same base version, only one of the requests can succeed.
-      As a result, two separate update requests that happen at the same time will not
-      unintentionally overwrite each other.
+      The version number of the object such as node, service, etc. This is needed
+      to avoid conflicting writes. The client must send the version number along
+      with the modified specification when updating these objects.
+
+      This approach ensures safe concurrency and determinism in that the change
+      on the object may not be applied if the version number has changed from the
+      last read. In other words, if two update requests specify the same base
+      version, only one of the requests can succeed. As a result, two separate
+      update requests that happen at the same time will not unintentionally
+      overwrite each other.
     type: "object"
     properties:
       Index:
@@ -2344,17 +2552,23 @@ definitions:
             Name: "vieux/sshfs:latest"
 
   TLSInfo:
-    description: "Information about the issuer of leaf TLS certificates and the trusted root CA certificate"
+    description: |
+      Information about the issuer of leaf TLS certificates and the trusted root
+      CA certificate.
     type: "object"
     properties:
       TrustRoot:
-        description: "The root CA certificate(s) that are used to validate leaf TLS certificates"
+        description: |
+          The root CA certificate(s) that are used to validate leaf TLS
+          certificates.
         type: "string"
       CertIssuerSubject:
-        description: "The base64-url-safe-encoded raw subject bytes of the issuer"
+        description:
+          The base64-url-safe-encoded raw subject bytes of the issuer.
         type: "string"
       CertIssuerPublicKey:
-        description: "The base64-url-safe-encoded raw public key bytes of the issuer"
+        description: |
+          The base64-url-safe-encoded raw public key bytes of the issuer.
         type: "string"
     example:
       TrustRoot: |
@@ -2450,7 +2664,9 @@ definitions:
         x-nullable: true
         properties:
           TaskHistoryRetentionLimit:
-            description: "The number of historic tasks to keep per instance or node. If negative, never remove completed or failed tasks."
+            description: |
+              The number of historic tasks to keep per instance or node. If
+              negative, never remove completed or failed tasks.
             type: "integer"
             format: "int64"
             example: 10
@@ -2464,26 +2680,34 @@ definitions:
             format: "uint64"
             example: 10000
           KeepOldSnapshots:
-            description: "The number of snapshots to keep beyond the current snapshot."
+            description: |
+              The number of snapshots to keep beyond the current snapshot.
             type: "integer"
             format: "uint64"
           LogEntriesForSlowFollowers:
-            description: "The number of log entries to keep around to sync up slow followers after a snapshot is created."
+            description: |
+              The number of log entries to keep around to sync up slow followers
+              after a snapshot is created.
             type: "integer"
             format: "uint64"
             example: 500
           ElectionTick:
             description: |
-              The number of ticks that a follower will wait for a message from the leader before becoming a candidate and starting an election. `ElectionTick` must be greater than `HeartbeatTick`.
+              The number of ticks that a follower will wait for a message from
+              the leader before becoming a candidate and starting an election.
+              `ElectionTick` must be greater than `HeartbeatTick`.
 
-              A tick currently defaults to one second, so these translate directly to seconds currently, but this is NOT guaranteed.
+              A tick currently defaults to one second, so these translate
+              directly to seconds currently, but this is NOT guaranteed.
             type: "integer"
             example: 3
           HeartbeatTick:
             description: |
-              The number of ticks between heartbeats. Every HeartbeatTick ticks, the leader will send a heartbeat to the followers.
+              The number of ticks between heartbeats. Every HeartbeatTick ticks,
+              the leader will send a heartbeat to the followers.
 
-              A tick currently defaults to one second, so these translate directly to seconds currently, but this is NOT guaranteed.
+              A tick currently defaults to one second, so these translate
+              directly to seconds currently, but this is NOT guaranteed.
             type: "integer"
             example: 1
       Dispatcher:
@@ -2492,7 +2716,8 @@ definitions:
         x-nullable: true
         properties:
           HeartbeatPeriod:
-            description: "The delay for an agent to send a heartbeat to the dispatcher."
+            description: |
+              The delay for an agent to send a heartbeat to the dispatcher.
             type: "integer"
             format: "int64"
             example: 5000000000
@@ -2507,36 +2732,53 @@ definitions:
             format: "int64"
             example: 7776000000000000
           ExternalCAs:
-            description: "Configuration for forwarding signing requests to an external certificate authority."
+            description: |
+              Configuration for forwarding signing requests to an external
+              certificate authority.
             type: "array"
             items:
               type: "object"
               properties:
                 Protocol:
-                  description: "Protocol for communication with the external CA (currently only `cfssl` is supported)."
+                  description: |
+                    Protocol for communication with the external CA (currently
+                    only `cfssl` is supported).
                   type: "string"
                   enum:
                     - "cfssl"
                   default: "cfssl"
                 URL:
-                  description: "URL where certificate signing requests should be sent."
+                  description: |
+                    URL where certificate signing requests should be sent.
                   type: "string"
                 Options:
-                  description: "An object with key/value pairs that are interpreted as protocol-specific options for the external CA driver."
+                  description: |
+                    An object with key/value pairs that are interpreted as
+                    protocol-specific options for the external CA driver.
                   type: "object"
                   additionalProperties:
                     type: "string"
                 CACert:
-                  description: "The root CA certificate (in PEM format) this external CA uses to issue TLS certificates (assumed to be to the current swarm root CA certificate if not provided)."
+                  description: |
+                    The root CA certificate (in PEM format) this external CA uses
+                    to issue TLS certificates (assumed to be to the current swarm
+                    root CA certificate if not provided).
                   type: "string"
           SigningCACert:
-            description: "The desired signing CA certificate for all swarm node TLS leaf certificates, in PEM format."
+            description: |
+              The desired signing CA certificate for all swarm node TLS leaf
+              certificates, in PEM format.
             type: "string"
           SigningCAKey:
-            description: "The desired signing CA key for all swarm node TLS leaf certificates, in PEM format."
+            description: |
+              The desired signing CA key for all swarm node TLS leaf certificates,
+              in PEM format.
             type: "string"
           ForceRotate:
-            description: "An integer whose purpose is to force swarm to generate a new signing CA certificate and key, if none have been specified in `SigningCACert` and `SigningCAKey`"
+            description: |
+              An integer whose purpose is to force swarm to generate a new
+              signing CA certificate and key, if none have been specified in
+              `SigningCACert` and `SigningCAKey`
             format: "uint64"
             type: "integer"
       EncryptionConfig:
@@ -2544,7 +2786,9 @@ definitions:
         type: "object"
         properties:
           AutoLockManagers:
-            description: "If set, generate a key and use it to lock data stored on the managers."
+            description: |
+              If set, generate a key and use it to lock data stored on the
+              managers.
             type: "boolean"
             example: false
       TaskDefaults:
@@ -2610,7 +2854,8 @@ definitions:
       TLSInfo:
         $ref: "#/definitions/TLSInfo"
       RootRotationInProgress:
-        description: "Whether there is currently a root CA rotation in progress for the swarm"
+        description: |
+          Whether there is currently a root CA rotation in progress for the swarm
         type: "boolean"
         example: false
       DataPathPort:
@@ -2624,7 +2869,8 @@ definitions:
         example: 4789
       DefaultAddrPool:
         description: |
-          Default Address Pool specifies default subnet pools for global scope networks.
+          Default Address Pool specifies default subnet pools for global scope
+          networks.
         type: "array"
         items:
           type: "string"
@@ -2632,7 +2878,8 @@ definitions:
           example: ["10.10.0.0/16", "20.20.0.0/16"]
       SubnetSize:
         description: |
-          SubnetSize specifies the subnet size of the networks created from the default subnet pool
+          SubnetSize specifies the subnet size of the networks created from the
+          default subnet pool.
         type: "integer"
         format: "uint32"
         maximum: 29
@@ -2692,7 +2939,9 @@ definitions:
           PluginPrivilege:
             type: "array"
             items:
-              description: "Describes a permission accepted by the user upon installing the plugin."
+              description: |
+                Describes a permission accepted by the user upon installing the
+                plugin.
               type: "object"
               properties:
                 Name:
@@ -2734,10 +2983,13 @@ definitions:
             items:
               type: "string"
           Hostname:
-            description: "The hostname to use for the container, as a valid RFC 1123 hostname."
+            description: |
+              The hostname to use for the container, as a valid
+              [RFC 1123](https://tools.ietf.org/html/rfc1123) hostname.
             type: "string"
           Env:
-            description: "A list of environment variables in the form `VAR=value`."
+            description: |
+              A list of environment variables in the form `VAR=value`.
             type: "array"
             items:
               type: "string"
@@ -2749,7 +3001,8 @@ definitions:
             type: "string"
           Groups:
             type: "array"
-            description: "A list of additional groups that the container process will run as."
+            description: |
+              A list of additional groups that the container process will run as.
             items:
               type: "string"
           Privileges:
@@ -2765,37 +3018,43 @@ definitions:
                     example: "0bt9dmxjvjiqermk6xrop3ekq"
                     description: |
                       Load credential spec from a Swarm Config with the given ID.
-                      The specified config must also be present in the Configs field with the Runtime property set.
+                      The specified config must also be present in the Configs
+                      field with the Runtime property set.
 
                       <p><br /></p>
 
 
-                      > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, and `CredentialSpec.Config` are mutually exclusive.
+                      > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`,
+                      > and `CredentialSpec.Config` are mutually exclusive.
                   File:
                     type: "string"
                     example: "spec.json"
                     description: |
-                      Load credential spec from this file. The file is read by the daemon, and must be present in the
-                      `CredentialSpecs` subdirectory in the docker data directory, which defaults to
-                      `C:\ProgramData\Docker\` on Windows.
+                      Load credential spec from this file. The file is read by
+                      the daemon, and must be present in the `CredentialSpecs`
+                      subdirectory in the docker data directory, which defaults
+                      to `C:\ProgramData\Docker\` on Windows.
 
-                      For example, specifying `spec.json` loads `C:\ProgramData\Docker\CredentialSpecs\spec.json`.
+                      For example, specifying `spec.json` loads
+                      `C:\ProgramData\Docker\CredentialSpecs\spec.json`.
 
                       <p><br /></p>
 
-                      > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, and `CredentialSpec.Config` are mutually exclusive.
+                      > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`,
+                      > and `CredentialSpec.Config` are mutually exclusive.
                   Registry:
                     type: "string"
                     description: |
-                      Load credential spec from this value in the Windows registry. The specified registry value must be
-                      located in:
+                      Load credential spec from this value in the Windows
+                      registry. The specified registry value must be located in:
 
                       `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\Containers\CredentialSpecs`
 
                       <p><br /></p>
 
 
-                      > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`, and `CredentialSpec.Config` are mutually exclusive.
+                      > **Note**: `CredentialSpec.File`, `CredentialSpec.Registry`,
+                      > and `CredentialSpec.Config` are mutually exclusive.
               SELinuxContext:
                 type: "object"
                 description: "SELinux labels of the container"
@@ -2825,7 +3084,9 @@ definitions:
             description: "Mount the container's root filesystem as read only."
             type: "boolean"
           Mounts:
-            description: "Specification for mounts to be added to containers created as part of the service."
+            description: |
+              Specification for mounts to be added to containers created as part
+              of the service.
             type: "array"
             items:
               $ref: "#/definitions/Mount"
@@ -2833,7 +3094,9 @@ definitions:
             description: "Signal to stop the container."
             type: "string"
           StopGracePeriod:
-            description: "Amount of time to wait for the container to terminate before forcefully killing it."
+            description: |
+              Amount of time to wait for the container to terminate before
+              forcefully killing it.
             type: "integer"
             format: "int64"
           HealthCheck:
@@ -2850,7 +3113,9 @@ definitions:
             items:
               type: "string"
           DNSConfig:
-            description: "Specification for DNS related configurations in resolver configuration file (`resolv.conf`)."
+            description: |
+              Specification for DNS related configurations in resolver configuration
+              file (`resolv.conf`).
             type: "object"
             properties:
               Nameservers:
@@ -2864,22 +3129,28 @@ definitions:
                 items:
                   type: "string"
               Options:
-                description: "A list of internal resolver variables to be modified (e.g., `debug`, `ndots:3`, etc.)."
+                description: |
+                  A list of internal resolver variables to be modified (e.g.,
+                  `debug`, `ndots:3`, etc.).
                 type: "array"
                 items:
                   type: "string"
           Secrets:
-            description: "Secrets contains references to zero or more secrets that will be exposed to the service."
+            description: |
+              Secrets contains references to zero or more secrets that will be
+              exposed to the service.
             type: "array"
             items:
               type: "object"
               properties:
                 File:
-                  description: "File represents a specific target that is backed by a file."
+                  description: |
+                    File represents a specific target that is backed by a file.
                   type: "object"
                   properties:
                     Name:
-                      description: "Name represents the final filename in the filesystem."
+                      description: |
+                        Name represents the final filename in the filesystem.
                       type: "string"
                     UID:
                       description: "UID represents the file UID."
@@ -2892,15 +3163,20 @@ definitions:
                       type: "integer"
                       format: "uint32"
                 SecretID:
-                  description: "SecretID represents the ID of the specific secret that we're referencing."
+                  description: |
+                    SecretID represents the ID of the specific secret that we're
+                    referencing.
                   type: "string"
                 SecretName:
                   description: |
-                    SecretName is the name of the secret that this references, but this is just provided for
-                    lookup/display purposes. The secret in the reference will be identified by its ID.
+                    SecretName is the name of the secret that this references,
+                    but this is just provided for lookup/display purposes. The
+                    secret in the reference will be identified by its ID.
                   type: "string"
           Configs:
-            description: "Configs contains references to zero or more configs that will be exposed to the service."
+            description: |
+              Configs contains references to zero or more configs that will be
+              exposed to the service.
             type: "array"
             items:
               type: "object"
@@ -2915,7 +3191,8 @@ definitions:
                   type: "object"
                   properties:
                     Name:
-                      description: "Name represents the final filename in the filesystem."
+                      description: |
+                        Name represents the final filename in the filesystem.
                       type: "string"
                     UID:
                       description: "UID represents the file UID."
@@ -2929,29 +3206,39 @@ definitions:
                       format: "uint32"
                 Runtime:
                   description: |
-                    Runtime represents a target that is not mounted into the container but is used by the task
+                    Runtime represents a target that is not mounted into the
+                    container but is used by the task
 
                     <p><br /><p>
 
-                    > **Note**: `Configs.File` and `Configs.Runtime` are mutually exclusive
+                    > **Note**: `Configs.File` and `Configs.Runtime` are mutually
+                    > exclusive
                   type: "object"
                 ConfigID:
-                  description: "ConfigID represents the ID of the specific config that we're referencing."
+                  description: |
+                    ConfigID represents the ID of the specific config that we're
+                    referencing.
                   type: "string"
                 ConfigName:
                   description: |
-                    ConfigName is the name of the config that this references, but this is just provided for
-                    lookup/display purposes. The config in the reference will be identified by its ID.
+                    ConfigName is the name of the config that this references,
+                    but this is just provided for lookup/display purposes. The
+                    config in the reference will be identified by its ID.
                   type: "string"
           Isolation:
             type: "string"
-            description: "Isolation technology of the containers running the service. (Windows only)"
+            description: |
+              Isolation technology of the containers running the service.
+              (Windows only)
             enum:
               - "default"
               - "process"
               - "hyperv"
           Init:
-            description: "Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used."
+            description: |
+              Run an init inside the container that forwards signals and reaps
+              processes. This field is omitted if empty, and the default (as
+              configured on the daemon) is used.
             type: "boolean"
             x-nullable: true
           Sysctls:
@@ -2983,7 +3270,9 @@ definitions:
             description: "ID of the container represented by this task"
             type: "string"
       Resources:
-        description: "Resource requirements which apply to each individual container created as part of the service."
+        description: |
+          Resource requirements which apply to each individual container created
+          as part of the service.
         type: "object"
         properties:
           Limits:
@@ -2993,7 +3282,9 @@ definitions:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
       RestartPolicy:
-        description: "Specification for the restart policy which applies to containers created as part of this service."
+        description: |
+          Specification for the restart policy which applies to containers
+          created as part of this service.
         type: "object"
         properties:
           Condition:
@@ -3008,12 +3299,16 @@ definitions:
             type: "integer"
             format: "int64"
           MaxAttempts:
-            description: "Maximum attempts to restart a given container before giving up (default value is 0, which is ignored)."
+            description: |
+              Maximum attempts to restart a given container before giving up
+              (default value is 0, which is ignored).
             type: "integer"
             format: "int64"
             default: 0
           Window:
-            description: "Windows is the time window used to evaluate the restart policy (default value is 0, which is unbounded)."
+            description: |
+              Windows is the time window used to evaluate the restart policy
+              (default value is 0, which is unbounded).
             type: "integer"
             format: "int64"
             default: 0
@@ -3052,7 +3347,10 @@ definitions:
               - "node.platform.os==linux"
               - "node.platform.arch==x86_64"
           Preferences:
-            description: "Preferences provide a way to make the scheduler aware of factors such as topology. They are provided in order from highest to lowest precedence."
+            description: |
+              Preferences provide a way to make the scheduler aware of factors
+              such as topology. They are provided in order from highest to
+              lowest precedence.
             type: "array"
             items:
               type: "object"
@@ -3061,7 +3359,8 @@ definitions:
                   type: "object"
                   properties:
                     SpreadDescriptor:
-                      description: "label descriptor, such as engine.labels.az"
+                      description: |
+                        label descriptor, such as `engine.labels.az`.
                       type: "string"
             example:
               - Spread:
@@ -3069,7 +3368,9 @@ definitions:
               - Spread:
                   SpreadDescriptor: "node.labels.rack"
           MaxReplicas:
-            description: "Maximum number of replicas for per node (default value is 0, which is unlimited)"
+            description: |
+              Maximum number of replicas for per node (default value is 0, which
+              is unlimited)
             type: "integer"
             format: "int64"
             default: 0
@@ -3083,10 +3384,13 @@ definitions:
             items:
               $ref: "#/definitions/Platform"
       ForceUpdate:
-        description: "A counter that triggers an update even if no relevant parameters have been changed."
+        description: |
+          A counter that triggers an update even if no relevant parameters have
+          been changed.
         type: "integer"
       Runtime:
-        description: "Runtime is the type of runtime specified for the task executor."
+        description: |
+          Runtime is the type of runtime specified for the task executor.
         type: "string"
       Networks:
         description: "Specifies which networks the service should attach to."
@@ -3094,7 +3398,10 @@ definitions:
         items:
           $ref: "#/definitions/NetworkAttachmentConfig"
       LogDriver:
-        description: "Specifies the log driver to use for tasks created from this spec. If not present, the default one for the swarm will be used, finally falling back to the engine default if not specified."
+        description: |
+          Specifies the log driver to use for tasks created from this spec. If
+          not present, the default one for the swarm will be used, finally
+          falling back to the engine default if not specified.
         type: "object"
         properties:
           Name:
@@ -3277,7 +3584,9 @@ definitions:
         type: "object"
         properties:
           Parallelism:
-            description: "Maximum number of tasks to be updated in one iteration (0 means unlimited parallelism)."
+            description: |
+              Maximum number of tasks to be updated in one iteration (0 means
+              unlimited parallelism).
             type: "integer"
             format: "int64"
           Delay:
@@ -3285,22 +3594,32 @@ definitions:
             type: "integer"
             format: "int64"
           FailureAction:
-            description: "Action to take if an updated task fails to run, or stops running during the update."
+            description: |
+              Action to take if an updated task fails to run, or stops running
+              during the update.
             type: "string"
             enum:
               - "continue"
               - "pause"
               - "rollback"
           Monitor:
-            description: "Amount of time to monitor each updated task for failures, in nanoseconds."
+            description: |
+              Amount of time to monitor each updated task for failures, in
+              nanoseconds.
             type: "integer"
             format: "int64"
           MaxFailureRatio:
-            description: "The fraction of tasks that may fail during an update before the failure action is invoked, specified as a floating point number between 0 and 1."
+            description: |
+              The fraction of tasks that may fail during an update before the
+              failure action is invoked, specified as a floating point number
+              between 0 and 1.
             type: "number"
             default: 0
           Order:
-            description: "The order of operations when rolling out an updated task. Either the old task is shut down before the new task is started, or the new task is started before the old task is shut down."
+            description: |
+              The order of operations when rolling out an updated task. Either
+              the old task is shut down before the new task is started, or the
+              new task is started before the old task is shut down.
             type: "string"
             enum:
               - "stop-first"
@@ -3310,29 +3629,42 @@ definitions:
         type: "object"
         properties:
           Parallelism:
-            description: "Maximum number of tasks to be rolled back in one iteration (0 means unlimited parallelism)."
+            description: |
+              Maximum number of tasks to be rolled back in one iteration (0 means
+              unlimited parallelism).
             type: "integer"
             format: "int64"
           Delay:
-            description: "Amount of time between rollback iterations, in nanoseconds."
+            description: |
+              Amount of time between rollback iterations, in nanoseconds.
             type: "integer"
             format: "int64"
           FailureAction:
-            description: "Action to take if an rolled back task fails to run, or stops running during the rollback."
+            description: |
+              Action to take if an rolled back task fails to run, or stops
+              running during the rollback.
             type: "string"
             enum:
               - "continue"
               - "pause"
           Monitor:
-            description: "Amount of time to monitor each rolled back task for failures, in nanoseconds."
+            description: |
+              Amount of time to monitor each rolled back task for failures, in
+              nanoseconds.
             type: "integer"
             format: "int64"
           MaxFailureRatio:
-            description: "The fraction of tasks that may fail during a rollback before the failure action is invoked, specified as a floating point number between 0 and 1."
+            description: |
+              The fraction of tasks that may fail during a rollback before the
+              failure action is invoked, specified as a floating point number
+              between 0 and 1.
             type: "number"
             default: 0
           Order:
-            description: "The order of operations when rolling back a task. Either the old task is shut down before the new task is started, or the new task is started before the old task is shut down."
+            description: |
+              The order of operations when rolling back a task. Either the old
+              task is shut down before the new task is started, or the new task
+              is started before the old task is shut down.
             type: "string"
             enum:
               - "stop-first"
@@ -3395,7 +3727,9 @@ definitions:
           - "dnsrr"
         default: "vip"
       Ports:
-        description: "List of exposed ports that this service is accessible on from the outside. Ports can only be provided if `vip` resolution mode is used."
+        description: |
+          List of exposed ports that this service is accessible on from the
+          outside. Ports can only be provided if `vip` resolution mode is used.
         type: "array"
         items:
           $ref: "#/definitions/EndpointPortConfig"
@@ -3647,7 +3981,9 @@ definitions:
         type: "string"
         example: ""
       Driver:
-        description: "Name of the secrets driver used to fetch the secret's value from an external secret store"
+        description: |
+          Name of the secrets driver used to fetch the secret's value from an
+          external secret store.
         $ref: "#/definitions/Driver"
       Templating:
         description: |
@@ -3752,7 +4088,8 @@ definitions:
         type: "boolean"
         example: false
       OOMKilled:
-        description: "Whether this container has been killed because it ran out of memory."
+        description: |
+          Whether this container has been killed because it ran out of memory.
         type: "boolean"
         example: false
       Dead:
@@ -3779,6 +4116,103 @@ definitions:
       Health:
         x-nullable: true
         $ref: "#/definitions/Health"
+
+  SystemVersion:
+    type: "object"
+    description: |
+      Response of Engine API: GET "/version"
+    properties:
+      Platform:
+        type: "object"
+        required: [Name]
+        properties:
+          Name:
+            type: "string"
+      Components:
+        type: "array"
+        description: |
+          Information about system components
+        items:
+          type: "object"
+          x-go-name: ComponentVersion
+          required: [Name, Version]
+          properties:
+            Name:
+              description: |
+                Name of the component
+              type: "string"
+              example: "Engine"
+            Version:
+              description: |
+                Version of the component
+              type: "string"
+              x-nullable: false
+              example: "19.03.12"
+            Details:
+              description: |
+                Key/value pairs of strings with additional information about the
+                component. These values are intended for informational purposes
+                only, and their content is not defined, and not part of the API
+                specification.
+
+                These messages can be printed by the client as information to the user.
+              type: "object"
+              x-nullable: true
+      Version:
+        description: "The version of the daemon"
+        type: "string"
+        example: "19.03.12"
+      ApiVersion:
+        description: |
+          The default (and highest) API version that is supported by the daemon
+        type: "string"
+        example: "1.40"
+      MinAPIVersion:
+        description: |
+          The minimum API version that is supported by the daemon
+        type: "string"
+        example: "1.12"
+      GitCommit:
+        description: |
+          The Git commit of the source code that was used to build the daemon
+        type: "string"
+        example: "48a66213fe"
+      GoVersion:
+        description: |
+          The version Go used to compile the daemon, and the version of the Go
+          runtime in use.
+        type: "string"
+        example: "go1.13.14"
+      Os:
+        description: |
+          The operating system that the daemon is running on ("linux" or "windows")
+        type: "string"
+        example: "linux"
+      Arch:
+        description: |
+          The architecture that the daemon is running on
+        type: "string"
+        example: "amd64"
+      KernelVersion:
+        description: |
+          The kernel version (`uname -r`) that the daemon is running on.
+
+          This field is omitted when empty.
+        type: "string"
+        example: "4.19.76-linuxkit"
+      Experimental:
+        description: |
+          Indicates if the daemon is started with experimental features enabled.
+
+          This field is omitted when empty / false.
+        type: "boolean"
+        example: true
+      BuildTime:
+        description: |
+          The date and time that the daemon was compiled.
+        type: "string"
+        example: "2020-06-22T15:49:27.000000000+00:00"
+
 
   SystemInfo:
     type: "object"
@@ -3907,15 +4341,20 @@ definitions:
         type: "boolean"
         example: true
       CpuCfsPeriod:
-        description: "Indicates if CPU CFS(Completely Fair Scheduler) period is supported by the host."
+        description: |
+          Indicates if CPU CFS(Completely Fair Scheduler) period is supported by
+          the host.
         type: "boolean"
         example: true
       CpuCfsQuota:
-        description: "Indicates if CPU CFS(Completely Fair Scheduler) quota is supported by the host."
+        description: |
+          Indicates if CPU CFS(Completely Fair Scheduler) quota is supported by
+          the host.
         type: "boolean"
         example: true
       CPUShares:
-        description: "Indicates if CPU Shares limiting is supported by the host."
+        description: |
+          Indicates if CPU Shares limiting is supported by the host.
         type: "boolean"
         example: true
       CPUSet:
@@ -3945,7 +4384,9 @@ definitions:
         type: "boolean"
         example: true
       Debug:
-        description: "Indicates if the daemon is running in debug-mode / with debug-level logging enabled."
+        description: |
+          Indicates if the daemon is running in debug-mode / with debug-level
+          logging enabled.
         type: "boolean"
         example: true
       NFd:
@@ -4026,7 +4467,7 @@ definitions:
         example: 4
       MemTotal:
         description: |
-          Total amount of physical memory available on the host, in kilobytes (kB).
+          Total amount of physical memory available on the host, in bytes.
         type: "integer"
         format: "int64"
         example: 2095882240
@@ -4579,19 +5020,23 @@ definitions:
         type: "string"
 
   NetworkAttachmentConfig:
-    description: "Specifies how a service should be attached to a particular network."
+    description: |
+      Specifies how a service should be attached to a particular network.
     type: "object"
     properties:
       Target:
-        description: "The target network for attachment. Must be a network name or ID."
+        description: |
+          The target network for attachment. Must be a network name or ID.
         type: "string"
       Aliases:
-        description: "Discoverable alternate names for the service on this network."
+        description: |
+          Discoverable alternate names for the service on this network.
         type: "array"
         items:
           type: "string"
       DriverOpts:
-        description: "Driver attachment options for the network target"
+        description: |
+          Driver attachment options for the network target.
         type: "object"
         additionalProperties:
           type: "string"
@@ -4601,32 +5046,42 @@ paths:
     get:
       summary: "List containers"
       description: |
-        Returns a list of containers. For details on the format, see [the inspect endpoint](#operation/ContainerInspect).
+        Returns a list of containers. For details on the format, see the
+        [inspect endpoint](#operation/ContainerInspect).
 
-        Note that it uses a different, smaller representation of a container than inspecting a single container. For example,
-        the list of linked containers is not propagated .
+        Note that it uses a different, smaller representation of a container
+        than inspecting a single container. For example, the list of linked
+        containers is not propagated .
       operationId: "ContainerList"
       produces:
         - "application/json"
       parameters:
         - name: "all"
           in: "query"
-          description: "Return all containers. By default, only running containers are shown"
+          description: |
+            Return all containers. By default, only running containers are shown.
           type: "boolean"
           default: false
         - name: "limit"
           in: "query"
-          description: "Return this number of most recently created containers, including non-running ones."
+          description: |
+            Return this number of most recently created containers, including
+            non-running ones.
           type: "integer"
         - name: "size"
           in: "query"
-          description: "Return the size of container as fields `SizeRw` and `SizeRootFs`."
+          description: |
+            Return the size of container as fields `SizeRw` and `SizeRootFs`.
           type: "boolean"
           default: false
         - name: "filters"
           in: "query"
           description: |
-            Filters to process on the container list, encoded as JSON (a `map[string][]string`). For example, `{"status": ["paused"]}` will only return paused containers. Available filters:
+            Filters to process on the container list, encoded as JSON (a
+            `map[string][]string`). For example, `{"status": ["paused"]}` will
+            only return paused containers.
+
+            Available filters:
 
             - `ancestor`=(`<image-name>[:<tag>]`, `<image id>`, or `<image@digest>`)
             - `before`=(`<container id>` or `<container name>`)
@@ -4797,7 +5252,9 @@ paths:
       parameters:
         - name: "name"
           in: "query"
-          description: "Assign the specified name to the container. Must match `/?[a-zA-Z0-9][a-zA-Z0-9_.-]+`."
+          description: |
+            Assign the specified name to the container. Must match
+            `/?[a-zA-Z0-9][a-zA-Z0-9_.-]+`.
           type: "string"
           pattern: "^/?[a-zA-Z0-9][a-zA-Z0-9_.-]+$"
         - name: "body"
@@ -4811,14 +5268,7 @@ paths:
                   HostConfig:
                     $ref: "#/definitions/HostConfig"
                   NetworkingConfig:
-                    description: "This container's networking configuration."
-                    type: "object"
-                    properties:
-                      EndpointsConfig:
-                        description: "A mapping of network name to endpoint configuration for that network."
-                        type: "object"
-                        additionalProperties:
-                          $ref: "#/definitions/EndpointSettings"
+                    $ref: "#/definitions/NetworkingConfig"
             example:
               Hostname: ""
               Domainname: ""
@@ -4880,6 +5330,14 @@ paths:
                   - {}
                 BlkioDeviceWriteIOps:
                   - {}
+                DeviceRequests:
+                  - Driver: "nvidia"
+                    Count: -1
+                    DeviceIDs": ["0", "1", "GPU-fef8089b-4820-abfc-e83e-94318197576e"]
+                    Capabilities: [["gpu", "nvidia", "compute"]]
+                    Options:
+                      property1: "string"
+                      property2: "string"
                 MemorySwappiness: 60
                 OomKillDisable: false
                 OomScoreAdj: 500
@@ -5014,7 +5472,7 @@ paths:
                 x-nullable: true
                 $ref: "#/definitions/ContainerState"
               Image:
-                description: "The container's image"
+                description: "The container's image ID"
                 type: "string"
               ResolvConfPath:
                 type: "string"
@@ -5052,7 +5510,9 @@ paths:
               GraphDriver:
                 $ref: "#/definitions/GraphDriverData"
               SizeRw:
-                description: "The size of files that have been created or changed by this container."
+                description: |
+                  The size of files that have been created or changed by this
+                  container.
                 type: "integer"
                 format: "int64"
               SizeRootFs:
@@ -5131,6 +5591,14 @@ paths:
                 CpuRealtimePeriod: 1000000
                 CpuRealtimeRuntime: 10000
                 Devices: []
+                DeviceRequests:
+                  - Driver: "nvidia"
+                    Count: -1
+                    DeviceIDs": ["0", "1", "GPU-fef8089b-4820-abfc-e83e-94318197576e"]
+                    Capabilities: [["gpu", "nvidia", "compute"]]
+                    Options:
+                      property1: "string"
+                      property2: "string"
                 IpcMode: ""
                 LxcConf: []
                 Memory: 0
@@ -5247,7 +5715,9 @@ paths:
   /containers/{id}/top:
     get:
       summary: "List processes running inside a container"
-      description: "On Unix systems, this is done by running the `ps` command. This endpoint is not supported on Windows."
+      description: |
+        On Unix systems, this is done by running the `ps` command. This endpoint
+        is not supported on Windows.
       operationId: "ContainerTop"
       responses:
         200:
@@ -5263,7 +5733,9 @@ paths:
                 items:
                   type: "string"
               Processes:
-                description: "Each process running in the container, where each is process is an array of values corresponding to the titles"
+                description: |
+                  Each process running in the container, where each is process
+                  is an array of values corresponding to the titles.
                 type: "array"
                 items:
                   type: "array"
@@ -5328,15 +5800,16 @@ paths:
       description: |
         Get `stdout` and `stderr` logs from a container.
 
-        Note: This endpoint works only for containers with the `json-file` or `journald` logging driver.
+        Note: This endpoint works only for containers with the `json-file` or
+        `journald` logging driver.
       operationId: "ContainerLogs"
       responses:
         200:
           description: |
-                  logs returned as a stream in response body.
-                  For the stream format, [see the documentation for the attach endpoint](#operation/ContainerAttach).
-                  Note that unlike the attach endpoint, the logs endpoint does not upgrade the connection and does not
-                  set Content-Type.
+            logs returned as a stream in response body.
+            For the stream format, [see the documentation for the attach endpoint](#operation/ContainerAttach).
+            Note that unlike the attach endpoint, the logs endpoint does not
+            upgrade the connection and does not set Content-Type.
           schema:
             type: "string"
             format: "binary"
@@ -5389,7 +5862,9 @@ paths:
           default: false
         - name: "tail"
           in: "query"
-          description: "Only return this number of log lines from the end of the logs. Specify as an integer or `all` to output all log lines."
+          description: |
+            Only return this number of log lines from the end of the logs.
+            Specify as an integer or `all` to output all log lines.
           type: "string"
           default: "all"
       tags: ["Container"]
@@ -5495,6 +5970,16 @@ paths:
         If either `precpu_stats.online_cpus` or `cpu_stats.online_cpus` is
         nil then for compatibility with older daemons the length of the
         corresponding `cpu_usage.percpu_usage` array should be used.
+
+        To calculate the values shown by the `stats` command of the docker cli tool
+        the following formulas can be used:
+        * used_memory = `memory_stats.usage - memory_stats.stats.cache`
+        * available_memory = `memory_stats.limit`
+        * Memory usage % = `(used_memory / available_memory) * 100.0`
+        * cpu_delta = `cpu_stats.cpu_usage.total_usage - precpu_stats.cpu_usage.total_usage`
+        * system_cpu_delta = `cpu_stats.system_cpu_usage - precpu_stats.system_cpu_usage`
+        * number_cpus = `lenght(cpu_stats.cpu_usage.percpu_usage)` or `cpu_stats.online_cpus`
+        * CPU usage % = `(cpu_delta / system_cpu_delta) * number_cpus * 100.0`
       operationId: "ContainerStats"
       produces: ["application/json"]
       responses:
@@ -5613,7 +6098,9 @@ paths:
           type: "string"
         - name: "stream"
           in: "query"
-          description: "Stream the output. If false, the stats will be output once and then it will disconnect."
+          description: |
+            Stream the output. If false, the stats will be output once and then
+            it will disconnect.
           type: "boolean"
           default: true
       tags: ["Container"]
@@ -5648,11 +6135,11 @@ paths:
           type: "string"
         - name: "h"
           in: "query"
-          description: "Height of the tty session in characters"
+          description: "Height of the TTY session in characters"
           type: "integer"
         - name: "w"
           in: "query"
-          description: "Width of the tty session in characters"
+          description: "Width of the TTY session in characters"
           type: "integer"
       tags: ["Container"]
   /containers/{id}/start:
@@ -5683,7 +6170,10 @@ paths:
           type: "string"
         - name: "detachKeys"
           in: "query"
-          description: "Override the key sequence for detaching a container. Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`."
+          description: |
+            Override the key sequence for detaching a container. Format is a
+            single character `[a-Z]` or `ctrl-<value>` where `<value>` is one
+            of: `a-z`, `@`, `^`, `[`, `,` or `_`.
           type: "string"
       tags: ["Container"]
   /containers/{id}/stop:
@@ -5749,7 +6239,9 @@ paths:
   /containers/{id}/kill:
     post:
       summary: "Kill a container"
-      description: "Send a POSIX signal to a container, defaulting to killing to the container."
+      description: |
+        Send a POSIX signal to a container, defaulting to killing to the
+        container.
       operationId: "ContainerKill"
       responses:
         204:
@@ -5787,7 +6279,9 @@ paths:
   /containers/{id}/update:
     post:
       summary: "Update a container"
-      description: "Change various configuration options of a container without having to recreate it."
+      description: |
+        Change various configuration options of a container without having to
+        recreate it.
       operationId: "ContainerUpdate"
       consumes: ["application/json"]
       produces: ["application/json"]
@@ -5887,7 +6381,10 @@ paths:
       description: |
         Use the freezer cgroup to suspend all processes in a container.
 
-        Traditionally, when suspending a process the `SIGSTOP` signal is used, which is observable by the process being suspended. With the freezer cgroup the process is unaware, and unable to capture, that it is being suspended, and subsequently resumed.
+        Traditionally, when suspending a process the `SIGSTOP` signal is used,
+        which is observable by the process being suspended. With the freezer
+        cgroup the process is unaware, and unable to capture, that it is being
+        suspended, and subsequently resumed.
       operationId: "ContainerPause"
       responses:
         204:
@@ -5940,15 +6437,20 @@ paths:
     post:
       summary: "Attach to a container"
       description: |
-        Attach to a container to read its output or send it input. You can attach to the same container multiple times and you can reattach to containers that have been detached.
+        Attach to a container to read its output or send it input. You can attach
+        to the same container multiple times and you can reattach to containers
+        that have been detached.
 
-        Either the `stream` or `logs` parameter must be `true` for this endpoint to do anything.
+        Either the `stream` or `logs` parameter must be `true` for this endpoint
+        to do anything.
 
-        See [the documentation for the `docker attach` command](https://docs.docker.com/engine/reference/commandline/attach/) for more details.
+        See the [documentation for the `docker attach` command](https://docs.docker.com/engine/reference/commandline/attach/)
+        for more details.
 
         ### Hijacking
 
-        This endpoint hijacks the HTTP connection to transport `stdin`, `stdout`, and `stderr` on the same socket.
+        This endpoint hijacks the HTTP connection to transport `stdin`, `stdout`,
+        and `stderr` on the same socket.
 
         This is the response from the daemon for an attach request:
 
@@ -5959,9 +6461,11 @@ paths:
         [STREAM]
         ```
 
-        After the headers and two new lines, the TCP connection can now be used for raw, bidirectional communication between the client and server.
+        After the headers and two new lines, the TCP connection can now be used
+        for raw, bidirectional communication between the client and server.
 
-        To hint potential proxies about connection hijacking, the Docker client can also optionally send connection upgrade headers.
+        To hint potential proxies about connection hijacking, the Docker client
+        can also optionally send connection upgrade headers.
 
         For example, the client sends this request to upgrade the connection:
 
@@ -5971,7 +6475,8 @@ paths:
         Connection: Upgrade
         ```
 
-        The Docker daemon will respond with a `101 UPGRADED` response, and will similarly follow with the raw stream:
+        The Docker daemon will respond with a `101 UPGRADED` response, and will
+        similarly follow with the raw stream:
 
         ```
         HTTP/1.1 101 UPGRADED
@@ -5984,9 +6489,14 @@ paths:
 
         ### Stream format
 
-        When the TTY setting is disabled in [`POST /containers/create`](#operation/ContainerCreate), the stream over the hijacked connected is multiplexed to separate out `stdout` and `stderr`. The stream consists of a series of frames, each containing a header and a payload.
+        When the TTY setting is disabled in [`POST /containers/create`](#operation/ContainerCreate),
+        the stream over the hijacked connected is multiplexed to separate out
+        `stdout` and `stderr`. The stream consists of a series of frames, each
+        containing a header and a payload.
 
-        The header contains the information which the stream writes (`stdout` or `stderr`). It also contains the size of the associated frame encoded in the last four bytes (`uint32`).
+        The header contains the information which the stream writes (`stdout` or
+        `stderr`). It also contains the size of the associated frame encoded in
+        the last four bytes (`uint32`).
 
         It is encoded on the first eight bytes like this:
 
@@ -6000,9 +6510,11 @@ paths:
         - 1: `stdout`
         - 2: `stderr`
 
-        `SIZE1, SIZE2, SIZE3, SIZE4` are the four bytes of the `uint32` size encoded as big endian.
+        `SIZE1, SIZE2, SIZE3, SIZE4` are the four bytes of the `uint32` size
+        encoded as big endian.
 
-        Following the header is the payload, which is the specified number of bytes of `STREAM_TYPE`.
+        Following the header is the payload, which is the specified number of
+        bytes of `STREAM_TYPE`.
 
         The simplest way to implement this protocol is the following:
 
@@ -6014,7 +6526,10 @@ paths:
 
         ### Stream format when using a TTY
 
-        When the TTY setting is enabled in [`POST /containers/create`](#operation/ContainerCreate), the stream is not multiplexed. The data exchanged over the hijacked connection is simply the raw data from the process PTY and client's `stdin`.
+        When the TTY setting is enabled in [`POST /containers/create`](#operation/ContainerCreate),
+        the stream is not multiplexed. The data exchanged over the hijacked
+        connection is simply the raw data from the process PTY and client's
+        `stdin`.
 
       operationId: "ContainerAttach"
       produces:
@@ -6047,21 +6562,28 @@ paths:
           type: "string"
         - name: "detachKeys"
           in: "query"
-          description: "Override the key sequence for detaching a container.Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`."
+          description: |
+            Override the key sequence for detaching a container.Format is a single
+            character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`,
+            `@`, `^`, `[`, `,` or `_`.
           type: "string"
         - name: "logs"
           in: "query"
           description: |
             Replay previous logs from the container.
 
-            This is useful for attaching to a container that has started and you want to output everything since the container started.
+            This is useful for attaching to a container that has started and you
+            want to output everything since the container started.
 
-            If `stream` is also enabled, once all the previous output has been returned, it will seamlessly transition into streaming current output.
+            If `stream` is also enabled, once all the previous output has been
+            returned, it will seamlessly transition into streaming current
+            output.
           type: "boolean"
           default: false
         - name: "stream"
           in: "query"
-          description: "Stream attached streams from the time the request was made onwards"
+          description: |
+            Stream attached streams from the time the request was made onwards.
           type: "boolean"
           default: false
         - name: "stdin"
@@ -6112,7 +6634,10 @@ paths:
           type: "string"
         - name: "detachKeys"
           in: "query"
-          description: "Override the key sequence for detaching a container.Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,`, or `_`."
+          description: |
+            Override the key sequence for detaching a container.Format is a single
+            character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`,
+            `@`, `^`, `[`, `,`, or `_`.
           type: "string"
         - name: "logs"
           in: "query"
@@ -6185,7 +6710,9 @@ paths:
           type: "string"
         - name: "condition"
           in: "query"
-          description: "Wait until a container state reaches the given condition, either 'not-running' (default), 'next-exit', or 'removed'."
+          description: |
+            Wait until a container state reaches the given condition, either
+            'not-running' (default), 'next-exit', or 'removed'.
           type: "string"
           default: "not-running"
       tags: ["Container"]
@@ -6213,7 +6740,9 @@ paths:
             $ref: "#/definitions/ErrorResponse"
           examples:
             application/json:
-              message: "You cannot remove a running container: c2ada9df5af8. Stop the container before attempting removal or force remove"
+              message: |
+                You cannot remove a running container: c2ada9df5af8. Stop the
+                container before attempting removal or force remove
         500:
           description: "server error"
           schema:
@@ -6243,7 +6772,10 @@ paths:
   /containers/{id}/archive:
     head:
       summary: "Get information about files in a container"
-      description: "A response header `X-Docker-Container-Path-Stat` is return containing a base64 - encoded JSON object with some filesystem header information about the path."
+      description: |
+        A response header `X-Docker-Container-Path-Stat` is returned, containing
+        a base64 - encoded JSON object with some filesystem header information
+        about the path.
       operationId: "ContainerArchiveInfo"
       responses:
         200:
@@ -6251,7 +6783,9 @@ paths:
           headers:
             X-Docker-Container-Path-Stat:
               type: "string"
-              description: "A base64 - encoded JSON object with some filesystem header information about the path"
+              description: |
+                A base64 - encoded JSON object with some filesystem header
+                information about the path
         400:
           description: "Bad parameter"
           schema:
@@ -6260,7 +6794,10 @@ paths:
               - type: "object"
                 properties:
                   message:
-                    description: "The error message. Either \"must specify path parameter\" (path cannot be empty) or \"not a directory\" (path was asserted to be a directory but exists as a file)."
+                    description: |
+                      The error message. Either "must specify path parameter"
+                      (path cannot be empty) or "not a directory" (path was
+                      asserted to be a directory but exists as a file).
                     type: "string"
                     x-nullable: false
         404:
@@ -6302,7 +6839,10 @@ paths:
               - type: "object"
                 properties:
                   message:
-                    description: "The error message. Either \"must specify path parameter\" (path cannot be empty) or \"not a directory\" (path was asserted to be a directory but exists as a file)."
+                    description: |
+                      The error message. Either "must specify path parameter"
+                      (path cannot be empty) or "not a directory" (path was
+                      asserted to be a directory but exists as a file).
                     type: "string"
                     x-nullable: false
         404:
@@ -6368,16 +6908,24 @@ paths:
           type: "string"
         - name: "noOverwriteDirNonDir"
           in: "query"
-          description: "If “1”, “true”, or “True” then it will be an error if unpacking the given content would cause an existing directory to be replaced with a non-directory and vice versa."
+          description: |
+            If `1`, `true`, or `True` then it will be an error if unpacking the
+            given content would cause an existing directory to be replaced with
+            a non-directory and vice versa.
           type: "string"
         - name: "copyUIDGID"
           in: "query"
-          description: "If “1”, “true”, then it will copy UID/GID maps to the dest file or dir"
+          description: |
+            If `1`, `true`, then it will copy UID/GID maps to the dest file or
+            dir
           type: "string"
         - name: "inputStream"
           in: "body"
           required: true
-          description: "The input stream must be a tar archive compressed with one of the following algorithms: identity (no compression), gzip, bzip2, xz."
+          description: |
+            The input stream must be a tar archive compressed with one of the
+            following algorithms: `identity` (no compression), `gzip`, `bzip2`,
+            or `xz`.
           schema:
             type: "string"
             format: "binary"
@@ -6475,7 +7023,10 @@ paths:
         - name: "filters"
           in: "query"
           description: |
-            A JSON encoded value of the filters (a `map[string][]string`) to process on the images list. Available filters:
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the images list.
+
+            Available filters:
 
             - `before`=(`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`)
             - `dangling=true`
@@ -6691,7 +7242,11 @@ paths:
           in: "query"
           type: "string"
           description: |
-            A JSON encoded value of the filters (a `map[string][]string`) to process on the list of build cache objects. Available filters:
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the list of build cache objects.
+
+            Available filters:
+
             - `until=<duration>`: duration relative to daemon's time, during which build cache was not used, in Go's duration format (e.g., '24h')
             - `id=<id>`
             - `parent=<id>`
@@ -6771,7 +7326,11 @@ paths:
           required: false
         - name: "X-Registry-Auth"
           in: "header"
-          description: "A base64url-encoded auth configuration. [See the authentication section for details.](#section/Authentication)"
+          description: |
+            A base64url-encoded auth configuration.
+
+            Refer to the [authentication section](#section/Authentication) for
+            details.
           type: "string"
         - name: "platform"
           in: "query"
@@ -6970,7 +7529,9 @@ paths:
       description: |
         Push an image to a registry.
 
-        If you wish to push an image on to a private registry, that image must already have a tag which references the registry. For example, `registry.example.com/myimage:latest`.
+        If you wish to push an image on to a private registry, that image must
+        already have a tag which references the registry. For example,
+        `registry.example.com/myimage:latest`.
 
         The push is cancelled if the HTTP connection is closed.
       operationId: "ImagePush"
@@ -6999,7 +7560,11 @@ paths:
           type: "string"
         - name: "X-Registry-Auth"
           in: "header"
-          description: "A base64url-encoded auth configuration. [See the authentication section for details.](#section/Authentication)"
+          description: |
+            A base64url-encoded auth configuration.
+
+            Refer to the [authentication section](#section/Authentication) for
+            details.
           type: "string"
           required: true
       tags: ["Image"]
@@ -7203,7 +7768,9 @@ paths:
   /auth:
     post:
       summary: "Check auth configuration"
-      description: "Validate credentials for a registry and, if available, get an identity token for accessing the registry without password."
+      description: |
+        Validate credentials for a registry and, if available, get an identity
+        token for accessing the registry without password.
       operationId: "SystemAuth"
       consumes: ["application/json"]
       produces: ["application/json"]
@@ -7266,63 +7833,7 @@ paths:
         200:
           description: "no error"
           schema:
-            type: "object"
-            title: "SystemVersionResponse"
-            properties:
-              Platform:
-                type: "object"
-                required: [Name]
-                properties:
-                  Name:
-                    type: "string"
-              Components:
-                type: "array"
-                items:
-                  type: "object"
-                  x-go-name: ComponentVersion
-                  required: [Name, Version]
-                  properties:
-                    Name:
-                      type: "string"
-                    Version:
-                      type: "string"
-                      x-nullable: false
-                    Details:
-                      type: "object"
-                      x-nullable: true
-
-              Version:
-                type: "string"
-              ApiVersion:
-                type: "string"
-              MinAPIVersion:
-                type: "string"
-              GitCommit:
-                type: "string"
-              GoVersion:
-                type: "string"
-              Os:
-                type: "string"
-              Arch:
-                type: "string"
-              KernelVersion:
-                type: "string"
-              Experimental:
-                type: "boolean"
-              BuildTime:
-                type: "string"
-          examples:
-            application/json:
-              Version: "17.04.0"
-              Os: "linux"
-              KernelVersion: "3.19.0-23-generic"
-              GoVersion: "go1.7.5"
-              GitCommit: "deadbee"
-              Arch: "amd64"
-              ApiVersion: "1.27"
-              MinAPIVersion: "1.12"
-              BuildTime: "2016-06-14T07:09:13.444803460+00:00"
-              Experimental: true
+            $ref: "#/definitions/SystemVersion"
         500:
           description: "server error"
           schema:
@@ -7714,11 +8225,16 @@ paths:
     get:
       summary: "Export several images"
       description: |
-        Get a tarball containing all images and metadata for several image repositories.
+        Get a tarball containing all images and metadata for several image
+        repositories.
 
-        For each value of the `names` parameter: if it is a specific name and tag (e.g. `ubuntu:latest`), then only that image (and its parents) are returned; if it is an image ID, similarly only that image (and its parents) are returned and there would be no names referenced in the 'repositories' file for this image ID.
+        For each value of the `names` parameter: if it is a specific name and
+        tag (e.g. `ubuntu:latest`), then only that image (and its parents) are
+        returned; if it is an image ID, similarly only that image (and its parents)
+        are returned and there would be no names referenced in the 'repositories'
+        file for this image ID.
 
-        For details on the format, see [the export image endpoint](#operation/ImageGet).
+        For details on the format, see the [export image endpoint](#operation/ImageGet).
       operationId: "ImageGetAll"
       produces:
         - "application/x-tar"
@@ -7746,7 +8262,7 @@ paths:
       description: |
         Load a set of images and tags into a repository.
 
-        For details on the format, see [the export image endpoint](#operation/ImageGet).
+        For details on the format, see the [export image endpoint](#operation/ImageGet).
       operationId: "ImageLoad"
       consumes:
         - "application/x-tar"
@@ -7819,12 +8335,16 @@ paths:
                 description: "Attach to `stderr` of the exec command."
               DetachKeys:
                 type: "string"
-                description: "Override the key sequence for detaching a container. Format is a single character `[a-Z]` or `ctrl-<value>` where `<value>` is one of: `a-z`, `@`, `^`, `[`, `,` or `_`."
+                description: |
+                  Override the key sequence for detaching a container. Format is
+                  a single character `[a-Z]` or `ctrl-<value>` where `<value>`
+                  is one of: `a-z`, `@`, `^`, `[`, `,` or `_`.
               Tty:
                 type: "boolean"
                 description: "Allocate a pseudo-TTY."
               Env:
-                description: "A list of environment variables in the form `[\"VAR=value\", ...]`."
+                description: |
+                  A list of environment variables in the form `["VAR=value", ...]`.
                 type: "array"
                 items:
                   type: "string"
@@ -7839,10 +8359,14 @@ paths:
                 default: false
               User:
                 type: "string"
-                description: "The user, and optionally, group to run the exec process inside the container. Format is one of: `user`, `user:group`, `uid`, or `uid:gid`."
+                description: |
+                  The user, and optionally, group to run the exec process inside
+                  the container. Format is one of: `user`, `user:group`, `uid`,
+                  or `uid:gid`.
               WorkingDir:
                 type: "string"
-                description: "The working directory for the exec process inside the container."
+                description: |
+                  The working directory for the exec process inside the container.
             example:
               AttachStdin: false
               AttachStdout: true
@@ -7864,7 +8388,10 @@ paths:
   /exec/{id}/start:
     post:
       summary: "Start an exec instance"
-      description: "Starts a previously set up exec instance. If detach is true, this endpoint returns immediately after starting the command. Otherwise, it sets up an interactive session with the command."
+      description: |
+        Starts a previously set up exec instance. If detach is true, this endpoint
+        returns immediately after starting the command. Otherwise, it sets up an
+        interactive session with the command.
       operationId: "ExecStart"
       consumes:
         - "application/json"
@@ -7905,7 +8432,9 @@ paths:
   /exec/{id}/resize:
     post:
       summary: "Resize an exec instance"
-      description: "Resize the TTY session used by an exec instance. This endpoint only works if `tty` was specified as part of creating and starting the exec instance."
+      description: |
+        Resize the TTY session used by an exec instance. This endpoint only works
+        if `tty` was specified as part of creating and starting the exec instance.
       operationId: "ExecResize"
       responses:
         201:
@@ -8025,7 +8554,8 @@ paths:
               Warnings:
                 type: "array"
                 x-nullable: false
-                description: "Warnings that occurred when fetching the list of volumes"
+                description: |
+                  Warnings that occurred when fetching the list of volumes.
                 items:
                   type: "string"
 
@@ -8094,7 +8624,8 @@ paths:
             title: "VolumeConfig"
             properties:
               Name:
-                description: "The new volume's name. If not specified, Docker generates a name."
+                description: |
+                  The new volume's name. If not specified, Docker generates a name.
                 type: "string"
                 x-nullable: false
               Driver:
@@ -8103,7 +8634,9 @@ paths:
                 default: "local"
                 x-nullable: false
               DriverOpts:
-                description: "A mapping of driver options and values. These options are passed directly to the driver and are driver specific."
+                description: |
+                  A mapping of driver options and values. These options are
+                  passed directly to the driver and are driver specific.
                 type: "object"
                 additionalProperties:
                   type: "string"
@@ -8217,10 +8750,12 @@ paths:
     get:
       summary: "List networks"
       description: |
-        Returns a list of networks. For details on the format, see [the network inspect endpoint](#operation/NetworkInspect).
+        Returns a list of networks. For details on the format, see the
+        [network inspect endpoint](#operation/NetworkInspect).
 
-        Note that it uses a different, smaller representation of a network than inspecting a single network. For example,
-        the list of containers attached to the network is not propagated in API versions 1.28 and up.
+        Note that it uses a different, smaller representation of a network than
+        inspecting a single network. For example, the list of containers attached
+        to the network is not propagated in API versions 1.28 and up.
       operationId: "NetworkList"
       produces:
         - "application/json"
@@ -8290,7 +8825,10 @@ paths:
         - name: "filters"
           in: "query"
           description: |
-            JSON encoded value of the filters (a `map[string][]string`) to process on the networks list. Available filters:
+            JSON encoded value of the filters (a `map[string][]string`) to process
+            on the networks list.
+
+            Available filters:
 
             - `dangling=<boolean>` When set to `true` (or `1`), returns all
                networks that are not in use by a container. When set to `false`
@@ -8415,7 +8953,14 @@ paths:
                 description: "The network's name."
                 type: "string"
               CheckDuplicate:
-                description: "Check for networks with duplicate names. Since Network is primarily keyed based on a random ID and not on the name, and network name is strictly a user-friendly alias to the network which is uniquely identified using ID, there is no guaranteed way to check for duplicates. CheckDuplicate is there to provide a best effort checking of any networks which has the same name but it is not guaranteed to catch all name collisions."
+                description: |
+                  Check for networks with duplicate names. Since Network is
+                  primarily keyed based on a random ID and not on the name, and
+                  network name is strictly a user-friendly alias to the network
+                  which is uniquely identified using ID, there is no guaranteed
+                  way to check for duplicates. CheckDuplicate is there to provide
+                  a best effort checking of any networks which has the same name
+                  but it is not guaranteed to catch all name collisions.
                 type: "boolean"
               Driver:
                 description: "Name of the network driver plugin to use."
@@ -8425,10 +8970,14 @@ paths:
                 description: "Restrict external access to the network."
                 type: "boolean"
               Attachable:
-                description: "Globally scoped network is manually attachable by regular containers from workers in swarm mode."
+                description: |
+                  Globally scoped network is manually attachable by regular
+                  containers from workers in swarm mode.
                 type: "boolean"
               Ingress:
-                description: "Ingress network is the network which provides the routing-mesh in swarm mode."
+                description: |
+                  Ingress network is the network which provides the routing-mesh
+                  in swarm mode.
                 type: "boolean"
               IPAM:
                 description: "Optional custom IP scheme for the network."
@@ -8557,10 +9106,12 @@ paths:
             properties:
               Container:
                 type: "string"
-                description: "The ID or name of the container to disconnect from the network."
+                description: |
+                  The ID or name of the container to disconnect from the network.
               Force:
                 type: "boolean"
-                description: "Force the container to disconnect from the network."
+                description: |
+                  Force the container to disconnect from the network.
       tags: ["Network"]
   /networks/prune:
     post:
@@ -8617,7 +9168,10 @@ paths:
           in: "query"
           type: "string"
           description: |
-            A JSON encoded value of the filters (a `map[string][]string`) to process on the plugin list. Available filters:
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the plugin list.
+
+            Available filters:
 
             - `capability=<capability name>`
             - `enable=<true>|<false>`
@@ -8633,7 +9187,9 @@ paths:
           schema:
             type: "array"
             items:
-              description: "Describes a permission the user has to accept upon installing the plugin."
+              description: |
+                Describes a permission the user has to accept upon installing
+                the plugin.
               type: "object"
               title: "PluginPrivilegeItem"
               properties:
@@ -8665,7 +9221,9 @@ paths:
       parameters:
         - name: "remote"
           in: "query"
-          description: "The name of the plugin. The `:latest` tag is optional, and is the default if omitted."
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
           required: true
           type: "string"
       tags:
@@ -8676,7 +9234,8 @@ paths:
       summary: "Install a plugin"
       operationId: "PluginPull"
       description: |
-        Pulls and installs a plugin. After the plugin is installed, it can be enabled using the [`POST /plugins/{name}/enable` endpoint](#operation/PostPluginsEnable).
+        Pulls and installs a plugin. After the plugin is installed, it can be
+        enabled using the [`POST /plugins/{name}/enable` endpoint](#operation/PostPluginsEnable).
       produces:
         - "application/json"
       responses:
@@ -8705,14 +9264,21 @@ paths:
           type: "string"
         - name: "X-Registry-Auth"
           in: "header"
-          description: "A base64url-encoded auth configuration to use when pulling a plugin from a registry. [See the authentication section for details.](#section/Authentication)"
+          description: |
+            A base64url-encoded auth configuration to use when pulling a plugin
+            from a registry.
+
+            Refer to the [authentication section](#section/Authentication) for
+            details.
           type: "string"
         - name: "body"
           in: "body"
           schema:
             type: "array"
             items:
-              description: "Describes a permission accepted by the user upon installing the plugin."
+              description: |
+                Describes a permission accepted by the user upon installing the
+                plugin.
               type: "object"
               properties:
                 Name:
@@ -8757,7 +9323,9 @@ paths:
       parameters:
         - name: "name"
           in: "path"
-          description: "The name of the plugin. The `:latest` tag is optional, and is the default if omitted."
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
           required: true
           type: "string"
       tags: ["Plugin"]
@@ -8781,12 +9349,16 @@ paths:
       parameters:
         - name: "name"
           in: "path"
-          description: "The name of the plugin. The `:latest` tag is optional, and is the default if omitted."
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
           required: true
           type: "string"
         - name: "force"
           in: "query"
-          description: "Disable the plugin before removing. This may result in issues if the plugin is in use by a container."
+          description: |
+            Disable the plugin before removing. This may result in issues if the
+            plugin is in use by a container.
           type: "boolean"
           default: false
       tags: ["Plugin"]
@@ -8808,7 +9380,9 @@ paths:
       parameters:
         - name: "name"
           in: "path"
-          description: "The name of the plugin. The `:latest` tag is optional, and is the default if omitted."
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
           required: true
           type: "string"
         - name: "timeout"
@@ -8835,7 +9409,9 @@ paths:
       parameters:
         - name: "name"
           in: "path"
-          description: "The name of the plugin. The `:latest` tag is optional, and is the default if omitted."
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
           required: true
           type: "string"
       tags: ["Plugin"]
@@ -8857,7 +9433,9 @@ paths:
       parameters:
         - name: "name"
           in: "path"
-          description: "The name of the plugin. The `:latest` tag is optional, and is the default if omitted."
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
           required: true
           type: "string"
         - name: "remote"
@@ -8870,14 +9448,21 @@ paths:
           type: "string"
         - name: "X-Registry-Auth"
           in: "header"
-          description: "A base64url-encoded auth configuration to use when pulling a plugin from a registry. [See the authentication section for details.](#section/Authentication)"
+          description: |
+            A base64url-encoded auth configuration to use when pulling a plugin
+            from a registry.
+
+            Refer to the [authentication section](#section/Authentication) for
+            details.
           type: "string"
         - name: "body"
           in: "body"
           schema:
             type: "array"
             items:
-              description: "Describes a permission accepted by the user upon installing the plugin."
+              description: |
+                Describes a permission accepted by the user upon installing the
+                plugin.
               type: "object"
               properties:
                 Name:
@@ -8918,7 +9503,9 @@ paths:
       parameters:
         - name: "name"
           in: "query"
-          description: "The name of the plugin. The `:latest` tag is optional, and is the default if omitted."
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
           required: true
           type: "string"
         - name: "tarContext"
@@ -8937,7 +9524,9 @@ paths:
       parameters:
         - name: "name"
           in: "path"
-          description: "The name of the plugin. The `:latest` tag is optional, and is the default if omitted."
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
           required: true
           type: "string"
       responses:
@@ -8961,7 +9550,9 @@ paths:
       parameters:
         - name: "name"
           in: "path"
-          description: "The name of the plugin. The `:latest` tag is optional, and is the default if omitted."
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
           required: true
           type: "string"
         - name: "body"
@@ -9110,7 +9701,9 @@ paths:
             $ref: "#/definitions/NodeSpec"
         - name: "version"
           in: "query"
-          description: "The version number of the node object being updated. This is required to avoid conflicting writes."
+          description: |
+            The version number of the node object being updated. This is required
+            to avoid conflicting writes.
           type: "integer"
           format: "int64"
           required: true
@@ -9171,20 +9764,35 @@ paths:
             type: "object"
             properties:
               ListenAddr:
-                description: "Listen address used for inter-manager communication, as well as determining the networking interface used for the VXLAN Tunnel Endpoint (VTEP). This can either be an address/port combination in the form `192.168.1.1:4567`, or an interface followed by a port number, like `eth0:4567`. If the port number is omitted, the default swarm listening port is used."
+                description: |
+                  Listen address used for inter-manager communication, as well
+                  as determining the networking interface used for the VXLAN
+                  Tunnel Endpoint (VTEP). This can either be an address/port
+                  combination in the form `192.168.1.1:4567`, or an interface
+                  followed by a port number, like `eth0:4567`. If the port number
+                  is omitted, the default swarm listening port is used.
                 type: "string"
               AdvertiseAddr:
-                description: "Externally reachable address advertised to other nodes. This can either be an address/port combination in the form `192.168.1.1:4567`, or an interface followed by a port number, like `eth0:4567`. If the port number is omitted, the port number from the listen address is used. If `AdvertiseAddr` is not specified, it will be automatically detected when possible."
+                description: |
+                  Externally reachable address advertised to other nodes. This
+                  can either be an address/port combination in the form
+                  `192.168.1.1:4567`, or an interface followed by a port number,
+                  like `eth0:4567`. If the port number is omitted, the port
+                  number from the listen address is used. If `AdvertiseAddr` is
+                  not specified, it will be automatically detected when possible.
                 type: "string"
               DataPathAddr:
                 description: |
-                  Address or interface to use for data path traffic (format: `<ip|interface>`), for example,  `192.168.1.1`,
-                  or an interface, like `eth0`. If `DataPathAddr` is unspecified, the same address as `AdvertiseAddr`
-                  is used.
+                  Address or interface to use for data path traffic (format:
+                  `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
+                  like `eth0`. If `DataPathAddr` is unspecified, the same address
+                  as `AdvertiseAddr` is used.
 
-                  The `DataPathAddr` specifies the address that global scope network drivers will publish towards other
-                  nodes in order to reach the containers running on this node. Using this parameter it is possible to
-                  separate the container data traffic from the management traffic of the cluster.
+                  The `DataPathAddr` specifies the address that global scope
+                  network drivers will publish towards other  nodes in order to
+                  reach the containers running on this node. Using this parameter
+                  it is possible to separate the container data traffic from the
+                  management traffic of the cluster.
                 type: "string"
               DataPathPort:
                 description: |
@@ -9195,7 +9803,8 @@ paths:
                 format: "uint32"
               DefaultAddrPool:
                 description: |
-                  Default Address Pool specifies default subnet pools for global scope networks.
+                  Default Address Pool specifies default subnet pools for global
+                  scope networks.
                 type: "array"
                 items:
                   type: "string"
@@ -9205,7 +9814,8 @@ paths:
                 type: "boolean"
               SubnetSize:
                 description: |
-                  SubnetSize specifies the subnet size of the networks created from the default subnet pool
+                  SubnetSize specifies the subnet size of the networks created
+                  from the default subnet pool.
                 type: "integer"
                 format: "uint32"
               Spec:
@@ -9252,24 +9862,37 @@ paths:
             type: "object"
             properties:
               ListenAddr:
-                description: "Listen address used for inter-manager communication if the node gets promoted to manager, as well as determining the networking interface used for the VXLAN Tunnel Endpoint (VTEP)."
+                description: |
+                  Listen address used for inter-manager communication if the node
+                  gets promoted to manager, as well as determining the networking
+                  interface used for the VXLAN Tunnel Endpoint (VTEP).
                 type: "string"
               AdvertiseAddr:
-                description: "Externally reachable address advertised to other nodes. This can either be an address/port combination in the form `192.168.1.1:4567`, or an interface followed by a port number, like `eth0:4567`. If the port number is omitted, the port number from the listen address is used. If `AdvertiseAddr` is not specified, it will be automatically detected when possible."
+                description: |
+                  Externally reachable address advertised to other nodes. This
+                  can either be an address/port combination in the form
+                  `192.168.1.1:4567`, or an interface followed by a port number,
+                  like `eth0:4567`. If the port number is omitted, the port
+                  number from the listen address is used. If `AdvertiseAddr` is
+                  not specified, it will be automatically detected when possible.
                 type: "string"
               DataPathAddr:
                 description: |
-                  Address or interface to use for data path traffic (format: `<ip|interface>`), for example,  `192.168.1.1`,
-                  or an interface, like `eth0`. If `DataPathAddr` is unspecified, the same address as `AdvertiseAddr`
-                  is used.
+                  Address or interface to use for data path traffic (format:
+                  `<ip|interface>`), for example,  `192.168.1.1`, or an interface,
+                  like `eth0`. If `DataPathAddr` is unspecified, the same addres
+                  as `AdvertiseAddr` is used.
 
-                  The `DataPathAddr` specifies the address that global scope network drivers will publish towards other
-                  nodes in order to reach the containers running on this node. Using this parameter it is possible to
-                  separate the container data traffic from the management traffic of the cluster.
+                  The `DataPathAddr` specifies the address that global scope
+                  network drivers will publish towards other nodes in order to
+                  reach the containers running on this node. Using this parameter
+                  it is possible to separate the container data traffic from the
+                  management traffic of the cluster.
 
                 type: "string"
               RemoteAddrs:
-                description: "Addresses of manager nodes already participating in the swarm."
+                description: |
+                  Addresses of manager nodes already participating in the swarm.
                 type: "array"
                 items:
                   type: "string"
@@ -9300,7 +9923,9 @@ paths:
             $ref: "#/definitions/ErrorResponse"
       parameters:
         - name: "force"
-          description: "Force leave swarm, even if this is the last manager or that it will break the cluster."
+          description: |
+            Force leave swarm, even if this is the last manager or that it will
+            break the cluster.
           in: "query"
           type: "boolean"
           default: false
@@ -9332,7 +9957,9 @@ paths:
             $ref: "#/definitions/SwarmSpec"
         - name: "version"
           in: "query"
-          description: "The version number of the swarm object being updated. This is required to avoid conflicting writes."
+          description: |
+            The version number of the swarm object being updated. This is
+            required to avoid conflicting writes.
           type: "integer"
           format: "int64"
           required: true
@@ -9435,7 +10062,10 @@ paths:
           in: "query"
           type: "string"
           description: |
-            A JSON encoded value of the filters (a `map[string][]string`) to process on the services list. Available filters:
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the services list.
+
+            Available filters:
 
             - `id=<service id>`
             - `label=<service label>`
@@ -9563,7 +10193,12 @@ paths:
                     foo: "bar"
         - name: "X-Registry-Auth"
           in: "header"
-          description: "A base64url-encoded auth configuration for pulling from private registries. [See the authentication section for details.](#section/Authentication)"
+          description: |
+            A base64url-encoded auth configuration for pulling from private
+            registries.
+
+            Refer to the [authentication section](#section/Authentication) for
+            details.
           type: "string"
       tags: ["Service"]
   /services/{id}:
@@ -9699,10 +10334,12 @@ paths:
 
         - name: "version"
           in: "query"
-          description: "The version number of the service object being updated.
-          This is required to avoid conflicting writes.
-          This version number should be the value as currently set on the service *before* the update.
-          You can find the current version by calling `GET /services/{id}`"
+          description: |
+            The version number of the service object being updated. This is
+            required to avoid conflicting writes.
+            This version number should be the value as currently set on the
+            service *before* the update. You can find the current version by
+            calling `GET /services/{id}`
           required: true
           type: "integer"
         - name: "registryAuthFrom"
@@ -9722,7 +10359,12 @@ paths:
           type: "string"
         - name: "X-Registry-Auth"
           in: "header"
-          description: "A base64url-encoded auth configuration for pulling from private registries. [See the authentication section for details.](#section/Authentication)"
+          description: |
+            A base64url-encoded auth configuration for pulling from private
+            registries.
+
+            Refer to the [authentication section](#section/Authentication) for
+            details.
           type: "string"
 
       tags: ["Service"]
@@ -9730,9 +10372,11 @@ paths:
     get:
       summary: "Get service logs"
       description: |
-        Get `stdout` and `stderr` logs from a service. See also [`/containers/{id}/logs`](#operation/ContainerLogs).
+        Get `stdout` and `stderr` logs from a service. See also
+        [`/containers/{id}/logs`](#operation/ContainerLogs).
 
-        **Note**: This endpoint works only for services with the `local`, `json-file` or `journald` logging drivers.
+        **Note**: This endpoint works only for services with the `local`,
+        `json-file` or `journald` logging drivers.
       operationId: "ServiceLogs"
       responses:
         200:
@@ -9793,7 +10437,9 @@ paths:
           default: false
         - name: "tail"
           in: "query"
-          description: "Only return this number of log lines from the end of the logs. Specify as an integer or `all` to output all log lines."
+          description: |
+            Only return this number of log lines from the end of the logs.
+            Specify as an integer or `all` to output all log lines.
           type: "string"
           default: "all"
       tags: ["Service"]
@@ -9934,7 +10580,10 @@ paths:
           in: "query"
           type: "string"
           description: |
-            A JSON encoded value of the filters (a `map[string][]string`) to process on the tasks list. Available filters:
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the tasks list.
+
+            Available filters:
 
             - `desired-state=(running | shutdown | accepted)`
             - `id=<task id>`
@@ -9977,9 +10626,11 @@ paths:
     get:
       summary: "Get task logs"
       description: |
-        Get `stdout` and `stderr` logs from a task. See also [`/containers/{id}/logs`](#operation/ContainerLogs).
+        Get `stdout` and `stderr` logs from a task.
+        See also [`/containers/{id}/logs`](#operation/ContainerLogs).
 
-        **Note**: This endpoint works only for services with the `local`, `json-file` or `journald` logging drivers.
+        **Note**: This endpoint works only for services with the `local`,
+        `json-file` or `journald` logging drivers.
       operationId: "TaskLogs"
       responses:
         200:
@@ -10040,7 +10691,9 @@ paths:
           default: false
         - name: "tail"
           in: "query"
-          description: "Only return this number of log lines from the end of the logs. Specify as an integer or `all` to output all log lines."
+          description: |
+            Only return this number of log lines from the end of the logs.
+            Specify as an integer or `all` to output all log lines.
           type: "string"
           default: "all"
       tags: ["Task"]
@@ -10094,7 +10747,10 @@ paths:
           in: "query"
           type: "string"
           description: |
-            A JSON encoded value of the filters (a `map[string][]string`) to process on the secrets list. Available filters:
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the secrets list.
+
+            Available filters:
 
             - `id=<secret id>`
             - `label=<key> or label=<key>=value`
@@ -10251,10 +10907,15 @@ paths:
           in: "body"
           schema:
             $ref: "#/definitions/SecretSpec"
-          description: "The spec of the secret to update. Currently, only the Labels field can be updated. All other fields must remain unchanged from the [SecretInspect endpoint](#operation/SecretInspect) response values."
+          description: |
+            The spec of the secret to update. Currently, only the Labels field
+            can be updated. All other fields must remain unchanged from the
+            [SecretInspect endpoint](#operation/SecretInspect) response values.
         - name: "version"
           in: "query"
-          description: "The version number of the secret object being updated. This is required to avoid conflicting writes."
+          description: |
+            The version number of the secret object being updated. This is
+            required to avoid conflicting writes.
           type: "integer"
           format: "int64"
           required: true
@@ -10293,7 +10954,10 @@ paths:
           in: "query"
           type: "string"
           description: |
-            A JSON encoded value of the filters (a `map[string][]string`) to process on the configs list. Available filters:
+            A JSON encoded value of the filters (a `map[string][]string`) to
+            process on the configs list.
+
+            Available filters:
 
             - `id=<config id>`
             - `label=<key> or label=<key>=value`
@@ -10437,10 +11101,15 @@ paths:
           in: "body"
           schema:
             $ref: "#/definitions/ConfigSpec"
-          description: "The spec of the config to update. Currently, only the Labels field can be updated. All other fields must remain unchanged from the [ConfigInspect endpoint](#operation/ConfigInspect) response values."
+          description: |
+            The spec of the config to update. Currently, only the Labels field
+            can be updated. All other fields must remain unchanged from the
+            [ConfigInspect endpoint](#operation/ConfigInspect) response values.
         - name: "version"
           in: "query"
-          description: "The version number of the config object being updated. This is required to avoid conflicting writes."
+          description: |
+            The version number of the config object being updated. This is
+            required to avoid conflicting writes.
           type: "integer"
           format: "int64"
           required: true
@@ -10448,7 +11117,8 @@ paths:
   /distribution/{name}/json:
     get:
       summary: "Get image information from the registry"
-      description: "Return image digest and platform information by contacting the registry."
+      description: |
+        Return image digest and platform information by contacting the registry.
       operationId: "DistributionInspect"
       produces:
         - "application/json"
@@ -10463,7 +11133,8 @@ paths:
             properties:
               Descriptor:
                 type: "object"
-                description: "A descriptor struct containing digest, media type, and size"
+                description: |
+                  A descriptor struct containing digest, media type, and size.
                 properties:
                   MediaType:
                     type: "string"
@@ -10478,7 +11149,8 @@ paths:
                       type: "string"
               Platforms:
                 type: "array"
-                description: "An array containing all platforms supported by the image"
+                description: |
+                  An array containing all platforms supported by the image.
                 items:
                   type: "object"
                   properties:
@@ -10537,11 +11209,13 @@ paths:
     post:
       summary: "Initialize interactive session"
       description: |
-        Start a new interactive session with a server. Session allows server to call back to the client for advanced capabilities.
+        Start a new interactive session with a server. Session allows server to
+        call back to the client for advanced capabilities.
 
         ### Hijacking
 
-        This endpoint hijacks the HTTP connection to HTTP2 transport that allows the client to expose gPRC services on that connection.
+        This endpoint hijacks the HTTP connection to HTTP2 transport that allows
+        the client to expose gPRC services on that connection.
 
         For example, the client sends this request to upgrade the connection:
 
@@ -10551,7 +11225,8 @@ paths:
         Connection: Upgrade
         ```
 
-        The Docker daemon will respond with a `101 UPGRADED` response follow with the raw stream:
+        The Docker daemon responds with a `101 UPGRADED` response follow with
+        the raw stream:
 
         ```
         HTTP/1.1 101 UPGRADED

--- a/clients/go/vendor/github.com/docker/docker/api/types/container/container_top.go
+++ b/clients/go/vendor/github.com/docker/docker/api/types/container/container_top.go
@@ -11,7 +11,9 @@ package container // import "github.com/docker/docker/api/types/container"
 // swagger:model ContainerTopOKBody
 type ContainerTopOKBody struct {
 
-	// Each process running in the container, where each is process is an array of values corresponding to the titles
+	// Each process running in the container, where each is process
+	// is an array of values corresponding to the titles.
+	//
 	// Required: true
 	Processes [][]string `json:"Processes"`
 

--- a/clients/go/vendor/github.com/docker/docker/api/types/volume.go
+++ b/clients/go/vendor/github.com/docker/docker/api/types/volume.go
@@ -27,10 +27,13 @@ type Volume struct {
 	Name string `json:"Name"`
 
 	// The driver specific options used when creating the volume.
+	//
 	// Required: true
 	Options map[string]string `json:"Options"`
 
-	// The level at which the volume exists. Either `global` for cluster-wide, or `local` for machine level.
+	// The level at which the volume exists. Either `global` for cluster-wide,
+	// or `local` for machine level.
+	//
 	// Required: true
 	Scope string `json:"Scope"`
 

--- a/clients/go/vendor/github.com/docker/docker/api/types/volume/volume_create.go
+++ b/clients/go/vendor/github.com/docker/docker/api/types/volume/volume_create.go
@@ -15,7 +15,9 @@ type VolumeCreateBody struct {
 	// Required: true
 	Driver string `json:"Driver"`
 
-	// A mapping of driver options and values. These options are passed directly to the driver and are driver specific.
+	// A mapping of driver options and values. These options are
+	// passed directly to the driver and are driver specific.
+	//
 	// Required: true
 	DriverOpts map[string]string `json:"DriverOpts"`
 
@@ -24,6 +26,7 @@ type VolumeCreateBody struct {
 	Labels map[string]string `json:"Labels"`
 
 	// The new volume's name. If not specified, Docker generates a name.
+	//
 	// Required: true
 	Name string `json:"Name"`
 }

--- a/clients/go/vendor/github.com/docker/docker/api/types/volume/volume_list.go
+++ b/clients/go/vendor/github.com/docker/docker/api/types/volume/volume_list.go
@@ -17,7 +17,8 @@ type VolumeListOKBody struct {
 	// Required: true
 	Volumes []*types.Volume `json:"Volumes"`
 
-	// Warnings that occurred when fetching the list of volumes
+	// Warnings that occurred when fetching the list of volumes.
+	//
 	// Required: true
 	Warnings []string `json:"Warnings"`
 }

--- a/clients/go/vendor/github.com/docker/docker/client/client_unix.go
+++ b/clients/go/vendor/github.com/docker/docker/client/client_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd openbsd darwin
+// +build linux freebsd openbsd netbsd darwin dragonfly
 
 package client // import "github.com/docker/docker/client"
 

--- a/clients/go/vendor/github.com/docker/docker/client/request.go
+++ b/clients/go/vendor/github.com/docker/docker/client/request.go
@@ -143,8 +143,7 @@ func (cli *Client) doRequest(ctx context.Context, req *http.Request) (serverResp
 
 		// Don't decorate context sentinel errors; users may be comparing to
 		// them directly.
-		switch err {
-		case context.Canceled, context.DeadlineExceeded:
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return serverResp, err
 		}
 

--- a/clients/go/vendor/github.com/docker/docker/pkg/archive/archive_linux.go
+++ b/clients/go/vendor/github.com/docker/docker/pkg/archive/archive_linux.go
@@ -151,7 +151,9 @@ func mknodChar0Overlay(cleansedOriginalPath string) error {
 	if err := ioutil.WriteFile(lowerDummy, []byte{}, 0600); err != nil {
 		return errors.Wrapf(err, "failed to create a dummy lower file %s", lowerDummy)
 	}
-	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)
+	// lowerdir needs ":" to be escaped: https://github.com/moby/moby/issues/40939#issuecomment-627098286
+	lowerEscaped := strings.ReplaceAll(lower, ":", "\\:")
+	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerEscaped, upper, work)
 	// docker/pkg/mount.Mount() requires procfs to be mounted. So we use syscall.Mount() directly instead.
 	if err := syscall.Mount("overlay", merged, "overlay", uintptr(0), mOpts); err != nil {
 		return errors.Wrapf(err, "failed to mount overlay (%s) on %s", mOpts, merged)
@@ -236,7 +238,9 @@ func createDirWithOverlayOpaque(tmp string) (string, error) {
 	if err := os.MkdirAll(lowerDummy, 0700); err != nil {
 		return "", errors.Wrapf(err, "failed to create a dummy lower directory %s", lowerDummy)
 	}
-	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)
+	// lowerdir needs ":" to be escaped: https://github.com/moby/moby/issues/40939#issuecomment-627098286
+	lowerEscaped := strings.ReplaceAll(lower, ":", "\\:")
+	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerEscaped, upper, work)
 	// docker/pkg/mount.Mount() requires procfs to be mounted. So we use syscall.Mount() directly instead.
 	if err := syscall.Mount("overlay", merged, "overlay", uintptr(0), mOpts); err != nil {
 		return "", errors.Wrapf(err, "failed to mount overlay (%s) on %s", mOpts, merged)

--- a/clients/go/vendor/modules.txt
+++ b/clients/go/vendor/modules.txt
@@ -23,7 +23,7 @@ github.com/davecgh/go-spew/spew
 github.com/docker/distribution/digestset
 github.com/docker/distribution/reference
 github.com/docker/distribution/registry/api/errcode
-# github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible => github.com/docker/engine v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible
+# github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
@@ -249,4 +249,3 @@ google.golang.org/protobuf/types/known/timestamppb
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 gopkg.in/yaml.v3
-# github.com/docker/docker => github.com/docker/engine v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible


### PR DESCRIPTION
## Description

Removes the `replace` directive and updates the docker dependency.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
