### PR TITLE
Make the StateWriter available to the command processors

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/WorkflowEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/WorkflowEventProcessors.java
@@ -16,7 +16,7 @@ import io.zeebe.engine.processing.message.OpenWorkflowInstanceSubscriptionProces
 import io.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
-import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.processing.timer.CancelTimerProcessor;
 import io.zeebe.engine.processing.timer.CreateTimerProcessor;
 import io.zeebe.engine.processing.timer.DueDateTimerChecker;
@@ -58,7 +58,7 @@ public final class WorkflowEventProcessors {
       final SubscriptionCommandSender subscriptionCommandSender,
       final CatchEventBehavior catchEventBehavior,
       final DueDateTimerChecker timerChecker,
-      final StateWriter stateWriter) {
+      final Writers writers) {
     final MutableWorkflowInstanceSubscriptionState subscriptionState =
         zeebeState.getWorkflowInstanceSubscriptionState();
 
@@ -76,7 +76,7 @@ public final class WorkflowEventProcessors {
     addTimerStreamProcessors(
         typedRecordProcessors, timerChecker, zeebeState, catchEventBehavior, expressionProcessor);
     addVariableDocumentStreamProcessors(typedRecordProcessors, zeebeState);
-    addWorkflowInstanceCreationStreamProcessors(typedRecordProcessors, zeebeState, stateWriter);
+    addWorkflowInstanceCreationStreamProcessors(typedRecordProcessors, zeebeState, writers);
 
     return bpmnStreamProcessor;
   }
@@ -161,7 +161,7 @@ public final class WorkflowEventProcessors {
   private static void addWorkflowInstanceCreationStreamProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final ZeebeState zeebeState,
-      final StateWriter stateWriter) {
+      final Writers writers) {
     final MutableElementInstanceState elementInstanceState = zeebeState.getElementInstanceState();
     final MutableVariableState variablesState = zeebeState.getVariableState();
     final KeyGenerator keyGenerator = zeebeState.getKeyGenerator();
@@ -172,7 +172,7 @@ public final class WorkflowEventProcessors {
             elementInstanceState,
             variablesState,
             keyGenerator,
-            stateWriter);
+            writers);
     typedRecordProcessors.onCommand(
         ValueType.WORKFLOW_INSTANCE_CREATION,
         WorkflowInstanceCreationIntent.CREATE,

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -232,7 +232,7 @@ public final class BpmnEventSubscriptionBehavior {
       final long elementInstanceKey,
       final WorkflowInstanceRecord eventRecord) {
 
-    streamWriter.appendNewEvent(
+    streamWriter.appendFollowUpEvent(
         elementInstanceKey, WorkflowInstanceIntent.ELEMENT_ACTIVATING, eventRecord);
 
     stateBehavior.createElementInstanceInFlowScope(context, elementInstanceKey, eventRecord);
@@ -373,7 +373,7 @@ public final class BpmnEventSubscriptionBehavior {
         deferredRecord -> {
           final var elementInstanceKey = deferredRecord.getKey();
 
-          streamWriter.appendNewEvent(
+          streamWriter.appendFollowUpEvent(
               elementInstanceKey,
               WorkflowInstanceIntent.ELEMENT_ACTIVATING,
               deferredRecord.getValue());
@@ -459,7 +459,7 @@ public final class BpmnEventSubscriptionBehavior {
                 final var elementInstanceKey = record.getKey();
                 final var interruptingRecord = record.getValue();
 
-                streamWriter.appendNewEvent(
+                streamWriter.appendFollowUpEvent(
                     elementInstanceKey,
                     WorkflowInstanceIntent.ELEMENT_ACTIVATING,
                     interruptingRecord);

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -128,7 +128,7 @@ public final class BpmnStateTransitionBehavior {
             .setElementId(sequenceFlow.getId())
             .setBpmnElementType(sequenceFlow.getElementType());
 
-    streamWriter.appendNewEvent(
+    streamWriter.appendFollowUpEvent(
         keyGenerator.nextKey(), WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN, record);
 
     stateBehavior.spawnToken(context);
@@ -146,7 +146,7 @@ public final class BpmnStateTransitionBehavior {
 
     final var childInstanceKey = keyGenerator.nextKey();
 
-    streamWriter.appendNewEvent(
+    streamWriter.appendFollowUpEvent(
         childInstanceKey, WorkflowInstanceIntent.ELEMENT_ACTIVATING, childInstanceRecord);
 
     stateBehavior.updateElementInstance(context, ElementInstance::spawnToken);
@@ -166,7 +166,7 @@ public final class BpmnStateTransitionBehavior {
 
     final var elementInstanceKey = keyGenerator.nextKey();
 
-    streamWriter.appendNewEvent(
+    streamWriter.appendFollowUpEvent(
         elementInstanceKey, WorkflowInstanceIntent.ELEMENT_ACTIVATING, elementInstanceRecord);
 
     stateBehavior.createElementInstanceInFlowScope(

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/TypedStreamWriterProxy.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/TypedStreamWriterProxy.java
@@ -46,11 +46,6 @@ public final class TypedStreamWriterProxy implements TypedStreamWriter {
   }
 
   @Override
-  public void appendNewEvent(final long key, final Intent intent, final RecordValue value) {
-    writer.appendNewEvent(key, intent, value);
-  }
-
-  @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     writer.appendFollowUpEvent(key, intent, value);
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/TransformingDeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/TransformingDeploymentCreateProcessor.java
@@ -20,6 +20,7 @@ import io.zeebe.engine.processing.deployment.transform.DeploymentTransformer;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
+import io.zeebe.engine.processing.streamprocessor.writers.EventApplyingStateWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
@@ -67,7 +68,7 @@ public final class TransformingDeploymentCreateProcessor
     timerInstanceState = zeebeState.getTimerState();
     keyGenerator = zeebeState.getKeyGenerator();
     typedStreamWriterProxy = new TypedStreamWriterProxy();
-    stateWriter = new StateWriter(typedStreamWriterProxy, eventAppliers);
+    stateWriter = new EventApplyingStateWriter(typedStreamWriterProxy, eventAppliers);
     deploymentTransformer = new DeploymentTransformer(stateWriter, zeebeState, expressionProcessor);
     this.catchEventBehavior = catchEventBehavior;
     this.expressionProcessor = expressionProcessor;

--- a/engine/src/main/java/io/zeebe/engine/processing/message/PublishMessageProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/PublishMessageProcessor.java
@@ -97,7 +97,7 @@ public final class PublishMessageProcessor implements TypedRecordProcessor<Messa
       final Consumer<SideEffectProducer> sideEffect) {
     messageKey = keyGenerator.nextKey();
 
-    streamWriter.appendNewEvent(messageKey, MessageIntent.PUBLISHED, command.getValue());
+    streamWriter.appendFollowUpEvent(messageKey, MessageIntent.PUBLISHED, command.getValue());
     responseWriter.writeEventOnCommand(
         messageKey, MessageIntent.PUBLISHED, command.getValue(), command);
 

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/CommandProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/CommandProcessor.java
@@ -7,7 +7,6 @@
  */
 package io.zeebe.engine.processing.streamprocessor;
 
-import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.Intent;
@@ -20,13 +19,6 @@ public interface CommandProcessor<T extends UnifiedRecordValue> {
 
   default boolean onCommand(final TypedRecord<T> command, final CommandControl<T> commandControl) {
     return true;
-  }
-
-  default boolean onCommand(
-      final TypedRecord<T> command,
-      final CommandControl<T> commandControl,
-      final TypedStreamWriter streamWriter) {
-    return onCommand(command, commandControl);
   }
 
   interface CommandControl<T> {

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
@@ -13,6 +13,7 @@ import io.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.KeyGenerator;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.RejectionType;
@@ -51,14 +52,12 @@ public final class CommandProcessorImpl<T extends UnifiedRecordValue>
   public CommandProcessorImpl(
       final CommandProcessor<T> commandProcessor,
       final KeyGenerator keyGenerator,
-      final StateWriter stateWriter,
-      final TypedCommandWriter commandWriter,
-      final TypedRejectionWriter rejectionWriter) {
+      final Writers writers) {
     wrappedProcessor = commandProcessor;
     this.keyGenerator = keyGenerator;
-    this.stateWriter = stateWriter;
-    this.commandWriter = commandWriter;
-    this.rejectionWriter = rejectionWriter;
+    stateWriter = writers.state();
+    commandWriter = writers.command();
+    rejectionWriter = writers.rejection();
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -9,7 +9,11 @@ package io.zeebe.engine.processing.streamprocessor;
 
 import io.zeebe.db.TransactionContext;
 import io.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.EventApplyingStateWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.NoopTypedStreamWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.state.EventApplier;
 import io.zeebe.engine.state.KeyGeneratorControls;
@@ -36,6 +40,7 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
   private ZeebeDbState zeebeState;
   private TransactionContext transactionContext;
   private EventApplier eventApplier;
+  private StateWriter stateWriter;
 
   private BooleanSupplier abortCondition;
   private Consumer<TypedRecord> onProcessedListener = record -> {};
@@ -109,12 +114,6 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return this;
   }
 
-  public ProcessingContext setDetectReprocessingInconsistency(
-      final boolean detectReprocessingInconsistency) {
-    this.detectReprocessingInconsistency = detectReprocessingInconsistency;
-    return this;
-  }
-
   public ProcessingContext eventApplier(final EventApplier eventApplier) {
     this.eventApplier = eventApplier;
     return this;
@@ -183,6 +182,30 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return abortCondition;
   }
 
+  @Override
+  public EventApplier getEventApplier() {
+    return eventApplier;
+  }
+
+  @Override
+  public StateWriter getStateWriter() {
+    if (stateWriter == null) {
+      // lazy init, because depends on both logstreamWriter and eventApplier
+      stateWriter = new EventApplyingStateWriter(logStreamWriter, eventApplier);
+    }
+    return stateWriter;
+  }
+
+  @Override
+  public TypedCommandWriter getCommandWriter() {
+    return logStreamWriter;
+  }
+
+  @Override
+  public TypedRejectionWriter getRejectionWriter() {
+    return logStreamWriter;
+  }
+
   public Consumer<TypedRecord> getOnProcessedListener() {
     return onProcessedListener;
   }
@@ -195,8 +218,9 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return detectReprocessingInconsistency;
   }
 
-  @Override
-  public EventApplier getEventApplier() {
-    return eventApplier;
+  public ProcessingContext setDetectReprocessingInconsistency(
+      final boolean detectReprocessingInconsistency) {
+    this.detectReprocessingInconsistency = detectReprocessingInconsistency;
+    return this;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -173,7 +173,7 @@ public final class ProcessingStateMachine {
 
     final int partitionId = logStream.getPartitionId();
     typedEvent = new TypedEventImpl(partitionId);
-    responseWriter = new TypedResponseWriterImpl(context.getCommandResponseWriter(), partitionId);
+    responseWriter = new TypedResponseWriterImpl(context.getWriters().response(), partitionId);
 
     metrics = new StreamProcessorMetrics(partitionId);
     onProcessedListener = context.getOnProcessedListener();

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReadonlyProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReadonlyProcessingContext.java
@@ -9,6 +9,9 @@ package io.zeebe.engine.processing.streamprocessor;
 
 import io.zeebe.db.TransactionContext;
 import io.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.state.EventApplier;
 import io.zeebe.engine.state.ZeebeState;
@@ -57,4 +60,13 @@ public interface ReadonlyProcessingContext {
 
   /** @return the consumer of events to apply their state changes */
   EventApplier getEventApplier();
+
+  /** @return the writer of events that also changes state for each event it writes */
+  StateWriter getStateWriter();
+
+  /** @return the writer, which is used by the processors to write (follow-up) commands */
+  TypedCommandWriter getCommandWriter();
+
+  /** @return the writer, which is used by the processors to write command rejections */
+  TypedRejectionWriter getRejectionWriter();
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReadonlyProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReadonlyProcessingContext.java
@@ -8,11 +8,8 @@
 package io.zeebe.engine.processing.streamprocessor;
 
 import io.zeebe.db.TransactionContext;
-import io.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
-import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
-import io.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.EventApplier;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.logstreams.log.LogStream;
@@ -37,8 +34,11 @@ public interface ReadonlyProcessingContext {
    */
   int getMaxFragmentSize();
 
-  /** @return the writer, which is used by the processor to write follow up events */
+  /** @return the actual log stream writer, used to write any record */
   TypedStreamWriter getLogStreamWriter();
+
+  /** @return the specific writers, like command, response, etc */
+  Writers getWriters();
 
   /** @return the pool, which contains the mapping from ValueType to UnpackedObject (record) */
   RecordValues getRecordValues();
@@ -52,21 +52,9 @@ public interface ReadonlyProcessingContext {
   /** @return the transaction context for the current actor */
   TransactionContext getTransactionContext();
 
-  /** @return the response writer, which is used during processing */
-  CommandResponseWriter getCommandResponseWriter();
-
   /** @return condition which indicates, whether the processing should stop or not */
   BooleanSupplier getAbortCondition();
 
   /** @return the consumer of events to apply their state changes */
   EventApplier getEventApplier();
-
-  /** @return the writer of events that also changes state for each event it writes */
-  StateWriter getStateWriter();
-
-  /** @return the writer, which is used by the processors to write (follow-up) commands */
-  TypedCommandWriter getCommandWriter();
-
-  /** @return the writer, which is used by the processors to write command rejections */
-  TypedRejectionWriter getRejectionWriter();
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorBuilder.java
@@ -121,7 +121,7 @@ public final class StreamProcessorBuilder {
     Objects.requireNonNull(actorScheduler, "No task scheduler provided.");
     Objects.requireNonNull(processingContext.getLogStream(), "No log stream provided.");
     Objects.requireNonNull(
-        processingContext.getCommandResponseWriter(), "No command response writer provided.");
+        processingContext.getWriters().response(), "No command response writer provided.");
     Objects.requireNonNull(zeebeDb, "No database provided.");
     Objects.requireNonNull(eventApplierFactory, "No factory for the event supplier provided.");
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/TypedRecordProcessor.java
@@ -13,6 +13,9 @@ import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import java.util.function.Consumer;
 
+// todo (#6202): remove TypedStreamWriter from this interface's method signatures
+// After the migration, none of these should be in use anymore and replaced by the CommandWriter and
+// StateWriter passed along to the constructors of the concrete processors.
 public interface TypedRecordProcessor<T extends UnifiedRecordValue>
     extends StreamProcessorLifecycleAware {
 

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/TypedRecordProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/TypedRecordProcessors.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.processing.streamprocessor;
 import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.KeyGenerator;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.RecordType;
@@ -27,23 +28,16 @@ public final class TypedRecordProcessors {
   private final TypedCommandWriter commandWriter;
   private final TypedRejectionWriter rejectionWriter;
 
-  private TypedRecordProcessors(
-      final KeyGenerator keyGenerator,
-      final StateWriter stateWriter,
-      final TypedCommandWriter commandWriter,
-      final TypedRejectionWriter rejectionWriter) {
+  private TypedRecordProcessors(final KeyGenerator keyGenerator, final Writers writers) {
     this.keyGenerator = keyGenerator;
-    this.stateWriter = stateWriter;
-    this.commandWriter = commandWriter;
-    this.rejectionWriter = rejectionWriter;
+    stateWriter = writers.state();
+    commandWriter = writers.command();
+    rejectionWriter = writers.rejection();
   }
 
   public static TypedRecordProcessors processors(
-      final KeyGenerator keyGenerator,
-      final StateWriter stateWriter,
-      final TypedCommandWriter commandWriter,
-      final TypedRejectionWriter rejectionWriter) {
-    return new TypedRecordProcessors(keyGenerator, stateWriter, commandWriter, rejectionWriter);
+      final KeyGenerator keyGenerator, final Writers writers) {
+    return new TypedRecordProcessors(keyGenerator, writers);
   }
 
   // TODO: could remove the ValueType argument as it follows from the intent

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/TypedRecordProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/TypedRecordProcessors.java
@@ -7,9 +7,6 @@
  */
 package io.zeebe.engine.processing.streamprocessor;
 
-import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
-import io.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.KeyGenerator;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -24,15 +21,11 @@ public final class TypedRecordProcessors {
   private final RecordProcessorMap recordProcessorMap = new RecordProcessorMap();
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
   private final KeyGenerator keyGenerator;
-  private final StateWriter stateWriter;
-  private final TypedCommandWriter commandWriter;
-  private final TypedRejectionWriter rejectionWriter;
+  private final Writers writers;
 
   private TypedRecordProcessors(final KeyGenerator keyGenerator, final Writers writers) {
     this.keyGenerator = keyGenerator;
-    stateWriter = writers.state();
-    commandWriter = writers.command();
-    rejectionWriter = writers.rejection();
+    this.writers = writers;
   }
 
   public static TypedRecordProcessors processors(
@@ -63,9 +56,7 @@ public final class TypedRecordProcessors {
 
   public <T extends UnifiedRecordValue> TypedRecordProcessors onCommand(
       final ValueType valueType, final Intent intent, final CommandProcessor<T> commandProcessor) {
-    final var processor =
-        new CommandProcessorImpl<>(
-            commandProcessor, keyGenerator, stateWriter, commandWriter, rejectionWriter);
+    final var processor = new CommandProcessorImpl<>(commandProcessor, keyGenerator, writers);
     return onCommand(valueType, intent, processor);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/EventApplyingStateWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/EventApplyingStateWriter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.streamprocessor.writers;
+
+import io.zeebe.engine.state.EventApplier;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.RecordValue;
+import io.zeebe.protocol.record.intent.Intent;
+import java.util.function.UnaryOperator;
+
+/**
+ * A state writer that uses the event applier, to alter the state for each written event.
+ *
+ * <p>Note that it does not write events to the stream itself, but it delegates this to the {@link
+ * TypedStreamWriter}.
+ *
+ * <p>Note that it does not change the state itself, but delegates this to the {@link EventApplier}.
+ */
+public final class EventApplyingStateWriter implements StateWriter {
+
+  private static final UnaryOperator<RecordMetadata> NO_MODIFIER = UnaryOperator.identity();
+
+  private final TypedStreamWriter streamWriter;
+  private final EventApplier eventApplier;
+
+  public EventApplyingStateWriter(
+      final TypedStreamWriter streamWriter, final EventApplier eventApplier) {
+    this.streamWriter = streamWriter;
+    this.eventApplier = eventApplier;
+  }
+
+  @Override
+  public void appendNewEvent(final long key, final Intent intent, final RecordValue value) {
+    appendFollowUpEvent(key, intent, value, NO_MODIFIER);
+  }
+
+  @Override
+  public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
+    appendFollowUpEvent(key, intent, value, NO_MODIFIER);
+  }
+
+  @Override
+  public void appendFollowUpEvent(
+      final long key,
+      final Intent intent,
+      final RecordValue value,
+      final UnaryOperator<RecordMetadata> modifier) {
+    streamWriter.appendFollowUpEvent(key, intent, value, modifier);
+    eventApplier.applyState(key, intent, value);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/EventApplyingStateWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/EventApplyingStateWriter.java
@@ -35,11 +35,6 @@ public final class EventApplyingStateWriter implements StateWriter {
   }
 
   @Override
-  public void appendNewEvent(final long key, final Intent intent, final RecordValue value) {
-    appendFollowUpEvent(key, intent, value, NO_MODIFIER);
-  }
-
-  @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     appendFollowUpEvent(key, intent, value, NO_MODIFIER);
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/NoopTypedStreamWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/NoopTypedStreamWriter.java
@@ -39,11 +39,6 @@ public final class NoopTypedStreamWriter implements TypedStreamWriter {
   }
 
   @Override
-  public void appendNewEvent(final long key, final Intent intent, final RecordValue value) {
-    // no op implementation
-  }
-
-  @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     // no op implementation
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/ReprocessingStreamWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/ReprocessingStreamWriter.java
@@ -60,13 +60,6 @@ public final class ReprocessingStreamWriter implements TypedStreamWriter {
   }
 
   @Override
-  public void appendNewEvent(final long key, final Intent intent, final RecordValue value) {
-
-    final var record = new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.EVENT);
-    records.add(record);
-  }
-
-  @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
 
     final var record = new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.EVENT);

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/StateWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/StateWriter.java
@@ -7,50 +7,5 @@
  */
 package io.zeebe.engine.processing.streamprocessor.writers;
 
-import io.zeebe.engine.state.appliers.EventAppliers;
-import io.zeebe.protocol.impl.record.RecordMetadata;
-import io.zeebe.protocol.record.RecordValue;
-import io.zeebe.protocol.record.intent.Intent;
-import java.util.function.UnaryOperator;
-
-/**
- * This event writer changes state for the events it writes to the stream.
- *
- * <p>Note that it does not write events to the stream itself, but it delegates this to the {@link
- * TypedStreamWriter}.
- *
- * <p>Note that it does not change the state itself, but delegates this to the {@link
- * EventAppliers}.
- */
-public final class StateWriter implements TypedEventWriter {
-
-  private static final UnaryOperator<RecordMetadata> NO_MODIFIER = UnaryOperator.identity();
-
-  private final TypedStreamWriter streamWriter;
-  private final EventAppliers eventAppliers;
-
-  public StateWriter(final TypedStreamWriter streamWriter, final EventAppliers eventAppliers) {
-    this.streamWriter = streamWriter;
-    this.eventAppliers = eventAppliers;
-  }
-
-  @Override
-  public void appendNewEvent(final long key, final Intent intent, final RecordValue value) {
-    appendFollowUpEvent(key, intent, value, NO_MODIFIER);
-  }
-
-  @Override
-  public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
-    appendFollowUpEvent(key, intent, value, NO_MODIFIER);
-  }
-
-  @Override
-  public void appendFollowUpEvent(
-      final long key,
-      final Intent intent,
-      final RecordValue value,
-      final UnaryOperator<RecordMetadata> modifier) {
-    streamWriter.appendFollowUpEvent(key, intent, value, modifier);
-    eventAppliers.applyState(key, intent, value);
-  }
-}
+/** An event writer that alters the state for each events it writes. */
+public interface StateWriter extends TypedEventWriter {}

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -14,8 +14,6 @@ import java.util.function.UnaryOperator;
 
 public interface TypedEventWriter {
 
-  void appendNewEvent(long key, Intent intent, RecordValue value);
-
   void appendFollowUpEvent(long key, Intent intent, RecordValue value);
 
   /** @deprecated The modifier parameter is not used at the time of writing */

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedRejectionWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedRejectionWriter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.streamprocessor.writers;
+
+import io.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.RecordValue;
+import io.zeebe.protocol.record.RejectionType;
+import java.util.function.UnaryOperator;
+
+public interface TypedRejectionWriter {
+
+  void appendRejection(
+      TypedRecord<? extends RecordValue> command, RejectionType type, String reason);
+
+  /** @deprecated The modifier parameter is not used at the time of writing */
+  @Deprecated
+  void appendRejection(
+      TypedRecord<? extends RecordValue> command,
+      RejectionType type,
+      String reason,
+      UnaryOperator<RecordMetadata> modifier);
+}

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriter.java
@@ -7,25 +7,9 @@
  */
 package io.zeebe.engine.processing.streamprocessor.writers;
 
-import io.zeebe.engine.processing.streamprocessor.TypedRecord;
-import io.zeebe.protocol.impl.record.RecordMetadata;
-import io.zeebe.protocol.record.RecordValue;
-import io.zeebe.protocol.record.RejectionType;
-import java.util.function.UnaryOperator;
-
 /** Things that only a stream processor should write to the log stream (+ commands) */
-public interface TypedStreamWriter extends TypedCommandWriter, TypedEventWriter {
-
-  void appendRejection(
-      TypedRecord<? extends RecordValue> command, RejectionType type, String reason);
-
-  /** @deprecated The modifier parameter is not used at the time of writing */
-  @Deprecated
-  void appendRejection(
-      TypedRecord<? extends RecordValue> command,
-      RejectionType type,
-      String reason,
-      UnaryOperator<RecordMetadata> modifier);
+public interface TypedStreamWriter
+    extends TypedCommandWriter, TypedEventWriter, TypedRejectionWriter {
 
   void configureSourceContext(long sourceRecordPosition);
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriterImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriterImpl.java
@@ -158,11 +158,6 @@ public class TypedStreamWriterImpl implements TypedStreamWriter {
   }
 
   @Override
-  public void appendNewEvent(final long key, final Intent intent, final RecordValue value) {
-    appendRecord(key, RecordType.EVENT, intent, value, NO_MODIFIER);
-  }
-
-  @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     appendRecord(key, RecordType.EVENT, intent, value, NO_MODIFIER);
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/Writers.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/Writers.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.streamprocessor.writers;
+
+/** Convenience class to aggregate all the writers */
+public final class Writers {
+
+  private final TypedStreamWriter stream;
+  private final StateWriter state;
+  private final CommandResponseWriter response;
+
+  public Writers(
+      final TypedStreamWriter stream,
+      final StateWriter state,
+      final CommandResponseWriter response) {
+    this.stream = stream;
+    this.state = state;
+    this.response = response;
+  }
+
+  /** @return the writer, which is used by the processors to write (follow-up) commands */
+  public TypedCommandWriter command() {
+    return stream;
+  }
+
+  /** @return the writer, which is used by the processors to write command rejections */
+  public TypedRejectionWriter rejection() {
+    return stream;
+  }
+
+  /** @return the writer of events that also changes state for each event it writes */
+  public StateWriter state() {
+    return state;
+  }
+
+  /** @return the response writer, which is used during processing */
+  public CommandResponseWriter response() {
+    return response;
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processing/workflowinstance/CreateWorkflowInstanceProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/workflowinstance/CreateWorkflowInstanceProcessor.java
@@ -13,6 +13,7 @@ import io.zeebe.engine.Loggers;
 import io.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.KeyGenerator;
 import io.zeebe.engine.state.deployment.DeployedWorkflow;
 import io.zeebe.engine.state.immutable.WorkflowState;
@@ -58,12 +59,12 @@ public final class CreateWorkflowInstanceProcessor
       final MutableElementInstanceState elementInstanceState,
       final MutableVariableState variablesState,
       final KeyGenerator keyGenerator,
-      final StateWriter stateWriter) {
+      final Writers writers) {
     this.workflowState = workflowState;
     this.elementInstanceState = elementInstanceState;
     this.variablesState = variablesState;
     this.keyGenerator = keyGenerator;
-    this.stateWriter = stateWriter;
+    stateWriter = writers.state();
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processing/workflowinstance/CreateWorkflowInstanceWithResultProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/workflowinstance/CreateWorkflowInstanceWithResultProcessor.java
@@ -9,7 +9,6 @@ package io.zeebe.engine.processing.workflowinstance;
 
 import io.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
-import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.state.instance.AwaitWorkflowInstanceResultMetadata;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.msgpack.property.ArrayProperty;
@@ -41,10 +40,9 @@ public final class CreateWorkflowInstanceWithResultProcessor
   @Override
   public boolean onCommand(
       final TypedRecord<WorkflowInstanceCreationRecord> command,
-      final CommandControl<WorkflowInstanceCreationRecord> controller,
-      final TypedStreamWriter streamWriter) {
+      final CommandControl<WorkflowInstanceCreationRecord> controller) {
     wrappedController.setCommand(command).setController(controller);
-    createProcessor.onCommand(command, wrappedController, streamWriter);
+    createProcessor.onCommand(command, wrappedController);
     return shouldRespond;
   }
 

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -35,6 +35,7 @@ public final class EventAppliers implements EventApplier {
           (key, value) ->
               LOG.debug("No state changed: tried to use unimplemented event applier {}", intent);
 
+  @SuppressWarnings("rawtypes")
   private final Map<Intent, TypedEventApplier> mapping = new HashMap<>();
 
   public EventAppliers(final ZeebeState state) {
@@ -50,6 +51,7 @@ public final class EventAppliers implements EventApplier {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public void applyState(final long key, final Intent intent, final RecordValue value) {
     final var eventApplier =
         mapping.getOrDefault(intent, UNIMPLEMENTED_EVENT_APPLIER.apply(intent));

--- a/engine/src/test/java/io/zeebe/engine/processing/CommandProcessorTestCase.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/CommandProcessorTestCase.java
@@ -17,7 +17,9 @@ import static org.mockito.Mockito.verify;
 
 import io.zeebe.engine.processing.streamprocessor.CommandProcessor.CommandControl;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.engine.util.MockTypedRecord;
 import io.zeebe.engine.util.ZeebeStateRule;
 import io.zeebe.protocol.impl.record.RecordMetadata;
@@ -27,6 +29,7 @@ import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceCreationIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import org.junit.ClassRule;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -46,6 +49,9 @@ public abstract class CommandProcessorTestCase<T extends UnifiedRecordValue> {
 
   @Mock(name = "TypedStreamWriter")
   protected TypedStreamWriter streamWriter;
+
+  @Mock(name = "StateWriter")
+  protected StateWriter stateWriter;
 
   @Captor protected ArgumentCaptor<T> acceptedRecordCaptor;
 
@@ -89,5 +95,14 @@ public abstract class CommandProcessorTestCase<T extends UnifiedRecordValue> {
     }
 
     return new MockTypedRecord<>(-1, metadata, value);
+  }
+
+  protected void verifyElementActivatingPublished(
+      final long instanceKey, final ElementInstance instance) {
+    verify(stateWriter)
+        .appendFollowUpEvent(
+            eq(instanceKey),
+            eq(WorkflowInstanceIntent.ELEMENT_ACTIVATING),
+            eq(instance.getValue()));
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/CommandProcessorTestCase.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/CommandProcessorTestCase.java
@@ -17,8 +17,10 @@ import static org.mockito.Mockito.verify;
 
 import io.zeebe.engine.processing.streamprocessor.CommandProcessor.CommandControl;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.engine.util.MockTypedRecord;
 import io.zeebe.engine.util.ZeebeStateRule;
@@ -30,6 +32,7 @@ import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceCreationIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -53,7 +56,17 @@ public abstract class CommandProcessorTestCase<T extends UnifiedRecordValue> {
   @Mock(name = "StateWriter")
   protected StateWriter stateWriter;
 
+  @Mock(name = "CommandResponseWriter")
+  protected CommandResponseWriter responseWriter;
+
   @Captor protected ArgumentCaptor<T> acceptedRecordCaptor;
+
+  protected Writers writers;
+
+  @Before
+  public void setup() {
+    writers = new Writers(streamWriter, stateWriter, responseWriter);
+  }
 
   protected T getAcceptedRecord(final Intent intent) {
     assertAccepted(intent);

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStreamProcessorRule.java
@@ -118,7 +118,8 @@ public final class WorkflowInstanceStreamProcessorRule extends ExternalResource
               mockSubscriptionCommandSender,
               new CatchEventBehavior(
                   zeebeState, expressionProcessor, mockSubscriptionCommandSender, 1),
-              new DueDateTimerChecker(zeebeState.getTimerState()));
+              new DueDateTimerChecker(zeebeState.getTimerState()),
+              processingContext.getStateWriter());
 
           JobEventProcessors.addJobProcessors(
               typedRecordProcessors, zeebeState, type -> {}, Integer.MAX_VALUE);

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStreamProcessorRule.java
@@ -119,7 +119,7 @@ public final class WorkflowInstanceStreamProcessorRule extends ExternalResource
               new CatchEventBehavior(
                   zeebeState, expressionProcessor, mockSubscriptionCommandSender, 1),
               new DueDateTimerChecker(zeebeState.getTimerState()),
-              processingContext.getStateWriter());
+              processingContext.getWriters());
 
           JobEventProcessors.addJobProcessors(
               typedRecordProcessors, zeebeState, type -> {}, Integer.MAX_VALUE);

--- a/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
@@ -92,7 +92,8 @@ public final class IncidentStreamProcessorRule extends ExternalResource {
                   mockSubscriptionCommandSender,
                   new CatchEventBehavior(
                       zeebeState, expressionProcessor, mockSubscriptionCommandSender, 1),
-                  mockTimerEventScheduler);
+                  mockTimerEventScheduler,
+                  processingContext.getStateWriter());
 
           final var jobErrorThrownProcessor =
               JobEventProcessors.addJobProcessors(

--- a/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
@@ -93,7 +93,7 @@ public final class IncidentStreamProcessorRule extends ExternalResource {
                   new CatchEventBehavior(
                       zeebeState, expressionProcessor, mockSubscriptionCommandSender, 1),
                   mockTimerEventScheduler,
-                  processingContext.getStateWriter());
+                  processingContext.getWriters());
 
           final var jobErrorThrownProcessor =
               JobEventProcessors.addJobProcessors(

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
@@ -103,7 +103,11 @@ public final class SkipFailingEventsTest {
         DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
-          return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
+          return TypedRecordProcessors.processors(
+                  zeebeState.getKeyGenerator(),
+                  processingContext.getStateWriter(),
+                  processingContext.getCommandWriter(),
+                  processingContext.getRejectionWriter())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE,
                   WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -142,7 +146,11 @@ public final class SkipFailingEventsTest {
         DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
-          return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
+          return TypedRecordProcessors.processors(
+                  zeebeState.getKeyGenerator(),
+                  processingContext.getStateWriter(),
+                  processingContext.getCommandWriter(),
+                  processingContext.getRejectionWriter())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE,
                   WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -190,7 +198,11 @@ public final class SkipFailingEventsTest {
         DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
-          return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
+          return TypedRecordProcessors.processors(
+                  zeebeState.getKeyGenerator(),
+                  processingContext.getStateWriter(),
+                  processingContext.getCommandWriter(),
+                  processingContext.getRejectionWriter())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_ACTIVATING, processor)
               .onEvent(
@@ -270,7 +282,11 @@ public final class SkipFailingEventsTest {
         DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
-          return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
+          return TypedRecordProcessors.processors(
+                  zeebeState.getKeyGenerator(),
+                  processingContext.getStateWriter(),
+                  processingContext.getCommandWriter(),
+                  processingContext.getRejectionWriter())
               .withListener(
                   new StreamProcessorLifecycleAware() {
                     @Override
@@ -328,7 +344,11 @@ public final class SkipFailingEventsTest {
         DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
-          return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
+          return TypedRecordProcessors.processors(
+                  zeebeState.getKeyGenerator(),
+                  processingContext.getStateWriter(),
+                  processingContext.getCommandWriter(),
+                  processingContext.getRejectionWriter())
               .onCommand(ValueType.JOB, JobIntent.COMPLETE, errorProneProcessor)
               .onEvent(ValueType.JOB, JobIntent.ACTIVATED, dumpProcessor);
         });
@@ -402,7 +422,11 @@ public final class SkipFailingEventsTest {
         DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
-          return TypedRecordProcessors.processors(zeebeState.getKeyGenerator())
+          return TypedRecordProcessors.processors(
+                  zeebeState.getKeyGenerator(),
+                  processingContext.getStateWriter(),
+                  processingContext.getCommandWriter(),
+                  processingContext.getRejectionWriter())
               .onCommand(ValueType.TIMER, TimerIntent.CREATE, errorProneProcessor);
         });
 

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
@@ -104,10 +104,7 @@ public final class SkipFailingEventsTest {
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
           return TypedRecordProcessors.processors(
-                  zeebeState.getKeyGenerator(),
-                  processingContext.getStateWriter(),
-                  processingContext.getCommandWriter(),
-                  processingContext.getRejectionWriter())
+                  zeebeState.getKeyGenerator(), processingContext.getWriters())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE,
                   WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -147,10 +144,7 @@ public final class SkipFailingEventsTest {
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
           return TypedRecordProcessors.processors(
-                  zeebeState.getKeyGenerator(),
-                  processingContext.getStateWriter(),
-                  processingContext.getCommandWriter(),
-                  processingContext.getRejectionWriter())
+                  zeebeState.getKeyGenerator(), processingContext.getWriters())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE,
                   WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -199,10 +193,7 @@ public final class SkipFailingEventsTest {
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
           return TypedRecordProcessors.processors(
-                  zeebeState.getKeyGenerator(),
-                  processingContext.getStateWriter(),
-                  processingContext.getCommandWriter(),
-                  processingContext.getRejectionWriter())
+                  zeebeState.getKeyGenerator(), processingContext.getWriters())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE, WorkflowInstanceIntent.ELEMENT_ACTIVATING, processor)
               .onEvent(
@@ -283,10 +274,7 @@ public final class SkipFailingEventsTest {
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
           return TypedRecordProcessors.processors(
-                  zeebeState.getKeyGenerator(),
-                  processingContext.getStateWriter(),
-                  processingContext.getCommandWriter(),
-                  processingContext.getRejectionWriter())
+                  zeebeState.getKeyGenerator(), processingContext.getWriters())
               .withListener(
                   new StreamProcessorLifecycleAware() {
                     @Override
@@ -345,10 +333,7 @@ public final class SkipFailingEventsTest {
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
           return TypedRecordProcessors.processors(
-                  zeebeState.getKeyGenerator(),
-                  processingContext.getStateWriter(),
-                  processingContext.getCommandWriter(),
-                  processingContext.getRejectionWriter())
+                  zeebeState.getKeyGenerator(), processingContext.getWriters())
               .onCommand(ValueType.JOB, JobIntent.COMPLETE, errorProneProcessor)
               .onEvent(ValueType.JOB, JobIntent.ACTIVATED, dumpProcessor);
         });
@@ -423,10 +408,7 @@ public final class SkipFailingEventsTest {
         (processingContext) -> {
           zeebeState = processingContext.getZeebeState();
           return TypedRecordProcessors.processors(
-                  zeebeState.getKeyGenerator(),
-                  processingContext.getStateWriter(),
-                  processingContext.getCommandWriter(),
-                  processingContext.getRejectionWriter())
+                  zeebeState.getKeyGenerator(), processingContext.getWriters())
               .onCommand(ValueType.TIMER, TimerIntent.CREATE, errorProneProcessor);
         });
 

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -187,7 +187,11 @@ public class StreamProcessorHealthTest {
               mockedLogStreamWriter =
                   new WrappedStreamWriter(processingContext.getLogStreamWriter());
               processingContext.logStreamWriter(mockedLogStreamWriter);
-              return processors(zeebeState.getKeyGenerator())
+              return processors(
+                      zeebeState.getKeyGenerator(),
+                      processingContext.getStateWriter(),
+                      processingContext.getCommandWriter(),
+                      processingContext.getRejectionWriter())
                   .onEvent(
                       ValueType.WORKFLOW_INSTANCE,
                       ELEMENT_ACTIVATING,

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -264,11 +264,6 @@ public class StreamProcessorHealthTest {
     }
 
     @Override
-    public void appendNewEvent(final long key, final Intent intent, final RecordValue value) {
-      wrappedWriter.appendNewEvent(key, intent, value);
-    }
-
-    @Override
     public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
       if (shouldFailErrorHandlingInTransaction.get()) {
         throw new RuntimeException("Expected failure on append followup event");

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -187,11 +187,7 @@ public class StreamProcessorHealthTest {
               mockedLogStreamWriter =
                   new WrappedStreamWriter(processingContext.getLogStreamWriter());
               processingContext.logStreamWriter(mockedLogStreamWriter);
-              return processors(
-                      zeebeState.getKeyGenerator(),
-                      processingContext.getStateWriter(),
-                      processingContext.getCommandWriter(),
-                      processingContext.getRejectionWriter())
+              return processors(zeebeState.getKeyGenerator(), processingContext.getWriters())
                   .onEvent(
                       ValueType.WORKFLOW_INSTANCE,
                       ELEMENT_ACTIVATING,

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
@@ -433,11 +433,7 @@ public final class StreamProcessorTest {
         processingContext -> {
           processingContextActor = processingContext.getActor();
           final ZeebeState state = processingContext.getZeebeState();
-          return processors(
-                  state.getKeyGenerator(),
-                  processingContext.getStateWriter(),
-                  processingContext.getCommandWriter(),
-                  processingContext.getRejectionWriter())
+          return processors(state.getKeyGenerator(), processingContext.getWriters())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE,
                   WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -496,11 +492,7 @@ public final class StreamProcessorTest {
         processingContext -> {
           processingContextActor = processingContext.getActor();
           final ZeebeState state = processingContext.getZeebeState();
-          return processors(
-                  state.getKeyGenerator(),
-                  processingContext.getStateWriter(),
-                  processingContext.getCommandWriter(),
-                  processingContext.getRejectionWriter())
+          return processors(state.getKeyGenerator(), processingContext.getWriters())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE,
                   WorkflowInstanceIntent.ELEMENT_ACTIVATING,

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
@@ -433,7 +433,11 @@ public final class StreamProcessorTest {
         processingContext -> {
           processingContextActor = processingContext.getActor();
           final ZeebeState state = processingContext.getZeebeState();
-          return processors(state.getKeyGenerator())
+          return processors(
+                  state.getKeyGenerator(),
+                  processingContext.getStateWriter(),
+                  processingContext.getCommandWriter(),
+                  processingContext.getRejectionWriter())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE,
                   WorkflowInstanceIntent.ELEMENT_ACTIVATING,
@@ -492,7 +496,11 @@ public final class StreamProcessorTest {
         processingContext -> {
           processingContextActor = processingContext.getActor();
           final ZeebeState state = processingContext.getZeebeState();
-          return processors(state.getKeyGenerator())
+          return processors(
+                  state.getKeyGenerator(),
+                  processingContext.getStateWriter(),
+                  processingContext.getCommandWriter(),
+                  processingContext.getRejectionWriter())
               .onEvent(
                   ValueType.WORKFLOW_INSTANCE,
                   WorkflowInstanceIntent.ELEMENT_ACTIVATING,

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
@@ -77,7 +77,11 @@ public final class TypedStreamProcessorTest {
         STREAM_NAME,
         DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) ->
-            TypedRecordProcessors.processors(keyGenerator)
+            TypedRecordProcessors.processors(
+                    keyGenerator,
+                    processingContext.getStateWriter(),
+                    processingContext.getCommandWriter(),
+                    processingContext.getRejectionWriter())
                 .onCommand(ValueType.DEPLOYMENT, DeploymentIntent.CREATE, new BatchProcessor()));
     final long firstEventPosition =
         streams
@@ -110,7 +114,11 @@ public final class TypedStreamProcessorTest {
         STREAM_NAME,
         DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) ->
-            TypedRecordProcessors.processors(keyGenerator)
+            TypedRecordProcessors.processors(
+                    keyGenerator,
+                    processingContext.getStateWriter(),
+                    processingContext.getCommandWriter(),
+                    processingContext.getRejectionWriter())
                 .onCommand(
                     ValueType.DEPLOYMENT, DeploymentIntent.CREATE, new ErrorProneProcessor()));
     final AtomicLong requestId = new AtomicLong(0);

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
@@ -77,11 +77,7 @@ public final class TypedStreamProcessorTest {
         STREAM_NAME,
         DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) ->
-            TypedRecordProcessors.processors(
-                    keyGenerator,
-                    processingContext.getStateWriter(),
-                    processingContext.getCommandWriter(),
-                    processingContext.getRejectionWriter())
+            TypedRecordProcessors.processors(keyGenerator, processingContext.getWriters())
                 .onCommand(ValueType.DEPLOYMENT, DeploymentIntent.CREATE, new BatchProcessor()));
     final long firstEventPosition =
         streams
@@ -114,11 +110,7 @@ public final class TypedStreamProcessorTest {
         STREAM_NAME,
         DefaultZeebeDbFactory.defaultFactory(),
         (processingContext) ->
-            TypedRecordProcessors.processors(
-                    keyGenerator,
-                    processingContext.getStateWriter(),
-                    processingContext.getCommandWriter(),
-                    processingContext.getRejectionWriter())
+            TypedRecordProcessors.processors(keyGenerator, processingContext.getWriters())
                 .onCommand(
                     ValueType.DEPLOYMENT, DeploymentIntent.CREATE, new ErrorProneProcessor()));
     final AtomicLong requestId = new AtomicLong(0);

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/TypedStreamProcessorTest.java
@@ -217,7 +217,7 @@ public final class TypedStreamProcessorTest {
         final TypedRecord<DeploymentRecord> record,
         final TypedResponseWriter responseWriter,
         final TypedStreamWriter streamWriter) {
-      streamWriter.appendNewEvent(
+      streamWriter.appendFollowUpEvent(
           keyGenerator.nextKey(), DeploymentIntent.CREATED, record.getValue());
       streamWriter.flush();
     }

--- a/engine/src/test/java/io/zeebe/engine/processing/variable/UpdateVariableDocumentProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/variable/UpdateVariableDocumentProcessorTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@RunWith(MockitoJUnitRunner.class)
 public final class UpdateVariableDocumentProcessorTest
     extends CommandProcessorTestCase<VariableDocumentRecord> {
 

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
@@ -59,8 +59,7 @@ public class StreamProcessingComposite {
           processingContext.onProcessedListener(onProcessedListener);
           return factory.build(
               TypedRecordProcessors.processors(
-                  zeebeState.getKeyGenerator(), processingContext.getStateWriter(),
-                  processingContext.getCommandWriter(), processingContext.getRejectionWriter()),
+                  zeebeState.getKeyGenerator(), processingContext.getWriters()),
               processingContext);
         });
   }

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessingComposite.java
@@ -58,7 +58,10 @@ public class StreamProcessingComposite {
           lastProcessedPositionState = processingContext.getLastProcessedPositionState();
           processingContext.onProcessedListener(onProcessedListener);
           return factory.build(
-              TypedRecordProcessors.processors(zeebeState.getKeyGenerator()), processingContext);
+              TypedRecordProcessors.processors(
+                  zeebeState.getKeyGenerator(), processingContext.getStateWriter(),
+                  processingContext.getCommandWriter(), processingContext.getRejectionWriter()),
+              processingContext);
         });
   }
 


### PR DESCRIPTION
## Description

Make the StateWriter available to the command processors.

This PR changes the following:
- extract `RejectionWriter` interface
- splits `EventApplyingStateWriter` implementation from `StateWriter` interface
- adds `StateWriter`, `CommandWriter` and `RejectionWriter` to `ProcessingContext`
- Passes `StateWriter` to constructors of processors in `EngineProcessors`
- removes `StreamWriter` from `CommandProcessor.onCommand` method signature

## Related issues

closes #6278 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
