### PR TITLE
Ensure safe concurrent access to snapshot store

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.esotericsoftware.kryo.serializers.FieldSerializer.Optional;
 import io.atomix.storage.StorageLevel;
 import io.atomix.utils.memory.MemorySize;
-import io.zeebe.snapshots.broker.impl.FileBasedSnapshotStoreFactory;
 import io.zeebe.snapshots.raft.ReceivableSnapshotStoreFactory;
 
 /** Raft storage configuration. */
@@ -33,8 +32,6 @@ public class RaftStorageConfig {
   private static final int DEFAULT_MAX_ENTRY_SIZE = 1024 * 1024;
   private static final boolean DEFAULT_FLUSH_EXPLICITLY = true;
   private static final long DEFAULT_FREE_DISK_SPACE = 1024L * 1024 * 1024 * 1; // 1GB
-  private static final ReceivableSnapshotStoreFactory DEFAULT_SNAPSHOT_STORE_FACTORY =
-      new FileBasedSnapshotStoreFactory();
 
   private String directory;
   private StorageLevel level = DEFAULT_STORAGE_LEVEL;
@@ -44,8 +41,7 @@ public class RaftStorageConfig {
   private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
 
   @Optional("SnapshotStoreFactory")
-  private ReceivableSnapshotStoreFactory persistedSnapshotStoreFactory =
-      DEFAULT_SNAPSHOT_STORE_FACTORY;
+  private ReceivableSnapshotStoreFactory persistedSnapshotStoreFactory;
 
   /**
    * Returns the partition data directory.

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractAppender.java
@@ -120,9 +120,8 @@ abstract class AbstractAppender implements AutoCloseable {
       prevIndex = prevEntry.index();
       prevTerm = prevEntry.entry().term();
     } else {
-      final var optCurrentSnapshot = raft.getPersistedSnapshotStore().getLatestSnapshot();
-      if (optCurrentSnapshot.isPresent()) {
-        final var currentSnapshot = optCurrentSnapshot.get();
+      final var currentSnapshot = raft.getCurrentSnapshot();
+      if (currentSnapshot != null) {
         prevIndex = currentSnapshot.getIndex();
         prevTerm = currentSnapshot.getTerm();
       }

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -343,16 +343,15 @@ final class LeaderAppender extends AbstractAppender {
   }
 
   private void tryToReplicateSnapshot(final RaftMemberContext member) {
-    final var optSnapshot = raft.getPersistedSnapshotStore().getLatestSnapshot();
+    final var persistedSnapshot = raft.getCurrentSnapshot();
 
-    if (optSnapshot.isPresent()
-        && member.getSnapshotIndex() < optSnapshot.get().getIndex()
-        && optSnapshot.get().getIndex() >= member.getLogReader().getCurrentIndex()) {
+    if (persistedSnapshot != null
+        && member.getSnapshotIndex() < persistedSnapshot.getIndex()
+        && persistedSnapshot.getIndex() >= member.getLogReader().getCurrentIndex()) {
       if (!member.canInstall()) {
         return;
       }
 
-      final var persistedSnapshot = optSnapshot.get();
       log.debug(
           "Replicating snapshot {} to {}",
           persistedSnapshot.getIndex(),

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -423,7 +423,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
                   .withTerm(raft.getTerm())
                   .withSucceeded(false)
                   .withLastLogIndex(raft.getLog().getLastIndex())
-                  .withLastSnapshotIndex(raft.getPersistedSnapshotStore().getCurrentSnapshotIndex())
+                  .withLastSnapshotIndex(raft.getCurrentSnapshotIndex())
                   .build()));
     } else {
       raft.setLeader(request.leader());

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -41,7 +41,7 @@ import io.atomix.utils.concurrent.ThreadContext;
 import io.zeebe.snapshots.raft.PersistedSnapshot;
 import io.zeebe.snapshots.raft.PersistedSnapshotListener;
 import io.zeebe.snapshots.raft.ReceivedSnapshot;
-import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
@@ -54,6 +54,7 @@ public class PassiveRole extends InactiveRole {
   private long pendingSnapshotStartTimestamp;
   private ReceivedSnapshot pendingSnapshot;
   private PersistedSnapshotListener snapshotListener;
+  private ByteBuffer nextPendingSnapshotChunkId;
 
   public PassiveRole(final RaftContext context) {
     super(context);
@@ -78,6 +79,15 @@ public class PassiveRole extends InactiveRole {
     if (snapshotListener != null) {
       raft.getPersistedSnapshotStore().removeSnapshotListener(snapshotListener);
     }
+
+    // as a safe guard, we clean up any orphaned pending snapshots
+    try {
+      raft.getPersistedSnapshotStore().purgePendingSnapshots().join();
+    } catch (final Exception e) {
+      log.warn(
+          "Failed to purge pending snapshots, which may result in unnecessary disk usage and should be monitored",
+          e);
+    }
     return super.stop();
   }
 
@@ -90,12 +100,9 @@ public class PassiveRole extends InactiveRole {
     // to fix the edge case where we might have been stopped
     // between persisting snapshot and truncating log we need to call on restart snapshot listener
     // again, such that we truncate the log when necessary
-    final var latestSnapshot = raft.getPersistedSnapshotStore().getLatestSnapshot();
-    if (latestSnapshot.isPresent()) {
-      final var persistedSnapshot = latestSnapshot.get();
-      if (snapshotListener != null) {
-        snapshotListener.onNewSnapshot(persistedSnapshot);
-      }
+    final var latestSnapshot = raft.getCurrentSnapshot();
+    if (latestSnapshot != null && snapshotListener != null) {
+      snapshotListener.onNewSnapshot(latestSnapshot);
     }
   }
 
@@ -161,13 +168,8 @@ public class PassiveRole extends InactiveRole {
     }
 
     // If the snapshot already exists locally, do not overwrite it with a replicated snapshot.
-    // Simply reply to the
-    // request successfully.
-    final var latestIndex =
-        raft.getPersistedSnapshotStore()
-            .getLatestSnapshot()
-            .map(PersistedSnapshot::getIndex)
-            .orElse(Long.MIN_VALUE);
+    // Simply reply to the request successfully.
+    final var latestIndex = raft.getCurrentSnapshotIndex();
     if (latestIndex >= request.index()) {
       abortPendingSnapshots();
 
@@ -217,14 +219,8 @@ public class PassiveRole extends InactiveRole {
       pendingSnapshotStartTimestamp = System.currentTimeMillis();
       snapshotReplicationMetrics.incrementCount();
     } else {
-      // skip if we already have this chunk
-      if (pendingSnapshot.containsChunk(request.chunkId())) {
-        return CompletableFuture.completedFuture(
-            logResponse(InstallResponse.builder().withStatus(RaftResponse.Status.OK).build()));
-      }
-
       // fail the request if this is not the expected next chunk
-      if (!pendingSnapshot.isExpectedChunk(request.chunkId())) {
+      if (!isExpectedChunk(request.chunkId())) {
         return CompletableFuture.completedFuture(
             logResponse(
                 InstallResponse.builder()
@@ -238,7 +234,7 @@ public class PassiveRole extends InactiveRole {
 
     boolean snapshotChunkConsumptionFailed;
     try {
-      snapshotChunkConsumptionFailed = !pendingSnapshot.apply(snapshotChunk);
+      snapshotChunkConsumptionFailed = !pendingSnapshot.apply(snapshotChunk).join();
     } catch (final Exception e) {
       log.error("Failed to write pending snapshot chunk {}, rolling back", pendingSnapshot, e);
       snapshotChunkConsumptionFailed = true;
@@ -261,8 +257,11 @@ public class PassiveRole extends InactiveRole {
       final long elapsed = System.currentTimeMillis() - pendingSnapshotStartTimestamp;
       log.debug("Committing snapshot {}", pendingSnapshot);
       try {
-        final var snapshot = pendingSnapshot.persist();
+        final var snapshot = pendingSnapshot.persist().join();
         log.info("Committed snapshot {}", snapshot);
+        // Must be executed immediately before any other operation on this threadcontext. Hence
+        // don't wait for the listener to be notified by the snapshot store.
+        snapshotListener.onNewSnapshot(snapshot);
       } catch (final Exception e) {
         log.error("Failed to commit pending snapshot {}, rolling back", pendingSnapshot, e);
         abortPendingSnapshots();
@@ -280,7 +279,7 @@ public class PassiveRole extends InactiveRole {
       snapshotReplicationMetrics.decrementCount();
       snapshotReplicationMetrics.observeDuration(elapsed);
     } else {
-      pendingSnapshot.setNextExpected(request.nextChunkId());
+      setNextExpected(request.nextChunkId());
     }
 
     return CompletableFuture.completedFuture(
@@ -347,7 +346,16 @@ public class PassiveRole extends InactiveRole {
                 .build()));
   }
 
+  private void setNextExpected(final ByteBuffer nextChunkId) {
+    nextPendingSnapshotChunkId = nextChunkId;
+  }
+
+  private boolean isExpectedChunk(final ByteBuffer chunkId) {
+    return nextPendingSnapshotChunkId == null || nextPendingSnapshotChunkId.equals(chunkId);
+  }
+
   private void abortPendingSnapshots() {
+    setNextExpected(null);
     if (pendingSnapshot != null) {
       log.info("Rolling back snapshot {}", pendingSnapshot);
       try {
@@ -359,15 +367,6 @@ public class PassiveRole extends InactiveRole {
       pendingSnapshotStartTimestamp = 0L;
 
       snapshotReplicationMetrics.decrementCount();
-    }
-
-    // as a safe guard, we clean up any orphaned pending snapshots
-    try {
-      raft.getPersistedSnapshotStore().purgePendingSnapshots();
-    } catch (final IOException e) {
-      log.error(
-          "Failed to purge pending snapshots, which may result in unnecessary disk usage and should be monitored",
-          e);
     }
   }
 
@@ -436,10 +435,9 @@ public class PassiveRole extends InactiveRole {
       if (lastEntry != null) {
         return checkPreviousEntry(request, lastEntry.index(), lastEntry.entry().term(), future);
       } else {
-        final var optCurrentSnapshot = raft.getPersistedSnapshotStore().getLatestSnapshot();
+        final var currentSnapshot = raft.getCurrentSnapshot();
 
-        if (optCurrentSnapshot.isPresent()) {
-          final var currentSnapshot = optCurrentSnapshot.get();
+        if (currentSnapshot != null) {
           return checkPreviousEntry(
               request, currentSnapshot.getIndex(), currentSnapshot.getTerm(), future);
         } else {
@@ -739,11 +737,7 @@ public class PassiveRole extends InactiveRole {
                 .withTerm(raft.getTerm())
                 .withSucceeded(succeeded)
                 .withLastLogIndex(lastLogIndex)
-                .withLastSnapshotIndex(
-                    raft.getPersistedSnapshotStore()
-                        .getLatestSnapshot()
-                        .map(PersistedSnapshot::getIndex)
-                        .orElse(0L))
+                .withLastSnapshotIndex(raft.getCurrentSnapshotIndex())
                 .build()));
     return succeeded;
   }

--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -16,12 +16,15 @@
 package io.atomix.raft.snapshot;
 
 import io.atomix.utils.time.WallClockTimestamp;
+import io.zeebe.snapshots.broker.SnapshotId;
 import io.zeebe.snapshots.raft.PersistedSnapshot;
 import io.zeebe.snapshots.raft.ReceivedSnapshot;
 import io.zeebe.snapshots.raft.SnapshotChunk;
 import io.zeebe.snapshots.raft.SnapshotChunkReader;
 import io.zeebe.util.StringUtil;
 import io.zeebe.util.buffer.BufferUtil;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
@@ -38,7 +41,6 @@ public class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapshot {
   private final WallClockTimestamp timestamp;
   private final String id;
   private final NavigableMap<String, String> chunks = new TreeMap<>();
-  private ByteBuffer nextExpected;
 
   InMemorySnapshot(final TestSnapshotStore testSnapshotStore, final String snapshotId) {
     this.testSnapshotStore = testSnapshotStore;
@@ -58,7 +60,7 @@ public class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapshot {
     this.index = index;
     this.term = term;
     this.timestamp = timestamp;
-    this.id = String.format("%d-%d-%d", index, term, timestamp.unixTimestamp());
+    id = String.format("%d-%d-%d", index, term, timestamp.unixTimestamp());
   }
 
   public static InMemorySnapshot newPersistedSnapshot(
@@ -161,33 +163,55 @@ public class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapshot {
   }
 
   @Override
-  public boolean containsChunk(final ByteBuffer chunkId) {
-    return chunks.containsKey(BufferUtil.bufferAsString(new UnsafeBuffer(chunkId)));
-  }
-
-  @Override
-  public boolean isExpectedChunk(final ByteBuffer chunkId) {
-    return chunkId.equals(nextExpected);
-  }
-
-  @Override
-  public void setNextExpected(final ByteBuffer nextChunkId) {
-    nextExpected = nextChunkId;
-  }
-
-  @Override
-  public boolean apply(final SnapshotChunk chunk) throws IOException {
+  public ActorFuture<Boolean> apply(final SnapshotChunk chunk) throws IOException {
     chunks.put(chunk.getChunkName(), StringUtil.fromBytes(chunk.getContent()));
-    return true;
+    return CompletableActorFuture.completed(true);
   }
 
   @Override
-  public void abort() {}
+  public ActorFuture<Void> abort() {
+    return CompletableActorFuture.completed(null);
+  }
 
   @Override
-  public PersistedSnapshot persist() {
+  public ActorFuture<PersistedSnapshot> persist() {
     testSnapshotStore.newSnapshot(this);
-    return this;
+    return CompletableActorFuture.completed(this);
+  }
+
+  @Override
+  public SnapshotId snapshotId() {
+    return new SnapshotId() {
+      @Override
+      public long getIndex() {
+        return index;
+      }
+
+      @Override
+      public long getTerm() {
+        return term;
+      }
+
+      @Override
+      public long getProcessedPosition() {
+        return 0;
+      }
+
+      @Override
+      public long getExportedPosition() {
+        return 0;
+      }
+
+      @Override
+      public WallClockTimestamp getTimestamp() {
+        return timestamp;
+      }
+
+      @Override
+      public String getSnapshotIdAsString() {
+        return id;
+      }
+    };
   }
 
   @Override

--- a/atomix/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/atomix/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -57,7 +57,9 @@ public class AtomixTest {
                               new RaftStorageConfig()
                                   .setDirectory(
                                       new File(atomixRule.getDataDir(), "start-stop-consensus")
-                                          .getPath()));
+                                          .getPath())
+                                  .setPersistedSnapshotStoreFactory(
+                                      new NoopSnapshotStoreFactory()));
 
                   final var raftPartitionGroup = new RaftPartitionGroup(groupConfig);
                   return builder.withPartitionGroups(raftPartitionGroup).build();

--- a/atomix/core/src/test/java/io/atomix/core/NoopSnapshotStore.java
+++ b/atomix/core/src/test/java/io/atomix/core/NoopSnapshotStore.java
@@ -1,11 +1,12 @@
 /*
+ * Copyright 2018-present Open Networking Foundation
  * Copyright © 2020 camunda services GmbH (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,85 +14,57 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.raft.snapshot;
+package io.atomix.core;
 
 import io.zeebe.snapshots.raft.PersistedSnapshot;
 import io.zeebe.snapshots.raft.PersistedSnapshotListener;
 import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
 import io.zeebe.snapshots.raft.ReceivedSnapshot;
 import io.zeebe.util.sched.future.ActorFuture;
-import io.zeebe.util.sched.future.CompletableActorFuture;
-import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicReference;
 
-public class TestSnapshotStore implements ReceivableSnapshotStore {
-
-  final AtomicReference<InMemorySnapshot> currentPersistedSnapshot;
-  final List<InMemorySnapshot> receivedSnapshots = new CopyOnWriteArrayList<>();
-  final List<PersistedSnapshotListener> listeners = new CopyOnWriteArrayList<>();
-
-  public TestSnapshotStore(final AtomicReference<InMemorySnapshot> persistedSnapshotRef) {
-    currentPersistedSnapshot = persistedSnapshotRef;
-  }
+class NoopSnapshotStore implements ReceivableSnapshotStore {
 
   @Override
   public boolean hasSnapshotId(final String id) {
-    return currentPersistedSnapshot.get() != null
-        && currentPersistedSnapshot.get().getId().equals(id);
+    return false;
   }
 
   @Override
   public Optional<PersistedSnapshot> getLatestSnapshot() {
-    return Optional.ofNullable(currentPersistedSnapshot.get());
+    return Optional.empty();
   }
 
   @Override
   public ActorFuture<Void> purgePendingSnapshots() {
-    receivedSnapshots.clear();
-    return CompletableActorFuture.completed(null);
+    return null;
   }
 
   @Override
   public ActorFuture<Boolean> addSnapshotListener(final PersistedSnapshotListener listener) {
-    listeners.add(listener);
     return null;
   }
 
   @Override
   public ActorFuture<Boolean> removeSnapshotListener(final PersistedSnapshotListener listener) {
-    listeners.remove(listener);
     return null;
   }
 
   @Override
   public long getCurrentSnapshotIndex() {
-    if (currentPersistedSnapshot.get() == null) {
-      return 0;
-    }
-    return currentPersistedSnapshot.get().getIndex();
+    return 0;
   }
 
   @Override
   public ActorFuture<Void> delete() {
-    currentPersistedSnapshot.set(null);
-    receivedSnapshots.clear();
     return null;
   }
 
   @Override
   public ReceivedSnapshot newReceivedSnapshot(final String snapshotId) {
-    final var newSnapshot = new InMemorySnapshot(this, snapshotId);
-    receivedSnapshots.add(newSnapshot);
-    return newSnapshot;
+    return null;
   }
 
   @Override
   public void close() {}
-
-  public void newSnapshot(final InMemorySnapshot persistedSnapshot) {
-    currentPersistedSnapshot.set(persistedSnapshot);
-    listeners.forEach(l -> l.onNewSnapshot(persistedSnapshot));
-  }
 }

--- a/atomix/core/src/test/java/io/atomix/core/NoopSnapshotStoreFactory.java
+++ b/atomix/core/src/test/java/io/atomix/core/NoopSnapshotStoreFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core;
+
+import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
+import io.zeebe.snapshots.raft.ReceivableSnapshotStoreFactory;
+import java.nio.file.Path;
+
+class NoopSnapshotStoreFactory implements ReceivableSnapshotStoreFactory {
+
+  public NoopSnapshotStoreFactory() {}
+
+  @Override
+  public ReceivableSnapshotStore createReceivableSnapshotStore(
+      final Path directory, final String partitionName) {
+    return new NoopSnapshotStore();
+  }
+}

--- a/atomix/core/src/test/java/io/atomix/core/RaftRolesTest.java
+++ b/atomix/core/src/test/java/io/atomix/core/RaftRolesTest.java
@@ -26,7 +26,6 @@ import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.RaftPartitionGroup;
-import io.zeebe.snapshots.broker.impl.FileBasedSnapshotStoreFactory;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -272,7 +271,7 @@ public final class RaftRolesTest {
                   .withMembers(memberIds)
                   .withDataDirectory(
                       new File(new File(atomixRule.getDataDir(), "log"), "" + nodeId))
-                  .withSnapshotStoreFactory(new FileBasedSnapshotStoreFactory())
+                  .withSnapshotStoreFactory(new NoopSnapshotStoreFactory())
                   .build();
 
           final Atomix atomix = builder.withPartitionGroups(partitionGroup).build();

--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -254,7 +254,7 @@ public final class Broker implements AutoCloseable {
   }
 
   private AutoCloseable atomixCreateStep(final BrokerCfg brokerCfg) {
-    final var snapshotStoreFactory = new FileBasedSnapshotStoreFactory();
+    final var snapshotStoreFactory = new FileBasedSnapshotStoreFactory(scheduler);
     snapshotStoreSupplier = snapshotStoreFactory;
     atomix = AtomixFactory.fromConfiguration(brokerCfg, snapshotStoreFactory);
 

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -21,6 +21,7 @@ import io.zeebe.snapshots.raft.ReceivedSnapshot;
 import io.zeebe.snapshots.raft.SnapshotChunk;
 import io.zeebe.snapshots.raft.TransientSnapshot;
 import io.zeebe.util.FileUtil;
+import io.zeebe.util.sched.future.ActorFuture;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -164,8 +165,8 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
     return db != null;
   }
 
-  private void takeSnapshot(final TransientSnapshot snapshot) {
-    snapshot.take(
+  private ActorFuture<Boolean> takeSnapshot(final TransientSnapshot snapshot) {
+    return snapshot.take(
         snapshotDir -> {
           if (db == null) {
             LOG.error("Expected to take a snapshot, but no database was opened");
@@ -340,7 +341,7 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
     }
 
     public boolean apply(final SnapshotChunk snapshotChunk) throws IOException {
-      return receivedSnapshot.apply(snapshotChunk);
+      return receivedSnapshot.apply(snapshotChunk).join();
     }
   }
 }

--- a/broker/src/test/java/io/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
+++ b/broker/src/test/java/io/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
@@ -38,7 +38,7 @@ public final class AtomixFactoryTest {
 
     // when
     final var atomix =
-        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory());
+        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory(null));
 
     // then
     final var config = getPartitionGroupConfig(atomix);
@@ -53,7 +53,7 @@ public final class AtomixFactoryTest {
 
     // when
     final var atomix =
-        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory());
+        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory(null));
 
     // then
     final var config = getPartitionGroupConfig(atomix);
@@ -68,7 +68,7 @@ public final class AtomixFactoryTest {
 
     // when
     final var atomix =
-        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory());
+        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory(null));
 
     // then
     final var config = getPartitionGroupConfig(atomix);
@@ -83,7 +83,7 @@ public final class AtomixFactoryTest {
 
     // when
     final var atomix =
-        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory());
+        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory(null));
 
     // then
     final var config = getPartitionGroupConfig(atomix);

--- a/broker/src/test/java/io/zeebe/broker/logstreams/NoopSnapshotStore.java
+++ b/broker/src/test/java/io/zeebe/broker/logstreams/NoopSnapshotStore.java
@@ -12,7 +12,8 @@ import io.zeebe.snapshots.raft.PersistedSnapshot;
 import io.zeebe.snapshots.raft.PersistedSnapshotListener;
 import io.zeebe.snapshots.raft.PersistedSnapshotStore;
 import io.zeebe.snapshots.raft.SnapshotChunkReader;
-import java.io.IOException;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.future.CompletableActorFuture;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -86,16 +87,20 @@ public class NoopSnapshotStore implements PersistedSnapshotStore {
   }
 
   @Override
-  public void purgePendingSnapshots() throws IOException {}
-
-  @Override
-  public void addSnapshotListener(final PersistedSnapshotListener listener) {
-    this.listeners.add(listener);
+  public ActorFuture<Void> purgePendingSnapshots() {
+    return CompletableActorFuture.completed(null);
   }
 
   @Override
-  public void removeSnapshotListener(final PersistedSnapshotListener listener) {
-    this.listeners.remove(listener);
+  public ActorFuture<Boolean> addSnapshotListener(final PersistedSnapshotListener listener) {
+    listeners.add(listener);
+    return null;
+  }
+
+  @Override
+  public ActorFuture<Boolean> removeSnapshotListener(final PersistedSnapshotListener listener) {
+    listeners.remove(listener);
+    return null;
   }
 
   @Override
@@ -104,7 +109,9 @@ public class NoopSnapshotStore implements PersistedSnapshotStore {
   }
 
   @Override
-  public void delete() {}
+  public ActorFuture<Void> delete() {
+    return null;
+  }
 
   @Override
   public void close() {}

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
@@ -67,7 +67,7 @@ public final class AsyncSnapshotingTest {
   @Before
   public void setup() throws IOException {
     final var rootDirectory = tempFolderRule.getRoot().toPath();
-    final var factory = new FileBasedSnapshotStoreFactory();
+    final var factory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get());
     final String partitionName = "1";
     factory.createReceivableSnapshotStore(rootDirectory, partitionName);
     persistedSnapshotStore = factory.getConstructableSnapshotStore(partitionName);

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
@@ -19,10 +19,13 @@ import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
 import io.zeebe.snapshots.raft.SnapshotChunk;
 import io.zeebe.snapshots.raft.TransientSnapshot;
 import io.zeebe.test.util.AutoCloseableRule;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,6 +35,7 @@ public final class FailingSnapshotChunkReplicationTest {
 
   @Rule public final TemporaryFolder tempFolderRule = new TemporaryFolder();
   @Rule public final AutoCloseableRule autoCloseableRule = new AutoCloseableRule();
+  @Rule public final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
 
   private StateControllerImpl replicatorSnapshotController;
   private StateControllerImpl receiverSnapshotController;
@@ -41,12 +45,12 @@ public final class FailingSnapshotChunkReplicationTest {
   public void setup(final SnapshotReplication replicator) throws IOException {
     final var senderRoot = tempFolderRule.newFolder("sender").toPath();
 
-    final var senderFactory = new FileBasedSnapshotStoreFactory();
+    final var senderFactory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get());
     senderFactory.createReceivableSnapshotStore(senderRoot, "1");
     senderStore = senderFactory.getConstructableSnapshotStore("1");
 
     final var receiverRoot = tempFolderRule.newFolder("receiver").toPath();
-    final var receiverFactory = new FileBasedSnapshotStoreFactory();
+    final var receiverFactory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get());
     receiverStore = receiverFactory.createReceivableSnapshotStore(receiverRoot, "1");
 
     replicatorSnapshotController =
@@ -94,7 +98,7 @@ public final class FailingSnapshotChunkReplicationTest {
     final var transientSnapshot = takeSnapshot();
 
     // when
-    transientSnapshot.persist();
+    transientSnapshot.persist().join();
 
     // then
     final List<SnapshotChunk> replicatedChunks = replicator.replicatedChunks;
@@ -111,7 +115,7 @@ public final class FailingSnapshotChunkReplicationTest {
     final var transientSnapshot = takeSnapshot();
 
     // when
-    transientSnapshot.persist();
+    transientSnapshot.persist().join();
 
     // then
     final List<SnapshotChunk> replicatedChunks = replicator.replicatedChunks;
@@ -128,13 +132,15 @@ public final class FailingSnapshotChunkReplicationTest {
 
     final List<SnapshotChunk> replicatedChunks = new ArrayList<>();
     private Consumer<SnapshotChunk> chunkConsumer;
+    // Consumers are usually running on a separate thread
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
     @Override
     public void replicate(final SnapshotChunk snapshot) {
       replicatedChunks.add(snapshot);
       if (chunkConsumer != null) {
         if (replicatedChunks.size() < 3) {
-          chunkConsumer.accept(snapshot);
+          executorService.execute(() -> chunkConsumer.accept(snapshot));
         }
       }
     }
@@ -152,13 +158,17 @@ public final class FailingSnapshotChunkReplicationTest {
 
     final List<SnapshotChunk> replicatedChunks = new ArrayList<>();
     private Consumer<SnapshotChunk> chunkConsumer;
+    // Consumers are usually running on a separate thread
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
     @Override
     public void replicate(final SnapshotChunk snapshot) {
       replicatedChunks.add(snapshot);
       if (chunkConsumer != null) {
-        chunkConsumer.accept(
-            replicatedChunks.size() > 1 ? new DisruptedSnapshotChunk(snapshot) : snapshot);
+        executorService.execute(
+            () ->
+                chunkConsumer.accept(
+                    replicatedChunks.size() > 1 ? new DisruptedSnapshotChunk(snapshot) : snapshot));
       }
     }
 

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
@@ -19,12 +19,17 @@ import io.zeebe.snapshots.broker.impl.FileBasedSnapshotStoreFactory;
 import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
 import io.zeebe.snapshots.raft.SnapshotChunk;
 import io.zeebe.test.util.AutoCloseableRule;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.zip.CRC32;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,6 +42,7 @@ public final class ReplicateStateControllerTest {
 
   @Rule public final TemporaryFolder tempFolderRule = new TemporaryFolder();
   @Rule public final AutoCloseableRule autoCloseableRule = new AutoCloseableRule();
+  @Rule public final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
 
   private StateControllerImpl replicatorSnapshotController;
   private StateControllerImpl receiverSnapshotController;
@@ -48,12 +54,12 @@ public final class ReplicateStateControllerTest {
   public void setup() throws IOException {
     final var senderRoot = tempFolderRule.newFolder("sender").toPath();
 
-    final var senderFactory = new FileBasedSnapshotStoreFactory();
+    final var senderFactory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get());
     senderFactory.createReceivableSnapshotStore(senderRoot, "1");
     senderStore = senderFactory.getConstructableSnapshotStore("1");
 
     final var receiverRoot = tempFolderRule.newFolder("receiver").toPath();
-    final var receiverFactory = new FileBasedSnapshotStoreFactory();
+    final var receiverFactory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get());
     receiverStore = receiverFactory.createReceivableSnapshotStore(receiverRoot, "1");
 
     replicator = new Replicator();
@@ -103,7 +109,7 @@ public final class ReplicateStateControllerTest {
     final var snapshot = replicatorSnapshotController.takeTransientSnapshot(1).orElseThrow();
 
     // when
-    snapshot.persist();
+    snapshot.persist().join();
 
     // then
     final List<SnapshotChunk> replicatedChunks = replicator.replicatedChunks;
@@ -128,7 +134,7 @@ public final class ReplicateStateControllerTest {
     final var snapshot = replicatorSnapshotController.takeTransientSnapshot(1).orElseThrow();
 
     // when
-    snapshot.persist();
+    snapshot.persist().join();
 
     // then
     final List<SnapshotChunk> replicatedChunks = replicator.replicatedChunks;
@@ -147,9 +153,14 @@ public final class ReplicateStateControllerTest {
     // given
     receiverSnapshotController.consumeReplicatedSnapshots();
     final var snapshot = replicatorSnapshotController.takeTransientSnapshot(1).orElseThrow();
+    final CompletableFuture<Void> snapshotTaken = new CompletableFuture<>();
+    snapshot.onSnapshotTaken((ignore, error) -> snapshotTaken.complete(null));
+    snapshotTaken.join();
 
     // when
-    snapshot.persist();
+    snapshot.persist().join();
+    Awaitility.await()
+        .until(() -> receiverStore.hasSnapshotId(snapshot.snapshotId().getSnapshotIdAsString()));
 
     // then
     final RocksDBWrapper wrapper = new RocksDBWrapper();
@@ -167,9 +178,18 @@ public final class ReplicateStateControllerTest {
     receiverSnapshotController.consumeReplicatedSnapshots();
     final var transientSnapshot =
         replicatorSnapshotController.takeTransientSnapshot(1).orElseThrow();
+    final CompletableFuture<Void> snapshotTaken = new CompletableFuture<>();
+    transientSnapshot.onSnapshotTaken((ignor, error) -> snapshotTaken.complete(null));
+    snapshotTaken.join();
+
+    final var snapshot = transientSnapshot.persist().join();
+    Awaitility.await()
+        .until(
+            () ->
+                receiverStore.hasSnapshotId(
+                    transientSnapshot.snapshotId().getSnapshotIdAsString()));
 
     // when
-    final var snapshot = transientSnapshot.persist();
     receiverSnapshotController.onNewSnapshot(snapshot);
 
     // then
@@ -186,12 +206,14 @@ public final class ReplicateStateControllerTest {
 
     final List<SnapshotChunk> replicatedChunks = new ArrayList<>();
     private Consumer<SnapshotChunk> chunkConsumer;
+    // Consumers are usually running on a separate thread
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
     @Override
     public void replicate(final SnapshotChunk snapshot) {
       replicatedChunks.add(snapshot);
       if (chunkConsumer != null) {
-        chunkConsumer.accept(snapshot);
+        executorService.execute(() -> chunkConsumer.accept(snapshot));
       }
     }
 

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -21,6 +21,8 @@ import io.zeebe.snapshots.raft.PersistableSnapshot;
 import io.zeebe.snapshots.raft.PersistedSnapshot;
 import io.zeebe.snapshots.raft.TransientSnapshot;
 import io.zeebe.test.util.AutoCloseableRule;
+import io.zeebe.util.sched.future.ActorFuture;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -38,6 +40,7 @@ public final class StateControllerImplTest {
 
   @Rule public final TemporaryFolder tempFolderRule = new TemporaryFolder();
   @Rule public final AutoCloseableRule autoCloseableRule = new AutoCloseableRule();
+  @Rule public final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
 
   private final MutableLong exporterPosition = new MutableLong(Long.MAX_VALUE);
   private StateControllerImpl snapshotController;
@@ -47,7 +50,7 @@ public final class StateControllerImplTest {
   public void setup() throws IOException {
     final var rootDirectory = tempFolderRule.newFolder("state").toPath();
 
-    final var factory = new FileBasedSnapshotStoreFactory();
+    final var factory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get());
     factory.createReceivableSnapshotStore(rootDirectory, "1");
     store = factory.getConstructableSnapshotStore("1");
 
@@ -87,7 +90,8 @@ public final class StateControllerImplTest {
 
     // when
     final var tmpSnapshot = snapshotController.takeTransientSnapshot(snapshotPosition);
-    final var snapshot = tmpSnapshot.map(TransientSnapshot::persist).orElseThrow();
+    final var snapshot =
+        tmpSnapshot.map(TransientSnapshot::persist).map(ActorFuture::join).orElseThrow();
 
     // then
     assertThat(snapshot)
@@ -160,11 +164,13 @@ public final class StateControllerImplTest {
         snapshotController
             .takeTransientSnapshot(snapshotPosition)
             .map(PersistableSnapshot::persist)
+            .map(ActorFuture::join)
             .orElseThrow();
 
     // when
     final var tmpSnapshot = snapshotController.takeTransientSnapshot(snapshotPosition + 1);
-    final var snapshot = tmpSnapshot.map(TransientSnapshot::persist).orElseThrow();
+    final var snapshot =
+        tmpSnapshot.map(TransientSnapshot::persist).map(ActorFuture::join).orElseThrow();
 
     // then
     assertThat(snapshot)
@@ -187,12 +193,14 @@ public final class StateControllerImplTest {
         snapshotController
             .takeTransientSnapshot(snapshotPosition)
             .map(PersistableSnapshot::persist)
+            .map(ActorFuture::join)
             .orElseThrow();
 
     // when
     exporterPosition.set(snapshotPosition + 1);
     final var tmpSnapshot = snapshotController.takeTransientSnapshot(snapshotPosition);
-    final var snapshot = tmpSnapshot.map(TransientSnapshot::persist).orElseThrow();
+    final var snapshot =
+        tmpSnapshot.map(TransientSnapshot::persist).map(ActorFuture::join).orElseThrow();
 
     // then
     assertThat(snapshot)
@@ -296,7 +304,7 @@ public final class StateControllerImplTest {
 
   private File takeSnapshot(final long position) {
     final var snapshot = snapshotController.takeTransientSnapshot(position).orElseThrow();
-    return snapshot.persist().getPath().toFile();
+    return snapshot.persist().join().getPath().toFile();
   }
 
   private void corruptLatestSnapshot() throws IOException {

--- a/snapshot/src/main/java/io/zeebe/snapshots/raft/PersistableSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/raft/PersistableSnapshot.java
@@ -7,16 +7,26 @@
  */
 package io.zeebe.snapshots.raft;
 
+import io.zeebe.snapshots.broker.SnapshotId;
+import io.zeebe.util.sched.future.ActorFuture;
+
 /** A volatile snapshot which can be persisted. */
 public interface PersistableSnapshot {
 
-  /** Aborts the not yet persisted snapshot and removes all related data. */
-  void abort();
+  /**
+   * Aborts the not yet persisted snapshot and removes all related data.
+   *
+   * @return a future which will be completed when the abort is done.
+   */
+  ActorFuture<Void> abort();
 
   /**
    * Persists the snapshot with all his data and returns the representation of this snapshot.
    *
-   * @return the persisted snapshot
+   * @return a future that will be completed with the persisted snapshot
    */
-  PersistedSnapshot persist();
+  ActorFuture<PersistedSnapshot> persist();
+
+  /** @return the snapshotId of the snapshot */
+  SnapshotId snapshotId();
 }

--- a/snapshot/src/main/java/io/zeebe/snapshots/raft/PersistedSnapshotStore.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/raft/PersistedSnapshotStore.java
@@ -8,7 +8,7 @@
 package io.zeebe.snapshots.raft;
 
 import io.zeebe.util.CloseableSilently;
-import java.io.IOException;
+import io.zeebe.util.sched.future.ActorFuture;
 import java.util.Optional;
 
 /**
@@ -37,25 +37,27 @@ public interface PersistedSnapshotStore extends CloseableSilently {
   /**
    * Purges all ongoing pending/transient/volatile snapshots.
    *
-   * @throws IOException when there was an unexpected IO issue
+   * @return future which will be completed when all pending snapshots are deleted
    */
-  void purgePendingSnapshots() throws IOException;
+  ActorFuture<Void> purgePendingSnapshots();
 
   /**
    * Adds an {@link PersistedSnapshotListener} to the store, which is notified when a new {@link
    * PersistedSnapshot} is persisted at this store.
    *
    * @param listener the listener which should be added and notified later
+   * @return
    */
-  void addSnapshotListener(PersistedSnapshotListener listener);
+  ActorFuture<Boolean> addSnapshotListener(PersistedSnapshotListener listener);
 
   /**
    * Removes an registered {@link PersistedSnapshotListener} from the store. The listener will no
    * longer called when a new {@link PersistedSnapshot} is persisted at this store.
    *
    * @param listener the listener which should be removed
+   * @return
    */
-  void removeSnapshotListener(PersistedSnapshotListener listener);
+  ActorFuture<Boolean> removeSnapshotListener(PersistedSnapshotListener listener);
 
   /**
    * @return the snapshot index of the latest {@link PersistedSnapshot}
@@ -69,6 +71,8 @@ public interface PersistedSnapshotStore extends CloseableSilently {
    * <p>The snapshot store will be deleted by simply reading {@code snapshot} file names from disk
    * and deleting snapshot files directly. Deleting the snapshot store does not involve reading any
    * snapshot files into memory.
+   *
+   * @return
    */
-  void delete();
+  ActorFuture<Void> delete();
 }

--- a/snapshot/src/main/java/io/zeebe/snapshots/raft/ReceivedSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/raft/ReceivedSnapshot.java
@@ -7,8 +7,8 @@
  */
 package io.zeebe.snapshots.raft;
 
+import io.zeebe.util.sched.future.ActorFuture;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 /**
  * A received volatile snapshot, which consist of several {@link SnapshotChunk}'s. It can be
@@ -24,34 +24,11 @@ public interface ReceivedSnapshot extends PersistableSnapshot {
   long index();
 
   /**
-   * Returns true if the chunk identified by the given ID has already been applied to the snapshot.
-   *
-   * @param chunkId the chunk ID to check for
-   * @return true if already applied, false otherwise
-   */
-  boolean containsChunk(ByteBuffer chunkId);
-
-  /**
-   * Returns true if the chunk identified by chunkId is the expected next chunk, false otherwise.
-   *
-   * @param chunkId the ID of the new chunk
-   * @return true if is expected, false otherwise
-   */
-  boolean isExpectedChunk(ByteBuffer chunkId);
-
-  /**
-   * Sets that the next expected chunk ID is the one with the given {@code nextChunkId}.
-   *
-   * @param nextChunkId the next expected chunk ID
-   */
-  void setNextExpected(ByteBuffer nextChunkId);
-
-  /**
    * Applies the next {@link SnapshotChunk} to the snapshot. Based on the implementation the chunk
    * can be validated before applied to the snapshot.
    *
    * @param chunk the {@link SnapshotChunk} which should be applied
    * @return returns true if everything succeeds, false otherwise
    */
-  boolean apply(SnapshotChunk chunk) throws IOException;
+  ActorFuture<Boolean> apply(SnapshotChunk chunk) throws IOException;
 }

--- a/snapshot/src/main/java/io/zeebe/snapshots/raft/TransientSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/raft/TransientSnapshot.java
@@ -7,7 +7,9 @@
  */
 package io.zeebe.snapshots.raft;
 
+import io.zeebe.util.sched.future.ActorFuture;
 import java.nio.file.Path;
+import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
 /** A transient snapshot which can be persisted after taking a snapshot. */
@@ -22,5 +24,12 @@ public interface TransientSnapshot extends PersistableSnapshot {
    *     success
    * @return true on success, false otherwise
    */
-  boolean take(Predicate<Path> takeSnapshot);
+  ActorFuture<Boolean> take(Predicate<Path> takeSnapshot);
+
+  /**
+   * Execute an operation after {@link TransientSnapshot#take(Predicate)} is completed.
+   *
+   * @param runnable the operation that should be executed after the transient snapshot is taken
+   */
+  void onSnapshotTaken(BiConsumer<Boolean, Throwable> runnable);
 }

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStoreFactoryTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStoreFactoryTest.java
@@ -9,6 +9,7 @@ package io.zeebe.snapshots.broker.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.zeebe.util.sched.ActorScheduler;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -20,7 +21,7 @@ public final class FileBasedSnapshotStoreFactoryTest {
   public void shouldCreateDirectoriesIfNotExist() {
     // given
     final var root = temporaryFolder.getRoot().toPath();
-    final var factory = new FileBasedSnapshotStoreFactory();
+    final var factory = new FileBasedSnapshotStoreFactory(createActorScheduler());
 
     // when
     final var store = factory.createReceivableSnapshotStore(root, "ignored");
@@ -33,5 +34,11 @@ public final class FileBasedSnapshotStoreFactoryTest {
         .exists()
         .isDirectory();
     assertThat(store.getLatestSnapshot()).isEmpty();
+  }
+
+  private ActorScheduler createActorScheduler() {
+    final var actorScheduler = ActorScheduler.newActorScheduler().build();
+    actorScheduler.start();
+    return actorScheduler;
   }
 }

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedTransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedTransientSnapshotTest.java
@@ -9,6 +9,7 @@ package io.zeebe.snapshots.broker.impl;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -17,6 +18,7 @@ import static org.mockito.Mockito.verify;
 import io.zeebe.snapshots.broker.ConstructableSnapshotStore;
 import io.zeebe.snapshots.raft.PersistedSnapshotListener;
 import io.zeebe.util.FileUtil;
+import io.zeebe.util.sched.ActorScheduler;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -37,7 +39,8 @@ public class FileBasedTransientSnapshotTest {
 
   @Before
   public void before() {
-    final FileBasedSnapshotStoreFactory factory = new FileBasedSnapshotStoreFactory();
+    final FileBasedSnapshotStoreFactory factory =
+        new FileBasedSnapshotStoreFactory(createActorScheduler());
     final String partitionName = "1";
     final File root = temporaryFolder.getRoot();
 
@@ -51,6 +54,12 @@ public class FileBasedTransientSnapshotTest {
             .resolve(FileBasedSnapshotStoreFactory.SNAPSHOTS_DIRECTORY);
     pendingSnapshotsDir =
         temporaryFolder.getRoot().toPath().resolve(FileBasedSnapshotStoreFactory.PENDING_DIRECTORY);
+  }
+
+  private ActorScheduler createActorScheduler() {
+    final var actorScheduler = ActorScheduler.newActorScheduler().build();
+    actorScheduler.start();
+    return actorScheduler;
   }
 
   @Test
@@ -91,7 +100,7 @@ public class FileBasedTransientSnapshotTest {
         persistedSnapshotStore.newTransientSnapshot(index, term, 3, 4).orElseThrow();
 
     // when
-    transientSnapshot.take(this::createSnapshotDir);
+    transientSnapshot.take(this::createSnapshotDir).join();
 
     // then
     assertThat(snapshotsDir.toFile().listFiles()).isEmpty();
@@ -117,10 +126,10 @@ public class FileBasedTransientSnapshotTest {
     final var index = 1L;
     final var term = 0L;
     final var transientSnapshot = persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0);
-    transientSnapshot.orElseThrow().take(this::createSnapshotDir);
+    transientSnapshot.orElseThrow().take(this::createSnapshotDir).join();
 
     // when
-    transientSnapshot.get().abort();
+    transientSnapshot.get().abort().join();
 
     // then
     assertThat(snapshotsDir.toFile().listFiles()).isEmpty();
@@ -136,7 +145,7 @@ public class FileBasedTransientSnapshotTest {
     transientSnapshot.orElseThrow().take(this::createSnapshotDir);
 
     // when
-    persistedSnapshotStore.purgePendingSnapshots();
+    persistedSnapshotStore.purgePendingSnapshots().join();
 
     // then
     assertThat(snapshotsDir.toFile().listFiles()).isEmpty();
@@ -151,10 +160,10 @@ public class FileBasedTransientSnapshotTest {
     final var transientSnapshot =
         persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
     transientSnapshot.take(this::createSnapshotDir);
-    final var persistSnapshot = transientSnapshot.persist();
+    final var persistSnapshot = transientSnapshot.persist().join();
 
     // when
-    persistedSnapshotStore.purgePendingSnapshots();
+    persistedSnapshotStore.purgePendingSnapshots().join();
 
     // then
     assertThat(pendingSnapshotsDir.toFile().listFiles()).isEmpty();
@@ -178,7 +187,7 @@ public class FileBasedTransientSnapshotTest {
     transientSnapshot.orElseThrow().take(this::createSnapshotDir);
 
     // when
-    final var persistedSnapshot = transientSnapshot.get().persist();
+    final var persistedSnapshot = transientSnapshot.get().persist().join();
 
     // then
     assertThat(pendingSnapshotsDir.toFile().listFiles()).isEmpty();
@@ -202,13 +211,13 @@ public class FileBasedTransientSnapshotTest {
     final var oldTransientSnapshot =
         persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
     oldTransientSnapshot.take(this::createSnapshotDir);
-    oldTransientSnapshot.persist();
+    oldTransientSnapshot.persist().join();
 
     // when
     final var newSnapshot =
         persistedSnapshotStore.newTransientSnapshot(index + 1, term, 1, 0).orElseThrow();
     newSnapshot.take(this::createSnapshotDir);
-    newSnapshot.persist();
+    newSnapshot.persist().join();
 
     // then
     assertThat(pendingSnapshotsDir.toFile().listFiles()).isEmpty();
@@ -241,7 +250,7 @@ public class FileBasedTransientSnapshotTest {
     final var newSnapshot =
         persistedSnapshotStore.newTransientSnapshot(index + 1, term, 1, 0).orElseThrow();
     newSnapshot.take(this::createSnapshotDir);
-    newSnapshot.persist();
+    newSnapshot.persist().join();
 
     // then
     assertThat(pendingSnapshotsDir.toFile().listFiles()).isEmpty();
@@ -274,7 +283,7 @@ public class FileBasedTransientSnapshotTest {
     final var newSnapshot =
         persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
     newSnapshot.take(this::createSnapshotDir);
-    final var newSnapshotId = newSnapshot.persist().getId();
+    final var newSnapshotId = newSnapshot.persist().join().getId();
 
     // then
     final var pendingSnapshotDirs = pendingSnapshotsDir.toFile().listFiles();
@@ -311,15 +320,17 @@ public class FileBasedTransientSnapshotTest {
         persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
 
     // when
-    oldTransientSnapshot.take(
-        path -> {
-          try {
-            FileUtil.ensureDirectoryExists(path);
-          } catch (final IOException e) {
-            throw new UncheckedIOException(e);
-          }
-          return false;
-        });
+    oldTransientSnapshot
+        .take(
+            path -> {
+              try {
+                FileUtil.ensureDirectoryExists(path);
+              } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+              }
+              return false;
+            })
+        .join();
 
     // then
     assertThat(pendingSnapshotsDir.toFile().listFiles()).isEmpty();
@@ -335,15 +346,20 @@ public class FileBasedTransientSnapshotTest {
         persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
 
     // when
-    oldTransientSnapshot.take(
-        path -> {
-          try {
-            FileUtil.ensureDirectoryExists(path);
-            throw new RuntimeException("EXPECTED");
-          } catch (final IOException e) {
-            throw new UncheckedIOException(e);
-          }
-        });
+    assertThatThrownBy(
+            () ->
+                oldTransientSnapshot
+                    .take(
+                        path -> {
+                          try {
+                            FileUtil.ensureDirectoryExists(path);
+                            throw new RuntimeException("EXPECTED");
+                          } catch (final IOException e) {
+                            throw new UncheckedIOException(e);
+                          }
+                        })
+                    .join())
+        .hasCauseInstanceOf(RuntimeException.class);
 
     // then
     assertThat(pendingSnapshotsDir.toFile().listFiles()).isEmpty();
@@ -359,10 +375,10 @@ public class FileBasedTransientSnapshotTest {
     final var transientSnapshot =
         persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
     persistedSnapshotStore.addSnapshotListener(listener);
-    transientSnapshot.take(this::createSnapshotDir);
+    transientSnapshot.take(this::createSnapshotDir).join();
 
     // when
-    final var persistedSnapshot = transientSnapshot.persist();
+    final var persistedSnapshot = transientSnapshot.persist().join();
 
     // then
     assertThat(pendingSnapshotsDir.toFile().listFiles()).isEmpty();
@@ -380,10 +396,10 @@ public class FileBasedTransientSnapshotTest {
         persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
     persistedSnapshotStore.addSnapshotListener(listener);
     persistedSnapshotStore.removeSnapshotListener(listener);
-    transientSnapshot.take(this::createSnapshotDir);
+    transientSnapshot.take(this::createSnapshotDir).join();
 
     // when
-    final var persistedSnapshot = transientSnapshot.persist();
+    final var persistedSnapshot = transientSnapshot.persist().join();
 
     // then
     assertThat(pendingSnapshotsDir.toFile().listFiles()).isEmpty();
@@ -402,15 +418,37 @@ public class FileBasedTransientSnapshotTest {
         persistedSnapshotStore
             .newTransientSnapshot(index, term, processedPosition, exporterPosition)
             .orElseThrow();
-    transientSnapshot.take(this::createSnapshotDir);
+    transientSnapshot.take(this::createSnapshotDir).join();
     // when
-    transientSnapshot.persist();
+    transientSnapshot.persist().join();
 
     // then
     assertThat(
             persistedSnapshotStore.newTransientSnapshot(
                 index, term, processedPosition, exporterPosition))
         .isEmpty();
+  }
+
+  @Test
+  public void shouldNotPersistInvalidPendingSnapshot() {
+    final var index = 1L;
+    final var term = 0L;
+    final var processedPosition = 2;
+    final var exporterPosition = 3;
+    final var transientSnapshot =
+        persistedSnapshotStore
+            .newTransientSnapshot(index, term, processedPosition, exporterPosition)
+            .orElseThrow();
+    transientSnapshot.take(this::createSnapshotDir).join();
+
+    // when
+    persistedSnapshotStore.purgePendingSnapshots().join();
+    final var persisted = transientSnapshot.persist();
+
+    // then
+    assertThatThrownBy(persisted::join)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Snapshot is not valid");
   }
 
   private boolean createSnapshotDir(final Path path) {

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/PersistedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/PersistedSnapshotStoreTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.utils.time.WallClockTimestamp;
 import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
+import io.zeebe.util.sched.ActorScheduler;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,12 +24,19 @@ public class PersistedSnapshotStoreTest {
 
   @Before
   public void before() {
-    final FileBasedSnapshotStoreFactory factory = new FileBasedSnapshotStoreFactory();
+    final FileBasedSnapshotStoreFactory factory =
+        new FileBasedSnapshotStoreFactory(createActorScheduler());
 
     final var partitionName = "1";
     final var root = temporaryFolder.getRoot();
 
     persistedSnapshotStore = factory.createReceivableSnapshotStore(root.toPath(), partitionName);
+  }
+
+  private ActorScheduler createActorScheduler() {
+    final var actorScheduler = ActorScheduler.newActorScheduler().build();
+    actorScheduler.start();
+    return actorScheduler;
   }
 
   @Test


### PR DESCRIPTION
## Description

- Make FileBasedSnapshotStore an actor
- Creating, persisting and deleting a snapshot always goes through the actor. So there are no concurrent modifications to the snapshots. Reading snapshot chunks is still outside of the actor.
- RaftContext keeps track of the current snapshot in a local member which is updated via snapshot listeners. This would prevent repeated async access to the snapshot store actor.

## Related issues

closes #6255 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.
* [ ] The changes are backwards compatibility with previous versions

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
