### PR TITLE
Restore the key generator on replay

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -12,7 +12,10 @@ import io.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.NoopTypedStreamWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.state.EventApplier;
+import io.zeebe.engine.state.KeyGeneratorControls;
+import io.zeebe.engine.state.ZeebeDbState;
 import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.mutable.MutableLastProcessedPositionState;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
 import io.zeebe.util.sched.ActorControl;
@@ -29,7 +32,7 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
 
   private RecordValues recordValues;
   private RecordProcessorMap recordProcessorMap;
-  private ZeebeState zeebeState;
+  private ZeebeDbState zeebeState;
   private TransactionContext transactionContext;
   private EventApplier eventApplier;
 
@@ -63,7 +66,7 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
     return this;
   }
 
-  public ProcessingContext zeebeState(final ZeebeState zeebeState) {
+  public ProcessingContext zeebeState(final ZeebeDbState zeebeState) {
     this.zeebeState = zeebeState;
     return this;
   }
@@ -108,6 +111,14 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
   public ProcessingContext eventApplier(final EventApplier eventApplier) {
     this.eventApplier = eventApplier;
     return this;
+  }
+
+  public KeyGeneratorControls getKeyGeneratorControls() {
+    return zeebeState.getKeyGeneratorControls();
+  }
+
+  public MutableLastProcessedPositionState getLastProcessedPositionState() {
+    return zeebeState.getLastProcessedPositionState();
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -14,6 +14,7 @@ import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriterImpl;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.mutable.MutableLastProcessedPositionState;
 import io.zeebe.logstreams.impl.Loggers;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
@@ -113,6 +114,7 @@ public final class ProcessingStateMachine {
       new MetadataEventFilter(new RecordProtocolVersionFilter().and(PROCESSING_FILTER));
 
   private final ZeebeState zeebeState;
+  private final MutableLastProcessedPositionState lastProcessedPositionState;
   private final RecordMetadata metadata = new RecordMetadata();
   private final TypedResponseWriterImpl responseWriter;
   private final ActorControl actor;
@@ -159,6 +161,7 @@ public final class ProcessingStateMachine {
     zeebeState = context.getZeebeState();
     transactionContext = context.getTransactionContext();
     abortCondition = context.getAbortCondition();
+    lastProcessedPositionState = context.getLastProcessedPositionState();
 
     writeRetryStrategy = new AbortableRetryStrategy(actor);
     sideEffectsRetryStrategy = new AbortableRetryStrategy(actor);
@@ -293,7 +296,7 @@ public final class ProcessingStateMachine {
                 this::setSideEffectProducer);
           }
 
-          zeebeState.getLastProcessedPositionState().markAsProcessed(position);
+          lastProcessedPositionState.markAsProcessed(position);
         });
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -12,6 +12,7 @@ import io.zeebe.db.ZeebeDb;
 import io.zeebe.engine.metrics.StreamProcessorMetrics;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriterImpl;
 import io.zeebe.engine.state.EventApplier;
+import io.zeebe.engine.state.ZeebeDbState;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.logstreams.impl.Loggers;
 import io.zeebe.logstreams.log.LogStream;
@@ -248,7 +249,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
   }
 
   private long recoverFromSnapshot() {
-    final ZeebeState zeebeState = recoverState();
+    final var zeebeState = recoverState();
+
     final long snapshotPosition =
         zeebeState.getLastProcessedPositionState().getLastSuccessfulProcessedRecordPosition();
 
@@ -265,9 +267,9 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
     return snapshotPosition;
   }
 
-  private ZeebeState recoverState() {
+  private ZeebeDbState recoverState() {
     final TransactionContext transactionContext = zeebeDb.createContext();
-    final ZeebeState zeebeState = new ZeebeState(partitionId, zeebeDb, transactionContext);
+    final ZeebeDbState zeebeState = new ZeebeDbState(partitionId, zeebeDb, transactionContext);
 
     processingContext.transactionContext(transactionContext);
     processingContext.zeebeState(zeebeState);

--- a/engine/src/main/java/io/zeebe/engine/state/KeyGeneratorControls.java
+++ b/engine/src/main/java/io/zeebe/engine/state/KeyGeneratorControls.java
@@ -7,14 +7,13 @@
  */
 package io.zeebe.engine.state;
 
-/** Generate unique keys. Should be used for records only. */
-@FunctionalInterface
-public interface KeyGenerator {
+/** Allows to manipulate the key generator. Should be used with caution. */
+public interface KeyGeneratorControls extends KeyGenerator {
 
   /**
-   * Returns the next key of a record and updates the key generator.
+   * Set the given value as the new key if it is higher than the current key.
    *
-   * @return the next key for a new record
+   * @param key the new key
    */
-  long nextKey();
+  void setKeyIfHigher(long key);
 }

--- a/engine/src/main/java/io/zeebe/engine/state/NextValueManager.java
+++ b/engine/src/main/java/io/zeebe/engine/state/NextValueManager.java
@@ -42,19 +42,29 @@ public final class NextValueManager {
   }
 
   public long getNextValue(final String key) {
-    nextValueKey.wrapString(key);
-
-    final NextValue readValue = nextValueColumnFamily.get(nextValueKey);
-
-    long previousKey = initialValue;
-    if (readValue != null) {
-      previousKey = readValue.get();
-    }
-
+    final long previousKey = getCurrentValue(key);
     final long nextKey = previousKey + 1;
     nextValue.set(nextKey);
     nextValueColumnFamily.put(nextValueKey, nextValue);
 
     return nextKey;
+  }
+
+  public void setValue(final String key, final long value) {
+    nextValueKey.wrapString(key);
+    nextValue.set(value);
+    nextValueColumnFamily.put(nextValueKey, nextValue);
+  }
+
+  public long getCurrentValue(final String key) {
+    nextValueKey.wrapString(key);
+
+    final NextValue readValue = nextValueColumnFamily.get(nextValueKey);
+
+    long currentValue = initialValue;
+    if (readValue != null) {
+      currentValue = readValue.get();
+    }
+    return currentValue;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/ZeebeDbState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/ZeebeDbState.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state;
+
+import io.zeebe.db.DbKey;
+import io.zeebe.db.DbValue;
+import io.zeebe.db.TransactionContext;
+import io.zeebe.db.ZeebeDb;
+import io.zeebe.engine.state.deployment.DbDeploymentState;
+import io.zeebe.engine.state.deployment.DbWorkflowState;
+import io.zeebe.engine.state.instance.DbElementInstanceState;
+import io.zeebe.engine.state.instance.DbEventScopeInstanceState;
+import io.zeebe.engine.state.instance.DbIncidentState;
+import io.zeebe.engine.state.instance.DbJobState;
+import io.zeebe.engine.state.instance.DbTimerInstanceState;
+import io.zeebe.engine.state.instance.DbVariableState;
+import io.zeebe.engine.state.message.DbMessageStartEventSubscriptionState;
+import io.zeebe.engine.state.message.DbMessageState;
+import io.zeebe.engine.state.message.DbMessageSubscriptionState;
+import io.zeebe.engine.state.message.DbWorkflowInstanceSubscriptionState;
+import io.zeebe.engine.state.mutable.MutableBlackListState;
+import io.zeebe.engine.state.mutable.MutableDeploymentState;
+import io.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.zeebe.engine.state.mutable.MutableIncidentState;
+import io.zeebe.engine.state.mutable.MutableJobState;
+import io.zeebe.engine.state.mutable.MutableLastProcessedPositionState;
+import io.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptionState;
+import io.zeebe.engine.state.mutable.MutableMessageState;
+import io.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
+import io.zeebe.engine.state.mutable.MutableTimerInstanceState;
+import io.zeebe.engine.state.mutable.MutableVariableState;
+import io.zeebe.engine.state.mutable.MutableWorkflowInstanceSubscriptionState;
+import io.zeebe.engine.state.mutable.MutableWorkflowState;
+import io.zeebe.engine.state.processing.DbBlackListState;
+import io.zeebe.engine.state.processing.DbKeyGenerator;
+import io.zeebe.engine.state.processing.DbLastProcessedPositionState;
+import io.zeebe.protocol.Protocol;
+import java.util.function.BiConsumer;
+
+public class ZeebeDbState implements ZeebeState {
+
+  private final ZeebeDb<ZbColumnFamilies> zeebeDb;
+  private final DbKeyGenerator keyGenerator;
+
+  private final MutableWorkflowState workflowState;
+  private final MutableTimerInstanceState timerInstanceState;
+  private final MutableElementInstanceState elementInstanceState;
+  private final MutableEventScopeInstanceState eventScopeInstanceState;
+  private final MutableVariableState variableState;
+
+  private final MutableDeploymentState deploymentState;
+  private final MutableJobState jobState;
+  private final MutableMessageState messageState;
+  private final MutableMessageSubscriptionState messageSubscriptionState;
+  private final MutableMessageStartEventSubscriptionState messageStartEventSubscriptionState;
+  private final MutableWorkflowInstanceSubscriptionState workflowInstanceSubscriptionState;
+  private final MutableIncidentState incidentState;
+  private final MutableBlackListState blackListState;
+  private final MutableLastProcessedPositionState lastProcessedPositionState;
+
+  private final int partitionId;
+
+  public ZeebeDbState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    this(Protocol.DEPLOYMENT_PARTITION, zeebeDb, transactionContext);
+  }
+
+  public ZeebeDbState(
+      final int partitionId,
+      final ZeebeDb<ZbColumnFamilies> zeebeDb,
+      final TransactionContext transactionContext) {
+    this.partitionId = partitionId;
+    this.zeebeDb = zeebeDb;
+    keyGenerator = new DbKeyGenerator(partitionId, zeebeDb, transactionContext);
+
+    variableState = new DbVariableState(zeebeDb, transactionContext, keyGenerator);
+    workflowState = new DbWorkflowState(zeebeDb, transactionContext);
+    timerInstanceState = new DbTimerInstanceState(zeebeDb, transactionContext);
+    elementInstanceState = new DbElementInstanceState(zeebeDb, transactionContext, variableState);
+    eventScopeInstanceState = new DbEventScopeInstanceState(zeebeDb, transactionContext);
+
+    deploymentState = new DbDeploymentState(zeebeDb, transactionContext);
+    jobState = new DbJobState(zeebeDb, transactionContext, partitionId);
+    messageState = new DbMessageState(zeebeDb, transactionContext);
+    messageSubscriptionState = new DbMessageSubscriptionState(zeebeDb, transactionContext);
+    messageStartEventSubscriptionState =
+        new DbMessageStartEventSubscriptionState(zeebeDb, transactionContext);
+    workflowInstanceSubscriptionState =
+        new DbWorkflowInstanceSubscriptionState(zeebeDb, transactionContext);
+    incidentState = new DbIncidentState(zeebeDb, transactionContext, partitionId);
+    blackListState = new DbBlackListState(zeebeDb, transactionContext);
+    lastProcessedPositionState = new DbLastProcessedPositionState(zeebeDb, transactionContext);
+  }
+
+  @Override
+  public MutableDeploymentState getDeploymentState() {
+    return deploymentState;
+  }
+
+  @Override
+  public MutableWorkflowState getWorkflowState() {
+    return workflowState;
+  }
+
+  @Override
+  public MutableJobState getJobState() {
+    return jobState;
+  }
+
+  @Override
+  public MutableMessageState getMessageState() {
+    return messageState;
+  }
+
+  @Override
+  public MutableMessageSubscriptionState getMessageSubscriptionState() {
+    return messageSubscriptionState;
+  }
+
+  @Override
+  public MutableMessageStartEventSubscriptionState getMessageStartEventSubscriptionState() {
+    return messageStartEventSubscriptionState;
+  }
+
+  @Override
+  public MutableWorkflowInstanceSubscriptionState getWorkflowInstanceSubscriptionState() {
+    return workflowInstanceSubscriptionState;
+  }
+
+  @Override
+  public MutableIncidentState getIncidentState() {
+    return incidentState;
+  }
+
+  @Override
+  public KeyGenerator getKeyGenerator() {
+    return keyGenerator;
+  }
+
+  public KeyGeneratorControls getKeyGeneratorControls() {
+    return keyGenerator;
+  }
+
+  @Override
+  public MutableBlackListState getBlackListState() {
+    return blackListState;
+  }
+
+  public MutableLastProcessedPositionState getLastProcessedPositionState() {
+    return lastProcessedPositionState;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionId;
+  }
+
+  @Override
+  public MutableVariableState getVariableState() {
+    return variableState;
+  }
+
+  @Override
+  public MutableTimerInstanceState getTimerState() {
+    return timerInstanceState;
+  }
+
+  @Override
+  public MutableElementInstanceState getElementInstanceState() {
+    return elementInstanceState;
+  }
+
+  @Override
+  public MutableEventScopeInstanceState getEventScopeInstanceState() {
+    return eventScopeInstanceState;
+  }
+
+  @Override
+  public boolean isEmpty(final ZbColumnFamilies column) {
+    final var newContext = zeebeDb.createContext();
+    return zeebeDb.isEmpty(column, newContext);
+  }
+
+  @Override
+  public <KeyType extends DbKey, ValueType extends DbValue> void forEach(
+      final ZbColumnFamilies columnFamily,
+      final KeyType keyInstance,
+      final ValueType valueInstance,
+      final BiConsumer<KeyType, ValueType> visitor) {
+
+    final var newContext = zeebeDb.createContext();
+
+    zeebeDb
+        .createColumnFamily(columnFamily, newContext, keyInstance, valueInstance)
+        .forEach(visitor);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/processing/DbKeyGenerator.java
+++ b/engine/src/main/java/io/zeebe/engine/state/processing/DbKeyGenerator.java
@@ -9,12 +9,12 @@ package io.zeebe.engine.state.processing;
 
 import io.zeebe.db.TransactionContext;
 import io.zeebe.db.ZeebeDb;
-import io.zeebe.engine.state.KeyGenerator;
+import io.zeebe.engine.state.KeyGeneratorControls;
 import io.zeebe.engine.state.NextValueManager;
 import io.zeebe.engine.state.ZbColumnFamilies;
 import io.zeebe.protocol.Protocol;
 
-public final class DbKeyGenerator implements KeyGenerator {
+public final class DbKeyGenerator implements KeyGeneratorControls {
 
   private static final long INITIAL_VALUE = 0;
 
@@ -39,5 +39,14 @@ public final class DbKeyGenerator implements KeyGenerator {
   @Override
   public long nextKey() {
     return nextValueManager.getNextValue(LATEST_KEY);
+  }
+
+  @Override
+  public void setKeyIfHigher(final long key) {
+    final var currentKey = nextValueManager.getCurrentValue(LATEST_KEY);
+
+    if (key > currentKey) {
+      nextValueManager.setValue(LATEST_KEY, key);
+    }
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -186,7 +186,6 @@ public class StreamProcessorHealthTest {
               final ZeebeState zeebeState = processingContext.getZeebeState();
               mockedLogStreamWriter =
                   new WrappedStreamWriter(processingContext.getLogStreamWriter());
-              processingContext.zeebeState(zeebeState);
               processingContext.logStreamWriter(mockedLogStreamWriter);
               return processors(zeebeState.getKeyGenerator())
                   .onEvent(

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorTest.java
@@ -168,11 +168,7 @@ public final class StreamProcessorTest {
     Awaitility.await()
         .untilAsserted(
             () -> {
-              Assertions.assertThat(
-                      streamProcessorRule
-                          .getZeebeState()
-                          .getLastProcessedPositionState()
-                          .getLastSuccessfulProcessedRecordPosition())
+              Assertions.assertThat(streamProcessorRule.getLastSuccessfulProcessedRecordPosition())
                   .isEqualTo(position);
             });
   }
@@ -719,11 +715,7 @@ public final class StreamProcessorTest {
 
     // then
     assertThat(onProcessedListener.await()).isTrue();
-    Assertions.assertThat(
-            streamProcessorRule
-                .getZeebeState()
-                .getLastProcessedPositionState()
-                .getLastSuccessfulProcessedRecordPosition())
+    Assertions.assertThat(streamProcessorRule.getLastSuccessfulProcessedRecordPosition())
         .isEqualTo(positionProcessedAfterResume);
   }
 

--- a/engine/src/test/java/io/zeebe/engine/state/KeyGeneratorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/KeyGeneratorTest.java
@@ -56,7 +56,7 @@ public final class KeyGeneratorTest {
     final ZeebeDb<ZbColumnFamilies> newDb = stateRule.createNewDb();
     final int secondPartitionId = Protocol.DEPLOYMENT_PARTITION + 1;
     final ZeebeState otherZeebeState =
-        new ZeebeState(secondPartitionId, newDb, newDb.createContext());
+        new ZeebeDbState(secondPartitionId, newDb, newDb.createContext());
 
     final KeyGenerator keyGenerator2 = otherZeebeState.getKeyGenerator();
 

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -183,6 +183,10 @@ public final class StreamProcessorRule implements TestRule {
     return streamProcessingComposite.getZeebeState();
   }
 
+  public long getLastSuccessfulProcessedRecordPosition() {
+    return streamProcessingComposite.getLastSuccessfulProcessedRecordPosition();
+  }
+
   public RecordStream events() {
     return new RecordStream(streams.events(getLogName(startPartitionId)));
   }

--- a/engine/src/test/java/io/zeebe/engine/util/ZeebeStateRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/ZeebeStateRule.java
@@ -11,6 +11,7 @@ import io.zeebe.db.ZeebeDb;
 import io.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.zeebe.engine.state.KeyGenerator;
 import io.zeebe.engine.state.ZbColumnFamilies;
+import io.zeebe.engine.state.ZeebeDbState;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.protocol.Protocol;
 import org.junit.rules.ExternalResource;
@@ -36,7 +37,7 @@ public final class ZeebeStateRule extends ExternalResource {
     tempFolder.create();
     db = createNewDb();
 
-    zeebeState = new ZeebeState(partition, db, db.createContext());
+    zeebeState = new ZeebeDbState(partition, db, db.createContext());
   }
 
   @Override


### PR DESCRIPTION
## Description

* reset the key generator after the replay to the highest key that was written on the stream
* update the key generator after skipping a command on replay
  * the key generator is used by not yet migrated processors
  * this part can be removed after all processors are migrated
* extract an interface from the ZeebeState to avoid that internal controls (key generator, last processed state) are exposed

Hints for the reviewer:
* I recommend to review the commits separately, the first includes the actual logic, the second is just the refactoring of the state
* the test `StreamProcessorReplayTest#shouldRestoreKeyGeneratorAfterSkippingCommand()` will be removed with the migration logic after all processors are migrated

## Related issues

closes #6164

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
