### PR TITLE
[Backport stable/0.26] fix(atomix): compact all index when reseting the segments

### DIFF
--- a/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournalWriter.java
+++ b/atomix/storage/src/main/java/io/atomix/storage/journal/SegmentedJournalWriter.java
@@ -87,6 +87,9 @@ public class SegmentedJournalWriter<E> implements JournalWriter<E> {
   @Override
   public void reset(final long index) {
     if (index > currentSegment.index()) {
+      // delete all index mapping
+      currentSegment.compactIndex(index + 1);
+      // delete all segments and create an empty one
       currentSegment = journal.resetSegments(index);
       currentWriter = currentSegment.writer();
     } else {


### PR DESCRIPTION
## Description

Backport #6253

closes #6237 