### PR TITLE
Introduce deployment distribution record

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
@@ -74,7 +74,8 @@ public final class EngineProcessors {
         typedRecordProcessors,
         deploymentResponder,
         expressionProcessor,
-        writers);
+        writers,
+        partitionsCount);
     addMessageProcessors(subscriptionCommandSender, zeebeState, typedRecordProcessors, writers);
 
     final TypedRecordProcessor<WorkflowInstanceRecord> bpmnStreamProcessor =
@@ -136,12 +137,18 @@ public final class EngineProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final DeploymentResponder deploymentResponder,
       final ExpressionProcessor expressionProcessor,
-      final Writers writers) {
+      final Writers writers,
+      final int partitionsCount) {
     final MutableWorkflowState workflowState = zeebeState.getWorkflowState();
     final boolean isDeploymentPartition = partitionId == Protocol.DEPLOYMENT_PARTITION;
     if (isDeploymentPartition) {
       DeploymentEventProcessors.addTransformingDeploymentProcessor(
-          typedRecordProcessors, zeebeState, catchEventBehavior, expressionProcessor);
+          typedRecordProcessors,
+          zeebeState,
+          catchEventBehavior,
+          expressionProcessor,
+          partitionsCount,
+          writers);
     } else {
       DeploymentEventProcessors.addDeploymentCreateProcessor(
           typedRecordProcessors, workflowState, deploymentResponder, partitionId);

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/DeploymentEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/DeploymentEventProcessors.java
@@ -12,6 +12,7 @@ import static io.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 import io.zeebe.engine.processing.common.CatchEventBehavior;
 import io.zeebe.engine.processing.common.ExpressionProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.mutable.MutableWorkflowState;
 import io.zeebe.protocol.record.ValueType;
@@ -33,10 +34,12 @@ public final class DeploymentEventProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final ZeebeState zeebeState,
       final CatchEventBehavior catchEventBehavior,
-      final ExpressionProcessor expressionProcessor) {
+      final ExpressionProcessor expressionProcessor,
+      final int partitionsCount,
+      final Writers writers) {
     final var processor =
         new TransformingDeploymentCreateProcessor(
-            zeebeState, catchEventBehavior, expressionProcessor);
+            zeebeState, catchEventBehavior, expressionProcessor, partitionsCount, writers);
     typedRecordProcessors.onCommand(ValueType.DEPLOYMENT, CREATE, processor);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
@@ -8,6 +8,7 @@
 package io.zeebe.engine.processing.streamprocessor;
 
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.impl.record.value.deployment.WorkflowRecord;
 import io.zeebe.protocol.impl.record.value.error.ErrorRecord;
@@ -54,6 +55,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.ERROR, ErrorRecord.class);
     registry.put(ValueType.WORKFLOW_INSTANCE_RESULT, WorkflowInstanceResultRecord.class);
     registry.put(ValueType.WORKFLOW, WorkflowRecord.class);
+    registry.put(ValueType.DEPLOYMENT_DISTRIBUTION, DeploymentDistributionRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
   }

--- a/engine/src/main/java/io/zeebe/engine/state/ZbColumnFamilies.java
+++ b/engine/src/main/java/io/zeebe/engine/state/ZbColumnFamilies.java
@@ -39,6 +39,7 @@ public enum ZbColumnFamilies {
 
   // pending deployments
   PENDING_DEPLOYMENT,
+  NEW_PENDING_DEPLOYMENT,
 
   // jobs
   JOBS,

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/DeploymentDistributionApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/DeploymentDistributionApplier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.mutable.MutableDeploymentState;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
+import io.zeebe.protocol.record.intent.DeploymentDistributionIntent;
+
+public class DeploymentDistributionApplier
+    implements TypedEventApplier<DeploymentDistributionIntent, DeploymentDistributionRecord> {
+
+  private final MutableDeploymentState deploymentState;
+
+  public DeploymentDistributionApplier(final ZeebeState zeebeState) {
+    deploymentState = zeebeState.getDeploymentState();
+  }
+
+  @Override
+  public void applyState(final long key, final DeploymentDistributionRecord value) {
+    // add partition on which deployment should be distributed
+    deploymentState.addPendingDeploymentDistribution(key, value.getPartitionId());
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -12,6 +12,7 @@ import io.zeebe.engine.state.EventApplier;
 import io.zeebe.engine.state.TypedEventApplier;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.protocol.record.RecordValue;
+import io.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.record.intent.WorkflowIntent;
@@ -44,6 +45,7 @@ public final class EventAppliers implements EventApplier {
         new WorkflowInstanceElementActivatedApplier(state));
 
     register(WorkflowIntent.CREATED, new WorkflowCreatedApplier(state));
+    register(DeploymentDistributionIntent.DISTRIBUTING, new DeploymentDistributionApplier(state));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -10,7 +10,10 @@ package io.zeebe.engine.state.deployment;
 import io.zeebe.db.ColumnFamily;
 import io.zeebe.db.TransactionContext;
 import io.zeebe.db.ZeebeDb;
+import io.zeebe.db.impl.DbCompositeKey;
+import io.zeebe.db.impl.DbInt;
 import io.zeebe.db.impl.DbLong;
+import io.zeebe.db.impl.DbNil;
 import io.zeebe.engine.processing.deployment.distribute.PendingDeploymentDistribution;
 import io.zeebe.engine.state.ZbColumnFamilies;
 import io.zeebe.engine.state.mutable.MutableDeploymentState;
@@ -22,12 +25,25 @@ public final class DbDeploymentState implements MutableDeploymentState {
   private final PendingDeploymentDistribution pendingDeploymentDistribution;
 
   private final DbLong deploymentKey;
+  private final DbInt partitionKey;
+  private final DbCompositeKey<DbLong, DbInt> deploymentPartitionKey;
+  private final ColumnFamily<DbCompositeKey<DbLong, DbInt>, DbNil> newPendingDeploymentColumnFamily;
+
   private final ColumnFamily<DbLong, PendingDeploymentDistribution> pendingDeploymentColumnFamily;
 
   public DbDeploymentState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
 
     deploymentKey = new DbLong();
+    partitionKey = new DbInt();
+    deploymentPartitionKey = new DbCompositeKey<>(deploymentKey, partitionKey);
+    newPendingDeploymentColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.NEW_PENDING_DEPLOYMENT,
+            transactionContext,
+            deploymentPartitionKey,
+            DbNil.INSTANCE);
+
     pendingDeploymentDistribution =
         new PendingDeploymentDistribution(new UnsafeBuffer(0, 0), -1, 0);
     pendingDeploymentColumnFamily =
@@ -71,5 +87,12 @@ public final class DbDeploymentState implements MutableDeploymentState {
     pendingDeploymentColumnFamily.forEach(
         (deploymentKey, pendingDeployment) ->
             consumer.accept(pendingDeployment, deploymentKey.getValue()));
+  }
+
+  @Override
+  public void addPendingDeploymentDistribution(final long deploymentKey, final int partition) {
+    this.deploymentKey.wrapLong(deploymentKey);
+    partitionKey.wrapInt(partition);
+    newPendingDeploymentColumnFamily.put(deploymentPartitionKey, DbNil.INSTANCE);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableDeploymentState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableDeploymentState.java
@@ -15,4 +15,6 @@ public interface MutableDeploymentState extends DeploymentState {
   void putPendingDeployment(long key, PendingDeploymentDistribution pendingDeploymentDistribution);
 
   PendingDeploymentDistribution removePendingDeployment(long key);
+
+  void addPendingDeploymentDistribution(long deploymentKey, int partition);
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/deployment/TransformingDeploymentCreateProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/deployment/TransformingDeploymentCreateProcessorTest.java
@@ -20,6 +20,10 @@ import io.zeebe.el.ExpressionLanguageFactory;
 import io.zeebe.engine.processing.common.CatchEventBehavior;
 import io.zeebe.engine.processing.common.ExpressionProcessor;
 import io.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.zeebe.engine.processing.streamprocessor.writers.CommandResponseWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.immutable.WorkflowState;
 import io.zeebe.engine.util.StreamProcessorRule;
 import io.zeebe.model.bpmn.Bpmn;
@@ -50,7 +54,11 @@ public final class TransformingDeploymentCreateProcessorTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     mockSubscriptionCommandSender = mock(SubscriptionCommandSender.class);
-
+    final var writersMock =
+        new Writers(
+            mock(TypedStreamWriter.class),
+            mock(StateWriter.class),
+            mock(CommandResponseWriter.class));
     when(mockSubscriptionCommandSender.openMessageSubscription(
             anyInt(), anyLong(), anyLong(), any(), any(), any(), anyBoolean()))
         .thenReturn(true);
@@ -77,7 +85,9 @@ public final class TransformingDeploymentCreateProcessorTest {
               zeebeState,
               new CatchEventBehavior(
                   zeebeState, expressionProcessor, mockSubscriptionCommandSender, 1),
-              expressionProcessor);
+              expressionProcessor,
+              1,
+              writersMock);
           return typedRecordProcessors;
         });
   }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/deployment/DeploymentDistributionRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/deployment/DeploymentDistributionRecord.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.protocol.impl.record.value.deployment;
+
+import io.zeebe.msgpack.property.IntegerProperty;
+import io.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
+
+public class DeploymentDistributionRecord extends UnifiedRecordValue
+    implements DeploymentDistributionRecordValue {
+
+  private final IntegerProperty partitionIdProperty = new IntegerProperty("partitionId");
+
+  public DeploymentDistributionRecord() {
+    declareProperty(partitionIdProperty);
+  }
+
+  public int getPartitionId() {
+    return partitionIdProperty.getValue();
+  }
+
+  public void setPartition(final int partitionId) {
+    partitionIdProperty.setValue(partitionId);
+  }
+}

--- a/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -17,6 +17,7 @@ import io.zeebe.protocol.impl.record.CopiedRecord;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.impl.record.VersionInfo;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
@@ -184,6 +185,19 @@ public final class JsonSerializableToJsonTest {
               return record;
             },
         "{'resources':[{'resourceType':'BPMN_XML','resourceName':'resource','resource':'Y29udGVudHM='}],'deployedWorkflows':[{'resource':'Y29udGVudHM=','checksum':'Y2hlY2tzdW0=','bpmnProcessId':'testProcess','version':12,'workflowKey':123,'resourceName':'resource'}]}"
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////// DeploymentDistributionRecord /////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      new Object[] {
+        "DeploymentDistributionRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final var record = new DeploymentDistributionRecord();
+              record.setPartition(2);
+              return record;
+            },
+        "{'partitionId':2}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       //////////////////////////////////// Empty DeploymentRecord /////////////////////////////////

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/DeploymentDistributionIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/DeploymentDistributionIntent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.protocol.record.intent;
+
+public enum DeploymentDistributionIntent implements Intent {
+  DISTRIBUTING((short) 0);
+
+  private final short value;
+
+  DeploymentDistributionIntent(final short value) {
+    this.value = value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return DISTRIBUTING;
+      default:
+        return UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+}

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/Intent.java
@@ -35,7 +35,8 @@ public interface Intent {
           VariableDocumentIntent.class,
           WorkflowInstanceCreationIntent.class,
           ErrorIntent.class,
-          WorkflowIntent.class);
+          WorkflowIntent.class,
+          DeploymentDistributionIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN =
       new Intent() {
@@ -88,6 +89,8 @@ public interface Intent {
         return WorkflowInstanceResultIntent.from(intent);
       case WORKFLOW:
         return WorkflowIntent.from(intent);
+      case DEPLOYMENT_DISTRIBUTION:
+        return DeploymentDistributionIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -133,6 +136,8 @@ public interface Intent {
         return WorkflowInstanceResultIntent.valueOf(intent);
       case WORKFLOW:
         return WorkflowIntent.valueOf(intent);
+      case DEPLOYMENT_DISTRIBUTION:
+        return DeploymentDistributionIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/DeploymentDistributionRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/DeploymentDistributionRecordValue.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.protocol.record.value;
+
+import io.zeebe.protocol.record.RecordValue;
+
+public interface DeploymentDistributionRecordValue extends RecordValue {
+
+  /** @return the partition where the deployment should be distributed */
+  int getPartitionId();
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -37,6 +37,7 @@
       <validValue name="ERROR">20</validValue>
       <validValue name="WORKFLOW_INSTANCE_RESULT">21</validValue>
       <validValue name="WORKFLOW">22</validValue>
+      <validValue name="DEPLOYMENT_DISTRIBUTION">23</validValue>
     </enum>
 
     <enum name="RecordType" encodingType="uint8">

--- a/test-util/src/main/java/io/zeebe/test/util/record/DeploymentDistributionRecordStream.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/DeploymentDistributionRecordStream.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.test.util.record;
+
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
+import java.util.stream.Stream;
+
+public final class DeploymentDistributionRecordStream
+    extends ExporterRecordStream<
+        DeploymentDistributionRecordValue, DeploymentDistributionRecordStream> {
+
+  public DeploymentDistributionRecordStream(
+      final Stream<Record<DeploymentDistributionRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected DeploymentDistributionRecordStream supply(
+      final Stream<Record<DeploymentDistributionRecordValue>> wrappedStream) {
+    return new DeploymentDistributionRecordStream(wrappedStream);
+  }
+
+  public DeploymentDistributionRecordStream withPartitionId(final int partitionId) {
+    return valueFilter(v -> v.getPartitionId() == partitionId);
+  }
+}

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporter.java
@@ -24,6 +24,7 @@ import io.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.zeebe.protocol.record.intent.VariableIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceSubscriptionIntent;
+import io.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
 import io.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.zeebe.protocol.record.value.IncidentRecordValue;
 import io.zeebe.protocol.record.value.JobBatchRecordValue;
@@ -148,6 +149,11 @@ public final class RecordingExporter implements Exporter {
 
   public static WorkflowRecordStream workflowRecords() {
     return new WorkflowRecordStream(records(ValueType.WORKFLOW, DeployedWorkflow.class));
+  }
+
+  public static DeploymentDistributionRecordStream deploymentDistributionRecords() {
+    return new DeploymentDistributionRecordStream(
+        records(ValueType.DEPLOYMENT_DISTRIBUTION, DeploymentDistributionRecordValue.class));
   }
 
   public static JobRecordStream jobRecords() {

--- a/zb-db/src/main/java/io/zeebe/db/impl/DbInt.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/DbInt.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.db.impl;
+
+import static io.zeebe.db.impl.ZeebeDbConstants.ZB_DB_BYTE_ORDER;
+
+import io.zeebe.db.DbKey;
+import io.zeebe.db.DbValue;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public final class DbInt implements DbKey, DbValue {
+
+  private int intValue;
+
+  public void wrapInt(final int value) {
+    intValue = value;
+  }
+
+  @Override
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
+    intValue = buffer.getInt(offset, ZB_DB_BYTE_ORDER);
+  }
+
+  @Override
+  public int getLength() {
+    return Integer.BYTES;
+  }
+
+  @Override
+  public void write(final MutableDirectBuffer buffer, final int offset) {
+    buffer.putInt(offset, intValue, ZB_DB_BYTE_ORDER);
+  }
+
+  public int getValue() {
+    return intValue;
+  }
+}

--- a/zb-db/src/test/java/io/zeebe/db/impl/DbIntTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/DbIntTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.db.impl;
+
+import static io.zeebe.db.impl.ZeebeDbConstants.ZB_DB_BYTE_ORDER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.agrona.ExpandableArrayBuffer;
+import org.junit.Test;
+
+/** */
+public final class DbIntTest {
+
+  private final DbInt zbInt = new DbInt();
+
+  @Test
+  public void shouldWrapInt() {
+    // given
+    zbInt.wrapInt(234);
+
+    // when
+    final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
+    zbInt.write(buffer, 0);
+
+    // then
+    assertThat(zbInt.getLength()).isEqualTo(Integer.BYTES);
+    assertThat(zbInt.getValue()).isEqualTo(234);
+    assertThat(buffer.getInt(0, ZB_DB_BYTE_ORDER)).isEqualTo(234);
+  }
+
+  @Test
+  public void shouldWrap() {
+    // given
+    final ExpandableArrayBuffer intBuffer = new ExpandableArrayBuffer();
+    intBuffer.putInt(0, 234, ZB_DB_BYTE_ORDER);
+    zbInt.wrap(intBuffer, 0, Integer.BYTES);
+
+    // when
+    final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
+    zbInt.write(buffer, 0);
+
+    // then
+    assertThat(zbInt.getLength()).isEqualTo(Integer.BYTES);
+    assertThat(zbInt.getValue()).isEqualTo(234);
+    assertThat(buffer.getInt(0, ZB_DB_BYTE_ORDER)).isEqualTo(234);
+  }
+}


### PR DESCRIPTION
## Description
Introduces deployment distribution record with DISTRIBUTING intent which is used to store the pending deployment keys and corresponding partitions in the state.
<!-- Please explain the changes you made here. -->

## Related issues
blocked by https://github.com/zeebe-io/zeebe/pull/6289
<!-- Which issues are closed by this PR or are related -->

related #6173

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
