### PR TITLE
Extract interface from RaftLogWriter and implement it via RaftLog

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogWriter.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogWriter.java
@@ -1,12 +1,11 @@
 /*
- * Copyright 2017-present Open Networking Foundation
  * Copyright © 2020 camunda services GmbH (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,13 +16,6 @@
 package io.atomix.raft.storage.log;
 
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
-import io.atomix.storage.journal.DelegatingJournalWriter;
-import io.atomix.storage.journal.SegmentedJournalWriter;
+import io.atomix.storage.journal.JournalWriter;
 
-/** Raft log writer. */
-public class RaftLogWriter extends DelegatingJournalWriter<RaftLogEntry> {
-
-  public RaftLogWriter(final SegmentedJournalWriter<RaftLogEntry> writer) {
-    super(writer);
-  }
-}
+public interface RaftLogWriter extends JournalWriter<RaftLogEntry> {}


### PR DESCRIPTION
## Description

This PR extracts a new `RaftLogWriter` interface from the previously named `RaftLogWriter` class, drops the old implementation, and implements the new interface via `RaftLog`. No new tests were added as this new `RaftLog` API is temporary and most of it will be dropped.

## Related issues

closes #6302 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
