### PR TITLE
Expose further RocksDB configuration

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -17,9 +17,14 @@ import org.springframework.util.unit.DataSize;
 public final class RocksdbCfg implements ConfigurationEntry {
 
   private Properties columnFamilyOptions;
-  private boolean statisticsEnabled;
+  private boolean enableStatistics = RocksDbConfiguration.DEFAULT_STATISTICS_ENABLED;
   private DataSize memoryLimit = DataSize.ofBytes(RocksDbConfiguration.DEFAULT_MEMORY_LIMIT);
   private int maxOpenFiles = RocksDbConfiguration.DEFAULT_UNLIMITED_MAX_OPEN_FILES;
+  private int maxWriteBufferNumber = RocksDbConfiguration.DEFAULT_MAX_WRITE_BUFFER_NUMBER;
+  private int minWriteBufferNumberToMerge =
+      RocksDbConfiguration.DEFAULT_MIN_WRITE_BUFFER_NUMBER_TO_MERGE;
+  private int ioRateBytesPerSecond = RocksDbConfiguration.DEFAULT_IO_RATE_BYTES_PER_SECOND;
+  private boolean disableWal = RocksDbConfiguration.DEFAULT_WAL_DISABLED;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -49,12 +54,12 @@ public final class RocksdbCfg implements ConfigurationEntry {
     this.columnFamilyOptions = columnFamilyOptions;
   }
 
-  public boolean isStatisticsEnabled() {
-    return statisticsEnabled;
+  public boolean isEnableStatistics() {
+    return enableStatistics;
   }
 
-  public void setStatisticsEnabled(final boolean statisticsEnabled) {
-    this.statisticsEnabled = statisticsEnabled;
+  public void setEnableStatistics(final boolean enableStatistics) {
+    this.enableStatistics = enableStatistics;
   }
 
   public DataSize getMemoryLimit() {
@@ -73,9 +78,48 @@ public final class RocksdbCfg implements ConfigurationEntry {
     this.maxOpenFiles = maxOpenFiles;
   }
 
+  public int getMaxWriteBufferNumber() {
+    return maxWriteBufferNumber;
+  }
+
+  public void setMaxWriteBufferNumber(final int maxWriteBufferNumber) {
+    this.maxWriteBufferNumber = maxWriteBufferNumber;
+  }
+
+  public int getMinWriteBufferNumberToMerge() {
+    return minWriteBufferNumberToMerge;
+  }
+
+  public void setMinWriteBufferNumberToMerge(final int minWriteBufferNumberToMerge) {
+    this.minWriteBufferNumberToMerge = minWriteBufferNumberToMerge;
+  }
+
+  public int getIoRateBytesPerSecond() {
+    return ioRateBytesPerSecond;
+  }
+
+  public void setIoRateBytesPerSecond(final int ioRateBytesPerSecond) {
+    this.ioRateBytesPerSecond = ioRateBytesPerSecond;
+  }
+
+  public boolean isDisableWal() {
+    return disableWal;
+  }
+
+  public void setDisableWal(final boolean disableWal) {
+    this.disableWal = disableWal;
+  }
+
   public RocksDbConfiguration createRocksDbConfiguration() {
-    return RocksDbConfiguration.of(
-        columnFamilyOptions, statisticsEnabled, memoryLimit.toBytes(), maxOpenFiles);
+    return new RocksDbConfiguration()
+        .setColumnFamilyOptions(columnFamilyOptions)
+        .setMaxOpenFiles(maxOpenFiles)
+        .setMaxWriteBufferNumber(maxWriteBufferNumber)
+        .setMemoryLimit(memoryLimit.toBytes())
+        .setMinWriteBufferNumberToMerge(minWriteBufferNumberToMerge)
+        .setStatisticsEnabled(enableStatistics)
+        .setIoRateBytesPerSecond(ioRateBytesPerSecond)
+        .setWalDisabled(disableWal);
   }
 
   @Override
@@ -83,12 +127,20 @@ public final class RocksdbCfg implements ConfigurationEntry {
     return "RocksdbCfg{"
         + "columnFamilyOptions="
         + columnFamilyOptions
-        + ", statisticsEnabled="
-        + statisticsEnabled
+        + ", enableStatistics="
+        + enableStatistics
         + ", memoryLimit="
         + memoryLimit
         + ", maxOpenFiles="
         + maxOpenFiles
+        + ", maxWriteBufferNumber="
+        + maxWriteBufferNumber
+        + ", minWriteBufferNumberToMerge="
+        + minWriteBufferNumberToMerge
+        + ", ioRateBytesPerSecond="
+        + ioRateBytesPerSecond
+        + ", disableWal="
+        + disableWal
         + '}';
   }
 

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
@@ -28,7 +28,7 @@ public class StateControllerPartitionStep implements PartitionStep {
     final var stateController =
         new StateControllerImpl(
             context.getPartitionId(),
-            DefaultZeebeDbFactory.defaultFactory(databaseCfg.getColumnFamilyOptions()),
+            DefaultZeebeDbFactory.defaultFactory(databaseCfg.createRocksDbConfiguration()),
             context
                 .getSnapshotStoreSupplier()
                 .getConstructableSnapshotStore(context.getRaftPartition().name()),

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/RocksdbCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/RocksdbCfgTest.java
@@ -25,7 +25,7 @@ public final class RocksdbCfgTest {
     final var rocksdb = cfg.getExperimental().getRocksdb();
 
     // then
-    assertThat(rocksdb.isStatisticsEnabled()).isFalse();
+    assertThat(rocksdb.isEnableStatistics()).isFalse();
   }
 
   @Test
@@ -73,6 +73,10 @@ public final class RocksdbCfgTest {
     assertThat(rocksDbConfiguration.getMemoryLimit())
         .isEqualTo(DataSize.ofMegabytes(512).toBytes());
     assertThat(rocksDbConfiguration.getMaxOpenFiles()).isEqualTo(-1);
+    assertThat(rocksDbConfiguration.getMaxWriteBufferNumber()).isEqualTo(6);
+    assertThat(rocksDbConfiguration.getMinWriteBufferNumberToMerge()).isEqualTo(3);
+    assertThat(rocksDbConfiguration.getIoRateBytesPerSecond()).isZero();
+    assertThat(rocksDbConfiguration.isWalDisabled()).isFalse();
   }
 
   @Test
@@ -101,8 +105,9 @@ public final class RocksdbCfgTest {
 
     // then
     final var columnFamilyOptions = rocksdb.getColumnFamilyOptions();
-    assertThat(columnFamilyOptions).containsEntry("compaction_pri", "kOldestSmallestSeqFirst");
-    assertThat(columnFamilyOptions).containsEntry("write_buffer_size", "67108864");
+    assertThat(columnFamilyOptions)
+        .containsEntry("compaction_pri", "kOldestSmallestSeqFirst")
+        .containsEntry("write_buffer_size", "67108864");
   }
 
   @Test
@@ -112,7 +117,7 @@ public final class RocksdbCfgTest {
     final var rocksdb = cfg.getExperimental().getRocksdb();
 
     // then
-    assertThat(rocksdb.isStatisticsEnabled()).isTrue();
+    assertThat(rocksdb.isEnableStatistics()).isTrue();
   }
 
   @Test
@@ -153,14 +158,14 @@ public final class RocksdbCfgTest {
   @Test
   public void shouldEnableStatisticsViaEnvironmentVariables() {
     // given
-    environment.put("zeebe.broker.experimental.rocksdb.statisticsEnabled", "true");
+    environment.put("zeebe.broker.experimental.rocksdb.enableStatistics", "true");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
     final var rocksdb = cfg.getExperimental().getRocksdb();
 
     // then
-    assertThat(rocksdb.isStatisticsEnabled()).isTrue();
+    assertThat(rocksdb.isEnableStatistics()).isTrue();
   }
 
   @Test
@@ -187,5 +192,97 @@ public final class RocksdbCfgTest {
 
     // then
     assertThat(rocksdb.getMaxOpenFiles()).isEqualTo(5);
+  }
+
+  @Test
+  public void shouldSetMaxWriteBufferNumberViaConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getMaxWriteBufferNumber()).isEqualTo(3);
+  }
+
+  @Test
+  public void shouldSetMaxWriteBufferNumberViaEnvironmentVariables() {
+    // given
+    environment.put("zeebe.broker.experimental.rocksdb.maxWriteBufferNumber", "5");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getMaxWriteBufferNumber()).isEqualTo(5);
+  }
+
+  @Test
+  public void shouldSetMinWriteBufferNumberToMergeViaConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getMinWriteBufferNumberToMerge()).isEqualTo(3);
+  }
+
+  @Test
+  public void shouldSetMinWriteBufferNumberToMergeViaEnvironmentVariables() {
+    // given
+    environment.put("zeebe.broker.experimental.rocksdb.minWriteBufferNumberToMerge", "5");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getMinWriteBufferNumberToMerge()).isEqualTo(5);
+  }
+
+  @Test
+  public void shouldSetIoRateBytesPerSecondViaConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getIoRateBytesPerSecond()).isEqualTo(4096);
+  }
+
+  @Test
+  public void shouldSetIoRateBytesPerSecondViaEnvironmentVariables() {
+    // given
+    environment.put("zeebe.broker.experimental.rocksdb.ioRateBytesPerSecond", "4096");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getIoRateBytesPerSecond()).isEqualTo(4096);
+  }
+
+  @Test
+  public void shouldSetIsDisableWalPerSecondViaConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.isDisableWal()).isTrue();
+  }
+
+  @Test
+  public void shouldSetIsDisableWalViaEnvironmentVariables() {
+    // given
+    environment.put("zeebe.broker.experimental.rocksdb.disableWal", "true");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.isDisableWal()).isTrue();
   }
 }

--- a/broker/src/test/resources/system/rocksdb-cfg.yaml
+++ b/broker/src/test/resources/system/rocksdb-cfg.yaml
@@ -5,6 +5,10 @@ zeebe:
         columnFamilyOptions:
           compaction_pri: "kOldestSmallestSeqFirst"
           write_buffer_size: 67108864
-        statisticsEnabled: true
+        enableStatistics: true
         memoryLimit: 32MB
         maxOpenFiles: 3
+        maxWriteBufferNumber: 3
+        minWriteBufferNumberToMerge: 3
+        ioRateBytesPerSecond: 4096
+        disableWal: true

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -528,17 +528,41 @@
           # write_buffer_size: 67108864
 
         # Enables RocksDB statistics, which will be written to the RocksDB log file.
-        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_STATISTICS_ENABLED
-        # statisticsEnabled: false
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_ENABLESTATISTICS
+        # enableStatistics: false
 
         # Configures the memory limit, which can be used by RocksDB. Be aware that this setting only applies to RocksDB, which is used by the Zeebe's state management and that
         # an RocksDB instance is used per partition.
-        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORY_LIMIT
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYLIMIT
         # memoryLimit: 512MB
 
         # Configures how many files are kept open by RocksDB, per default it is unlimited (-1).
         # This is a performance optimization: if you set a value greater than zero, it will keep track and cap the number of open
         # files in the TableCache. On accessing the files it needs to look them up in the cache.
         # You should configure this property if the maximum open files are limited on your system, or if you have thousands of files in your RocksDB state as there is a memory overhead to keeping all of them open, and setting maxOpenFiles will bound that.
-        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MAX_OPEN_FILES
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MAXOPENFILES
         # maxOpenFiles: -1
+
+        # Configures the maximum number of simultaneous write buffers/memtables RocksDB will have in memory. Normally about 2/3s of the memoryLimit
+        # is used by the write buffers, and this is shared equally by each write buffers. This means the higher maxWriteBufferNumber is, the less
+        # memory is available for each. This means you will flush less data at once, but may flush more often.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MAXWRITEBUFFERNUMBER
+        # maxWriteBufferNumber: 6
+
+        # Configures how many write buffers should be full before they are merged and flushed to disk. Having a higher number here means you may
+        # flush less often, but will flush more data at once. Have a lower one means flushing more often, but flushing less data at once.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MINWRITEBUFFERNUMBERTOMERGE
+        # minWriteBufferNumberToMerge: 3
+
+        # Configures a rate limit for write I/O of RocksDB. Setting any value less than or equal to 0 will disable this, which is the default setting.
+        # Setting a rate limit on the write I/O can help achieve more stable performance by avoiding write spikes consuming all available IOPS, leading to
+        # more predictable read rates.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_IORATEBYTESPERSECOND
+        # ioRateBytesPerSecond: 0
+
+        # Configures if the RocksDB write-ahead-log is used or not. By default, every write in RocksDB goes to the active write buffer and the WAL; this
+        # helps recover a RocksDB instance should it crash before the write buffer is flushed. Zeebe however only recovers from specific point-in-time snapshot,
+        # and never from a previously active RocksDB instance, which makes it a good candidate to disable the WAL. It's currently disabled by default as
+        # performance is a bit less predictable when disabling the WAL.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL
+        # disableWal: false

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -489,17 +489,41 @@
           # write_buffer_size: 67108864
 
         # Enables RocksDB statistics, which will be written to the RocksDB log file.
-        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_STATISTICS_ENABLED
-        # statisticsEnabled: false
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_ENABLESTATISTICS
+        # enableStatistics: false
 
         # Configures the memory limit, which can be used by RocksDB. Be aware that this setting only applies to RocksDB, which is used by the Zeebe's state management and that
         # an RocksDB instance is used per partition.
-        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORY_LIMIT
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MEMORYLIMIT
         # memoryLimit: 512MB
 
         # Configures how many files are kept open by RocksDB, per default it is unlimited (-1).
         # This is a performance optimization: if you set a value greater than zero, it will keep track and cap the number of open
         # files in the TableCache. On accessing the files it needs to look them up in the cache.
         # You should configure this property if the maximum open files are limited on your system, or if you have thousands of files in your RocksDB state as there is a memory overhead to keeping all of them open, and setting maxOpenFiles will bound that.
-        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MAX_OPEN_FILES
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MAXOPENFILES
         # maxOpenFiles: -1
+
+        # Configures the maximum number of simultaneous write buffers/memtables RocksDB will have in memory. Normally about 2/3s of the memoryLimit
+        # is used by the write buffers, and this is shared equally by each write buffers. This means the higher maxWriteBufferNumber is, the less
+        # memory is available for each. This means you will flush less data at once, but may flush more often.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MAXWRITEBUFFERNUMBER
+        # maxWriteBufferNumber: 6
+
+        # Configures how many write buffers should be full before they are merged and flushed to disk. Having a higher number here means you may
+        # flush less often, but will flush more data at once. Have a lower one means flushing more often, but flushing less data at once.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_MINWRITEBUFFERNUMBERTOMERGE
+        # minWriteBufferNumberToMerge: 3
+
+        # Configures a rate limit for write I/O of RocksDB. Setting any value less than or equal to 0 will disable this, which is the default setting.
+        # Setting a rate limit on the write I/O can help achieve more stable performance by avoiding write spikes consuming all available IOPS, leading to
+        # more predictable read rates.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_IORATEBYTESPERSECOND
+        # ioRateBytesPerSecond: 0
+
+        # Configures if the RocksDB write-ahead-log is used or not. By default, every write in RocksDB goes to the active write buffer and the WAL; this
+        # helps recover a RocksDB instance should it crash before the write buffer is flushed. Zeebe however only recovers from specific point-in-time snapshot,
+        # and never from a previously active RocksDB instance, which makes it a good candidate to disable the WAL. It's currently disabled by default as
+        # performance is a bit less predictable when disabling the WAL.
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ROCKSDB_DISABLEWAL
+        # disableWal: false

--- a/engine/src/main/java/io/zeebe/engine/state/DefaultZeebeDbFactory.java
+++ b/engine/src/main/java/io/zeebe/engine/state/DefaultZeebeDbFactory.java
@@ -39,7 +39,8 @@ public final class DefaultZeebeDbFactory {
    */
   public static ZeebeDbFactory<ZbColumnFamilies> defaultFactory(
       final Properties userProvidedColumnFamilyOptions) {
-    return defaultFactory(RocksDbConfiguration.of(userProvidedColumnFamilyOptions));
+    return defaultFactory(
+        new RocksDbConfiguration().setColumnFamilyOptions(userProvidedColumnFamilyOptions));
   }
 
   /**

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -13,10 +13,18 @@ public final class RocksDbConfiguration {
 
   public static final long DEFAULT_MEMORY_LIMIT = 512 * 1024 * 1024L;
   public static final int DEFAULT_UNLIMITED_MAX_OPEN_FILES = -1;
+  public static final int DEFAULT_MAX_WRITE_BUFFER_NUMBER = 6;
+  public static final int DEFAULT_MIN_WRITE_BUFFER_NUMBER_TO_MERGE = 3;
+  public static final boolean DEFAULT_STATISTICS_ENABLED = false;
+  public static final boolean DEFAULT_WAL_DISABLED = false;
+  public static final int DEFAULT_IO_RATE_BYTES_PER_SECOND = 0;
 
-  private final Properties columnFamilyOptions;
-  private final boolean statisticsEnabled;
-  private final long memoryLimit;
+  private Properties columnFamilyOptions = new Properties();
+  private boolean statisticsEnabled = DEFAULT_STATISTICS_ENABLED;
+  private long memoryLimit = DEFAULT_MEMORY_LIMIT;
+  private int maxWriteBufferNumber = DEFAULT_MAX_WRITE_BUFFER_NUMBER;
+  private int minWriteBufferNumberToMerge = DEFAULT_MIN_WRITE_BUFFER_NUMBER_TO_MERGE;
+  private boolean walDisabled = DEFAULT_WAL_DISABLED;
 
   /**
    * Defines how many files are kept open by RocksDB, per default it is unlimited (-1). This is done
@@ -25,58 +33,91 @@ public final class RocksDbConfiguration {
    *
    * <p>https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide#general-options
    */
-  private final int maxOpenFiles;
+  private int maxOpenFiles = DEFAULT_UNLIMITED_MAX_OPEN_FILES;
 
-  private RocksDbConfiguration(
-      final Properties columnFamilyOptions,
-      final boolean statisticsEnabled,
-      final long memoryLimit,
-      final int maxOpenFiles) {
-    this.columnFamilyOptions = columnFamilyOptions;
-    this.statisticsEnabled = statisticsEnabled;
-    this.memoryLimit = memoryLimit;
-    this.maxOpenFiles = maxOpenFiles;
-  }
+  /**
+   * Allows limiting the rate of I/O writes by RocksDB. This affects all writes performed by
+   * RocksDB, including flushing, compaction, WAL, etc. It can be useful to configure to prevent
+   * write spikes from affecting reads, thereby achieving a more predictable performance.
+   *
+   * <p>Setting to 0 (the default) or less will disable any rate limiting.
+   *
+   * <p>https://github.com/facebook/rocksdb/wiki/Rate-Limiter
+   */
+  private int ioRateBytesPerSecond = DEFAULT_IO_RATE_BYTES_PER_SECOND;
 
-  public static RocksDbConfiguration empty() {
-    return of(new Properties());
-  }
-
-  public static RocksDbConfiguration of(final Properties properties) {
-    return of(properties, false);
-  }
-
-  public static RocksDbConfiguration of(
-      final Properties properties, final boolean statisticsEnabled) {
-    return of(properties, statisticsEnabled, DEFAULT_MEMORY_LIMIT);
-  }
-
-  public static RocksDbConfiguration of(
-      final Properties properties, final boolean statisticsEnabled, final long memoryLimit) {
-    return of(properties, statisticsEnabled, memoryLimit, DEFAULT_UNLIMITED_MAX_OPEN_FILES);
-  }
-
-  public static RocksDbConfiguration of(
-      final Properties properties,
-      final boolean statisticsEnabled,
-      final long memoryLimit,
-      final int maxOpenFiles) {
-    return new RocksDbConfiguration(properties, statisticsEnabled, memoryLimit, maxOpenFiles);
-  }
+  public RocksDbConfiguration() {}
 
   public Properties getColumnFamilyOptions() {
     return columnFamilyOptions;
+  }
+
+  public RocksDbConfiguration setColumnFamilyOptions(final Properties columnFamilyOptions) {
+    this.columnFamilyOptions = columnFamilyOptions;
+    return this;
   }
 
   public boolean isStatisticsEnabled() {
     return statisticsEnabled;
   }
 
+  public RocksDbConfiguration setStatisticsEnabled(final boolean statisticsEnabled) {
+    this.statisticsEnabled = statisticsEnabled;
+    return this;
+  }
+
   public long getMemoryLimit() {
     return memoryLimit;
   }
 
+  public RocksDbConfiguration setMemoryLimit(final long memoryLimit) {
+    this.memoryLimit = memoryLimit;
+    return this;
+  }
+
   public int getMaxOpenFiles() {
     return maxOpenFiles;
+  }
+
+  public RocksDbConfiguration setMaxOpenFiles(final int maxOpenFiles) {
+    this.maxOpenFiles = maxOpenFiles;
+    return this;
+  }
+
+  public int getMaxWriteBufferNumber() {
+    return maxWriteBufferNumber;
+  }
+
+  public RocksDbConfiguration setMaxWriteBufferNumber(final int maxWriteBufferNumber) {
+    this.maxWriteBufferNumber = maxWriteBufferNumber;
+    return this;
+  }
+
+  public int getMinWriteBufferNumberToMerge() {
+    return minWriteBufferNumberToMerge;
+  }
+
+  public RocksDbConfiguration setMinWriteBufferNumberToMerge(
+      final int minWriteBufferNumberToMerge) {
+    this.minWriteBufferNumberToMerge = minWriteBufferNumberToMerge;
+    return this;
+  }
+
+  public int getIoRateBytesPerSecond() {
+    return ioRateBytesPerSecond;
+  }
+
+  public RocksDbConfiguration setIoRateBytesPerSecond(final int ioRateBytesPerSecond) {
+    this.ioRateBytesPerSecond = ioRateBytesPerSecond;
+    return this;
+  }
+
+  public boolean isWalDisabled() {
+    return walDisabled;
+  }
+
+  public RocksDbConfiguration setWalDisabled(final boolean walDisabled) {
+    this.walDisabled = walDisabled;
+    return this;
   }
 }

--- a/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -74,7 +74,8 @@ public final class ZeebeRocksDbFactoryTest {
         (ZeebeRocksDbFactory<DefaultColumnFamily>) ZeebeRocksDbFactory.newFactory();
     final var factoryWithCustomOptions =
         (ZeebeRocksDbFactory<DefaultColumnFamily>)
-            ZeebeRocksDbFactory.newFactory(RocksDbConfiguration.of(customProperties));
+            ZeebeRocksDbFactory.newFactory(
+                new RocksDbConfiguration().setColumnFamilyOptions(customProperties));
 
     // when
     final var defaults = factoryWithDefaults.createColumnFamilyOptions(new ArrayList<>());
@@ -106,7 +107,8 @@ public final class ZeebeRocksDbFactoryTest {
 
     final var factoryWithCustomOptions =
         (ZeebeRocksDbFactory<DefaultColumnFamily>)
-            ZeebeRocksDbFactory.newFactory(RocksDbConfiguration.of(customProperties));
+            ZeebeRocksDbFactory.newFactory(
+                new RocksDbConfiguration().setColumnFamilyOptions(customProperties));
 
     // expect
     assertThatThrownBy(


### PR DESCRIPTION
## Description

This PR exposes further configuration for RocksDB:

- Disabling usage of the write-ahead-log
- Rate limiting write I/O for RocksDB only
- Setting the maximum number of write buffers to create
- Setting the minimum number of writer buffers to fill before merging and flushing

Since the constructor would now become quite big, it also converts the `RocksDbConfiguration` object from immutable to mutable, and with all setters using a chainable API.

## Related issues

closes #6161 
closes #6261

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [x] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
