### PR TITLE
Restore processing positions on reprocessing

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.processing.streamprocessor;
 import io.zeebe.db.TransactionContext;
 import io.zeebe.db.ZeebeDbTransaction;
 import io.zeebe.engine.metrics.StreamProcessorMetrics;
+import io.zeebe.engine.processing.streamprocessor.StreamProcessor.Positions;
 import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriterImpl;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
@@ -478,10 +479,17 @@ public final class ProcessingStateMachine {
     return !onErrorHandlingLoop;
   }
 
-  public void startProcessing(final long lastReprocessedPosition) {
+  public void startProcessing(final Positions restoredPositions) {
+
     if (lastSuccessfulProcessedEventPosition == StreamProcessor.UNSET_POSITION) {
-      lastSuccessfulProcessedEventPosition = lastReprocessedPosition;
+      lastSuccessfulProcessedEventPosition = restoredPositions.getLastSuccessfulProcessedPosition();
     }
+
+    if (lastWrittenEventPosition == StreamProcessor.UNSET_POSITION) {
+      lastWrittenEventPosition = restoredPositions.getLastWrittenPositions();
+      writtenEventPosition = lastWrittenEventPosition;
+    }
+
     actor.submit(this::readNextEvent);
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStatePropertyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStatePropertyTest.java
@@ -99,6 +99,7 @@ public class ReplayStatePropertyTest {
             () ->
                 assertThat(engineRule.getStreamProcessor(1).getCurrentPhase().join())
                     .isEqualTo(Phase.PROCESSING));
+    waitForProcessingToStop();
 
     // then
     final var replayState = engineRule.collectState();

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorReprocessingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorReprocessingTest.java
@@ -603,11 +603,13 @@ public final class StreamProcessorReprocessingTest {
   }
 
   @Test
-  public void shouldUpdateLastProcessedPositionAfterReprocessing() throws Exception {
+  public void shouldRestorePositionsAfterReprocessing() throws Exception {
     // given
     final long firstPosition =
         streamProcessorRule.writeWorkflowInstanceEvent(ELEMENT_ACTIVATING, 1);
-    streamProcessorRule.writeWorkflowInstanceEventWithSource(ELEMENT_ACTIVATED, 1, firstPosition);
+    final long secondPosition =
+        streamProcessorRule.writeWorkflowInstanceEventWithSource(
+            ELEMENT_ACTIVATED, 1, firstPosition);
 
     waitUntil(
         () ->
@@ -634,6 +636,7 @@ public final class StreamProcessorReprocessingTest {
     recoveredLatch.await();
 
     assertThat(streamProcessor.getLastProcessedPositionAsync().get()).isEqualTo(firstPosition);
+    assertThat(streamProcessor.getLastWrittenPositionAsync().get()).isEqualTo(secondPosition);
   }
 
   @Test


### PR DESCRIPTION
## Description

Restores the last written positions on reprocessing in order to avoid a race condition which we have with our property based testings. See https://github.com/zeebe-io/zeebe/issues/6321
<!-- Please explain the changes you made here. -->


I assigned multiple people, so who ever has time to review it.
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/zeebe-io/zeebe/issues/6321

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
