### PR TITLE
Improve the stability of the replay tests

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingContext.java
@@ -18,6 +18,7 @@ import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.mutable.MutableLastProcessedPositionState;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamReader;
+import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.util.sched.ActorControl;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
@@ -38,6 +39,7 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
 
   private BooleanSupplier abortCondition;
   private Consumer<TypedRecord> onProcessedListener = record -> {};
+  private Consumer<LoggedEvent> onSkippedListener = record -> {};
   private int maxFragmentSize;
   private boolean detectReprocessingInconsistency;
 
@@ -94,6 +96,11 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
 
   public ProcessingContext onProcessedListener(final Consumer<TypedRecord> onProcessedListener) {
     this.onProcessedListener = onProcessedListener;
+    return this;
+  }
+
+  public ProcessingContext onSkippedListener(final Consumer<LoggedEvent> onSkippedListener) {
+    this.onSkippedListener = onSkippedListener;
     return this;
   }
 
@@ -178,6 +185,10 @@ public final class ProcessingContext implements ReadonlyProcessingContext {
 
   public Consumer<TypedRecord> getOnProcessedListener() {
     return onProcessedListener;
+  }
+
+  public Consumer<LoggedEvent> getOnSkippedListener() {
+    return onSkippedListener;
   }
 
   public boolean isDetectReprocessingInconsistency() {

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStatePropertyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStatePropertyTest.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.processing.streamprocessor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.zeebe.engine.processing.streamprocessor.StreamProcessor.Phase;
+import io.zeebe.engine.state.ZbColumnFamilies;
 import io.zeebe.engine.util.EngineRule;
 import io.zeebe.engine.util.WorkflowExecutor;
 import io.zeebe.model.bpmn.BpmnModelInstance;
@@ -23,6 +24,7 @@ import io.zeebe.test.util.record.RecordingExporter;
 import java.util.Collection;
 import org.assertj.core.api.SoftAssertions;
 import org.awaitility.Awaitility;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,11 +38,22 @@ public class ReplayStatePropertyTest {
   private static final int WORKFLOW_COUNT = 5;
   private static final int EXECUTION_PATH_COUNT = 5;
 
-  @Rule public final EngineRule engineRule = EngineRule.singlePartition();
+  @Rule
+  public final EngineRule engineRule =
+      EngineRule.singlePartition()
+          .withOnProcessedCallback(record -> lastProcessedPosition = record.getPosition())
+          .withOnSkippedCallback(record -> lastProcessedPosition = record.getPosition());
 
   @Parameter public TestDataRecord record;
 
   private final WorkflowExecutor workflowExecutor = new WorkflowExecutor(engineRule);
+
+  private long lastProcessedPosition = -1L;
+
+  @Before
+  public void init() {
+    lastProcessedPosition = -1L;
+  }
 
   /**
    * This test takes a random workflow and execution path in that workflow. A process instance is
@@ -75,11 +88,8 @@ public class ReplayStatePropertyTest {
 
     final var position = result.getPosition();
 
-    Awaitility.await()
-        .until(
-            () ->
-                engineRule.getStreamProcessor(1).getLastProcessedPositionAsync().join()
-                    == position);
+    Awaitility.await("await the last workflow record to be processed")
+        .untilAsserted(() -> assertThat(lastProcessedPosition).isEqualTo(position));
 
     stopAndRestartEngineAndCompareStates();
   }
@@ -87,6 +97,8 @@ public class ReplayStatePropertyTest {
   private void stopAndRestartEngineAndCompareStates() {
     // given
     waitForProcessingToStop();
+
+    engineRule.pauseProcessing(1);
 
     final var processingState = engineRule.collectState();
     engineRule.stop();
@@ -105,45 +117,35 @@ public class ReplayStatePropertyTest {
 
     final var softly = new SoftAssertions();
 
-    processingState.forEach(
-        (column, processingEntries) -> {
-          final var replayEntries = replayState.get(column);
+    processingState.entrySet().stream()
+        .filter(entry -> entry.getKey() != ZbColumnFamilies.DEFAULT)
+        .forEach(
+            entry -> {
+              final var column = entry.getKey();
+              final var processingEntries = entry.getValue();
+              final var replayEntries = replayState.get(column);
 
-          if (processingEntries.isEmpty()) {
-            softly
-                .assertThat(replayEntries)
-                .describedAs("The state column '%s' should be empty after replay", column)
-                .isEmpty();
-          } else {
-            softly
-                .assertThat(replayEntries)
-                .describedAs("The state column '%s' has different entries after replay", column)
-                .containsExactlyInAnyOrderEntriesOf(processingEntries);
-          }
-        });
+              if (processingEntries.isEmpty()) {
+                softly
+                    .assertThat(replayEntries)
+                    .describedAs("The state column '%s' should be empty after replay", column)
+                    .isEmpty();
+              } else {
+                softly
+                    .assertThat(replayEntries)
+                    .describedAs("The state column '%s' has different entries after replay", column)
+                    .containsExactlyInAnyOrderEntriesOf(processingEntries);
+              }
+            });
 
     softly.assertAll();
   }
 
   private void waitForProcessingToStop() {
-    final var lastWrittenPosition =
-        engineRule.getStreamProcessor(1).getLastWrittenPositionAsync().join();
-
-    /* the last written position is -1 directly after a replay and before new records are being
-     * written. In this state we don't need to wait at all. In all other states we wait until the
-     * processed position has advanced to the last written position */
-    if (lastWrittenPosition != -1) {
-      Awaitility.await()
-          .untilAsserted(
-              () -> {
-                final var processed =
-                    engineRule.getStreamProcessor(1).getLastProcessedPositionAsync().join();
-                final var written =
-                    engineRule.getStreamProcessor(1).getLastWrittenPositionAsync().join();
-
-                assertThat(written).isEqualTo(processed);
-              });
-    }
+    Awaitility.await("await the last written record to be processed")
+        .untilAsserted(
+            () ->
+                assertThat(lastProcessedPosition).isEqualTo(engineRule.getLastWrittenPosition(1)));
   }
 
   @Parameters(name = "{0}")

--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -187,6 +187,10 @@ public final class StreamProcessorRule implements TestRule {
     return streamProcessingComposite.getLastSuccessfulProcessedRecordPosition();
   }
 
+  public long getLastWrittenPosition(final int partitionId) {
+    return streams.getLastWrittenPosition(getLogName(partitionId));
+  }
+
   public RecordStream events() {
     return new RecordStream(streams.events(getLogName(startPartitionId)));
   }

--- a/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
+++ b/engine/src/test/java/io/zeebe/engine/util/TestStreams.java
@@ -137,7 +137,7 @@ public final class TestStreams {
         logStream -> listLogStorage.setPositionListener(logStream::setCommitPosition));
   }
 
-  public SynchronousLogStream createLogStream(
+  private SynchronousLogStream createLogStream(
       final String name,
       final int partitionId,
       final LogStorage logStorage,
@@ -157,6 +157,11 @@ public final class TestStreams {
     closeables.manage(logContext);
     closeables.manage(() -> logContextMap.remove(name));
     return logStream;
+  }
+
+  public long getLastWrittenPosition(final String name) {
+    // the position of a written record is directly committed, we can use it as a synonym
+    return getLogStream(name).getCommitPosition();
   }
 
   public SynchronousLogStream getLogStream(final String name) {


### PR DESCRIPTION
## Description

* get the last written position directly from the stream to capture also records that are not written by a processor (e.g. timers, message TTL checker, etc.)
* get the last processed position from a stream processor callback that is invoked after processed or skipped a record to capture follow-up events that may be skipped (e.g. `MessageSubscription:OPENED`)
* ignore the last-processed-position column in the replay tests since we will not restore this position on replay eventually

## Related issues

closes #6321

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
