### PR TITLE
chore(journal): improve journal module test coverage

### DIFF
--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalReader.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalReader.java
@@ -36,7 +36,6 @@ class SegmentedJournalReader implements JournalReader {
   private void initialize() {
     currentSegment = journal.getFirstSegment();
     currentReader = currentSegment.createReader();
-    final long nextIndex = journal.getFirstIndex();
   }
 
   public long getCurrentIndex() {

--- a/journal/src/test/java/io/zeebe/journal/file/JournalReaderTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/JournalReaderTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.Namespaces;
+import io.zeebe.journal.JournalReader;
+import io.zeebe.journal.JournalRecord;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class JournalReaderTest {
+
+  private static final int ENTRIES = 4;
+  @TempDir Path directory;
+  private final Namespace namespace =
+      new Namespace.Builder()
+          .register(Namespaces.BASIC)
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+          .register(PersistedJournalRecord.class)
+          .register(UnsafeBuffer.class)
+          .name("Journal")
+          .build();
+  private final DirectBuffer data = new UnsafeBuffer("test".getBytes(StandardCharsets.UTF_8));
+  private final int entrySize =
+      namespace.serialize(new PersistedJournalRecord(1, 1, Integer.MAX_VALUE, data)).length
+          + Integer.BYTES;
+  private JournalReader reader;
+  private SegmentedJournal journal;
+
+  @BeforeEach
+  public void setup() {
+    journal =
+        SegmentedJournal.builder()
+            .withDirectory(directory.resolve("data").toFile())
+            .withMaxSegmentSize(entrySize * ENTRIES / 2 + JournalSegmentDescriptor.BYTES)
+            .withMaxEntrySize(entrySize)
+            .withJournalIndexDensity(5)
+            .build();
+    reader = journal.openReader();
+  }
+
+  @Test
+  public void shouldSeek() {
+    // when
+    for (int i = 1; i <= ENTRIES; i++) {
+      journal.append(i, data).index();
+    }
+    reader.seek(2);
+
+    // then
+    for (int i = 0; i < 3; i++) {
+      final JournalRecord record = reader.next();
+      assertThat(record.asqn()).isEqualTo(2 + i);
+      assertThat(record.index()).isEqualTo(2 + i);
+      assertThat(record.data()).isEqualTo(data);
+    }
+    assertThat(reader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldSeekToFirst() {
+    // when
+    long firstIndex = -1;
+    for (int i = 1; i <= ENTRIES; i++) {
+      final long index = journal.append(i, data).index();
+      if (firstIndex == -1) {
+        firstIndex = index;
+      }
+    }
+    reader.next(); // move reader before seekToFirst
+    reader.next();
+    reader.seekToFirst();
+
+    // then
+    final JournalRecord record = reader.next();
+    assertThat(record.index()).isEqualTo(firstIndex);
+    assertThat(record.asqn()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldSeekToLast() {
+    // when
+    long lastIndex = -1;
+    for (int i = 1; i <= ENTRIES; i++) {
+      lastIndex = journal.append(i, data).index();
+    }
+    reader.seekToLast();
+
+    // then
+    final JournalRecord record = reader.next();
+    assertThat(record.index()).isEqualTo(lastIndex);
+    assertThat(record.asqn()).isEqualTo(4);
+    assertThat(reader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldNotReadIfSeekIsHigherThanLast() {
+    // when
+    for (int i = 1; i <= ENTRIES; i++) {
+      journal.append(i, data).index();
+    }
+    reader.seek(99L);
+
+    // then
+    assertThat(reader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldReadAppendedDataAfterSeek() {
+    // when
+    for (int i = 0; i < ENTRIES; i++) {
+      journal.append(data).index();
+    }
+
+    reader.seek(99L);
+    assertThat(reader.hasNext()).isFalse();
+    journal.append(data);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+  }
+
+  @Test
+  public void shouldSeekToAsqn() {
+    // given
+    long asqn = 10;
+    JournalRecord lastRecordWritten = null;
+    for (int i = 1; i <= ENTRIES; i++) {
+      final JournalRecord record = journal.append(asqn++, data);
+      assertThat(record.index()).isEqualTo(i);
+      lastRecordWritten = record;
+    }
+    assertThat(reader.hasNext()).isTrue();
+
+    // when
+    reader.seekToAsqn(lastRecordWritten.asqn() - 2);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    assertThat(reader.next().asqn()).isEqualTo(lastRecordWritten.asqn() - 2);
+  }
+
+  @Test
+  public void shouldSeekToHighestAsqnLowerThanProvidedAsqn() {
+    // given
+    final var expectedRecord = journal.append(1, data);
+    journal.append(5, data);
+
+    // when
+    reader.seekToAsqn(4);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    final var record = reader.next();
+    assertThat(record.index()).isEqualTo(expectedRecord.index());
+    assertThat(record.asqn()).isEqualTo(expectedRecord.asqn());
+    assertThat(record.data()).isEqualTo(expectedRecord.data());
+    assertThat(record.checksum()).isEqualTo(expectedRecord.checksum());
+  }
+
+  @Test
+  @Disabled("https://github.com/zeebe-io/zeebe/issues/6358")
+  public void shouldSeekToHighestLowerAsqnEvenIfRecordHasNone() {
+    // given
+    final var expectedRecord = journal.append(1, data);
+    journal.append(data);
+    journal.append(5, data);
+
+    // when
+    reader.seekToAsqn(3);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    final var record = reader.next();
+    assertThat(record.index()).isEqualTo(expectedRecord.index());
+    assertThat(record.asqn()).isEqualTo(expectedRecord.asqn());
+    assertThat(record.data()).isEqualTo(expectedRecord.data());
+    assertThat(record.checksum()).isEqualTo(expectedRecord.checksum());
+  }
+
+  @Test
+  public void shouldSeekToNonExistentAsqn() {
+    // given
+    final var expectedRecord = journal.append(data);
+    journal.append(5, data);
+
+    // when
+    reader.seekToAsqn(1);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    final var record = reader.next();
+    assertThat(record.index()).isEqualTo(expectedRecord.index());
+    assertThat(record.asqn()).isEqualTo(expectedRecord.asqn());
+    assertThat(record.data()).isEqualTo(expectedRecord.data());
+    assertThat(record.checksum()).isEqualTo(expectedRecord.checksum());
+
+    assertThat(reader.next().asqn()).isEqualTo(5);
+  }
+
+  @Test
+  public void shouldSeekToFirstIfLowerThanFirst() {
+    // when
+    long firstIndex = -1;
+    for (int i = 1; i <= ENTRIES; i++) {
+      final long index = journal.append(i, data).index();
+
+      if (firstIndex == -1) {
+        firstIndex = index;
+      }
+    }
+    reader.seek(-1);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    final JournalRecord record = reader.next();
+    assertThat(record.asqn()).isEqualTo(1);
+    assertThat(record.index()).isEqualTo(firstIndex);
+    assertThat(record.data()).isEqualTo(data);
+  }
+
+  @Test
+  public void shouldSeekAfterTruncate() {
+    // when
+    long lastIndex = -1;
+    for (int i = 1; i <= ENTRIES; i++) {
+      lastIndex = journal.append(i, data).index();
+    }
+    journal.deleteAfter(lastIndex - 2);
+    reader.seek(lastIndex - 2);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    assertThat(reader.next().index()).isEqualTo(lastIndex - 2);
+    assertThat(reader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldSeekAfterCompact() {
+    // when
+    journal.append(1, data).index();
+    journal.append(2, data).index();
+    journal.append(3, data).index();
+    journal.deleteUntil(3);
+    reader.seek(1);
+
+    // then
+    final JournalRecord next = reader.next();
+    assertThat(next.index()).isEqualTo(3);
+    assertThat(next.asqn()).isEqualTo(3);
+    assertThat(reader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldSeekToIndex() {
+    // given
+    long asqn = 1;
+    JournalRecord lastRecordWritten = null;
+    for (int i = 1; i <= ENTRIES; i++) {
+      final JournalRecord record = journal.append(asqn++, data);
+      assertThat(record.index()).isEqualTo(i);
+      lastRecordWritten = record;
+    }
+    assertThat(reader.hasNext()).isTrue();
+
+    // when - compact up to the first index of segment 3
+    reader.seek(lastRecordWritten.index() - 1);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    assertThat(reader.next().index()).isEqualTo(lastRecordWritten.index() - 1);
+  }
+}

--- a/journal/src/test/java/io/zeebe/journal/file/JournalTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/JournalTest.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.Namespaces;
+import io.zeebe.journal.Journal;
+import io.zeebe.journal.JournalReader;
+import io.zeebe.journal.JournalRecord;
+import io.zeebe.journal.StorageException.InvalidChecksum;
+import io.zeebe.journal.StorageException.InvalidIndex;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class JournalTest {
+
+  @TempDir Path directory;
+  private final Namespace namespace =
+      new Namespace.Builder()
+          .register(Namespaces.BASIC)
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+          .register(PersistedJournalRecord.class)
+          .register(UnsafeBuffer.class)
+          .name("Journal")
+          .build();
+  private byte[] entry;
+  private final DirectBuffer data = new UnsafeBuffer();
+  private Journal journal;
+
+  @BeforeEach
+  public void setup() {
+    entry = "TestData".getBytes();
+    data.wrap(entry);
+
+    final int entrySize = getSerializedSize(data);
+    final int entriesPerSegment = 10;
+    journal = openJournal(entrySize, entriesPerSegment);
+  }
+
+  @Test
+  public void shouldBeEmpty() {
+    // when-then
+    assertThat(journal.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void shouldNotBeEmpty() {
+    // given
+    journal.append(1, data);
+
+    // when-then
+    assertThat(journal.isEmpty()).isFalse();
+  }
+
+  @Test
+  public void shouldAppendData() {
+    // when
+    final var recordAppended = journal.append(1, data);
+    assertThat(recordAppended.index()).isEqualTo(1);
+    assertThat(recordAppended.asqn()).isEqualTo(1);
+
+    // then
+    final var recordRead = journal.openReader().next();
+    assertThat(recordAppended.index()).isEqualTo(recordRead.index());
+    assertThat(recordAppended.asqn()).isEqualTo(recordRead.asqn());
+    assertThat(recordAppended.checksum()).isEqualTo(recordRead.checksum());
+  }
+
+  @Test
+  public void shouldAppendMultipleRecords() {
+    // when
+    for (int i = 0; i < 10; i++) {
+      final var recordAppended = journal.append(i + 10, data);
+      assertThat(recordAppended.index()).isEqualTo(i + 1);
+    }
+
+    // then
+    final var reader = journal.openReader();
+    for (int i = 0; i < 10; i++) {
+      assertThat(reader.hasNext()).isTrue();
+      final var recordRead = reader.next();
+      assertThat(recordRead.index()).isEqualTo(i + 1);
+      final byte[] data = new byte[recordRead.data().capacity()];
+      recordRead.data().getBytes(0, data);
+      assertThat(recordRead.asqn()).isEqualTo(i + 10);
+      assertThat(data).containsExactly(entry);
+    }
+  }
+
+  @Test
+  public void shouldAppendAndReadMultipleRecords() {
+    final var reader = journal.openReader();
+    for (int i = 0; i < 10; i++) {
+      // given
+      entry = ("TestData" + i).getBytes();
+      data.wrap(entry);
+
+      // when
+      final var recordAppended = journal.append(i + 10, data);
+      assertThat(recordAppended.index()).isEqualTo(i + 1);
+
+      // then
+      assertThat(reader.hasNext()).isTrue();
+      final var recordRead = reader.next();
+      assertThat(recordRead.index()).isEqualTo(i + 1);
+      final byte[] data = new byte[recordRead.data().capacity()];
+      recordRead.data().getBytes(0, data);
+      assertThat(recordRead.asqn()).isEqualTo(i + 10);
+      assertThat(data).containsExactly(entry);
+    }
+  }
+
+  @Test
+  public void shouldReset() {
+    // given
+    long asqn = 1;
+    assertThat(journal.getLastIndex()).isEqualTo(0);
+    journal.append(asqn++, data);
+    journal.append(asqn++, data);
+
+    // when
+    journal.reset(2);
+
+    // then
+    assertThat(journal.isEmpty()).isTrue();
+    assertThat(journal.getLastIndex()).isEqualTo(1);
+    final var record = journal.append(asqn++, data);
+    assertThat(record.index()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldResetWhileReading() {
+    // given
+    final var reader = journal.openReader();
+    long asqn = 1;
+    assertThat(journal.getLastIndex()).isEqualTo(0);
+    journal.append(asqn++, data);
+    journal.append(asqn++, data);
+    final var record1 = reader.next();
+    assertThat(record1.index()).isEqualTo(1);
+
+    // when
+    journal.reset(2);
+
+    // then
+    assertThat(journal.getLastIndex()).isEqualTo(1);
+    final var record = journal.append(asqn++, data);
+    assertThat(record.index()).isEqualTo(2);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    final var record2 = reader.next();
+    assertThat(record2.index()).isEqualTo(2);
+    assertThat(record2.asqn()).isEqualTo(record.asqn());
+  }
+
+  @Test
+  public void shouldWriteToTruncatedIndex() {
+    // given
+    final var reader = journal.openReader();
+    assertThat(journal.getLastIndex()).isEqualTo(0);
+    journal.append(1, data);
+    journal.append(2, data);
+    journal.append(3, data);
+    final var record1 = reader.next();
+    assertThat(record1.index()).isEqualTo(1);
+
+    // when
+    journal.deleteAfter(1);
+
+    // then
+    assertThat(journal.getLastIndex()).isEqualTo(1);
+    final var record = journal.append(4, data);
+    assertThat(record.index()).isEqualTo(2);
+    assertThat(record.asqn()).isEqualTo(4);
+    assertThat(reader.hasNext()).isTrue();
+
+    final var newRecord = reader.next();
+    assertThat(newRecord.index()).isEqualTo(record.index());
+    assertThat(newRecord.asqn()).isEqualTo(record.asqn());
+    assertThat(newRecord.data()).isEqualTo(record.data());
+  }
+
+  @Test
+  public void shouldTruncate() {
+    // given
+    final var reader = journal.openReader();
+    assertThat(journal.getLastIndex()).isEqualTo(0);
+    journal.append(1, data);
+    journal.append(2, data);
+    journal.append(3, data);
+    final var record1 = reader.next();
+    assertThat(record1.index()).isEqualTo(1);
+
+    // when
+    journal.deleteAfter(1);
+
+    // then
+    assertThat(journal.getLastIndex()).isEqualTo(1);
+    assertThat(reader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldNotReadTruncatedEntries() {
+    // given
+    final int totalWrites = 10;
+    final int truncateIndex = 5;
+    int asqn = 1;
+    final Map<Integer, JournalRecord> written = new HashMap<>();
+
+    final var reader = journal.openReader();
+
+    int writerIndex;
+    for (writerIndex = 1; writerIndex <= totalWrites; writerIndex++) {
+      final var record = journal.append(asqn++, data);
+      assertThat(record.index()).isEqualTo(writerIndex);
+      written.put(writerIndex, record);
+    }
+
+    int readerIndex;
+    for (readerIndex = 1; readerIndex <= truncateIndex; readerIndex++) {
+      assertThat(reader.hasNext()).isTrue();
+      final var record = reader.next();
+      assertThat(record.index()).isEqualTo(readerIndex);
+      assertThat(record.asqn()).isEqualTo(written.get(readerIndex).asqn());
+    }
+
+    // when
+    journal.deleteAfter(truncateIndex);
+
+    for (writerIndex = truncateIndex + 1; writerIndex <= totalWrites; writerIndex++) {
+      final var record = journal.append(asqn++, data);
+      assertThat(record.index()).isEqualTo(writerIndex);
+      written.put(writerIndex, record);
+    }
+
+    // then
+    for (; readerIndex <= totalWrites; readerIndex++) {
+      assertThat(reader.hasNext()).isTrue();
+      final var record = reader.next();
+      assertThat(record.index()).isEqualTo(readerIndex);
+      assertThat(record.asqn()).isEqualTo(written.get(readerIndex).asqn());
+    }
+  }
+
+  @Test
+  public void shouldAppendJournalRecord() {
+    // given
+    final var receiverJournal =
+        SegmentedJournal.builder()
+            .withDirectory(directory.resolve("data-2").toFile())
+            .withJournalIndexDensity(5)
+            .build();
+    final var record = journal.append(10, data);
+
+    // when
+    receiverJournal.append(record);
+
+    // then
+    final var reader = receiverJournal.openReader();
+    assertThat(reader.hasNext()).isTrue();
+    assertThat(reader.next().asqn()).isEqualTo(10);
+  }
+
+  @Test
+  public void shouldNotAppendRecordWithAlreadyAppendedIndex() {
+    // given
+    final var record = journal.append(1, data);
+    journal.append(data);
+
+    // when/then
+    assertThatThrownBy(() -> journal.append(record)).isInstanceOf(InvalidIndex.class);
+  }
+
+  @Test
+  public void shouldNotAppendRecordWithGapInIndex() {
+    // given
+    final var receiverJournal =
+        SegmentedJournal.builder()
+            .withDirectory(directory.resolve("data-2").toFile())
+            .withJournalIndexDensity(5)
+            .build();
+    journal.append(1, data);
+    final var record = journal.append(1, data);
+
+    // when/then
+    assertThatThrownBy(() -> receiverJournal.append(record)).isInstanceOf(InvalidIndex.class);
+  }
+
+  @Test
+  public void shouldNotAppendLastRecord() {
+    // given
+    final var record = journal.append(1, data);
+
+    // when/then
+    assertThatThrownBy(() -> journal.append(record)).isInstanceOf(InvalidIndex.class);
+  }
+
+  @Test
+  public void shouldNotAppendRecordWithInvalidChecksum() {
+    // given
+    final var receiverJournal =
+        SegmentedJournal.builder()
+            .withDirectory(directory.resolve("data-2").toFile())
+            .withJournalIndexDensity(5)
+            .build();
+    final var record = journal.append(1, data);
+
+    // when
+    final var invalidChecksumRecord =
+        new PersistedJournalRecord(record.index(), record.asqn(), -1, record.data());
+
+    // then
+    assertThatThrownBy(() -> receiverJournal.append(invalidChecksumRecord))
+        .isInstanceOf(InvalidChecksum.class);
+  }
+
+  @Test
+  public void shouldReturnFirstIndex() {
+    // when
+    final long firstIndex = journal.append(data).index();
+    journal.append(data);
+
+    // then
+    assertThat(journal.getFirstIndex()).isEqualTo(firstIndex);
+  }
+
+  @Test
+  public void shouldReturnLastIndex() {
+    // when
+    journal.append(data);
+    final long lastIndex = journal.append(data).index();
+
+    // then
+    assertThat(journal.getLastIndex()).isEqualTo(lastIndex);
+  }
+
+  @Test
+  public void shouldOpenAndClose() throws Exception {
+    // when/then
+    assertThat(journal.isOpen()).isTrue();
+    journal.close();
+    assertThat(journal.isOpen()).isFalse();
+  }
+
+  @Test
+  public void shouldReadReopenedJournal() throws Exception {
+    // when
+    final long index = journal.append(data).index();
+    journal.close();
+    assertThat(journal.isOpen()).isFalse();
+    journal = openJournal(getSerializedSize(data), 2);
+    final JournalReader reader = journal.openReader();
+
+    // then
+    assertThat(journal.isOpen()).isTrue();
+    assertThat(reader.hasNext()).isTrue();
+
+    final JournalRecord record = reader.next();
+    assertThat(record.index()).isEqualTo(index);
+    assertThat(record.data()).isEqualTo(data);
+  }
+
+  private int getSerializedSize(final DirectBuffer data) {
+    return namespace.serialize(new PersistedJournalRecord(1, 1, Integer.MAX_VALUE, data)).length
+        + Integer.BYTES;
+  }
+
+  private SegmentedJournal openJournal(final int entrySize, final int entriesPerSegment) {
+    return SegmentedJournal.builder()
+        .withDirectory(directory.resolve("data").toFile())
+        .withMaxSegmentSize(entriesPerSegment * entrySize + JournalSegmentDescriptor.BYTES)
+        .withJournalIndexDensity(5)
+        .build();
+  }
+}

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.Namespaces;
+import io.zeebe.journal.JournalReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class SegmentedJournalReaderTest {
+
+  private static final int ENTRIES_PER_SEGMENT = 2;
+  @TempDir Path directory;
+  private final Namespace namespace =
+      new Namespace.Builder()
+          .register(Namespaces.BASIC)
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+          .register(PersistedJournalRecord.class)
+          .register(UnsafeBuffer.class)
+          .name("Journal")
+          .build();
+  private final DirectBuffer data = new UnsafeBuffer("test".getBytes(StandardCharsets.UTF_8));
+  private final int entrySize =
+      namespace.serialize(new PersistedJournalRecord(1, 1, Integer.MAX_VALUE, data)).length
+          + Integer.BYTES;
+  private JournalReader reader;
+  private SegmentedJournal journal;
+
+  @BeforeEach
+  public void setup() {
+    journal =
+        SegmentedJournal.builder()
+            .withDirectory(directory.resolve("data").toFile())
+            .withMaxSegmentSize(entrySize * ENTRIES_PER_SEGMENT + JournalSegmentDescriptor.BYTES)
+            .withMaxEntrySize(entrySize)
+            .withJournalIndexDensity(5)
+            .build();
+    reader = journal.openReader();
+  }
+
+  @Test
+  public void shouldReadAfterCompact() {
+    // given
+    final int entriesPerSegment = 10;
+    long asqn = 1;
+
+    for (int i = 1; i <= entriesPerSegment * 5; i++) {
+      assertThat(journal.append(asqn++, data).index()).isEqualTo(i);
+    }
+    assertThat(reader.hasNext()).isTrue();
+
+    // when - compact up to the first index of segment 3
+    final int indexToCompact = entriesPerSegment * 2 + 1;
+    journal.deleteUntil(indexToCompact);
+
+    // then
+    assertThat(reader.hasNext()).isTrue();
+    assertThat(reader.next().index()).isEqualTo(indexToCompact);
+  }
+}

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
@@ -16,370 +16,40 @@
 package io.zeebe.journal.file;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Namespaces;
+import io.zeebe.journal.JournalReader;
 import io.zeebe.journal.JournalRecord;
-import io.zeebe.journal.StorageException.InvalidChecksum;
-import io.zeebe.journal.StorageException.InvalidIndex;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class SegmentedJournalTest {
 
   @TempDir Path directory;
-  final DirectBuffer data = new UnsafeBuffer();
-  private SegmentedJournal journal;
-  private byte[] entry;
-  private int entriesPerSegment;
+  private final Namespace namespace =
+      new Namespace.Builder()
+          .register(Namespaces.BASIC)
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+          .register(PersistedJournalRecord.class)
+          .register(UnsafeBuffer.class)
+          .name("Journal")
+          .build();
   private final int journalIndexDensity = 5;
-
-  @BeforeEach
-  public void setup() {
-    final var namespace =
-        new Namespace.Builder()
-            .register(Namespaces.BASIC)
-            .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
-            .register(PersistedJournalRecord.class)
-            .register(UnsafeBuffer.class)
-            .name("Journal")
-            .build();
-
-    entry = "TestData".getBytes();
-    data.wrap(entry);
-
-    final var entrySize =
-        namespace.serialize(new PersistedJournalRecord(1, 1, Integer.MAX_VALUE, data)).length
-            + Integer.BYTES;
-    entriesPerSegment = 10;
-
-    journal =
-        SegmentedJournal.builder()
-            .withDirectory(directory.resolve("data").toFile())
-            .withMaxSegmentSize(entriesPerSegment * entrySize + JournalSegmentDescriptor.BYTES)
-            .withJournalIndexDensity(journalIndexDensity)
-            .build();
-  }
-
-  @Test
-  public void shouldBeEmpty() {
-    // when-then
-    assertThat(journal.isEmpty()).isTrue();
-  }
-
-  @Test
-  public void shouldNotBeEmpty() {
-    // given
-    journal.append(1, data);
-
-    // when-then
-    assertThat(journal.isEmpty()).isFalse();
-  }
-
-  @Test
-  public void shouldAppendData() {
-    // when
-    final var recordAppended = journal.append(1, data);
-    assertThat(recordAppended.index()).isEqualTo(1);
-    assertThat(recordAppended.asqn()).isEqualTo(1);
-
-    // then
-    final var recordRead = journal.openReader().next();
-    assertThat(recordAppended.index()).isEqualTo(recordRead.index());
-    assertThat(recordAppended.asqn()).isEqualTo(recordRead.asqn());
-    assertThat(recordAppended.checksum()).isEqualTo(recordRead.checksum());
-  }
-
-  @Test
-  public void shouldAppendMultipleRecords() {
-    // when
-    for (int i = 0; i < 10; i++) {
-      final var recordAppended = journal.append(i + 10, data);
-      assertThat(recordAppended.index()).isEqualTo(i + 1);
-    }
-
-    // then
-    final var reader = journal.openReader();
-    for (int i = 0; i < 10; i++) {
-      assertThat(reader.hasNext()).isTrue();
-      final var recordRead = reader.next();
-      assertThat(recordRead.index()).isEqualTo(i + 1);
-      final byte[] data = new byte[recordRead.data().capacity()];
-      recordRead.data().getBytes(0, data);
-      assertThat(recordRead.asqn()).isEqualTo(i + 10);
-      assertThat(data).containsExactly(entry);
-    }
-  }
-
-  @Test
-  public void shouldAppendAndReadMultipleRecords() {
-    final var reader = journal.openReader();
-    for (int i = 0; i < 10; i++) {
-      // given
-      entry = ("TestData" + i).getBytes();
-      data.wrap(entry);
-
-      // when
-      final var recordAppended = journal.append(i + 10, data);
-      assertThat(recordAppended.index()).isEqualTo(i + 1);
-
-      // then
-      assertThat(reader.hasNext()).isTrue();
-      final var recordRead = reader.next();
-      assertThat(recordRead.index()).isEqualTo(i + 1);
-      final byte[] data = new byte[recordRead.data().capacity()];
-      recordRead.data().getBytes(0, data);
-      assertThat(recordRead.asqn()).isEqualTo(i + 10);
-      assertThat(data).containsExactly(entry);
-    }
-  }
-
-  @Test
-  public void shouldReset() {
-    // given
-    long asqn = 1;
-    assertThat(journal.getLastIndex()).isEqualTo(0);
-    journal.append(asqn++, data);
-    journal.append(asqn++, data);
-
-    // when
-    journal.reset(2);
-
-    // then
-    assertThat(journal.getLastIndex()).isEqualTo(1);
-    final var record = journal.append(asqn++, data);
-    assertThat(record.index()).isEqualTo(2);
-  }
-
-  @Test
-  public void shouldResetWhileReading() {
-    // given
-    final var reader = journal.openReader();
-    long asqn = 1;
-    assertThat(journal.getLastIndex()).isEqualTo(0);
-    journal.append(asqn++, data);
-    journal.append(asqn++, data);
-    final var record1 = reader.next();
-    assertThat(record1.index()).isEqualTo(1);
-
-    // when
-    journal.reset(2);
-
-    // then
-    assertThat(journal.getLastIndex()).isEqualTo(1);
-    final var record = journal.append(asqn++, data);
-    assertThat(record.index()).isEqualTo(2);
-
-    // then
-    assertThat(reader.hasNext()).isTrue();
-    final var record2 = reader.next();
-    assertThat(record2.index()).isEqualTo(2);
-    assertThat(record2.asqn()).isEqualTo(record.asqn());
-  }
-
-  @Test
-  public void shouldTruncate() {
-    // given
-    final var reader = journal.openReader();
-    assertThat(journal.getLastIndex()).isEqualTo(0);
-    journal.append(1, data);
-    journal.append(2, data);
-    journal.append(3, data);
-    final var record1 = reader.next();
-    assertThat(record1.index()).isEqualTo(1);
-
-    // when
-    journal.deleteAfter(2);
-
-    // then - should write after the truncated index
-    assertThat(journal.getLastIndex()).isEqualTo(2);
-    final var record = journal.append(4, data);
-    assertThat(record.index()).isEqualTo(3);
-
-    // then
-    assertThat(reader.hasNext()).isTrue();
-    final var record2 = reader.next();
-    assertThat(record2.index()).isEqualTo(2);
-    assertThat(record2.asqn()).isEqualTo(2);
-    assertThat(reader.hasNext()).isTrue();
-
-    // then - should not read truncated entry
-    final var record3 = reader.next();
-    assertThat(record3.index()).isEqualTo(3);
-    assertThat(record3.asqn()).isEqualTo(4);
-  }
-
-  @Test
-  public void shouldNotReadTruncatedEntries() {
-    // given
-    final int totalWrites = 10;
-    final int truncateIndex = 5;
-    int asqn = 1;
-    final Map<Integer, JournalRecord> written = new HashMap<>();
-
-    final var reader = journal.openReader();
-
-    int writerIndex;
-    for (writerIndex = 1; writerIndex <= totalWrites; writerIndex++) {
-      final var record = journal.append(asqn++, data);
-      assertThat(record.index()).isEqualTo(writerIndex);
-      written.put(writerIndex, record);
-    }
-
-    int readerIndex;
-    for (readerIndex = 1; readerIndex <= truncateIndex; readerIndex++) {
-      assertThat(reader.hasNext()).isTrue();
-      final var record = reader.next();
-      assertThat(record.index()).isEqualTo(readerIndex);
-      assertThat(record.asqn()).isEqualTo(written.get(readerIndex).asqn());
-    }
-
-    // when
-    journal.deleteAfter(truncateIndex);
-
-    for (writerIndex = truncateIndex + 1; writerIndex <= totalWrites; writerIndex++) {
-      final var record = journal.append(asqn++, data);
-      assertThat(record.index()).isEqualTo(writerIndex);
-      written.put(writerIndex, record);
-    }
-
-    for (; readerIndex <= totalWrites; readerIndex++) {
-      assertThat(reader.hasNext()).isTrue();
-      final var record = reader.next();
-      assertThat(record.index()).isEqualTo(readerIndex);
-      assertThat(record.asqn()).isEqualTo(written.get(readerIndex).asqn());
-    }
-  }
-
-  @Test
-  public void shouldReadAfterCompact() {
-    // given
-    final var reader = journal.openReader();
-    long asqn = 1;
-
-    for (int i = 1; i <= entriesPerSegment * 5; i++) {
-      assertThat(journal.append(asqn++, data).index()).isEqualTo(i);
-    }
-    assertThat(reader.hasNext()).isTrue();
-
-    // when - compact up to the first index of segment 3
-    final int indexToCompact = entriesPerSegment * 2 + 1;
-    journal.deleteUntil(indexToCompact);
-
-    // then
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.next().index()).isEqualTo(indexToCompact);
-  }
-
-  @Test
-  public void shouldSeekToIndex() {
-    // given
-    final var reader = journal.openReader();
-    long asqn = 1;
-    JournalRecord lastRecordWritten = null;
-    for (int i = 1; i <= entriesPerSegment * 2; i++) {
-      final JournalRecord record = journal.append(asqn++, data);
-      assertThat(record.index()).isEqualTo(i);
-      lastRecordWritten = record;
-    }
-    assertThat(reader.hasNext()).isTrue();
-
-    // when - compact up to the first index of segment 3
-    reader.seek(lastRecordWritten.index() - 1);
-
-    // then
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.next().index()).isEqualTo(lastRecordWritten.index() - 1);
-  }
-
-  @Test
-  public void shouldSeekToAsqn() {
-    // given
-    final var reader = journal.openReader();
-    long asqn = 10;
-    JournalRecord lastRecordWritten = null;
-    for (int i = 1; i <= entriesPerSegment * 2; i++) {
-      final JournalRecord record = journal.append(asqn++, data);
-      assertThat(record.index()).isEqualTo(i);
-      lastRecordWritten = record;
-    }
-    assertThat(reader.hasNext()).isTrue();
-
-    // when
-    reader.seekToAsqn(lastRecordWritten.asqn() - 2);
-
-    // then
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.next().asqn()).isEqualTo(lastRecordWritten.asqn() - 2);
-  }
-
-  @Test
-  public void shouldAppendJournalRecord() {
-    // given
-    final var receiverJournal =
-        SegmentedJournal.builder()
-            .withDirectory(directory.resolve("data-2").toFile())
-            .withJournalIndexDensity(5)
-            .build();
-    final var record = journal.append(10, data);
-
-    // when
-    receiverJournal.append(record);
-
-    // then
-    final var reader = receiverJournal.openReader();
-    assertThat(reader.hasNext()).isTrue();
-    assertThat(reader.next().asqn()).isEqualTo(10);
-  }
-
-  @Test
-  public void shouldNotAppendRecordWithInvalidIndex() {
-    // given
-    final var receiverJournal =
-        SegmentedJournal.builder()
-            .withDirectory(directory.resolve("data-2").toFile())
-            .withJournalIndexDensity(5)
-            .build();
-    final var record = journal.append(1, data);
-    receiverJournal.append(record);
-
-    // when
-    final var invalidIndexRecord = record;
-
-    // then
-    assertThatThrownBy(() -> receiverJournal.append(invalidIndexRecord))
-        .isInstanceOf(InvalidIndex.class);
-  }
-
-  @Test
-  public void shouldNotAppendRecordWithInvalidChecksum() {
-    // given
-    final var receiverJournal =
-        SegmentedJournal.builder()
-            .withDirectory(directory.resolve("data-2").toFile())
-            .withJournalIndexDensity(5)
-            .build();
-    final var record = journal.append(1, data);
-
-    // when
-    final var invalidChecksumRecord =
-        new PersistedJournalRecord(record.index(), record.asqn(), -1, record.data());
-
-    // then
-    assertThatThrownBy(() -> receiverJournal.append(invalidChecksumRecord))
-        .isInstanceOf(InvalidChecksum.class);
-  }
+  private final DirectBuffer data = new UnsafeBuffer("test".getBytes(StandardCharsets.UTF_8));
+  private final int entrySize =
+      namespace.serialize(new PersistedJournalRecord(1, 1, Integer.MAX_VALUE, data)).length
+          + Integer.BYTES;
 
   @Test
   public void shouldDeleteIndexMappingsOnReset() {
     // given
+    final SegmentedJournal journal = openJournal(10);
+
     long asqn = 1;
     // append until there are two index mappings
     for (int i = 0; i < 2 * journalIndexDensity; i++) {
@@ -399,7 +69,9 @@ public class SegmentedJournalTest {
   @Test
   public void shouldUpdateIndexMappingsOnCompact() {
     // given
+    final int entriesPerSegment = 10;
     long asqn = 1;
+    final SegmentedJournal journal = openJournal(entriesPerSegment);
     for (int i = 0; i < 3 * entriesPerSegment; i++) {
       journal.append(asqn++, data);
     }
@@ -416,10 +88,13 @@ public class SegmentedJournalTest {
   @Test
   public void shouldUpdateIndexMappingsOnTruncate() {
     // given
+    final int entriesPerSegment = 10;
     long asqn = 1;
+    final SegmentedJournal journal = openJournal(entriesPerSegment);
     for (int i = 0; i < 2 * journalIndexDensity; i++) {
       journal.append(asqn++, data);
     }
+
     assertThat(journal.getJournalIndex().lookup(journalIndexDensity)).isNotNull();
     assertThat(journal.getJournalIndex().lookup(2 * journalIndexDensity).index())
         .isEqualTo(2 * journalIndexDensity);
@@ -431,5 +106,245 @@ public class SegmentedJournalTest {
     assertThat(journal.getJournalIndex().lookup(journalIndexDensity)).isNotNull();
     assertThat(journal.getJournalIndex().lookup(2 * journalIndexDensity).index())
         .isEqualTo(journalIndexDensity);
+  }
+
+  @Test
+  public void shouldCreateNewSegmentIfEntryExceedsBuffer() {
+    // given
+    final int asqn = 1;
+    // one entry fits but not two
+    final SegmentedJournal journal = openJournal(1.5f);
+
+    final JournalReader reader = journal.openReader();
+
+    // when
+    for (int i = 0; i < 2; i++) {
+      journal.append(asqn + i, data);
+    }
+
+    // then
+    assertThat(journal.getFirstSegment()).isNotEqualTo(journal.getLastSegment());
+
+    for (int i = 0; i < 2; i++) {
+      assertThat(reader.hasNext()).isTrue();
+      final JournalRecord entry = reader.next();
+      assertThat(entry.asqn()).isEqualTo(asqn + i);
+      assertThat(entry.data()).isEqualTo(data);
+    }
+  }
+
+  @Test
+  public void shouldNotTruncateIfIndexIsHigherThanLast() {
+    // given
+    final int asqn = 1;
+    final SegmentedJournal journal = openJournal(1);
+    final JournalReader reader = journal.openReader();
+
+    // when
+    long lastIndex = -1;
+    for (int i = 0; i < 2; i++) {
+      lastIndex = journal.append(asqn + i, data).index();
+    }
+    journal.deleteAfter(lastIndex);
+
+    // then
+    for (int i = 0; i < 2; i++) {
+      assertThat(reader.hasNext()).isTrue();
+      final JournalRecord entry = reader.next();
+      assertThat(entry.asqn()).isEqualTo(asqn + i);
+      assertThat(entry.data()).isEqualTo(data);
+    }
+  }
+
+  @Test
+  public void shouldNotCompactIfIndexIsLowerThanFirst() {
+    // given
+    final int asqn = 1;
+    final SegmentedJournal journal = openJournal(1.5f);
+    final JournalReader reader = journal.openReader();
+
+    // when
+    final long firstIndex = journal.append(asqn, data).index();
+    journal.append(asqn + 1, data);
+    journal.deleteUntil(firstIndex);
+
+    // then
+    for (int i = 0; i < 2; i++) {
+      assertThat(reader.hasNext()).isTrue();
+      final JournalRecord entry = reader.next();
+      assertThat(entry.asqn()).isEqualTo(asqn + i);
+      assertThat(entry.data()).isEqualTo(data);
+      assertThat(entry.index()).isEqualTo(firstIndex + i);
+    }
+  }
+
+  @Test
+  public void shouldTruncateNextEntry() {
+    // given
+    final SegmentedJournal journal = openJournal(2);
+    final JournalReader reader = journal.openReader();
+
+    // when
+    final long first = journal.append(1, data).index();
+    journal.append(2, data).index();
+    journal.append(3, data).index();
+
+    assertThat(reader.next().index()).isEqualTo(first);
+    journal.deleteAfter(first);
+
+    // then
+    assertThat(reader.hasNext()).isFalse();
+  }
+
+  @Test
+  public void shouldTruncateReadEntry() {
+    // given
+    final SegmentedJournal journal = openJournal(2);
+    final JournalReader reader = journal.openReader();
+
+    // when
+    final long first = journal.append(1, data).index();
+    journal.append(2, data).index();
+
+    assertThat(reader.hasNext()).isTrue();
+    journal.deleteAfter(first - 1);
+
+    // then
+    assertThat(reader.hasNext()).isFalse();
+    assertThat(journal.getLastIndex()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldTruncateNextSegment() {
+    // given
+    final SegmentedJournal journal = openJournal(1);
+    final JournalReader reader = journal.openReader();
+
+    // when
+    final long firstIndex = journal.append(1, data).index();
+    journal.append(2, data);
+    journal.deleteAfter(firstIndex);
+
+    // then
+    assertThat(reader.next().index()).isEqualTo(firstIndex);
+    assertThat(reader.hasNext()).isFalse();
+    assertThat(journal.getLastIndex()).isEqualTo(firstIndex);
+  }
+
+  @Test
+  public void shouldReadSegmentStartAfterMidSegmentTruncate() {
+    final int entryPerSegment = 2;
+    final SegmentedJournal journal = openJournal(2);
+    final JournalReader reader = journal.openReader();
+
+    // when
+    long lastIndex = -1;
+    for (int i = 0; i < entryPerSegment * 2; i++) {
+      lastIndex = journal.append(i + 1, data).index();
+    }
+    journal.deleteAfter(lastIndex - 1);
+
+    // then
+    assertThat(reader.seek(lastIndex - 1)).isTrue();
+    assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
+    assertThat(journal.getLastIndex()).isEqualTo(lastIndex - 1);
+  }
+
+  @Test
+  public void shouldCompactUpToStartOfSegment() {
+    final int entryPerSegment = 2;
+    final SegmentedJournal journal = openJournal(entryPerSegment);
+    final JournalReader reader = journal.openReader();
+
+    // when
+    long lastIndex = -1;
+    for (int i = 0; i < entryPerSegment * 2; i++) {
+      lastIndex = journal.append(i + 1, data).index();
+    }
+    assertThat(reader.hasNext()).isTrue();
+    journal.deleteUntil(lastIndex);
+
+    // then
+    assertThat(journal.getFirstIndex()).isEqualTo(lastIndex - 1);
+    assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
+  }
+
+  @Test
+  public void shouldReturnCorrectFirstIndexAfterCompaction() {
+    final int entryPerSegment = 2;
+    final SegmentedJournal journal = openJournal(2);
+
+    // when
+    long lastIndex = -1;
+    for (int i = 0; i < entryPerSegment * 2; i++) {
+      lastIndex = journal.append(i + 1, data).index();
+    }
+    journal.deleteUntil(lastIndex);
+
+    // then
+    assertThat(journal.getFirstIndex()).isEqualTo(lastIndex - 1);
+  }
+
+  @Test
+  public void shouldWriteAndReadAfterTruncate() {
+    final SegmentedJournal journal = openJournal(2);
+    final JournalReader reader = journal.openReader();
+
+    // when
+    final long first = journal.append(1, data).index();
+    journal.append(2, data);
+    journal.deleteAfter(first - 1);
+    data.wrap("new".getBytes());
+    final long last = journal.append(3, data).index();
+
+    // then
+    assertThat(first).isEqualTo(last);
+
+    assertThat(reader.hasNext()).isTrue();
+    final JournalRecord record = reader.next();
+    assertThat(record.index()).isEqualTo(last);
+    assertThat(record.asqn()).isEqualTo(3);
+    assertThat(record.data()).isEqualTo(data);
+  }
+
+  @Test
+  public void shouldAppendEntriesOfDifferentSizesOverSegmentSize() {
+    // given
+    data.wrap("1234567890".getBytes(StandardCharsets.UTF_8));
+    final int entrySize =
+        namespace.serialize(new PersistedJournalRecord(1, 1, Integer.MAX_VALUE, data)).length
+            + Integer.BYTES;
+    final SegmentedJournal journal = openJournal(1, entrySize);
+    final JournalReader reader = journal.openReader();
+
+    // when
+    data.wrap("12345".getBytes(StandardCharsets.UTF_8));
+    journal.append(data);
+    data.wrap("1234567".getBytes(StandardCharsets.UTF_8));
+    journal.append(data);
+    data.wrap("1234567890".getBytes(StandardCharsets.UTF_8));
+    journal.append(data);
+
+    // then
+    data.wrap("12345".getBytes(StandardCharsets.UTF_8));
+    assertThat(reader.next().data()).isEqualTo(data);
+    data.wrap("1234567".getBytes(StandardCharsets.UTF_8));
+    assertThat(reader.next().data()).isEqualTo(data);
+    data.wrap("1234567890".getBytes(StandardCharsets.UTF_8));
+    assertThat(reader.next().data()).isEqualTo(data);
+    assertThat(reader.hasNext()).isFalse();
+  }
+
+  private SegmentedJournal openJournal(final float entriesPerSegment) {
+    return openJournal(entriesPerSegment, entrySize);
+  }
+
+  private SegmentedJournal openJournal(final float entriesPerSegment, final int entrySize) {
+    return SegmentedJournal.builder()
+        .withDirectory(directory.resolve("data").toFile())
+        .withMaxSegmentSize((int) (entrySize * entriesPerSegment) + JournalSegmentDescriptor.BYTES)
+        .withMaxEntrySize(entrySize)
+        .withJournalIndexDensity(journalIndexDensity)
+        .build();
   }
 }


### PR DESCRIPTION
## Description

The JournalTest contains tests which are generally unaware of the segmented implementation of the journal. The SegmentedJournalTest is aware of segments and tests corner cases accordingly. The JournalReader tests the reader API especially the parts that aren't used in other tests.

## Related issues

closes #6222

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
