### PR TITLE
Generate workflows with intermediate message events

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/message/PublishMessageProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/PublishMessageProcessor.java
@@ -107,7 +107,7 @@ public final class PublishMessageProcessor implements TypedRecordProcessor<Messa
     sideEffect.accept(this::sendCorrelateCommand);
 
     if (messageRecord.getTimeToLive() > 0L) {
-      final Message message = newMessage(messageKey, messageRecord);
+      final Message message = newMessage(messageKey, messageRecord, command.getTimestamp());
       messageState.put(message);
 
       // avoid correlating this message to the workflow again
@@ -199,7 +199,8 @@ public final class PublishMessageProcessor implements TypedRecordProcessor<Messa
     return success ? responseWriter.flush() : false;
   }
 
-  private Message newMessage(final long messageKey, final MessageRecord messageRecord) {
+  private Message newMessage(
+      final long messageKey, final MessageRecord messageRecord, final long publishedTimestamp) {
     return new Message(
         messageKey,
         messageRecord.getNameBuffer(),
@@ -207,6 +208,6 @@ public final class PublishMessageProcessor implements TypedRecordProcessor<Messa
         messageRecord.getVariablesBuffer(),
         messageRecord.getMessageIdBuffer(),
         messageRecord.getTimeToLive(),
-        messageRecord.getTimeToLive() + ActorClock.currentTimeMillis());
+        publishedTimestamp + messageRecord.getTimeToLive());
   }
 }

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/TestDataGenerator.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/TestDataGenerator.java
@@ -49,7 +49,7 @@ public class TestDataGenerator {
   }
 
   public static TestDataRecord regenerateTestRecord(
-      final int workflowSeed, final int executionPathSeed) {
+      final long workflowSeed, final long executionPathSeed) {
     final RandomWorkflowGenerator generator =
         new RandomWorkflowGenerator(workflowSeed, null, null, null);
 

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -28,13 +28,7 @@ public class BlockSequenceBuilder implements BlockBuilder {
   private static final List<BlockBuilderFactory> BLOCK_BUILDER_FACTORIES =
       Arrays.asList(
           new ServiceTaskBlockBuilder.Factory(),
-          // new IntermediateMessageCatchEventBlockBuilder.Factory(),
-          /* The logic for IntermediateMessageCatchEventBlockBuilder is not fully implemented yet.
-           * the logic to generate a workflow and execution path is sound. What is incomplete
-           * is the execution logic of the corresponding execution step. What is missing there is
-           * that after publishing the message, the process should wait until the message has been
-           * correlated.
-           */
+          new IntermediateMessageCatchEventBlockBuilder.Factory(),
           new SubProcessBlockBuilder.Factory(),
           new ExclusiveGatewayBlockBuilder.Factory(),
           new ParallelGatewayBlockBuilder.Factory());
@@ -66,6 +60,7 @@ public class BlockSequenceBuilder implements BlockBuilder {
     }
   }
 
+  @Override
   public AbstractFlowNodeBuilder<?, ?> buildFlowNodes(
       final AbstractFlowNodeBuilder<?, ?> nodeBuilder) {
     AbstractFlowNodeBuilder<?, ?> workflowWorkInProgress = nodeBuilder;


### PR DESCRIPTION
## Description

* generate and execute workflows that contains an intermediate message event
* make the message deadline deterministic based on the command timestamp 
  * otherwise, the deadline is different after reprocessing which would fail the tests  
* print the generator test data if a test fails to make it reproducible

## Related issues

Preparation for #6178

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
