### PR TITLE
Remove RaftLogReader#isEmpty

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
@@ -28,10 +28,6 @@ public class RaftLogReader implements java.util.Iterator<Indexed<RaftLogEntry>>,
     this.delegate = delegate;
   }
 
-  public boolean isEmpty() {
-    return delegate.isEmpty();
-  }
-
   public long getFirstIndex() {
     return delegate.getFirstIndex();
   }

--- a/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
@@ -25,19 +25,26 @@ public final class AtomixLogStorageReader implements LogStorageReader {
     this.zeebeIndexMapping = zeebeIndexMapping;
   }
 
+  /**
+   * Naive implementation that reads the whole log to check for a {@link ZeebeEntry}. Most of the
+   * log should be made of these, so in practice this should be fast enough, however callers should
+   * take care when calling this method.
+   *
+   * <p>The reader will be positioned either at the end of the log, or at the position of the first
+   * {@link ZeebeEntry} encountered, such that reading the next entry will return the entry after
+   * it.
+   *
+   * @return true if there are no {@link ZeebeEntry}, false otherwise
+   */
   @Override
   public boolean isEmpty() {
-    if (!reader.isEmpty()) {
-      // although seemingly inefficient, the log will contain mostly ZeebeEntry entries and a few
-      // InitialEntry, so this should be rather fast in practice
-      reader.reset();
-      while (reader.hasNext()) {
-        if (reader.next().type() == ZeebeEntry.class) {
-          return false;
-        }
+    reader.reset();
+
+    while (reader.hasNext()) {
+      if (reader.next().type() == ZeebeEntry.class) {
+        return false;
       }
     }
-
     return true;
   }
 


### PR DESCRIPTION
## Description

This PR removes `RaftLogReader#isEmpty` in order to simplify #6307. It removes the call to check if the journal is empty and simply scans the log for `ZeebeEntry`. This is a naive implementation which may be slow, however in practice the log is made up of mostly `ZeebeEntry`, or it's empty - in which case it should return fairly quickly.

## Related issues

related to #6307

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
