### PR TITLE
Remove RaftLogReader#getNextIndex

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -212,7 +212,6 @@ public final class RaftMemberContext {
 
   @Override
   public String toString() {
-    final RaftLogReader reader = this.reader;
     return toStringHelper(this)
         .add("member", member.memberId())
         .add("term", term)
@@ -221,7 +220,6 @@ public final class RaftMemberContext {
         .add("nextSnapshotIndex", nextSnapshotIndex)
         .add("nextSnapshotChunk", nextSnapshotChunk)
         .add("matchIndex", matchIndex)
-        .add("nextIndex", reader != null ? reader.getNextIndex() : matchIndex + 1)
         .add("heartbeatTime", heartbeatTime)
         .add("appending", inFlightAppendCount)
         .add("appendSucceeded", appendSucceeded)

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractAppender.java
@@ -327,10 +327,8 @@ abstract class AbstractAppender implements AutoCloseable {
   }
 
   private void resetNextIndex(final RaftMemberContext member, final long nextIndex) {
-    if (member.getLogReader().getNextIndex() != nextIndex) {
-      member.getLogReader().reset(nextIndex);
-      log.trace("Reset next index for {} to {}", member, nextIndex);
-    }
+    member.getLogReader().reset(nextIndex);
+    log.trace("Reset next index for {} to {}", member, nextIndex);
   }
 
   /** Resets the snapshot index of the member when a response fails. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -477,9 +477,7 @@ public class PassiveRole extends InactiveRole {
     // If the previous log index is less than the last written entry index, look up the entry.
     if (request.prevLogIndex() < lastEntryIndex) {
       // Reset the reader to the previous log index.
-      if (reader.getNextIndex() != request.prevLogIndex()) {
-        reader.reset(request.prevLogIndex());
-      }
+      reader.reset(request.prevLogIndex());
 
       // The previous entry should exist in the log if we've gotten this far.
       if (!reader.hasNext()) {
@@ -633,9 +631,7 @@ public class PassiveRole extends InactiveRole {
       final Long checksum,
       final long index) {
     // Reset the reader to the current entry index.
-    if (reader.getNextIndex() != index) {
-      reader.reset(index);
-    }
+    reader.reset(index);
 
     // If the reader does not have any next entry, that indicates an inconsistency between
     // the reader and writer.

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
@@ -48,10 +48,6 @@ public class RaftLogReader implements java.util.Iterator<Indexed<RaftLogEntry>>,
     return delegate.getCurrentEntry();
   }
 
-  public long getNextIndex() {
-    return delegate.getNextIndex();
-  }
-
   @Override
   public boolean hasNext() {
     return delegate.hasNext();

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestHelper.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestHelper.java
@@ -21,6 +21,7 @@ import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.storage.log.RaftLogReader.Mode;
+import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.zeebe.ZeebeEntry;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
 import io.atomix.storage.journal.Indexed;
@@ -92,8 +93,11 @@ public class ZeebeTestHelper {
       final RaftPartitionServer partition, final Indexed<ZeebeEntry> indexed) {
     try (final RaftLogReader reader = partition.openReader(indexed.index(), Mode.COMMITS)) {
 
-      if (reader.hasNext() && reader.getNextIndex() == indexed.index()) {
-        return isEntryEqualTo(reader.next().cast(), indexed);
+      if (reader.hasNext()) {
+        final Indexed<RaftLogEntry> entry = reader.next();
+        if (entry.index() == indexed.index()) {
+          return isEntryEqualTo(entry.cast(), indexed);
+        }
       }
     }
 


### PR DESCRIPTION
## Description

In preparation for #6307, this PR removes usages of `RaftLogReader#getNextIndex`. In most cases it gets away with simply taking the last read entry and returning its index + 1, but it was used in some cases to avoid doing seeks when a "next" would be sufficient. This was replaced with always seeking.

This is currently a performance drop, but with the new journal in #6307, seeking to the index you already are at will be a NOOP, so this concern will go away.

## Related issues

related to #6307 
blocks #6307 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
