### PR TITLE
chore(atomix/storage): refactor Raft to not rely on reader state

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -287,7 +287,7 @@ final class LeaderAppender extends AbstractAppender {
   @Override
   protected boolean hasMoreEntries(final RaftMemberContext member) {
     // If the member's nextIndex is an entry in the local log then more entries can be sent.
-    return member.getLogReader().hasNext();
+    return member.hasNextEntry();
   }
 
   /** Handles a {@link io.atomix.raft.protocol.RaftResponse.Status#ERROR} response. */
@@ -347,7 +347,7 @@ final class LeaderAppender extends AbstractAppender {
 
     if (persistedSnapshot != null
         && member.getSnapshotIndex() < persistedSnapshot.getIndex()
-        && persistedSnapshot.getIndex() >= member.getLogReader().getCurrentIndex()) {
+        && persistedSnapshot.getIndex() >= member.getCurrentIndex()) {
       if (!member.canInstall()) {
         return;
       }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
@@ -36,14 +36,6 @@ public class RaftLogReader implements java.util.Iterator<Indexed<RaftLogEntry>>,
     return delegate.getLastIndex();
   }
 
-  public long getCurrentIndex() {
-    return delegate.getCurrentIndex();
-  }
-
-  public Indexed<RaftLogEntry> getCurrentEntry() {
-    return delegate.getCurrentEntry();
-  }
-
   @Override
   public boolean hasNext() {
     return delegate.hasNext();

--- a/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixLogStorageReader.java
@@ -151,13 +151,6 @@ public final class AtomixLogStorageReader implements LogStorageReader {
    * @param index index to seek to
    */
   public Optional<Indexed<ZeebeEntry>> findEntry(final long index) {
-    if (reader.getCurrentIndex() == index) {
-      final var entry = reader.getCurrentEntry();
-      if (entry != null && entry.type().equals(ZeebeEntry.class)) {
-        return Optional.of(reader.getCurrentEntry().cast());
-      }
-    }
-
     // in the future, reset/seek to the same index will be a NOOP so we can just call it all the
     // time; right now it's a bit slow, but we will immediately implement the new journal so this
     // is fine


### PR DESCRIPTION
## Description

Removes usages of `getCurrentEntry` and `getCurrentIndex` from Raft.

## Related issues

related to #6307

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
