### PR TITLE
Add infrastructure to migrate bpmn element processors

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/WorkflowEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/WorkflowEventProcessors.java
@@ -98,6 +98,13 @@ public final class WorkflowEventProcessors {
       final BpmnStreamProcessor bpmnStepProcessor) {
 
     Arrays.stream(WorkflowInstanceIntent.values())
+        .filter(WorkflowInstanceIntent::isElementCommandIntent)
+        .forEach(
+            intent ->
+                typedRecordProcessors.onCommand(
+                    ValueType.WORKFLOW_INSTANCE, intent, bpmnStepProcessor));
+
+    Arrays.stream(WorkflowInstanceIntent.values())
         .filter(WorkflowEventProcessors::isWorkflowInstanceEvent)
         .forEach(
             intent ->

--- a/engine/src/main/java/io/zeebe/engine/processing/WorkflowEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/WorkflowEventProcessors.java
@@ -68,7 +68,7 @@ public final class WorkflowEventProcessors {
         typedRecordProcessors, zeebeState.getElementInstanceState());
 
     final var bpmnStreamProcessor =
-        new BpmnStreamProcessor(expressionProcessor, catchEventBehavior, zeebeState);
+        new BpmnStreamProcessor(expressionProcessor, catchEventBehavior, zeebeState, writers);
     addBpmnStepProcessor(typedRecordProcessors, bpmnStreamProcessor);
 
     addMessageStreamProcessors(

--- a/engine/src/main/java/io/zeebe/engine/processing/WorkflowEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/WorkflowEventProcessors.java
@@ -40,16 +40,8 @@ import io.zeebe.protocol.record.intent.WorkflowInstanceCreationIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceSubscriptionIntent;
 import java.util.Arrays;
-import java.util.List;
 
 public final class WorkflowEventProcessors {
-
-  private static final List<WorkflowInstanceIntent> WORKFLOW_INSTANCE_COMMANDS =
-      Arrays.asList(WorkflowInstanceIntent.CANCEL);
-
-  private static boolean isWorkflowInstanceEvent(final WorkflowInstanceIntent intent) {
-    return !WORKFLOW_INSTANCE_COMMANDS.contains(intent);
-  }
 
   public static TypedRecordProcessor<WorkflowInstanceRecord> addWorkflowProcessors(
       final ZeebeState zeebeState,
@@ -88,9 +80,12 @@ public final class WorkflowEventProcessors {
     final WorkflowInstanceCommandProcessor commandProcessor =
         new WorkflowInstanceCommandProcessor(elementInstanceState);
 
-    WORKFLOW_INSTANCE_COMMANDS.forEach(
-        intent ->
-            typedRecordProcessors.onCommand(ValueType.WORKFLOW_INSTANCE, intent, commandProcessor));
+    Arrays.stream(WorkflowInstanceIntent.values())
+        .filter(WorkflowInstanceIntent::isWorkflowInstanceCommand)
+        .forEach(
+            intent ->
+                typedRecordProcessors.onCommand(
+                    ValueType.WORKFLOW_INSTANCE, intent, commandProcessor));
   }
 
   private static void addBpmnStepProcessor(
@@ -98,14 +93,14 @@ public final class WorkflowEventProcessors {
       final BpmnStreamProcessor bpmnStepProcessor) {
 
     Arrays.stream(WorkflowInstanceIntent.values())
-        .filter(WorkflowInstanceIntent::isElementCommandIntent)
+        .filter(WorkflowInstanceIntent::isBpmnElementCommand)
         .forEach(
             intent ->
                 typedRecordProcessors.onCommand(
                     ValueType.WORKFLOW_INSTANCE, intent, bpmnStepProcessor));
 
     Arrays.stream(WorkflowInstanceIntent.values())
-        .filter(WorkflowEventProcessors::isWorkflowInstanceEvent)
+        .filter(WorkflowInstanceIntent::isBpmnElementEvent)
         .forEach(
             intent ->
                 typedRecordProcessors.onEvent(

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
@@ -24,6 +24,34 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
   Class<T> getType();
 
   /**
+   * The element is about to be entered. Perform every action to initialize and activate the
+   * element.
+   *
+   * <p>If the element is a wait-state (i.e. it is waiting for an event or an external trigger) then
+   * it is waiting after this step to continue. Otherwise, it continues directly to the next step.
+   *
+   * <p>Possible actions:
+   *
+   * <ul>
+   *   <li>apply input mappings
+   *   <li>open event subscriptions
+   *   <li>initialize child elements - if the element is a container (e.g. a sub-process)
+   * </ul>
+   *
+   * Next step:
+   *
+   * <ul>
+   *   <li>activating - the element is initialized
+   *   <li>activated - if no incidents raised
+   *   <li>complete - if no incidents raised & not a wait-state.
+   * </ul>
+   *
+   * @param element the instance of the BPMN element that is executed
+   * @param context workflow instance-related data of the element that is executed
+   */
+  default void onActivate(final T element, final BpmnElementContextImpl context) {}
+
+  /**
    * The element is entered (initial step). Perform every action to initialize the element.
    *
    * <p>Possible actions:
@@ -37,7 +65,9 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    *
    * @param element the instance of the BPMN element that is executed
    * @param context workflow instance-related data of the element that is executed
+   * @deprecated will be replaced by onActivate
    */
+  @Deprecated // todo (#6202): remove method
   void onActivating(final T element, final BpmnElementContext context);
 
   /**
@@ -55,7 +85,9 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    *
    * @param element the instance of the BPMN element that is executed
    * @param context workflow instance-related data of the element that is executed
+   * @deprecated will be replaced by onActivate
    */
+  @Deprecated // todo (#6202): remove method
   void onActivated(final T element, final BpmnElementContext context);
 
   /**

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
@@ -151,6 +151,28 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
   void onCompleted(final T element, final BpmnElementContext context);
 
   /**
+   * The element is going to be terminated. Perform every action to terminate the element and
+   * continue with the element that caused the termination (e.g. the triggered boundary event).
+   *
+   * <p>Possible actions:
+   *
+   * <ul>
+   *   <li>close event subscriptions
+   *   <li>resolve incidents
+   *   <li>activate the triggered boundary event - if any
+   *   <li>activate the triggered event sub-process - if any
+   *   <li>continue with parent element
+   *   <li>clean up the state
+   * </ul>
+   *
+   * Next step: none.
+   *
+   * @param element the instance of the BPMN element that is executed
+   * @param context workflow instance-related data of the element that is executed
+   */
+  default void onTerminate(final T element, final BpmnElementContextImpl context) {}
+
+  /**
    * The element is going to be terminated. Perform every action to terminate the element.
    *
    * <p>Possible actions:
@@ -163,7 +185,9 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    *
    * @param element the instance of the BPMN element that is executed
    * @param context workflow instance-related data of the element that is executed
+   * @deprecated will be replaced by onTerminate
    */
+  @Deprecated // todo (#6202): remove method
   void onTerminating(final T element, final BpmnElementContext context);
 
   /**
@@ -184,7 +208,9 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    *
    * @param element the instance of the BPMN element that is executed
    * @param context workflow instance-related data of the element that is executed
+   * @deprecated will be replaced by onTerminate
    */
+  @Deprecated // todo (#6202): remove method
   void onTerminated(final T element, final BpmnElementContext context);
 
   /**

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
@@ -49,7 +49,7 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @param element the instance of the BPMN element that is executed
    * @param context workflow instance-related data of the element that is executed
    */
-  default void onActivate(final T element, final BpmnElementContextImpl context) {}
+  default void onActivate(final T element, final BpmnElementContext context) {}
 
   /**
    * The element is entered (initial step). Perform every action to initialize the element.
@@ -109,7 +109,7 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @param element the instance of the BPMN element that is executed
    * @param context workflow instance-related data of the element that is executed
    */
-  default void onComplete(final T element, final BpmnElementContextImpl context) {}
+  default void onComplete(final T element, final BpmnElementContext context) {}
 
   /**
    * The element is going to be left. Perform every action to leave the element.
@@ -170,7 +170,7 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @param element the instance of the BPMN element that is executed
    * @param context workflow instance-related data of the element that is executed
    */
-  default void onTerminate(final T element, final BpmnElementContextImpl context) {}
+  default void onTerminate(final T element, final BpmnElementContext context) {}
 
   /**
    * The element is going to be terminated. Perform every action to terminate the element.

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
@@ -91,6 +91,27 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
   void onActivated(final T element, final BpmnElementContext context);
 
   /**
+   * The element is going to be left. Perform every action to leave the element and continue with
+   * the next element.
+   *
+   * <p>Possible actions:
+   *
+   * <ul>
+   *   <li>apply output mappings
+   *   <li>close event subscriptions
+   *   <li>take outgoing sequence flows - if any
+   *   <li>continue with parent element - if no outgoing sequence flows
+   *   <li>clean up the state
+   * </ul>
+   *
+   * Next step: none.
+   *
+   * @param element the instance of the BPMN element that is executed
+   * @param context workflow instance-related data of the element that is executed
+   */
+  default void onComplete(final T element, final BpmnElementContextImpl context) {}
+
+  /**
    * The element is going to be left. Perform every action to leave the element.
    *
    * <p>Possible actions:
@@ -104,7 +125,9 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    *
    * @param element the instance of the BPMN element that is executed
    * @param context workflow instance-related data of the element that is executed
+   * @deprecated will be replaced by onComplete
    */
+  @Deprecated // todo (#6202): remove method
   void onCompleting(final T element, final BpmnElementContext context);
 
   /**
@@ -122,7 +145,9 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    *
    * @param element the instance of the BPMN element that is executed
    * @param context workflow instance-related data of the element that is executed
+   * @deprecated will be replaced by onComplete
    */
+  @Deprecated // todo (#6202): remove method
   void onCompleted(final T element, final BpmnElementContext context);
 
   /**

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -113,7 +113,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<WorkflowI
         break;
       case COMPLETE_ELEMENT:
         if (MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
-          // TODO (saig0): invoke the migrated processor to complete the element
+          processor.onComplete(element, context);
         } else {
           processor.onCompleting(element, context);
         }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.processing.bpmn;
 
 import io.zeebe.engine.Loggers;
 import io.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
+import io.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.zeebe.engine.processing.bpmn.behavior.TypedResponseWriterProxy;
 import io.zeebe.engine.processing.bpmn.behavior.TypedStreamWriterProxy;
 import io.zeebe.engine.processing.common.CatchEventBehavior;
@@ -21,6 +22,7 @@ import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectQueue;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.immutable.WorkflowState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
@@ -41,11 +43,13 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<WorkflowI
   private final WorkflowState workflowState;
   private final BpmnElementProcessors processors;
   private final WorkflowInstanceStateTransitionGuard stateTransitionGuard;
+  private final BpmnStateTransitionBehavior stateTransitionBehavior;
 
   public BpmnStreamProcessor(
       final ExpressionProcessor expressionProcessor,
       final CatchEventBehavior catchEventBehavior,
-      final ZeebeState zeebeState) {
+      final ZeebeState zeebeState,
+      final Writers writers) {
     workflowState = zeebeState.getWorkflowState();
 
     final var bpmnBehaviors =
@@ -56,10 +60,12 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<WorkflowI
             sideEffectQueue,
             zeebeState,
             catchEventBehavior,
-            this::getContainerProcessor);
+            this::getContainerProcessor,
+            writers);
     processors = new BpmnElementProcessors(bpmnBehaviors);
 
     stateTransitionGuard = bpmnBehaviors.stateTransitionGuard();
+    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
   }
 
   private BpmnElementContainerProcessor<ExecutableFlowElement> getContainerProcessor(
@@ -106,21 +112,24 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<WorkflowI
     switch (intent) {
       case ACTIVATE_ELEMENT:
         if (MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
-          processor.onActivate(element, context);
+          final var activatingContext = stateTransitionBehavior.transitionToActivating(context);
+          processor.onActivate(element, activatingContext);
         } else {
           processor.onActivating(element, context);
         }
         break;
       case COMPLETE_ELEMENT:
         if (MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
-          processor.onComplete(element, context);
+          final var completingContext = stateTransitionBehavior.transitionToCompleting(context);
+          processor.onComplete(element, completingContext);
         } else {
           processor.onCompleting(element, context);
         }
         break;
       case TERMINATE_ELEMENT:
         if (MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
-          processor.onTerminate(element, context);
+          final var terminatingContext = stateTransitionBehavior.transitionToTerminating(context);
+          processor.onTerminate(element, terminatingContext);
         } else {
           processor.onTerminating(element, context);
         }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -120,7 +120,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<WorkflowI
         break;
       case TERMINATE_ELEMENT:
         if (MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
-          // TODO (saig0): invoke the migrated processor to terminate the element
+          processor.onTerminate(element, context);
         } else {
           processor.onTerminating(element, context);
         }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -74,6 +74,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<WorkflowI
       final TypedStreamWriter streamWriter,
       final Consumer<SideEffectProducer> sideEffect) {
 
+    // todo (#6202): replace writer proxies by Writers
     // initialize
     streamWriterProxy.wrap(streamWriter);
     responseWriterProxy.wrap(responseWriter, writer -> sideEffectQueue.add(writer::flush));
@@ -105,7 +106,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<WorkflowI
     switch (intent) {
       case ACTIVATE_ELEMENT:
         if (MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
-          // TODO (saig0): invoke the migrated processor to activate the element
+          processor.onActivate(element, context);
         } else {
           processor.onActivating(element, context);
         }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStateTransitionGuard.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStateTransitionGuard.java
@@ -54,6 +54,9 @@ public final class WorkflowInstanceStateTransitionGuard {
 
   private Either<String, ?> checkStateTransition(final BpmnElementContext context) {
     switch (context.getIntent()) {
+      case ACTIVATE_ELEMENT:
+        return Either.right(null);
+
       case ELEMENT_ACTIVATING:
       case ELEMENT_ACTIVATED:
       case ELEMENT_COMPLETING:

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStateTransitionGuard.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStateTransitionGuard.java
@@ -56,6 +56,9 @@ public final class WorkflowInstanceStateTransitionGuard {
     switch (context.getIntent()) {
       case ACTIVATE_ELEMENT:
         return Either.right(null);
+      case COMPLETE_ELEMENT:
+        return hasElementInstanceWithState(context, WorkflowInstanceIntent.ELEMENT_ACTIVATED)
+            .flatMap(ok -> hasActiveFlowScopeInstance(context));
 
       case ELEMENT_ACTIVATING:
       case ELEMENT_ACTIVATED:

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStateTransitionGuard.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStateTransitionGuard.java
@@ -126,7 +126,7 @@ public final class WorkflowInstanceStateTransitionGuard {
       final WorkflowInstanceIntent expectedState,
       final WorkflowInstanceIntent... otherExpected) {
     final var currentState = elementInstance.getState();
-    if (expectedState != currentState || !Arrays.asList(otherExpected).contains(currentState)) {
+    if (expectedState != currentState && !Arrays.asList(otherExpected).contains(currentState)) {
       return Either.left(
           String.format(
               "Expected element instance to be in state '%s' or one of '%s' but was '%s'.",

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -17,6 +17,7 @@ import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffects;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import java.util.function.Function;
@@ -44,7 +45,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final ZeebeState zeebeState,
       final CatchEventBehavior catchEventBehavior,
       final Function<BpmnElementType, BpmnElementContainerProcessor<ExecutableFlowElement>>
-          processorLookup) {
+          processorLookup,
+      final Writers writers) {
 
     this.streamWriter = streamWriter;
     this.expressionBehavior = expressionBehavior;
@@ -59,7 +61,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             stateBehavior,
             new WorkflowEngineMetrics(zeebeState.getPartitionId()),
             stateTransitionGuard,
-            processorLookup);
+            processorLookup,
+            writers);
     eventSubscriptionBehavior =
         new BpmnEventSubscriptionBehavior(
             stateBehavior,

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/Writers.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/Writers.java
@@ -42,4 +42,10 @@ public final class Writers {
   public CommandResponseWriter response() {
     return response;
   }
+
+  // todo (#6202): remove after migrations finished
+  @Deprecated
+  public TypedEventWriter events() {
+    return stream;
+  }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/workflowinstance/CreateWorkflowInstanceProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/workflowinstance/CreateWorkflowInstanceProcessor.java
@@ -12,7 +12,7 @@ import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
 import io.zeebe.engine.Loggers;
 import io.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
-import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.KeyGenerator;
 import io.zeebe.engine.state.deployment.DeployedWorkflow;
@@ -52,7 +52,7 @@ public final class CreateWorkflowInstanceProcessor
   private final MutableElementInstanceState elementInstanceState;
   private final MutableVariableState variablesState;
   private final KeyGenerator keyGenerator;
-  private final StateWriter stateWriter;
+  private final TypedEventWriter eventWriter;
 
   public CreateWorkflowInstanceProcessor(
       final WorkflowState workflowState,
@@ -64,7 +64,7 @@ public final class CreateWorkflowInstanceProcessor
     this.elementInstanceState = elementInstanceState;
     this.variablesState = variablesState;
     this.keyGenerator = keyGenerator;
-    stateWriter = writers.state();
+    eventWriter = writers.events();
   }
 
   @Override
@@ -83,7 +83,7 @@ public final class CreateWorkflowInstanceProcessor
     }
 
     final ElementInstance workflowInstance = createElementInstance(workflow, workflowInstanceKey);
-    stateWriter.appendFollowUpEvent(
+    eventWriter.appendFollowUpEvent(
         workflowInstanceKey,
         WorkflowInstanceIntent.ELEMENT_ACTIVATING,
         workflowInstance.getValue());

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/WorkflowInstanceIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/WorkflowInstanceIntent.java
@@ -16,6 +16,7 @@
 package io.zeebe.protocol.record.intent;
 
 import java.util.EnumSet;
+import java.util.Set;
 
 public enum WorkflowInstanceIntent implements WorkflowInstanceRelatedIntent {
   CANCEL((short) 0, false),
@@ -35,7 +36,8 @@ public enum WorkflowInstanceIntent implements WorkflowInstanceRelatedIntent {
   COMPLETE_ELEMENT((short) 10),
   TERMINATE_ELEMENT((short) 11);
 
-  private static final EnumSet<WorkflowInstanceIntent> ELEMENT_COMMAND_INTENTS =
+  private static final Set<WorkflowInstanceIntent> WORKFLOW_INSTANCE_COMMANDS = EnumSet.of(CANCEL);
+  private static final Set<WorkflowInstanceIntent> BPMN_ELEMENT_COMMANDS =
       EnumSet.of(ACTIVATE_ELEMENT, COMPLETE_ELEMENT, TERMINATE_ELEMENT);
 
   private final short value;
@@ -95,7 +97,15 @@ public enum WorkflowInstanceIntent implements WorkflowInstanceRelatedIntent {
     return shouldBlacklist;
   }
 
-  public static boolean isElementCommandIntent(final WorkflowInstanceIntent intent) {
-    return ELEMENT_COMMAND_INTENTS.contains(intent);
+  public static boolean isWorkflowInstanceCommand(final WorkflowInstanceIntent intent) {
+    return WORKFLOW_INSTANCE_COMMANDS.contains(intent);
+  }
+
+  public static boolean isBpmnElementCommand(final WorkflowInstanceIntent intent) {
+    return BPMN_ELEMENT_COMMANDS.contains(intent);
+  }
+
+  public static boolean isBpmnElementEvent(final WorkflowInstanceIntent intent) {
+    return !isWorkflowInstanceCommand(intent) && !isBpmnElementCommand(intent);
   }
 }

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/WorkflowInstanceIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/WorkflowInstanceIntent.java
@@ -15,6 +15,8 @@
  */
 package io.zeebe.protocol.record.intent;
 
+import java.util.EnumSet;
+
 public enum WorkflowInstanceIntent implements WorkflowInstanceRelatedIntent {
   CANCEL((short) 0, false),
 
@@ -32,6 +34,9 @@ public enum WorkflowInstanceIntent implements WorkflowInstanceRelatedIntent {
   ACTIVATE_ELEMENT((short) 9),
   COMPLETE_ELEMENT((short) 10),
   TERMINATE_ELEMENT((short) 11);
+
+  private static final EnumSet<WorkflowInstanceIntent> ELEMENT_COMMAND_INTENTS =
+      EnumSet.of(ACTIVATE_ELEMENT, COMPLETE_ELEMENT, TERMINATE_ELEMENT);
 
   private final short value;
   private final boolean shouldBlacklist;
@@ -88,5 +93,9 @@ public enum WorkflowInstanceIntent implements WorkflowInstanceRelatedIntent {
   @Override
   public boolean shouldBlacklistInstanceOnError() {
     return shouldBlacklist;
+  }
+
+  public static boolean isElementCommandIntent(final WorkflowInstanceIntent intent) {
+    return ELEMENT_COMMAND_INTENTS.contains(intent);
   }
 }


### PR DESCRIPTION
## Description

The BPMN element processors require extra infrastructure before they can be migrated. To reduce the size of the individual processor migration PRs, this PR adds that code separately.

The largest change here is to transition the referred element's state when processing one of the new commands: so transition to Element_Activating when processing Activate_Element. This helps the processor to receive a context that actually resembles the current state, instead of the intended state.

This PR also replaces the usage of the `StateWriter` to the `EventWriter` for the `CreateWorkflowInstanceProcessor`, because this would result in problems. For a full description see the specific commit message.

For the reviewer: First, I think we shouldn't mind the sonar failure. It's mainly concerns the BpmnStreamProcessor's long switch statement with large cases, which will be reduced in #6202 anyways. Secondly, do you think we need any tests for this? This does not change any real behaviour, since none of the element processors have been migrated yet.

## Related issues

closes #6350 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
