### PR TITLE
Return next index for all seek methods in JournalReader

### DIFF
--- a/journal/src/main/java/io/zeebe/journal/JournalReader.java
+++ b/journal/src/main/java/io/zeebe/journal/JournalReader.java
@@ -23,30 +23,75 @@ public interface JournalReader extends Iterator<JournalRecord>, AutoCloseable {
    * Seek to a record at the given index. if seek(index) return true, {@link JournalReader#next()}
    * should return a record at index.
    *
-   * <p>if the index is less than {@link Journal#getFirstIndex()}, {@link JournalReader#next()}
-   * should return a record at index {@link Journal#getFirstIndex()}. If the index is greater than
-   * {@link Journal#getLastIndex()}, then it seeks to lastIndex + 1, and {@link
-   * JournalReader#hasNext()} returns false.
+   * <p>If the journal is empty, it will return {@link Journal#getFirstIndex()}, but it should not
+   * do anything.
+   *
+   * <p>If the index is less than {@link Journal#getFirstIndex()}, {@link JournalReader#next()}
+   * should return a record at index {@link Journal#getFirstIndex()}.
+   *
+   * <p>If the index is greater than {@link Journal#getLastIndex()}, the read is positioned past the
+   * end of the journal, such that {@link JournalReader#hasNext()} will return false. In this case,
+   * the returned index would be {@code {@link Journal#getLastIndex()} + 1}.
+   *
+   * <p>Callers are expected to call {@link #hasNext()} after a seek, regardless of the result
+   * returned.
    *
    * @param index the index to seek to.
-   * @return true if a record at the index exists, false otherwise.
+   * @return the index of the next record to be read
    */
-  boolean seek(long index);
+  long seek(long index);
 
   /**
-   * Seek to the first index of the journal. Equivalent to calling seek(journal.getFirstIndex()).
+   * Seek to the first index of the journal. The index returned is that of the record which would be
+   * returned by calling {@link #next()}.
+   *
+   * <p>Equivalent to calling seek(journal.getFirstIndex()).
+   *
+   * <p>Callers are expected to call {@link #hasNext()} after a seek, regardless of the result
+   * returned.
+   *
+   * <p>If the journal is empty, then the index returned is the {@link Journal#getFirstIndex()}.
+   *
+   * @return the first index of the journal
    */
-  void seekToFirst();
-
-  /** Seek to the last index of the journal. Equivalent to calling seek(journal.getLastIndex()). */
-  void seekToLast();
+  long seekToFirst();
 
   /**
-   * Seek to a record with the highest asqn less than or equal to the given asqn.
+   * Seek to the last index of the journal. The index returned is that of the record which would be
+   * returned by calling {@link #next()}.
+   *
+   * <p>Equivalent to calling seek(journal.getLastIndex()).
+   *
+   * <p>Callers are expected to call {@link #hasNext()} after a seek, regardless of the result
+   * returned.
+   *
+   * <p>If the journal is empty, then the index returned is the {@link Journal#getLastIndex()},
+   * which may be lower than {@link Journal#getFirstIndex()}.
+   *
+   * @return the last index of the journal
+   */
+  long seekToLast();
+
+  /**
+   * Seek to a record with the highest ASQN less than or equal to the given {@code asqn}.
+   *
+   * <p>If all records have an higher ASQN, but at least the first record has none, then the read
+   * will be positioned at the record right before the first record with a valid ASQN.
+   *
+   * <p>If no records have a valid ASQN, then the reader will be positioned at the end of the
+   * journal, which would be equivalent to calling {@link #seekToLast()}.
+   *
+   * <p>It's possible that the next record has an ASQN of {@code -1}, as not all records have an
+   * ASQN assigned.
+   *
+   * <p>Callers are expected to call {@link #hasNext()} after a seek, regardless of the result
+   * returned.
+   *
+   * <p>The index returned is that of a valid record, or if the journal is empty, {@link
+   * Journal#getFirstIndex()}.
    *
    * @param asqn application sequence number to seek
-   * @return true if such a record exists, false if there are no records with asqn less than or
-   *     equal to the given asqn.
+   * @return the index of the record that will be returned by {@link #next()}
    */
-  boolean seekToAsqn(long asqn);
+  long seekToAsqn(long asqn);
 }

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class SegmentedJournalReaderTest {
+class SegmentedJournalReaderTest {
 
   private static final int ENTRIES_PER_SEGMENT = 2;
   @TempDir Path directory;
@@ -48,7 +48,7 @@ public class SegmentedJournalReaderTest {
   private SegmentedJournal journal;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     journal =
         SegmentedJournal.builder()
             .withDirectory(directory.resolve("data").toFile())
@@ -60,7 +60,7 @@ public class SegmentedJournalReaderTest {
   }
 
   @Test
-  public void shouldReadAfterCompact() {
+  void shouldReadAfterCompact() {
     // given
     final int entriesPerSegment = 10;
     long asqn = 1;

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
@@ -245,7 +245,7 @@ public class SegmentedJournalTest {
     journal.deleteAfter(lastIndex - 1);
 
     // then
-    assertThat(reader.seek(lastIndex - 1)).isTrue();
+    assertThat(reader.seek(lastIndex - 1)).isEqualTo(lastIndex - 1);
     assertThat(reader.next().index()).isEqualTo(lastIndex - 1);
     assertThat(journal.getLastIndex()).isEqualTo(lastIndex - 1);
   }


### PR DESCRIPTION
## Description

This PR changes the signature of all seek methods in the `JournalReader` to return the index of the entry that would be returned by `#next()` (if any).

It also documents the interface based on how it currently behaves, and not the desired implementation - this is so consumers right now (i.e. me) can more easily use this methods without running into weird cases because the implementation differs from the desired API. The API documentation should be changed once we know what the correct behaviour should be (especially `seekToAsqn`).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
