### PR TITLE
Skip records with no valid asqn when seeking

### DIFF
--- a/journal/src/main/java/io/zeebe/journal/JournalReader.java
+++ b/journal/src/main/java/io/zeebe/journal/JournalReader.java
@@ -75,14 +75,10 @@ public interface JournalReader extends Iterator<JournalRecord>, AutoCloseable {
   /**
    * Seek to a record with the highest ASQN less than or equal to the given {@code asqn}.
    *
-   * <p>If all records have an higher ASQN, but at least the first record has none, then the read
-   * will be positioned at the record right before the first record with a valid ASQN.
-   *
-   * <p>If no records have a valid ASQN, then the reader will be positioned at the end of the
-   * journal, which would be equivalent to calling {@link #seekToLast()}.
-   *
-   * <p>It's possible that the next record has an ASQN of {@code -1}, as not all records have an
-   * ASQN assigned.
+   * <p>If there are no records with a lower or equal ASQN, then the reader will be positioned at
+   * the beginning of the record. That is it behaves as if {@link JournalReader#seekToFirst()}. In
+   * this case it's possible that the next record has an ASQN of {@code -1}, as not all records have
+   * an ASQN assigned.
    *
    * <p>Callers are expected to call {@link #hasNext()} after a seek, regardless of the result
    * returned.

--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalReader.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalReader.java
@@ -16,6 +16,8 @@
  */
 package io.zeebe.journal.file;
 
+import static io.zeebe.journal.file.SegmentedJournal.ASQN_IGNORE;
+
 import io.zeebe.journal.JournalReader;
 import io.zeebe.journal.JournalRecord;
 import java.util.NoSuchElementException;
@@ -134,7 +136,7 @@ class SegmentedJournalReader implements JournalReader {
     JournalRecord record = null;
     while (hasNext()) {
       final var currentRecord = next();
-      if (currentRecord.asqn() <= asqn) {
+      if (currentRecord.asqn() <= asqn && currentRecord.asqn() != ASQN_IGNORE) {
         record = currentRecord;
       } else if (currentRecord.asqn() >= asqn) {
         break;
@@ -145,7 +147,7 @@ class SegmentedJournalReader implements JournalReader {
     // if the journal only contained entries with ASQN greater than the one requested, it will be at
     // the second entry (as it has read the first one)
     if (record == null) {
-      return getNextIndex();
+      return seekToFirst();
     }
 
     // This is needed so that the next() returns the correct record

--- a/journal/src/test/java/io/zeebe/journal/file/JournalReaderTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/JournalReaderTest.java
@@ -28,7 +28,6 @@ import java.nio.file.Path;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -194,8 +193,7 @@ class JournalReaderTest {
   }
 
   @Test
-  @Disabled("https://github.com/zeebe-io/zeebe/issues/6358")
-  void shouldSeekToHighestLowerAsqnEvenIfRecordHasNone() {
+  void shouldSeekToHighestLowerAsqnSkippingRecordsWithNoAsqn() {
     // given
     final var expectedRecord = journal.append(1, data);
     journal.append(data);
@@ -215,7 +213,7 @@ class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekToNonExistentAsqn() {
+  void shouldSeekToFirstWhenAllAsqnIsHigher() {
     // given
     final var expectedRecord = journal.append(data);
     journal.append(5, data);
@@ -333,7 +331,7 @@ class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekToEndWhenNoValidAsqnFound() {
+  void shouldSeekToFirstWhenNoRecordsWithValidAsqnExists() {
     // given
     for (int i = 0; i < ENTRIES; i++) {
       journal.append(data);
@@ -343,7 +341,7 @@ class JournalReaderTest {
     final long nextIndex = reader.seekToAsqn(32);
 
     // then
-    assertThat(nextIndex).isEqualTo(journal.getLastIndex());
+    assertThat(nextIndex).isEqualTo(journal.getFirstIndex());
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().asqn()).isEqualTo(ASQN_IGNORE);
   }


### PR DESCRIPTION
## Description

When seek to records using ASQN skip records that does not have a valid asqn.

## Related issues

closes #6358 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
