### PR TITLE
Extract common logic used by MappedJournalSegment-Writer Reader

### DIFF
--- a/journal/src/main/java/io/zeebe/journal/file/ChecksumGenerator.java
+++ b/journal/src/main/java/io/zeebe/journal/file/ChecksumGenerator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import java.util.zip.CRC32;
+import org.agrona.DirectBuffer;
+
+public final class ChecksumGenerator {
+
+  private final CRC32 crc32 = new CRC32();
+
+  /** Compute checksum of given DirectBuffer */
+  public int compute(final DirectBuffer data) {
+    final byte[] slice = new byte[data.capacity()];
+    data.getBytes(0, slice);
+    crc32.reset();
+    crc32.update(slice);
+    return (int) crc32.getValue();
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
@@ -16,46 +16,31 @@
  */
 package io.zeebe.journal.file;
 
-import io.atomix.utils.serializer.Namespace;
-import io.atomix.utils.serializer.Namespaces;
 import io.zeebe.journal.JournalRecord;
-import java.nio.BufferUnderflowException;
-import java.nio.ByteBuffer;
+import io.zeebe.journal.file.record.JournalRecordReaderUtil;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel.MapMode;
 import java.util.NoSuchElementException;
-import java.util.zip.CRC32;
-import org.agrona.DirectBuffer;
 import org.agrona.IoUtil;
-import org.agrona.concurrent.UnsafeBuffer;
 
 /** Log segment reader. */
 class MappedJournalSegmentReader {
 
-  private static final Namespace NAMESPACE =
-      new Namespace.Builder()
-          .register(Namespaces.BASIC)
-          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
-          .register(PersistedJournalRecord.class)
-          .register(UnsafeBuffer.class)
-          .name("Journal")
-          .build();
   private final MappedByteBuffer buffer;
-  private final int maxEntrySize;
   private final JournalIndex index;
   private final JournalSegment segment;
   private JournalRecord currentEntry;
   private JournalRecord nextEntry;
-  private final CRC32 crc32 = new CRC32();
+  private final JournalRecordReaderUtil recordReader;
 
   MappedJournalSegmentReader(
       final JournalSegmentFile file,
       final JournalSegment segment,
       final int maxEntrySize,
       final JournalIndex index) {
-    this.maxEntrySize = maxEntrySize;
     this.index = index;
     this.segment = segment;
+    recordReader = new JournalRecordReaderUtil(maxEntrySize);
     buffer =
         IoUtil.mapExistingFile(
             file.file(), MapMode.READ_ONLY, file.name(), 0, segment.descriptor().maxSegmentSize());
@@ -136,51 +121,7 @@ class MappedJournalSegmentReader {
 
   /** Reads the next entry in the segment. */
   private void readNext(final long expectedIndex) {
-
-    // Mark the buffer so it can be reset if necessary.
-    buffer.mark();
-
-    try {
-      // Read the length of the record.
-      final int length = buffer.getInt();
-
-      // If the buffer length is zero then return.
-      if (length <= 0 || length > maxEntrySize) {
-        buffer.reset();
-        nextEntry = null;
-        return;
-      }
-
-      final ByteBuffer slice = buffer.slice();
-      slice.limit(length);
-
-      // If the stored checksum equals the computed checksum, return the record.
-      slice.rewind();
-      final PersistedJournalRecord record = NAMESPACE.deserialize(slice);
-      final var checksum = record.checksum();
-      // TODO: checksum should also include asqn.
-      // TODO: It is now copying the data to calculate the checksum. This should be fixed.
-      final var expectedChecksum = computeChecksum(record.data());
-      if (checksum != expectedChecksum || expectedIndex != record.index()) {
-        nextEntry = null;
-        buffer.reset();
-        return;
-      }
-      nextEntry = record;
-      buffer.position(buffer.position() + length);
-
-    } catch (final BufferUnderflowException e) {
-      buffer.reset();
-      nextEntry = null;
-    }
-  }
-
-  private int computeChecksum(final DirectBuffer data) {
-    final byte[] slice = new byte[data.capacity()];
-    data.getBytes(0, slice);
-    crc32.reset();
-    crc32.update(slice);
-    return (int) crc32.getValue();
+    nextEntry = recordReader.read(buffer, expectedIndex);
   }
 
   long getCurrentIndex() {

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
@@ -16,41 +16,34 @@
  */
 package io.zeebe.journal.file;
 
-import com.esotericsoftware.kryo.KryoException;
-import io.atomix.utils.serializer.Namespace;
-import io.atomix.utils.serializer.Namespaces;
 import io.zeebe.journal.JournalRecord;
 import io.zeebe.journal.StorageException;
 import io.zeebe.journal.StorageException.InvalidChecksum;
 import io.zeebe.journal.StorageException.InvalidIndex;
+import io.zeebe.journal.file.record.JournalRecordBufferWriter;
+import io.zeebe.journal.file.record.JournalRecordReaderUtil;
+import io.zeebe.journal.file.record.KryoSerializer;
+import io.zeebe.journal.file.record.PersistedJournalRecord;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
-import java.util.zip.CRC32;
 import org.agrona.DirectBuffer;
 import org.agrona.IoUtil;
-import org.agrona.concurrent.UnsafeBuffer;
 
 /** Segment writer. */
 class MappedJournalSegmentWriter {
 
-  private static final Namespace NAMESPACE =
-      new Namespace.Builder()
-          .register(Namespaces.BASIC)
-          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
-          .register(PersistedJournalRecord.class)
-          .register(UnsafeBuffer.class)
-          .name("Journal")
-          .build();
   private final MappedByteBuffer buffer;
   private final JournalSegment segment;
-  private final int maxEntrySize;
   private final JournalIndex index;
   private final long firstIndex;
-  private final CRC32 crc32 = new CRC32();
   private JournalRecord lastEntry;
   private boolean isOpen = true;
+  private final JournalRecordReaderUtil recordUtil;
+  private final int maxEntrySize;
+  private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
+  private final JournalRecordBufferWriter serializer = new KryoSerializer();
 
   MappedJournalSegmentWriter(
       final JournalSegmentFile file,
@@ -59,6 +52,7 @@ class MappedJournalSegmentWriter {
       final JournalIndex index) {
     this.segment = segment;
     this.maxEntrySize = maxEntrySize;
+    recordUtil = new JournalRecordReaderUtil(maxEntrySize);
     this.index = index;
     firstIndex = segment.index();
     buffer = mapFile(file, segment);
@@ -90,57 +84,14 @@ class MappedJournalSegmentWriter {
 
   public JournalRecord append(final long asqn, final DirectBuffer data) {
     // Store the entry index.
-    final long index = getNextIndex();
+    final long recordIndex = getNextIndex();
 
     // TODO: Should reject append if the asqn is not greater than the previous record
 
-    // Serialize the entry.
     final int recordStartPosition = buffer.position();
-    if (recordStartPosition + Integer.BYTES > buffer.limit()) {
-      throw new BufferOverflowException();
-    }
-
-    buffer.position(recordStartPosition + Integer.BYTES);
-
-    // compute checksum and construct the record
-    // TODO: checksum should also include asqn. https://github.com/zeebe-io/zeebe/issues/6218
-    // TODO: It is now copying the data to calculate the checksum. This should be fixed when
-    // we change the serialization format. https://github.com/zeebe-io/zeebe/issues/6219
-    final var checksum = computeChecksum(data);
-    final var recordToWrite = new PersistedJournalRecord(index, asqn, checksum, data);
-
-    try {
-      NAMESPACE.serialize(recordToWrite, buffer);
-    } catch (final KryoException e) {
-      throw new BufferOverflowException();
-    }
-
-    final int length = buffer.position() - (recordStartPosition + Integer.BYTES);
-
-    // If the entry length exceeds the maximum entry size then throw an exception.
-    if (length > maxEntrySize) {
-      // Just reset the buffer. There's no need to zero the bytes since we haven't written the
-      // length or checksum.
-      buffer.position(recordStartPosition);
-      throw new StorageException.TooLarge(
-          "Entry size " + length + " exceeds maximum allowed bytes (" + maxEntrySize + ")");
-    }
-
-    buffer.position(recordStartPosition);
-    buffer.putInt(length);
-    buffer.position(recordStartPosition + Integer.BYTES + length);
-
-    lastEntry = recordToWrite;
-    this.index.index(lastEntry, recordStartPosition);
+    lastEntry = write(buffer, recordIndex, asqn, data);
+    index.index(lastEntry, recordStartPosition);
     return lastEntry;
-  }
-
-  private int computeChecksum(final DirectBuffer data) {
-    final byte[] slice = new byte[data.capacity()];
-    data.getBytes(0, slice);
-    crc32.reset();
-    crc32.update(slice);
-    return (int) crc32.getValue();
   }
 
   public void append(final JournalRecord record) {
@@ -155,20 +106,55 @@ class MappedJournalSegmentWriter {
     }
 
     final int recordStartPosition = buffer.position();
+    lastEntry = write(buffer, record);
+    index.index(lastEntry, recordStartPosition);
+  }
+
+  /**
+   * Create and writes a new JournalRecord with the given index,asqn and data to the buffer. After
+   * the method returns, the position of buffer will be advanced to a position were the next record
+   * will be written.
+   */
+  private JournalRecord write(
+      final ByteBuffer buffer, final long index, final long asqn, final DirectBuffer data) {
+
+    // compute checksum and construct the record
+    // TODO: checksum should also include asqn. https://github.com/zeebe-io/zeebe/issues/6218
+    // TODO: It is now copying the data to calculate the checksum. This should be fixed when
+    // we change the serialization format. https://github.com/zeebe-io/zeebe/issues/6219
+    final var checksum = checksumGenerator.compute(data);
+    final var recordToWrite = new PersistedJournalRecord(index, asqn, checksum, data);
+
+    writeInternal(buffer, recordToWrite);
+    return recordToWrite;
+  }
+
+  /**
+   * Write the record to the buffer. After the method returns, the position of buffer will be
+   * advanced to a position were the next record will be written.
+   */
+  private JournalRecord write(final ByteBuffer buffer, final JournalRecord record) {
+    final var checksum = checksumGenerator.compute(record.data());
+    if (checksum != record.checksum()) {
+      throw new InvalidChecksum("Checksum invalid for record " + record);
+    }
+    writeInternal(buffer, record);
+    return record;
+  }
+
+  private void writeInternal(final ByteBuffer buffer, final JournalRecord recordToWrite) {
+    final int recordStartPosition = buffer.position();
+    buffer.mark();
     if (recordStartPosition + Integer.BYTES > buffer.limit()) {
       throw new BufferOverflowException();
     }
 
     buffer.position(recordStartPosition + Integer.BYTES);
-    final var checksum = computeChecksum(record.data());
-
-    if (checksum != record.checksum()) {
-      throw new InvalidChecksum("Checksum invalid for record " + record);
-    }
     try {
-      NAMESPACE.serialize(record, buffer);
-    } catch (final KryoException e) {
-      throw new BufferOverflowException();
+      serializer.write(recordToWrite, buffer);
+    } catch (final BufferOverflowException e) {
+      buffer.reset();
+      throw e;
     }
 
     final int length = buffer.position() - (recordStartPosition + Integer.BYTES);
@@ -177,7 +163,7 @@ class MappedJournalSegmentWriter {
     if (length > maxEntrySize) {
       // Just reset the buffer. There's no need to zero the bytes since we haven't written the
       // length or checksum.
-      buffer.position(recordStartPosition);
+      buffer.reset();
       throw new StorageException.TooLarge(
           "Entry size " + length + " exceeds maximum allowed bytes (" + maxEntrySize + ")");
     }
@@ -185,9 +171,6 @@ class MappedJournalSegmentWriter {
     buffer.position(recordStartPosition);
     buffer.putInt(length);
     buffer.position(recordStartPosition + Integer.BYTES + length);
-
-    lastEntry = record;
-    index.index(lastEntry, recordStartPosition);
   }
 
   private void reset(final long index) {
@@ -195,39 +178,17 @@ class MappedJournalSegmentWriter {
 
     // Clear the buffer indexes.
     buffer.position(JournalSegmentDescriptor.BYTES);
-
-    // Read the entry length.
     buffer.mark();
-
     try {
-      var recordPosition = buffer.position();
-      int length = buffer.getInt();
-
-      // If the length is non-zero, read the entry.
-      while (length > 0 && length <= maxEntrySize && (index == 0 || nextIndex <= index)) {
-
-        final ByteBuffer slice = buffer.slice();
-        slice.limit(length);
-
-        // If the stored checksum equals the computed checksum, return the record.
-        slice.rewind();
-        final PersistedJournalRecord record = NAMESPACE.deserialize(slice);
-        final var checksum = record.checksum();
-        final var expectedChecksum = computeChecksum(record.data());
-        if (checksum != expectedChecksum || nextIndex != record.index()) {
-          buffer.reset();
-          return;
+      while (index == 0 || nextIndex <= index) {
+        final var nextEntry = recordUtil.read(buffer, nextIndex);
+        if (nextEntry == null) {
+          break;
         }
-        lastEntry = record;
-        this.index.index(record, recordPosition);
+        lastEntry = nextEntry;
         nextIndex++;
-        buffer.position(recordPosition + Integer.BYTES + length);
-
-        recordPosition = buffer.position();
         buffer.mark();
-        length = buffer.getInt();
       }
-
     } catch (final BufferUnderflowException e) {
       // Reached end of the segment
     } finally {

--- a/journal/src/main/java/io/zeebe/journal/file/record/JournalRecordBufferReader.java
+++ b/journal/src/main/java/io/zeebe/journal/file/record/JournalRecordBufferReader.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file.record;
+
+import io.zeebe.journal.JournalRecord;
+import java.nio.ByteBuffer;
+
+public interface JournalRecordBufferReader {
+
+  /**
+   * Reads the {@link JournalRecord} from the buffer at it's current position ({@code *
+   * buffer.position()}). A valid record must exist in the buffer at this position.
+   *
+   * @param buffer to read
+   * @return a journal record that is read.
+   */
+  JournalRecord read(ByteBuffer buffer);
+}

--- a/journal/src/main/java/io/zeebe/journal/file/record/JournalRecordBufferWriter.java
+++ b/journal/src/main/java/io/zeebe/journal/file/record/JournalRecordBufferWriter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file.record;
+
+import io.zeebe.journal.JournalRecord;
+import java.nio.ByteBuffer;
+
+public interface JournalRecordBufferWriter {
+
+  /**
+   * Writes a {@link JournalRecord} to the buffer at it's current position ({@code
+   * buffer.position()})
+   *
+   * @param record to write
+   * @param buffer to which the record will be written
+   */
+  void write(JournalRecord record, ByteBuffer buffer);
+}

--- a/journal/src/main/java/io/zeebe/journal/file/record/JournalRecordReaderUtil.java
+++ b/journal/src/main/java/io/zeebe/journal/file/record/JournalRecordReaderUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file.record;
+
+import io.zeebe.journal.JournalRecord;
+import io.zeebe.journal.file.ChecksumGenerator;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+
+/**
+ * Common methods used by SegmentWriter and MappedJournalSegmentReader to read records from a
+ * buffer.
+ */
+public final class JournalRecordReaderUtil {
+  private final JournalRecordBufferReader serializer = new KryoSerializer();
+
+  private final int maxEntrySize;
+  private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
+
+  public JournalRecordReaderUtil(final int maxEntrySize) {
+    this.maxEntrySize = maxEntrySize;
+  }
+
+  /**
+   * Reads the JournalRecord in the buffer at the current position. After the methods returns, the
+   * position of {@code buffer} will be advanced to the next record.
+   */
+  public JournalRecord read(final ByteBuffer buffer, final long expectedIndex) {
+    // Mark the buffer so it can be reset if necessary.
+    buffer.mark();
+
+    try {
+      // Read the length of the record.
+      final int length = buffer.getInt();
+
+      // If the buffer length is zero then return.
+      if (length <= 0 || length > maxEntrySize) {
+        buffer.reset();
+        return null;
+      }
+
+      final ByteBuffer slice = buffer.slice();
+      slice.limit(length);
+
+      // If the stored checksum equals the computed checksum, return the record.
+      slice.rewind();
+      final JournalRecord record = serializer.read(slice);
+      final var checksum = record.checksum();
+      // TODO: checksum should also include asqn.
+      // TODO: It is now copying the data to calculate the checksum. This should be fixed.
+      final var expectedChecksum = checksumGenerator.compute(record.data());
+      if (checksum != expectedChecksum || expectedIndex != record.index()) {
+        buffer.reset();
+        return null;
+      }
+      buffer.position(buffer.position() + length);
+      buffer.mark();
+      return record;
+
+    } catch (final BufferUnderflowException e) {
+      buffer.reset();
+    }
+    return null;
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/record/KryoSerializer.java
+++ b/journal/src/main/java/io/zeebe/journal/file/record/KryoSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file.record;
+
+import com.esotericsoftware.kryo.KryoException;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.Namespaces;
+import io.zeebe.journal.JournalRecord;
+import java.nio.BufferOverflowException;
+import java.nio.ByteBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public final class KryoSerializer implements JournalRecordBufferWriter, JournalRecordBufferReader {
+  private static final Namespace NAMESPACE =
+      new Namespace.Builder()
+          .register(Namespaces.BASIC)
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+          .register(PersistedJournalRecord.class)
+          .register(UnsafeBuffer.class)
+          .name("Journal")
+          .build();
+
+  public JournalRecord read(final ByteBuffer buffer) {
+    return NAMESPACE.deserialize(buffer);
+  }
+
+  public void write(final JournalRecord record, final ByteBuffer buffer) {
+    try {
+      NAMESPACE.serialize(record, buffer);
+    } catch (final KryoException e) {
+      // Happens when there is not enough space left in the buffer
+      throw new BufferOverflowException();
+    }
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/record/PersistedJournalRecord.java
+++ b/journal/src/main/java/io/zeebe/journal/file/record/PersistedJournalRecord.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.zeebe.journal.file;
+package io.zeebe.journal.file.record;
 
 import com.google.common.base.Objects;
 import io.zeebe.journal.JournalRecord;
 import org.agrona.DirectBuffer;
 
 /** Journal Record */
-class PersistedJournalRecord implements JournalRecord {
+public final class PersistedJournalRecord implements JournalRecord {
 
   private final DirectBuffer data;
   private final long index;

--- a/journal/src/test/java/io/zeebe/journal/file/JournalReaderTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/JournalReaderTest.java
@@ -22,6 +22,7 @@ import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Namespaces;
 import io.zeebe.journal.JournalReader;
 import io.zeebe.journal.JournalRecord;
+import io.zeebe.journal.file.record.PersistedJournalRecord;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Namespaces;
 import io.zeebe.journal.JournalReader;
+import io.zeebe.journal.file.record.PersistedJournalRecord;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.agrona.DirectBuffer;

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
@@ -21,6 +21,7 @@ import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Namespaces;
 import io.zeebe.journal.JournalReader;
 import io.zeebe.journal.JournalRecord;
+import io.zeebe.journal.file.record.PersistedJournalRecord;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.agrona.DirectBuffer;

--- a/journal/src/test/java/io/zeebe/journal/file/SparseJournalIndexTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SparseJournalIndexTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.zeebe.journal.JournalRecord;
+import io.zeebe.journal.file.record.PersistedJournalRecord;
 import org.junit.jupiter.api.Test;
 
 /** Sparse journal index test. */

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/ClientReconnectTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/client/ClientReconnectTest.java
@@ -55,7 +55,7 @@ public final class ClientReconnectTest {
             () -> {
               try {
                 return createWorkflowInstance(workflowKey);
-              } catch (ClientException e) {
+              } catch (final ClientException e) {
                 // ignore failures until broker is up again
                 return -1L;
               }


### PR DESCRIPTION
## Description

Both MappedJournalSegmentWriter and MappedJournalSegmentReader has code to iterate over existing records and to calculate checksums. This PR removes the duplicated logic.

This is in preparation to introducing new serialization format in journal so that there is only one place to update. #6310

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
