### PR TITLE
Apply event sourcing to message publish processor

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
@@ -84,24 +84,32 @@ public final class EventHandle {
             workflowKey, newElementInstanceKey, elementId, variables);
 
     if (triggered) {
-
       final var workflowInstanceKey = keyGenerator.nextKey();
-      final var eventOccurredKey = keyGenerator.nextKey();
-
-      eventOccurredRecord
-          .setBpmnElementType(BpmnElementType.START_EVENT)
-          .setWorkflowKey(workflowKey)
-          .setWorkflowInstanceKey(workflowInstanceKey)
-          .setElementId(elementId);
-
-      streamWriter.appendFollowUpEvent(
-          eventOccurredKey, WorkflowInstanceIntent.EVENT_OCCURRED, eventOccurredRecord);
-
+      activateStartEvent(streamWriter, workflowKey, workflowInstanceKey, elementId);
       return workflowInstanceKey;
 
     } else {
       return -1L;
     }
+  }
+
+  public void activateStartEvent(
+      final TypedStreamWriter streamWriter,
+      final long workflowKey,
+      final long workflowInstanceKey,
+      final DirectBuffer elementId) {
+
+    final var eventOccurredKey = keyGenerator.nextKey();
+
+    eventOccurredRecord
+        .setBpmnElementType(BpmnElementType.START_EVENT)
+        .setWorkflowKey(workflowKey)
+        .setWorkflowInstanceKey(workflowInstanceKey)
+        .setElementId(elementId);
+
+    // TODO (saig0): create the workflow instance by writing an ACTIVATE command (#6184)
+    streamWriter.appendFollowUpEvent(
+        eventOccurredKey, WorkflowInstanceIntent.EVENT_OCCURRED, eventOccurredRecord);
   }
 
   private boolean isEventSubprocess(final ExecutableFlowElement catchEvent) {

--- a/engine/src/main/java/io/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -42,13 +42,14 @@ public final class MessageEventProcessors {
         .onCommand(
             ValueType.MESSAGE,
             MessageIntent.PUBLISH,
-            new PublishMessageProcessor(
+            new MessagePublishProcessor(
                 messageState,
                 subscriptionState,
                 startEventSubscriptionState,
                 eventScopeInstanceState,
                 subscriptionCommandSender,
-                keyGenerator))
+                keyGenerator,
+                writers))
         .onCommand(
             ValueType.MESSAGE, MessageIntent.EXPIRE, new MessageExpireProcessor(writers.state()))
         .onCommand(

--- a/engine/src/main/java/io/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
@@ -45,7 +45,9 @@ public final class PendingMessageSubscriptionChecker implements Runnable {
             subscription.getCorrelationKey());
 
     if (success) {
-      subscriptionState.updateSentTimeInTransaction(subscription, ActorClock.currentTimeMillis());
+      // TODO (saig0): the state change of the sent time should be reflected by a record (#6364)
+      final var sentTime = ActorClock.currentTimeMillis();
+      subscriptionState.updateSentTimeInTransaction(subscription, sentTime);
     }
 
     return success;

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -11,7 +11,8 @@ import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceReco
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.intent.JobIntent;
-import io.zeebe.protocol.record.intent.MessageIntent;
+import io.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -56,11 +57,14 @@ public final class MigratedStreamProcessors {
     MIGRATED_VALUE_TYPES.put(ValueType.ERROR, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.WORKFLOW, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.DEPLOYMENT_DISTRIBUTION, MIGRATED);
+    MIGRATED_VALUE_TYPES.put(ValueType.MESSAGE, MIGRATED);
+
     MIGRATED_VALUE_TYPES.put(
-        ValueType.MESSAGE,
-        record ->
-            record.getIntent() == MessageIntent.EXPIRE
-                || record.getIntent() == MessageIntent.EXPIRED);
+        ValueType.MESSAGE_SUBSCRIPTION,
+        record -> record.getIntent() == MessageSubscriptionIntent.CORRELATING);
+    MIGRATED_VALUE_TYPES.put(
+        ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
+        record -> record.getIntent() == MessageStartEventSubscriptionIntent.CORRELATED);
   }
 
   private MigratedStreamProcessors() {}

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReProcessingStateMachine.java
@@ -113,7 +113,12 @@ public final class ReProcessingStateMachine {
   private final RecordProcessorMap recordProcessorMap;
 
   private final EventFilter eventFilter =
-      new MetadataEventFilter(new RecordProtocolVersionFilter().and(REPLAY_FILTER));
+      new MetadataEventFilter(
+          new RecordProtocolVersionFilter()
+          // TODO (saig0): enable the replay filter after all stream processors are migrated (#6202)
+          // until then, we need to restore the key generator for already migrated processors
+          //          .and(REPLAY_FILTER)
+          );
 
   private final LogStreamReader logStreamReader;
   private final ReprocessingStreamWriter reprocessingStreamWriter = new ReprocessingStreamWriter();

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -16,6 +16,8 @@ import io.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.intent.MessageIntent;
+import io.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.record.intent.WorkflowIntent;
 import java.util.HashMap;
@@ -48,13 +50,26 @@ public final class EventAppliers implements EventApplier {
     register(
         WorkflowInstanceIntent.ELEMENT_ACTIVATED,
         new WorkflowInstanceElementActivatedApplier(state));
+
     register(WorkflowIntent.CREATED, new WorkflowCreatedApplier(state));
     register(DeploymentDistributionIntent.DISTRIBUTING, new DeploymentDistributionApplier(state));
     register(
         DeploymentDistributionIntent.COMPLETED,
         new DeploymentDistributionCompletedApplier(state.getDeploymentState()));
 
+    register(MessageIntent.PUBLISHED, new MessagePublishedApplier(state.getMessageState()));
     register(MessageIntent.EXPIRED, new MessageExpiredApplier(state.getMessageState()));
+
+    register(
+        MessageSubscriptionIntent.CORRELATING,
+        new MessageSubscriptionCorrelatingApplier(
+            state.getMessageSubscriptionState(), state.getMessageState()));
+
+    register(
+        MessageStartEventSubscriptionIntent.CORRELATED,
+        new MessageStartEventSubscriptionCorrelatedApplier(
+            state.getMessageState(), state.getEventScopeInstanceState()));
+
     registerJobIntentEventAppliers(state);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/MessagePublishedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/MessagePublishedApplier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.message.Message;
+import io.zeebe.engine.state.mutable.MutableMessageState;
+import io.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.zeebe.protocol.record.intent.MessageIntent;
+
+public final class MessagePublishedApplier
+    implements TypedEventApplier<MessageIntent, MessageRecord> {
+
+  private final MutableMessageState messageState;
+
+  public MessagePublishedApplier(final MutableMessageState messageState) {
+    this.messageState = messageState;
+  }
+
+  @Override
+  public void applyState(final long key, final MessageRecord value) {
+    // TODO (saig0): reuse the message record in the state
+    final var message =
+        new Message(
+            key,
+            value.getNameBuffer(),
+            value.getCorrelationKeyBuffer(),
+            value.getVariablesBuffer(),
+            value.getMessageIdBuffer(),
+            value.getTimeToLive(),
+            value.getDeadline());
+
+    messageState.put(message);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/MessageStartEventSubscriptionCorrelatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/MessageStartEventSubscriptionCorrelatedApplier.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.zeebe.engine.state.mutable.MutableMessageState;
+import io.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
+import io.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import org.agrona.DirectBuffer;
+
+public final class MessageStartEventSubscriptionCorrelatedApplier
+    implements TypedEventApplier<
+        MessageStartEventSubscriptionIntent, MessageStartEventSubscriptionRecord> {
+
+  private final MutableMessageState messageState;
+  private final MutableEventScopeInstanceState eventScopeInstanceState;
+
+  public MessageStartEventSubscriptionCorrelatedApplier(
+      final MutableMessageState messageState,
+      final MutableEventScopeInstanceState eventScopeInstanceState) {
+    this.messageState = messageState;
+    this.eventScopeInstanceState = eventScopeInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final MessageStartEventSubscriptionRecord value) {
+    // avoid correlating this message to one instance of this workflow again
+    messageState.putMessageCorrelation(value.getMessageKey(), value.getBpmnProcessIdBuffer());
+
+    final DirectBuffer correlationKey = value.getCorrelationKeyBuffer();
+    if (correlationKey.capacity() > 0) {
+      // lock the workflow for this correlation key
+      // - other messages with same correlation key are not correlated to this workflow
+      // until the created instance is ended
+      messageState.putActiveWorkflowInstance(value.getBpmnProcessIdBuffer(), correlationKey);
+      messageState.putWorkflowInstanceCorrelationKey(
+          value.getWorkflowInstanceKey(), correlationKey);
+    }
+
+    // write the event trigger for the start event
+    eventScopeInstanceState.triggerEvent(
+        value.getWorkflowKey(),
+        value.getMessageKey(),
+        value.getStartEventIdBuffer(),
+        value.getVariablesBuffer());
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionCorrelatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionCorrelatingApplier.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.message.MessageSubscription;
+import io.zeebe.engine.state.mutable.MutableMessageState;
+import io.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
+import io.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.zeebe.util.sched.clock.ActorClock;
+
+public final class MessageSubscriptionCorrelatingApplier
+    implements TypedEventApplier<MessageSubscriptionIntent, MessageSubscriptionRecord> {
+
+  private final MutableMessageSubscriptionState messageSubscriptionState;
+  private final MutableMessageState messageState;
+
+  public MessageSubscriptionCorrelatingApplier(
+      final MutableMessageSubscriptionState messageSubscriptionState,
+      final MutableMessageState messageState) {
+    this.messageSubscriptionState = messageSubscriptionState;
+    this.messageState = messageState;
+  }
+
+  @Override
+  public void applyState(final long key, final MessageSubscriptionRecord value) {
+    final var subscription =
+        new MessageSubscription(
+            value.getWorkflowInstanceKey(),
+            value.getElementInstanceKey(),
+            value.getBpmnProcessIdBuffer(),
+            value.getMessageNameBuffer(),
+            value.getCorrelationKeyBuffer(),
+            value.shouldCloseOnCorrelate());
+
+    // TODO (saig0): the send time for the retry should be deterministic (#6364)
+    final var sentTime = ActorClock.currentTimeMillis();
+    messageSubscriptionState.updateToCorrelatingState(
+        subscription, value.getVariablesBuffer(), sentTime, value.getMessageKey());
+
+    // avoid correlating this message to one instance of this workflow again
+    messageState.putMessageCorrelation(value.getMessageKey(), value.getBpmnProcessIdBuffer());
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceActivityTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceActivityTest.java
@@ -956,11 +956,12 @@ public final class MultiInstanceActivityTest {
     assertThat(
             RecordingExporter.messageSubscriptionRecords()
                 .withWorkflowInstanceKey(workflowInstanceKey)
-                .limit(4))
+                .limit(5))
         .extracting(Record::getIntent)
         .containsExactly(
             MessageSubscriptionIntent.OPEN,
             MessageSubscriptionIntent.OPENED,
+            MessageSubscriptionIntent.CORRELATING,
             MessageSubscriptionIntent.CORRELATE,
             MessageSubscriptionIntent.CORRELATED);
 
@@ -1074,11 +1075,12 @@ public final class MultiInstanceActivityTest {
     assertThat(
             RecordingExporter.messageSubscriptionRecords()
                 .withWorkflowInstanceKey(workflowInstanceKey)
-                .limit(6))
+                .limit(7))
         .extracting(Record::getIntent)
         .containsExactly(
             MessageSubscriptionIntent.OPEN,
             MessageSubscriptionIntent.OPENED,
+            MessageSubscriptionIntent.CORRELATING,
             MessageSubscriptionIntent.CORRELATE,
             MessageSubscriptionIntent.CORRELATED,
             MessageSubscriptionIntent.CLOSE,

--- a/engine/src/test/java/io/zeebe/engine/processing/message/PublishMessageTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/message/PublishMessageTest.java
@@ -172,7 +172,7 @@ public final class PublishMessageTest {
   }
 
   @Test
-  public void shouldDeleteMessageAfterTTL() {
+  public void shouldExpireMessageAfterTTL() {
     // given
     final long timeToLive = 100;
 
@@ -197,7 +197,7 @@ public final class PublishMessageTest {
   }
 
   @Test
-  public void shouldDeleteMessageImmediatelyWithZeroTTL() {
+  public void shouldExpireMessageImmediatelyWithZeroTTL() {
     // given
     final long timeToLive = 0L;
 

--- a/engine/src/test/java/io/zeebe/engine/util/WorkflowExecutor.java
+++ b/engine/src/test/java/io/zeebe/engine/util/WorkflowExecutor.java
@@ -123,6 +123,11 @@ public class WorkflowExecutor {
         .withCorrelationKey("")
         .withVariables(publishMessage.getVariables())
         .publish();
+
+    RecordingExporter.messageStartEventSubscriptionRecords(
+            MessageStartEventSubscriptionIntent.CORRELATED)
+        .withMessageName(publishMessage.getMessageName())
+        .await();
   }
 
   private void createWorkflowInstance(final StepStartProcessInstance startProcess) {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -32,6 +32,9 @@
             },
             "messageKey": {
               "type": "long"
+            },
+            "variables": {
+              "enabled": false
             }
           }
         }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
@@ -26,6 +26,9 @@
             },
             "variables": {
               "enabled": false
+            },
+            "deadline": {
+              "type": "long"
             }
           }
         }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/MessageRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/MessageRecord.java
@@ -24,6 +24,8 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
   private final StringProperty correlationKeyProp = new StringProperty("correlationKey");
   // TTL in milliseconds
   private final LongProperty timeToLiveProp = new LongProperty("timeToLive");
+  private final LongProperty deadlineProp = new LongProperty("deadline", -1);
+
   private final DocumentProperty variablesProp = new DocumentProperty("variables");
   private final StringProperty messageIdProp = new StringProperty("messageId", "");
 
@@ -32,7 +34,8 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
         .declareProperty(correlationKeyProp)
         .declareProperty(timeToLiveProp)
         .declareProperty(variablesProp)
-        .declareProperty(messageIdProp);
+        .declareProperty(messageIdProp)
+        .declareProperty(deadlineProp);
   }
 
   public boolean hasMessageId() {
@@ -64,6 +67,7 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
     return BufferUtil.bufferAsString(messageIdProp.getValue());
   }
 
+  @Override
   public long getTimeToLive() {
     return timeToLiveProp.getValue();
   }
@@ -121,5 +125,15 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
   @JsonIgnore
   public DirectBuffer getVariablesBuffer() {
     return variablesProp.getValue();
+  }
+
+  @Override
+  public long getDeadline() {
+    return deadlineProp.getValue();
+  }
+
+  public MessageRecord setDeadline(final long deadline) {
+    deadlineProp.setValue(deadline);
+    return this;
   }
 }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
@@ -10,10 +10,13 @@ package io.zeebe.protocol.impl.record.value.message;
 import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.zeebe.msgpack.property.DocumentProperty;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
+import io.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
+import java.util.Map;
 import org.agrona.DirectBuffer;
 
 public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValue
@@ -24,11 +27,20 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
   private final StringProperty messageNameProp = new StringProperty("messageName", "");
   private final StringProperty startEventIdProp = new StringProperty("startEventId", "");
 
+  private final LongProperty workflowInstanceKeyProp = new LongProperty("workflowInstanceKey", -1L);
+  private final LongProperty messageKeyProp = new LongProperty("messageKey", -1L);
+  private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
+  private final DocumentProperty variablesProp = new DocumentProperty("variables");
+
   public MessageStartEventSubscriptionRecord() {
     declareProperty(workflowKeyProp)
         .declareProperty(messageNameProp)
         .declareProperty(startEventIdProp)
-        .declareProperty(bpmnProcessIdProp);
+        .declareProperty(bpmnProcessIdProp)
+        .declareProperty(workflowInstanceKeyProp)
+        .declareProperty(messageKeyProp)
+        .declareProperty(correlationKeyProp)
+        .declareProperty(variablesProp);
   }
 
   public void wrap(final MessageStartEventSubscriptionRecord record) {
@@ -91,5 +103,55 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
   @JsonIgnore
   public DirectBuffer getBpmnProcessIdBuffer() {
     return bpmnProcessIdProp.getValue();
+  }
+
+  @Override
+  public String getCorrelationKey() {
+    return bufferAsString(correlationKeyProp.getValue());
+  }
+
+  public MessageStartEventSubscriptionRecord setCorrelationKey(final DirectBuffer correlationKey) {
+    correlationKeyProp.setValue(correlationKey);
+    return this;
+  }
+
+  @Override
+  public long getMessageKey() {
+    return messageKeyProp.getValue();
+  }
+
+  public MessageStartEventSubscriptionRecord setMessageKey(final long messageKey) {
+    messageKeyProp.setValue(messageKey);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getCorrelationKeyBuffer() {
+    return correlationKeyProp.getValue();
+  }
+
+  @Override
+  public long getWorkflowInstanceKey() {
+    return workflowInstanceKeyProp.getValue();
+  }
+
+  public MessageStartEventSubscriptionRecord setWorkflowInstanceKey(final long key) {
+    workflowInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return MsgPackConverter.convertToMap(variablesProp.getValue());
+  }
+
+  public MessageStartEventSubscriptionRecord setVariables(final DirectBuffer variables) {
+    variablesProp.setValue(variables);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variablesProp.getValue();
   }
 }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -11,10 +11,13 @@ import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.zeebe.msgpack.property.BooleanProperty;
+import io.zeebe.msgpack.property.DocumentProperty;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
+import io.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import java.util.Map;
 import org.agrona.DirectBuffer;
 
 public final class MessageSubscriptionRecord extends UnifiedRecordValue
@@ -29,6 +32,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private final BooleanProperty closeOnCorrelateProp =
       new BooleanProperty("closeOnCorrelate", true);
 
+  private final DocumentProperty variablesProp = new DocumentProperty("variables");
+
   public MessageSubscriptionRecord() {
     declareProperty(workflowInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -36,7 +41,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(messageNameProp)
         .declareProperty(correlationKeyProp)
         .declareProperty(closeOnCorrelateProp)
-        .declareProperty(bpmnProcessIdProp);
+        .declareProperty(bpmnProcessIdProp)
+        .declareProperty(variablesProp);
   }
 
   public boolean shouldCloseOnCorrelate() {
@@ -121,5 +127,20 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getBpmnProcessIdBuffer() {
     return bpmnProcessIdProp.getValue();
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return MsgPackConverter.convertToMap(variablesProp.getValue());
+  }
+
+  public MessageSubscriptionRecord setVariables(final DirectBuffer variables) {
+    variablesProp.setValue(variables);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variablesProp.getValue();
   }
 }

--- a/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -402,9 +402,10 @@ public final class JsonSerializableToJsonTest {
                   .setName(wrapString(messageName))
                   .setVariables(VARIABLES_MSGPACK)
                   .setTimeToLive(timeToLive)
+                  .setDeadline(22L)
                   .setMessageId(wrapString(messageId));
             },
-        "{'timeToLive':12,'correlationKey':'test-key','variables':{'foo':'bar'},'messageId':'test-id','name':'test-message'}"
+        "{'timeToLive':12,'correlationKey':'test-key','variables':{'foo':'bar'},'messageId':'test-id','name':'test-message','deadline':22}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////// Empty MessageRecord ///////////////////////////////////////
@@ -422,7 +423,7 @@ public final class JsonSerializableToJsonTest {
                   .setCorrelationKey(correlationKey)
                   .setName(messageName);
             },
-        "{'timeToLive':12,'correlationKey':'test-key','variables':{},'messageId':'','name':'test-message'}"
+        "{'timeToLive':12,'correlationKey':'test-key','variables':{},'messageId':'','name':'test-message','deadline':-1}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -441,9 +442,13 @@ public final class JsonSerializableToJsonTest {
                   .setMessageName(wrapString(messageName))
                   .setStartEventId(wrapString(startEventId))
                   .setWorkflowKey(workflowKey)
-                  .setBpmnProcessId(wrapString(bpmnProcessId));
+                  .setBpmnProcessId(wrapString(bpmnProcessId))
+                  .setWorkflowInstanceKey(2L)
+                  .setMessageKey(3L)
+                  .setCorrelationKey(wrapString("test-key"))
+                  .setVariables(VARIABLES_MSGPACK);
             },
-        "{'workflowKey':22334,'messageName':'name','startEventId':'startEvent','bpmnProcessId':'workflow'}"
+        "{'workflowKey':22334,'messageName':'name','startEventId':'startEvent','bpmnProcessId':'workflow','workflowInstanceKey':2,'messageKey':3,'correlationKey':'test-key','variables':{'foo':'bar'}}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -457,7 +462,7 @@ public final class JsonSerializableToJsonTest {
 
               return new MessageStartEventSubscriptionRecord().setWorkflowKey(workflowKey);
             },
-        "{'workflowKey':22334,'messageName':'','startEventId':'','bpmnProcessId':''}"
+        "{'workflowKey':22334,'messageName':'','startEventId':'','bpmnProcessId':'','workflowInstanceKey':-1,'messageKey':-1,'correlationKey':'','variables':{}}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -480,9 +485,10 @@ public final class JsonSerializableToJsonTest {
                   .setMessageKey(messageKey)
                   .setMessageName(wrapString(messageName))
                   .setWorkflowInstanceKey(workflowInstanceKey)
-                  .setCorrelationKey(wrapString(correlationKey));
+                  .setCorrelationKey(wrapString(correlationKey))
+                  .setVariables(VARIABLES_MSGPACK);
             },
-        "{'workflowInstanceKey':2,'elementInstanceKey':1,'messageName':'name','correlationKey':'key','bpmnProcessId':'workflow','messageKey':3}"
+        "{'workflowInstanceKey':2,'elementInstanceKey':1,'messageName':'name','correlationKey':'key','bpmnProcessId':'workflow','messageKey':3,'variables':{'foo':'bar'}}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////// Empty MessageSubscriptionRecord
@@ -499,7 +505,7 @@ public final class JsonSerializableToJsonTest {
                   .setWorkflowInstanceKey(workflowInstanceKey)
                   .setElementInstanceKey(elementInstanceKey);
             },
-        "{'workflowInstanceKey':1,'elementInstanceKey':13,'messageName':'','correlationKey':'','bpmnProcessId':'','messageKey':-1}"
+        "{'workflowInstanceKey':1,'elementInstanceKey':13,'messageName':'','correlationKey':'','bpmnProcessId':'','messageKey':-1,'variables':{}}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -128,7 +128,7 @@
             <ignored>
               <!-- ignore new methods in the interface -->
               <className>
-                io/zeebe/protocol/record/value/deployment/DeployedWorkflow
+                io/zeebe/protocol/record/value/**/**
               </className>
               <method>*</method>
               <differenceType>7012</differenceType>

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/MessageStartEventSubscriptionIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/MessageStartEventSubscriptionIntent.java
@@ -19,6 +19,8 @@ public enum MessageStartEventSubscriptionIntent implements Intent {
   OPEN((short) 0),
   OPENED((short) 1),
 
+  CORRELATED((short) 4),
+
   CLOSE((short) 2),
   CLOSED((short) 3);
 
@@ -43,6 +45,8 @@ public enum MessageStartEventSubscriptionIntent implements Intent {
         return CLOSE;
       case 3:
         return CLOSED;
+      case 4:
+        return CORRELATED;
       default:
         return UNKNOWN;
     }

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
@@ -19,6 +19,7 @@ public enum MessageSubscriptionIntent implements WorkflowInstanceRelatedIntent {
   OPEN((short) 0),
   OPENED((short) 1),
 
+  CORRELATING((short) 8),
   CORRELATE((short) 2),
   CORRELATED((short) 3),
 
@@ -63,6 +64,8 @@ public enum MessageSubscriptionIntent implements WorkflowInstanceRelatedIntent {
         return CLOSE;
       case 7:
         return CLOSED;
+      case 8:
+        return CORRELATING;
       default:
         return Intent.UNKNOWN;
     }

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/MessageRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/MessageRecordValue.java
@@ -40,4 +40,11 @@ public interface MessageRecordValue extends RecordValueWithVariables {
 
   /** @return the time to live of the message */
   long getTimeToLive();
+
+  /**
+   * @return the unix timestamp in milliseconds until when the message can be correlated. If the
+   *     deadline is exceeded then the message expires and will be removed. If this property is not
+   *     set, it returns -1 instead.
+   */
+  long getDeadline();
 }

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/MessageStartEventSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/MessageStartEventSubscriptionRecordValue.java
@@ -15,7 +15,7 @@
  */
 package io.zeebe.protocol.record.value;
 
-import io.zeebe.protocol.record.RecordValue;
+import io.zeebe.protocol.record.RecordValueWithVariables;
 import io.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 
 /**
@@ -23,7 +23,7 @@ import io.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
  *
  * <p>See {@link MessageStartEventSubscriptionIntent} for intents.
  */
-public interface MessageStartEventSubscriptionRecordValue extends RecordValue {
+public interface MessageStartEventSubscriptionRecordValue extends RecordValueWithVariables {
 
   /** @return the workflow key tied to the subscription */
   long getWorkflowKey();
@@ -36,4 +36,22 @@ public interface MessageStartEventSubscriptionRecordValue extends RecordValue {
 
   /** @return the name of the message */
   String getMessageName();
+
+  /**
+   * @return the key of the workflow instance that was created by this message. It is only set when
+   *     a message is correlated to this subscription. Otherwise, it returns -1.
+   */
+  long getWorkflowInstanceKey();
+
+  /**
+   * @return the correlation key of the message. It is only set when a message is correlated to this
+   *     subscription. Otherwise, it returns an empty string.
+   */
+  String getCorrelationKey();
+
+  /**
+   * @return the key of the message. It is only set when a message is correlated to this
+   *     subscription. Otherwise, it returns -1.
+   */
+  long getMessageKey();
 }

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
@@ -15,7 +15,7 @@
  */
 package io.zeebe.protocol.record.value;
 
-import io.zeebe.protocol.record.RecordValue;
+import io.zeebe.protocol.record.RecordValueWithVariables;
 import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 
 /**
@@ -23,9 +23,11 @@ import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
  *
  * <p>See {@link MessageSubscriptionIntent} for intents.
  */
-public interface MessageSubscriptionRecordValue extends RecordValue, WorkflowInstanceRelated {
+public interface MessageSubscriptionRecordValue
+    extends RecordValueWithVariables, WorkflowInstanceRelated {
 
   /** @return the workflow instance key tied to the subscription */
+  @Override
   long getWorkflowInstanceKey();
 
   /** @return the element instance key tied to the subscription */


### PR DESCRIPTION
## Description

* use the state writer in the message publish processor to apply the state changes
  * rename the processor to match the common pattern (record + intent + "Processor")  
  * use only the immutable states
  * keep using the `EventHandle` to share the common behavior to trigger start events
* new properties in records to apply the state changes from the events:
  * message: `deadline` 
  * message subscription: `variables`
  * message start event subscription: `workflowInstanceKey`, `messageKey`, `correlationKey`, `variables`
* new intents to persist a pending message correlation:
  * message subscription: `CORRELATING`
  * message start event subscription: `CORRELATED`  
* extend the ES templates for the new record properties
  * there is no template for message start event subscription yet    
* disable the replay filter to restore the key generator for migrated processors

Hints for the reviewer:
* no further improvements of the message processor to keep the changes minimal
* solve the open TODO "reuse the message record in the state" in a follow-up PR

## Related issues

The last part of #6178.

closes #6178 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
