### PR TITLE
6176 job processors part2

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
@@ -19,7 +19,6 @@ import io.zeebe.engine.processing.deployment.distribute.DeploymentDistributeProc
 import io.zeebe.engine.processing.deployment.distribute.DeploymentDistributor;
 import io.zeebe.engine.processing.deployment.distribute.DeploymentRedistributor;
 import io.zeebe.engine.processing.incident.IncidentEventProcessors;
-import io.zeebe.engine.processing.job.JobErrorThrownProcessor;
 import io.zeebe.engine.processing.job.JobEventProcessors;
 import io.zeebe.engine.processing.message.MessageEventProcessors;
 import io.zeebe.engine.processing.message.command.SubscriptionCommandSender;
@@ -88,12 +87,10 @@ public final class EngineProcessors {
             catchEventBehavior,
             writers);
 
-    final JobErrorThrownProcessor jobErrorThrownProcessor =
-        addJobProcessors(
-            zeebeState, typedRecordProcessors, onJobsAvailableCallback, maxFragmentSize, writers);
+    addJobProcessors(
+        zeebeState, typedRecordProcessors, onJobsAvailableCallback, maxFragmentSize, writers);
 
-    addIncidentProcessors(
-        zeebeState, bpmnStreamProcessor, typedRecordProcessors, jobErrorThrownProcessor, writers);
+    addIncidentProcessors(zeebeState, bpmnStreamProcessor, typedRecordProcessors, writers);
 
     return typedRecordProcessors;
   }
@@ -167,19 +164,17 @@ public final class EngineProcessors {
       final ZeebeState zeebeState,
       final TypedRecordProcessor<WorkflowInstanceRecord> bpmnStreamProcessor,
       final TypedRecordProcessors typedRecordProcessors,
-      final JobErrorThrownProcessor jobErrorThrownProcessor,
       final Writers writers) {
-    IncidentEventProcessors.addProcessors(
-        typedRecordProcessors, zeebeState, bpmnStreamProcessor, jobErrorThrownProcessor);
+    IncidentEventProcessors.addProcessors(typedRecordProcessors, zeebeState, bpmnStreamProcessor);
   }
 
-  private static JobErrorThrownProcessor addJobProcessors(
+  private static void addJobProcessors(
       final ZeebeState zeebeState,
       final TypedRecordProcessors typedRecordProcessors,
       final Consumer<String> onJobsAvailableCallback,
       final int maxFragmentSize,
       final Writers writers) {
-    return JobEventProcessors.addJobProcessors(
+    JobEventProcessors.addJobProcessors(
         typedRecordProcessors, zeebeState, onJobsAvailableCallback, maxFragmentSize);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/common/ErrorEventHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/ErrorEventHandler.java
@@ -7,11 +7,9 @@
  */
 package io.zeebe.engine.processing.common;
 
-import io.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
-import io.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
-import io.zeebe.engine.processing.deployment.model.element.ExecutableWorkflow;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
 import io.zeebe.engine.state.KeyGenerator;
+import io.zeebe.engine.state.analyzers.CatchEventAnalyzer;
 import io.zeebe.engine.state.immutable.ElementInstanceState;
 import io.zeebe.engine.state.immutable.WorkflowState;
 import io.zeebe.engine.state.instance.ElementInstance;
@@ -23,11 +21,10 @@ public final class ErrorEventHandler {
 
   private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
 
-  private final CatchEventTuple catchEventTuple = new CatchEventTuple();
-
   private final WorkflowState workflowState;
   private final ElementInstanceState elementInstanceState;
   private final EventHandle eventHandle;
+  private final CatchEventAnalyzer stateAnalyzer;
 
   public ErrorEventHandler(
       final WorkflowState workflowState,
@@ -38,6 +35,7 @@ public final class ErrorEventHandler {
     this.elementInstanceState = elementInstanceState;
 
     eventHandle = new EventHandle(keyGenerator, eventScopeInstanceState);
+    stateAnalyzer = new CatchEventAnalyzer(workflowState, elementInstanceState);
   }
 
   /**
@@ -55,103 +53,18 @@ public final class ErrorEventHandler {
       final ElementInstance instance,
       final TypedEventWriter eventWriter) {
 
-    final var foundCatchEvent = findCatchEvent(errorCode, instance);
+    final var foundCatchEvent = stateAnalyzer.findCatchEvent(errorCode, instance);
     if (foundCatchEvent != null) {
 
       eventHandle.triggerEvent(
-          eventWriter, foundCatchEvent.instance, foundCatchEvent.catchEvent, NO_VARIABLES);
+          eventWriter,
+          foundCatchEvent.getElementInstance(),
+          foundCatchEvent.getCatchEvent(),
+          NO_VARIABLES);
 
       return true;
     }
 
     return false;
-  }
-
-  public boolean hasCatchEvent(final DirectBuffer errorCode, final ElementInstance instance) {
-    return findCatchEvent(errorCode, instance) != null;
-  }
-
-  private CatchEventTuple findCatchEvent(final DirectBuffer errorCode, ElementInstance instance) {
-    // assuming that error events are used rarely
-    // - just walk through the scope hierarchy and look for a matching catch event
-
-    while (instance != null && instance.isActive()) {
-      final var instanceRecord = instance.getValue();
-      final var workflow = getWorkflow(instanceRecord.getWorkflowKey());
-
-      final var found = findCatchEventInWorkflow(errorCode, workflow, instance);
-      if (found != null) {
-        return found;
-      }
-
-      // find in parent workflow instance if exists
-      final var parentElementInstanceKey = instanceRecord.getParentElementInstanceKey();
-      instance = elementInstanceState.getInstance(parentElementInstanceKey);
-    }
-
-    // no matching catch event found
-    return null;
-  }
-
-  private CatchEventTuple findCatchEventInWorkflow(
-      final DirectBuffer errorCode, final ExecutableWorkflow workflow, ElementInstance instance) {
-
-    while (instance != null && instance.isActive() && !instance.isInterrupted()) {
-      final var found = findCatchEventInScope(errorCode, workflow, instance);
-      if (found != null) {
-        return found;
-      }
-
-      // find in parent scope if exists
-      final var instanceParentKey = instance.getParentKey();
-      instance = elementInstanceState.getInstance(instanceParentKey);
-    }
-
-    return null;
-  }
-
-  private CatchEventTuple findCatchEventInScope(
-      final DirectBuffer errorCode,
-      final ExecutableWorkflow workflow,
-      final ElementInstance instance) {
-
-    final var workflowInstanceRecord = instance.getValue();
-    final var elementId = workflowInstanceRecord.getElementIdBuffer();
-    final var elementType = workflowInstanceRecord.getBpmnElementType();
-
-    final var element = workflow.getElementById(elementId, elementType, ExecutableActivity.class);
-
-    for (final ExecutableCatchEvent catchEvent : element.getEvents()) {
-      if (hasErrorCode(catchEvent, errorCode)) {
-
-        catchEventTuple.instance = instance;
-        catchEventTuple.catchEvent = catchEvent;
-        return catchEventTuple;
-      }
-    }
-
-    return null;
-  }
-
-  private boolean hasErrorCode(
-      final ExecutableCatchEvent catchEvent, final DirectBuffer errorCode) {
-    return catchEvent.isError() && catchEvent.getError().getErrorCode().equals(errorCode);
-  }
-
-  private ExecutableWorkflow getWorkflow(final long workflowKey) {
-
-    final var deployedWorkflow = workflowState.getWorkflowByKey(workflowKey);
-    if (deployedWorkflow == null) {
-      throw new IllegalStateException(
-          String.format(
-              "Expected workflow with key '%d' to be deployed but not found", workflowKey));
-    }
-
-    return deployedWorkflow.getWorkflow();
-  }
-
-  private static class CatchEventTuple {
-    private ExecutableCatchEvent catchEvent;
-    private ElementInstance instance;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/common/ErrorEventHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/ErrorEventHandler.java
@@ -10,7 +10,7 @@ package io.zeebe.engine.processing.common;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableWorkflow;
-import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
 import io.zeebe.engine.state.KeyGenerator;
 import io.zeebe.engine.state.immutable.ElementInstanceState;
 import io.zeebe.engine.state.immutable.WorkflowState;
@@ -47,24 +47,28 @@ public final class ErrorEventHandler {
    *
    * @param errorCode the error code of the error event
    * @param instance the instance there the event propagation starts
-   * @param streamWriter the writer to be used for writing the followup event
+   * @param eventWriter the writer to be used for writing the followup event
    * @return {@code true} if the error event is thrown and caught by an catch event
    */
   public boolean throwErrorEvent(
       final DirectBuffer errorCode,
       final ElementInstance instance,
-      final TypedStreamWriter streamWriter) {
+      final TypedEventWriter eventWriter) {
 
     final var foundCatchEvent = findCatchEvent(errorCode, instance);
     if (foundCatchEvent != null) {
 
       eventHandle.triggerEvent(
-          streamWriter, foundCatchEvent.instance, foundCatchEvent.catchEvent, NO_VARIABLES);
+          eventWriter, foundCatchEvent.instance, foundCatchEvent.catchEvent, NO_VARIABLES);
 
       return true;
     }
 
     return false;
+  }
+
+  public boolean hasCatchEvent(final DirectBuffer errorCode, final ElementInstance instance) {
+    return findCatchEvent(errorCode, instance) != null;
   }
 
   private CatchEventTuple findCatchEvent(final DirectBuffer errorCode, ElementInstance instance) {

--- a/engine/src/main/java/io/zeebe/engine/processing/common/ErrorEventHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/ErrorEventHandler.java
@@ -21,8 +21,6 @@ public final class ErrorEventHandler {
 
   private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
 
-  private final WorkflowState workflowState;
-  private final ElementInstanceState elementInstanceState;
   private final EventHandle eventHandle;
   private final CatchEventAnalyzer stateAnalyzer;
 
@@ -31,8 +29,6 @@ public final class ErrorEventHandler {
       final ElementInstanceState elementInstanceState,
       final MutableEventScopeInstanceState eventScopeInstanceState,
       final KeyGenerator keyGenerator) {
-    this.workflowState = workflowState;
-    this.elementInstanceState = elementInstanceState;
 
     eventHandle = new EventHandle(keyGenerator, eventScopeInstanceState);
     stateAnalyzer = new CatchEventAnalyzer(workflowState, elementInstanceState);

--- a/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.processing.common;
 
 import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
+import io.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.state.KeyGenerator;
 import io.zeebe.engine.state.instance.ElementInstance;
@@ -32,7 +33,7 @@ public final class EventHandle {
   }
 
   public boolean triggerEvent(
-      final TypedStreamWriter streamWriter,
+      final TypedEventWriter eventWriter,
       final ElementInstance eventScopeInstance,
       final ExecutableFlowElement catchEvent,
       final DirectBuffer variables) {
@@ -65,7 +66,7 @@ public final class EventHandle {
         eventOccurredRecord.wrap(eventScopeInstance.getValue());
       }
 
-      streamWriter.appendFollowUpEvent(
+      eventWriter.appendFollowUpEvent(
           eventOccurredKey, WorkflowInstanceIntent.EVENT_OCCURRED, eventOccurredRecord);
     }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/incident/IncidentEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/incident/IncidentEventProcessors.java
@@ -7,7 +7,6 @@
  */
 package io.zeebe.engine.processing.incident;
 
-import io.zeebe.engine.processing.job.JobErrorThrownProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.zeebe.engine.state.ZeebeState;
@@ -20,14 +19,13 @@ public final class IncidentEventProcessors {
   public static void addProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final ZeebeState zeebeState,
-      final TypedRecordProcessor<WorkflowInstanceRecord> bpmnStreamProcessor,
-      final JobErrorThrownProcessor jobErrorThrownProcessor) {
+      final TypedRecordProcessor<WorkflowInstanceRecord> bpmnStreamProcessor) {
     typedRecordProcessors
         .onCommand(
             ValueType.INCIDENT, IncidentIntent.CREATE, new CreateIncidentProcessor(zeebeState))
         .onCommand(
             ValueType.INCIDENT,
             IncidentIntent.RESOLVE,
-            new ResolveIncidentProcessor(zeebeState, bpmnStreamProcessor, jobErrorThrownProcessor));
+            new ResolveIncidentProcessor(zeebeState, bpmnStreamProcessor));
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/incident/ResolveIncidentProcessor.java
@@ -38,17 +38,16 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
 
   private final ZeebeState zeebeState;
   private final TypedRecordProcessor<WorkflowInstanceRecord> bpmnStreamProcessor;
-  private final JobErrorThrownProcessor jobErrorThrownProcessor;
 
   private final IncidentRecordWrapper incidentRecordWrapper = new IncidentRecordWrapper();
+  private final JobErrorThrownProcessor jobErrorThrownProcessor;
 
   public ResolveIncidentProcessor(
       final ZeebeState zeebeState,
-      final TypedRecordProcessor<WorkflowInstanceRecord> bpmnStreamProcessor,
-      final JobErrorThrownProcessor jobErrorThrownProcessor) {
+      final TypedRecordProcessor<WorkflowInstanceRecord> bpmnStreamProcessor) {
     this.bpmnStreamProcessor = bpmnStreamProcessor;
     this.zeebeState = zeebeState;
-    this.jobErrorThrownProcessor = jobErrorThrownProcessor;
+    jobErrorThrownProcessor = new JobErrorThrownProcessor(zeebeState);
   }
 
   @Override
@@ -133,6 +132,7 @@ public final class ResolveIncidentProcessor implements TypedRecordProcessor<Inci
       jobState.resolve(jobKey, job);
 
     } else if (state == State.ERROR_THROWN) {
+
       // try to throw the error again
       jobErrorThrownProcessor.processRecord(jobKey, job, streamWriter);
     }

--- a/engine/src/main/java/io/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
@@ -49,7 +49,6 @@ final class DefaultJobCommandPreconditionGuard<J extends JobRecord> {
     } else if (jobState == State.NOT_FOUND) {
       final String message = String.format(NO_JOB_FOUND_MESSAGE, intent, jobKey);
       commandControl.reject(RejectionType.NOT_FOUND, message);
-
     } else {
       final String message = String.format(INVALID_JOB_STATE_MESSAGE, intent, jobKey, jobState);
       commandControl.reject(RejectionType.INVALID_STATE, message);

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -14,13 +14,13 @@ import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.JobIntent;
 
-public final class CancelProcessor implements CommandProcessor<JobRecord> {
+public final class JobCancelProcessor implements CommandProcessor<JobRecord> {
 
   public static final String NO_JOB_FOUND_MESSAGE =
       "Expected to cancel job with key '%d', but no such job was found";
   private final MutableJobState state;
 
-  public CancelProcessor(final MutableJobState state) {
+  public JobCancelProcessor(final MutableJobState state) {
     this.state = state;
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -9,7 +9,8 @@ package io.zeebe.engine.processing.job;
 
 import io.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
-import io.zeebe.engine.state.mutable.MutableJobState;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.immutable.JobState;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.JobIntent;
@@ -18,19 +19,18 @@ public final class JobCancelProcessor implements CommandProcessor<JobRecord> {
 
   public static final String NO_JOB_FOUND_MESSAGE =
       "Expected to cancel job with key '%d', but no such job was found";
-  private final MutableJobState state;
+  private final JobState jobState;
 
-  public JobCancelProcessor(final MutableJobState state) {
-    this.state = state;
+  public JobCancelProcessor(final ZeebeState state) {
+    jobState = state.getJobState();
   }
 
   @Override
   public boolean onCommand(
       final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
     final long jobKey = command.getKey();
-    final JobRecord job = state.getJob(jobKey);
+    final JobRecord job = jobState.getJob(jobKey);
     if (job != null) {
-      state.cancel(jobKey, job);
       commandControl.accept(JobIntent.CANCELED, job);
     } else {
       commandControl.reject(RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, jobKey));

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -21,13 +21,13 @@ import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 
-public final class CompleteProcessor implements CommandProcessor<JobRecord> {
+public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
 
   private final JobState jobState;
   private final ElementInstanceState elementInstanceState;
   private final DefaultJobCommandPreconditionGuard<JobRecord> defaultProcessor;
 
-  public CompleteProcessor(final ZeebeState state) {
+  public JobCompleteProcessor(final ZeebeState state) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
     defaultProcessor =

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobErrorThrownProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobErrorThrownProcessor.java
@@ -23,6 +23,7 @@ import io.zeebe.protocol.record.intent.IncidentIntent;
 import io.zeebe.protocol.record.value.ErrorType;
 import org.agrona.DirectBuffer;
 
+@Deprecated // TODO (#6174) delete after refactoring incident processors
 public class JobErrorThrownProcessor implements TypedRecordProcessor<JobRecord> {
 
   private final IncidentRecord incidentEvent = new IncidentRecord();

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
@@ -35,7 +35,7 @@ public final class JobEventProcessors {
         .onCommand(ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(zeebeState))
         .onCommand(
             ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(zeebeState))
-        .onCommand(ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(jobState))
+        .onCommand(ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(zeebeState))
         .onCommand(
             ValueType.JOB_BATCH,
             JobBatchIntent.ACTIVATE,

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
@@ -32,8 +32,9 @@ public final class JobEventProcessors {
         .onCommand(ValueType.JOB, JobIntent.COMPLETE, new JobCompleteProcessor(zeebeState))
         .onCommand(ValueType.JOB, JobIntent.FAIL, new JobFailProcessor(zeebeState))
         .onCommand(ValueType.JOB, JobIntent.THROW_ERROR, new JobThrowErrorProcessor(zeebeState))
-        .onCommand(ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(jobState))
-        .onCommand(ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(jobState))
+        .onCommand(ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(zeebeState))
+        .onCommand(
+            ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(zeebeState))
         .onCommand(ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(jobState))
         .onCommand(
             ValueType.JOB_BATCH,

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
@@ -18,7 +18,7 @@ import java.util.function.Consumer;
 
 public final class JobEventProcessors {
 
-  public static JobErrorThrownProcessor addJobProcessors(
+  public static void addJobProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final ZeebeState zeebeState,
       final Consumer<String> onJobsAvailableCallback,
@@ -27,14 +27,11 @@ public final class JobEventProcessors {
     final var jobState = zeebeState.getJobState();
     final var keyGenerator = zeebeState.getKeyGenerator();
 
-    final var jobErrorThrownProcessor = new JobErrorThrownProcessor(zeebeState);
-
     typedRecordProcessors
         .onCommand(ValueType.JOB, JobIntent.CREATE, new CreateProcessor())
         .onCommand(ValueType.JOB, JobIntent.COMPLETE, new CompleteProcessor(zeebeState))
         .onCommand(ValueType.JOB, JobIntent.FAIL, new FailProcessor(zeebeState))
-        .onCommand(ValueType.JOB, JobIntent.THROW_ERROR, new JobThrowErrorProcessor(jobState))
-        .onEvent(ValueType.JOB, JobIntent.ERROR_THROWN, jobErrorThrownProcessor)
+        .onCommand(ValueType.JOB, JobIntent.THROW_ERROR, new JobThrowErrorProcessor(zeebeState))
         .onCommand(ValueType.JOB, JobIntent.TIME_OUT, new TimeOutProcessor(jobState))
         .onCommand(ValueType.JOB, JobIntent.UPDATE_RETRIES, new UpdateRetriesProcessor(jobState))
         .onCommand(ValueType.JOB, JobIntent.CANCEL, new CancelProcessor(jobState))
@@ -51,7 +48,5 @@ public final class JobEventProcessors {
                 jobState.setJobsAvailableCallback(onJobsAvailableCallback);
               }
             });
-
-    return jobErrorThrownProcessor;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
@@ -29,12 +29,12 @@ public final class JobEventProcessors {
 
     typedRecordProcessors
         .onCommand(ValueType.JOB, JobIntent.CREATE, new CreateProcessor())
-        .onCommand(ValueType.JOB, JobIntent.COMPLETE, new CompleteProcessor(zeebeState))
-        .onCommand(ValueType.JOB, JobIntent.FAIL, new FailProcessor(zeebeState))
+        .onCommand(ValueType.JOB, JobIntent.COMPLETE, new JobCompleteProcessor(zeebeState))
+        .onCommand(ValueType.JOB, JobIntent.FAIL, new JobFailProcessor(zeebeState))
         .onCommand(ValueType.JOB, JobIntent.THROW_ERROR, new JobThrowErrorProcessor(zeebeState))
-        .onCommand(ValueType.JOB, JobIntent.TIME_OUT, new TimeOutProcessor(jobState))
-        .onCommand(ValueType.JOB, JobIntent.UPDATE_RETRIES, new UpdateRetriesProcessor(jobState))
-        .onCommand(ValueType.JOB, JobIntent.CANCEL, new CancelProcessor(jobState))
+        .onCommand(ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(jobState))
+        .onCommand(ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(jobState))
+        .onCommand(ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(jobState))
         .onCommand(
             ValueType.JOB_BATCH,
             JobBatchIntent.ACTIVATE,

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobFailProcessor.java
@@ -23,7 +23,7 @@ import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.value.ErrorType;
 import org.agrona.DirectBuffer;
 
-public final class FailProcessor implements CommandProcessor<JobRecord> {
+public final class JobFailProcessor implements CommandProcessor<JobRecord> {
 
   private static final DirectBuffer DEFAULT_ERROR_MESSAGE = wrapString("No more retries left.");
   private final IncidentRecord incidentEvent = new IncidentRecord();
@@ -31,7 +31,7 @@ public final class FailProcessor implements CommandProcessor<JobRecord> {
   private final JobState jobState;
   private final DefaultJobCommandPreconditionGuard<JobRecord> defaultProcessor;
 
-  public FailProcessor(final ZeebeState state) {
+  public JobFailProcessor(final ZeebeState state) {
     jobState = state.getJobState();
     defaultProcessor =
         new DefaultJobCommandPreconditionGuard<>("fail", jobState, this::acceptCommand);

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -7,22 +7,45 @@
  */
 package io.zeebe.engine.processing.job;
 
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+
+import io.zeebe.engine.processing.common.ErrorEventHandler;
 import io.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
-import io.zeebe.engine.state.mutable.MutableJobState;
+import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.immutable.ElementInstanceState;
+import io.zeebe.engine.state.immutable.JobState;
+import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.record.intent.IncidentIntent;
+import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.value.ErrorType;
+import org.agrona.DirectBuffer;
 
 public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
+  private final IncidentRecord incidentEvent = new IncidentRecord();
 
-  private final MutableJobState state;
+  private final JobState jobState;
+  private final ElementInstanceState elementInstanceState;
   private final DefaultJobCommandPreconditionGuard<JobRecord> defaultProcessor;
+  private final ErrorEventHandler errorEventHandler;
 
-  public JobThrowErrorProcessor(final MutableJobState state) {
-    this.state = state;
+  public JobThrowErrorProcessor(final ZeebeState state) {
+    jobState = state.getJobState();
+    elementInstanceState = state.getElementInstanceState();
+    errorEventHandler =
+        new ErrorEventHandler(
+            state.getWorkflowState(),
+            state.getElementInstanceState(),
+            state.getEventScopeInstanceState(),
+            state.getKeyGenerator());
+
     defaultProcessor =
         new DefaultJobCommandPreconditionGuard<>(
-            "throw an error for", this.state, this::acceptCommand);
+            "throw an error for", jobState, this::acceptCommand);
   }
 
   @Override
@@ -35,12 +58,60 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
       final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
     final long jobKey = command.getKey();
 
-    final JobRecord job = state.getJob(jobKey);
+    final JobRecord job = jobState.getJob(jobKey);
     job.setErrorCode(command.getValue().getErrorCodeBuffer());
     job.setErrorMessage(command.getValue().getErrorMessageBuffer());
 
-    state.throwError(jobKey, job);
-
     commandControl.accept(JobIntent.ERROR_THROWN, job);
+  }
+
+  @Override
+  public void afterAccept(
+      final TypedCommandWriter commandWriter,
+      final StateWriter stateWriter,
+      final long jobKey,
+      final Intent intent,
+      final JobRecord job) {
+
+    final var serviceTaskInstanceKey = job.getElementInstanceKey();
+    final var serviceTaskInstance = elementInstanceState.getInstance(serviceTaskInstanceKey);
+
+    if (serviceTaskInstance != null && serviceTaskInstance.isActive()) {
+
+      final var errorCode = job.getErrorCodeBuffer();
+
+      final boolean errorThrown =
+          errorEventHandler.throwErrorEvent(errorCode, serviceTaskInstance, stateWriter);
+      if (!errorThrown) {
+        raiseIncident(jobKey, job, commandWriter);
+      }
+    }
+  }
+
+  private void raiseIncident(
+      final long key, final JobRecord job, final TypedCommandWriter commandWriter) {
+
+    final DirectBuffer jobErrorMessage = job.getErrorMessageBuffer();
+    DirectBuffer incidentErrorMessage =
+        wrapString(
+            String.format(
+                "An error was thrown with the code '%s' but not caught.", job.getErrorCode()));
+    if (jobErrorMessage.capacity() > 0) {
+      incidentErrorMessage = jobErrorMessage;
+    }
+
+    incidentEvent.reset();
+    incidentEvent
+        .setErrorType(ErrorType.UNHANDLED_ERROR_EVENT)
+        .setErrorMessage(incidentErrorMessage)
+        .setBpmnProcessId(job.getBpmnProcessIdBuffer())
+        .setWorkflowKey(job.getWorkflowKey())
+        .setWorkflowInstanceKey(job.getWorkflowInstanceKey())
+        .setElementId(job.getElementIdBuffer())
+        .setElementInstanceKey(job.getElementInstanceKey())
+        .setJobKey(key)
+        .setVariableScopeKey(job.getElementInstanceKey());
+
+    commandWriter.appendNewCommand(IncidentIntent.CREATE, incidentEvent);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -9,43 +9,61 @@ package io.zeebe.engine.processing.job;
 
 import static io.zeebe.util.buffer.BufferUtil.wrapString;
 
-import io.zeebe.engine.processing.common.ErrorEventHandler;
+import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
 import io.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.zeebe.engine.state.KeyGenerator;
 import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.analyzers.CatchEventAnalyzer;
 import io.zeebe.engine.state.immutable.ElementInstanceState;
+import io.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.zeebe.engine.state.immutable.JobState;
+import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
+import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.IncidentIntent;
 import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.protocol.record.value.ErrorType;
 import org.agrona.DirectBuffer;
 
 public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
+
+  /**
+   * Marker element ID. This ID is used to indicate that a given catch event could not be found. The
+   * marker ID is used to prevent repeated catch event lookups, which is an expensive operation
+   * (particularly when no catch event can be found)
+   */
+  public static final String NO_CATCH_EVENT_FOUND = "NO_CATCH_EVENT_FOUND";
+
   private final IncidentRecord incidentEvent = new IncidentRecord();
+  private final WorkflowInstanceRecord eventOccurredRecord = new WorkflowInstanceRecord();
 
   private final JobState jobState;
   private final ElementInstanceState elementInstanceState;
   private final DefaultJobCommandPreconditionGuard<JobRecord> defaultProcessor;
-  private final ErrorEventHandler errorEventHandler;
+  private final CatchEventAnalyzer stateAnalyzer;
+  private final KeyGenerator keyGenerator;
+  private final EventScopeInstanceState eventScopeInstanceState;
 
   public JobThrowErrorProcessor(final ZeebeState state) {
+    keyGenerator = state.getKeyGenerator();
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
-    errorEventHandler =
-        new ErrorEventHandler(
-            state.getWorkflowState(),
-            state.getElementInstanceState(),
-            state.getEventScopeInstanceState(),
-            state.getKeyGenerator());
+    eventScopeInstanceState = state.getEventScopeInstanceState();
 
     defaultProcessor =
         new DefaultJobCommandPreconditionGuard<>(
             "throw an error for", jobState, this::acceptCommand);
+
+    stateAnalyzer = new CatchEventAnalyzer(state.getWorkflowState(), elementInstanceState);
   }
 
   @Override
@@ -62,7 +80,33 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
     job.setErrorCode(command.getValue().getErrorCodeBuffer());
     job.setErrorMessage(command.getValue().getErrorMessageBuffer());
 
-    commandControl.accept(JobIntent.ERROR_THROWN, job);
+    final var serviceTaskInstanceKey = job.getElementInstanceKey();
+    final var serviceTaskInstance = elementInstanceState.getInstance(serviceTaskInstanceKey);
+
+    final var errorCode = job.getErrorCodeBuffer();
+    final var foundCatchEvent = stateAnalyzer.findCatchEvent(errorCode, serviceTaskInstance);
+
+    if (foundCatchEvent == null) {
+      job.setElementId(NO_CATCH_EVENT_FOUND);
+
+      commandControl.accept(JobIntent.ERROR_THROWN, job);
+    } else if (!serviceTaskInstanceIsActive(serviceTaskInstance)) {
+      commandControl.reject(
+          RejectionType.INVALID_STATE,
+          "Expected to find active service task, but was " + serviceTaskInstance);
+    } else if (!eventScopeInstanceState.isAcceptingEvent(
+        foundCatchEvent.getElementInstance().getKey())) {
+      commandControl.reject(
+          RejectionType.INVALID_STATE,
+          "Expected to find event scope that is accepting events, but was "
+              + foundCatchEvent.getElementInstance());
+    } else {
+      commandControl.accept(JobIntent.ERROR_THROWN, job);
+    }
+  }
+
+  private boolean serviceTaskInstanceIsActive(final ElementInstance serviceTaskInstance) {
+    return serviceTaskInstance != null && serviceTaskInstance.isActive();
   }
 
   @Override
@@ -73,19 +117,46 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
       final Intent intent,
       final JobRecord job) {
 
-    final var serviceTaskInstanceKey = job.getElementInstanceKey();
-    final var serviceTaskInstance = elementInstanceState.getInstance(serviceTaskInstanceKey);
+    final var serviceTaskInstanceKey = job.getElementId();
 
-    if (serviceTaskInstance != null && serviceTaskInstance.isActive()) {
-
-      final var errorCode = job.getErrorCodeBuffer();
-
-      final boolean errorThrown =
-          errorEventHandler.throwErrorEvent(errorCode, serviceTaskInstance, stateWriter);
-      if (!errorThrown) {
-        raiseIncident(jobKey, job, commandWriter);
-      }
+    if (NO_CATCH_EVENT_FOUND.equals(serviceTaskInstanceKey)) {
+      raiseIncident(jobKey, job, commandWriter);
+      return;
     }
+
+    final var serviceTaskInstance = elementInstanceState.getInstance(job.getElementInstanceKey());
+    final var errorCode = job.getErrorCodeBuffer();
+
+    final var foundCatchEvent = stateAnalyzer.findCatchEvent(errorCode, serviceTaskInstance);
+    // TODO (#6472) send TERMINATE_ELEMENT command instead
+    writeEventOccurredRecord(stateWriter, foundCatchEvent);
+  }
+
+  private void writeEventOccurredRecord(
+      final StateWriter stateWriter, final CatchEventAnalyzer.CatchEventTuple foundCatchEvent) {
+    final var eventScopeInstance = foundCatchEvent.getElementInstance();
+    final var catchEvent = foundCatchEvent.getCatchEvent();
+
+    eventOccurredRecord.wrap(eventScopeInstance.getValue());
+
+    final long eventOccurredKey;
+    if (isEventSubprocess(catchEvent)) {
+      eventOccurredKey = keyGenerator.nextKey();
+      eventOccurredRecord
+          .setElementId(catchEvent.getId())
+          .setBpmnElementType(BpmnElementType.START_EVENT)
+          .setFlowScopeKey(eventScopeInstance.getKey());
+    } else {
+      eventOccurredKey = eventScopeInstance.getKey();
+    }
+
+    stateWriter.appendFollowUpEvent(
+        eventOccurredKey, WorkflowInstanceIntent.EVENT_OCCURRED, eventOccurredRecord);
+  }
+
+  private boolean isEventSubprocess(final ExecutableFlowElement catchEvent) {
+    return catchEvent instanceof ExecutableStartEvent
+        && ((ExecutableStartEvent) catchEvent).getEventSubProcess() != null;
   }
 
   private void raiseIncident(

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -16,12 +16,12 @@ import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.JobIntent;
 
-public final class TimeOutProcessor implements CommandProcessor<JobRecord> {
+public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
   public static final String NOT_ACTIVATED_JOB_MESSAGE =
       "Expected to time out activated job with key '%d', but %s";
   private final JobState state;
 
-  public TimeOutProcessor(final MutableJobState state) {
+  public JobTimeOutProcessor(final MutableJobState state) {
     this.state = state;
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -9,9 +9,9 @@ package io.zeebe.engine.processing.job;
 
 import io.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.immutable.JobState;
 import io.zeebe.engine.state.immutable.JobState.State;
-import io.zeebe.engine.state.mutable.MutableJobState;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.JobIntent;
@@ -19,24 +19,24 @@ import io.zeebe.protocol.record.intent.JobIntent;
 public final class JobTimeOutProcessor implements CommandProcessor<JobRecord> {
   public static final String NOT_ACTIVATED_JOB_MESSAGE =
       "Expected to time out activated job with key '%d', but %s";
-  private final JobState state;
+  private final JobState jobState;
 
-  public JobTimeOutProcessor(final MutableJobState state) {
-    this.state = state;
+  public JobTimeOutProcessor(final ZeebeState state) {
+    jobState = state.getJobState();
   }
 
   @Override
   public boolean onCommand(
       final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
     final long jobKey = command.getKey();
-    final JobState.State jobState = state.getState(jobKey);
+    final JobState.State state = jobState.getState(jobKey);
 
-    if (jobState == State.ACTIVATED) {
+    if (state == State.ACTIVATED) {
       commandControl.accept(JobIntent.TIMED_OUT, command.getValue());
     } else {
       final String textState;
 
-      switch (jobState) {
+      switch (state) {
         case ACTIVATABLE:
           textState = "it must be activated first";
           break;

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -14,7 +14,7 @@ import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.JobIntent;
 
-public final class UpdateRetriesProcessor implements CommandProcessor<JobRecord> {
+public final class JobUpdateRetriesProcessor implements CommandProcessor<JobRecord> {
 
   private static final String NO_JOB_FOUND_MESSAGE =
       "Expected to update retries for job with key '%d', but no such job was found";
@@ -24,7 +24,7 @@ public final class UpdateRetriesProcessor implements CommandProcessor<JobRecord>
 
   private final MutableJobState state;
 
-  public UpdateRetriesProcessor(final MutableJobState state) {
+  public JobUpdateRetriesProcessor(final MutableJobState state) {
     this.state = state;
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -9,7 +9,8 @@ package io.zeebe.engine.processing.job;
 
 import io.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
-import io.zeebe.engine.state.mutable.MutableJobState;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.immutable.JobState;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.JobIntent;
@@ -22,10 +23,10 @@ public final class JobUpdateRetriesProcessor implements CommandProcessor<JobReco
       "Expected to update retries for job with key '%d' with a positive amount of retries, "
           + "but the amount given was '%d'";
 
-  private final MutableJobState state;
+  private final JobState jobState;
 
-  public JobUpdateRetriesProcessor(final MutableJobState state) {
-    this.state = state;
+  public JobUpdateRetriesProcessor(final ZeebeState state) {
+    jobState = state.getJobState();
   }
 
   @Override
@@ -35,9 +36,13 @@ public final class JobUpdateRetriesProcessor implements CommandProcessor<JobReco
     final int retries = command.getValue().getRetries();
 
     if (retries > 0) {
-      final JobRecord updatedJob = state.updateJobRetries(key, retries);
-      if (updatedJob != null) {
-        commandControl.accept(JobIntent.RETRIES_UPDATED, updatedJob);
+      final JobRecord job = jobState.getJob(key);
+
+      if (job != null) {
+        // update retries for response sent to client
+        job.setRetries(retries);
+
+        commandControl.accept(JobIntent.RETRIES_UPDATED, job);
       } else {
         commandControl.reject(RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, key));
       }

--- a/engine/src/main/java/io/zeebe/engine/processing/job/TimeOutProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/TimeOutProcessor.java
@@ -19,7 +19,7 @@ import io.zeebe.protocol.record.intent.JobIntent;
 public final class TimeOutProcessor implements CommandProcessor<JobRecord> {
   public static final String NOT_ACTIVATED_JOB_MESSAGE =
       "Expected to time out activated job with key '%d', but %s";
-  private final MutableJobState state;
+  private final JobState state;
 
   public TimeOutProcessor(final MutableJobState state) {
     this.state = state;
@@ -32,7 +32,6 @@ public final class TimeOutProcessor implements CommandProcessor<JobRecord> {
     final JobState.State jobState = state.getState(jobKey);
 
     if (jobState == State.ACTIVATED) {
-      state.timeout(command.getKey(), command.getValue());
       commandControl.accept(JobIntent.TIMED_OUT, command.getValue());
     } else {
       final String textState;

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -51,7 +51,9 @@ public final class MigratedStreamProcessors {
                 JobIntent.COMPLETE,
                 JobIntent.COMPLETED,
                 JobIntent.FAIL,
-                JobIntent.FAILED)));
+                JobIntent.FAILED,
+                JobIntent.THROW_ERROR,
+                JobIntent.ERROR_THROWN)));
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.TESTING_ONLY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.EXCLUSIVE_GATEWAY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.PARALLEL_GATEWAY);

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -55,7 +55,9 @@ public final class MigratedStreamProcessors {
                 JobIntent.THROW_ERROR,
                 JobIntent.ERROR_THROWN,
                 JobIntent.TIME_OUT,
-                JobIntent.TIMED_OUT)));
+                JobIntent.TIMED_OUT,
+                JobIntent.UPDATE_RETRIES,
+                JobIntent.RETRIES_UPDATED)));
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.TESTING_ONLY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.EXCLUSIVE_GATEWAY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.PARALLEL_GATEWAY);

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -53,7 +53,9 @@ public final class MigratedStreamProcessors {
                 JobIntent.FAIL,
                 JobIntent.FAILED,
                 JobIntent.THROW_ERROR,
-                JobIntent.ERROR_THROWN)));
+                JobIntent.ERROR_THROWN,
+                JobIntent.TIME_OUT,
+                JobIntent.TIMED_OUT)));
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.TESTING_ONLY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.EXCLUSIVE_GATEWAY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.PARALLEL_GATEWAY);

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -57,7 +57,9 @@ public final class MigratedStreamProcessors {
                 JobIntent.TIME_OUT,
                 JobIntent.TIMED_OUT,
                 JobIntent.UPDATE_RETRIES,
-                JobIntent.RETRIES_UPDATED)));
+                JobIntent.RETRIES_UPDATED,
+                JobIntent.CANCEL,
+                JobIntent.CANCELED)));
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.TESTING_ONLY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.EXCLUSIVE_GATEWAY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.PARALLEL_GATEWAY);

--- a/engine/src/main/java/io/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
+++ b/engine/src/main/java/io/zeebe/engine/state/analyzers/CatchEventAnalyzer.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.analyzers;
+
+import io.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
+import io.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
+import io.zeebe.engine.processing.deployment.model.element.ExecutableWorkflow;
+import io.zeebe.engine.state.immutable.ElementInstanceState;
+import io.zeebe.engine.state.immutable.WorkflowState;
+import io.zeebe.engine.state.instance.ElementInstance;
+import org.agrona.DirectBuffer;
+
+/**
+ * Helper class that analyzes a workflow instance at runtime. It provides information about the
+ * existence of catch events. The information is derived from {@link WorkflowState} and {@link
+ * ElementInstanceState}.
+ */
+public final class CatchEventAnalyzer {
+
+  private final CatchEventTuple catchEventTuple = new CatchEventTuple();
+
+  private final WorkflowState workflowState;
+  private final ElementInstanceState elementInstanceState;
+
+  public CatchEventAnalyzer(
+      final WorkflowState workflowState, final ElementInstanceState elementInstanceState) {
+    this.workflowState = workflowState;
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  public boolean hasCatchEvent(final DirectBuffer errorCode, final ElementInstance instance) {
+    return findCatchEvent(errorCode, instance) != null;
+  }
+
+  public CatchEventTuple findCatchEvent(final DirectBuffer errorCode, ElementInstance instance) {
+    // assuming that error events are used rarely
+    // - just walk through the scope hierarchy and look for a matching catch event
+
+    while (instance != null && instance.isActive()) {
+      final var instanceRecord = instance.getValue();
+      final var workflow = getWorkflow(instanceRecord.getWorkflowKey());
+
+      final var found = findCatchEventInWorkflow(errorCode, workflow, instance);
+      if (found != null) {
+        return found;
+      }
+
+      // find in parent workflow instance if exists
+      final var parentElementInstanceKey = instanceRecord.getParentElementInstanceKey();
+      instance = elementInstanceState.getInstance(parentElementInstanceKey);
+    }
+
+    // no matching catch event found
+    return null;
+  }
+
+  private CatchEventTuple findCatchEventInWorkflow(
+      final DirectBuffer errorCode, final ExecutableWorkflow workflow, ElementInstance instance) {
+
+    while (instance != null && instance.isActive() && !instance.isInterrupted()) {
+      final var found = findCatchEventInScope(errorCode, workflow, instance);
+      if (found != null) {
+        return found;
+      }
+
+      // find in parent scope if exists
+      final var instanceParentKey = instance.getParentKey();
+      instance = elementInstanceState.getInstance(instanceParentKey);
+    }
+
+    return null;
+  }
+
+  private CatchEventTuple findCatchEventInScope(
+      final DirectBuffer errorCode,
+      final ExecutableWorkflow workflow,
+      final ElementInstance instance) {
+
+    final var workflowInstanceRecord = instance.getValue();
+    final var elementId = workflowInstanceRecord.getElementIdBuffer();
+    final var elementType = workflowInstanceRecord.getBpmnElementType();
+
+    final var element = workflow.getElementById(elementId, elementType, ExecutableActivity.class);
+
+    for (final ExecutableCatchEvent catchEvent : element.getEvents()) {
+      if (hasErrorCode(catchEvent, errorCode)) {
+
+        catchEventTuple.instance = instance;
+        catchEventTuple.catchEvent = catchEvent;
+        return catchEventTuple;
+      }
+    }
+
+    return null;
+  }
+
+  private boolean hasErrorCode(
+      final ExecutableCatchEvent catchEvent, final DirectBuffer errorCode) {
+    return catchEvent.isError() && catchEvent.getError().getErrorCode().equals(errorCode);
+  }
+
+  private ExecutableWorkflow getWorkflow(final long workflowKey) {
+
+    final var deployedWorkflow = workflowState.getWorkflowByKey(workflowKey);
+    if (deployedWorkflow == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected workflow with key '%d' to be deployed but not found", workflowKey));
+    }
+
+    return deployedWorkflow.getWorkflow();
+  }
+
+  public static final class CatchEventTuple {
+    private ExecutableCatchEvent catchEvent;
+    private ElementInstance instance;
+
+    public ExecutableCatchEvent getCatchEvent() {
+      return catchEvent;
+    }
+
+    public ElementInstance getElementInstance() {
+      return instance;
+    }
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ErrorThrownEventApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ErrorThrownEventApplier.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.processing.common.ErrorEventHandler;
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.zeebe.engine.state.mutable.MutableJobState;
+import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.record.intent.JobIntent;
+
+public class ErrorThrownEventApplier implements TypedEventApplier<JobIntent, JobRecord> {
+
+  private final MutableJobState jobState;
+  private final MutableElementInstanceState elementInstanceState;
+  private final ErrorEventHandler errorEventHandler;
+
+  ErrorThrownEventApplier(final ZeebeState state) {
+    jobState = state.getJobState();
+    elementInstanceState = state.getElementInstanceState();
+
+    errorEventHandler =
+        new ErrorEventHandler(
+            state.getWorkflowState(),
+            state.getElementInstanceState(),
+            state.getEventScopeInstanceState(),
+            state.getKeyGenerator());
+  }
+
+  @Override
+  public void applyState(final long jobKey, final JobRecord job) {
+    jobState.throwError(jobKey, job);
+
+    final var serviceTaskInstanceKey = job.getElementInstanceKey();
+    final var serviceTaskInstance = elementInstanceState.getInstance(serviceTaskInstanceKey);
+
+    final var errorCode = job.getErrorCodeBuffer();
+
+    if (errorEventHandler.hasCatchEvent(errorCode, serviceTaskInstance)) {
+
+      // remove job reference to not cancel it while terminating the task
+      serviceTaskInstance.setJobKey(-1L);
+      elementInstanceState.updateInstance(serviceTaskInstance);
+
+      jobState.delete(jobKey, job);
+    }
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -114,9 +114,9 @@ public final class EventAppliers implements EventApplier {
 
   private void registerJobIntentEventAppliers(final ZeebeState state) {
     register(JobIntent.CREATED, new JobCreatedApplier(state));
-    register(JobIntent.COMPLETED, new JobCompletedEventApplier(state));
+    register(JobIntent.COMPLETED, new JobCompletedApplier(state));
     register(JobIntent.FAILED, new JobFailedApplier(state));
-    register(JobIntent.ERROR_THROWN, new ErrorThrownEventApplier(state));
+    register(JobIntent.ERROR_THROWN, new JobErrorThrownApplier(state));
     register(JobIntent.TIMED_OUT, new JobTimedOutApplier(state));
   }
 

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -117,6 +117,7 @@ public final class EventAppliers implements EventApplier {
     register(JobIntent.COMPLETED, new JobCompletedEventApplier(state));
     register(JobIntent.FAILED, new JobFailedApplier(state));
     register(JobIntent.ERROR_THROWN, new ErrorThrownEventApplier(state));
+    register(JobIntent.TIMED_OUT, new JobTimedOutApplier(state));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -116,6 +116,7 @@ public final class EventAppliers implements EventApplier {
     register(JobIntent.CREATED, new JobCreatedApplier(state));
     register(JobIntent.COMPLETED, new JobCompletedEventApplier(state));
     register(JobIntent.FAILED, new JobFailedApplier(state));
+    register(JobIntent.ERROR_THROWN, new ErrorThrownEventApplier(state));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -118,6 +118,7 @@ public final class EventAppliers implements EventApplier {
     register(JobIntent.FAILED, new JobFailedApplier(state));
     register(JobIntent.ERROR_THROWN, new JobErrorThrownApplier(state));
     register(JobIntent.TIMED_OUT, new JobTimedOutApplier(state));
+    register(JobIntent.RETRIES_UPDATED, new JobRetriesUpdatedApplier(state));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -113,12 +113,13 @@ public final class EventAppliers implements EventApplier {
   }
 
   private void registerJobIntentEventAppliers(final ZeebeState state) {
-    register(JobIntent.CREATED, new JobCreatedApplier(state));
+    register(JobIntent.CANCELED, new JobCanceledApplier(state));
     register(JobIntent.COMPLETED, new JobCompletedApplier(state));
-    register(JobIntent.FAILED, new JobFailedApplier(state));
+    register(JobIntent.CREATED, new JobCreatedApplier(state));
     register(JobIntent.ERROR_THROWN, new JobErrorThrownApplier(state));
-    register(JobIntent.TIMED_OUT, new JobTimedOutApplier(state));
+    register(JobIntent.FAILED, new JobFailedApplier(state));
     register(JobIntent.RETRIES_UPDATED, new JobRetriesUpdatedApplier(state));
+    register(JobIntent.TIMED_OUT, new JobTimedOutApplier(state));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/JobCanceledApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/JobCanceledApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.mutable.MutableJobState;
+import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.record.intent.JobIntent;
+
+public class JobCanceledApplier implements TypedEventApplier<JobIntent, JobRecord> {
+
+  private final MutableJobState jobState;
+
+  JobCanceledApplier(final ZeebeState state) {
+    jobState = state.getJobState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobRecord value) {
+    jobState.cancel(key, value);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/JobCompletedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/JobCompletedApplier.java
@@ -18,14 +18,14 @@ import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 
-class JobCompletedEventApplier implements TypedEventApplier<JobIntent, JobRecord> {
+class JobCompletedApplier implements TypedEventApplier<JobIntent, JobRecord> {
 
   private final MutableJobState jobState;
   private final MutableElementInstanceState elementInstanceState;
   private final MutableEventScopeInstanceState eventScopeInstanceState;
   private final MutableVariableState variableState;
 
-  JobCompletedEventApplier(final ZeebeState state) {
+  JobCompletedApplier(final ZeebeState state) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
     eventScopeInstanceState = state.getEventScopeInstanceState();

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/JobErrorThrownApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/JobErrorThrownApplier.java
@@ -15,13 +15,13 @@ import io.zeebe.engine.state.mutable.MutableJobState;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.record.intent.JobIntent;
 
-public class ErrorThrownEventApplier implements TypedEventApplier<JobIntent, JobRecord> {
+public class JobErrorThrownApplier implements TypedEventApplier<JobIntent, JobRecord> {
 
   private final MutableJobState jobState;
   private final MutableElementInstanceState elementInstanceState;
   private final ErrorEventHandler errorEventHandler;
 
-  ErrorThrownEventApplier(final ZeebeState state) {
+  JobErrorThrownApplier(final ZeebeState state) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
 

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/JobRetriesUpdatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/JobRetriesUpdatedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.mutable.MutableJobState;
+import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.record.intent.JobIntent;
+
+public class JobRetriesUpdatedApplier implements TypedEventApplier<JobIntent, JobRecord> {
+
+  private final MutableJobState jobState;
+
+  JobRetriesUpdatedApplier(final ZeebeState state) {
+    jobState = state.getJobState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobRecord value) {
+    jobState.updateJobRetries(key, value.getRetries());
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/JobTimedOutApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/JobTimedOutApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.mutable.MutableJobState;
+import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.record.intent.JobIntent;
+
+public class JobTimedOutApplier implements TypedEventApplier<JobIntent, JobRecord> {
+
+  private final MutableJobState jobState;
+
+  JobTimedOutApplier(final ZeebeState state) {
+    jobState = state.getJobState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobRecord value) {
+    jobState.timeout(key, value);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/immutable/EventScopeInstanceState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/immutable/EventScopeInstanceState.java
@@ -28,4 +28,10 @@ public interface EventScopeInstanceState {
    * @return the next event trigger or null if none exist
    */
   EventTrigger peekEventTrigger(long eventScopeKey);
+
+  /**
+   * @param eventScopeKey the key of the event scope the event is triggered in
+   * @return true if the event can be accepted
+   */
+  boolean isAcceptingEvent(long eventScopeKey);
 }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/DbEventScopeInstanceState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/DbEventScopeInstanceState.java
@@ -106,6 +106,14 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
+  public boolean isAcceptingEvent(final long eventScopeKey) {
+    this.eventScopeKey.wrapLong(eventScopeKey);
+    final EventScopeInstance instance = eventScopeInstanceColumnFamily.get(this.eventScopeKey);
+
+    return isAcceptingEvent(instance);
+  }
+
+  @Override
   public boolean triggerEvent(
       final long eventScopeKey,
       final long eventKey,
@@ -114,7 +122,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
     this.eventScopeKey.wrapLong(eventScopeKey);
     final EventScopeInstance instance = eventScopeInstanceColumnFamily.get(this.eventScopeKey);
 
-    if (instance != null && instance.isAccepting()) {
+    if (isAcceptingEvent(instance)) {
       if (instance.isInterrupting(elementId)) {
         instance.setAccepting(false);
         eventScopeInstanceColumnFamily.put(this.eventScopeKey, instance);
@@ -126,6 +134,10 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
     } else {
       return false;
     }
+  }
+
+  private boolean isAcceptingEvent(final EventScopeInstance instance) {
+    return instance != null && instance.isAccepting();
   }
 
   private void createTrigger(

--- a/engine/src/test/java/io/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
@@ -164,7 +164,7 @@ public final class ErrorEventIncidentTest {
         .hasErrorType(ErrorType.UNHANDLED_ERROR_EVENT)
         .hasErrorMessage(
             String.format("An error was thrown with the code '%s' but not caught.", ERROR_CODE))
-        .hasElementId("task-in-subprocess");
+        .hasElementId("NO_CATCH_EVENT_FOUND");
   }
 
   @Test

--- a/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
@@ -95,12 +95,10 @@ public final class IncidentStreamProcessorRule extends ExternalResource {
                   mockTimerEventScheduler,
                   processingContext.getWriters());
 
-          final var jobErrorThrownProcessor =
-              JobEventProcessors.addJobProcessors(
-                  typedRecordProcessors, zeebeState, type -> {}, Integer.MAX_VALUE);
+          JobEventProcessors.addJobProcessors(
+              typedRecordProcessors, zeebeState, type -> {}, Integer.MAX_VALUE);
 
-          IncidentEventProcessors.addProcessors(
-              typedRecordProcessors, zeebeState, stepProcessor, jobErrorThrownProcessor);
+          IncidentEventProcessors.addProcessors(typedRecordProcessors, zeebeState, stepProcessor);
 
           return typedRecordProcessors;
         });

--- a/engine/src/test/java/io/zeebe/engine/util/WorkflowExecutor.java
+++ b/engine/src/test/java/io/zeebe/engine/util/WorkflowExecutor.java
@@ -81,7 +81,13 @@ public class WorkflowExecutor {
         .activate()
         .getValue()
         .getJobKeys()
-        .forEach(jobKey -> engineRule.job().withKey(jobKey).withRetries(2).fail());
+        .forEach(
+            jobKey -> {
+              if (activateAndFailJob.isUpdateRetries()) {
+                engineRule.job().withKey(jobKey).withRetries(5).updateRetries();
+              }
+              engineRule.job().withKey(jobKey).withRetries(1).fail();
+            });
   }
 
   private void waitForJobToBeCreated(final String jobType) {

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ServiceTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ServiceTaskBlockBuilder.java
@@ -8,6 +8,7 @@
 package io.zeebe.test.util.bpmn.random.blocks;
 
 import io.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.zeebe.model.bpmn.builder.ExclusiveGatewayBuilder;
 import io.zeebe.model.bpmn.builder.ServiceTaskBuilder;
 import io.zeebe.test.util.bpmn.random.AbstractExecutionStep;
 import io.zeebe.test.util.bpmn.random.BlockBuilder;
@@ -17,25 +18,50 @@ import io.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.zeebe.test.util.bpmn.random.IDGenerator;
 import java.util.Random;
 
-/** Generates a service task * */
+/** Generates a service task. The service task may have boundary events */
 public class ServiceTaskBlockBuilder implements BlockBuilder {
 
   private final String serviceTaskId;
-  private final String jobTypeId;
+  private final String jobType;
+  private final String errorCode;
 
-  public ServiceTaskBlockBuilder(final IDGenerator idGenerator) {
+  private final boolean hasBoundaryEvents;
+  private final boolean hasBoundaryErrorEvent;
+
+  public ServiceTaskBlockBuilder(final IDGenerator idGenerator, final Random random) {
     serviceTaskId = idGenerator.nextId();
-    jobTypeId = "job_" + serviceTaskId;
+    jobType = "job_" + serviceTaskId;
+    errorCode = "error_" + serviceTaskId;
+
+    hasBoundaryErrorEvent = random.nextInt(100) < 10;
+
+    hasBoundaryEvents = hasBoundaryErrorEvent; // extend here for additional boundary events
   }
 
   @Override
   public AbstractFlowNodeBuilder<?, ?> buildFlowNodes(
       final AbstractFlowNodeBuilder<?, ?> nodeBuilder) {
-    final ServiceTaskBuilder result = nodeBuilder.serviceTask(serviceTaskId);
 
-    result.zeebeJobRetries("3");
+    final ServiceTaskBuilder serviceTaskBuilder = nodeBuilder.serviceTask(serviceTaskId);
 
-    result.zeebeJobType("job_" + serviceTaskId);
+    serviceTaskBuilder.zeebeJobRetries("3");
+
+    serviceTaskBuilder.zeebeJobType(jobType);
+
+    AbstractFlowNodeBuilder<?, ?> result = serviceTaskBuilder;
+
+    if (hasBoundaryEvents) {
+      final String joinGatewayId = "join_" + serviceTaskId;
+      final ExclusiveGatewayBuilder exclusiveGatewayBuilder =
+          serviceTaskBuilder.exclusiveGateway(joinGatewayId);
+
+      if (hasBoundaryErrorEvent) {
+        result =
+            ((ServiceTaskBuilder) exclusiveGatewayBuilder.moveToNode(serviceTaskId))
+                .boundaryEvent("boundary_error_" + serviceTaskId, b -> b.error(errorCode))
+                .connectTo(joinGatewayId);
+      }
+    }
 
     return result;
   }
@@ -48,16 +74,42 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
   public ExecutionPathSegment findRandomExecutionPath(final Random random) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
+    result.append(buildStepsForFailedExecutions(random));
+
+    result.append(buildStepForSuccessfulExecution(random));
+
+    return result;
+  }
+
+  private ExecutionPathSegment buildStepsForFailedExecutions(final Random random) {
+    final ExecutionPathSegment result = new ExecutionPathSegment();
+
     if (random.nextBoolean()) {
-      result.append(new StepActivateAndTimeoutJob(jobTypeId));
+      result.append(new StepActivateAndTimeoutJob(jobType));
     }
 
     if (random.nextBoolean()) {
       final boolean updateRetries = random.nextBoolean();
-      result.append(new StepActivateAndFailJob(jobTypeId, updateRetries));
+      result.append(new StepActivateAndFailJob(jobType, updateRetries));
     }
 
-    result.append(new StepActivateAndCompleteJob(jobTypeId));
+    return result;
+  }
+
+  /**
+   * This method build the step that results in a successful execution of the service task.
+   * Successful execution here does not necessarily mean that the job is completed orderly.
+   * Successful execution is any execution which moves the token past the service task, so that the
+   * workflow can continue.
+   */
+  private AbstractExecutionStep buildStepForSuccessfulExecution(final Random random) {
+    final AbstractExecutionStep result;
+
+    if (hasBoundaryErrorEvent && random.nextBoolean()) {
+      result = new StepActivateJobAndThrowError(jobType, errorCode);
+    } else {
+      result = new StepActivateAndCompleteJob(jobType);
+    }
 
     return result;
   }
@@ -180,11 +232,59 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
     }
   }
 
+  public static class StepActivateJobAndThrowError extends AbstractExecutionStep {
+
+    private final String jobType;
+    private final String errorCode;
+
+    public StepActivateJobAndThrowError(final String jobType, final String errorCode) {
+      super();
+      this.jobType = jobType;
+      this.errorCode = errorCode;
+    }
+
+    public String getJobType() {
+      return jobType;
+    }
+
+    public String getErrorCode() {
+      return errorCode;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final StepActivateJobAndThrowError that = (StepActivateJobAndThrowError) o;
+
+      if (jobType != null ? !jobType.equals(that.jobType) : that.jobType != null) {
+        return false;
+      }
+      if (errorCode != null ? !errorCode.equals(that.errorCode) : that.errorCode != null) {
+        return false;
+      }
+      return variables.equals(that.variables);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = jobType != null ? jobType.hashCode() : 0;
+      result = errorCode != null ? errorCode.hashCode() : 0;
+      result = 31 * result + variables.hashCode();
+      return result;
+    }
+  }
+
   public static class Factory implements BlockBuilderFactory {
 
     @Override
     public BlockBuilder createBlockBuilder(final ConstructionContext context) {
-      return new ServiceTaskBlockBuilder(context.getIdGenerator());
+      return new ServiceTaskBlockBuilder(context.getIdGenerator(), context.getRandom());
     }
 
     @Override

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ServiceTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ServiceTaskBlockBuilder.java
@@ -45,7 +45,8 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
     if (random.nextBoolean()) {
-      result.append(new StepActivateAndFailJob(jobTypeId));
+      final boolean updateRetries = random.nextBoolean();
+      result.append(new StepActivateAndFailJob(jobTypeId, updateRetries));
     }
 
     result.append(new StepActivateAndCompleteJob(jobTypeId));
@@ -91,13 +92,19 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
 
   public static final class StepActivateAndFailJob extends AbstractExecutionStep {
     private final String jobType;
+    private final boolean updateRetries;
 
-    public StepActivateAndFailJob(final String jobType) {
+    public StepActivateAndFailJob(final String jobType, final boolean updateRetries) {
       this.jobType = jobType;
+      this.updateRetries = updateRetries;
     }
 
     public String getJobType() {
       return jobType;
+    }
+
+    public boolean isUpdateRetries() {
+      return updateRetries;
     }
 
     @Override
@@ -111,6 +118,9 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
 
       final StepActivateAndFailJob that = (StepActivateAndFailJob) o;
 
+      if (updateRetries != that.updateRetries) {
+        return false;
+      }
       if (jobType != null ? !jobType.equals(that.jobType) : that.jobType != null) {
         return false;
       }
@@ -120,6 +130,7 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
     @Override
     public int hashCode() {
       int result = jobType != null ? jobType.hashCode() : 0;
+      result = 31 * result + (updateRetries ? 1 : 0);
       result = 31 * result + variables.hashCode();
       return result;
     }

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ServiceTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ServiceTaskBlockBuilder.java
@@ -40,9 +40,17 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
     return result;
   }
 
+  /**
+   * This generates a sequence of one or more steps. The final step is always a successful
+   * activation and complete cycle. The steps before are randomly determined failed attempts.
+   */
   @Override
   public ExecutionPathSegment findRandomExecutionPath(final Random random) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
+
+    if (random.nextBoolean()) {
+      result.append(new StepActivateAndTimeoutJob(jobTypeId));
+    }
 
     if (random.nextBoolean()) {
       final boolean updateRetries = random.nextBoolean();
@@ -131,6 +139,42 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
     public int hashCode() {
       int result = jobType != null ? jobType.hashCode() : 0;
       result = 31 * result + (updateRetries ? 1 : 0);
+      result = 31 * result + variables.hashCode();
+      return result;
+    }
+  }
+
+  public static final class StepActivateAndTimeoutJob extends AbstractExecutionStep {
+    private final String jobType;
+
+    public StepActivateAndTimeoutJob(final String jobType) {
+      this.jobType = jobType;
+    }
+
+    public String getJobType() {
+      return jobType;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final StepActivateAndTimeoutJob that = (StepActivateAndTimeoutJob) o;
+
+      if (jobType != null ? !jobType.equals(that.jobType) : that.jobType != null) {
+        return false;
+      }
+      return variables.equals(that.variables);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = jobType != null ? jobType.hashCode() : 0;
       result = 31 * result + variables.hashCode();
       return result;
     }


### PR DESCRIPTION
## Description

Event sourcing for the remaining job processors. Also some extensions to the random workflow generation to cover more cases/commands.

The issue is not complete yet, though. The event sourcing for the job batch processors is still missing. But I think this PR has a good scope and size.

## Related issues

#6176 

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
