### PR TITLE
chore(journal): implement JournalRecord equals and hashcode

### DIFF
--- a/journal/src/main/java/io/zeebe/journal/file/PersistedJournalRecord.java
+++ b/journal/src/main/java/io/zeebe/journal/file/PersistedJournalRecord.java
@@ -15,6 +15,7 @@
  */
 package io.zeebe.journal.file;
 
+import com.google.common.base.Objects;
 import io.zeebe.journal.JournalRecord;
 import org.agrona.DirectBuffer;
 
@@ -52,5 +53,25 @@ class PersistedJournalRecord implements JournalRecord {
   @Override
   public DirectBuffer data() {
     return data;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == this) {
+      return true;
+    } else if (o == null || !o.getClass().equals(this.getClass())) {
+      return false;
+    }
+
+    final PersistedJournalRecord other = (PersistedJournalRecord) o;
+    return this.asqn == other.asqn
+        && this.checksum == other.checksum
+        && this.index == other.index
+        && this.data.equals(other.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(asqn, checksum, index, data);
   }
 }

--- a/journal/src/test/java/io/zeebe/journal/file/JournalReaderTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/JournalReaderTest.java
@@ -185,11 +185,7 @@ class JournalReaderTest {
     // then
     assertThat(nextIndex).isEqualTo(expectedRecord.index());
     assertThat(reader.hasNext()).isTrue();
-    final var record = reader.next();
-    assertThat(record.index()).isEqualTo(expectedRecord.index());
-    assertThat(record.asqn()).isEqualTo(expectedRecord.asqn());
-    assertThat(record.data()).isEqualTo(expectedRecord.data());
-    assertThat(record.checksum()).isEqualTo(expectedRecord.checksum());
+    assertThat(reader.next()).isEqualTo(expectedRecord);
   }
 
   @Test
@@ -205,11 +201,7 @@ class JournalReaderTest {
     // then
     assertThat(nextIndex).isEqualTo(expectedRecord.index());
     assertThat(reader.hasNext()).isTrue();
-    final var record = reader.next();
-    assertThat(record.index()).isEqualTo(expectedRecord.index());
-    assertThat(record.asqn()).isEqualTo(expectedRecord.asqn());
-    assertThat(record.data()).isEqualTo(expectedRecord.data());
-    assertThat(record.checksum()).isEqualTo(expectedRecord.checksum());
+    assertThat(reader.next()).isEqualTo(expectedRecord);
   }
 
   @Test
@@ -224,12 +216,7 @@ class JournalReaderTest {
     // then
     assertThat(nextIndex).isEqualTo(expectedRecord.index());
     assertThat(reader.hasNext()).isTrue();
-    final var record = reader.next();
-    assertThat(record.index()).isEqualTo(expectedRecord.index());
-    assertThat(record.asqn()).isEqualTo(expectedRecord.asqn());
-    assertThat(record.data()).isEqualTo(expectedRecord.data());
-    assertThat(record.checksum()).isEqualTo(expectedRecord.checksum());
-
+    assertThat(reader.next()).isEqualTo(expectedRecord);
     assertThat(reader.next().asqn()).isEqualTo(5);
   }
 

--- a/journal/src/test/java/io/zeebe/journal/file/JournalTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/JournalTest.java
@@ -83,9 +83,7 @@ public class JournalTest {
 
     // then
     final var recordRead = journal.openReader().next();
-    assertThat(recordAppended.index()).isEqualTo(recordRead.index());
-    assertThat(recordAppended.asqn()).isEqualTo(recordRead.asqn());
-    assertThat(recordAppended.checksum()).isEqualTo(recordRead.checksum());
+    assertThat(recordAppended).isEqualTo(recordRead);
   }
 
   @Test
@@ -198,9 +196,7 @@ public class JournalTest {
     assertThat(reader.hasNext()).isTrue();
 
     final var newRecord = reader.next();
-    assertThat(newRecord.index()).isEqualTo(record.index());
-    assertThat(newRecord.asqn()).isEqualTo(record.asqn());
-    assertThat(newRecord.data()).isEqualTo(record.data());
+    assertThat(newRecord).isEqualTo(record);
   }
 
   @Test
@@ -243,8 +239,7 @@ public class JournalTest {
     for (readerIndex = 1; readerIndex <= truncateIndex; readerIndex++) {
       assertThat(reader.hasNext()).isTrue();
       final var record = reader.next();
-      assertThat(record.index()).isEqualTo(readerIndex);
-      assertThat(record.asqn()).isEqualTo(written.get(readerIndex).asqn());
+      assertThat(record).isEqualTo(written.get(readerIndex));
     }
 
     // when
@@ -260,8 +255,7 @@ public class JournalTest {
     for (; readerIndex <= totalWrites; readerIndex++) {
       assertThat(reader.hasNext()).isTrue();
       final var record = reader.next();
-      assertThat(record.index()).isEqualTo(readerIndex);
-      assertThat(record.asqn()).isEqualTo(written.get(readerIndex).asqn());
+      assertThat(record).isEqualTo(written.get(readerIndex));
     }
   }
 
@@ -368,7 +362,7 @@ public class JournalTest {
   @Test
   public void shouldReadReopenedJournal() throws Exception {
     // when
-    final long index = journal.append(data).index();
+    final var appendedRecord = journal.append(data);
     journal.close();
     assertThat(journal.isOpen()).isFalse();
     journal = openJournal(getSerializedSize(data), 2);
@@ -377,10 +371,7 @@ public class JournalTest {
     // then
     assertThat(journal.isOpen()).isTrue();
     assertThat(reader.hasNext()).isTrue();
-
-    final JournalRecord record = reader.next();
-    assertThat(record.index()).isEqualTo(index);
-    assertThat(record.data()).isEqualTo(data);
+    assertThat(reader.next()).isEqualTo(appendedRecord);
   }
 
   private int getSerializedSize(final DirectBuffer data) {


### PR DESCRIPTION
## Description
Implements `equals` and `hashCode` in the PersistedJournalRecord so equality can be more easily asserted in tests. Also changes tests to use the new implementation.

## Related issues

closes #6360 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
