### PR TITLE
fix(broker): fix race condition in persisting snapshot

### DIFF
--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedTransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedTransientSnapshotTest.java
@@ -137,7 +137,7 @@ public class FileBasedTransientSnapshotTest {
   }
 
   @Test
-  public void shouldPurgePendingOnStore() throws Exception {
+  public void shouldPurgePendingOnStore() {
     // given
     final var index = 1L;
     final var term = 0L;
@@ -153,7 +153,7 @@ public class FileBasedTransientSnapshotTest {
   }
 
   @Test
-  public void shouldNotDeletePersistedSnapshotOnPurge() throws Exception {
+  public void shouldNotDeletePersistedSnapshotOnPurge() {
     // given
     final var index = 1L;
     final var term = 0L;
@@ -497,6 +497,34 @@ public class FileBasedTransientSnapshotTest {
     assertThatThrownBy(persisted::join)
         .hasCauseInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Snapshot is not valid");
+  }
+
+  @Test
+  public void shouldPersistIdempotently() {
+    // given
+    final var transientSnapshot =
+        persistedSnapshotStore.newTransientSnapshot(1L, 2L, 3, 4).orElseThrow();
+    transientSnapshot.take(this::createSnapshotDir).join();
+    final var firstSnapshot = transientSnapshot.persist().join();
+    assertSnapshotWasMoved();
+
+    // when
+    final var secondSnapshot = transientSnapshot.persist().join();
+
+    // then
+    assertThat(firstSnapshot).isEqualTo(secondSnapshot);
+    assertSnapshotWasMoved();
+  }
+
+  private void assertSnapshotWasMoved() {
+    assertThat(pendingSnapshotsDir.toFile().listFiles()).isEmpty();
+    final var snapshotDirs = snapshotsDir.toFile().listFiles();
+    assertThat(snapshotDirs).isNotNull().hasSize(1);
+    final var snapshotDir = snapshotDirs[0];
+    assertThat(snapshotDir.listFiles())
+        .isNotNull()
+        .extracting(File::getName)
+        .containsExactlyInAnyOrder("file1.txt", "CHECKSUM");
   }
 
   private boolean createSnapshotDir(final Path path) {


### PR DESCRIPTION
## Description

It's possible for a second call to `persist` to be executed between the first call to `persist` and the subsequent nulling of the pending snapshot (since it happens in an `onComplete` block). This PR eliminates this race condition and changes the 'persist' operation to be idempotent so that external race conditions don't cause it to fail.
 
## Related issues

closes #6377 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
