### PR TITLE
chore(snapshot): use actor naming pattern

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 public class RaftPartition implements Partition {
 
   private static final Logger LOG = LoggerFactory.getLogger(RaftPartition.class);
+  private static final String PARTITION_NAME_FORMAT = "%s-partition-%d";
   private final PartitionId partitionId;
   private final RaftPartitionGroupConfig config;
   private final File dataDirectory;
@@ -159,8 +160,7 @@ public class RaftPartition implements Partition {
    * @return the partition name
    */
   public String name() {
-
-    return String.format("%s-partition-%d", partitionId.group(), partitionId.id());
+    return String.format(PARTITION_NAME_FORMAT, partitionId.group(), partitionId.id());
   }
 
   /** Closes the partition. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -160,11 +160,12 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
   }
 
   private RaftServer buildServer() {
+    final var partitionId = partition.id().id();
     persistedSnapshotStore =
         config
             .getStorageConfig()
             .getPersistedSnapshotStoreFactory()
-            .createReceivableSnapshotStore(partition.dataDirectory().toPath(), partition.name());
+            .createReceivableSnapshotStore(partition.dataDirectory().toPath(), partitionId);
 
     return RaftServer.builder(localMemberId)
         .withName(partition.name())

--- a/atomix/core/src/test/java/io/atomix/core/NoopSnapshotStoreFactory.java
+++ b/atomix/core/src/test/java/io/atomix/core/NoopSnapshotStoreFactory.java
@@ -26,7 +26,7 @@ class NoopSnapshotStoreFactory implements ReceivableSnapshotStoreFactory {
 
   @Override
   public ReceivableSnapshotStore createReceivableSnapshotStore(
-      final Path directory, final String partitionName) {
+      final Path directory, final int partitionId) {
     return new NoopSnapshotStore();
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -206,7 +206,8 @@ public final class Broker implements AutoCloseable {
     final StartProcess startContext = new StartProcess("Broker-" + localBroker.getNodeId());
 
     startContext.addStep("actor scheduler", this::actorSchedulerStep);
-    startContext.addStep("membership and replication protocol", () -> atomixCreateStep(brokerCfg));
+    startContext.addStep(
+        "membership and replication protocol", () -> atomixCreateStep(brokerCfg, localBroker));
     startContext.addStep(
         "command api transport",
         () ->
@@ -253,8 +254,9 @@ public final class Broker implements AutoCloseable {
         scheduler.stop().get(brokerContext.getStepTimeout().toMillis(), TimeUnit.MILLISECONDS);
   }
 
-  private AutoCloseable atomixCreateStep(final BrokerCfg brokerCfg) {
-    final var snapshotStoreFactory = new FileBasedSnapshotStoreFactory(scheduler);
+  private AutoCloseable atomixCreateStep(final BrokerCfg brokerCfg, final BrokerInfo localBroker) {
+    final var snapshotStoreFactory =
+        new FileBasedSnapshotStoreFactory(scheduler, localBroker.getNodeId());
     snapshotStoreSupplier = snapshotStoreFactory;
     atomix = AtomixFactory.fromConfiguration(brokerCfg, snapshotStoreFactory);
 

--- a/broker/src/main/java/io/zeebe/broker/logstreams/LogDeletionService.java
+++ b/broker/src/main/java/io/zeebe/broker/logstreams/LogDeletionService.java
@@ -25,7 +25,7 @@ public final class LogDeletionService extends Actor implements PersistedSnapshot
       final PersistedSnapshotStore persistedSnapshotStore) {
     this.persistedSnapshotStore = persistedSnapshotStore;
     this.logCompactor = logCompactor;
-    actorName = buildActorName(nodeId, "DeletionService-" + partitionId);
+    actorName = buildActorName(nodeId, "DeletionService", partitionId);
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -56,7 +56,7 @@ public final class ZeebePartition extends Actor
     context.setActor(actor);
     context.setDiskSpaceAvailable(true);
 
-    actorName = buildActorName(context.getNodeId(), "ZeebePartition-" + context.getPartitionId());
+    actorName = buildActorName(context.getNodeId(), "ZeebePartition", context.getPartitionId());
     context.setComponentHealthMonitor(new CriticalComponentsHealthMonitor(actor, LOG));
     raftPartitionHealth =
         new RaftPartitionHealth(context.getRaftPartition(), actor, this::onRaftFailed);

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -58,7 +58,7 @@ public final class AsyncSnapshotDirector extends Actor {
     this.logStream = logStream;
     processorName = streamProcessor.getName();
     this.snapshotRate = snapshotRate;
-    actorName = buildActorName(nodeId, "SnapshotDirector-" + logStream.getPartitionId());
+    actorName = buildActorName(nodeId, "SnapshotDirector", logStream.getPartitionId());
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/StateReplication.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/StateReplication.java
@@ -40,7 +40,7 @@ public final class StateReplication implements SnapshotReplication {
       final PartitionMessagingService messagingService, final int partitionId, final int nodeId) {
     this.messagingService = messagingService;
     replicationTopic = String.format(REPLICATION_TOPIC_FORMAT, partitionId);
-    threadName = buildActorName(nodeId, "StateReplication-" + partitionId);
+    threadName = buildActorName(nodeId, "StateReplication", partitionId);
   }
 
   @Override

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
@@ -16,7 +16,6 @@ import io.zeebe.util.sched.future.ActorFuture;
 
 public class ExporterDirectorPartitionStep implements PartitionStep {
   private static final int EXPORTER_PROCESSOR_ID = 1003;
-  private static final String EXPORTER_NAME = "Exporter-%d";
 
   @Override
   public ActorFuture<Void> open(final PartitionContext context) {
@@ -25,9 +24,7 @@ public class ExporterDirectorPartitionStep implements PartitionStep {
     final ExporterDirectorContext exporterCtx =
         new ExporterDirectorContext()
             .id(EXPORTER_PROCESSOR_ID)
-            .name(
-                Actor.buildActorName(
-                    context.getNodeId(), String.format(EXPORTER_NAME, context.getPartitionId())))
+            .name(Actor.buildActorName(context.getNodeId(), "Exporter", context.getPartitionId()))
             .logStream(context.getLogStream())
             .zeebeDb(context.getZeebeDb())
             .descriptors(exporterDescriptors);

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/LeaderPostStoragePartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/LeaderPostStoragePartitionStep.java
@@ -18,7 +18,7 @@ public class LeaderPostStoragePartitionStep implements PartitionStep {
   public ActorFuture<Void> open(final PartitionContext context) {
     context
         .getSnapshotStoreSupplier()
-        .getPersistedSnapshotStore(context.getRaftPartition().name())
+        .getPersistedSnapshotStore(context.getRaftPartition().id().id())
         .addSnapshotListener(context.getSnapshotController());
 
     return CompletableActorFuture.completed(null);
@@ -28,7 +28,7 @@ public class LeaderPostStoragePartitionStep implements PartitionStep {
   public ActorFuture<Void> close(final PartitionContext context) {
     context
         .getSnapshotStoreSupplier()
-        .getPersistedSnapshotStore(context.getRaftPartition().name())
+        .getPersistedSnapshotStore(context.getRaftPartition().id().id())
         .removeSnapshotListener(context.getSnapshotController());
     return CompletableActorFuture.completed(null);
   }

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/LogDeletionPartitionStep.java
@@ -27,7 +27,7 @@ public class LogDeletionPartitionStep implements PartitionStep {
             logCompactor,
             context
                 .getSnapshotStoreSupplier()
-                .getPersistedSnapshotStore(context.getRaftPartition().name()));
+                .getPersistedSnapshotStore(context.getRaftPartition().id().id()));
 
     context.setLogDeletionService(deletionService);
     return context.getScheduler().submitActor(deletionService);

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
@@ -31,10 +31,8 @@ public class StateControllerPartitionStep implements PartitionStep {
             DefaultZeebeDbFactory.defaultFactory(databaseCfg.createRocksDbConfiguration()),
             context
                 .getSnapshotStoreSupplier()
-                .getConstructableSnapshotStore(context.getRaftPartition().name()),
-            context
-                .getSnapshotStoreSupplier()
-                .getReceivableSnapshotStore(context.getRaftPartition().name()),
+                .getConstructableSnapshotStore(context.getPartitionId()),
+            context.getSnapshotStoreSupplier().getReceivableSnapshotStore(context.getPartitionId()),
             runtimeDirectory,
             context.getSnapshotReplication(),
             new AtomixRecordEntrySupplierImpl(

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/ZeebeDbPartitionStep.java
@@ -20,7 +20,7 @@ public class ZeebeDbPartitionStep implements PartitionStep {
   public ActorFuture<Void> open(final PartitionContext context) {
     context
         .getSnapshotStoreSupplier()
-        .getPersistedSnapshotStore(context.getRaftPartition().name())
+        .getPersistedSnapshotStore(context.getRaftPartition().id().id())
         .addSnapshotListener(context.getSnapshotController());
 
     final ZeebeDb zeebeDb;

--- a/broker/src/test/java/io/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
+++ b/broker/src/test/java/io/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
@@ -8,6 +8,7 @@
 package io.zeebe.broker.clustering.atomix;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import io.atomix.core.Atomix;
 import io.atomix.raft.partition.RaftPartitionGroup;
@@ -38,7 +39,7 @@ public final class AtomixFactoryTest {
 
     // when
     final var atomix =
-        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory(null));
+        AtomixFactory.fromConfiguration(brokerConfig, mock(FileBasedSnapshotStoreFactory.class));
 
     // then
     final var config = getPartitionGroupConfig(atomix);
@@ -53,7 +54,7 @@ public final class AtomixFactoryTest {
 
     // when
     final var atomix =
-        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory(null));
+        AtomixFactory.fromConfiguration(brokerConfig, mock(FileBasedSnapshotStoreFactory.class));
 
     // then
     final var config = getPartitionGroupConfig(atomix);
@@ -68,7 +69,7 @@ public final class AtomixFactoryTest {
 
     // when
     final var atomix =
-        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory(null));
+        AtomixFactory.fromConfiguration(brokerConfig, mock(FileBasedSnapshotStoreFactory.class));
 
     // then
     final var config = getPartitionGroupConfig(atomix);
@@ -83,7 +84,7 @@ public final class AtomixFactoryTest {
 
     // when
     final var atomix =
-        AtomixFactory.fromConfiguration(brokerConfig, new FileBasedSnapshotStoreFactory(null));
+        AtomixFactory.fromConfiguration(brokerConfig, mock(FileBasedSnapshotStoreFactory.class));
 
     // then
     final var config = getPartitionGroupConfig(atomix);

--- a/broker/src/test/java/io/zeebe/broker/logstreams/AtomixLogDeletionServiceTest.java
+++ b/broker/src/test/java/io/zeebe/broker/logstreams/AtomixLogDeletionServiceTest.java
@@ -139,6 +139,8 @@ public final class AtomixLogDeletionServiceTest {
           .withMaxSegmentSize(JournalSegmentDescriptor.BYTES + 2 * Integer.BYTES + length)
           .withSnapshotStore(
               new FileBasedSnapshotStore(
+                  1,
+                  1,
                   new SnapshotMetrics("1"),
                   folder.newFolder("runtime").toPath(),
                   folder.newFolder("snapshots").toPath()));

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
@@ -67,17 +67,17 @@ public final class AsyncSnapshotingTest {
   @Before
   public void setup() throws IOException {
     final var rootDirectory = tempFolderRule.getRoot().toPath();
-    final var factory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get());
-    final String partitionName = "1";
-    factory.createReceivableSnapshotStore(rootDirectory, partitionName);
-    persistedSnapshotStore = factory.getConstructableSnapshotStore(partitionName);
+    final var factory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get(), 1);
+    final int partitionId = 1;
+    factory.createReceivableSnapshotStore(rootDirectory, partitionId);
+    persistedSnapshotStore = factory.getConstructableSnapshotStore(partitionId);
 
     snapshotController =
         new StateControllerImpl(
             1,
             ZeebeRocksDbFactory.newFactory(),
             persistedSnapshotStore,
-            factory.getReceivableSnapshotStore(partitionName),
+            factory.getReceivableSnapshotStore(partitionId),
             rootDirectory.resolve("runtime"),
             new NoneSnapshotReplication(),
             l ->

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
@@ -45,20 +45,20 @@ public final class FailingSnapshotChunkReplicationTest {
   public void setup(final SnapshotReplication replicator) throws IOException {
     final var senderRoot = tempFolderRule.newFolder("sender").toPath();
 
-    final var senderFactory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get());
-    senderFactory.createReceivableSnapshotStore(senderRoot, "1");
-    senderStore = senderFactory.getConstructableSnapshotStore("1");
+    final var senderFactory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get(), 1);
+    senderFactory.createReceivableSnapshotStore(senderRoot, 1);
+    senderStore = senderFactory.getConstructableSnapshotStore(1);
 
     final var receiverRoot = tempFolderRule.newFolder("receiver").toPath();
-    final var receiverFactory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get());
-    receiverStore = receiverFactory.createReceivableSnapshotStore(receiverRoot, "1");
+    final var receiverFactory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get(), 2);
+    receiverStore = receiverFactory.createReceivableSnapshotStore(receiverRoot, 1);
 
     replicatorSnapshotController =
         new StateControllerImpl(
             1,
             ZeebeRocksDbFactory.newFactory(),
             senderStore,
-            senderFactory.getReceivableSnapshotStore("1"),
+            senderFactory.getReceivableSnapshotStore(1),
             senderRoot.resolve("runtime"),
             replicator,
             l ->
@@ -72,8 +72,8 @@ public final class FailingSnapshotChunkReplicationTest {
         new StateControllerImpl(
             1,
             ZeebeRocksDbFactory.newFactory(),
-            receiverFactory.getConstructableSnapshotStore("1"),
-            receiverFactory.getReceivableSnapshotStore("1"),
+            receiverFactory.getConstructableSnapshotStore(1),
+            receiverFactory.getReceivableSnapshotStore(1),
             receiverRoot.resolve("runtime"),
             replicator,
             l ->

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
@@ -54,13 +54,13 @@ public final class ReplicateStateControllerTest {
   public void setup() throws IOException {
     final var senderRoot = tempFolderRule.newFolder("sender").toPath();
 
-    final var senderFactory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get());
-    senderFactory.createReceivableSnapshotStore(senderRoot, "1");
-    senderStore = senderFactory.getConstructableSnapshotStore("1");
+    final var senderFactory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get(), 1);
+    senderFactory.createReceivableSnapshotStore(senderRoot, 1);
+    senderStore = senderFactory.getConstructableSnapshotStore(1);
 
     final var receiverRoot = tempFolderRule.newFolder("receiver").toPath();
-    final var receiverFactory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get());
-    receiverStore = receiverFactory.createReceivableSnapshotStore(receiverRoot, "1");
+    final var receiverFactory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get(), 2);
+    receiverStore = receiverFactory.createReceivableSnapshotStore(receiverRoot, 1);
 
     replicator = new Replicator();
     replicatorSnapshotController =
@@ -68,7 +68,7 @@ public final class ReplicateStateControllerTest {
             1,
             ZeebeRocksDbFactory.newFactory(),
             senderStore,
-            senderFactory.getReceivableSnapshotStore("1"),
+            senderFactory.getReceivableSnapshotStore(1),
             senderRoot.resolve("runtime"),
             replicator,
             l ->
@@ -82,7 +82,7 @@ public final class ReplicateStateControllerTest {
         new StateControllerImpl(
             1,
             ZeebeRocksDbFactory.newFactory(),
-            receiverFactory.getConstructableSnapshotStore("1"),
+            receiverFactory.getConstructableSnapshotStore(1),
             receiverStore,
             receiverRoot.resolve("runtime"),
             replicator,

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -50,16 +50,16 @@ public final class StateControllerImplTest {
   public void setup() throws IOException {
     final var rootDirectory = tempFolderRule.newFolder("state").toPath();
 
-    final var factory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get());
-    factory.createReceivableSnapshotStore(rootDirectory, "1");
-    store = factory.getConstructableSnapshotStore("1");
+    final var factory = new FileBasedSnapshotStoreFactory(actorSchedulerRule.get(), 1);
+    factory.createReceivableSnapshotStore(rootDirectory, 1);
+    store = factory.getConstructableSnapshotStore(1);
 
     snapshotController =
         new StateControllerImpl(
             1,
             ZeebeRocksDbFactory.newFactory(),
             store,
-            factory.getReceivableSnapshotStore("1"),
+            factory.getReceivableSnapshotStore(1),
             rootDirectory.resolve("runtime"),
             new NoneSnapshotReplication(),
             l ->

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -86,7 +86,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
             .abortCondition(this::isClosed);
     logStream = processingContext.getLogStream();
     partitionId = logStream.getPartitionId();
-    actorName = buildActorName(processorBuilder.getNodeId(), "StreamProcessor-" + partitionId);
+    actorName = buildActorName(processorBuilder.getNodeId(), "StreamProcessor", partitionId);
   }
 
   public static StreamProcessorBuilder builder() {

--- a/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -69,7 +69,7 @@ public final class LogStreamImpl extends Actor implements LogStream, FailureList
 
     this.partitionId = partitionId;
     this.nodeId = nodeId;
-    actorName = buildActorName(nodeId, "LogStream-" + partitionId);
+    actorName = buildActorName(nodeId, "LogStream", partitionId);
 
     this.maxFrameLength = maxFrameLength;
     this.logStorage = logStorage;
@@ -270,7 +270,7 @@ public final class LogStreamImpl extends Actor implements LogStream, FailureList
     }
 
     writeBuffer =
-        Dispatchers.create(buildActorName(nodeId, "dispatcher-" + partitionId))
+        Dispatchers.create(buildActorName(nodeId, "dispatcher", partitionId))
             .maxFragmentLength(maxFrameLength)
             .initialPosition(initialPosition)
             .name(logName + "-write-buffer")
@@ -284,7 +284,7 @@ public final class LogStreamImpl extends Actor implements LogStream, FailureList
               if (throwable == null) {
                 appender =
                     new LogStorageAppender(
-                        buildActorName(nodeId, "LogAppender-" + partitionId),
+                        buildActorName(nodeId, "LogAppender", partitionId),
                         partitionId,
                         logStorage,
                         subscription,

--- a/snapshot/src/main/java/io/zeebe/snapshots/broker/SnapshotStoreSupplier.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/broker/SnapshotStoreSupplier.java
@@ -15,24 +15,24 @@ public interface SnapshotStoreSupplier {
   /**
    * Returns a partition's {@link ConstructableSnapshotStore}
    *
-   * @param partitionName
+   * @param partitionId
    * @return a ConstructableSnapshotStore
    */
-  ConstructableSnapshotStore getConstructableSnapshotStore(String partitionName);
+  ConstructableSnapshotStore getConstructableSnapshotStore(int partitionId);
 
   /**
    * Returns a partition's {@link ReceivableSnapshotStore}
    *
-   * @param partitionName
+   * @param partitionId
    * @return a ReceivableSnapshotStore
    */
-  ReceivableSnapshotStore getReceivableSnapshotStore(final String partitionName);
+  ReceivableSnapshotStore getReceivableSnapshotStore(final int partitionId);
 
   /**
    * Returns a partition's {@link PersistedSnapshotStore}
    *
-   * @param partitionName
+   * @param partitionId
    * @return a PersistedSnapshotStore
    */
-  PersistedSnapshotStore getPersistedSnapshotStore(String partitionName);
+  PersistedSnapshotStore getPersistedSnapshotStore(int partitionId);
 }

--- a/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStore.java
@@ -61,8 +61,11 @@ public final class FileBasedSnapshotStore extends Actor
   // used to write concurrently received snapshots in different pending directories
   private final AtomicLong receivingSnapshotStartCount;
   private final Set<PersistableSnapshot> pendingSnapshots = new HashSet<>();
+  private final String actorName;
 
   public FileBasedSnapshotStore(
+      final int nodeId,
+      final int partitionId,
       final SnapshotMetrics snapshotMetrics,
       final Path snapshotsDirectory,
       final Path pendingDirectory) {
@@ -72,10 +75,16 @@ public final class FileBasedSnapshotStore extends Actor
     receivingSnapshotStartCount = new AtomicLong();
 
     listeners = new CopyOnWriteArraySet<>();
+    actorName = buildActorName(nodeId, "SnapshotStore", partitionId);
 
     // load previous snapshots
     currentPersistedSnapshotRef = new AtomicReference<>(loadLatestSnapshot(snapshotsDirectory));
     purgePendingSnapshotsDirectory();
+  }
+
+  @Override
+  public String getName() {
+    return actorName;
   }
 
   private FileBasedSnapshot loadLatestSnapshot(final Path snapshotDirectory) {

--- a/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStoreFactory.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStoreFactory.java
@@ -14,9 +14,8 @@ import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
 import io.zeebe.snapshots.raft.ReceivableSnapshotStoreFactory;
 import io.zeebe.util.sched.ActorScheduler;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
 import org.agrona.IoUtil;
+import org.agrona.collections.Int2ObjectHashMap;
 
 /**
  * Loads existing snapshots in memory, cleaning out old and/or invalid snapshots if present.
@@ -33,16 +32,19 @@ public final class FileBasedSnapshotStoreFactory
   public static final String SNAPSHOTS_DIRECTORY = "snapshots";
   public static final String PENDING_DIRECTORY = "pending";
 
-  private final Map<String, FileBasedSnapshotStore> partitionSnapshotStores = new HashMap();
+  private final Int2ObjectHashMap<FileBasedSnapshotStore> partitionSnapshotStores =
+      new Int2ObjectHashMap<>();
   private final ActorScheduler actorScheduler;
+  private final int nodeId;
 
-  public FileBasedSnapshotStoreFactory(final ActorScheduler actorScheduler) {
+  public FileBasedSnapshotStoreFactory(final ActorScheduler actorScheduler, final int nodeId) {
     this.actorScheduler = actorScheduler;
+    this.nodeId = nodeId;
   }
 
   @Override
   public ReceivableSnapshotStore createReceivableSnapshotStore(
-      final Path root, final String partitionName) {
+      final Path root, final int partitionId) {
     final var snapshotDirectory = root.resolve(SNAPSHOTS_DIRECTORY);
     final var pendingDirectory = root.resolve(PENDING_DIRECTORY);
 
@@ -50,31 +52,35 @@ public final class FileBasedSnapshotStoreFactory
     IoUtil.ensureDirectoryExists(pendingDirectory.toFile(), "Pending snapshot directory");
 
     return partitionSnapshotStores.computeIfAbsent(
-        partitionName,
-        p -> createAndOpenNewSnapshotStore(partitionName, snapshotDirectory, pendingDirectory));
+        partitionId,
+        p -> createAndOpenNewSnapshotStore(partitionId, snapshotDirectory, pendingDirectory));
   }
 
   private FileBasedSnapshotStore createAndOpenNewSnapshotStore(
-      final String partitionName, final Path snapshotDirectory, final Path pendingDirectory) {
+      final int partitionId, final Path snapshotDirectory, final Path pendingDirectory) {
     final var snapshotStore =
         new FileBasedSnapshotStore(
-            new SnapshotMetrics(partitionName), snapshotDirectory, pendingDirectory);
+            nodeId,
+            partitionId,
+            new SnapshotMetrics(Integer.toString(partitionId)),
+            snapshotDirectory,
+            pendingDirectory);
     actorScheduler.submitActor(snapshotStore).join();
     return snapshotStore;
   }
 
   @Override
-  public ConstructableSnapshotStore getConstructableSnapshotStore(final String partitionName) {
-    return partitionSnapshotStores.get(partitionName);
+  public ConstructableSnapshotStore getConstructableSnapshotStore(final int partitionId) {
+    return partitionSnapshotStores.get(partitionId);
   }
 
   @Override
-  public ReceivableSnapshotStore getReceivableSnapshotStore(final String partitionName) {
-    return partitionSnapshotStores.get(partitionName);
+  public ReceivableSnapshotStore getReceivableSnapshotStore(final int partitionId) {
+    return partitionSnapshotStores.get(partitionId);
   }
 
   @Override
-  public PersistedSnapshotStore getPersistedSnapshotStore(final String partitionName) {
-    return partitionSnapshotStores.get(partitionName);
+  public PersistedSnapshotStore getPersistedSnapshotStore(final int partitionId) {
+    return partitionSnapshotStores.get(partitionId);
   }
 }

--- a/snapshot/src/main/java/io/zeebe/snapshots/raft/ReceivableSnapshotStoreFactory.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/raft/ReceivableSnapshotStoreFactory.java
@@ -20,8 +20,8 @@ public interface ReceivableSnapshotStoreFactory {
    * Creates a snapshot store operating in the given {@code directory}.
    *
    * @param directory the root directory where snapshots should be stored
-   * @param partitionName the partition name for this store
+   * @param partitionId the id of the partition for this store
    * @return a new {@link PersistedSnapshotStore}
    */
-  ReceivableSnapshotStore createReceivableSnapshotStore(Path directory, String partitionName);
+  ReceivableSnapshotStore createReceivableSnapshotStore(Path directory, int partitionId);
 }

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedReceivedSnapshotTest.java
@@ -48,18 +48,18 @@ public class FileBasedReceivedSnapshotTest {
 
   @Before
   public void before() throws Exception {
-    final String partitionName = "1";
+    final int partitiondId = 1;
     final File senderRoot = temporaryFolder.newFolder("sender");
 
     final var senderSnapshotStoreFactory =
-        new FileBasedSnapshotStoreFactory(createActorScheduler());
-    senderSnapshotStoreFactory.createReceivableSnapshotStore(senderRoot.toPath(), partitionName);
-    senderSnapshotStore = senderSnapshotStoreFactory.getConstructableSnapshotStore(partitionName);
+        new FileBasedSnapshotStoreFactory(createActorScheduler(), 1);
+    senderSnapshotStoreFactory.createReceivableSnapshotStore(senderRoot.toPath(), partitiondId);
+    senderSnapshotStore = senderSnapshotStoreFactory.getConstructableSnapshotStore(partitiondId);
 
     final var receiverRoot = temporaryFolder.newFolder("received");
     receiverSnapshotStore =
-        new FileBasedSnapshotStoreFactory(createActorScheduler())
-            .createReceivableSnapshotStore(receiverRoot.toPath(), partitionName);
+        new FileBasedSnapshotStoreFactory(createActorScheduler(), 2)
+            .createReceivableSnapshotStore(receiverRoot.toPath(), partitiondId);
 
     receiverSnapshotsDir =
         receiverRoot.toPath().resolve(FileBasedSnapshotStoreFactory.SNAPSHOTS_DIRECTORY);
@@ -268,10 +268,10 @@ public class FileBasedReceivedSnapshotTest {
     final var term = 0L;
 
     final FileBasedSnapshotStoreFactory fileBasedSnapshotStoreFactory =
-        new FileBasedSnapshotStoreFactory(createActorScheduler());
+        new FileBasedSnapshotStoreFactory(createActorScheduler(), 1);
     fileBasedSnapshotStoreFactory.createReceivableSnapshotStore(
-        temporaryFolder.newFolder("other").toPath(), "1");
-    final var otherStore = fileBasedSnapshotStoreFactory.getConstructableSnapshotStore("1");
+        temporaryFolder.newFolder("other").toPath(), 1);
+    final var otherStore = fileBasedSnapshotStoreFactory.getConstructableSnapshotStore(1);
     final var olderTransient = otherStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
     olderTransient.take(this::takeSnapshot).join();
     final var olderPersistedSnapshot = olderTransient.persist().join();
@@ -400,7 +400,7 @@ public class FileBasedReceivedSnapshotTest {
     assertThat(committedSnapshotDir.listFiles())
         .isNotNull()
         .extracting(File::getName)
-        .containsExactly(persistedSnapshot.getPath().toFile().list());
+        .containsExactlyInAnyOrder(persistedSnapshot.getPath().toFile().list());
 
     assertThat(receiverPendingSnapshotsDir.toFile().listFiles()).isEmpty();
   }

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStoreFactoryTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStoreFactoryTest.java
@@ -21,10 +21,10 @@ public final class FileBasedSnapshotStoreFactoryTest {
   public void shouldCreateDirectoriesIfNotExist() {
     // given
     final var root = temporaryFolder.getRoot().toPath();
-    final var factory = new FileBasedSnapshotStoreFactory(createActorScheduler());
+    final var factory = new FileBasedSnapshotStoreFactory(createActorScheduler(), 1);
 
     // when
-    final var store = factory.createReceivableSnapshotStore(root, "ignored");
+    final var store = factory.createReceivableSnapshotStore(root, 1);
 
     // then
     assertThat(root.resolve(FileBasedSnapshotStoreFactory.SNAPSHOTS_DIRECTORY))

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStoreTest.java
@@ -39,15 +39,15 @@ public class FileBasedSnapshotStoreTest {
   private Path pendingSnapshotsDir;
   private FileBasedSnapshotStoreFactory factory;
   private File root;
-  private String partitionName;
+  private int partitionId;
 
   @Before
   public void before() {
-    factory = new FileBasedSnapshotStoreFactory(createActorScheduler());
-    partitionName = "1";
+    factory = new FileBasedSnapshotStoreFactory(createActorScheduler(), 1);
+    partitionId = 1;
     root = temporaryFolder.getRoot();
 
-    factory.createReceivableSnapshotStore(root.toPath(), partitionName);
+    factory.createReceivableSnapshotStore(root.toPath(), partitionId);
 
     snapshotsDir =
         temporaryFolder
@@ -78,7 +78,7 @@ public class FileBasedSnapshotStoreTest {
     // given
 
     // when
-    factory.getPersistedSnapshotStore(partitionName).delete().join();
+    factory.getPersistedSnapshotStore(partitionId).delete().join();
 
     // then
     assertThat(pendingSnapshotsDir).doesNotExist();
@@ -92,7 +92,7 @@ public class FileBasedSnapshotStoreTest {
     final var term = 0L;
     final var transientSnapshot =
         factory
-            .getConstructableSnapshotStore(partitionName)
+            .getConstructableSnapshotStore(partitionId)
             .newTransientSnapshot(index, term, 1, 0)
             .orElseThrow();
     transientSnapshot.take(this::createSnapshotDir);
@@ -100,8 +100,8 @@ public class FileBasedSnapshotStoreTest {
 
     // when
     final var snapshotStore =
-        new FileBasedSnapshotStoreFactory(createActorScheduler())
-            .createReceivableSnapshotStore(root.toPath(), partitionName);
+        new FileBasedSnapshotStoreFactory(createActorScheduler(), 1)
+            .createReceivableSnapshotStore(root.toPath(), partitionId);
 
     // then
     final var currentSnapshotIndex = snapshotStore.getCurrentSnapshotIndex();
@@ -136,8 +136,8 @@ public class FileBasedSnapshotStoreTest {
 
     // when
     final var snapshotStore =
-        new FileBasedSnapshotStoreFactory(createActorScheduler())
-            .createReceivableSnapshotStore(root.toPath(), partitionName);
+        new FileBasedSnapshotStoreFactory(createActorScheduler(), 1)
+            .createReceivableSnapshotStore(root.toPath(), partitionId);
 
     // then
     final var currentSnapshotIndex = snapshotStore.getCurrentSnapshotIndex();
@@ -155,7 +155,7 @@ public class FileBasedSnapshotStoreTest {
     final var term = 0L;
     final var transientSnapshot =
         factory
-            .getConstructableSnapshotStore(partitionName)
+            .getConstructableSnapshotStore(partitionId)
             .newTransientSnapshot(index, term, 1, 0)
             .orElseThrow();
     transientSnapshot.take(this::createSnapshotDir);
@@ -165,8 +165,8 @@ public class FileBasedSnapshotStoreTest {
 
     // when
     final var snapshotStore =
-        new FileBasedSnapshotStoreFactory(createActorScheduler())
-            .createReceivableSnapshotStore(root.toPath(), partitionName);
+        new FileBasedSnapshotStoreFactory(createActorScheduler(), 1)
+            .createReceivableSnapshotStore(root.toPath(), partitionId);
 
     // then
     final var currentSnapshotIndex = snapshotStore.getCurrentSnapshotIndex();

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedTransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedTransientSnapshotTest.java
@@ -40,12 +40,12 @@ public class FileBasedTransientSnapshotTest {
   @Before
   public void before() {
     final FileBasedSnapshotStoreFactory factory =
-        new FileBasedSnapshotStoreFactory(createActorScheduler());
-    final String partitionName = "1";
+        new FileBasedSnapshotStoreFactory(createActorScheduler(), 1);
+    final int partitionId = 1;
     final File root = temporaryFolder.getRoot();
 
-    factory.createReceivableSnapshotStore(root.toPath(), partitionName);
-    persistedSnapshotStore = factory.getConstructableSnapshotStore(partitionName);
+    factory.createReceivableSnapshotStore(root.toPath(), partitionId);
+    persistedSnapshotStore = factory.getConstructableSnapshotStore(partitionId);
 
     snapshotsDir =
         temporaryFolder

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/PersistedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/PersistedSnapshotStoreTest.java
@@ -25,12 +25,12 @@ public class PersistedSnapshotStoreTest {
   @Before
   public void before() {
     final FileBasedSnapshotStoreFactory factory =
-        new FileBasedSnapshotStoreFactory(createActorScheduler());
+        new FileBasedSnapshotStoreFactory(createActorScheduler(), 1);
 
-    final var partitionName = "1";
+    final var partitionId = 1;
     final var root = temporaryFolder.getRoot();
 
-    persistedSnapshotStore = factory.createReceivableSnapshotStore(root.toPath(), partitionName);
+    persistedSnapshotStore = factory.createReceivableSnapshotStore(root.toPath(), partitionId);
   }
 
   private ActorScheduler createActorScheduler() {

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/ReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/ReceivedSnapshotTest.java
@@ -36,16 +36,16 @@ public class ReceivedSnapshotTest {
 
   @Before
   public void before() throws Exception {
-    final String partitionName = "1";
+    final int partitionId = 1;
 
-    final var senderFactory = new FileBasedSnapshotStoreFactory(createActorScheduler());
+    final var senderFactory = new FileBasedSnapshotStoreFactory(createActorScheduler(), 1);
     senderFactory.createReceivableSnapshotStore(
-        temporaryFolder.newFolder("sender").toPath(), partitionName);
-    senderSnapshotStore = senderFactory.getConstructableSnapshotStore(partitionName);
+        temporaryFolder.newFolder("sender").toPath(), partitionId);
+    senderSnapshotStore = senderFactory.getConstructableSnapshotStore(partitionId);
     receiverSnapshotStore =
-        new FileBasedSnapshotStoreFactory(createActorScheduler())
+        new FileBasedSnapshotStoreFactory(createActorScheduler(), 2)
             .createReceivableSnapshotStore(
-                temporaryFolder.newFolder("received").toPath(), partitionName);
+                temporaryFolder.newFolder("received").toPath(), partitionId);
   }
 
   private ActorScheduler createActorScheduler() {

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/SnapshotChunkReaderTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/SnapshotChunkReaderTest.java
@@ -41,12 +41,12 @@ public class SnapshotChunkReaderTest {
   @Before
   public void before() {
     final FileBasedSnapshotStoreFactory factory =
-        new FileBasedSnapshotStoreFactory(createActorScheduler());
-    final String partitionName = "1";
+        new FileBasedSnapshotStoreFactory(createActorScheduler(), 1);
+    final int partitionId = 1;
     final File root = temporaryFolder.getRoot();
 
-    factory.createReceivableSnapshotStore(root.toPath(), partitionName);
-    persistedSnapshotStore = factory.getConstructableSnapshotStore(partitionName);
+    factory.createReceivableSnapshotStore(root.toPath(), partitionId);
+    persistedSnapshotStore = factory.getConstructableSnapshotStore(partitionId);
   }
 
   private ActorScheduler createActorScheduler() {

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/TransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/TransientSnapshotTest.java
@@ -40,12 +40,12 @@ public class TransientSnapshotTest {
   @Before
   public void before() {
     final FileBasedSnapshotStoreFactory factory =
-        new FileBasedSnapshotStoreFactory(createActorScheduler());
-    final String partitionName = "1";
+        new FileBasedSnapshotStoreFactory(createActorScheduler(), 1);
+    final int partitionId = 1;
     final File root = temporaryFolder.getRoot();
 
-    factory.createReceivableSnapshotStore(root.toPath(), partitionName);
-    persistedSnapshotStore = factory.getConstructableSnapshotStore(partitionName);
+    factory.createReceivableSnapshotStore(root.toPath(), partitionId);
+    persistedSnapshotStore = factory.getConstructableSnapshotStore(partitionId);
   }
 
   private ActorScheduler createActorScheduler() {

--- a/util/src/main/java/io/zeebe/util/sched/Actor.java
+++ b/util/src/main/java/io/zeebe/util/sched/Actor.java
@@ -74,6 +74,10 @@ public abstract class Actor implements CloseableSilently, AsyncClosable {
     return String.format("Broker-%d-%s", nodeId, name);
   }
 
+  public static String buildActorName(final int nodeId, final String name, final int partitionId) {
+    return String.format("Broker-%d-%s-%d", nodeId, name, partitionId);
+  }
+
   /**
    * Invoked when a task throws an exception when the actor phase is not 'STARTING' and 'CLOSING'.
    *


### PR DESCRIPTION
## Description

 * SnapshotStore follows same actor name pattern
 * FileSnapshotStoreFactory gets node id and partition id instead of partition name
 * This unifies also SnapshotMetrics, since we normally use only the id as label not raft-partition-partition-1
 * Actor.buildActorName is overloaded to support partition id as format, so we dont need to do it everywhere.

I haven't enforced the actor naming yet since this would cause a lot of others changes. If you think we should do that then I would create a follow up issue @deepthidevaki 

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6375 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
