### PR TITLE
Remove unused configuration raft storage configuration

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -31,7 +31,6 @@ import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.NoopEntryValidator;
-import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.index.JournalIndex;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -75,16 +74,13 @@ import java.util.function.Supplier;
  * <h2>Storage</h2>
  *
  * By default, the log is stored on disk, but users can override the default {@link RaftStorage}
- * configuration via {@link RaftServer.Builder#withStorage(RaftStorage)}. Most notably, to configure
- * the storage module to store entries in memory instead of disk, configure the {@link
- * StorageLevel}.
+ * configuration via {@link RaftServer.Builder#withStorage(RaftStorage)}.
  *
  * <pre>{@code
  * RaftServer server = RaftServer.builder(address)
  *   .withStateMachine(MyStateMachine::new)
  *   .withStorage(Storage.builder()
  *     .withDirectory(new File("logs"))
- *     .withStorageLevel(StorageLevel.DISK)
  *     .build())
  *   .build();
  * }</pre>
@@ -160,7 +156,7 @@ public interface RaftServer {
    *
    * <p>The server name is provided to the server via the {@link Builder#withName(String) builder
    * configuration}. The name is used internally to manage the server's on-disk state. {@link
-   * RaftLog Log}, {@link snapshot}, and {@link io.atomix.raft.storage.system.MetaStore
+   * RaftLog Log}, {@code snapshot}, and {@link io.atomix.raft.storage.system.MetaStore
    * configuration} files stored on disk use the server name as the prefix.
    *
    * @return The server name.
@@ -173,8 +169,7 @@ public interface RaftServer {
    * <p>The {@link RaftCluster} is representative of the server's current view of the cluster
    * configuration. The first time the server is {@link #bootstrap() started}, the cluster
    * configuration will be initialized using the {@link MemberId} list provided to the server {@link
-   * #builder(MemberId) builder}. For {@link StorageLevel#DISK persistent} servers, subsequent
-   * starts will result in the last known cluster configuration being loaded from disk.
+   * #builder(MemberId) builder}
    *
    * @return The server's cluster configuration.
    */

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/RaftCluster.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/RaftCluster.java
@@ -18,7 +18,6 @@ package io.atomix.raft.cluster;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftServer;
-import io.atomix.storage.StorageLevel;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -63,8 +62,7 @@ import java.util.function.Consumer;
  * When a member is removed from the cluster, the configuration change removing the member will be
  * replicated to all the servers in the cluster and persisted to disk. Once a member has been
  * removed, for that member to rejoin the cluster it must fully restart and request to rejoin the
- * cluster. For servers configured with a persistent {@link StorageLevel}, cluster configurations
- * are stored on disk.
+ * cluster. Cluster configurations are stored on disk.
  *
  * <p>Additionally, members can be {@link RaftMember#promote() promoted} and {@link
  * RaftMember#demote() demoted} by any other member of the cluster. When a member state is changed,
@@ -72,7 +70,7 @@ import java.util.function.Consumer;
  * replicated through the Raft consensus algorithm. <em>During</em> the configuration change,
  * servers' cluster configurations will be updated. Once the configuration change is complete, it
  * will be persisted to disk on all servers and is guaranteed not to be lost even in the event of a
- * full cluster shutdown (assuming the server uses a persistent {@link StorageLevel}).
+ * full cluster shutdown.
  */
 public interface RaftCluster {
 
@@ -217,8 +215,7 @@ public interface RaftCluster {
    *
    * <p>The term is representative of the epoch determined by the underlying Raft consensus
    * algorithm. The term is a monotonically increasing number used by Raft to represent a point in
-   * logical time. If the cluster is persistent (i.e. all servers use a persistent {@link
-   * StorageLevel}), the term is guaranteed to be unique and monotonically increasing even across
+   * logical time. The term is guaranteed to be unique and monotonically increasing even across
    * cluster restarts. Additionally, for any given term, Raft guarantees that only a single {@link
    * #getLeader() leader} can be elected.
    *

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -34,7 +34,6 @@ import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.zeebe.EntryValidator;
-import io.atomix.storage.StorageLevel;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
@@ -273,7 +272,6 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
           .nextId(Namespaces.BEGIN_USER_CUSTOM_ID + 100)
           .register(RaftPartitionGroupConfig.class)
           .register(RaftStorageConfig.class)
-          .register(StorageLevel.class)
           .build();
     }
 
@@ -386,17 +384,6 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
     public Builder withMaxAppendBatchSize(final int maxAppendBatchSize) {
       checkArgument(maxAppendBatchSize > 0, "maxAppendBatchSize must be positive");
       config.setMaxAppendBatchSize(maxAppendBatchSize);
-      return this;
-    }
-
-    /**
-     * Sets the storage level.
-     *
-     * @param storageLevel the storage level
-     * @return the Raft partition group builder
-     */
-    public Builder withStorageLevel(final StorageLevel storageLevel) {
-      config.getStorageConfig().setLevel(storageLevel);
       return this;
     }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
@@ -16,10 +16,7 @@
  */
 package io.atomix.raft.partition;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.esotericsoftware.kryo.serializers.FieldSerializer.Optional;
-import io.atomix.storage.StorageLevel;
 import io.atomix.utils.memory.MemorySize;
 import io.zeebe.snapshots.raft.ReceivableSnapshotStoreFactory;
 
@@ -27,7 +24,6 @@ import io.zeebe.snapshots.raft.ReceivableSnapshotStoreFactory;
 public class RaftStorageConfig {
 
   private static final String DATA_PREFIX = ".data";
-  private static final StorageLevel DEFAULT_STORAGE_LEVEL = StorageLevel.DISK;
   private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
   private static final int DEFAULT_MAX_ENTRY_SIZE = 1024 * 1024;
   private static final boolean DEFAULT_FLUSH_EXPLICITLY = true;
@@ -35,7 +31,6 @@ public class RaftStorageConfig {
   private static final int DEFAULT_JOURNAL_INDEX_DENSITY = 100;
 
   private String directory;
-  private StorageLevel level = DEFAULT_STORAGE_LEVEL;
   private int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
   private long segmentSize = DEFAULT_MAX_SEGMENT_SIZE;
   private boolean flushExplicitly = DEFAULT_FLUSH_EXPLICITLY;
@@ -55,26 +50,6 @@ public class RaftStorageConfig {
     return directory != null
         ? directory
         : System.getProperty("atomix.data", DATA_PREFIX) + "/" + groupName;
-  }
-
-  /**
-   * Returns the partition storage level.
-   *
-   * @return the partition storage level
-   */
-  public StorageLevel getLevel() {
-    return level;
-  }
-
-  /**
-   * Sets the partition storage level.
-   *
-   * @param storageLevel the partition storage level
-   * @return the Raft partition group configuration
-   */
-  public RaftStorageConfig setLevel(final StorageLevel storageLevel) {
-    level = checkNotNull(storageLevel);
-    return this;
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -282,7 +282,6 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
     return RaftStorage.builder()
         .withPrefix(partition.name())
         .withDirectory(partition.dataDirectory())
-        .withStorageLevel(storageConfig.getLevel())
         .withMaxSegmentSize((int) storageConfig.getSegmentSize().bytes())
         .withMaxEntrySize((int) storageConfig.getMaxEntrySize().bytes())
         .withFlushExplicitly(storageConfig.shouldFlushExplicitly())

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -20,7 +20,6 @@ import io.atomix.raft.partition.impl.RaftNamespaces;
 import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.zeebe.ZeebeEntry;
-import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.Indexed;
 import io.atomix.utils.serializer.Namespace;
 import io.zeebe.journal.Journal;
@@ -211,18 +210,6 @@ public class RaftLog implements Closeable {
      */
     public Builder withName(final String name) {
       journalBuilder.withName(name);
-      return this;
-    }
-
-    /**
-     * Sets the log storage level, returning the builder for method chaining.
-     *
-     * <p>The storage level indicates how individual entries should be persisted in the journal.
-     *
-     * @param storageLevel The log storage level.
-     * @return The storage builder.
-     */
-    public Builder withStorageLevel(final StorageLevel storageLevel) {
       return this;
     }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
@@ -21,10 +21,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.storage.RaftStorage;
-import io.atomix.storage.StorageLevel;
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.FileBuffer;
-import io.atomix.storage.buffer.HeapBuffer;
 import io.atomix.utils.serializer.Serializer;
 import java.io.File;
 import org.slf4j.Logger;
@@ -59,13 +57,8 @@ public class MetaStore implements AutoCloseable {
     final File metaFile = new File(storage.directory(), String.format("%s.meta", storage.prefix()));
     metadataBuffer = FileBuffer.allocate(metaFile, 12);
 
-    if (storage.storageLevel() == StorageLevel.MEMORY) {
-      configurationBuffer = HeapBuffer.allocate(32);
-    } else {
-      final File confFile =
-          new File(storage.directory(), String.format("%s.conf", storage.prefix()));
-      configurationBuffer = FileBuffer.allocate(confFile, 32);
-    }
+    final File confFile = new File(storage.directory(), String.format("%s.conf", storage.prefix()));
+    configurationBuffer = FileBuffer.allocate(confFile, 32);
   }
 
   /**

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -30,7 +30,6 @@ import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.storage.log.RaftLogReader.Mode;
 import io.atomix.raft.zeebe.NoopEntryValidator;
 import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
-import io.atomix.storage.StorageLevel;
 import io.zeebe.util.collection.Tuple;
 import java.io.File;
 import java.io.IOException;
@@ -185,7 +184,6 @@ public final class ControllableRaftContexts {
     final var memberDirectory = getMemberDirectory(directory, memberId.toString());
     final RaftStorage.Builder defaults =
         RaftStorage.builder()
-            .withStorageLevel(StorageLevel.DISK)
             .withDirectory(memberDirectory)
             .withMaxSegmentSize(1024 * 10)
             .withFreeDiskSpace(100)

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -38,7 +38,6 @@ import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.NoopEntryValidator;
 import io.atomix.raft.zeebe.ZeebeEntry;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
-import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.Indexed;
 import io.atomix.utils.AbstractIdentifier;
 import io.atomix.utils.concurrent.SingleThreadContext;
@@ -479,7 +478,6 @@ public final class RaftRule extends ExternalResource {
     final var memberDirectory = getMemberDirectory(directory, memberId.toString());
     final RaftStorage.Builder defaults =
         RaftStorage.builder()
-            .withStorageLevel(StorageLevel.DISK)
             .withDirectory(memberDirectory)
             .withMaxSegmentSize(1024 * 10)
             .withFreeDiskSpace(100)

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -48,7 +48,6 @@ import io.atomix.raft.storage.log.entry.InitializeEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.zeebe.ZeebeEntry;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
-import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.Indexed;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.atomix.utils.concurrent.ThreadContext;
@@ -191,7 +190,6 @@ public class RaftTest extends ConcurrentTestCase {
     final var directory = new File(this.directory.toFile(), memberId.toString());
     final RaftStorage.Builder defaults =
         RaftStorage.builder()
-            .withStorageLevel(StorageLevel.DISK)
             .withDirectory(directory)
             .withSnapshotStore(new TestSnapshotStore(new AtomicReference<>()))
             .withMaxSegmentSize(1024 * 10)

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/RaftStorageTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/RaftStorageTest.java
@@ -45,7 +45,6 @@ public class RaftStorageTest {
     assertEquals(1024 * 1024 * 32, storage.maxLogSegmentSize());
     assertEquals(1024L * 1024 * 1024, storage.freeDiskSpace());
     assertTrue(storage.isFlushExplicitly());
-    assertFalse(storage.isRetainStaleSnapshots());
   }
 
   @Test
@@ -57,14 +56,12 @@ public class RaftStorageTest {
             .withMaxSegmentSize(1024 * 1024)
             .withFreeDiskSpace(100)
             .withFlushExplicitly(false)
-            .withRetainStaleSnapshots()
             .build();
     assertEquals("foo", storage.prefix());
     assertEquals(new File(PATH.toFile(), "foo"), storage.directory());
     assertEquals(1024 * 1024, storage.maxLogSegmentSize());
     assertEquals(100, storage.freeDiskSpace());
     assertFalse(storage.isFlushExplicitly());
-    assertTrue(storage.isRetainStaleSnapshots());
   }
 
   @Test

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
@@ -30,7 +30,6 @@ import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.RaftPartitionGroup;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
 import io.atomix.raft.snapshot.TestSnapshotStore;
-import io.atomix.storage.StorageLevel;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
@@ -119,7 +118,6 @@ public class ZeebeTestNode {
         .withNumPartitions(1)
         .withPartitionSize(members.size())
         .withFlushExplicitly(true)
-        .withStorageLevel(StorageLevel.DISK)
         .withSegmentSize(1024L)
         .withMaxEntrySize(512)
         .withSnapshotStoreFactory(

--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -82,8 +82,6 @@ env:
     value: "0.8"
   - name: ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
     value: "0.9"
-  - name: ZEEBE_BROKER_DATA_USEMMAP
-    value: "true"
 
 # RESOURCES
 resources:

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -111,7 +111,6 @@ public final class AtomixFactory {
             .withSnapshotStoreFactory(snapshotStoreFactory)
             .withMaxAppendBatchSize((int) experimentalCfg.getMaxAppendBatchSizeInBytes())
             .withMaxAppendsPerFollower(experimentalCfg.getMaxAppendsPerFollower())
-            .withStorageLevel(dataCfg.getAtomixStorageLevel())
             .withEntryValidator(new ZeebeEntryValidator())
             .withFlushExplicitly(!experimentalCfg.isDisableExplicitRaftFlush())
             .withFreeDiskSpace(dataCfg.getFreeDiskSpaceReplicationWatermark())

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -9,7 +9,6 @@ package io.zeebe.broker.system.configuration;
 
 import static io.zeebe.util.StringUtil.LIST_SANITIZER;
 
-import io.atomix.storage.StorageLevel;
 import io.zeebe.broker.Loggers;
 import java.io.File;
 import java.time.Duration;
@@ -46,7 +45,6 @@ public final class DataCfg implements ConfigurationEntry {
 
   private int logIndexDensity = 100;
 
-  private boolean useMmap = true;
   private boolean diskUsageMonitoringEnabled = DEFAULT_DISK_USAGE_MONITORING_ENABLED;
   private double diskUsageReplicationWatermark = DEFAULT_DISK_USAGE_REPLICATION_WATERMARK;
   private double diskUsageCommandWatermark = DEFAULT_DISK_USAGE_COMMAND_WATERMARK;
@@ -131,18 +129,6 @@ public final class DataCfg implements ConfigurationEntry {
     this.logIndexDensity = logIndexDensity;
   }
 
-  public boolean useMmap() {
-    return useMmap;
-  }
-
-  public void setUseMmap(final boolean useMmap) {
-    this.useMmap = useMmap;
-  }
-
-  public StorageLevel getAtomixStorageLevel() {
-    return useMmap() ? StorageLevel.MAPPED : StorageLevel.DISK;
-  }
-
   public boolean isDiskUsageMonitoringEnabled() {
     return diskUsageMonitoringEnabled;
   }
@@ -196,8 +182,6 @@ public final class DataCfg implements ConfigurationEntry {
         + snapshotPeriod
         + ", logIndexDensity="
         + logIndexDensity
-        + ", useMmap="
-        + useMmap
         + ", diskUsageMonitoringEnabled="
         + diskUsageMonitoringEnabled
         + ", diskUsageReplicationWatermark="

--- a/broker/src/test/java/io/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
+++ b/broker/src/test/java/io/zeebe/broker/clustering/atomix/AtomixFactoryTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.mock;
 import io.atomix.core.Atomix;
 import io.atomix.raft.partition.RaftPartitionGroup;
 import io.atomix.raft.partition.RaftPartitionGroupConfig;
-import io.atomix.storage.StorageLevel;
 import io.zeebe.broker.system.configuration.BrokerCfg;
 import io.zeebe.snapshots.broker.impl.FileBasedSnapshotStoreFactory;
 import io.zeebe.util.Environment;
@@ -29,36 +28,6 @@ public final class AtomixFactoryTest {
   @Before
   public void setUp() {
     environment = new Environment();
-  }
-
-  @Test
-  public void shouldUseMappedStorageLevel() {
-    // given
-    final var brokerConfig = newConfig();
-    brokerConfig.getData().setUseMmap(true);
-
-    // when
-    final var atomix =
-        AtomixFactory.fromConfiguration(brokerConfig, mock(FileBasedSnapshotStoreFactory.class));
-
-    // then
-    final var config = getPartitionGroupConfig(atomix);
-    assertThat(config.getStorageConfig().getLevel()).isEqualTo(StorageLevel.MAPPED);
-  }
-
-  @Test
-  public void shouldUseDiskStorageLevel() {
-    // given
-    final var brokerConfig = newConfig();
-    brokerConfig.getData().setUseMmap(false);
-
-    // when
-    final var atomix =
-        AtomixFactory.fromConfiguration(brokerConfig, mock(FileBasedSnapshotStoreFactory.class));
-
-    // then
-    final var config = getPartitionGroupConfig(atomix);
-    assertThat(config.getStorageConfig().getLevel()).isEqualTo(StorageLevel.DISK);
   }
 
   @Test

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -676,15 +676,6 @@ public final class BrokerCfgTest {
   }
 
   @Test
-  public void shouldUseMmap() {
-    // given
-    environment.put("zeebe.broker.data.useMmap", "true");
-
-    // then
-    assertUseMmap(true);
-  }
-
-  @Test
   public void shouldNotPrintConfidentialInformation() throws Exception {
     // given
     final var brokerCfg = TestConfigReader.readConfig("elasticexporter", environment);
@@ -771,17 +762,6 @@ public final class BrokerCfgTest {
   private void assertDefaultHost(final String host) {
     assertHost("default", host);
     assertHost("empty", host);
-  }
-
-  private void assertUseMmap(final boolean useMmap) {
-    assertUseMmap("default", useMmap);
-    assertUseMmap("empty", useMmap);
-  }
-
-  private void assertUseMmap(final String configFileName, final boolean useMmap) {
-    final var config = TestConfigReader.readConfig(configFileName, environment);
-    final var data = config.getData();
-    assertThat(data.useMmap()).isEqualTo(useMmap);
   }
 
   private void assertHost(final String configFileName, final String host) {

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
@@ -9,7 +9,6 @@ package io.zeebe.broker.system.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.atomix.storage.StorageLevel;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
@@ -33,42 +32,6 @@ public class DataCfgTest {
   }
 
   @Test
-  public void shouldGetMappedAtomixStorageLevel() {
-    // given
-    final var sutDataCfg = new DataCfg();
-
-    // when
-    sutDataCfg.setUseMmap(true);
-
-    // then
-    final var actual = sutDataCfg.getAtomixStorageLevel();
-    assertThat(actual).isEqualTo(StorageLevel.MAPPED);
-  }
-
-  @Test
-  public void shouldGetDiskAtomixStorageLevel() {
-    // given
-    final var sutDataCfg = new DataCfg();
-
-    // when
-    sutDataCfg.setUseMmap(false);
-
-    // then
-    final var actual = sutDataCfg.getAtomixStorageLevel();
-    assertThat(actual).isEqualTo(StorageLevel.DISK);
-  }
-
-  @Test
-  public void shouldGetMappedAtomixStorageLevelAsDefault() {
-    // given
-    final var sutDataCfg = new DataCfg();
-
-    // then
-    final var actual = sutDataCfg.getAtomixStorageLevel();
-    assertThat(actual).isEqualTo(StorageLevel.MAPPED);
-  }
-
-  @Test
   public void shouldSetWatermarksTo1IfDisabled() {
     // given
     final DataCfg dataCfg = new DataCfg();
@@ -80,7 +43,7 @@ public class DataCfgTest {
     dataCfg.init(new BrokerCfg(), "/base");
 
     // then
-    assertThat(dataCfg.isDiskUsageMonitoringEnabled()).isEqualTo(false);
+    assertThat(dataCfg.isDiskUsageMonitoringEnabled()).isFalse();
     assertThat(dataCfg.getDiskUsageCommandWatermark()).isEqualTo(1.0);
     assertThat(dataCfg.getDiskUsageReplicationWatermark()).isEqualTo(1.0);
   }

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -174,16 +174,6 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_LOGSEGMENTSIZE.
       # logSegmentSize: 128MB
 
-      # Configure whether data log segment file channels should be memory mapped.
-      # WARNING: This is an experimental setting. It is not yet as mature as direct file channels (default).
-      #
-      # Zeebe reads the data log segment files using file channels.
-      # Memory mapping these should generally allow for faster processing,
-      # resulting in reduced cycle times (i.e. total duration of a single process instance).
-      #
-      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_USEMMAP.
-      # useMmap: false
-
       # How often we take snapshots of streams (time unit)
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_SNAPSHOTPERIOD.
       # snapshotPeriod: 15m

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -126,16 +126,6 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_LOGSEGMENTSIZE.
       # logSegmentSize: 128MB
 
-      # Configure whether data log segment file channels should be memory mapped.
-      # WARNING: This setting has been deprecated. In future versions, log segment file channels will always be memory mapped.
-      #
-      # Zeebe reads the data log segment files using file channels.
-      # Memory mapping these should generally allow for faster processing,
-      # resulting in reduced cycle times (i.e. total duration of a single process instance).
-      #
-      # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_USEMMAP.
-      # useMmap: true
-
       # How often we take snapshots of streams (time unit)
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_SNAPSHOTPERIOD.
       # snapshotPeriod: 15m

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
@@ -20,7 +20,6 @@ import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.ValidationResult;
 import io.atomix.raft.zeebe.ZeebeEntry;
 import io.atomix.raft.zeebe.ZeebeLogAppender;
-import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.Indexed;
 import io.zeebe.logstreams.spi.LogStorage;
 import io.zeebe.logstreams.storage.atomix.AtomixAppenderSupplier;
@@ -232,10 +231,8 @@ public final class AtomixLogStorageRule extends ExternalResource
   private RaftStorage.Builder buildDefaultStorage() {
     return RaftStorage.builder()
         .withFlushExplicitly(true)
-        .withStorageLevel(StorageLevel.DISK)
         .withNamespace(RaftNamespaces.RAFT_STORAGE)
-        .withJournalIndexDensity(1)
-        .withRetainStaleSnapshots();
+        .withJournalIndexDensity(1);
   }
 
   private final class NoopListener implements AppendListener {

--- a/update-tests/src/test/java/io/zeebe/test/ContainerState.java
+++ b/update-tests/src/test/java/io/zeebe/test/ContainerState.java
@@ -94,7 +94,6 @@ final class ContainerState implements CloseableResource {
         new ZeebeContainer("camunda/zeebe:" + brokerVersion)
             .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
             .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "128KB")
-            .withEnv("ZEEBE_BROKER_DATA_USEMMAP", "true")
             .withEnv("ZEEBE_BROKER_DATA_LOGSEGMENTSIZE", "64MB")
             .withEnv("ZEEBE_BROKER_DATA_SNAPSHOTPERIOD", "1m")
             .withEnv("ZEEBE_BROKER_DATA_LOGINDEXDENSITY", "1")


### PR DESCRIPTION
## Description

This PR removes the `storageLevel` and `retainStaleSnapshots` configuration from the `RaftStorageConfig` and related builders/configurations. It also removes the experimental `useMmap` config, as we now only support `mmap`. The `StorageLevel` enum itself is not dropped and will be dropped when the old journal is removed.

## Related issues

closes #6397 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
