### PR TITLE
Apply event sourcing to the exclusive gateway processor 

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.processing.bpmn.behavior;
 
 import io.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.zeebe.engine.processing.common.Failure;
+import io.zeebe.engine.processing.streamprocessor.MigratedStreamProcessors;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.immutable.IncidentState;
@@ -16,6 +17,7 @@ import io.zeebe.engine.state.instance.StoredRecord.Purpose;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.zeebe.protocol.record.intent.IncidentIntent;
+import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import io.zeebe.protocol.record.value.ErrorType;
 
 public final class BpmnIncidentBehavior {
@@ -68,14 +70,33 @@ public final class BpmnIncidentBehavior {
         .setErrorType(errorType)
         .setErrorMessage(errorMessage);
 
+    final var intent = determineCommandIntent(context);
     elementInstanceState.storeRecord(
         context.getElementInstanceKey(),
         context.getFlowScopeKey(),
         context.getRecordValue(),
-        context.getIntent(),
+        intent,
         Purpose.FAILED);
 
     streamWriter.appendNewCommand(IncidentIntent.CREATE, incidentCommand);
+  }
+
+  private WorkflowInstanceIntent determineCommandIntent(final BpmnElementContext context) {
+    if (!MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
+      return context.getIntent();
+    } else {
+      if (context.getIntent() == WorkflowInstanceIntent.ELEMENT_ACTIVATING) {
+        return WorkflowInstanceIntent.ACTIVATE_ELEMENT;
+      } else if (context.getIntent() == WorkflowInstanceIntent.ELEMENT_COMPLETING) {
+        return WorkflowInstanceIntent.COMPLETE_ELEMENT;
+      }
+    }
+    throw new UnsupportedOperationException(
+        String.format(
+            "Expected to raise incident, but element state %s not one of incident supporting states %s %s",
+            context.getIntent(),
+            WorkflowInstanceIntent.ELEMENT_ACTIVATING,
+            WorkflowInstanceIntent.ELEMENT_COMPLETING));
   }
 
   public void resolveIncidents(final BpmnElementContext context) {

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -76,7 +76,7 @@ public final class BpmnStateTransitionBehavior {
         return context.copy(
             context.getElementInstanceKey(),
             context.getRecordValue(),
-            WorkflowInstanceIntent.ELEMENT_COMPLETING);
+            WorkflowInstanceIntent.ELEMENT_ACTIVATING);
       }
     }
     return transitionTo(context, WorkflowInstanceIntent.ELEMENT_ACTIVATING);

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
@@ -57,37 +57,49 @@ public final class ExclusiveGatewayProcessor
   }
 
   @Override
-  public void onActivating(
+  public void onActivate(
       final ExecutableExclusiveGateway element, final BpmnElementContext context) {
     if (element.getOutgoing().isEmpty()) {
       // there are no flows to take: the gateway is an implicit end for the flow scope
-      stateTransitionBehavior.transitionToActivated(context);
-      return;
+      final var activatedContext = stateTransitionBehavior.transitionToActivated(context);
+      // todo (@korthout): write COMPLETE_ELEMENT command
+      stateTransitionBehavior.transitionToCompleting(activatedContext);
+    } else {
+      // find outgoing sequence flow with fulfilled condition or the default
+      findSequenceFlowToTake(element, context)
+          .ifRightOrLeft(
+              sequenceFlow -> {
+                final var activatedContext = stateTransitionBehavior.transitionToActivated(context);
+
+                // todo (@korthout): this should be done differently... we can't change state
+                // without a record
+                // defer sequence flow taken, as it will only be taken when the gateway is completed
+                record.wrap(context.getRecordValue());
+                record.setElementId(sequenceFlow.getId());
+                record.setBpmnElementType(BpmnElementType.SEQUENCE_FLOW);
+                deferredRecordsBehavior.deferNewRecord(
+                    context,
+                    context.getElementInstanceKey(),
+                    record,
+                    WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN);
+
+                // todo (@korthout): write COMPLETE_ELEMENT command
+                stateTransitionBehavior.transitionToCompleting(activatedContext);
+              },
+              failure -> incidentBehavior.createIncident(failure, context));
     }
+  }
 
-    // find outgoing sequence flow with fulfilled condition or the default
-    findSequenceFlowToTake(element, context)
-        .ifRightOrLeft(
-            sequenceFlow -> {
-              stateTransitionBehavior.transitionToActivated(context);
-
-              // defer sequence flow taken, as it will only be taken when the gateway is completed
-              record.wrap(context.getRecordValue());
-              record.setElementId(sequenceFlow.getId());
-              record.setBpmnElementType(BpmnElementType.SEQUENCE_FLOW);
-              deferredRecordsBehavior.deferNewRecord(
-                  context,
-                  context.getElementInstanceKey(),
-                  record,
-                  WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN);
-            },
-            failure -> incidentBehavior.createIncident(failure, context));
+  @Override
+  public void onActivating(
+      final ExecutableExclusiveGateway element, final BpmnElementContext context) {
+    throw new UnsupportedOperationException("This method is replaced by onActivate");
   }
 
   @Override
   public void onActivated(
       final ExecutableExclusiveGateway element, final BpmnElementContext context) {
-    stateTransitionBehavior.transitionToCompleting(context);
+    throw new UnsupportedOperationException("This method is replaced by onActivate");
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -53,6 +53,7 @@ public final class MigratedStreamProcessors {
                 JobIntent.FAIL,
                 JobIntent.FAILED)));
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.TESTING_ONLY);
+    MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.EXCLUSIVE_GATEWAY);
 
     MIGRATED_VALUE_TYPES.put(ValueType.ERROR, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.WORKFLOW, MIGRATED);

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -72,27 +72,30 @@ public final class EventAppliers implements EventApplier {
   }
 
   private void registerWorkflowInstanceEventAppliers(final ZeebeState state) {
+    final var elementInstanceState = state.getElementInstanceState();
+    final var eventScopeInstanceState = state.getEventScopeInstanceState();
     register(
         WorkflowInstanceIntent.ELEMENT_ACTIVATING,
-        new WorkflowInstanceElementActivatingApplier(state));
+        new WorkflowInstanceElementActivatingApplier(elementInstanceState));
     register(
         WorkflowInstanceIntent.ELEMENT_ACTIVATED,
-        new WorkflowInstanceElementActivatedApplier(state));
+        new WorkflowInstanceElementActivatedApplier(elementInstanceState));
     register(
         WorkflowInstanceIntent.ELEMENT_COMPLETING,
-        new WorkflowInstanceElementCompletingApplier(state));
+        new WorkflowInstanceElementCompletingApplier(elementInstanceState));
     register(
         WorkflowInstanceIntent.ELEMENT_COMPLETED,
-        new WorkflowInstanceElementCompletedApplier(state));
+        new WorkflowInstanceElementCompletedApplier(elementInstanceState, eventScopeInstanceState));
     register(
         WorkflowInstanceIntent.ELEMENT_TERMINATING,
-        new WorkflowInstanceElementTerminatingApplier(state));
+        new WorkflowInstanceElementTerminatingApplier(elementInstanceState));
     register(
         WorkflowInstanceIntent.ELEMENT_TERMINATED,
-        new WorkflowInstanceElementTerminatedApplier(state));
+        new WorkflowInstanceElementTerminatedApplier(
+            elementInstanceState, eventScopeInstanceState));
     register(
         WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN,
-        new WorkflowInstanceSequenceFlowTakenApplier(state));
+        new WorkflowInstanceSequenceFlowTakenApplier(elementInstanceState));
   }
 
   private void registerJobIntentEventAppliers(final ZeebeState state) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -47,12 +47,7 @@ public final class EventAppliers implements EventApplier {
   private final Map<Intent, TypedEventApplier> mapping = new HashMap<>();
 
   public EventAppliers(final ZeebeState state) {
-    register(
-        WorkflowInstanceIntent.ELEMENT_ACTIVATING,
-        new WorkflowInstanceElementActivatingApplier(state));
-    register(
-        WorkflowInstanceIntent.ELEMENT_ACTIVATED,
-        new WorkflowInstanceElementActivatedApplier(state));
+    registerWorkflowInstanceEventAppliers(state);
 
     register(WorkflowIntent.CREATED, new WorkflowCreatedApplier(state));
     register(DeploymentDistributionIntent.DISTRIBUTING, new DeploymentDistributionApplier(state));
@@ -74,6 +69,30 @@ public final class EventAppliers implements EventApplier {
             state.getMessageState(), state.getEventScopeInstanceState()));
 
     registerJobIntentEventAppliers(state);
+  }
+
+  private void registerWorkflowInstanceEventAppliers(final ZeebeState state) {
+    register(
+        WorkflowInstanceIntent.ELEMENT_ACTIVATING,
+        new WorkflowInstanceElementActivatingApplier(state));
+    register(
+        WorkflowInstanceIntent.ELEMENT_ACTIVATED,
+        new WorkflowInstanceElementActivatedApplier(state));
+    register(
+        WorkflowInstanceIntent.ELEMENT_COMPLETING,
+        new WorkflowInstanceElementCompletingApplier(state));
+    register(
+        WorkflowInstanceIntent.ELEMENT_COMPLETED,
+        new WorkflowInstanceElementCompletedApplier(state));
+    register(
+        WorkflowInstanceIntent.ELEMENT_TERMINATING,
+        new WorkflowInstanceElementTerminatingApplier(state));
+    register(
+        WorkflowInstanceIntent.ELEMENT_TERMINATED,
+        new WorkflowInstanceElementTerminatedApplier(state));
+    register(
+        WorkflowInstanceIntent.SEQUENCE_FLOW_TAKEN,
+        new WorkflowInstanceSequenceFlowTakenApplier(state));
   }
 
   private void registerJobIntentEventAppliers(final ZeebeState state) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -48,6 +48,9 @@ public final class EventAppliers implements EventApplier {
 
   public EventAppliers(final ZeebeState state) {
     register(
+        WorkflowInstanceIntent.ELEMENT_ACTIVATING,
+        new WorkflowInstanceElementActivatingApplier(state));
+    register(
         WorkflowInstanceIntent.ELEMENT_ACTIVATED,
         new WorkflowInstanceElementActivatedApplier(state));
 

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementActivatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementActivatedApplier.java
@@ -8,7 +8,6 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
-import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
@@ -19,8 +18,8 @@ final class WorkflowInstanceElementActivatedApplier
 
   private final MutableElementInstanceState elementInstanceState;
 
-  WorkflowInstanceElementActivatedApplier(final ZeebeState state) {
-    elementInstanceState = state.getElementInstanceState();
+  WorkflowInstanceElementActivatedApplier(final MutableElementInstanceState elementInstanceState) {
+    this.elementInstanceState = elementInstanceState;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementActivatingApplier.java
@@ -8,7 +8,6 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
-import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
@@ -19,8 +18,9 @@ final class WorkflowInstanceElementActivatingApplier
 
   private final MutableElementInstanceState elementInstanceState;
 
-  public WorkflowInstanceElementActivatingApplier(final ZeebeState state) {
-    elementInstanceState = state.getElementInstanceState();
+  public WorkflowInstanceElementActivatingApplier(
+      final MutableElementInstanceState elementInstanceState) {
+    this.elementInstanceState = elementInstanceState;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementActivatingApplier.java
@@ -7,25 +7,29 @@
  */
 package io.zeebe.engine.state.appliers;
 
+import io.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.zeebe.engine.state.TypedEventApplier;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 
-/** Applies state changes for `WorkflowInstance:Element_Activated` */
-final class WorkflowInstanceElementActivatedApplier
+/** Applies state changes for `WorkflowInstance:Element_Activating` */
+public class WorkflowInstanceElementActivatingApplier
     implements TypedEventApplier<WorkflowInstanceIntent, WorkflowInstanceRecord> {
 
   private final MutableElementInstanceState elementInstanceState;
+  private final BpmnStateBehavior stateBehavior;
 
-  WorkflowInstanceElementActivatedApplier(final ZeebeState state) {
+  public WorkflowInstanceElementActivatingApplier(final ZeebeState state) {
     elementInstanceState = state.getElementInstanceState();
+    stateBehavior = new BpmnStateBehavior(state);
   }
 
   @Override
-  public void applyState(final long key, final WorkflowInstanceRecord value) {
-    elementInstanceState.updateInstance(
-        key, instance -> instance.setState(WorkflowInstanceIntent.ELEMENT_ACTIVATED));
+  public void applyState(final long elementInstanceKey, final WorkflowInstanceRecord value) {
+    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
+    elementInstanceState.newInstance(
+        flowScopeInstance, elementInstanceKey, value, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementCompletedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementCompletedApplier.java
@@ -10,23 +10,26 @@ package io.zeebe.engine.state.appliers;
 import io.zeebe.engine.state.TypedEventApplier;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 
-/** Applies state changes for `WorkflowInstance:Element_Activating` */
-final class WorkflowInstanceElementActivatingApplier
+/** Applies state changes for `WorkflowInstance:Element_Completed` */
+final class WorkflowInstanceElementCompletedApplier
     implements TypedEventApplier<WorkflowInstanceIntent, WorkflowInstanceRecord> {
 
   private final MutableElementInstanceState elementInstanceState;
+  private final MutableEventScopeInstanceState eventScopeInstanceState;
 
-  public WorkflowInstanceElementActivatingApplier(final ZeebeState state) {
+  public WorkflowInstanceElementCompletedApplier(final ZeebeState state) {
     elementInstanceState = state.getElementInstanceState();
+    eventScopeInstanceState = state.getEventScopeInstanceState();
   }
 
   @Override
-  public void applyState(final long elementInstanceKey, final WorkflowInstanceRecord value) {
-    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
-    elementInstanceState.newInstance(
-        flowScopeInstance, elementInstanceKey, value, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
+  public void applyState(final long key, final WorkflowInstanceRecord value) {
+    eventScopeInstanceState.deleteInstance(key);
+    elementInstanceState.consumeToken(value.getFlowScopeKey());
+    elementInstanceState.removeInstance(key);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementCompletedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementCompletedApplier.java
@@ -8,7 +8,6 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
-import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
@@ -21,9 +20,11 @@ final class WorkflowInstanceElementCompletedApplier
   private final MutableElementInstanceState elementInstanceState;
   private final MutableEventScopeInstanceState eventScopeInstanceState;
 
-  public WorkflowInstanceElementCompletedApplier(final ZeebeState state) {
-    elementInstanceState = state.getElementInstanceState();
-    eventScopeInstanceState = state.getEventScopeInstanceState();
+  public WorkflowInstanceElementCompletedApplier(
+      final MutableElementInstanceState elementInstanceState,
+      final MutableEventScopeInstanceState eventScopeInstanceState) {
+    this.elementInstanceState = elementInstanceState;
+    this.eventScopeInstanceState = eventScopeInstanceState;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementCompletingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementCompletingApplier.java
@@ -13,20 +13,19 @@ import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 
-/** Applies state changes for `WorkflowInstance:Element_Activating` */
-final class WorkflowInstanceElementActivatingApplier
+/** Applies state changes for `WorkflowInstance:Element_Completing` */
+final class WorkflowInstanceElementCompletingApplier
     implements TypedEventApplier<WorkflowInstanceIntent, WorkflowInstanceRecord> {
 
   private final MutableElementInstanceState elementInstanceState;
 
-  public WorkflowInstanceElementActivatingApplier(final ZeebeState state) {
+  public WorkflowInstanceElementCompletingApplier(final ZeebeState state) {
     elementInstanceState = state.getElementInstanceState();
   }
 
   @Override
-  public void applyState(final long elementInstanceKey, final WorkflowInstanceRecord value) {
-    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
-    elementInstanceState.newInstance(
-        flowScopeInstance, elementInstanceKey, value, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
+  public void applyState(final long key, final WorkflowInstanceRecord value) {
+    elementInstanceState.updateInstance(
+        key, instance -> instance.setState(WorkflowInstanceIntent.ELEMENT_COMPLETING));
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementCompletingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementCompletingApplier.java
@@ -8,7 +8,6 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
-import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
@@ -19,8 +18,9 @@ final class WorkflowInstanceElementCompletingApplier
 
   private final MutableElementInstanceState elementInstanceState;
 
-  public WorkflowInstanceElementCompletingApplier(final ZeebeState state) {
-    elementInstanceState = state.getElementInstanceState();
+  public WorkflowInstanceElementCompletingApplier(
+      final MutableElementInstanceState elementInstanceState) {
+    this.elementInstanceState = elementInstanceState;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementTerminatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementTerminatedApplier.java
@@ -10,23 +10,26 @@ package io.zeebe.engine.state.appliers;
 import io.zeebe.engine.state.TypedEventApplier;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 
-/** Applies state changes for `WorkflowInstance:Element_Activating` */
-final class WorkflowInstanceElementActivatingApplier
+/** Applies state changes for `WorkflowInstance:Element_Terminated` */
+final class WorkflowInstanceElementTerminatedApplier
     implements TypedEventApplier<WorkflowInstanceIntent, WorkflowInstanceRecord> {
 
   private final MutableElementInstanceState elementInstanceState;
+  private final MutableEventScopeInstanceState eventScopeInstanceState;
 
-  public WorkflowInstanceElementActivatingApplier(final ZeebeState state) {
+  public WorkflowInstanceElementTerminatedApplier(final ZeebeState state) {
     elementInstanceState = state.getElementInstanceState();
+    eventScopeInstanceState = state.getEventScopeInstanceState();
   }
 
   @Override
-  public void applyState(final long elementInstanceKey, final WorkflowInstanceRecord value) {
-    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
-    elementInstanceState.newInstance(
-        flowScopeInstance, elementInstanceKey, value, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
+  public void applyState(final long key, final WorkflowInstanceRecord value) {
+    elementInstanceState.consumeToken(value.getFlowScopeKey());
+    eventScopeInstanceState.deleteInstance(key);
+    elementInstanceState.removeInstance(key);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementTerminatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementTerminatedApplier.java
@@ -8,7 +8,6 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
-import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
@@ -21,9 +20,11 @@ final class WorkflowInstanceElementTerminatedApplier
   private final MutableElementInstanceState elementInstanceState;
   private final MutableEventScopeInstanceState eventScopeInstanceState;
 
-  public WorkflowInstanceElementTerminatedApplier(final ZeebeState state) {
-    elementInstanceState = state.getElementInstanceState();
-    eventScopeInstanceState = state.getEventScopeInstanceState();
+  public WorkflowInstanceElementTerminatedApplier(
+      final MutableElementInstanceState elementInstanceState,
+      final MutableEventScopeInstanceState eventScopeInstanceState) {
+    this.elementInstanceState = elementInstanceState;
+    this.eventScopeInstanceState = eventScopeInstanceState;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementTerminatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementTerminatingApplier.java
@@ -13,20 +13,19 @@ import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 
-/** Applies state changes for `WorkflowInstance:Element_Activating` */
-final class WorkflowInstanceElementActivatingApplier
+/** Applies state changes for `WorkflowInstance:Element_Terminating` */
+final class WorkflowInstanceElementTerminatingApplier
     implements TypedEventApplier<WorkflowInstanceIntent, WorkflowInstanceRecord> {
 
   private final MutableElementInstanceState elementInstanceState;
 
-  public WorkflowInstanceElementActivatingApplier(final ZeebeState state) {
+  public WorkflowInstanceElementTerminatingApplier(final ZeebeState state) {
     elementInstanceState = state.getElementInstanceState();
   }
 
   @Override
-  public void applyState(final long elementInstanceKey, final WorkflowInstanceRecord value) {
-    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
-    elementInstanceState.newInstance(
-        flowScopeInstance, elementInstanceKey, value, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
+  public void applyState(final long key, final WorkflowInstanceRecord value) {
+    elementInstanceState.updateInstance(
+        key, instance -> instance.setState(WorkflowInstanceIntent.ELEMENT_TERMINATING));
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementTerminatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementTerminatingApplier.java
@@ -8,7 +8,6 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
-import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
@@ -19,8 +18,9 @@ final class WorkflowInstanceElementTerminatingApplier
 
   private final MutableElementInstanceState elementInstanceState;
 
-  public WorkflowInstanceElementTerminatingApplier(final ZeebeState state) {
-    elementInstanceState = state.getElementInstanceState();
+  public WorkflowInstanceElementTerminatingApplier(
+      final MutableElementInstanceState elementInstanceState) {
+    this.elementInstanceState = elementInstanceState;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceSequenceFlowTakenApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceSequenceFlowTakenApplier.java
@@ -13,20 +13,18 @@ import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 
-/** Applies state changes for `WorkflowInstance:Element_Activating` */
-final class WorkflowInstanceElementActivatingApplier
+/** Applies state changes for `WorkflowInstance:Sequence_Flow_Taken` */
+final class WorkflowInstanceSequenceFlowTakenApplier
     implements TypedEventApplier<WorkflowInstanceIntent, WorkflowInstanceRecord> {
 
   private final MutableElementInstanceState elementInstanceState;
 
-  public WorkflowInstanceElementActivatingApplier(final ZeebeState state) {
+  public WorkflowInstanceSequenceFlowTakenApplier(final ZeebeState state) {
     elementInstanceState = state.getElementInstanceState();
   }
 
   @Override
-  public void applyState(final long elementInstanceKey, final WorkflowInstanceRecord value) {
-    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
-    elementInstanceState.newInstance(
-        flowScopeInstance, elementInstanceKey, value, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
+  public void applyState(final long key, final WorkflowInstanceRecord value) {
+    elementInstanceState.spawnToken(value.getFlowScopeKey());
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceSequenceFlowTakenApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceSequenceFlowTakenApplier.java
@@ -8,7 +8,6 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
-import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
@@ -19,8 +18,9 @@ final class WorkflowInstanceSequenceFlowTakenApplier
 
   private final MutableElementInstanceState elementInstanceState;
 
-  public WorkflowInstanceSequenceFlowTakenApplier(final ZeebeState state) {
-    elementInstanceState = state.getElementInstanceState();
+  public WorkflowInstanceSequenceFlowTakenApplier(
+      final MutableElementInstanceState elementInstanceState) {
+    this.elementInstanceState = elementInstanceState;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -22,6 +22,7 @@ import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceReco
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public final class DbElementInstanceState implements MutableElementInstanceState {
@@ -166,6 +167,13 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   @Override
   public void updateInstance(final ElementInstance scopeInstance) {
     writeElementInstance(scopeInstance);
+  }
+
+  @Override
+  public void updateInstance(final long key, final Consumer<ElementInstance> modifier) {
+    final var scopeInstance = getInstance(key);
+    modifier.accept(scopeInstance);
+    updateInstance(scopeInstance);
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableElementInstanceState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableElementInstanceState.java
@@ -13,6 +13,7 @@ import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.engine.state.instance.StoredRecord.Purpose;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
+import java.util.function.Consumer;
 
 public interface MutableElementInstanceState extends ElementInstanceState {
 
@@ -24,6 +25,8 @@ public interface MutableElementInstanceState extends ElementInstanceState {
   void removeInstance(long key);
 
   void updateInstance(ElementInstance scopeInstance);
+
+  void updateInstance(long key, Consumer<ElementInstance> modifier);
 
   void consumeToken(long scopeKey);
 

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayTest.java
@@ -163,17 +163,19 @@ public final class ExclusiveGatewayTest {
 
     List<Record<WorkflowInstanceRecordValue>> gateWays =
         RecordingExporter.workflowInstanceRecords()
-            .withIntent(WorkflowInstanceIntent.ELEMENT_ACTIVATING)
+            .withIntent(WorkflowInstanceIntent.ACTIVATE_ELEMENT)
             .withElementType(BpmnElementType.EXCLUSIVE_GATEWAY)
             .withWorkflowInstanceKey(workflowInstance1)
             .limit(2)
             .asList();
 
+    // assert that gateway activation originates from sequence flow taken and that the correct flow
+    // was taken
     assertThat(gateWays.get(0).getSourceRecordPosition())
         .isEqualTo(sequenceFlows.get(0).getPosition());
-    assertThat(sequenceFlows.get(1).getValue().getElementId()).isEqualTo("s1");
     assertThat(gateWays.get(1).getSourceRecordPosition())
         .isEqualTo(sequenceFlows.get(1).getPosition());
+    assertThat(sequenceFlows.get(1).getValue().getElementId()).isEqualTo("s1");
 
     // when
     final long workflowInstance2 =
@@ -188,7 +190,7 @@ public final class ExclusiveGatewayTest {
 
     gateWays =
         RecordingExporter.workflowInstanceRecords()
-            .withIntent(WorkflowInstanceIntent.ELEMENT_ACTIVATING)
+            .withIntent(WorkflowInstanceIntent.ACTIVATE_ELEMENT)
             .withElementType(BpmnElementType.EXCLUSIVE_GATEWAY)
             .withWorkflowInstanceKey(workflowInstance2)
             .limit(2)
@@ -196,9 +198,9 @@ public final class ExclusiveGatewayTest {
 
     assertThat(gateWays.get(0).getSourceRecordPosition())
         .isEqualTo(sequenceFlows.get(0).getPosition());
-    assertThat(sequenceFlows.get(1).getValue().getElementId()).isEqualTo("s2");
     assertThat(gateWays.get(1).getSourceRecordPosition())
         .isEqualTo(sequenceFlows.get(1).getPosition());
+    assertThat(sequenceFlows.get(1).getValue().getElementId()).isEqualTo("s2");
   }
 
   @Test
@@ -235,6 +237,7 @@ public final class ExclusiveGatewayTest {
     assertThat(workflowEvents)
         .extracting(Record::getIntent)
         .containsExactly(
+            WorkflowInstanceIntent.ACTIVATE_ELEMENT,
             WorkflowInstanceIntent.ELEMENT_ACTIVATING,
             WorkflowInstanceIntent.ELEMENT_ACTIVATED,
             WorkflowInstanceIntent.ELEMENT_COMPLETING,

--- a/engine/src/test/java/io/zeebe/engine/processing/incident/ConditionIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/ConditionIncidentTest.java
@@ -146,6 +146,7 @@ public final class ConditionIncidentTest {
     // then
     assertThat(
             RecordingExporter.workflowInstanceRecords()
+                .onlyEvents()
                 .withRecordKey(incidentEvent.getValue().getElementInstanceKey())
                 .limit(2))
         .extracting(Record::getIntent)
@@ -184,6 +185,7 @@ public final class ConditionIncidentTest {
     // then
     assertThat(
             RecordingExporter.workflowInstanceRecords()
+                .onlyEvents()
                 .withRecordKey(incidentEvent.getValue().getElementInstanceKey())
                 .limit(2))
         .extracting(Record::getIntent)


### PR DESCRIPTION
## Description

- adds onActivate, onComplete and onTerminate to the exclusive gateway processor
  - the wait state is removed, which means that onComplete is not implemented
  - Instead, onActivate does all the processing from activating: transition to activated, transition to completing, transition to completed, and either:
    - taking a sequenceflow
    - or informing the flow scope that it completed
  - this also allowed us to fully remove record deferral for the processing of this element type
- adds event appliers for:
  - WorkflowInstance:Element_Activating
  - WorkflowInstance:Element_Activated
  - WorkflowInstance:Element_Completing
  - WorkflowInstance:Element_Completed
  - WorkflowInstance:Element_Terminating
  - WorkflowInstance:Element_Terminated
  - WorkflowInstance:Sequence_Flow_Taken
- writes ACTIVATE_ELEMENT when sequence flow taken to the exclusive gateway element
- writes TERMINATE_ELEMENT for child instance, when flow scope terminates
- to allow Incident:Resolve to process the command again, the Element_Activating event is only written the first time the Activate_Element command is processed, likewise for Element_Completing event on processing Complete_Element again
- to allow the replay of the written sequence flow taken event without migrating the sequence flow processor, this adds a dirty hack to the `ReprocessingStateMachine`.
- adds updateElementInstance convenience method to `ElementInstanceState`

## Related issues

closes #6189

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
