### PR TITLE
Make all AppendListener methods default

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/zeebe/ZeebeLogAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/zeebe/ZeebeLogAppender.java
@@ -47,21 +47,21 @@ public interface ZeebeLogAppender {
      *
      * @param indexed the entry that was written to the log
      */
-    void onWrite(Indexed<ZeebeEntry> indexed);
+    default void onWrite(final Indexed<ZeebeEntry> indexed) {}
 
     /**
      * Called when an error occurred while writing the entry to the log.
      *
      * @param error the error that occurred
      */
-    void onWriteError(Throwable error);
+    default void onWriteError(final Throwable error) {}
 
     /**
      * Called when the entry has been committed.
      *
      * @param indexed the entry that was committed
      */
-    void onCommit(Indexed<ZeebeEntry> indexed);
+    default void onCommit(final Indexed<ZeebeEntry> indexed) {}
 
     /**
      * Called when an error occurred while replicating or committing an entry, typically when if an
@@ -70,6 +70,6 @@ public interface ZeebeLogAppender {
      * @param indexed the entry that should have been committed
      * @param error the error that occurred
      */
-    void onCommitError(Indexed<ZeebeEntry> indexed, Throwable error);
+    default void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {}
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -608,9 +608,6 @@ public final class RaftRule extends ExternalResource {
     private final CompletableFuture<Long> commitFuture = new CompletableFuture<>();
 
     @Override
-    public void onWrite(final Indexed<ZeebeEntry> indexed) {}
-
-    @Override
     public void onWriteError(final Throwable error) {
       commitFuture.completeExceptionally(error);
     }

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -589,9 +589,6 @@ public class RaftTest extends ConcurrentTestCase {
     private final CompletableFuture<Long> commitFuture = new CompletableFuture<>();
 
     @Override
-    public void onWrite(final Indexed<ZeebeEntry> indexed) {}
-
-    @Override
     public void onWriteError(final Throwable error) {
       fail("Unexpected write error: " + error.getMessage());
     }

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -102,20 +102,10 @@ public class LeaderRoleTest {
     final CountDownLatch latch = new CountDownLatch(1);
     final AppendListener listener =
         new AppendListener() {
-
           @Override
           public void onWrite(final Indexed<ZeebeEntry> indexed) {
             latch.countDown();
           }
-
-          @Override
-          public void onWriteError(final Throwable error) {}
-
-          @Override
-          public void onCommit(final Indexed<ZeebeEntry> indexed) {}
-
-          @Override
-          public void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {}
         };
 
     // when
@@ -142,20 +132,10 @@ public class LeaderRoleTest {
     final CountDownLatch latch = new CountDownLatch(1);
     final AppendListener listener =
         new AppendListener() {
-
           @Override
           public void onWrite(final Indexed<ZeebeEntry> indexed) {
             latch.countDown();
           }
-
-          @Override
-          public void onWriteError(final Throwable error) {}
-
-          @Override
-          public void onCommit(final Indexed<ZeebeEntry> indexed) {}
-
-          @Override
-          public void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {}
         };
 
     // when
@@ -176,21 +156,11 @@ public class LeaderRoleTest {
     final CountDownLatch latch = new CountDownLatch(1);
     final AppendListener listener =
         new AppendListener() {
-
-          @Override
-          public void onWrite(final Indexed<ZeebeEntry> indexed) {}
-
           @Override
           public void onWriteError(final Throwable error) {
             caughtError.set(error);
             latch.countDown();
           }
-
-          @Override
-          public void onCommit(final Indexed<ZeebeEntry> indexed) {}
-
-          @Override
-          public void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {}
         };
 
     // when
@@ -214,21 +184,11 @@ public class LeaderRoleTest {
     final CountDownLatch latch = new CountDownLatch(1);
     final AppendListener listener =
         new AppendListener() {
-
-          @Override
-          public void onWrite(final Indexed<ZeebeEntry> indexed) {}
-
           @Override
           public void onWriteError(final Throwable error) {
             caughtError.set(error);
             latch.countDown();
           }
-
-          @Override
-          public void onCommit(final Indexed<ZeebeEntry> indexed) {}
-
-          @Override
-          public void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {}
         };
 
     // when
@@ -253,21 +213,11 @@ public class LeaderRoleTest {
     final CountDownLatch latch = new CountDownLatch(1);
     final AppendListener listener =
         new AppendListener() {
-
-          @Override
-          public void onWrite(final Indexed<ZeebeEntry> indexed) {}
-
           @Override
           public void onWriteError(final Throwable error) {
             caughtError.set(error);
             latch.countDown();
           }
-
-          @Override
-          public void onCommit(final Indexed<ZeebeEntry> indexed) {}
-
-          @Override
-          public void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {}
         };
 
     // when
@@ -290,21 +240,11 @@ public class LeaderRoleTest {
     final CountDownLatch latch = new CountDownLatch(1);
     final AppendListener listener =
         new AppendListener() {
-
-          @Override
-          public void onWrite(final Indexed<ZeebeEntry> indexed) {}
-
           @Override
           public void onWriteError(final Throwable error) {
             caughtError.set(error);
             latch.countDown();
           }
-
-          @Override
-          public void onCommit(final Indexed<ZeebeEntry> indexed) {}
-
-          @Override
-          public void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {}
         };
 
     // when
@@ -328,43 +268,17 @@ public class LeaderRoleTest {
     final CountDownLatch latch = new CountDownLatch(1);
 
     // when
-    leaderRole.appendEntry(
-        0,
-        1,
-        data,
-        new AppendListener() {
-          @Override
-          public void onWrite(final Indexed<ZeebeEntry> indexed) {}
-
-          @Override
-          public void onWriteError(final Throwable error) {}
-
-          @Override
-          public void onCommit(final Indexed<ZeebeEntry> indexed) {}
-
-          @Override
-          public void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {}
-        });
+    leaderRole.appendEntry(0, 1, data, new AppendListener() {});
     leaderRole.appendEntry(
         2,
         3,
         data,
         new AppendListener() {
-
-          @Override
-          public void onWrite(final Indexed<ZeebeEntry> indexed) {}
-
           @Override
           public void onWriteError(final Throwable error) {
             caughtError.set(error);
             latch.countDown();
           }
-
-          @Override
-          public void onCommit(final Indexed<ZeebeEntry> indexed) {}
-
-          @Override
-          public void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {}
         });
 
     // then
@@ -394,21 +308,11 @@ public class LeaderRoleTest {
     final CountDownLatch latch = new CountDownLatch(2);
     final AppendListener listener =
         new AppendListener() {
-
           @Override
           public void onWrite(final Indexed<ZeebeEntry> indexed) {
             entries.add(indexed.entry());
             latch.countDown();
           }
-
-          @Override
-          public void onWriteError(final Throwable error) {}
-
-          @Override
-          public void onCommit(final Indexed<ZeebeEntry> indexed) {}
-
-          @Override
-          public void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {}
         };
 
     // when
@@ -456,18 +360,9 @@ public class LeaderRoleTest {
     final AppendListener listener =
         new AppendListener() {
           @Override
-          public void onWrite(final Indexed<ZeebeEntry> indexed) {}
-
-          @Override
           public void onWriteError(final Throwable error) {
             latch.countDown();
           }
-
-          @Override
-          public void onCommit(final Indexed<ZeebeEntry> indexed) {}
-
-          @Override
-          public void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {}
         };
 
     // when


### PR DESCRIPTION
## Description

This PR makes all methods in the `ZeebeLogAppender` listener default, such that consumers can register only for the events they care. It also cleans up implementations by having them only implement the methods they care about. Generally for such event listeners, it makes sense to make them all default as most consumers only care about some events, not all.

## Related issues

Split off while working on #6407 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
