### PR TITLE
Introduce DeploymentDistribution COMPLETE-COMPLETED

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
@@ -13,6 +13,7 @@ import io.zeebe.engine.processing.common.ExpressionProcessor;
 import io.zeebe.engine.processing.deployment.DeploymentCreatedProcessor;
 import io.zeebe.engine.processing.deployment.DeploymentEventProcessors;
 import io.zeebe.engine.processing.deployment.DeploymentResponder;
+import io.zeebe.engine.processing.deployment.distribute.CompleteDeploymentDistributionProcessor;
 import io.zeebe.engine.processing.deployment.distribute.DeploymentDistributeProcessor;
 import io.zeebe.engine.processing.deployment.distribute.DeploymentDistributor;
 import io.zeebe.engine.processing.incident.IncidentEventProcessors;
@@ -31,6 +32,7 @@ import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.zeebe.protocol.record.intent.DeploymentIntent;
 import io.zeebe.util.sched.ActorControl;
 import java.util.function.Consumer;
@@ -110,6 +112,13 @@ public final class EngineProcessors {
 
     typedRecordProcessors.onCommand(
         ValueType.DEPLOYMENT, DeploymentIntent.DISTRIBUTE, deploymentDistributeProcessor);
+
+    final var completeDeploymentDistributionProcessor =
+        new CompleteDeploymentDistributionProcessor(writers);
+    typedRecordProcessors.onCommand(
+        ValueType.DEPLOYMENT_DISTRIBUTION,
+        DeploymentDistributionIntent.COMPLETE,
+        completeDeploymentDistributionProcessor);
   }
 
   private static TypedRecordProcessor<WorkflowInstanceRecord> addWorkflowProcessors(

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/distribute/CompleteDeploymentDistributionProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/distribute/CompleteDeploymentDistributionProcessor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.deployment.distribute;
+
+import io.zeebe.engine.processing.streamprocessor.TypedRecord;
+import io.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
+import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
+import io.zeebe.protocol.record.intent.DeploymentDistributionIntent;
+import java.util.function.Consumer;
+
+public class CompleteDeploymentDistributionProcessor
+    implements TypedRecordProcessor<DeploymentDistributionRecord> {
+
+  private final StateWriter stateWriter;
+
+  public CompleteDeploymentDistributionProcessor(final Writers writers) {
+    stateWriter = writers.state();
+  }
+
+  @Override
+  public void processRecord(
+      final long position,
+      final TypedRecord<DeploymentDistributionRecord> record,
+      final TypedResponseWriter responseWriter,
+      final TypedStreamWriter streamWriter,
+      final Consumer<SideEffectProducer> sideEffect) {
+
+    final var deploymentKey = record.getKey();
+    // DeploymentDistribution.COMPLETE is idempotent
+    // even if we already removed the pending we will not reject it
+    stateWriter.appendFollowUpEvent(
+        deploymentKey, DeploymentDistributionIntent.COMPLETED, record.getValue());
+
+    // todo(zell): https://github.com/zeebe-io/zeebe/issues/6173
+    // check whether it was the last pending
+    // then write Deployment.FULLY_DISTRIBUTED
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -55,6 +55,7 @@ public final class MigratedStreamProcessors {
 
     MIGRATED_VALUE_TYPES.put(ValueType.ERROR, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.WORKFLOW, MIGRATED);
+    MIGRATED_VALUE_TYPES.put(ValueType.DEPLOYMENT_DISTRIBUTION, MIGRATED);
     MIGRATED_VALUE_TYPES.put(
         ValueType.MESSAGE,
         record ->

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/DeploymentDistributionCompletedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/DeploymentDistributionCompletedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.mutable.MutableDeploymentState;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
+import io.zeebe.protocol.record.intent.DeploymentDistributionIntent;
+
+public class DeploymentDistributionCompletedApplier
+    implements TypedEventApplier<DeploymentDistributionIntent, DeploymentDistributionRecord> {
+
+  private final MutableDeploymentState deploymentState;
+
+  public DeploymentDistributionCompletedApplier(final MutableDeploymentState deploymentState) {
+    this.deploymentState = deploymentState;
+  }
+
+  @Override
+  public void applyState(final long key, final DeploymentDistributionRecord value) {
+    // remove partition on which deployment has been distributed
+    deploymentState.removePendingDeploymentDistribution(key, value.getPartitionId());
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -50,6 +50,9 @@ public final class EventAppliers implements EventApplier {
         new WorkflowInstanceElementActivatedApplier(state));
     register(WorkflowIntent.CREATED, new WorkflowCreatedApplier(state));
     register(DeploymentDistributionIntent.DISTRIBUTING, new DeploymentDistributionApplier(state));
+    register(
+        DeploymentDistributionIntent.COMPLETED,
+        new DeploymentDistributionCompletedApplier(state.getDeploymentState()));
 
     register(MessageIntent.EXPIRED, new MessageExpiredApplier(state.getMessageState()));
     registerJobIntentEventAppliers(state);

--- a/engine/src/main/java/io/zeebe/engine/state/immutable/DeploymentState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/immutable/DeploymentState.java
@@ -15,4 +15,6 @@ public interface DeploymentState {
   PendingDeploymentDistribution getPendingDeployment(long key);
 
   void foreachPending(ObjLongConsumer<PendingDeploymentDistribution> consumer);
+
+  boolean hasPendingDeploymentDistribution(long deploymentKey);
 }

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableDeploymentState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableDeploymentState.java
@@ -17,4 +17,6 @@ public interface MutableDeploymentState extends DeploymentState {
   PendingDeploymentDistribution removePendingDeployment(long key);
 
   void addPendingDeploymentDistribution(long deploymentKey, int partition);
+
+  void removePendingDeploymentDistribution(long key, int partitionId);
 }

--- a/engine/src/test/java/io/zeebe/engine/state/deployment/DeploymentStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/deployment/DeploymentStateTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.engine.state.mutable.MutableDeploymentState;
+import io.zeebe.engine.util.ZeebeStateRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DeploymentStateTest {
+
+  @Rule public final ZeebeStateRule stateRule = new ZeebeStateRule();
+
+  private MutableDeploymentState deploymentState;
+
+  @Before
+  public void setUp() {
+    final var zeebeState = stateRule.getZeebeState();
+    deploymentState = zeebeState.getDeploymentState();
+  }
+
+  @Test
+  public void shouldReturnFalseOnEmptyStateForHasPendingCheck() {
+    // given
+
+    // when
+    final var hasPending = deploymentState.hasPendingDeploymentDistribution(10L);
+
+    // then
+    assertThat(hasPending).isFalse();
+  }
+
+  @Test
+  public void shouldAddPendingDeployment() {
+    // given
+    final var deploymentKey = 10L;
+    final var partition = 1;
+
+    // when
+    deploymentState.addPendingDeploymentDistribution(deploymentKey, partition);
+
+    // then
+    assertThat(deploymentState.hasPendingDeploymentDistribution(deploymentKey)).isTrue();
+  }
+
+  @Test
+  public void shouldReturnFalseForDifferentPendingDeploymentOnHasPendingCheck() {
+    // given
+    final var deploymentKey = 10L;
+    final var partition = 1;
+    deploymentState.addPendingDeploymentDistribution(deploymentKey, partition);
+
+    // when
+    final var hasPending = deploymentState.hasPendingDeploymentDistribution(12L);
+
+    // then
+    assertThat(hasPending).isFalse();
+  }
+
+  @Test
+  public void shouldRemovePendingDeployment() {
+    // given
+    final var deploymentKey = 10L;
+    final var partition = 1;
+    deploymentState.addPendingDeploymentDistribution(deploymentKey, partition);
+
+    // when
+    deploymentState.removePendingDeploymentDistribution(deploymentKey, partition);
+
+    // then
+    assertThat(deploymentState.hasPendingDeploymentDistribution(deploymentKey)).isFalse();
+  }
+
+  @Test
+  public void shouldRemovePendingDeploymentIdempotent() {
+    // given
+    final var deploymentKey = 10L;
+    final var partition = 1;
+    deploymentState.addPendingDeploymentDistribution(deploymentKey, partition);
+    deploymentState.removePendingDeploymentDistribution(deploymentKey, partition);
+
+    // when
+    deploymentState.removePendingDeploymentDistribution(deploymentKey, partition);
+
+    // then
+    assertThat(deploymentState.hasPendingDeploymentDistribution(deploymentKey)).isFalse();
+  }
+
+  @Test
+  public void shouldReturnTrueForDifferentPendingDeploymentOnHasPendingCheck() {
+    // given
+    final var deploymentKey = 10L;
+    final var partition = 1;
+    deploymentState.addPendingDeploymentDistribution(deploymentKey, partition);
+    deploymentState.addPendingDeploymentDistribution(12L, partition);
+    deploymentState.removePendingDeploymentDistribution(deploymentKey, partition);
+
+    // when
+    final var hasPending = deploymentState.hasPendingDeploymentDistribution(12L);
+
+    // then
+    assertThat(hasPending).isTrue();
+  }
+}

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/DeploymentDistributionIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/DeploymentDistributionIntent.java
@@ -16,7 +16,9 @@
 package io.zeebe.protocol.record.intent;
 
 public enum DeploymentDistributionIntent implements Intent {
-  DISTRIBUTING((short) 0);
+  DISTRIBUTING((short) 0),
+  COMPLETE((short) 1),
+  COMPLETED((short) 2);
 
   private final short value;
 
@@ -32,6 +34,10 @@ public enum DeploymentDistributionIntent implements Intent {
     switch (value) {
       case 0:
         return DISTRIBUTING;
+      case 1:
+        return COMPLETE;
+      case 2:
+        return COMPLETED;
       default:
         return UNKNOWN;
     }


### PR DESCRIPTION
## Description

Pre work for https://github.com/zeebe-io/zeebe/issues/6173. introduces COMPLETE-COMPLETED, which are the response after deployment distribution was done. It will remove the pending from the state and later the deployment record. 


**Note:** This command is currently not written. I will use it in the upcoming PR's.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->


## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
