### PR TITLE
Reset lastAppendedEntry on reset

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -156,6 +156,7 @@ public class RaftLog implements Closeable {
 
   public void reset(final long index) {
     journal.reset(index);
+    lastAppendedEntry = null;
   }
 
   public void truncate(final long index) {


### PR DESCRIPTION
## Description

This PR ensures we reset the `lastAppendedEntry` in the RaftLog every time the log is mutated (on append, on truncate, and on reset - on compact is omitted as it doesn't affect the validity of the entry).

This was discovered by the `RandomizedRaftTest` being "flaky".

## Related issues

related to #6414

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
