### PR TITLE
[BACKPORT 0.26] fix(broker): fix race condition in persisting snapshot

### DIFF
--- a/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedTransientSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedTransientSnapshot.java
@@ -34,6 +34,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
   private final FileBasedSnapshotMetadata metadata;
   private final ActorFuture<Boolean> takenFuture = new CompletableActorFuture<>();
   private boolean isValid = false;
+  private PersistedSnapshot snapshot;
 
   FileBasedTransientSnapshot(
       final FileBasedSnapshotMetadata metadata,
@@ -66,6 +67,8 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
         if (!isValid) {
           abortInternal();
         }
+
+        snapshot = null;
         takenFuture.complete(isValid);
       } catch (final Exception exception) {
         LOGGER.warn("Unexpected exception on taking snapshot ({})", metadata, exception);
@@ -91,6 +94,10 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
     final CompletableActorFuture<PersistedSnapshot> future = new CompletableActorFuture<>();
     actor.call(
         () -> {
+          if (snapshot != null) {
+            future.complete(snapshot);
+            return;
+          }
           if (!takenFuture.isDone()) {
             future.completeExceptionally(new IllegalStateException("Snapshot is not taken"));
             return;
@@ -101,7 +108,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
             return;
           }
           try {
-            final var snapshot = snapshotStore.newSnapshot(metadata, directory);
+            snapshot = snapshotStore.newSnapshot(metadata, directory);
             future.complete(snapshot);
           } catch (final Exception e) {
             future.completeExceptionally(e);
@@ -118,6 +125,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
   private void abortInternal() {
     try {
       isValid = false;
+      snapshot = null;
       LOGGER.debug("DELETE dir {}", directory);
       FileUtil.deleteFolder(directory);
     } catch (final IOException e) {


### PR DESCRIPTION
## Description

Backports #6383. No changes were made to the PR.

## Related issues

closes #6377

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
