### PR TITLE
Store and remove deployment record in the state for distribution

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
@@ -114,7 +114,7 @@ public final class EngineProcessors {
         ValueType.DEPLOYMENT, DeploymentIntent.DISTRIBUTE, deploymentDistributeProcessor);
 
     final var completeDeploymentDistributionProcessor =
-        new CompleteDeploymentDistributionProcessor(writers);
+        new CompleteDeploymentDistributionProcessor(zeebeState.getDeploymentState(), writers);
     typedRecordProcessors.onCommand(
         ValueType.DEPLOYMENT_DISTRIBUTION,
         DeploymentDistributionIntent.COMPLETE,

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/TransformingDeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/TransformingDeploymentCreateProcessor.java
@@ -109,7 +109,7 @@ public final class TransformingDeploymentCreateProcessor
       }
 
       responseWriter.writeEventOnCommand(key, DeploymentIntent.CREATED, deploymentEvent, command);
-      streamWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
+      stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
 
       partitions.forEach(
           partitionId -> {

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/distribute/CompleteDeploymentDistributionProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/distribute/CompleteDeploymentDistributionProcessor.java
@@ -14,17 +14,22 @@ import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.zeebe.engine.state.immutable.DeploymentState;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentDistributionRecord;
 import io.zeebe.protocol.record.intent.DeploymentDistributionIntent;
+import io.zeebe.protocol.record.intent.DeploymentIntent;
 import java.util.function.Consumer;
 
 public class CompleteDeploymentDistributionProcessor
     implements TypedRecordProcessor<DeploymentDistributionRecord> {
 
   private final StateWriter stateWriter;
+  private final DeploymentState deploymentState;
 
-  public CompleteDeploymentDistributionProcessor(final Writers writers) {
+  public CompleteDeploymentDistributionProcessor(
+      final DeploymentState deploymentState, final Writers writers) {
     stateWriter = writers.state();
+    this.deploymentState = deploymentState;
   }
 
   @Override
@@ -41,8 +46,13 @@ public class CompleteDeploymentDistributionProcessor
     stateWriter.appendFollowUpEvent(
         deploymentKey, DeploymentDistributionIntent.COMPLETED, record.getValue());
 
-    // todo(zell): https://github.com/zeebe-io/zeebe/issues/6173
-    // check whether it was the last pending
-    // then write Deployment.FULLY_DISTRIBUTED
+    if (!deploymentState.hasPendingDeploymentDistribution(deploymentKey)) {
+      final var storedDeploymentRecord = deploymentState.getStoredDeploymentRecord(deploymentKey);
+
+      if (storedDeploymentRecord != null) {
+        stateWriter.appendFollowUpEvent(
+            deploymentKey, DeploymentIntent.FULLY_DISTRIBUTED, storedDeploymentRecord);
+      }
+    }
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/ZbColumnFamilies.java
+++ b/engine/src/main/java/io/zeebe/engine/state/ZbColumnFamilies.java
@@ -40,6 +40,7 @@ public enum ZbColumnFamilies {
   // pending deployments
   PENDING_DEPLOYMENT,
   NEW_PENDING_DEPLOYMENT,
+  DEPLOYMENT_RAW,
 
   // jobs
   JOBS,

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/DeploymentCreatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/DeploymentCreatedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.mutable.MutableDeploymentState;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.zeebe.protocol.record.intent.DeploymentIntent;
+
+public class DeploymentCreatedApplier
+    implements TypedEventApplier<DeploymentIntent, DeploymentRecord> {
+
+  private final MutableDeploymentState deploymentState;
+
+  public DeploymentCreatedApplier(final ZeebeState zeebeState) {
+    deploymentState = zeebeState.getDeploymentState();
+  }
+
+  @Override
+  public void applyState(final long key, final DeploymentRecord value) {
+    deploymentState.storeDeploymentRecord(key, value);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/DeploymentFullyDistributedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/DeploymentFullyDistributedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.mutable.MutableDeploymentState;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.zeebe.protocol.record.intent.DeploymentIntent;
+
+public class DeploymentFullyDistributedApplier
+    implements TypedEventApplier<DeploymentIntent, DeploymentRecord> {
+
+  private final MutableDeploymentState deploymentState;
+
+  public DeploymentFullyDistributedApplier(final ZeebeState zeebeState) {
+    deploymentState = zeebeState.getDeploymentState();
+  }
+
+  @Override
+  public void applyState(final long key, final DeploymentRecord value) {
+    deploymentState.removeDeploymentRecord(key);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -13,6 +13,7 @@ import io.zeebe.engine.state.TypedEventApplier;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.intent.DeploymentDistributionIntent;
+import io.zeebe.protocol.record.intent.DeploymentIntent;
 import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.intent.MessageIntent;
@@ -56,6 +57,9 @@ public final class EventAppliers implements EventApplier {
     register(
         DeploymentDistributionIntent.COMPLETED,
         new DeploymentDistributionCompletedApplier(state.getDeploymentState()));
+
+    register(DeploymentIntent.CREATED, new DeploymentCreatedApplier(state));
+    register(DeploymentIntent.FULLY_DISTRIBUTED, new DeploymentFullyDistributedApplier(state));
 
     register(MessageIntent.PUBLISHED, new MessagePublishedApplier(state.getMessageState()));
     register(MessageIntent.EXPIRED, new MessageExpiredApplier(state.getMessageState()));

--- a/engine/src/main/java/io/zeebe/engine/state/deployment/DeploymentRaw.java
+++ b/engine/src/main/java/io/zeebe/engine/state/deployment/DeploymentRaw.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.deployment;
+
+import io.zeebe.db.DbValue;
+import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.msgpack.property.ObjectProperty;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/** DeplyomentRecord wrapper to store the record in the State. */
+public class DeploymentRaw extends UnpackedObject implements DbValue {
+
+  private final ObjectProperty<DeploymentRecord> deploymentRecordProperty =
+      new ObjectProperty<>("deploymentRecord", new DeploymentRecord());
+
+  public DeploymentRaw() {
+    declareProperty(deploymentRecordProperty);
+  }
+
+  public void setDeploymentRecord(final DeploymentRecord deploymentRecord) {
+    final MutableDirectBuffer valueBuffer = new UnsafeBuffer(0, 0);
+    final int encodedLength = deploymentRecord.getLength();
+    valueBuffer.wrap(new byte[encodedLength]);
+
+    deploymentRecord.write(valueBuffer, 0);
+    deploymentRecordProperty.getValue().wrap(valueBuffer, 0, encodedLength);
+  }
+
+  public DeploymentRecord getDeploymentRecord() {
+    return deploymentRecordProperty.getValue();
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/immutable/DeploymentState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/immutable/DeploymentState.java
@@ -8,6 +8,7 @@
 package io.zeebe.engine.state.immutable;
 
 import io.zeebe.engine.processing.deployment.distribute.PendingDeploymentDistribution;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import java.util.function.ObjLongConsumer;
 
 public interface DeploymentState {
@@ -17,4 +18,6 @@ public interface DeploymentState {
   void foreachPending(ObjLongConsumer<PendingDeploymentDistribution> consumer);
 
   boolean hasPendingDeploymentDistribution(long deploymentKey);
+
+  DeploymentRecord getStoredDeploymentRecord(long deploymentKey);
 }

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableDeploymentState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableDeploymentState.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.state.mutable;
 
 import io.zeebe.engine.processing.deployment.distribute.PendingDeploymentDistribution;
 import io.zeebe.engine.state.immutable.DeploymentState;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 
 public interface MutableDeploymentState extends DeploymentState {
 
@@ -19,4 +20,8 @@ public interface MutableDeploymentState extends DeploymentState {
   void addPendingDeploymentDistribution(long deploymentKey, int partition);
 
   void removePendingDeploymentDistribution(long key, int partitionId);
+
+  void storeDeploymentRecord(long key, DeploymentRecord value);
+
+  void removeDeploymentRecord(long key);
 }

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/DeploymentIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/DeploymentIntent.java
@@ -18,8 +18,11 @@ package io.zeebe.protocol.record.intent;
 public enum DeploymentIntent implements Intent {
   CREATE((short) 0),
   CREATED((short) 1),
+
   DISTRIBUTE((short) 2),
-  DISTRIBUTED((short) 3);
+  DISTRIBUTED((short) 3),
+
+  FULLY_DISTRIBUTED((short) 4);
 
   private final short value;
 
@@ -41,6 +44,8 @@ public enum DeploymentIntent implements Intent {
         return DISTRIBUTE;
       case 3:
         return DISTRIBUTED;
+      case 4:
+        return FULLY_DISTRIBUTED;
       default:
         return UNKNOWN;
     }


### PR DESCRIPTION

## Description
 * introduce new intent DeploymentIntent.DISTRIBUTING
     * Event applier stores the deployment record in the state
 * The stored deployment record can then be used for later deployment distributing (retries)
 * introduce new DeploymentIntent.FULLY_DISTRIBUTED
     * Event applier removes deployment from state

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #6173

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
