### PR TITLE
chore(broker): use previous index for snapshot id

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Broker</name>
@@ -97,6 +99,12 @@
     <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-client-java</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/AtomixRecordEntrySupplier.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/AtomixRecordEntrySupplier.java
@@ -9,16 +9,15 @@ package io.zeebe.broker.system.partitions;
 
 import io.atomix.raft.storage.log.Indexed;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
-import io.atomix.raft.zeebe.ZeebeEntry;
 import java.util.Optional;
 
 /**
- * Implementations of this interface should provide the correct {@link Indexed<ZeebeEntry>} when
- * given a Record#getPosition()
+ * Implementations of this interface should return the previous {@link Indexed<RaftLogEntry>} of a
+ * RaftLogEntry that contains a {@link io.atomix.raft.zeebe.ZeebeEntry} with the given position.
  */
 @FunctionalInterface
 public interface AtomixRecordEntrySupplier extends AutoCloseable {
-  Optional<Indexed<RaftLogEntry>> getIndexedEntry(long position);
+  Optional<Indexed<RaftLogEntry>> getPreviousIndexedEntry(long position);
 
   @Override
   default void close() {}

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -83,7 +83,7 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
     final long exportedPosition = exporterPositionSupplier.applyAsLong(openDb());
     final long snapshotPosition =
         determineSnapshotPosition(lowerBoundSnapshotPosition, exportedPosition);
-    final var optionalIndexed = entrySupplier.getIndexedEntry(snapshotPosition);
+    final var optionalIndexed = entrySupplier.getPreviousIndexedEntry(snapshotPosition);
     if (optionalIndexed.isEmpty()) {
       LOG.warn(
           "Failed to take snapshot. Expected to find an indexed entry for determined snapshot position {}, but found no matching indexed entry which contains this position.",

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/BrokerSnapshotTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/BrokerSnapshotTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.partitions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.raft.partition.RaftPartition;
+import io.atomix.raft.storage.log.RaftLogReader;
+import io.atomix.raft.storage.log.RaftLogReader.Mode;
+import io.zeebe.broker.clustering.atomix.AtomixFactory;
+import io.zeebe.broker.system.management.BrokerAdminService;
+import io.zeebe.broker.system.management.PartitionStatus;
+import io.zeebe.broker.test.EmbeddedBrokerRule;
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.ZeebeClientBuilder;
+import io.zeebe.snapshots.broker.SnapshotId;
+import io.zeebe.snapshots.broker.impl.FileBasedSnapshotMetadata;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class BrokerSnapshotTest {
+
+  private static final int PARTITION_ID = 1;
+  @Rule public final EmbeddedBrokerRule brokerRule = new EmbeddedBrokerRule();
+
+  private RaftLogReader journalReader;
+  private BrokerAdminService brokerAdminService;
+  private ZeebeClient client;
+
+  @Before
+  public void setup() {
+    final RaftPartition raftPartition =
+        (RaftPartition)
+            brokerRule
+                .getBroker()
+                .getAtomix()
+                .getPartitionService()
+                .getPartitionGroup(AtomixFactory.GROUP_NAME)
+                .getPartition(PartitionId.from(AtomixFactory.GROUP_NAME, PARTITION_ID));
+    journalReader = raftPartition.getServer().openReader(1, Mode.COMMITS);
+    brokerAdminService = brokerRule.getBroker().getBrokerAdminService();
+
+    final String contactPoint =
+        io.zeebe.util.SocketUtil.toHostAndPortString(brokerRule.getGatewayAddress());
+    final ZeebeClientBuilder zeebeClientBuilder =
+        ZeebeClient.newClientBuilder().usePlaintext().gatewayAddress(contactPoint);
+    client = zeebeClientBuilder.build();
+  }
+
+  @After
+  public void after() {
+    CloseHelper.closeAll(client, journalReader);
+  }
+
+  @Test
+  public void shouldTakeSnapshotAtCorrectIndex() {
+    // given
+    createSomeEvents();
+
+    // when
+    brokerAdminService.takeSnapshot();
+    final SnapshotId snapshotId = waitForSnapshotAtBroker(brokerAdminService, PARTITION_ID);
+
+    // then
+    final long processedIndex = journalReader.seekToAsqn(snapshotId.getProcessedPosition());
+    final long expectedSnapshotIndex = processedIndex - 1;
+
+    assertThat(snapshotId.getIndex()).isEqualTo(expectedSnapshotIndex);
+  }
+
+  private void createSomeEvents() {
+    IntStream.range(0, 10).forEach(this::publishMaxMessageSizeMessage);
+  }
+
+  private void publishMaxMessageSizeMessage(final int key) {
+    client.newPublishMessageCommand().messageName("msg").correlationKey("msg-" + key).send().join();
+  }
+
+  private SnapshotId waitForSnapshotAtBroker(
+      final BrokerAdminService adminService, final int partitionId) {
+    Awaitility.await()
+        .pollInterval(1, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(
+                        adminService
+                            .getPartitionStatus()
+                            .get(partitionId)
+                            .getProcessedPositionInSnapshot())
+                    .isNotNull());
+    final PartitionStatus partitionStatus = brokerAdminService.getPartitionStatus().get(1);
+    return FileBasedSnapshotMetadata.ofFileName(partitionStatus.getSnapshotId()).get();
+  }
+}


### PR DESCRIPTION
## Description

* Get the previous entry when lookingup index for the snapshot position
* Add an integration test that fails without this fix

## Related issues

closes #6438 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
