### PR TITLE
Extract the document indexing logic out of the variable state

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/variable/UpdateVariableStreamWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/variable/UpdateVariableStreamWriter.java
@@ -10,7 +10,7 @@ package io.zeebe.engine.processing.variable;
 import io.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
 import io.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
-import io.zeebe.engine.state.instance.DbVariableState.VariableListener;
+import io.zeebe.engine.state.variable.DbVariableState.VariableListener;
 import io.zeebe.protocol.impl.record.value.variable.VariableRecord;
 import io.zeebe.protocol.record.intent.VariableIntent;
 import org.agrona.DirectBuffer;

--- a/engine/src/main/java/io/zeebe/engine/state/ZeebeDbState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/ZeebeDbState.java
@@ -18,7 +18,6 @@ import io.zeebe.engine.state.instance.DbEventScopeInstanceState;
 import io.zeebe.engine.state.instance.DbIncidentState;
 import io.zeebe.engine.state.instance.DbJobState;
 import io.zeebe.engine.state.instance.DbTimerInstanceState;
-import io.zeebe.engine.state.instance.DbVariableState;
 import io.zeebe.engine.state.message.DbMessageStartEventSubscriptionState;
 import io.zeebe.engine.state.message.DbMessageState;
 import io.zeebe.engine.state.message.DbMessageSubscriptionState;
@@ -40,6 +39,7 @@ import io.zeebe.engine.state.mutable.MutableWorkflowState;
 import io.zeebe.engine.state.processing.DbBlackListState;
 import io.zeebe.engine.state.processing.DbKeyGenerator;
 import io.zeebe.engine.state.processing.DbLastProcessedPositionState;
+import io.zeebe.engine.state.variable.DbVariableState;
 import io.zeebe.protocol.Protocol;
 import java.util.function.BiConsumer;
 

--- a/engine/src/main/java/io/zeebe/engine/state/immutable/VariablesState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/immutable/VariablesState.java
@@ -7,7 +7,7 @@
  */
 package io.zeebe.engine.state.immutable;
 
-import io.zeebe.engine.state.instance.DbVariableState.VariableListener;
+import io.zeebe.engine.state.variable.DbVariableState.VariableListener;
 import java.util.Collection;
 import org.agrona.DirectBuffer;
 

--- a/engine/src/main/java/io/zeebe/engine/state/variable/DocumentEntry.java
+++ b/engine/src/main/java/io/zeebe/engine/state/variable/DocumentEntry.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.variable;
+
+import io.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public final class DocumentEntry {
+
+  private final DirectBuffer name = new UnsafeBuffer();
+  private final DirectBuffer value = new UnsafeBuffer();
+
+  DocumentEntry() {}
+
+  DocumentEntry(final DirectBuffer name, final DirectBuffer value) {
+    this.name.wrap(name);
+    this.value.wrap(value);
+  }
+
+  void wrap(
+      final DirectBuffer buffer,
+      final int nameOffset,
+      final int nameLength,
+      final int valueOffset,
+      final int valueLength) {
+    name.wrap(buffer, nameOffset, nameLength);
+    value.wrap(buffer, valueOffset, valueLength);
+  }
+
+  public DirectBuffer getName() {
+    return name;
+  }
+
+  public DirectBuffer getValue() {
+    return value;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getName().hashCode();
+    result = 31 * result + getValue().hashCode();
+    return result;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final DocumentEntry that = (DocumentEntry) o;
+
+    if (!getName().equals(that.getName())) {
+      return false;
+    }
+    return getValue().equals(that.getValue());
+  }
+
+  @Override
+  public String toString() {
+    return "DocumentEntry{"
+        + "name="
+        + BufferUtil.bufferAsString(name)
+        + ", value="
+        + BufferUtil.bufferAsHexString(value)
+        + '}';
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/variable/DocumentEntryIterator.java
+++ b/engine/src/main/java/io/zeebe/engine/state/variable/DocumentEntryIterator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.variable;
+
+import io.zeebe.msgpack.spec.MsgPackReader;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import org.agrona.DirectBuffer;
+import org.agrona.collections.Int2IntHashMap.EntryIterator;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * Iterates of a document by reading the offsets directly from the associated {@code
+ * offsetIterator}. Expected usage only through {@link IndexedDocument#iterator()}.
+ *
+ * <p>Note that keys are expected to be strings, and as such the length is removed from the MsgPack
+ * representation before being added as the name in the {@link DocumentEntry}. String values are
+ * kept as is, as values can be any kind of object.
+ */
+final class DocumentEntryIterator implements Iterator<DocumentEntry> {
+
+  private final MsgPackReader reader;
+  private final DocumentEntry entry = new DocumentEntry();
+  private final DirectBuffer document = new UnsafeBuffer();
+
+  private EntryIterator offsetIterator;
+  private int documentLength;
+
+  DocumentEntryIterator() {
+    this(new MsgPackReader());
+  }
+
+  DocumentEntryIterator(final MsgPackReader reader) {
+    this.reader = reader;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return offsetIterator.hasNext();
+  }
+
+  @Override
+  public DocumentEntry next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    offsetIterator.next();
+    final int keyOffset = offsetIterator.getIntKey();
+    final int valueOffset = offsetIterator.getIntValue();
+
+    reader.wrap(document, keyOffset, documentLength - keyOffset);
+    final int nameLength = reader.readStringLength();
+    final int nameOffset = keyOffset + reader.getOffset();
+
+    reader.wrap(document, valueOffset, documentLength - valueOffset);
+    reader.skipValue();
+    final int valueLength = reader.getOffset();
+
+    entry.wrap(document, nameOffset, nameLength, valueOffset, valueLength);
+    return entry;
+  }
+
+  @Override
+  public void remove() {
+    offsetIterator.remove();
+  }
+
+  void wrap(final DirectBuffer document, final EntryIterator offsetIterator) {
+    this.document.wrap(document);
+    this.offsetIterator = offsetIterator;
+    documentLength = document.capacity();
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/variable/IndexedDocument.java
+++ b/engine/src/main/java/io/zeebe/engine/state/variable/IndexedDocument.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.variable;
+
+import io.zeebe.msgpack.spec.MsgPackReader;
+import org.agrona.DirectBuffer;
+import org.agrona.collections.Int2IntHashMap;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * This class indexes a MsgPack document from the given buffer by doing an initial parsing and
+ * caching the offsets for each key-value pair. When iterating, it will then only iterate over these
+ * pairs and access them directly via the buffer.
+ *
+ * <p>This class is meant to be mutable and reusable - this means that the expected usage is to
+ * index the document and read it/iterate over it BEFORE indexing a new document again.
+ *
+ * <p>Similarly, the iterator will reuse and mutate the same {@link DocumentEntry} instance on each
+ * {@link DocumentEntryIterator#next()} call, meaning that if you want to collect entries you should
+ * clone them before calling {@link DocumentEntryIterator#next()} again.
+ */
+public final class IndexedDocument implements Iterable<DocumentEntry> {
+
+  private final MsgPackReader reader;
+
+  // variable name offset -> variable value offset
+  private final Int2IntHashMap entries = new Int2IntHashMap(-1);
+  private final DocumentEntryIterator iterator = new DocumentEntryIterator();
+  private final DirectBuffer document = new UnsafeBuffer();
+
+  public IndexedDocument() {
+    this(new MsgPackReader());
+  }
+
+  public IndexedDocument(final MsgPackReader reader) {
+    this.reader = reader;
+  }
+
+  public void index(final DirectBuffer document) {
+    this.document.wrap(document);
+    entries.clear();
+    reader.wrap(document, 0, document.capacity());
+
+    final int variables = reader.readMapHeader();
+    for (int i = 0; i < variables; i++) {
+      final int keyOffset = reader.getOffset();
+      reader.skipValue();
+      final int valueOffset = reader.getOffset();
+      reader.skipValue();
+
+      entries.put(keyOffset, valueOffset);
+    }
+  }
+
+  @Override
+  public DocumentEntryIterator iterator() {
+    iterator.wrap(document, entries.entrySet().iterator());
+    return iterator;
+  }
+
+  public boolean isEmpty() {
+    return entries.isEmpty();
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/variable/VariableInstance.java
+++ b/engine/src/main/java/io/zeebe/engine/state/variable/VariableInstance.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.0. You may not use this file
  * except in compliance with the Zeebe Community License 1.0.
  */
-package io.zeebe.engine.state.instance;
+package io.zeebe.engine.state.variable;
 
 import io.zeebe.db.DbValue;
 import io.zeebe.msgpack.UnpackedObject;

--- a/engine/src/test/java/io/zeebe/engine/state/variable/IndexedDocumentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/variable/IndexedDocumentTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.variable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.msgpack.spec.MsgPackReader;
+import io.zeebe.test.util.MsgPackUtil;
+import io.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Some notes about these tests:
+ *
+ * <ul>
+ *   <li>the document iterator reuses the same document entry, so it's important to clone the entry
+ *       when collecting it for testing
+ *   <li>keys are stored without the string length - this is because variable names are always
+ *       strings, and the whole buffer is the string. When creating ad hoc document entries for
+ *       comparison, you have to pack the string then remove its length for the key
+ * </ul>
+ */
+final class IndexedDocumentTest {
+
+  private final IndexedDocument indexedDocument = new IndexedDocument();
+
+  @Test
+  void shouldIndexDocument() {
+    // given
+    final Map<String, Object> document = Map.of("foo", "bar", "baz", "buz");
+
+    // when
+    indexedDocument.index(MsgPackUtil.asMsgPack(document));
+
+    // then
+    final List<DocumentEntry> entries = collectEntries();
+    assertThat(entries)
+        .hasSize(document.size())
+        .containsExactlyInAnyOrder(
+            new DocumentEntry(packStringWithoutLength("foo"), packString("bar")),
+            new DocumentEntry(packStringWithoutLength("baz"), packString("buz")));
+  }
+
+  @Test
+  void shouldRemoveEntriesViaIterator() {
+    // given
+    final Map<String, Object> document = Map.of("foo", "bar", "baz", "buz");
+    indexedDocument.index(MsgPackUtil.asMsgPack(document));
+    final DocumentEntryIterator iterator = indexedDocument.iterator();
+
+    // when
+    final DocumentEntry remainingEntry = cloneEntry(iterator.next());
+    final DocumentEntry removedEntry = cloneEntry(iterator.next());
+    iterator.remove();
+
+    // then
+    final List<DocumentEntry> entries = collectEntries();
+    assertThat(entries).hasSize(1).containsOnly(remainingEntry).doesNotContain(removedEntry);
+  }
+
+  @Test
+  void shouldWrapNewDocument() {
+    // given
+    final Map<String, Object> initialDocument = Map.of("foo", "bar", "baz", "buz");
+    final Map<String, Object> finalDocument = Map.of("bar", "foo", "buz", "baz");
+    indexedDocument.index(MsgPackUtil.asMsgPack(initialDocument));
+    final List<DocumentEntry> initialEntries = collectEntries();
+
+    // when
+    indexedDocument.index(MsgPackUtil.asMsgPack(finalDocument));
+
+    // then
+    final List<DocumentEntry> finalEntries = collectEntries();
+    assertThat(finalEntries)
+        .hasSize(finalDocument.size())
+        .doesNotContainAnyElementsOf(initialEntries)
+        .containsExactlyInAnyOrder(
+            new DocumentEntry(packStringWithoutLength("bar"), packString("foo")),
+            new DocumentEntry(packStringWithoutLength("buz"), packString("baz")));
+  }
+
+  private List<DocumentEntry> collectEntries() {
+    final List<DocumentEntry> entries = new ArrayList<>();
+    for (final DocumentEntry entry : indexedDocument) {
+      entries.add(cloneEntry(entry));
+    }
+    return entries;
+  }
+
+  private DocumentEntry cloneEntry(final DocumentEntry entry) {
+    return new DocumentEntry(
+        BufferUtil.cloneBuffer(entry.getName()), BufferUtil.cloneBuffer(entry.getValue()));
+  }
+
+  private DirectBuffer packString(final String value) {
+    return MsgPackUtil.encodeMsgPack(b -> b.packString(value));
+  }
+
+  private DirectBuffer packStringWithoutLength(final String key) {
+    final MsgPackReader reader = new MsgPackReader();
+    final DirectBuffer buffer = packString(key);
+    reader.wrap(buffer, 0, buffer.capacity());
+    reader.readStringLength();
+
+    final int offset = reader.getOffset();
+    return new UnsafeBuffer(buffer, offset, buffer.capacity() - offset);
+  }
+}


### PR DESCRIPTION
## Description

This PR is the first step to #6175 - it extracts the document indexing logic out of `DbVariableState` such that it will be reusable when we introduce a new behaviour to merge documents into the variable state with propagation logic. Apart from extracting the code as is, notable changes were:

- Formatting according to the Google plugin (this is the last commit, maybe you can ignore it for less noise)
- Changing `IndexedDocument`/`DocumentEntryIterator` from implementing `Iterable<Void>`/`Iterator<Void>` to `Iterable<DocumentEntry>`/`Iterator<DocumentEntry>`, and introducing a new data holder class `DocumentEntry`.
- Adding tests to `IndexedDocument`, updating existing tests in `DbVariableStateTest`.
- Moving all of this to a new `state.variable` package.

## Related issues

related to #6175 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
