### PR TITLE
Provide a way to get the parent scope key of a variable scope

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnWorkflowResultSenderBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnWorkflowResultSenderBehavior.java
@@ -14,7 +14,7 @@ import io.zeebe.engine.processing.bpmn.BpmnProcessingException;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.immutable.ElementInstanceState;
-import io.zeebe.engine.state.immutable.VariablesState;
+import io.zeebe.engine.state.immutable.VariableState;
 import io.zeebe.engine.state.instance.AwaitWorkflowInstanceResultMetadata;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceResultRecord;
 import io.zeebe.protocol.record.ValueType;
@@ -29,13 +29,13 @@ public final class BpmnWorkflowResultSenderBehavior {
   private final WorkflowInstanceResultRecord resultRecord = new WorkflowInstanceResultRecord();
 
   private final ElementInstanceState elementInstanceState;
-  private final VariablesState variablesState;
+  private final VariableState variableState;
   private final TypedResponseWriter responseWriter;
 
   public BpmnWorkflowResultSenderBehavior(
       final ZeebeState zeebeState, final TypedResponseWriter responseWriter) {
     elementInstanceState = zeebeState.getElementInstanceState();
-    variablesState = zeebeState.getVariableState();
+    variableState = zeebeState.getVariableState();
     this.responseWriter = responseWriter;
   }
 
@@ -92,10 +92,10 @@ public final class BpmnWorkflowResultSenderBehavior {
 
     if (variablesToCollect.isEmpty()) {
       // collect all workflow instance variables
-      return variablesState.getVariablesAsDocument(context.getWorkflowInstanceKey());
+      return variableState.getVariablesAsDocument(context.getWorkflowInstanceKey());
 
     } else {
-      return variablesState.getVariablesAsDocument(
+      return variableState.getVariablesAsDocument(
           context.getWorkflowInstanceKey(), variablesToCollect);
     }
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -14,7 +14,7 @@ import io.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.state.KeyGenerator;
-import io.zeebe.engine.state.immutable.VariablesState;
+import io.zeebe.engine.state.immutable.VariableState;
 import io.zeebe.engine.state.mutable.MutableJobState;
 import io.zeebe.msgpack.value.DocumentValue;
 import io.zeebe.msgpack.value.LongValue;
@@ -40,7 +40,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 public final class JobBatchActivateProcessor implements TypedRecordProcessor<JobBatchRecord> {
 
   private final MutableJobState jobState;
-  private final VariablesState variablesState;
+  private final VariableState variableState;
   private final KeyGenerator keyGenerator;
   private final long maxRecordLength;
   private final long maxJobBatchLength;
@@ -49,12 +49,12 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
 
   public JobBatchActivateProcessor(
       final MutableJobState jobState,
-      final VariablesState variablesState,
+      final VariableState variableState,
       final KeyGenerator keyGenerator,
       final long maxRecordLength) {
 
     this.jobState = jobState;
-    this.variablesState = variablesState;
+    this.variableState = variableState;
     this.keyGenerator = keyGenerator;
 
     this.maxRecordLength = maxRecordLength;
@@ -180,9 +180,9 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final Collection<DirectBuffer> variableNames, final long elementInstanceKey) {
     final DirectBuffer variables;
     if (variableNames.isEmpty()) {
-      variables = variablesState.getVariablesAsDocument(elementInstanceKey);
+      variables = variableState.getVariablesAsDocument(elementInstanceKey);
     } else {
-      variables = variablesState.getVariablesAsDocument(elementInstanceKey, variableNames);
+      variables = variableState.getVariablesAsDocument(elementInstanceKey, variableNames);
     }
     return variables;
   }

--- a/engine/src/main/java/io/zeebe/engine/state/immutable/VariableState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/immutable/VariableState.java
@@ -11,7 +11,10 @@ import io.zeebe.engine.state.variable.DbVariableState.VariableListener;
 import java.util.Collection;
 import org.agrona.DirectBuffer;
 
-public interface VariablesState {
+public interface VariableState {
+
+  /** The value of the parent scope key for scope with no parents. */
+  long NO_PARENT = -1;
 
   DirectBuffer getVariableLocal(long scopeKey, DirectBuffer name);
 
@@ -30,4 +33,10 @@ public interface VariablesState {
   boolean isEmpty();
 
   void setListener(VariableListener listener);
+
+  /**
+   * @return returns the parent scope key of the given {@code childScopeKey}, or {@link
+   *     VariableState#NO_PARENT}
+   */
+  long getParentScopeKey(long childScopeKey);
 }

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableVariableState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableVariableState.java
@@ -7,10 +7,10 @@
  */
 package io.zeebe.engine.state.mutable;
 
-import io.zeebe.engine.state.immutable.VariablesState;
+import io.zeebe.engine.state.immutable.VariableState;
 import org.agrona.DirectBuffer;
 
-public interface MutableVariableState extends VariablesState {
+public interface MutableVariableState extends VariableState {
 
   void setVariablesLocalFromDocument(long scopeKey, long workflowKey, DirectBuffer document);
 

--- a/engine/src/test/java/io/zeebe/engine/state/variable/VariableStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/variable/VariableStateTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.immutable.VariableState;
 import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.engine.state.mutable.MutableVariableState;
@@ -483,6 +484,31 @@ public final class VariableStateTest {
 
     final DirectBuffer varChild = variablesState.getVariableLocal(child, wrapString("a"));
     assertEquality(varChild, "1");
+  }
+
+  @Test
+  public void shouldReturnParentScopeKey() {
+    // given
+    declareScope(parent);
+    declareScope(parent, child);
+
+    // when
+    final long parentScopeKey = variablesState.getParentScopeKey(child);
+
+    // then
+    assertThat(parentScopeKey).isEqualTo(parent);
+  }
+
+  @Test
+  public void shouldReturnNoParentForRootScopeKey() {
+    // given
+    declareScope(parent);
+
+    // when
+    final long parentScopeKey = variablesState.getParentScopeKey(parent);
+
+    // then
+    assertThat(parentScopeKey).isEqualTo(VariableState.NO_PARENT);
   }
 
   /** Making sure the method is reusable and does not leave data structures dirty */


### PR DESCRIPTION
## Description

As part of #6175, we will need a way to walk the scope hierarchy of variable scopes in order to properly merge variable documents, and this will be done outside of the `VariableState`. The simplest solution is simply to expose `getParentScopeKey` which returns either the parent scope key, or `NO_PARENT` if there is none.

If we end up walking this hierarchy a lot, then we could always introduce a more complex abstraction, but this is fine for now.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #6175 
blocked by #6446

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
