### PR TITLE
Apply event sourcing to the parallel gateway processor

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
@@ -68,7 +68,9 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @deprecated will be replaced by onActivate
    */
   @Deprecated // todo (#6202): remove method
-  void onActivating(final T element, final BpmnElementContext context);
+  default void onActivating(final T element, final BpmnElementContext context) {
+    throw new UnsupportedOperationException("This method is replaced by onActivate");
+  }
 
   /**
    * The element is initialized. If the element is a wait-state (i.e. it is waiting for an event or
@@ -88,7 +90,9 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @deprecated will be replaced by onActivate
    */
   @Deprecated // todo (#6202): remove method
-  void onActivated(final T element, final BpmnElementContext context);
+  default void onActivated(final T element, final BpmnElementContext context) {
+    throw new UnsupportedOperationException("This method is replaced by onActivate");
+  }
 
   /**
    * The element is going to be left. Perform every action to leave the element and continue with
@@ -128,7 +132,9 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @deprecated will be replaced by onComplete
    */
   @Deprecated // todo (#6202): remove method
-  void onCompleting(final T element, final BpmnElementContext context);
+  default void onCompleting(final T element, final BpmnElementContext context) {
+    throw new UnsupportedOperationException("This method is replaced by onComplete");
+  }
 
   /**
    * The element is left (final step). Continue with the next element.
@@ -148,7 +154,9 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @deprecated will be replaced by onComplete
    */
   @Deprecated // todo (#6202): remove method
-  void onCompleted(final T element, final BpmnElementContext context);
+  default void onCompleted(final T element, final BpmnElementContext context) {
+    throw new UnsupportedOperationException("This method is replaced by onComplete");
+  }
 
   /**
    * The element is going to be terminated. Perform every action to terminate the element and
@@ -188,7 +196,9 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @deprecated will be replaced by onTerminate
    */
   @Deprecated // todo (#6202): remove method
-  void onTerminating(final T element, final BpmnElementContext context);
+  default void onTerminating(final T element, final BpmnElementContext context) {
+    throw new UnsupportedOperationException("This method is replaced by onTerminate");
+  }
 
   /**
    * The element is terminated (final step). Continue with the element that caused the termination
@@ -211,7 +221,9 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @deprecated will be replaced by onTerminate
    */
   @Deprecated // todo (#6202): remove method
-  void onTerminated(final T element, final BpmnElementContext context);
+  default void onTerminated(final T element, final BpmnElementContext context) {
+    throw new UnsupportedOperationException("This method is replaced by onTerminate");
+  }
 
   /**
    * An event subscription of the element is triggered. Leave the element if it waited for this

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
@@ -67,18 +67,6 @@ public final class ExclusiveGatewayProcessor
   }
 
   @Override
-  public void onActivating(
-      final ExecutableExclusiveGateway element, final BpmnElementContext context) {
-    throw new UnsupportedOperationException("This method is replaced by onActivate");
-  }
-
-  @Override
-  public void onActivated(
-      final ExecutableExclusiveGateway element, final BpmnElementContext context) {
-    throw new UnsupportedOperationException("This method is replaced by onActivate");
-  }
-
-  @Override
   public void onComplete(
       final ExecutableExclusiveGateway element, final BpmnElementContext context) {
     throw new UnsupportedOperationException(
@@ -88,35 +76,11 @@ public final class ExclusiveGatewayProcessor
   }
 
   @Override
-  public void onCompleting(
-      final ExecutableExclusiveGateway element, final BpmnElementContext context) {
-    throw new UnsupportedOperationException("This method is replaced by onActivate");
-  }
-
-  @Override
-  public void onCompleted(
-      final ExecutableExclusiveGateway element, final BpmnElementContext context) {
-    throw new UnsupportedOperationException("This method is replaced by onActivate");
-  }
-
-  @Override
   public void onTerminate(
       final ExecutableExclusiveGateway element, final BpmnElementContext context) {
     incidentBehavior.resolveIncidents(context);
     final var terminated = stateTransitionBehavior.transitionToTerminated(context);
     stateTransitionBehavior.onElementTerminated(element, terminated);
-  }
-
-  @Override
-  public void onTerminating(
-      final ExecutableExclusiveGateway element, final BpmnElementContext context) {
-    throw new UnsupportedOperationException("This method is replaced by onTerminate");
-  }
-
-  @Override
-  public void onTerminated(
-      final ExecutableExclusiveGateway element, final BpmnElementContext context) {
-    throw new UnsupportedOperationException("This method is replaced by onTerminate");
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -54,6 +54,7 @@ public final class MigratedStreamProcessors {
                 JobIntent.FAILED)));
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.TESTING_ONLY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.EXCLUSIVE_GATEWAY);
+    MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.PARALLEL_GATEWAY);
 
     MIGRATED_VALUE_TYPES.put(ValueType.ERROR, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.WORKFLOW, MIGRATED);


### PR DESCRIPTION
## Description

- adds onActivate, onComplete and onTerminate to the exclusive gateway processor
  - the wait state is removed, which means that onComplete is not implemented
  - Instead, onActivate does all the processing from activating: transition to activated, transition to completing, transition to completed, and take all outgoing sequence flows
  - the event appliers already exist to take care of all the state changes
- also introduces some default methods for the deprecated methods of the element processors, which allows us to already clean up the migrated element processors

Out of scope: [remove the sequence flow processor #6450](https://github.com/zeebe-io/zeebe/issues/6450)

## Related issues

closes #6190 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
