### PR TITLE
Extract variable document merging into specific behavior

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -32,7 +32,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-
     <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-protocol</artifactId>
@@ -152,6 +151,23 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.msgpack</groupId>
+      <artifactId>jackson-dataformat-msgpack</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/EventApplyingStateWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/EventApplyingStateWriter.java
@@ -25,12 +25,12 @@ public final class EventApplyingStateWriter implements StateWriter {
 
   private static final UnaryOperator<RecordMetadata> NO_MODIFIER = UnaryOperator.identity();
 
-  private final TypedStreamWriter streamWriter;
+  private final TypedEventWriter eventWriter;
   private final EventApplier eventApplier;
 
   public EventApplyingStateWriter(
-      final TypedStreamWriter streamWriter, final EventApplier eventApplier) {
-    this.streamWriter = streamWriter;
+      final TypedEventWriter eventWriter, final EventApplier eventApplier) {
+    this.eventWriter = eventWriter;
     this.eventApplier = eventApplier;
   }
 
@@ -45,7 +45,7 @@ public final class EventApplyingStateWriter implements StateWriter {
       final Intent intent,
       final RecordValue value,
       final UnaryOperator<RecordMetadata> modifier) {
-    streamWriter.appendFollowUpEvent(key, intent, value, modifier);
+    eventWriter.appendFollowUpEvent(key, intent, value, modifier);
     eventApplier.applyState(key, intent, value);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/variable/UpdateVariableDocumentProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/variable/UpdateVariableDocumentProcessor.java
@@ -22,13 +22,20 @@ import org.agrona.DirectBuffer;
 
 public final class UpdateVariableDocumentProcessor
     implements CommandProcessor<VariableDocumentRecord> {
+
   private final ElementInstanceState elementInstanceState;
-  private final MutableVariableState variablesState;
+  private final VariableDocumentBehavior variableDocumentBehavior;
 
   public UpdateVariableDocumentProcessor(
       final ElementInstanceState elementInstanceState, final MutableVariableState variablesState) {
+    this(elementInstanceState, new VariableDocumentBehavior(variablesState));
+  }
+
+  public UpdateVariableDocumentProcessor(
+      final ElementInstanceState elementInstanceState,
+      final VariableDocumentBehavior variableDocumentBehavior) {
     this.elementInstanceState = elementInstanceState;
-    this.variablesState = variablesState;
+    this.variableDocumentBehavior = variableDocumentBehavior;
   }
 
   @Override
@@ -81,10 +88,10 @@ public final class UpdateVariableDocumentProcessor
   private UpdateOperation getUpdateOperation(final VariableDocumentUpdateSemantic updateSemantics) {
     switch (updateSemantics) {
       case LOCAL:
-        return variablesState::setVariablesLocalFromDocument;
+        return variableDocumentBehavior::mergeLocalDocument;
       case PROPAGATE:
       default:
-        return variablesState::setVariablesFromDocument;
+        return variableDocumentBehavior::mergeDocument;
     }
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/variable/VariableDocumentBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/variable/VariableDocumentBehavior.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.variable;
+
+import io.zeebe.engine.state.mutable.MutableVariableState;
+import io.zeebe.engine.state.variable.DocumentEntry;
+import io.zeebe.engine.state.variable.IndexedDocument;
+import io.zeebe.engine.state.variable.VariableInstance;
+import java.util.Iterator;
+import org.agrona.DirectBuffer;
+
+public final class VariableDocumentBehavior {
+
+  private final MutableVariableState variableState;
+  private final IndexedDocument indexedDocument = new IndexedDocument();
+
+  public VariableDocumentBehavior(final MutableVariableState variableState) {
+    this.variableState = variableState;
+  }
+
+  /**
+   * Merges the given document directly on the given scope key.
+   *
+   * <p>If any variable from the document already exists on the current scope, a {@code
+   * Variable.UPDATED} record is produced as a follow up event.
+   *
+   * <p>For all variables from the document which do not exist in the current scope, a {@code
+   * Variable.CREATED} record is produced as a follow up event.
+   *
+   * @param scopeKey the scope key for each variable
+   * @param workflowKey the workflow key to be associated with each variable
+   * @param document the document to merge
+   */
+  public void mergeLocalDocument(
+      final long scopeKey, final long workflowKey, final DirectBuffer document) {
+    indexedDocument.index(document);
+    if (indexedDocument.isEmpty()) {
+      return;
+    }
+
+    for (final DocumentEntry entry : indexedDocument) {
+      variableState.setVariableLocal(scopeKey, workflowKey, entry.getName(), entry.getValue());
+    }
+  }
+
+  /**
+   * Merges the given document, propagating its changes from the bottom to the top of the scope
+   * hierarchy.
+   *
+   * <p>Starting at the given {@code scopeKey}, it will overwrite any variables that exist in that
+   * scope with the corresponding values from the given document. Variables that were not set
+   * because they did not exist in the current scope are collected as a sub document, which will
+   * then be merged with the parent scope, recursively, until there are no more. If we reach a scope
+   * with no parent, then any remaining variables are created there.
+   *
+   * <p>If any variable from the document already exists on the current scope, a {@code
+   * Variable.UPDATED} record is produced as a follow up event.
+   *
+   * <p>For all variables from the document which do not exist in the current scope, a {@code
+   * Variable.CREATED} record is produced as a follow up event.
+   *
+   * @param scopeKey the bottom-most scope key to start with
+   * @param workflowKey the workflow key to be associated with each variable
+   * @param document the document to merge
+   */
+  public void mergeDocument(
+      final long scopeKey, final long workflowKey, final DirectBuffer document) {
+    indexedDocument.index(document);
+    if (indexedDocument.isEmpty()) {
+      return;
+    }
+
+    long currentScope = scopeKey;
+    long parentScope;
+
+    while ((parentScope = variableState.getParentScopeKey(currentScope)) > 0
+        && !indexedDocument.isEmpty()) {
+      final Iterator<DocumentEntry> entryIterator = indexedDocument.iterator();
+
+      while (entryIterator.hasNext()) {
+        final DocumentEntry entry = entryIterator.next();
+        // seems unnecessary to grab a reference yet, but will soon be used to produce follow up
+        // events with the right key
+        final VariableInstance variableInstance =
+            variableState.getVariableInstanceLocal(currentScope, entry.getName());
+
+        if (variableInstance != null) {
+          variableState.setVariableLocal(
+              currentScope, workflowKey, entry.getName(), entry.getValue());
+          entryIterator.remove();
+        }
+      }
+      currentScope = parentScope;
+    }
+
+    for (final DocumentEntry entry : indexedDocument) {
+      variableState.setVariableLocal(currentScope, workflowKey, entry.getName(), entry.getValue());
+    }
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableVariableState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableVariableState.java
@@ -12,8 +12,6 @@ import org.agrona.DirectBuffer;
 
 public interface MutableVariableState extends VariableState {
 
-  void setVariablesLocalFromDocument(long scopeKey, long workflowKey, DirectBuffer document);
-
   void setVariableLocal(long scopeKey, long workflowKey, DirectBuffer name, DirectBuffer value);
 
   void setVariableLocal(
@@ -33,8 +31,6 @@ public interface MutableVariableState extends VariableState {
       DirectBuffer value,
       int valueOffset,
       int valueLength);
-
-  void setVariablesFromDocument(long scopeKey, long workflowKey, DirectBuffer document);
 
   void createScope(long childKey, long parentKey);
 

--- a/engine/src/main/java/io/zeebe/engine/state/variable/DbVariableState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/variable/DbVariableState.java
@@ -18,23 +18,21 @@ import io.zeebe.engine.state.ZbColumnFamilies;
 import io.zeebe.engine.state.instance.ParentScopeKey;
 import io.zeebe.engine.state.instance.TemporaryVariables;
 import io.zeebe.engine.state.mutable.MutableVariableState;
-import io.zeebe.msgpack.spec.MsgPackReader;
 import io.zeebe.msgpack.spec.MsgPackWriter;
 import io.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.MutableInteger;
 import org.agrona.collections.ObjectHashSet;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public class DbVariableState implements MutableVariableState {
 
-  private final MsgPackReader reader = new MsgPackReader();
   private final MsgPackWriter writer = new MsgPackWriter();
   private final ExpandableArrayBuffer documentResultBuffer = new ExpandableArrayBuffer();
   private final DirectBuffer resultView = new UnsafeBuffer(0, 0);
@@ -63,11 +61,9 @@ public class DbVariableState implements MutableVariableState {
   private final ObjectHashSet<DirectBuffer> variablesToCollect = new ObjectHashSet<>();
 
   // setting variables
-  private final IndexedDocument indexedDocument = new IndexedDocument(reader);
   private final KeyGenerator keyGenerator;
 
   private VariableListener listener;
-  private int variableCount = 0;
 
   public DbVariableState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
@@ -99,19 +95,6 @@ public class DbVariableState implements MutableVariableState {
             transactionContext,
             scopeKey,
             temporaryVariables);
-  }
-
-  @Override
-  public void setVariablesLocalFromDocument(
-      final long scopeKey, final long workflowKey, final DirectBuffer document) {
-    indexedDocument.index(document);
-    if (indexedDocument.isEmpty()) {
-      return;
-    }
-
-    for (final DocumentEntry entry : indexedDocument) {
-      setVariableLocal(scopeKey, workflowKey, entry.getName(), entry.getValue());
-    }
   }
 
   @Override
@@ -181,40 +164,6 @@ public class DbVariableState implements MutableVariableState {
             scopeKey,
             rootScopeKey);
       }
-
-    } else {
-      // not updated
-    }
-  }
-
-  @Override
-  public void setVariablesFromDocument(
-      final long scopeKey, final long workflowKey, final DirectBuffer document) {
-    indexedDocument.index(document);
-    if (indexedDocument.isEmpty()) {
-      return;
-    }
-
-    long currentScope = scopeKey;
-    long parentScope;
-
-    while ((parentScope = getParentScopeKey(currentScope)) > 0) {
-      final Iterator<DocumentEntry> entryIterator = indexedDocument.iterator();
-
-      while (entryIterator.hasNext()) {
-        final DocumentEntry entry = entryIterator.next();
-        final boolean hasVariable = hasVariableLocal(currentScope, entry.getName());
-
-        if (hasVariable) {
-          setVariableLocal(currentScope, workflowKey, entry.getName(), entry.getValue());
-          entryIterator.remove();
-        }
-      }
-      currentScope = parentScope;
-    }
-
-    for (final DocumentEntry entry : indexedDocument) {
-      setVariableLocal(currentScope, workflowKey, entry.getName(), entry.getValue());
     }
   }
 
@@ -370,13 +319,10 @@ public class DbVariableState implements MutableVariableState {
 
   @Override
   public DirectBuffer getVariablesLocalAsDocument(final long scopeKey) {
-
     writer.wrap(documentResultBuffer, 0);
-
     writer.reserveMapHeader();
 
-    variableCount = 0;
-
+    final MutableInteger variableCount = new MutableInteger();
     visitVariablesLocal(
         scopeKey,
         name -> true,
@@ -384,11 +330,11 @@ public class DbVariableState implements MutableVariableState {
           writer.writeString(name.getBuffer());
           writer.writeRaw(value.getValue());
 
-          variableCount += 1;
+          variableCount.addAndGet(1);
         },
         () -> false);
 
-    writer.writeReservedMapHeader(0, variableCount);
+    writer.writeReservedMapHeader(0, variableCount.get());
 
     resultView.wrap(documentResultBuffer, 0, writer.getOffset());
     return resultView;
@@ -487,10 +433,10 @@ public class DbVariableState implements MutableVariableState {
     variablesColumnFamily.whileEqualPrefix(
         this.scopeKey,
         (compositeKey, variable) -> {
-          final DbString variableName = compositeKey.getSecond();
+          final DbString name = compositeKey.getSecond();
 
-          if (variableFilter.test(variableName)) {
-            variableConsumer.accept(variableName, variable);
+          if (variableFilter.test(name)) {
+            variableConsumer.accept(name, variable);
           }
 
           return !completionCondition.getAsBoolean();

--- a/engine/src/test/java/io/zeebe/engine/processing/variable/VariableDocumentBehaviorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/variable/VariableDocumentBehaviorTest.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.processing.variable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.zeebe.db.ZeebeDb;
+import io.zeebe.engine.processing.streamprocessor.writers.EventApplyingStateWriter;
+import io.zeebe.engine.state.DefaultZeebeDbFactory;
+import io.zeebe.engine.state.ZbColumnFamilies;
+import io.zeebe.engine.state.ZeebeDbState;
+import io.zeebe.engine.state.ZeebeState;
+import io.zeebe.engine.state.appliers.EventAppliers;
+import io.zeebe.engine.state.immutable.VariableState;
+import io.zeebe.engine.state.mutable.MutableVariableState;
+import io.zeebe.engine.util.RecordingTypedEventWriter;
+import io.zeebe.engine.util.RecordingTypedEventWriter.RecordedEvent;
+import io.zeebe.protocol.record.intent.VariableIntent;
+import io.zeebe.protocol.record.value.VariableRecordValue;
+import io.zeebe.protocol.record.value.VariableRecordValueAssert;
+import io.zeebe.test.util.MsgPackUtil;
+import io.zeebe.util.buffer.BufferUtil;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.agrona.CloseHelper;
+import org.agrona.DirectBuffer;
+import org.agrona.io.DirectBufferInputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.msgpack.jackson.dataformat.MessagePackFactory;
+
+/**
+ * The following tests currently assert both that the right follow up events are produced AND that
+ * the state was correctly modified. This is because right now the behaviour modifies the state, and
+ * relies on the listener to produce follow up events.
+ *
+ * <p>Once event sourcing has been applied to variables, we can stop asserting on the state and rely
+ * purely on the events - other tests should ensure the state is correctly built up from the events.
+ */
+final class VariableDocumentBehaviorTest {
+
+  private final RecordingTypedEventWriter eventWriter = new RecordingTypedEventWriter();
+
+  private ZeebeDb<ZbColumnFamilies> db;
+  private ZeebeState zeebeState;
+  private MutableVariableState state;
+  private VariableDocumentBehavior behavior;
+
+  @BeforeEach
+  void beforeEach(final @TempDir File directory) {
+    db = DefaultZeebeDbFactory.defaultFactory().createDb(directory);
+    zeebeState = new ZeebeDbState(db, db.createContext());
+
+    state = zeebeState.getVariableState();
+    behavior = new VariableDocumentBehavior(state);
+  }
+
+  @AfterEach
+  void afterEach() {
+    CloseHelper.close(db);
+  }
+
+  @Test
+  void shouldMergeLocalDocument() {
+    // given
+    final int workflowKey = 1;
+    final int parentScopeKey = 1;
+    final int childScopeKey = 2;
+    final Map<String, Object> document = Map.of("foo", "bar", "baz", "buz");
+    state.createScope(parentScopeKey, VariableState.NO_PARENT);
+    state.createScope(childScopeKey, parentScopeKey);
+    final long childFooKey = setVariable(childScopeKey, workflowKey, "foo", "qux");
+
+    // when
+    listenForStateChanges();
+    behavior.mergeLocalDocument(childScopeKey, workflowKey, MsgPackUtil.asMsgPack(document));
+
+    // then
+    assertThat(getScopeVariables(childScopeKey))
+        .containsOnly(entry("foo", "bar"), entry("baz", "buz"));
+    assertThat(getScopeVariables(parentScopeKey)).isEmpty();
+
+    final List<RecordedEvent<VariableRecordValue>> events = getFollowUpEvents();
+    assertThat(events)
+        .satisfiesExactlyInAnyOrder(
+            event -> {
+              assertThat(event.intent).isEqualTo(VariableIntent.CREATED);
+              VariableRecordValueAssert.assertThat(event.value)
+                  .hasName("baz")
+                  .hasValue("\"buz\"")
+                  .hasScopeKey(childScopeKey)
+                  .hasWorkflowKey(workflowKey)
+                  .hasWorkflowInstanceKey(parentScopeKey);
+            },
+            event -> {
+              assertThat(event.intent).isEqualTo(VariableIntent.UPDATED);
+              assertThat(event.key).isEqualTo(childFooKey);
+              VariableRecordValueAssert.assertThat(event.value)
+                  .hasName("foo")
+                  .hasValue("\"bar\"")
+                  .hasScopeKey(childScopeKey)
+                  .hasWorkflowKey(workflowKey)
+                  .hasWorkflowInstanceKey(parentScopeKey);
+            });
+  }
+
+  @Test
+  void shouldNotMergeLocalDocumentIfEmpty() {
+    // given
+    final int workflowKey = 1;
+    final int scopeKey = 1;
+    final Map<String, Object> document = Map.of();
+    setVariable(scopeKey, workflowKey, "foo", "qux");
+
+    // when
+    listenForStateChanges();
+    behavior.mergeLocalDocument(scopeKey, workflowKey, MsgPackUtil.asMsgPack(document));
+
+    // then
+    assertThat(getScopeVariables(scopeKey)).containsOnly(entry("foo", "qux"));
+    assertThat(getFollowUpEvents()).isEmpty();
+  }
+
+  @Test
+  void shouldMergeDocumentWithoutPropagatingMoreThanOnce() {
+    // given
+    final int workflowKey = 1;
+    final int rootScopeKey = 1;
+    final int parentScopeKey = 2;
+    final int childScopeKey = 3;
+    final Map<String, Object> document = Map.of("foo", "bar");
+    state.createScope(rootScopeKey, VariableState.NO_PARENT);
+    state.createScope(parentScopeKey, rootScopeKey);
+    state.createScope(childScopeKey, parentScopeKey);
+    final long parentFooKey = setVariable(parentScopeKey, workflowKey, "foo", "qux");
+    setVariable(rootScopeKey, workflowKey, "foo", "biz");
+
+    // when
+    listenForStateChanges();
+    behavior.mergeDocument(childScopeKey, workflowKey, MsgPackUtil.asMsgPack(document));
+
+    // then
+    assertThat(getScopeVariables(parentScopeKey)).containsOnly(entry("foo", "bar"));
+    assertThat(getScopeVariables(rootScopeKey)).containsOnly(entry("foo", "biz"));
+
+    final List<RecordedEvent<VariableRecordValue>> events = getFollowUpEvents();
+    assertThat(events)
+        .satisfiesExactlyInAnyOrder(
+            event -> {
+              assertThat(event.intent).isEqualTo(VariableIntent.UPDATED);
+              assertThat(event.key).isEqualTo(parentFooKey);
+              VariableRecordValueAssert.assertThat(event.value)
+                  .hasName("foo")
+                  .hasValue("\"bar\"")
+                  .hasScopeKey(parentScopeKey)
+                  .hasWorkflowKey(workflowKey)
+                  .hasWorkflowInstanceKey(rootScopeKey);
+            });
+  }
+
+  @Test
+  void shouldMergeDocumentPropagatingToRoot() {
+    // given
+    final int workflowKey = 1;
+    final int rootScopeKey = 1;
+    final int parentScopeKey = 2;
+    final int childScopeKey = 3;
+    final Map<String, Object> document = Map.of("foo", "bar", "buz", "baz");
+    state.createScope(rootScopeKey, VariableState.NO_PARENT);
+    state.createScope(parentScopeKey, rootScopeKey);
+    state.createScope(childScopeKey, parentScopeKey);
+
+    // when
+    listenForStateChanges();
+    behavior.mergeDocument(childScopeKey, workflowKey, MsgPackUtil.asMsgPack(document));
+
+    // then
+    assertThat(getScopeVariables(rootScopeKey))
+        .containsOnly(entry("foo", "bar"), entry("buz", "baz"));
+    assertThat(getScopeVariables(parentScopeKey)).isEmpty();
+    assertThat(getScopeVariables(childScopeKey)).isEmpty();
+
+    final List<RecordedEvent<VariableRecordValue>> events = getFollowUpEvents();
+    assertThat(events)
+        .satisfiesExactlyInAnyOrder(
+            event -> {
+              assertThat(event.intent).isEqualTo(VariableIntent.CREATED);
+              VariableRecordValueAssert.assertThat(event.value)
+                  .hasName("foo")
+                  .hasValue("\"bar\"")
+                  .hasScopeKey(rootScopeKey)
+                  .hasWorkflowKey(workflowKey)
+                  .hasWorkflowInstanceKey(rootScopeKey);
+            },
+            event -> {
+              assertThat(event.intent).isEqualTo(VariableIntent.CREATED);
+              VariableRecordValueAssert.assertThat(event.value)
+                  .hasName("buz")
+                  .hasValue("\"baz\"")
+                  .hasScopeKey(rootScopeKey)
+                  .hasWorkflowKey(workflowKey)
+                  .hasWorkflowInstanceKey(rootScopeKey);
+            });
+  }
+
+  @Test
+  void shouldMergeDocumentWithoutPropagatingExistingVariables() {
+    // given
+    final int workflowKey = 1;
+    final int parentScopeKey = 1;
+    final int childScopeKey = 2;
+    final Map<String, Object> document = Map.of("foo", "bar");
+    state.createScope(parentScopeKey, VariableState.NO_PARENT);
+    state.createScope(childScopeKey, parentScopeKey);
+    final long childFooKey = setVariable(childScopeKey, workflowKey, "foo", "qux");
+    setVariable(parentScopeKey, workflowKey, "foo", "biz");
+
+    // when
+    listenForStateChanges();
+    behavior.mergeDocument(childScopeKey, workflowKey, MsgPackUtil.asMsgPack(document));
+
+    // then
+    assertThat(getScopeVariables(childScopeKey)).containsOnly(entry("foo", "bar"));
+    assertThat(getScopeVariables(parentScopeKey)).containsOnly(entry("foo", "biz"));
+
+    final List<RecordedEvent<VariableRecordValue>> events = getFollowUpEvents();
+    assertThat(events)
+        .satisfiesExactlyInAnyOrder(
+            event -> {
+              assertThat(event.intent).isEqualTo(VariableIntent.UPDATED);
+              assertThat(event.key).isEqualTo(childFooKey);
+              VariableRecordValueAssert.assertThat(event.value)
+                  .hasName("foo")
+                  .hasValue("\"bar\"")
+                  .hasScopeKey(childScopeKey)
+                  .hasWorkflowKey(workflowKey)
+                  .hasWorkflowInstanceKey(parentScopeKey);
+            });
+  }
+
+  @Test
+  void shouldNotMergeDocumentIfEmpty() {
+    // given
+    final int workflowKey = 1;
+    final int parentScopeKey = 1;
+    final int childScopeKey = 2;
+    final Map<String, Object> document = Map.of();
+    state.createScope(parentScopeKey, VariableState.NO_PARENT);
+    state.createScope(childScopeKey, parentScopeKey);
+    setVariable(parentScopeKey, workflowKey, "foo", "qux");
+    setVariable(childScopeKey, workflowKey, "foo", "bar");
+
+    // when
+    listenForStateChanges();
+    behavior.mergeDocument(childScopeKey, workflowKey, MsgPackUtil.asMsgPack(document));
+
+    // then
+    assertThat(getScopeVariables(parentScopeKey)).containsOnly(entry("foo", "qux"));
+    assertThat(getScopeVariables(childScopeKey)).containsOnly(entry("foo", "bar"));
+
+    final List<RecordedEvent<VariableRecordValue>> events = getFollowUpEvents();
+    assertThat(events).isEmpty();
+  }
+
+  /**
+   * This sets up the test to start listening for follow up events. It's usually a good idea to do
+   * this after the initial setup so you can easily ignore those events.
+   */
+  private void listenForStateChanges() {
+    final EventAppliers eventApplier = new EventAppliers(zeebeState);
+    final EventApplyingStateWriter stateWriter =
+        new EventApplyingStateWriter(eventWriter, eventApplier);
+    final UpdateVariableStreamWriter listener = new UpdateVariableStreamWriter(stateWriter);
+    state.setListener(listener);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<RecordedEvent<VariableRecordValue>> getFollowUpEvents() {
+    return eventWriter.getEvents().stream()
+        .filter(e -> e.value instanceof VariableRecordValue)
+        .map(e -> (RecordedEvent<VariableRecordValue>) e)
+        .collect(Collectors.toList());
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private long setVariable(
+      final long scopeKey, final long workflowKey, final String name, final String value) {
+    final DirectBuffer nameBuffer = BufferUtil.wrapString(name);
+    state.setVariableLocal(scopeKey, workflowKey, nameBuffer, packString(value));
+    return state.getVariableInstanceLocal(scopeKey, nameBuffer).getKey();
+  }
+
+  private DirectBuffer packString(final String value) {
+    return MsgPackUtil.encodeMsgPack(b -> b.packString(value));
+  }
+
+  private Map<String, Object> getScopeVariables(final long scopeKey) {
+    final DirectBuffer rawDocument = state.getVariablesLocalAsDocument(scopeKey);
+    try (final DirectBufferInputStream input = new DirectBufferInputStream(rawDocument)) {
+      return new ObjectMapper(new MessagePackFactory()).readValue(input, new TypeReference<>() {});
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/RecordingTypedEventWriter.java
+++ b/engine/src/test/java/io/zeebe/engine/util/RecordingTypedEventWriter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.util;
+
+import io.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+import io.zeebe.protocol.record.RecordValue;
+import io.zeebe.protocol.record.intent.Intent;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.UnaryOperator;
+
+/**
+ * An event writer which simply records follow up events in a thread-safe way. Can be passed to a
+ * {@link io.zeebe.engine.processing.streamprocessor.writers.StateWriter} for easy unit testing of
+ * behaviors and processors.
+ */
+public final class RecordingTypedEventWriter implements TypedEventWriter {
+
+  private final List<RecordedEvent<?>> events = new CopyOnWriteArrayList<>();
+
+  public List<RecordedEvent<?>> getEvents() {
+    return events;
+  }
+
+  @Override
+  public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
+    events.add(new RecordedEvent<>(key, intent, value));
+  }
+
+  @Override
+  public void appendFollowUpEvent(
+      final long key,
+      final Intent intent,
+      final RecordValue value,
+      final UnaryOperator<RecordMetadata> modifier) {
+    appendFollowUpEvent(key, intent, value);
+  }
+
+  public static final class RecordedEvent<T extends RecordValue> {
+
+    public final long key;
+    public final Intent intent;
+    public final T value;
+
+    public RecordedEvent(final long key, final Intent intent, final T value) {
+      this.key = key;
+      this.intent = intent;
+      this.value = (T) Records.cloneValue(value);
+    }
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/util/Records.java
+++ b/engine/src/test/java/io/zeebe/engine/util/Records.java
@@ -16,11 +16,15 @@ import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.util.ReflectUtil;
 import io.zeebe.util.buffer.BufferUtil;
+import java.nio.ByteBuffer;
 import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public final class Records {
 
@@ -172,5 +176,17 @@ public final class Records {
         .setRepetitions(0)
         .setWorkflowKey(1);
     return event;
+  }
+
+  public static <T extends UnpackedObject & RecordValue> T cloneValue(final RecordValue value) {
+    final UnpackedObject unpackedValue = (UnpackedObject) value;
+    final MutableDirectBuffer buffer =
+        new UnsafeBuffer(ByteBuffer.allocate(unpackedValue.getLength()));
+    final T cloned = (T) ReflectUtil.newInstance(value.getClass());
+
+    unpackedValue.write(buffer, 0);
+    cloned.wrap(buffer, 0, unpackedValue.getLength());
+
+    return cloned;
   }
 }


### PR DESCRIPTION
## Description

In preparation for #6175, this PR extracts the variable document merging logic out of the `DbVariableState` and into a separate behaviour. This is because with #6175, only single `Variable.CREATED` and `Variable.UPDATED` events will be applied to the state, not documents.

This is an intermediate state - the tests, for example, currently assert both the events written and the expected state of the `VariableState`. Later they will only assert the events.

## Related issues

related to #6175 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
