### PR TITLE
Make exporter accept multiple elasticsearch hosts

### DIFF
--- a/exporters/elasticsearch-exporter/README.md
+++ b/exporters/elasticsearch-exporter/README.md
@@ -25,7 +25,7 @@ in this module's resources folder.
 
 You can configure the Elasticsearch Exporter with the following arguments:
 
-* `url` (`string`): a valid URL as a string (e.g. `http://localhost:9200`)
+* `url` (`string`): a valid URLs as comma-separated string (e.g. `http://localhost:9200,http://localhost:9201`)
 
 All other options fall under a two categories, both expressed as nested maps: `bulk` and `index`.
 
@@ -125,6 +125,9 @@ Here is a complete, default configuration example:
       className: io.zeebe.exporter.ElasticsearchExporter
 
       args:
+        # A comma separated list of URLs pointing to the Elasticsearch instances you wish to export to.
+        # For example, if you want to connect to multiple nodes for redundancy:
+        # url: http://localhost:9200,http://localhost:9201
         url: http://localhost:9200
 
         bulk:

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchClient.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -250,9 +251,10 @@ public class ElasticsearchClient {
   }
 
   private RestClient createClient() {
-    final HttpHost httpHost = urlToHttpHost(configuration.url);
+    final HttpHost[] httpHosts = urlsToHttpHosts(configuration.url);
     final RestClientBuilder builder =
-        RestClient.builder(httpHost).setHttpClientConfigCallback(this::setHttpClientConfigCallback);
+        RestClient.builder(httpHosts)
+            .setHttpClientConfigCallback(this::setHttpClientConfigCallback);
 
     return builder.build();
   }
@@ -277,6 +279,13 @@ public class ElasticsearchClient {
             configuration.getAuthentication().getPassword()));
 
     builder.setDefaultCredentialsProvider(credentialsProvider);
+  }
+
+  private static HttpHost[] urlsToHttpHosts(final String urls) {
+    return Arrays.stream(urls.split(","))
+        .map(String::trim)
+        .map(ElasticsearchClient::urlToHttpHost)
+        .toArray(HttpHost[]::new);
   }
 
   private static HttpHost urlToHttpHost(final String url) {

--- a/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -13,8 +13,10 @@ import io.zeebe.protocol.record.ValueType;
 
 public class ElasticsearchExporterConfiguration {
 
-  // elasticsearch http url
-  public String url = "http://localhost:9200";
+  private static final String DEFAULT_URL = "http://localhost:9200";
+
+  /** Comma-separated Elasticsearch http urls */
+  public String url = DEFAULT_URL;
 
   public final IndexConfiguration index = new IndexConfiguration();
   public final BulkConfiguration bulk = new BulkConfiguration();


### PR DESCRIPTION
## Description

Allows elasticsearch exporter to use comma-separated list of hosts.

There was a PR to close this issue (#5636), but it was not updated since October of last year.

Secondly, this PR uses string of comma-separated hosts, but not array of strings. It allows to set multiple ES hosts via environment variable (`ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URLS: 'http://elasticsearch-1:9200,http://elasticsearch-2:9200'`).

## Related issues

closes #5635

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
