### PR TITLE
Apply event-sourcing to the message subscription create processor

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/message/MessageCorrelator.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/MessageCorrelator.java
@@ -9,51 +9,56 @@ package io.zeebe.engine.processing.message;
 
 import io.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
-import io.zeebe.engine.state.message.MessageSubscription;
+import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.zeebe.engine.state.immutable.MessageState;
 import io.zeebe.engine.state.message.StoredMessage;
-import io.zeebe.engine.state.mutable.MutableMessageState;
-import io.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.zeebe.util.sched.clock.ActorClock;
 import java.util.function.Consumer;
-import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.collections.MutableBoolean;
 
 public final class MessageCorrelator {
 
-  private final DirectBuffer messageVariables = new UnsafeBuffer();
-  private final MutableMessageState messageState;
-  private final MutableMessageSubscriptionState subscriptionState;
+  private final MessageState messageState;
   private final SubscriptionCommandSender commandSender;
+  private final StateWriter stateWriter;
+
   private Consumer<SideEffectProducer> sideEffect;
   private MessageSubscriptionRecord subscriptionRecord;
-  private MessageSubscription subscription;
-  private long messageKey;
 
   public MessageCorrelator(
-      final MutableMessageState messageState,
-      final MutableMessageSubscriptionState subscriptionState,
-      final SubscriptionCommandSender commandSender) {
+      final MessageState messageState,
+      final SubscriptionCommandSender commandSender,
+      final StateWriter stateWriter) {
     this.messageState = messageState;
-    this.subscriptionState = subscriptionState;
     this.commandSender = commandSender;
+    this.stateWriter = stateWriter;
   }
 
-  public void correlateNextMessage(
-      final MessageSubscription subscription,
+  public boolean correlateNextMessage(
       final MessageSubscriptionRecord subscriptionRecord,
       final Consumer<SideEffectProducer> sideEffect) {
-    this.subscription = subscription;
     this.subscriptionRecord = subscriptionRecord;
     this.sideEffect = sideEffect;
 
+    final var isMessageCorrelated = new MutableBoolean(false);
+
     messageState.visitMessages(
-        subscription.getMessageName(), subscription.getCorrelationKey(), this::correlateMessage);
+        subscriptionRecord.getMessageNameBuffer(),
+        subscriptionRecord.getCorrelationKeyBuffer(),
+        storedMessage -> {
+          // correlate the first message which is not correlated to the workflow instance yet
+          final var isCorrelated = correlateMessage(storedMessage);
+          isMessageCorrelated.set(isCorrelated);
+          return !isCorrelated;
+        });
+
+    return isMessageCorrelated.get();
   }
 
   private boolean correlateMessage(final StoredMessage storedMessage) {
-    // correlate the first message which is not correlated to the workflow instance yet
-    messageKey = storedMessage.getMessageKey();
+    final long messageKey = storedMessage.getMessageKey();
     final var message = storedMessage.getMessage();
 
     final boolean correlateMessage =
@@ -62,17 +67,15 @@ public final class MessageCorrelator {
                 messageKey, subscriptionRecord.getBpmnProcessIdBuffer());
 
     if (correlateMessage) {
-      subscriptionState.updateToCorrelatingState(
-          subscription, message.getVariablesBuffer(), ActorClock.currentTimeMillis(), messageKey);
+      subscriptionRecord.setMessageKey(messageKey).setVariables(message.getVariablesBuffer());
 
-      // send the correlate instead of acknowledge command
-      messageVariables.wrap(message.getVariablesBuffer());
+      stateWriter.appendFollowUpEvent(
+          -1, MessageSubscriptionIntent.CORRELATING, subscriptionRecord);
+
       sideEffect.accept(this::sendCorrelateCommand);
-
-      messageState.putMessageCorrelation(messageKey, subscriptionRecord.getBpmnProcessIdBuffer());
     }
 
-    return !correlateMessage;
+    return correlateMessage;
   }
 
   private boolean sendCorrelateCommand() {
@@ -81,8 +84,8 @@ public final class MessageCorrelator {
         subscriptionRecord.getElementInstanceKey(),
         subscriptionRecord.getBpmnProcessIdBuffer(),
         subscriptionRecord.getMessageNameBuffer(),
-        messageKey,
-        messageVariables,
-        subscription.getCorrelationKey());
+        subscriptionRecord.getMessageKey(),
+        subscriptionRecord.getVariablesBuffer(),
+        subscriptionRecord.getCorrelationKeyBuffer());
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -54,14 +54,14 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE, MessageIntent.EXPIRE, new MessageExpireProcessor(writers.state()))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
-            MessageSubscriptionIntent.OPEN,
-            new OpenMessageSubscriptionProcessor(
-                messageState, subscriptionState, subscriptionCommandSender))
+            MessageSubscriptionIntent.CREATE,
+            new MessageSubscriptionCreateProcessor(
+                messageState, subscriptionState, subscriptionCommandSender, writers))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CORRELATE,
             new CorrelateMessageSubscriptionProcessor(
-                messageState, subscriptionState, subscriptionCommandSender))
+                messageState, subscriptionState, subscriptionCommandSender, writers))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CLOSE,

--- a/engine/src/main/java/io/zeebe/engine/processing/message/command/SubscriptionCommandMessageHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/command/SubscriptionCommandMessageHandler.java
@@ -129,7 +129,7 @@ public final class SubscriptionCommandMessageHandler
     return writeCommand(
         openMessageSubscriptionCommand.getSubscriptionPartitionId(),
         ValueType.MESSAGE_SUBSCRIPTION,
-        MessageSubscriptionIntent.OPEN,
+        MessageSubscriptionIntent.CREATE,
         messageSubscriptionRecord);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -64,7 +64,11 @@ public final class MigratedStreamProcessors {
 
     MIGRATED_VALUE_TYPES.put(
         ValueType.MESSAGE_SUBSCRIPTION,
-        record -> record.getIntent() == MessageSubscriptionIntent.CORRELATING);
+        MIGRATED_INTENT_FILTER_FACTORY.apply(
+            List.of(
+                MessageSubscriptionIntent.CREATE,
+                MessageSubscriptionIntent.CREATED,
+                MessageSubscriptionIntent.CORRELATING)));
     MIGRATED_VALUE_TYPES.put(
         ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
         record -> record.getIntent() == MessageStartEventSubscriptionIntent.CORRELATED);

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -67,6 +67,9 @@ public final class EventAppliers implements EventApplier {
     register(MessageIntent.EXPIRED, new MessageExpiredApplier(state.getMessageState()));
 
     register(
+        MessageSubscriptionIntent.CREATED,
+        new MessageSubscriptionCreatedApplier(state.getMessageSubscriptionState()));
+    register(
         MessageSubscriptionIntent.CORRELATING,
         new MessageSubscriptionCorrelatingApplier(
             state.getMessageSubscriptionState(), state.getMessageState()));

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionCreatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionCreatedApplier.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.message.MessageSubscription;
+import io.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
+import io.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+
+public final class MessageSubscriptionCreatedApplier
+    implements TypedEventApplier<MessageSubscriptionIntent, MessageSubscriptionRecord> {
+
+  private final MutableMessageSubscriptionState subscriptionState;
+
+  public MessageSubscriptionCreatedApplier(
+      final MutableMessageSubscriptionState subscriptionState) {
+    this.subscriptionState = subscriptionState;
+  }
+
+  @Override
+  public void applyState(final long key, final MessageSubscriptionRecord record) {
+
+    final var subscription =
+        new MessageSubscription(
+            record.getWorkflowInstanceKey(),
+            record.getElementInstanceKey(),
+            record.getBpmnProcessIdBuffer(),
+            record.getMessageNameBuffer(),
+            record.getCorrelationKeyBuffer(),
+            record.shouldCloseOnCorrelate());
+
+    // TODO (saig0): reuse the subscription record in the state (#6180)
+    subscriptionState.put(subscription);
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceActivityTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceActivityTest.java
@@ -940,7 +940,7 @@ public final class MultiInstanceActivityTest {
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size() - 1);
 
     // make sure message subcription is opened, before publishing
-    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
         .withWorkflowInstanceKey(workflowInstanceKey)
         .await();
 
@@ -959,8 +959,8 @@ public final class MultiInstanceActivityTest {
                 .limit(5))
         .extracting(Record::getIntent)
         .containsExactly(
-            MessageSubscriptionIntent.OPEN,
-            MessageSubscriptionIntent.OPENED,
+            MessageSubscriptionIntent.CREATE,
+            MessageSubscriptionIntent.CREATED,
             MessageSubscriptionIntent.CORRELATING,
             MessageSubscriptionIntent.CORRELATE,
             MessageSubscriptionIntent.CORRELATED);
@@ -1036,7 +1036,7 @@ public final class MultiInstanceActivityTest {
     completeJobs(workflowInstanceKey, INPUT_COLLECTION.size() - 1);
 
     // make sure message subscription is opened, before publishing
-    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
         .withWorkflowInstanceKey(workflowInstanceKey)
         .await();
 
@@ -1078,8 +1078,8 @@ public final class MultiInstanceActivityTest {
                 .limit(7))
         .extracting(Record::getIntent)
         .containsExactly(
-            MessageSubscriptionIntent.OPEN,
-            MessageSubscriptionIntent.OPENED,
+            MessageSubscriptionIntent.CREATE,
+            MessageSubscriptionIntent.CREATED,
             MessageSubscriptionIntent.CORRELATING,
             MessageSubscriptionIntent.CORRELATE,
             MessageSubscriptionIntent.CORRELATED,

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceReceiveTaskTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceReceiveTaskTest.java
@@ -78,7 +78,7 @@ public final class MultiInstanceReceiveTaskTest {
             .collect(Collectors.toList());
 
     assertThat(
-            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
                 .withWorkflowInstanceKey(workflowInstanceKey)
                 .limit(3))
         .hasSize(3)
@@ -142,7 +142,7 @@ public final class MultiInstanceReceiveTaskTest {
             .withVariable(INPUT_COLLECTION, Arrays.asList(10, 20, 30))
             .create();
 
-    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
         .withWorkflowInstanceKey(workflowInstanceKey)
         .limit(3)
         .exists();

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceSubProcessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceSubProcessTest.java
@@ -240,7 +240,7 @@ public final class MultiInstanceSubProcessTest {
 
     // then
     assertThat(
-            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
                 .withWorkflowInstanceKey(workflowInstanceKey)
                 .limit(3))
         .hasSize(3)

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
@@ -86,7 +86,7 @@ public class InterruptingEventSubprocessTest {
             s -> s.message(b -> b.name(messageName).zeebeCorrelationKeyExpression("key"))),
         eventTrigger(
             key -> {
-              RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+              RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
                   .withWorkflowInstanceKey(key)
                   .withMessageName(messageName)
                   .await();
@@ -336,7 +336,7 @@ public class InterruptingEventSubprocessTest {
 
     final long wfInstanceKey = createInstanceAndWaitForTask(workflow(eventSubprocess));
 
-    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
         .withWorkflowInstanceKey(wfInstanceKey)
         .withMessageName("other-message")
         .await();

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/MultipleEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/MultipleEventSubprocessTest.java
@@ -109,7 +109,7 @@ public final class MultipleEventSubprocessTest {
         ENGINE.workflowInstance().ofBpmnProcessId(PROCESS_ID).withVariable("key", "123").create();
 
     assertThat(
-            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
                 .withWorkflowInstanceKey(wfInstanceKey)
                 .exists())
         .describedAs("Expected event subprocess message start subscription to be opened.")
@@ -252,7 +252,7 @@ public final class MultipleEventSubprocessTest {
   }
 
   private void triggerMessageStart(final long wfInstanceKey, final String msgName) {
-    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
         .withWorkflowInstanceKey(wfInstanceKey)
         .await();
 

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/NonInterruptingEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/NonInterruptingEventSubprocessTest.java
@@ -83,7 +83,7 @@ public class NonInterruptingEventSubprocessTest {
             s -> s.message(b -> b.name(messageName).zeebeCorrelationKeyExpression("key"))),
         eventTrigger(
             key -> {
-              RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+              RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
                   .withWorkflowInstanceKey(key)
                   .withMessageName(messageName)
                   .await();

--- a/engine/src/test/java/io/zeebe/engine/processing/message/MessageCatchElementTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/message/MessageCatchElementTest.java
@@ -175,7 +175,7 @@ public final class MessageCatchElementTest {
         getFirstElementRecord(enteredState);
 
     final Record<MessageSubscriptionRecordValue> messageSubscription =
-        getFirstMessageSubscriptionRecord(MessageSubscriptionIntent.OPENED);
+        getFirstMessageSubscriptionRecord(MessageSubscriptionIntent.CREATED);
 
     assertThat(messageSubscription.getValueType()).isEqualTo(ValueType.MESSAGE_SUBSCRIPTION);
     assertThat(messageSubscription.getRecordType()).isEqualTo(RecordType.EVENT);
@@ -242,7 +242,7 @@ public final class MessageCatchElementTest {
     final Record<WorkflowInstanceRecordValue> catchEventEntered =
         getFirstElementRecord(enteredState);
 
-    getFirstMessageSubscriptionRecord(MessageSubscriptionIntent.OPENED);
+    getFirstMessageSubscriptionRecord(MessageSubscriptionIntent.CREATED);
 
     // when
     final var messagePublished =
@@ -272,7 +272,7 @@ public final class MessageCatchElementTest {
         .hasWorkflowInstanceKey(workflowInstanceKey)
         .hasElementInstanceKey(catchEventEntered.getKey())
         .hasMessageName(MESSAGE_NAME)
-        .hasCorrelationKey("");
+        .hasCorrelationKey(correlationKey);
   }
 
   @Test
@@ -281,7 +281,7 @@ public final class MessageCatchElementTest {
     final Record<WorkflowInstanceRecordValue> catchEventEntered =
         getFirstElementRecord(enteredState);
 
-    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
         .withWorkflowInstanceKey(workflowInstanceKey)
         .await();
 
@@ -352,7 +352,7 @@ public final class MessageCatchElementTest {
   @Test
   public void testMessageSubscriptionLifecycle() {
     // given
-    getFirstMessageSubscriptionRecord(MessageSubscriptionIntent.OPENED);
+    getFirstMessageSubscriptionRecord(MessageSubscriptionIntent.CREATED);
 
     // when
     ENGINE_RULE
@@ -370,8 +370,8 @@ public final class MessageCatchElementTest {
                 .limit(5))
         .extracting(Record::getRecordType, Record::getIntent)
         .containsExactly(
-            tuple(RecordType.COMMAND, MessageSubscriptionIntent.OPEN),
-            tuple(RecordType.EVENT, MessageSubscriptionIntent.OPENED),
+            tuple(RecordType.COMMAND, MessageSubscriptionIntent.CREATE),
+            tuple(RecordType.EVENT, MessageSubscriptionIntent.CREATED),
             tuple(RecordType.EVENT, MessageSubscriptionIntent.CORRELATING),
             tuple(RecordType.COMMAND, MessageSubscriptionIntent.CORRELATE),
             tuple(RecordType.EVENT, MessageSubscriptionIntent.CORRELATED));

--- a/engine/src/test/java/io/zeebe/engine/processing/message/MessageCorrelationMultiplePartitionsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/message/MessageCorrelationMultiplePartitionsTest.java
@@ -84,7 +84,7 @@ public final class MessageCorrelationMultiplePartitionsTest {
 
     // then
     assertThat(
-            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
                 .limit(30))
         .extracting(r -> tuple(r.getPartitionId(), r.getValue().getCorrelationKey()))
         .containsOnly(
@@ -153,7 +153,7 @@ public final class MessageCorrelationMultiplePartitionsTest {
             });
 
     assertThat(
-            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
                 .limit(15)
                 .count())
         .isEqualTo(15);
@@ -179,7 +179,7 @@ public final class MessageCorrelationMultiplePartitionsTest {
 
     // then
     assertThat(
-            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
                 .limit(30))
         .extracting(r -> tuple(r.getPartitionId(), r.getValue().getCorrelationKey()))
         .hasSize(30)

--- a/engine/src/test/java/io/zeebe/engine/processing/message/MessageCorrelationTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/message/MessageCorrelationTest.java
@@ -104,7 +104,8 @@ public final class MessageCorrelationTest {
             .create();
 
     assertThat(
-            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED).exists())
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+                .exists())
         .isTrue();
 
     // when
@@ -263,7 +264,8 @@ public final class MessageCorrelationTest {
             .create();
 
     assertThat(
-            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED).exists())
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+                .exists())
         .isTrue();
 
     // when

--- a/engine/src/test/java/io/zeebe/engine/processing/message/MessageStartEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/message/MessageStartEventTest.java
@@ -323,7 +323,7 @@ public final class MessageStartEventTest {
         .withVariables(Map.of("key", CORRELATION_KEY_1, "x", 1))
         .publish();
 
-    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED).await();
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED).await();
 
     final var message2 =
         engine

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/BlacklistInstanceTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/BlacklistInstanceTest.java
@@ -134,8 +134,8 @@ public final class BlacklistInstanceTest {
       ////////////////////////////////////////
       /////////////// MSG SUB ////////////////
       ////////////////////////////////////////
-      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.OPEN, true},
-      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.OPENED, true},
+      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CREATE, true},
+      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CREATED, true},
       {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CORRELATE, true},
       {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CORRELATED, true},
       {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CLOSE, true},

--- a/engine/src/test/java/io/zeebe/engine/util/WorkflowExecutor.java
+++ b/engine/src/test/java/io/zeebe/engine/util/WorkflowExecutor.java
@@ -89,7 +89,7 @@ public class WorkflowExecutor {
   }
 
   private void publishMessage(final StepPublishMessage publishMessage) {
-    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
         .withMessageName(publishMessage.getMessageName())
         .withCorrelationKey(IntermediateMessageCatchEventBlockBuilder.CORRELATION_KEY_VALUE)
         .await();

--- a/protocol/ignored-changes.xml
+++ b/protocol/ignored-changes.xml
@@ -29,11 +29,11 @@
   <difference>
     <className>io/zeebe/protocol/record/intent/MessageIntent</className>
     <differenceType>6001</differenceType>
-    <field>DELETE</field>
+    <field>*</field>
   </difference>
   <difference>
-    <className>io/zeebe/protocol/record/intent/MessageIntent</className>
+    <className>io/zeebe/protocol/record/intent/MessageSubscriptionIntent</className>
     <differenceType>6001</differenceType>
-    <field>DELETED</field>
+    <field>*</field>
   </difference>
 </differences>

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
@@ -16,8 +16,8 @@
 package io.zeebe.protocol.record.intent;
 
 public enum MessageSubscriptionIntent implements WorkflowInstanceRelatedIntent {
-  OPEN((short) 0),
-  OPENED((short) 1),
+  CREATE((short) 0),
+  CREATED((short) 1),
 
   CORRELATING((short) 8),
   CORRELATE((short) 2),
@@ -49,9 +49,9 @@ public enum MessageSubscriptionIntent implements WorkflowInstanceRelatedIntent {
   public static Intent from(final short value) {
     switch (value) {
       case 0:
-        return OPEN;
+        return CREATE;
       case 1:
-        return OPENED;
+        return CREATED;
       case 2:
         return CORRELATE;
       case 3:

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceRecoveryClusteredTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/DiskSpaceRecoveryClusteredTest.java
@@ -92,7 +92,7 @@ public class DiskSpaceRecoveryClusteredTest {
         .timeout(Duration.ofSeconds(60))
         .until(
             () ->
-                RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.OPENED)
+                RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
                         .limit(3)
                         .count()
                     == 3);


### PR DESCRIPTION
## Description

* align the message subscription intents `OPEN`/`OPENED` and rename them to `CREATE`/`CREATED`
* rename the processor to align with the intent
* replace the state changes in the processor by the state writer and mark it as migrated
* remove invalid assertions of buffers from the stream processor test

**Hints for the reviewer**
* the open todo "reuse the subscription record in the state" will be done after all message subscription processors are migrated
* same for #2805 and probably #3346

## Related issues

Part of #6180

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
