### PR TITLE
Apply event-sourcing to the message subscription correlate processor

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -60,7 +60,7 @@ public final class MessageEventProcessors {
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CORRELATE,
-            new CorrelateMessageSubscriptionProcessor(
+            new MessageSubscriptionCorrelateProcessor(
                 messageState, subscriptionState, subscriptionCommandSender, writers))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -68,7 +68,9 @@ public final class MigratedStreamProcessors {
             List.of(
                 MessageSubscriptionIntent.CREATE,
                 MessageSubscriptionIntent.CREATED,
-                MessageSubscriptionIntent.CORRELATING)));
+                MessageSubscriptionIntent.CORRELATING,
+                MessageSubscriptionIntent.CORRELATE,
+                MessageSubscriptionIntent.CORRELATED)));
     MIGRATED_VALUE_TYPES.put(
         ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
         record -> record.getIntent() == MessageStartEventSubscriptionIntent.CORRELATED);

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -73,6 +73,9 @@ public final class EventAppliers implements EventApplier {
         MessageSubscriptionIntent.CORRELATING,
         new MessageSubscriptionCorrelatingApplier(
             state.getMessageSubscriptionState(), state.getMessageState()));
+    register(
+        MessageSubscriptionIntent.CORRELATED,
+        new MessageSubscriptionCorrelatedApplier(state.getMessageSubscriptionState()));
 
     register(
         MessageStartEventSubscriptionIntent.CORRELATED,

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionCorrelatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionCorrelatedApplier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
+import io.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+
+public final class MessageSubscriptionCorrelatedApplier
+    implements TypedEventApplier<MessageSubscriptionIntent, MessageSubscriptionRecord> {
+
+  private final MutableMessageSubscriptionState messageSubscriptionState;
+
+  public MessageSubscriptionCorrelatedApplier(
+      final MutableMessageSubscriptionState messageSubscriptionState) {
+    this.messageSubscriptionState = messageSubscriptionState;
+  }
+
+  @Override
+  public void applyState(final long key, final MessageSubscriptionRecord value) {
+    // TODO (saig0): the record doesn't contain the sent time but it's required for cleaning (#6364)
+    // - workaround: load the subscription from the state instead of using the record directly
+    final var subscription =
+        messageSubscriptionState.get(value.getElementInstanceKey(), value.getMessageNameBuffer());
+
+    if (value.shouldCloseOnCorrelate()) {
+      messageSubscriptionState.remove(subscription);
+    } else {
+      messageSubscriptionState.resetSentTime(subscription);
+    }
+  }
+}


### PR DESCRIPTION
## Description

* replace the state changes in the processor by the state writer and mark it as migrated

## Related issues

Part of #6180

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
