### PR TITLE
Apply event-sourcing to the message subscription delete processor

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -64,8 +64,9 @@ public final class MessageEventProcessors {
                 messageState, subscriptionState, subscriptionCommandSender, writers))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
-            MessageSubscriptionIntent.CLOSE,
-            new CloseMessageSubscriptionProcessor(subscriptionState, subscriptionCommandSender))
+            MessageSubscriptionIntent.DELETE,
+            new MessageSubscriptionDeleteProcessor(
+                subscriptionState, subscriptionCommandSender, writers))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.REJECT,

--- a/engine/src/main/java/io/zeebe/engine/processing/message/command/SubscriptionCommandMessageHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/command/SubscriptionCommandMessageHandler.java
@@ -217,7 +217,7 @@ public final class SubscriptionCommandMessageHandler
     return writeCommand(
         closeMessageSubscriptionCommand.getSubscriptionPartitionId(),
         ValueType.MESSAGE_SUBSCRIPTION,
-        MessageSubscriptionIntent.CLOSE,
+        MessageSubscriptionIntent.DELETE,
         messageSubscriptionRecord);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -78,7 +78,9 @@ public final class MigratedStreamProcessors {
                 MessageSubscriptionIntent.CREATED,
                 MessageSubscriptionIntent.CORRELATING,
                 MessageSubscriptionIntent.CORRELATE,
-                MessageSubscriptionIntent.CORRELATED)));
+                MessageSubscriptionIntent.CORRELATED,
+                MessageSubscriptionIntent.DELETE,
+                MessageSubscriptionIntent.DELETED)));
     MIGRATED_VALUE_TYPES.put(
         ValueType.MESSAGE_START_EVENT_SUBSCRIPTION,
         record -> record.getIntent() == MessageStartEventSubscriptionIntent.CORRELATED);

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -66,16 +66,7 @@ public final class EventAppliers implements EventApplier {
     register(MessageIntent.PUBLISHED, new MessagePublishedApplier(state.getMessageState()));
     register(MessageIntent.EXPIRED, new MessageExpiredApplier(state.getMessageState()));
 
-    register(
-        MessageSubscriptionIntent.CREATED,
-        new MessageSubscriptionCreatedApplier(state.getMessageSubscriptionState()));
-    register(
-        MessageSubscriptionIntent.CORRELATING,
-        new MessageSubscriptionCorrelatingApplier(
-            state.getMessageSubscriptionState(), state.getMessageState()));
-    register(
-        MessageSubscriptionIntent.CORRELATED,
-        new MessageSubscriptionCorrelatedApplier(state.getMessageSubscriptionState()));
+    registerMessageSubscriptionAppliers(state);
 
     register(
         MessageStartEventSubscriptionIntent.CORRELATED,
@@ -120,6 +111,22 @@ public final class EventAppliers implements EventApplier {
     register(JobIntent.FAILED, new JobFailedApplier(state));
     register(JobIntent.RETRIES_UPDATED, new JobRetriesUpdatedApplier(state));
     register(JobIntent.TIMED_OUT, new JobTimedOutApplier(state));
+  }
+
+  private void registerMessageSubscriptionAppliers(final ZeebeState state) {
+    register(
+        MessageSubscriptionIntent.CREATED,
+        new MessageSubscriptionCreatedApplier(state.getMessageSubscriptionState()));
+    register(
+        MessageSubscriptionIntent.CORRELATING,
+        new MessageSubscriptionCorrelatingApplier(
+            state.getMessageSubscriptionState(), state.getMessageState()));
+    register(
+        MessageSubscriptionIntent.CORRELATED,
+        new MessageSubscriptionCorrelatedApplier(state.getMessageSubscriptionState()));
+    register(
+        MessageSubscriptionIntent.DELETED,
+        new MessageSubscriptionDeletedApplier(state.getMessageSubscriptionState()));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionDeletedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionDeletedApplier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
+import io.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+
+public final class MessageSubscriptionDeletedApplier
+    implements TypedEventApplier<MessageSubscriptionIntent, MessageSubscriptionRecord> {
+
+  private final MutableMessageSubscriptionState subscriptionState;
+
+  public MessageSubscriptionDeletedApplier(
+      final MutableMessageSubscriptionState subscriptionState) {
+    this.subscriptionState = subscriptionState;
+  }
+
+  @Override
+  public void applyState(final long key, final MessageSubscriptionRecord value) {
+
+    subscriptionState.remove(value.getElementInstanceKey(), value.getMessageNameBuffer());
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceActivityTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceActivityTest.java
@@ -1083,8 +1083,8 @@ public final class MultiInstanceActivityTest {
             MessageSubscriptionIntent.CORRELATING,
             MessageSubscriptionIntent.CORRELATE,
             MessageSubscriptionIntent.CORRELATED,
-            MessageSubscriptionIntent.CLOSE,
-            MessageSubscriptionIntent.CLOSED);
+            MessageSubscriptionIntent.DELETE,
+            MessageSubscriptionIntent.DELETED);
 
     assertThat(
             RecordingExporter.workflowInstanceRecords()

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceReceiveTaskTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceReceiveTaskTest.java
@@ -152,7 +152,7 @@ public final class MultiInstanceReceiveTaskTest {
 
     // then
     assertThat(
-            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CLOSED)
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.DELETED)
                 .withWorkflowInstanceKey(workflowInstanceKey)
                 .limit(3))
         .hasSize(3);

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
@@ -351,7 +351,7 @@ public class InterruptingEventSubprocessTest {
                 .withWorkflowInstanceKey(wfInstanceKey)
                 .withMessageName("other-message"))
         .extracting(Record::getIntent)
-        .contains(MessageSubscriptionIntent.CLOSED);
+        .contains(MessageSubscriptionIntent.DELETED);
 
     assertThat(
             RecordingExporter.records()

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/MultipleEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/MultipleEventSubprocessTest.java
@@ -118,7 +118,7 @@ public final class MultipleEventSubprocessTest {
 
     // then
     assertThat(
-            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CLOSED)
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.DELETED)
                 .withWorkflowInstanceKey(wfInstanceKey)
                 .withMessageName(helper.getMessageName())
                 .exists())

--- a/engine/src/test/java/io/zeebe/engine/processing/message/MessageCatchElementTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/message/MessageCatchElementTest.java
@@ -290,7 +290,7 @@ public final class MessageCatchElementTest {
 
     // then
     final Record<MessageSubscriptionRecordValue> messageSubscription =
-        getFirstMessageSubscriptionRecord(MessageSubscriptionIntent.CLOSED);
+        getFirstMessageSubscriptionRecord(MessageSubscriptionIntent.DELETED);
 
     assertThat(messageSubscription.getRecordType()).isEqualTo(RecordType.EVENT);
 

--- a/engine/src/test/java/io/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -175,7 +175,7 @@ public final class MessageStreamProcessorTest {
                 .exists());
 
     // when
-    rule.writeCommand(MessageSubscriptionIntent.CLOSE, subscription);
+    rule.writeCommand(MessageSubscriptionIntent.DELETE, subscription);
     rule.writeCommand(MessageSubscriptionIntent.CORRELATE, subscription);
 
     // then
@@ -199,13 +199,13 @@ public final class MessageStreamProcessorTest {
                 .exists());
 
     // when
-    rule.writeCommand(MessageSubscriptionIntent.CLOSE, subscription);
-    rule.writeCommand(MessageSubscriptionIntent.CLOSE, subscription);
+    rule.writeCommand(MessageSubscriptionIntent.DELETE, subscription);
+    rule.writeCommand(MessageSubscriptionIntent.DELETE, subscription);
 
     // then
     final Record<MessageSubscriptionRecord> rejection = awaitAndGetFirstSubscriptionRejection();
 
-    assertThat(rejection.getIntent()).isEqualTo(MessageSubscriptionIntent.CLOSE);
+    assertThat(rejection.getIntent()).isEqualTo(MessageSubscriptionIntent.DELETE);
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
 
     // cannot verify messageName buffer since it is a view around another buffer which is changed

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/BlacklistInstanceTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/BlacklistInstanceTest.java
@@ -138,8 +138,8 @@ public final class BlacklistInstanceTest {
       {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CREATED, true},
       {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CORRELATE, true},
       {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CORRELATED, true},
-      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CLOSE, true},
-      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.CLOSED, true},
+      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.DELETE, true},
+      {ValueType.MESSAGE_SUBSCRIPTION, MessageSubscriptionIntent.DELETED, true},
 
       ////////////////////////////////////////
       //////////////// TIMERS ////////////////

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
@@ -26,8 +26,8 @@ public enum MessageSubscriptionIntent implements WorkflowInstanceRelatedIntent {
   REJECT((short) 4),
   REJECTED((short) 5),
 
-  CLOSE((short) 6),
-  CLOSED((short) 7);
+  DELETE((short) 6),
+  DELETED((short) 7);
 
   private final short value;
   private final boolean shouldBlacklist;
@@ -61,9 +61,9 @@ public enum MessageSubscriptionIntent implements WorkflowInstanceRelatedIntent {
       case 5:
         return REJECTED;
       case 6:
-        return CLOSE;
+        return DELETE;
       case 7:
-        return CLOSED;
+        return DELETED;
       case 8:
         return CORRELATING;
       default:


### PR DESCRIPTION
## Description

* align the message subscription intents `CLOSE`/`CLOSED` and rename them to `DELETE`/`DELETED`
* rename the processor to align with the intent
* replace the state changes in the processor by the state writer and mark it as migrated

## Related issues

Part of #6180

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
