### PR TITLE
Improving the message subscription state

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -56,7 +56,7 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CREATE,
             new MessageSubscriptionCreateProcessor(
-                messageState, subscriptionState, subscriptionCommandSender, writers))
+                messageState, subscriptionState, subscriptionCommandSender, writers, keyGenerator))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CORRELATE,

--- a/engine/src/main/java/io/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
@@ -55,13 +55,15 @@ public final class MessageSubscriptionDeleteProcessor
       final Consumer<SideEffectProducer> sideEffect) {
     subscriptionRecord = record.getValue();
 
-    final boolean exists =
-        subscriptionState.existSubscriptionForElementInstance(
+    final var messageSubscription =
+        subscriptionState.get(
             subscriptionRecord.getElementInstanceKey(), subscriptionRecord.getMessageNameBuffer());
 
-    if (exists) {
+    if (messageSubscription != null) {
       stateWriter.appendFollowUpEvent(
-          record.getKey(), MessageSubscriptionIntent.DELETED, subscriptionRecord);
+          messageSubscription.getKey(),
+          MessageSubscriptionIntent.DELETED,
+          messageSubscription.getRecord());
 
     } else {
       rejectCommand(record);

--- a/engine/src/main/java/io/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
@@ -34,15 +34,17 @@ public final class PendingMessageSubscriptionChecker implements Runnable {
   }
 
   private boolean sendCommand(final MessageSubscription subscription) {
+    final var record = subscription.getRecord();
+
     final boolean success =
         commandSender.correlateWorkflowInstanceSubscription(
-            subscription.getWorkflowInstanceKey(),
-            subscription.getElementInstanceKey(),
-            subscription.getBpmnProcessId(),
-            subscription.getMessageName(),
-            subscription.getMessageKey(),
-            subscription.getMessageVariables(),
-            subscription.getCorrelationKey());
+            record.getWorkflowInstanceKey(),
+            record.getElementInstanceKey(),
+            record.getBpmnProcessIdBuffer(),
+            record.getMessageNameBuffer(),
+            record.getMessageKey(),
+            record.getVariablesBuffer(),
+            record.getCorrelationKeyBuffer());
 
     if (success) {
       // TODO (saig0): the state change of the sent time should be reflected by a record (#6364)

--- a/engine/src/main/java/io/zeebe/engine/processing/message/Subscriptions.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/Subscriptions.java
@@ -7,8 +7,9 @@
  */
 package io.zeebe.engine.processing.message;
 
-import io.zeebe.engine.state.message.MessageSubscription;
 import io.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
+import io.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.zeebe.util.buffer.BufferUtil;
 import io.zeebe.util.collection.Reusable;
 import io.zeebe.util.collection.ReusableObjectList;
 import java.util.function.Consumer;
@@ -35,9 +36,9 @@ public final class Subscriptions {
     return false;
   }
 
-  public void add(final MessageSubscription subscription) {
+  public void add(final MessageSubscriptionRecord subscription) {
     final var newSubscription = subscriptions.add();
-    newSubscription.setBpmnProcessId(subscription.getBpmnProcessId());
+    newSubscription.setBpmnProcessId(BufferUtil.cloneBuffer(subscription.getBpmnProcessIdBuffer()));
     newSubscription.workflowInstanceKey = subscription.getWorkflowInstanceKey();
     newSubscription.elementInstanceKey = subscription.getElementInstanceKey();
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/message/command/SubscriptionCommandMessageHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/command/SubscriptionCommandMessageHandler.java
@@ -124,7 +124,7 @@ public final class SubscriptionCommandMessageHandler
         .setMessageKey(-1)
         .setMessageName(openMessageSubscriptionCommand.getMessageName())
         .setCorrelationKey(openMessageSubscriptionCommand.getCorrelationKey())
-        .setCloseOnCorrelate(openMessageSubscriptionCommand.shouldCloseOnCorrelate());
+        .setInterrupting(openMessageSubscriptionCommand.shouldCloseOnCorrelate());
 
     return writeCommand(
         openMessageSubscriptionCommand.getSubscriptionPartitionId(),
@@ -259,7 +259,7 @@ public final class SubscriptionCommandMessageHandler
         .setMessageName(resetMessageCorrelationCommand.getMessageName())
         .setCorrelationKey(resetMessageCorrelationCommand.getCorrelationKey())
         .setMessageKey(resetMessageCorrelationCommand.getMessageKey())
-        .setCloseOnCorrelate(false);
+        .setInterrupting(false);
 
     return writeCommand(
         resetMessageCorrelationCommand.getSubscriptionPartitionId(),

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionCorrelatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionCorrelatedApplier.java
@@ -29,7 +29,7 @@ public final class MessageSubscriptionCorrelatedApplier
     final var subscription =
         messageSubscriptionState.get(value.getElementInstanceKey(), value.getMessageNameBuffer());
 
-    if (value.shouldCloseOnCorrelate()) {
+    if (value.isInterrupting()) {
       messageSubscriptionState.remove(subscription);
     } else {
       messageSubscriptionState.resetSentTime(subscription);

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionCorrelatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionCorrelatingApplier.java
@@ -8,7 +8,6 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
-import io.zeebe.engine.state.message.MessageSubscription;
 import io.zeebe.engine.state.mutable.MutableMessageState;
 import io.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -30,19 +29,9 @@ public final class MessageSubscriptionCorrelatingApplier
 
   @Override
   public void applyState(final long key, final MessageSubscriptionRecord value) {
-    final var subscription =
-        new MessageSubscription(
-            value.getWorkflowInstanceKey(),
-            value.getElementInstanceKey(),
-            value.getBpmnProcessIdBuffer(),
-            value.getMessageNameBuffer(),
-            value.getCorrelationKeyBuffer(),
-            value.shouldCloseOnCorrelate());
-
     // TODO (saig0): the send time for the retry should be deterministic (#6364)
     final var sentTime = ActorClock.currentTimeMillis();
-    messageSubscriptionState.updateToCorrelatingState(
-        subscription, value.getVariablesBuffer(), sentTime, value.getMessageKey());
+    messageSubscriptionState.updateToCorrelatingState(value, sentTime);
 
     // avoid correlating this message to one instance of this workflow again
     messageState.putMessageCorrelation(value.getMessageKey(), value.getBpmnProcessIdBuffer());

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionCreatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/MessageSubscriptionCreatedApplier.java
@@ -8,7 +8,6 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
-import io.zeebe.engine.state.message.MessageSubscription;
 import io.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
@@ -26,16 +25,6 @@ public final class MessageSubscriptionCreatedApplier
   @Override
   public void applyState(final long key, final MessageSubscriptionRecord record) {
 
-    final var subscription =
-        new MessageSubscription(
-            record.getWorkflowInstanceKey(),
-            record.getElementInstanceKey(),
-            record.getBpmnProcessIdBuffer(),
-            record.getMessageNameBuffer(),
-            record.getCorrelationKeyBuffer(),
-            record.shouldCloseOnCorrelate());
-
-    // TODO (saig0): reuse the subscription record in the state (#6180)
-    subscriptionState.put(subscription);
+    subscriptionState.put(key, record);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -16,6 +16,8 @@ import io.zeebe.db.impl.DbNil;
 import io.zeebe.db.impl.DbString;
 import io.zeebe.engine.state.ZbColumnFamilies;
 import io.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
+import io.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
 public final class DbMessageSubscriptionState implements MutableMessageSubscriptionState {
@@ -88,12 +90,15 @@ public final class DbMessageSubscriptionState implements MutableMessageSubscript
   }
 
   @Override
-  public void put(final MessageSubscription subscription) {
-    elementInstanceKey.wrapLong(subscription.getElementInstanceKey());
-    messageName.wrapBuffer(subscription.getMessageName());
-    subscriptionColumnFamily.put(elementKeyAndMessageName, subscription);
+  public void put(final long key, final MessageSubscriptionRecord record) {
+    elementInstanceKey.wrapLong(record.getElementInstanceKey());
+    messageName.wrapBuffer(record.getMessageNameBuffer());
 
-    correlationKey.wrapBuffer(subscription.getCorrelationKey());
+    messageSubscription.setKey(key).setRecord(record).setCommandSentTime(0);
+
+    subscriptionColumnFamily.put(elementKeyAndMessageName, messageSubscription);
+
+    correlationKey.wrapBuffer(record.getCorrelationKeyBuffer());
     messageNameAndCorrelationKeyColumnFamily.put(
         nameCorrelationAndElementInstanceKey, DbNil.INSTANCE);
   }
@@ -132,12 +137,25 @@ public final class DbMessageSubscriptionState implements MutableMessageSubscript
 
   @Override
   public void updateToCorrelatingState(
-      final MessageSubscription subscription,
-      final DirectBuffer messageVariables,
-      final long sentTime,
-      final long messageKey) {
-    subscription.setMessageVariables(messageVariables);
-    subscription.setMessageKey(messageKey);
+      final MessageSubscriptionRecord record, final long sentTime) {
+    final var messageKey = record.getMessageKey();
+    var messageVariables = record.getVariablesBuffer();
+    if (record == messageSubscription.getRecord()) {
+      // copy the buffer before loading the subscription to avoid that it is overridden
+      messageVariables = BufferUtil.cloneBuffer(record.getVariablesBuffer());
+    }
+
+    final var subscription = get(record.getElementInstanceKey(), record.getMessageNameBuffer());
+    if (subscription == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected subscription but not found. [element-instance-key: %d, message-name: %s]",
+              record.getElementInstanceKey(), record.getMessageName()));
+    }
+
+    // update the message key and the variables
+    subscription.getRecord().setMessageKey(messageKey).setVariables(messageVariables);
+
     updateSentTime(subscription, sentTime);
   }
 
@@ -154,8 +172,9 @@ public final class DbMessageSubscriptionState implements MutableMessageSubscript
 
   @Override
   public void updateSentTime(final MessageSubscription subscription, final long sentTime) {
-    elementInstanceKey.wrapLong(subscription.getElementInstanceKey());
-    messageName.wrapBuffer(subscription.getMessageName());
+    final var record = subscription.getRecord();
+    elementInstanceKey.wrapLong(record.getElementInstanceKey());
+    messageName.wrapBuffer(record.getMessageNameBuffer());
 
     removeSubscriptionFromSentTimeColumnFamily(subscription);
 
@@ -209,8 +228,9 @@ public final class DbMessageSubscriptionState implements MutableMessageSubscript
   public void remove(final MessageSubscription subscription) {
     subscriptionColumnFamily.delete(elementKeyAndMessageName);
 
-    messageName.wrapBuffer(subscription.getMessageName());
-    correlationKey.wrapBuffer(subscription.getCorrelationKey());
+    final var record = subscription.getRecord();
+    messageName.wrapBuffer(record.getMessageNameBuffer());
+    correlationKey.wrapBuffer(record.getCorrelationKeyBuffer());
     messageNameAndCorrelationKeyColumnFamily.delete(nameCorrelationAndElementInstanceKey);
 
     removeSubscriptionFromSentTimeColumnFamily(subscription);

--- a/engine/src/main/java/io/zeebe/engine/state/message/MessageSubscription.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/MessageSubscription.java
@@ -9,94 +9,39 @@ package io.zeebe.engine.state.message;
 
 import io.zeebe.db.DbValue;
 import io.zeebe.msgpack.UnpackedObject;
-import io.zeebe.msgpack.property.BooleanProperty;
 import io.zeebe.msgpack.property.LongProperty;
-import io.zeebe.msgpack.property.StringProperty;
-import org.agrona.DirectBuffer;
-import org.agrona.MutableDirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
+import io.zeebe.msgpack.property.ObjectProperty;
+import io.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 
 public final class MessageSubscription extends UnpackedObject implements DbValue {
 
-  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId");
-  private final StringProperty messageNameProp = new StringProperty("messageName");
-  private final StringProperty correlationKeyProp = new StringProperty("correlationKey");
-  private final StringProperty messageVariablesProp = new StringProperty("messageVariables", "");
+  private final ObjectProperty<MessageSubscriptionRecord> recordProp =
+      new ObjectProperty<>("record", new MessageSubscriptionRecord());
 
-  private final LongProperty workflowInstanceKeyProp = new LongProperty("workflowInstanceKey", 0);
-  private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", 0);
-  private final LongProperty messageKeyProp = new LongProperty("messageKey", 0);
+  private final LongProperty keyProp = new LongProperty("key", -1L);
+
   private final LongProperty commandSentTimeProp = new LongProperty("commandSentTime", 0);
-  private final BooleanProperty closeOnCorrelateProp =
-      new BooleanProperty("closeOnCorrelate", false);
 
   public MessageSubscription() {
-    declareProperty(bpmnProcessIdProp)
-        .declareProperty(messageNameProp)
-        .declareProperty(correlationKeyProp)
-        .declareProperty(messageVariablesProp)
-        .declareProperty(workflowInstanceKeyProp)
-        .declareProperty(elementInstanceKeyProp)
-        .declareProperty(messageKeyProp)
-        .declareProperty(commandSentTimeProp)
-        .declareProperty(closeOnCorrelateProp);
+    declareProperty(recordProp).declareProperty(keyProp).declareProperty(commandSentTimeProp);
   }
 
-  public MessageSubscription(
-      final long workflowInstanceKey,
-      final long elementInstanceKey,
-      final DirectBuffer bpmnProcessId,
-      final DirectBuffer messageName,
-      final DirectBuffer correlationKey,
-      final boolean closeOnCorrelate) {
-    this();
-    workflowInstanceKeyProp.setValue(workflowInstanceKey);
-    elementInstanceKeyProp.setValue(elementInstanceKey);
-
-    bpmnProcessIdProp.setValue(bpmnProcessId);
-    messageNameProp.setValue(messageName);
-    correlationKeyProp.setValue(correlationKey);
-    closeOnCorrelateProp.setValue(closeOnCorrelate);
+  public MessageSubscriptionRecord getRecord() {
+    return recordProp.getValue();
   }
 
-  public DirectBuffer getBpmnProcessId() {
-    return bpmnProcessIdProp.getValue();
+  public MessageSubscription setRecord(final MessageSubscriptionRecord record) {
+    recordProp.getValue().wrap(record);
+    return this;
   }
 
-  public DirectBuffer getMessageName() {
-    return messageNameProp.getValue();
+  public long getKey() {
+    return keyProp.getValue();
   }
 
-  public DirectBuffer getCorrelationKey() {
-    return correlationKeyProp.getValue();
-  }
-
-  public DirectBuffer getMessageVariables() {
-    return messageVariablesProp.getValue();
-  }
-
-  public void setMessageVariables(final DirectBuffer variables) {
-    messageVariablesProp.setValue(variables);
-  }
-
-  public long getWorkflowInstanceKey() {
-    return workflowInstanceKeyProp.getValue();
-  }
-
-  public long getElementInstanceKey() {
-    return elementInstanceKeyProp.getValue();
-  }
-
-  public void setElementInstanceKey(final long elementInstanceKey) {
-    elementInstanceKeyProp.setValue(elementInstanceKey);
-  }
-
-  public long getMessageKey() {
-    return messageKeyProp.getValue();
-  }
-
-  public void setMessageKey(final long messageKey) {
-    messageKeyProp.setValue(messageKey);
+  public MessageSubscription setKey(final long key) {
+    keyProp.setValue(key);
+    return this;
   }
 
   public long getCommandSentTime() {
@@ -109,21 +54,5 @@ public final class MessageSubscription extends UnpackedObject implements DbValue
 
   public boolean isCorrelating() {
     return commandSentTimeProp.getValue() > 0;
-  }
-
-  public boolean shouldCloseOnCorrelate() {
-    return closeOnCorrelateProp.getValue();
-  }
-
-  public void setCloseOnCorrelate(final boolean closeOnCorrelate) {
-    closeOnCorrelateProp.setValue(closeOnCorrelate);
-  }
-
-  @Override
-  public void wrap(final DirectBuffer buffer, int offset, final int length) {
-    final byte[] bytes = new byte[length];
-    final MutableDirectBuffer newBuffer = new UnsafeBuffer(bytes);
-    buffer.getBytes(0, bytes, 0, length);
-    super.wrap(newBuffer, 0, length);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableMessageSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableMessageSubscriptionState.java
@@ -9,17 +9,14 @@ package io.zeebe.engine.state.mutable;
 
 import io.zeebe.engine.state.immutable.MessageSubscriptionState;
 import io.zeebe.engine.state.message.MessageSubscription;
+import io.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import org.agrona.DirectBuffer;
 
 public interface MutableMessageSubscriptionState extends MessageSubscriptionState {
 
-  void put(MessageSubscription subscription);
+  void put(long key, MessageSubscriptionRecord record);
 
-  void updateToCorrelatingState(
-      MessageSubscription subscription,
-      DirectBuffer messageVariables,
-      long sentTime,
-      long messageKey);
+  void updateToCorrelatingState(MessageSubscriptionRecord record, long sentTime);
 
   void resetSentTime(MessageSubscription subscription);
 

--- a/engine/src/test/java/io/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -250,7 +250,7 @@ public final class MessageStreamProcessorTest {
     // given
     final MessageSubscriptionRecord subscription = messageSubscription();
     final MessageRecord message = message();
-    subscription.setCloseOnCorrelate(false);
+    subscription.setInterrupting(false);
 
     // when
     rule.writeCommand(MessageSubscriptionIntent.CREATE, subscription);
@@ -297,7 +297,7 @@ public final class MessageStreamProcessorTest {
   @Test
   public void shouldCorrelateMultipleMessagesOneBeforeOpenOneAfter() {
     // given
-    final MessageSubscriptionRecord subscription = messageSubscription().setCloseOnCorrelate(false);
+    final MessageSubscriptionRecord subscription = messageSubscription().setInterrupting(false);
     final MessageRecord first = message().setVariables(asMsgPack("foo", "bar"));
     final MessageRecord second = message().setVariables(asMsgPack("foo", "baz"));
 
@@ -322,7 +322,7 @@ public final class MessageStreamProcessorTest {
   @Test
   public void shouldCorrelateMultipleMessagesTwoBeforeOpen() {
     // given
-    final MessageSubscriptionRecord subscription = messageSubscription().setCloseOnCorrelate(false);
+    final MessageSubscriptionRecord subscription = messageSubscription().setInterrupting(false);
     final MessageRecord first = message().setVariables(asMsgPack("foo", "bar"));
     final MessageRecord second = message().setVariables(asMsgPack("foo", "baz"));
 
@@ -439,7 +439,7 @@ public final class MessageStreamProcessorTest {
         .setMessageKey(-1L)
         .setMessageName(wrapString("order canceled"))
         .setCorrelationKey(wrapString("order-123"))
-        .setCloseOnCorrelate(true);
+        .setInterrupting(true);
 
     return subscription;
   }

--- a/engine/src/test/java/io/zeebe/engine/state/message/MessageSubscriptionStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/message/MessageSubscriptionStateTest.java
@@ -13,6 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.zeebe.engine.util.ZeebeStateRule;
+import io.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
+import io.zeebe.test.util.MsgPackUtil;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
@@ -35,12 +37,12 @@ public final class MessageSubscriptionStateTest {
   @Test
   public void shouldNotExistWithDifferentElementKey() {
     // given
-    final MessageSubscription subscription = subscriptionWithElementInstanceKey(1);
-    state.put(subscription);
+    final var subscription = subscriptionWithElementInstanceKey(1);
+    state.put(1L, subscription);
 
     // when
     final boolean exist =
-        state.existSubscriptionForElementInstance(2, subscription.getMessageName());
+        state.existSubscriptionForElementInstance(2, subscription.getMessageNameBuffer());
 
     // then
     assertThat(exist).isFalse();
@@ -49,8 +51,8 @@ public final class MessageSubscriptionStateTest {
   @Test
   public void shouldNotExistWithDifferentMessageName() {
     // given
-    final MessageSubscription subscription = subscriptionWithElementInstanceKey(1);
-    state.put(subscription);
+    final var subscription = subscriptionWithElementInstanceKey(1);
+    state.put(1L, subscription);
 
     // when
     final boolean exist =
@@ -64,13 +66,13 @@ public final class MessageSubscriptionStateTest {
   @Test
   public void shouldExistSubscription() {
     // given
-    final MessageSubscription subscription = subscriptionWithElementInstanceKey(1);
-    state.put(subscription);
+    final var subscription = subscriptionWithElementInstanceKey(1);
+    state.put(1L, subscription);
 
     // when
     final boolean exist =
         state.existSubscriptionForElementInstance(
-            subscription.getElementInstanceKey(), subscription.getMessageName());
+            subscription.getElementInstanceKey(), subscription.getMessageNameBuffer());
 
     // then
     assertThat(exist).isTrue();
@@ -79,8 +81,8 @@ public final class MessageSubscriptionStateTest {
   @Test
   public void shouldVisitSubscription() {
     // given
-    final MessageSubscription subscription = subscription("messageName", "correlationKey", 1);
-    state.put(subscription);
+    final var subscription = subscription("messageName", "correlationKey", 1);
+    state.put(1L, subscription);
 
     // when
     final List<MessageSubscription> subscriptions = new ArrayList<>();
@@ -89,33 +91,33 @@ public final class MessageSubscriptionStateTest {
 
     // then
     assertThat(subscriptions).hasSize(1);
-    assertThat(subscriptions.get(0).getWorkflowInstanceKey())
+    assertThat(subscriptions.get(0).getRecord().getWorkflowInstanceKey())
         .isEqualTo(subscription.getWorkflowInstanceKey());
-    assertThat(subscriptions.get(0).getElementInstanceKey())
+    assertThat(subscriptions.get(0).getRecord().getElementInstanceKey())
         .isEqualTo(subscription.getElementInstanceKey());
-    assertThat(subscriptions.get(0).getMessageName()).isEqualTo(subscription.getMessageName());
-    assertThat(subscriptions.get(0).getCorrelationKey())
+    assertThat(subscriptions.get(0).getRecord().getMessageName())
+        .isEqualTo(subscription.getMessageName());
+    assertThat(subscriptions.get(0).getRecord().getCorrelationKey())
         .isEqualTo(subscription.getCorrelationKey());
-    assertThat(subscriptions.get(0).getMessageVariables())
-        .isEqualTo(subscription.getMessageVariables());
-    assertThat(subscriptions.get(0).getCommandSentTime())
-        .isEqualTo(subscription.getCommandSentTime());
+    assertThat(subscriptions.get(0).getRecord().getVariables())
+        .isEqualTo(subscription.getVariables());
+    assertThat(subscriptions.get(0).getCommandSentTime()).isZero();
   }
 
   @Test
   public void shouldVisitSubscriptionsInOrder() {
     // given
-    state.put(subscription("messageName", "correlationKey", 1));
-    state.put(subscription("messageName", "correlationKey", 2));
-    state.put(subscription("otherMessageName", "correlationKey", 3));
-    state.put(subscription("messageName", "otherCorrelationKey", 4));
+    state.put(1L, subscription("messageName", "correlationKey", 1));
+    state.put(2L, subscription("messageName", "correlationKey", 2));
+    state.put(3L, subscription("otherMessageName", "correlationKey", 3));
+    state.put(4L, subscription("messageName", "otherCorrelationKey", 4));
 
     // when
     final List<Long> keys = new ArrayList<>();
     state.visitSubscriptions(
         wrapString("messageName"),
         wrapString("correlationKey"),
-        s -> keys.add(s.getElementInstanceKey()));
+        s -> keys.add(s.getRecord().getElementInstanceKey()));
 
     // then
     assertThat(keys).hasSize(2).containsExactly(1L, 2L);
@@ -124,8 +126,8 @@ public final class MessageSubscriptionStateTest {
   @Test
   public void shouldVisitSubsctionsUntilStop() {
     // given
-    state.put(subscription("messageName", "correlationKey", 1));
-    state.put(subscription("messageName", "correlationKey", 2));
+    state.put(1L, subscription("messageName", "correlationKey", 1));
+    state.put(2L, subscription("messageName", "correlationKey", 2));
 
     // when
     final List<Long> keys = new ArrayList<>();
@@ -133,7 +135,7 @@ public final class MessageSubscriptionStateTest {
         wrapString("messageName"),
         wrapString("correlationKey"),
         s -> {
-          keys.add(s.getElementInstanceKey());
+          keys.add(s.getRecord().getElementInstanceKey());
           return false;
         });
 
@@ -144,17 +146,17 @@ public final class MessageSubscriptionStateTest {
   @Test
   public void shouldNoVisitMessageSubscriptionBeforeTime() {
     // given
-    final MessageSubscription subscription1 = subscriptionWithElementInstanceKey(1L);
-    state.put(subscription1);
-    state.updateSentTime(subscription1, 1_000);
+    final var subscription1 = subscriptionWithElementInstanceKey(1L);
+    state.put(1L, subscription1);
+    state.updateToCorrelatingState(subscription1, 1_000);
 
-    final MessageSubscription subscription2 = subscriptionWithElementInstanceKey(2L);
-    state.put(subscription2);
-    state.updateSentTime(subscription2, 3_000);
+    final var subscription2 = subscriptionWithElementInstanceKey(2L);
+    state.put(2L, subscription2);
+    state.updateToCorrelatingState(subscription2, 3_000);
 
     // then
     final List<Long> keys = new ArrayList<>();
-    state.visitSubscriptionBefore(1_000, s -> keys.add(s.getElementInstanceKey()));
+    state.visitSubscriptionBefore(1_000, s -> keys.add(s.getRecord().getElementInstanceKey()));
 
     assertThat(keys).isEmpty();
   }
@@ -162,17 +164,17 @@ public final class MessageSubscriptionStateTest {
   @Test
   public void shouldVisitMessageSubscriptionBeforeTime() {
     // given
-    final MessageSubscription subscription1 = subscriptionWithElementInstanceKey(1L);
-    state.put(subscription1);
-    state.updateSentTime(subscription1, 1_000);
+    final var subscription1 = subscriptionWithElementInstanceKey(1L);
+    state.put(1L, subscription1);
+    state.updateToCorrelatingState(subscription1, 1_000);
 
-    final MessageSubscription subscription2 = subscriptionWithElementInstanceKey(2L);
-    state.put(subscription2);
-    state.updateSentTime(subscription2, 3_000);
+    final var subscription2 = subscriptionWithElementInstanceKey(2L);
+    state.put(2L, subscription2);
+    state.updateToCorrelatingState(subscription2, 3_000);
 
     // then
     final List<Long> keys = new ArrayList<>();
-    state.visitSubscriptionBefore(2_000, s -> keys.add(s.getElementInstanceKey()));
+    state.visitSubscriptionBefore(2_000, s -> keys.add(s.getRecord().getElementInstanceKey()));
 
     assertThat(keys).hasSize(1).contains(1L);
   }
@@ -180,17 +182,17 @@ public final class MessageSubscriptionStateTest {
   @Test
   public void shouldFindMessageSubscriptionBeforeTimeInOrder() {
     // given
-    final MessageSubscription subscription1 = subscriptionWithElementInstanceKey(1L);
-    state.put(subscription1);
-    state.updateSentTime(subscription1, 1_000);
+    final var subscription1 = subscriptionWithElementInstanceKey(1L);
+    state.put(1L, subscription1);
+    state.updateToCorrelatingState(subscription1, 1_000);
 
-    final MessageSubscription subscription2 = subscriptionWithElementInstanceKey(2L);
-    state.put(subscription2);
-    state.updateSentTime(subscription2, 2_000);
+    final var subscription2 = subscriptionWithElementInstanceKey(2L);
+    state.put(2L, subscription2);
+    state.updateToCorrelatingState(subscription2, 2_000);
 
     // then
     final List<Long> keys = new ArrayList<>();
-    state.visitSubscriptionBefore(3_000, s -> keys.add(s.getElementInstanceKey()));
+    state.visitSubscriptionBefore(3_000, s -> keys.add(s.getRecord().getElementInstanceKey()));
 
     assertThat(keys).hasSize(2).containsExactly(1L, 2L);
   }
@@ -198,16 +200,16 @@ public final class MessageSubscriptionStateTest {
   @Test
   public void shouldNotVisitMessageSubscriptionIfSentTimeNotSet() {
     // given
-    final MessageSubscription subscription1 = subscriptionWithElementInstanceKey(1L);
-    state.put(subscription1);
-    state.updateSentTime(subscription1, 1_000);
+    final var subscription1 = subscriptionWithElementInstanceKey(1L);
+    state.put(1L, subscription1);
+    state.updateToCorrelatingState(subscription1, 1_000);
 
-    final MessageSubscription subscription2 = subscriptionWithElementInstanceKey(2L);
-    state.put(subscription2);
+    final var subscription2 = subscriptionWithElementInstanceKey(2L);
+    state.put(2L, subscription2);
 
     // then
     final List<Long> keys = new ArrayList<>();
-    state.visitSubscriptionBefore(2_000, s -> keys.add(s.getElementInstanceKey()));
+    state.visitSubscriptionBefore(2_000, s -> keys.add(s.getRecord().getElementInstanceKey()));
 
     assertThat(keys).hasSize(1).contains(1L);
   }
@@ -215,15 +217,18 @@ public final class MessageSubscriptionStateTest {
   @Test
   public void shouldUpdateMessageSubscriptionSentTime() {
     // given
-    final MessageSubscription subscription = subscriptionWithElementInstanceKey(1L);
-    state.put(subscription);
+    final var record = subscriptionWithElementInstanceKey(1L);
+    state.put(1L, record);
+
+    final var subscription =
+        state.get(record.getElementInstanceKey(), record.getMessageNameBuffer());
 
     // when
     state.updateSentTime(subscription, 1_000);
 
     // then
     final List<Long> keys = new ArrayList<>();
-    state.visitSubscriptionBefore(2_000, s -> keys.add(s.getElementInstanceKey()));
+    state.visitSubscriptionBefore(2_000, s -> keys.add(s.getRecord().getElementInstanceKey()));
 
     assertThat(keys).hasSize(1).contains(1L);
 
@@ -231,7 +236,7 @@ public final class MessageSubscriptionStateTest {
     state.updateSentTime(subscription, 1_500);
 
     keys.clear();
-    state.visitSubscriptionBefore(2_000, s -> keys.add(s.getElementInstanceKey()));
+    state.visitSubscriptionBefore(2_000, s -> keys.add(s.getRecord().getElementInstanceKey()));
 
     assertThat(keys).hasSize(1).contains(1L);
   }
@@ -239,30 +244,42 @@ public final class MessageSubscriptionStateTest {
   @Test
   public void shouldUpdateCorrelationState() {
     // given
-    final MessageSubscription subscription = subscriptionWithElementInstanceKey(1L);
-    state.put(subscription);
+    final var subscription = subscriptionWithElementInstanceKey(1L);
+    state.put(1L, subscription);
 
-    assertThat(subscription.isCorrelating()).isFalse();
+    assertThat(
+            state
+                .get(subscription.getElementInstanceKey(), subscription.getMessageNameBuffer())
+                .isCorrelating())
+        .isFalse();
 
     // when
-    state.updateToCorrelatingState(subscription, wrapString("{\"foo\":\"bar\"}"), 1_000, 5);
+    subscription.setVariables(MsgPackUtil.asMsgPack("{\"foo\":\"bar\"}")).setMessageKey(5L);
+    state.updateToCorrelatingState(subscription, 1_000);
 
     // then
-    assertThat(subscription.isCorrelating()).isTrue();
+    assertThat(
+            state
+                .get(subscription.getElementInstanceKey(), subscription.getMessageNameBuffer())
+                .isCorrelating())
+        .isTrue();
 
     // and
     final List<MessageSubscription> subscriptions = new ArrayList<>();
     state.visitSubscriptions(
-        subscription.getMessageName(), subscription.getCorrelationKey(), subscriptions::add);
+        subscription.getMessageNameBuffer(),
+        subscription.getCorrelationKeyBuffer(),
+        subscriptions::add);
 
     assertThat(subscriptions).hasSize(1);
-    assertThat(subscriptions.get(0).getMessageVariables())
-        .isEqualTo(subscription.getMessageVariables());
-    assertThat(subscriptions.get(0).getMessageKey()).isEqualTo(subscription.getMessageKey());
+    assertThat(subscriptions.get(0).getRecord().getVariables())
+        .isEqualTo(subscription.getVariables());
+    assertThat(subscriptions.get(0).getRecord().getMessageKey())
+        .isEqualTo(subscription.getMessageKey());
 
     // and
     final List<Long> keys = new ArrayList<>();
-    state.visitSubscriptionBefore(2_000, s -> keys.add(s.getElementInstanceKey()));
+    state.visitSubscriptionBefore(2_000, s -> keys.add(s.getRecord().getElementInstanceKey()));
 
     assertThat(keys).hasSize(1).contains(1L);
   }
@@ -270,52 +287,52 @@ public final class MessageSubscriptionStateTest {
   @Test
   public void shouldRemoveSubscription() {
     // given
-    final MessageSubscription subscription = subscriptionWithElementInstanceKey(1L);
-    state.put(subscription);
-    state.updateSentTime(subscription, 1_000);
+    final var subscription = subscriptionWithElementInstanceKey(1L);
+    state.put(1L, subscription);
+    state.updateToCorrelatingState(subscription, 1_000);
 
     // when
-    state.remove(1L, subscription.getMessageName());
+    state.remove(1L, subscription.getMessageNameBuffer());
 
     // then
     final List<Long> keys = new ArrayList<>();
     state.visitSubscriptions(
-        subscription.getMessageName(),
-        subscription.getCorrelationKey(),
-        s -> keys.add(s.getElementInstanceKey()));
+        subscription.getMessageNameBuffer(),
+        subscription.getCorrelationKeyBuffer(),
+        s -> keys.add(s.getRecord().getElementInstanceKey()));
 
     assertThat(keys).isEmpty();
 
     // and
-    state.visitSubscriptionBefore(2_000, s -> keys.add(s.getElementInstanceKey()));
+    state.visitSubscriptionBefore(2_000, s -> keys.add(s.getRecord().getElementInstanceKey()));
 
     assertThat(keys).isEmpty();
 
     // and
-    assertThat(state.existSubscriptionForElementInstance(1L, subscription.getMessageName()))
+    assertThat(state.existSubscriptionForElementInstance(1L, subscription.getMessageNameBuffer()))
         .isFalse();
   }
 
   @Test
   public void shouldNotFailOnRemoveSubscriptionTwice() {
     // given
-    final MessageSubscription subscription = subscriptionWithElementInstanceKey(1L);
-    state.put(subscription);
+    final var subscription = subscriptionWithElementInstanceKey(1L);
+    state.put(1L, subscription);
 
     // when
-    state.remove(1L, subscription.getMessageName());
-    state.remove(1L, subscription.getMessageName());
+    state.remove(1L, subscription.getMessageNameBuffer());
+    state.remove(1L, subscription.getMessageNameBuffer());
 
     // then
-    assertThat(state.existSubscriptionForElementInstance(1L, subscription.getMessageName()))
+    assertThat(state.existSubscriptionForElementInstance(1L, subscription.getMessageNameBuffer()))
         .isFalse();
   }
 
   @Test
   public void shouldNotRemoveSubscriptionOnDifferentKey() {
     // given
-    state.put(subscription("messageName", "correlationKey", 1L));
-    state.put(subscription("messageName", "correlationKey", 2L));
+    state.put(1L, subscription("messageName", "correlationKey", 1L));
+    state.put(2L, subscription("messageName", "correlationKey", 2L));
 
     // when
     state.remove(2L, wrapString("messageName"));
@@ -325,23 +342,24 @@ public final class MessageSubscriptionStateTest {
     state.visitSubscriptions(
         wrapString("messageName"),
         wrapString("correlationKey"),
-        s -> keys.add(s.getElementInstanceKey()));
+        s -> keys.add(s.getRecord().getElementInstanceKey()));
 
     assertThat(keys).hasSize(1).contains(1L);
   }
 
-  private MessageSubscription subscriptionWithElementInstanceKey(final long elementInstanceKey) {
+  private MessageSubscriptionRecord subscriptionWithElementInstanceKey(
+      final long elementInstanceKey) {
     return subscription("messageName", "correlationKey", elementInstanceKey);
   }
 
-  private MessageSubscription subscription(
+  private MessageSubscriptionRecord subscription(
       final String name, final String correlationKey, final long elementInstanceKey) {
-    return new MessageSubscription(
-        1L,
-        elementInstanceKey,
-        wrapString("workflow"),
-        wrapString(name),
-        wrapString(correlationKey),
-        true);
+    return new MessageSubscriptionRecord()
+        .setWorkflowInstanceKey(1L)
+        .setElementInstanceKey(elementInstanceKey)
+        .setBpmnProcessId(wrapString("workflow"))
+        .setMessageName(wrapString(name))
+        .setCorrelationKey(wrapString(correlationKey))
+        .setInterrupting(true);
   }
 }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -35,6 +35,9 @@
             },
             "variables": {
               "enabled": false
+            },
+            "interrupting": {
+              "type": "boolean"
             }
           }
         }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -29,8 +29,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private final LongProperty messageKeyProp = new LongProperty("messageKey", -1L);
   private final StringProperty messageNameProp = new StringProperty("messageName", "");
   private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
-  private final BooleanProperty closeOnCorrelateProp =
-      new BooleanProperty("closeOnCorrelate", true);
+  private final BooleanProperty interruptingProp = new BooleanProperty("interrupting", true);
 
   private final DocumentProperty variablesProp = new DocumentProperty("variables");
 
@@ -40,13 +39,24 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(messageKeyProp)
         .declareProperty(messageNameProp)
         .declareProperty(correlationKeyProp)
-        .declareProperty(closeOnCorrelateProp)
+        .declareProperty(interruptingProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(variablesProp);
   }
 
-  public boolean shouldCloseOnCorrelate() {
-    return closeOnCorrelateProp.getValue();
+  public void wrap(final MessageSubscriptionRecord record) {
+    setWorkflowInstanceKey(record.getWorkflowInstanceKey());
+    setElementInstanceKey(record.getElementInstanceKey());
+    setMessageKey(record.getMessageKey());
+    setMessageName(record.getMessageNameBuffer());
+    setCorrelationKey(record.getCorrelationKeyBuffer());
+    setInterrupting(record.isInterrupting());
+    setBpmnProcessId(record.getBpmnProcessIdBuffer());
+    setVariables(record.getVariablesBuffer());
+  }
+
+  public boolean isInterrupting() {
+    return interruptingProp.getValue();
   }
 
   @JsonIgnore
@@ -119,8 +129,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  public MessageSubscriptionRecord setCloseOnCorrelate(final boolean closeOnCorrelate) {
-    closeOnCorrelateProp.setValue(closeOnCorrelate);
+  public MessageSubscriptionRecord setInterrupting(final boolean interrupting) {
+    interruptingProp.setValue(interrupting);
     return this;
   }
 

--- a/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -488,7 +488,7 @@ public final class JsonSerializableToJsonTest {
                   .setCorrelationKey(wrapString(correlationKey))
                   .setVariables(VARIABLES_MSGPACK);
             },
-        "{'workflowInstanceKey':2,'elementInstanceKey':1,'messageName':'name','correlationKey':'key','bpmnProcessId':'workflow','messageKey':3,'variables':{'foo':'bar'}}"
+        "{'workflowInstanceKey':2,'elementInstanceKey':1,'messageName':'name','correlationKey':'key','bpmnProcessId':'workflow','messageKey':3,'variables':{'foo':'bar'},'interrupting':true}"
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ///////////////////////////////// Empty MessageSubscriptionRecord
@@ -505,7 +505,7 @@ public final class JsonSerializableToJsonTest {
                   .setWorkflowInstanceKey(workflowInstanceKey)
                   .setElementInstanceKey(elementInstanceKey);
             },
-        "{'workflowInstanceKey':1,'elementInstanceKey':13,'messageName':'','correlationKey':'','bpmnProcessId':'','messageKey':-1,'variables':{}}"
+        "{'workflowInstanceKey':1,'elementInstanceKey':13,'messageName':'','correlationKey':'','bpmnProcessId':'','messageKey':-1,'variables':{},'interrupting':true}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
@@ -44,4 +44,10 @@ public interface MessageSubscriptionRecordValue
 
   /** @return the key of the correlated message */
   long getMessageKey();
+
+  /**
+   * @return {@code true} if the event tied to the subscription is interrupting. Otherwise, it
+   *     returns {@code false} if the event is non-interrupting.
+   */
+  boolean isInterrupting();
 }


### PR DESCRIPTION
## Description

* reuse the message subscription record in the state to avoid duplication
* introduce a key for message subscriptions and use this key for writing events
* rename the record property "closeOnCorrelate" to "interrupting" to make the intention of it more clear
* expose the record property "interrupting" in the interface and add it to the ES template

## Related issues

Follow-up of #6180 
Contribute to #2805

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
