### PR TITLE
Store records for incidents on activating

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
@@ -175,7 +175,7 @@ public final class EngineProcessors {
       final int maxFragmentSize,
       final Writers writers) {
     JobEventProcessors.addJobProcessors(
-        typedRecordProcessors, zeebeState, onJobsAvailableCallback, maxFragmentSize);
+        typedRecordProcessors, zeebeState, onJobsAvailableCallback, maxFragmentSize, writers);
   }
 
   private static void addMessageProcessors(

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
@@ -70,13 +70,16 @@ public final class BpmnIncidentBehavior {
         .setErrorType(errorType)
         .setErrorMessage(errorMessage);
 
-    final var intent = determineCommandIntent(context);
-    elementInstanceState.storeRecord(
-        context.getElementInstanceKey(),
-        context.getFlowScopeKey(),
-        context.getRecordValue(),
-        intent,
-        Purpose.FAILED);
+    // todo: remove storing record after incident is migrated
+    if (!MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
+      final var intent = determineCommandIntent(context);
+      elementInstanceState.storeRecord(
+          context.getElementInstanceKey(),
+          context.getFlowScopeKey(),
+          context.getRecordValue(),
+          intent,
+          Purpose.FAILED);
+    }
 
     streamWriter.appendNewCommand(IncidentIntent.CREATE, incidentCommand);
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.processing.job;
 import io.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
 import io.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
 import io.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.JobBatchIntent;
@@ -22,14 +23,15 @@ public final class JobEventProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final ZeebeState zeebeState,
       final Consumer<String> onJobsAvailableCallback,
-      final int maxRecordSize) {
+      final int maxRecordSize,
+      final Writers writers) {
 
     final var jobState = zeebeState.getJobState();
     final var keyGenerator = zeebeState.getKeyGenerator();
 
     typedRecordProcessors
         .onCommand(ValueType.JOB, JobIntent.CREATE, new CreateProcessor())
-        .onCommand(ValueType.JOB, JobIntent.COMPLETE, new JobCompleteProcessor(zeebeState))
+        .onCommand(ValueType.JOB, JobIntent.COMPLETE, new JobCompleteProcessor(zeebeState, writers))
         .onCommand(ValueType.JOB, JobIntent.FAIL, new JobFailProcessor(zeebeState))
         .onCommand(ValueType.JOB, JobIntent.THROW_ERROR, new JobThrowErrorProcessor(zeebeState))
         .onCommand(ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(zeebeState))

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementActivatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementActivatedApplier.java
@@ -8,6 +8,7 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.instance.StoredRecord.Purpose;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
@@ -26,5 +27,12 @@ final class WorkflowInstanceElementActivatedApplier
   public void applyState(final long key, final WorkflowInstanceRecord value) {
     elementInstanceState.updateInstance(
         key, instance -> instance.setState(WorkflowInstanceIntent.ELEMENT_ACTIVATED));
+
+    // We store the record to use it on resolving the incident, which is no longer used after
+    // migrating the incident processor.
+    // In order to migrate the other processors we need to write (and here remove) the record in an
+    // event applier.
+    // todo: we need to remove it later
+    elementInstanceState.removeStoredRecord(value.getFlowScopeKey(), key, Purpose.FAILED);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementActivatingApplier.java
@@ -8,6 +8,7 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.instance.StoredRecord.Purpose;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
@@ -28,5 +29,18 @@ final class WorkflowInstanceElementActivatingApplier
     final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
     elementInstanceState.newInstance(
         flowScopeInstance, elementInstanceKey, value, WorkflowInstanceIntent.ELEMENT_ACTIVATING);
+
+    // We store the record to use it on resolving the incident, which is no longer used after
+    // migrating the incident processor.
+    // In order to migrate the other processors we need to write the record in an event applier. The
+    // record is removed in the ACTIVATED again
+    // (which happens either after resolving or immediately)
+    // todo: we need to remove it later
+    elementInstanceState.storeRecord(
+        elementInstanceKey,
+        value.getFlowScopeKey(),
+        value,
+        WorkflowInstanceIntent.ACTIVATE_ELEMENT,
+        Purpose.FAILED);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementCompletedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementCompletedApplier.java
@@ -31,6 +31,7 @@ final class WorkflowInstanceElementCompletedApplier
   public void applyState(final long key, final WorkflowInstanceRecord value) {
     eventScopeInstanceState.deleteInstance(key);
     elementInstanceState.consumeToken(value.getFlowScopeKey());
+    // stored records for incidents are removed when the instance is deleted
     elementInstanceState.removeInstance(key);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementCompletingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/WorkflowInstanceElementCompletingApplier.java
@@ -8,6 +8,7 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.instance.StoredRecord.Purpose;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.intent.WorkflowInstanceIntent;
@@ -24,8 +25,22 @@ final class WorkflowInstanceElementCompletingApplier
   }
 
   @Override
-  public void applyState(final long key, final WorkflowInstanceRecord value) {
+  public void applyState(final long elementInstanceKey, final WorkflowInstanceRecord value) {
     elementInstanceState.updateInstance(
-        key, instance -> instance.setState(WorkflowInstanceIntent.ELEMENT_COMPLETING));
+        elementInstanceKey,
+        instance -> instance.setState(WorkflowInstanceIntent.ELEMENT_COMPLETING));
+
+    // We store the record to use it on resolving the incident, which is no longer used after
+    // migrating the incident processor.
+    // In order to migrate the other processors we need to write the record in an event applier. The
+    // record is removed in the COMPLETED again
+    // (which happens either after resolving or immediately)
+    // todo: we need to remove it later
+    elementInstanceState.storeRecord(
+        elementInstanceKey,
+        value.getFlowScopeKey(),
+        value,
+        WorkflowInstanceIntent.COMPLETE_ELEMENT,
+        Purpose.FAILED);
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/WorkflowInstanceStreamProcessorRule.java
@@ -111,6 +111,7 @@ public final class WorkflowInstanceStreamProcessorRule extends ExternalResource
                   ExpressionLanguageFactory.createExpressionLanguage(),
                   variablesState::getVariable);
 
+          final var writers = processingContext.getWriters();
           WorkflowEventProcessors.addWorkflowProcessors(
               zeebeState,
               expressionProcessor,
@@ -119,10 +120,10 @@ public final class WorkflowInstanceStreamProcessorRule extends ExternalResource
               new CatchEventBehavior(
                   zeebeState, expressionProcessor, mockSubscriptionCommandSender, 1),
               new DueDateTimerChecker(zeebeState.getTimerState()),
-              processingContext.getWriters());
+              writers);
 
           JobEventProcessors.addJobProcessors(
-              typedRecordProcessors, zeebeState, type -> {}, Integer.MAX_VALUE);
+              typedRecordProcessors, zeebeState, type -> {}, Integer.MAX_VALUE, writers);
           typedRecordProcessors.withListener(this);
           return typedRecordProcessors;
         });

--- a/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
@@ -84,6 +84,7 @@ public final class IncidentStreamProcessorRule extends ExternalResource {
                   ExpressionLanguageFactory.createExpressionLanguage(),
                   variablesState::getVariable);
 
+          final var writers = processingContext.getWriters();
           final var stepProcessor =
               WorkflowEventProcessors.addWorkflowProcessors(
                   zeebeState,
@@ -93,10 +94,10 @@ public final class IncidentStreamProcessorRule extends ExternalResource {
                   new CatchEventBehavior(
                       zeebeState, expressionProcessor, mockSubscriptionCommandSender, 1),
                   mockTimerEventScheduler,
-                  processingContext.getWriters());
+                  writers);
 
           JobEventProcessors.addJobProcessors(
-              typedRecordProcessors, zeebeState, type -> {}, Integer.MAX_VALUE);
+              typedRecordProcessors, zeebeState, type -> {}, Integer.MAX_VALUE, writers);
 
           IncidentEventProcessors.addProcessors(typedRecordProcessors, zeebeState, stepProcessor);
 

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java
@@ -47,19 +47,17 @@ public class ReplayStateRandomizedPropertyTest {
   private static final int WORKFLOW_COUNT = 5;
   private static final int EXECUTION_PATH_COUNT = 5;
 
+  @Rule public TestWatcher failedTestDataPrinter = new FailedTestDataPrinter();
+  @Parameter public TestDataRecord record;
+  private long lastProcessedPosition = -1L;
+
   @Rule
   public final EngineRule engineRule =
       EngineRule.singlePartition()
           .withOnProcessedCallback(record -> lastProcessedPosition = record.getPosition())
           .withOnSkippedCallback(record -> lastProcessedPosition = record.getPosition());
 
-  @Rule public TestWatcher failedTestDataPrinter = new FailedTestDataPrinter();
-
-  @Parameter public TestDataRecord record;
-
   private final WorkflowExecutor workflowExecutor = new WorkflowExecutor(engineRule);
-
-  private long lastProcessedPosition = -1L;
 
   @Before
   public void init() {
@@ -169,8 +167,8 @@ public class ReplayStateRandomizedPropertyTest {
   @Parameters(name = "{0}")
   public static Collection<TestDataRecord> getTestRecords() {
     // use the following code to rerun a specific test case:
-    //    final var workflowSeed = 4151337193744273092L;
-    //    final var executionPathSeed = 8078198989481167852L;
+    //    final var workflowSeed = 3499044774323385558L;
+    //    final var executionPathSeed = 3627169465144620203L;
     //    return List.of(TestDataGenerator.regenerateTestRecord(workflowSeed, executionPathSeed));
     return TestDataGenerator.generateTestRecords(WORKFLOW_COUNT, EXECUTION_PATH_COUNT);
   }


### PR DESCRIPTION
## Description

Handles storing the record for migrated processors. Currently incident handling need to have the record in the state, this will be removed later.


I created a separate PR because we need that in other processors as well, so we can make better progress on others as well.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #6195 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
