### PR TITLE
Migrate creating event scope

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -19,6 +19,7 @@ import io.zeebe.engine.processing.deployment.model.element.ExecutableMessage;
 import io.zeebe.engine.processing.message.MessageCorrelationKeyException;
 import io.zeebe.engine.processing.message.MessageNameException;
 import io.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.zeebe.engine.processing.streamprocessor.MigratedStreamProcessors;
 import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffects;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.state.ZeebeState;
@@ -120,7 +121,8 @@ public final class CatchEventBehavior {
       }
     }
 
-    if (!events.isEmpty()) {
+    // todo: remove after all are migrated
+    if (!MigratedStreamProcessors.isMigrated(context.getBpmnElementType()) && !events.isEmpty()) {
       eventScopeInstanceState.createIfNotExists(
           context.getElementInstanceKey(), supplier.getInterruptingElementIds());
     }
@@ -189,6 +191,7 @@ public final class CatchEventBehavior {
     subscription.setCorrelationKey(correlationKey);
     subscription.setTargetElementId(handler.getId());
     subscription.setCloseOnCorrelate(closeOnCorrelate);
+    // todo(zell): phil will migrate this via writing the open subscription
     workflowInstanceSubscriptionState.put(subscription);
 
     sideEffects.add(

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -87,12 +87,14 @@ public final class EventAppliers implements EventApplier {
   private void registerWorkflowInstanceEventAppliers(final ZeebeState state) {
     final var elementInstanceState = state.getElementInstanceState();
     final var eventScopeInstanceState = state.getEventScopeInstanceState();
+    final var workflowState = state.getWorkflowState();
     register(
         WorkflowInstanceIntent.ELEMENT_ACTIVATING,
         new WorkflowInstanceElementActivatingApplier(elementInstanceState));
     register(
         WorkflowInstanceIntent.ELEMENT_ACTIVATED,
-        new WorkflowInstanceElementActivatedApplier(elementInstanceState));
+        new WorkflowInstanceElementActivatedApplier(
+            elementInstanceState, workflowState, eventScopeInstanceState));
     register(
         WorkflowInstanceIntent.ELEMENT_COMPLETING,
         new WorkflowInstanceElementCompletingApplier(elementInstanceState));


### PR DESCRIPTION
## Description

Migrates creating event scope if not exist for sub process, this can then also used for other processor migrations where we need that. For example it is needed by process processor.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #6195 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
