### PR TITLE
chore(clients/go): command results are outputted instead of logged

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/cancelInstance.go
+++ b/clients/go/cmd/zbctl/internal/commands/cancelInstance.go
@@ -51,7 +51,7 @@ var cancelInstanceCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = logHumanAndPrintJSON(CancelInstanceResponseWrapper{resp})
+		err = printOutput(CancelInstanceResponseWrapper{resp})
 		return err
 	},
 }

--- a/clients/go/cmd/zbctl/internal/commands/completeJob.go
+++ b/clients/go/cmd/zbctl/internal/commands/completeJob.go
@@ -57,7 +57,7 @@ var completeJobCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = logHumanAndPrintJSON(CompleteJobResponseWrapper{resp})
+		err = printOutput(CompleteJobResponseWrapper{resp})
 		return err
 	},
 }

--- a/clients/go/cmd/zbctl/internal/commands/failJob.go
+++ b/clients/go/cmd/zbctl/internal/commands/failJob.go
@@ -57,7 +57,7 @@ var failJobCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = logHumanAndPrintJSON(FailJobResponseWrapper{resp})
+		err = printOutput(FailJobResponseWrapper{resp})
 		return err
 	},
 }

--- a/clients/go/cmd/zbctl/internal/commands/output.go
+++ b/clients/go/cmd/zbctl/internal/commands/output.go
@@ -16,7 +16,6 @@ package commands
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 const humanOutput = "human"
@@ -39,38 +38,21 @@ func addOutputFlag(c *cobra.Command) {
 	)
 }
 
-func printHumanAndJSON(p Printable) error {
-	var responseAsString string
-	if outputFlag == humanOutput {
-		human, err := p.human()
-		if err != nil {
-			return err
-		}
-		responseAsString = human
-	} else if outputFlag == jsonOutput {
-		json, err := p.json()
-		if err != nil {
-			return err
-		}
-		responseAsString = json
-	}
-	fmt.Print(responseAsString)
-	return nil
-}
+func printOutput(p Printable) error {
+	var output string
+	var err error
 
-func logHumanAndPrintJSON(p Printable) error {
 	if outputFlag == humanOutput {
-		human, err := p.human()
-		if err != nil {
-			return err
-		}
-		log.Println(human)
+		output, err = p.human()
 	} else if outputFlag == jsonOutput {
-		json, err := p.json()
-		if err != nil {
-			return err
-		}
-		fmt.Println(json)
+		output, err = p.json()
+
 	}
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(output)
 	return nil
 }

--- a/clients/go/cmd/zbctl/internal/commands/resolveIncident.go
+++ b/clients/go/cmd/zbctl/internal/commands/resolveIncident.go
@@ -50,7 +50,7 @@ var resolveIncidentCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = logHumanAndPrintJSON(ResolveIncidentResponseWrapper{resp})
+		err = printOutput(ResolveIncidentResponseWrapper{resp})
 		return err
 	},
 }

--- a/clients/go/cmd/zbctl/internal/commands/setVariables.go
+++ b/clients/go/cmd/zbctl/internal/commands/setVariables.go
@@ -32,7 +32,7 @@ func (s SetVariablesResponseWrapper) human() (string, error) {
 		"' to '",
 		setVariablesVariablesFlag,
 		"' with command '",
-		s.resp.GetKey(),
+		s.resp.GetKey(), "'",
 	), nil
 }
 
@@ -65,7 +65,7 @@ var setVariablesCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = logHumanAndPrintJSON(SetVariablesResponseWrapper{response})
+		err = printOutput(SetVariablesResponseWrapper{response})
 		return err
 	},
 }

--- a/clients/go/cmd/zbctl/internal/commands/status.go
+++ b/clients/go/cmd/zbctl/internal/commands/status.go
@@ -58,11 +58,15 @@ func (s StatusResponseWrapper) human() (string, error) {
 		stringBuilder.WriteString(fmt.Sprintf("    Version: %s\n", version))
 
 		sort.Sort(ByPartitionID(broker.Partitions))
-		for _, partition := range broker.Partitions {
-			stringBuilder.WriteString(fmt.Sprintf("    Partition %d : %s, %s\n",
+		for i, partition := range broker.Partitions {
+			stringBuilder.WriteString(fmt.Sprintf("    Partition %d : %s, %s",
 				partition.PartitionId,
 				roleToString(partition.Role),
 				healthToString(partition.Health)))
+
+			if i < len(broker.Partitions)-1 {
+				stringBuilder.WriteRune('\n')
+			}
 		}
 	}
 	return stringBuilder.String(), nil
@@ -94,7 +98,7 @@ var statusCmd = &cobra.Command{
 			return err
 		}
 
-		err = printHumanAndJSON(StatusResponseWrapper{resp})
+		err = printOutput(StatusResponseWrapper{resp})
 		if err != nil {
 			return err
 		}

--- a/clients/go/cmd/zbctl/internal/commands/throwErrorJob.go
+++ b/clients/go/cmd/zbctl/internal/commands/throwErrorJob.go
@@ -32,7 +32,7 @@ type ThrowErrorResponseWrapper struct {
 }
 
 func (t ThrowErrorResponseWrapper) human() (string, error) {
-	return fmt.Sprintf("Threw error with code '%s' on job with key %d\n", errorCode, jobKey), nil
+	return fmt.Sprintf("Threw error with code '%s' on job with key %d", errorCode, jobKey), nil
 }
 
 func (t ThrowErrorResponseWrapper) json() (string, error) {
@@ -53,7 +53,7 @@ var throwErrorJobCmd = &cobra.Command{
 			return err
 		}
 
-		err = logHumanAndPrintJSON(ThrowErrorResponseWrapper{resp})
+		err = printOutput(ThrowErrorResponseWrapper{resp})
 		return err
 	},
 }

--- a/clients/go/cmd/zbctl/internal/commands/updateRetries.go
+++ b/clients/go/cmd/zbctl/internal/commands/updateRetries.go
@@ -52,7 +52,7 @@ var updateRetriesCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		err = logHumanAndPrintJSON(UpdateJobRetriesResponseWrapper{resp})
+		err = printOutput(UpdateJobRetriesResponseWrapper{resp})
 
 		return err
 	},


### PR DESCRIPTION
## Description

Changes zbctl commands so that their output is printed to stdout with `fmt` instead of `log` and refactors output printing based on this change.

## Related issues

closes #6490 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
