### PR TITLE
chore(ci): use new cloud credentials

### DIFF
--- a/.ci/jobs/github_camunda_cloud.dsl
+++ b/.ci/jobs/github_camunda_cloud.dsl
@@ -1,0 +1,49 @@
+// vim: set filetype=groovy:
+
+organizationFolder('camunda-cloud') {
+
+    description('Jobs for https://github.com/camunda-cloud')
+    displayName('camunda-cloud')
+
+    organizations {
+        github {
+            repoOwner('camunda-cloud')
+            credentialsId('github-cloud-zeebe-app')
+
+            traits {
+                cleanBeforeCheckoutTrait {
+                    extension {
+                        deleteUntrackedNestedRepositories(false)
+                    }
+                }
+                gitHubBranchDiscovery {
+                    strategyId(3)
+                }
+                pruneStaleBranchTrait()
+                localBranchTrait()
+                sourceWildcardFilter {
+                  includes('zeebe*')
+                  excludes('')
+                }
+            }
+        }
+    }
+
+    orphanedItemStrategy {
+        discardOldItems {
+            numToKeep(10)
+        }
+    }
+
+    triggers {
+        periodicFolderTrigger {
+            interval('8h')
+        }
+    }
+
+    configure {
+        def traits = it / navigators / 'org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator' / traits
+        // Note: the 'traits' variable can be used to configure options that are
+        // not exposed via normal Jenkins API like above 'gitHubBranchDiscovery'
+    }
+}

--- a/.ci/pipelines/docker_zeebe.groovy
+++ b/.ci/pipelines/docker_zeebe.groovy
@@ -63,9 +63,9 @@ spec:
     stages {
         stage('Prepare') {
             steps {
-                git url: 'git@github.com:zeebe-io/zeebe',
+                git url: 'https://github.com/camunda-cloud/zeebe.git',
                         branch: "${params.BRANCH}",
-                        credentialsId: 'camunda-jenkins-github-ssh',
+                        credentialsId: 'github-cloud-zeebe-app',
                         poll: false
 
                 container('maven') {

--- a/.ci/pipelines/docs_zeebe_io.groovy
+++ b/.ci/pipelines/docs_zeebe_io.groovy
@@ -46,7 +46,7 @@ spec:
     stages {
         stage('Prepare') {
             steps {
-                git url: 'git@github.com:zeebe-io/zeebe', branch: "${params.BRANCH}", credentialsId: 'camunda-jenkins-github-ssh', poll: false
+                git url: 'https://github.com/camunda-cloud/zeebe.git', branch: "${params.BRANCH}", credentialsId: 'github-cloud-zeebe-app', poll: false
                 container('debian') {
                     sh '.ci/scripts/docs/prepare.sh'
                 }

--- a/.ci/pipelines/release_zeebe.groovy
+++ b/.ci/pipelines/release_zeebe.groovy
@@ -61,7 +61,7 @@ spec:
         GPG_PASS = credentials('password_maven_central_gpg_signing_key')
         GPG_PUB_KEY = credentials('maven_central_gpg_signing_key_pub')
         GPG_SEC_KEY = credentials('maven_central_gpg_signing_key_sec')
-        GITHUB_TOKEN = credentials('camunda-jenkins-github')
+        GITHUB_TOKEN = credentials('github-cloud-zeebe-app')
         RELEASE_VERSION = "${params.RELEASE_VERSION}"
         RELEASE_BRANCH = "release-${params.RELEASE_VERSION}"
         DEVELOPMENT_VERSION = "${params.DEVELOPMENT_VERSION}"
@@ -81,9 +81,9 @@ spec:
     stages {
         stage('Prepare') {
             steps {
-                git url: 'git@github.com:zeebe-io/zeebe',
+                git url: 'https://github.com/camunda-cloud/zeebe.git',
                         branch: "${env.RELEASE_BRANCH}",
-                        credentialsId: 'camunda-jenkins-github-ssh',
+                        credentialsId: 'github-cloud-zeebe-app',
                         poll: false
 
                 container('maven') {
@@ -98,9 +98,7 @@ spec:
         stage('Build') {
             steps {
                 container('golang') {
-                    sshagent(['camunda-jenkins-github-ssh']) {
-                        sh '.ci/scripts/release/build-go.sh'
-                    }
+                    sh '.ci/scripts/release/build-go.sh'
                 }
                 container('maven') {
                     configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
@@ -113,10 +111,8 @@ spec:
         stage('Maven Release') {
             steps {
                 container('maven') {
-                    sshagent(['camunda-jenkins-github-ssh']) {
-                        configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-                            sh '.ci/scripts/release/maven-release.sh'
-                        }
+                    configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                        sh '.ci/scripts/release/maven-release.sh'
                     }
                 }
             }
@@ -125,15 +121,11 @@ spec:
         stage('Update Compat Version') {
             steps {
                 container('golang') {
-                    sshagent(['camunda-jenkins-github-ssh']) {
-                        sh '.ci/scripts/release/compat-update-go.sh'
-                    }
+                    sh '.ci/scripts/release/compat-update-go.sh'
                 }
                 container('maven') {
-                    sshagent(['camunda-jenkins-github-ssh']) {
-                        configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-                            sh '.ci/scripts/release/compat-update-java.sh'
-                        }
+                    configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                        sh '.ci/scripts/release/compat-update-java.sh'
                     }
                 }
             }
@@ -144,15 +136,11 @@ spec:
             when { expression { return params.PUSH_CHANGES } }
             steps {
                 container('maven') {
-                    sshagent(['camunda-jenkins-github-ssh']) {
-                        sh '.ci/scripts/release/github-release.sh'
-                    }
+                    sh '.ci/scripts/release/github-release.sh'
                 }
 
                 container('golang') {
-                    sshagent(['camunda-jenkins-github-ssh']) {
-                        sh '.ci/scripts/release/post-github.sh'
-                    }
+                    sh '.ci/scripts/release/post-github.sh'
                 }
             }
         }

--- a/.ci/pipelines/release_zeebe_java8.groovy
+++ b/.ci/pipelines/release_zeebe_java8.groovy
@@ -61,7 +61,7 @@ spec:
         GPG_PASS = credentials('password_maven_central_gpg_signing_key')
         GPG_PUB_KEY = credentials('maven_central_gpg_signing_key_pub')
         GPG_SEC_KEY = credentials('maven_central_gpg_signing_key_sec')
-        GITHUB_TOKEN = credentials('camunda-jenkins-github')
+        GITHUB_TOKEN = credentials('github-cloud-zeebe-app')
         RELEASE_VERSION = "${params.RELEASE_VERSION}"
         RELEASE_BRANCH = "release-${params.RELEASE_VERSION}"
         DEVELOPMENT_VERSION = "${params.DEVELOPMENT_VERSION}"
@@ -81,9 +81,9 @@ spec:
     stages {
         stage('Prepare') {
             steps {
-                git url: 'git@github.com:zeebe-io/zeebe',
+                git url: 'https://github.com/camunda-cloud/zeebe.git',
                         branch: "${env.RELEASE_BRANCH}",
-                        credentialsId: 'camunda-jenkins-github-ssh',
+                        credentialsId: 'github-cloud-zeebe-app',
                         poll: false
 
                 container('maven') {
@@ -109,10 +109,8 @@ spec:
         stage('Maven Release') {
             steps {
                 container('maven') {
-                    sshagent(['camunda-jenkins-github-ssh']) {
-                        configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
-                            sh '.ci/scripts/release/maven-release.sh'
-                        }
+                    configFileProvider([configFile(fileId: 'maven-nexus-settings-zeebe', variable: 'MAVEN_SETTINGS_XML')]) {
+                        sh '.ci/scripts/release/maven-release.sh'
                     }
                 }
             }

--- a/.ci/scripts/distribution/build-go.sh
+++ b/.ci/scripts/distribution/build-go.sh
@@ -3,14 +3,14 @@ set -o pipefail
 
 export CGO_ENABLED=0
 
-ORG_DIR=${GOPATH}/src/github.com/zeebe-io
+ORG_DIR=${GOPATH}/src/github.com/camunda-cloud
 
 mkdir -p ${ORG_DIR}
 ln -s ${PWD} ${ORG_DIR}/zeebe
 
 cd ${ORG_DIR}/zeebe/clients/go
 
-PREFIX=github.com/zeebe-io/zeebe/clients/go
+PREFIX=github.com/camunda-cloud/zeebe/clients/go
 EXCLUDE=""
 
 for file in {internal,cmd/zbctl/internal}/*; do

--- a/.ci/scripts/distribution/test-go.sh
+++ b/.ci/scripts/distribution/test-go.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -eux
-ORG_DIR=${GOPATH}/src/github.com/zeebe-io
+ORG_DIR=${GOPATH}/src/github.com/camunda-cloud
 
 cd ${ORG_DIR}/zeebe/clients/go
 

--- a/.ci/scripts/release/build-go.sh
+++ b/.ci/scripts/release/build-go.sh
@@ -2,7 +2,7 @@
 
 export CGO_ENABLED=0
 
-ORG_DIR=${GOPATH}/src/github.com/zeebe-io
+ORG_DIR=${GOPATH}/src/github.com/camunda-cloud
 GOBINDATA_VERSION="3.1.3"
 
 mkdir -p ${ORG_DIR}
@@ -15,14 +15,6 @@ go install ./...
 cd ${ORG_DIR}/zeebe/clients/go/internal/embedded
 echo ${RELEASE_VERSION} > data/VERSION
 go-bindata -pkg embedded -o embedded.go -prefix data data/
-
-# configure Jenkins GitHub user
-git config --global user.email "ci@camunda.com"
-git config --global user.name "camunda-jenkins"
-
-# trust github ssh key
-mkdir -p ~/.ssh/
-ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 git commit -am "chore(project): update go embedded version data"
 git push origin ${RELEASE_BRANCH} 

--- a/.ci/scripts/release/compat-update-go.sh
+++ b/.ci/scripts/release/compat-update-go.sh
@@ -7,7 +7,7 @@ if [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   mv /usr/bin/gocompat_linux_amd64 /usr/bin/gocompat
   chmod +x /usr/bin/gocompat
 
-  cd ${GOPATH}/src/github.com/zeebe-io/zeebe/clients/go
+  cd ${GOPATH}/src/github.com/camunda-cloud/zeebe/clients/go
   gocompat save ./...
 
   git commit -am "chore(project): update go versions"

--- a/.ci/scripts/release/github-release.sh
+++ b/.ci/scripts/release/github-release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xeu
 
 export GITHUB_TOKEN=${GITHUB_TOKEN_PSW}
-export GITHUB_ORG=zeebe-io
+export GITHUB_ORG=camunda-cloud
 export GITHUB_REPO=zeebe
 
 curl -sL https://github.com/meterup/github-release/releases/download/v0.7.5/linux-amd64-github-release.bz2 | bzip2 -fd - > github-release

--- a/.ci/scripts/release/post-github.sh
+++ b/.ci/scripts/release/post-github.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ${GOPATH}/src/github.com/zeebe-io/zeebe/clients/go/internal/embedded
+cd ${GOPATH}/src/github.com/camunda-cloud/zeebe/clients/go/internal/embedded
 
 echo ${DEVELOPMENT_VERSION} > data/VERSION
 go-bindata -pkg embedded -o embedded.go -prefix data/ data/

--- a/.ci/scripts/release/prepare-go.sh
+++ b/.ci/scripts/release/prepare-go.sh
@@ -1,5 +1,9 @@
 #!/bin/sh -eux
 
+# configure Jenkins GitHub user for GO container
+git config --global user.email "ci@camunda.com"
+git config --global user.name "camunda-jenkins"
+
 GOCOMPAT_VERSION="v0.2.0"
 
 curl -sL https://github.com/smola/gocompat/releases/download/${GOCOMPAT_VERSION}/gocompat_linux_amd64.tar.gz | tar xzvf - -C /usr/bin gocompat_linux_amd64

--- a/.ci/scripts/release/prepare.sh
+++ b/.ci/scripts/release/prepare.sh
@@ -1,6 +1,10 @@
 #!/bin/bash -xue
 
-# configure Jenkins GitHub user
+# remove origin and use GitHub App (reflected on filesystem and globally active)
+git remote remove origin
+git remote add origin https://${GITHUB_TOKEN_USR}:${GITHUB_TOKEN_PSW}@github.com/camunda-cloud/zeebe.git
+
+# configure Jenkins GitHub user for Maven container
 git config --global user.email "ci@camunda.com"
 git config --global user.name "camunda-jenkins"
 

--- a/.ci/seed.dsl
+++ b/.ci/seed.dsl
@@ -17,8 +17,8 @@ def seedJob = job('seed-job-zeebe') {
   scm {
     git {
       remote {
-        github 'zeebe-io/zeebe', 'ssh'
-        credentials 'camunda-jenkins-github-ssh'
+        github 'camunda-cloud/zeebe', 'https'
+        credentials 'github-cloud-zeebe-app'
       }
       branch 'develop'
       extensions {

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
   </modules>
 
   <scm>
-    <url>https://github.com/zeebe-io/zeebe</url>
-    <connection>scm:git:git@github.com:zeebe-io/zeebe.git</connection>
-    <developerConnection>scm:git:git@github.com:zeebe-io/zeebe.git</developerConnection>
+    <url>https://github.com/camunda-cloud/zeebe</url>
+    <connection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda-cloud/zeebe.git</connection>
+    <developerConnection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda-cloud/zeebe.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
add cloud org folder

## Description

**Do not merge before the credentials are not active on the zeebe jenkins**

Due to moving the zeebe repository from `zeebe-io` to `camunda-cloud`, a new GitHub credential is needed since we don't share the app publicly across organizations.
For this, a new organization folder is added to cover the `camunda-cloud` org and includes all repositories that start with `zeebe*` and include a `Jenkinsfile`.
Repositories that don't fit this use case can be added appending a space and the repository name (with or without wildcard).

Since the Camunda-Cloud Orga will not include the `camunda-jenkins` user and as we, infra, want to get rid of the user, the GitHub app will be used for most operations.

Similar to the changes done in [operate](https://github.com/camunda-cloud/operate/pull/1054) and [tasklist](https://github.com/camunda-cloud/tasklist/pull/798).
The GitHub App will sign a token, which can be used for cloning and other operations concerning GitHub.
Therefore, all clones are switched to `https`, for the release process the `jenkins ssh key` is removed, and the origin is changed to include the auth for scripts to be able to commit and push throughout the process.

From the zeebe team it would be interesting to know whether those `ORG_DIR` related to go have to be changed or not.

## Related issues

related to [INFRA-2231](https://jira.camunda.com/browse/INFRA-2231)

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
