### PR TITLE
Update bors merge commit titles

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -6,4 +6,6 @@ required_approvals = 1
 
 delete_merged_branches = true
 
+commit_title = "merge: ${PR_REFS}"
+
 cut_body_after = "# Pull Request Checklist"


### PR DESCRIPTION
## Description

Bors nowadays supports changing the commit title template for the merge commits it creates. This PR uses that template to align the commit title with the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format used within this repo.

With this commit template, bors will create merge commits with titles like:
`merge: #123`, `merge: #123 #124`, `merge: #123 #124 #125`, etc

## Related issues

No related issues
