### PR TITLE
feat(clients/java): Introduce the new client builder for Camunda Cloud clusters

### DIFF
--- a/clients/java/ignored-changes.xml
+++ b/clients/java/ignored-changes.xml
@@ -22,4 +22,9 @@
     <differenceType>7012</differenceType>
     <method>io.zeebe.client.api.worker.JobWorkerBuilderStep1$JobWorkerBuilderStep3 backoffSupplier(io.zeebe.client.api.worker.BackoffSupplier)</method>
   </difference>
+  <difference>
+    <className>io/zeebe/client/ZeebeClient</className>
+    <differenceType>7012</differenceType>
+    <method>io.zeebe.client.ZeebeClientCloudBuilderStep1 newCloudClientBuilder()</method>
+  </difference>
 </differences>

--- a/clients/java/src/main/java/io/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/zeebe/client/ClientProperties.java
@@ -51,4 +51,21 @@ public final class ClientProperties {
 
   /** @see io.zeebe.client.ZeebeClientBuilder#keepAlive(Duration) */
   public static final String KEEP_ALIVE = "zeebe.client.keepalive";
+
+  /** @see ZeebeClientCloudBuilderStep1#withClusterId(java.lang.String) */
+  public static final String CLOUD_CLUSTER_ID = "zeebe.client.cloud.clusterId";
+
+  /**
+   * @see ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2#withClientId(java.lang.String)
+   */
+  public static final String CLOUD_CLIENT_ID = "zeebe.client.cloud.clientId";
+
+  /**
+   * @see
+   *     ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3#withClientSecret(
+   *     java.lang.String)
+   */
+  public static final String CLOUD_CLIENT_SECRET = "zeebe.client.cloud.secret";
+
+  private ClientProperties() {}
 }

--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClient.java
@@ -27,6 +27,7 @@ import io.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
 import io.zeebe.client.api.worker.JobClient;
 import io.zeebe.client.api.worker.JobWorkerBuilderStep1;
 import io.zeebe.client.impl.ZeebeClientBuilderImpl;
+import io.zeebe.client.impl.ZeebeClientCloudBuilderImpl;
 import io.zeebe.client.impl.ZeebeClientImpl;
 
 /** The client to communicate with a Zeebe broker/cluster. */
@@ -50,6 +51,11 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
   /** @return a builder to configure and create a new {@link ZeebeClient}. */
   static ZeebeClientBuilder newClientBuilder() {
     return new ZeebeClientBuilderImpl();
+  }
+
+  /** @return a builder with convenient methods to connect to the Camunda Cloud cluster. */
+  static ZeebeClientCloudBuilderStep1 newCloudClientBuilder() {
+    return new ZeebeClientCloudBuilderImpl();
   }
 
   /**

--- a/clients/java/src/main/java/io/zeebe/client/ZeebeClientCloudBuilderStep1.java
+++ b/clients/java/src/main/java/io/zeebe/client/ZeebeClientCloudBuilderStep1.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client;
+
+public interface ZeebeClientCloudBuilderStep1 {
+
+  /**
+   * Sets the cluster id of the Camunda Cloud cluster. This parameter is mandatory.
+   *
+   * @param clusterId cluster id of the Camunda Cloud cluster.
+   */
+  ZeebeClientCloudBuilderStep2 withClusterId(String clusterId);
+
+  interface ZeebeClientCloudBuilderStep2 {
+
+    /**
+     * Sets the client id that will be used to authenticate against the Camunda Cloud cluster. This
+     * parameter is mandatory.
+     *
+     * @param clientId client id that will be used in the authentication.
+     */
+    ZeebeClientCloudBuilderStep3 withClientId(String clientId);
+
+    interface ZeebeClientCloudBuilderStep3 {
+
+      /**
+       * Sets the client secret that will be used to authenticate against the Camunda Cloud cluster.
+       * This parameter is mandatory.
+       *
+       * @param clientSecret client secret that will be used in the authentication.
+       */
+      ZeebeClientCloudBuilderStep4 withClientSecret(String clientSecret);
+
+      interface ZeebeClientCloudBuilderStep4 extends ZeebeClientBuilder {}
+    }
+  }
+}

--- a/clients/java/src/main/java/io/zeebe/client/impl/BuilderUtils.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/BuilderUtils.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl;
+
+final class BuilderUtils {
+
+  private BuilderUtils() {}
+
+  static void appendProperty(
+      final StringBuilder sb, final String propertyName, final Object value) {
+    sb.append(propertyName).append(": ").append(value).append("\n");
+  }
+}

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -20,6 +20,7 @@ import static io.zeebe.client.ClientProperties.DEFAULT_MESSAGE_TIME_TO_LIVE;
 import static io.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
 import static io.zeebe.client.ClientProperties.KEEP_ALIVE;
 import static io.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
+import static io.zeebe.client.impl.BuilderUtils.appendProperty;
 
 import io.grpc.ClientInterceptor;
 import io.zeebe.client.ClientProperties;
@@ -40,9 +41,10 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   public static final String PLAINTEXT_CONNECTION_VAR = "ZEEBE_INSECURE_CONNECTION";
   public static final String CA_CERTIFICATE_VAR = "ZEEBE_CA_CERTIFICATE_PATH";
   public static final String KEEP_ALIVE_VAR = "ZEEBE_KEEP_ALIVE";
+  public static final String DEFAULT_GATEWAY_ADDRESS = "0.0.0.0:26500";
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
-  private String gatewayAddress = "0.0.0.0:26500";
+  private String gatewayAddress = DEFAULT_GATEWAY_ADDRESS;
   private int jobWorkerMaxJobsActive = 32;
   private int numJobWorkerExecutionThreads = 1;
   private String defaultJobWorkerName = "default";
@@ -336,10 +338,5 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     }
 
     return builder.build();
-  }
-
-  private static void appendProperty(
-      final StringBuilder sb, final String propertyName, final Object value) {
-    sb.append(propertyName).append(": ").append(value).append("\n");
   }
 }

--- a/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.client.impl;
+
+import static io.zeebe.client.impl.BuilderUtils.appendProperty;
+import static io.zeebe.client.impl.command.ArgumentUtil.ensureNotNull;
+
+import io.grpc.ClientInterceptor;
+import io.zeebe.client.ClientProperties;
+import io.zeebe.client.CredentialsProvider;
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.ZeebeClientBuilder;
+import io.zeebe.client.ZeebeClientCloudBuilderStep1;
+import io.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2;
+import io.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3;
+import io.zeebe.client.ZeebeClientCloudBuilderStep1.ZeebeClientCloudBuilderStep2.ZeebeClientCloudBuilderStep3.ZeebeClientCloudBuilderStep4;
+import io.zeebe.client.api.JsonMapper;
+import io.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Properties;
+
+public class ZeebeClientCloudBuilderImpl
+    implements ZeebeClientCloudBuilderStep1,
+        ZeebeClientCloudBuilderStep2,
+        ZeebeClientCloudBuilderStep3,
+        ZeebeClientCloudBuilderStep4 {
+
+  private static final String BASE_ADDRESS = "zeebe.camunda.io";
+  private static final String BASE_AUTH_URL = "https://login.cloud.camunda.io/oauth/token";
+
+  private final ZeebeClientBuilderImpl innerBuilder = new ZeebeClientBuilderImpl();
+
+  private String clusterId;
+  private String clientId;
+  private String clientSecret;
+
+  @Override
+  public ZeebeClientCloudBuilderStep2 withClusterId(final String clusterId) {
+    this.clusterId = clusterId;
+    return this;
+  }
+
+  @Override
+  public ZeebeClientCloudBuilderStep3 withClientId(final String clientId) {
+    this.clientId = clientId;
+    return this;
+  }
+
+  @Override
+  public ZeebeClientCloudBuilderStep4 withClientSecret(final String clientSecret) {
+    this.clientSecret = clientSecret;
+    return this;
+  }
+
+  @Override
+  public ZeebeClientBuilder gatewayAddress(final String gatewayAddress) {
+    return innerBuilder.gatewayAddress(gatewayAddress);
+  }
+
+  @Override
+  public ZeebeClientBuilder usePlaintext() {
+    return innerBuilder.usePlaintext();
+  }
+
+  @Override
+  public ZeebeClientBuilder credentialsProvider(final CredentialsProvider credentialsProvider) {
+    return innerBuilder.credentialsProvider(credentialsProvider);
+  }
+
+  @Override
+  public ZeebeClientBuilder withProperties(final Properties properties) {
+    if (properties.containsKey(ClientProperties.CLOUD_CLUSTER_ID)) {
+      withClusterId(properties.getProperty(ClientProperties.CLOUD_CLUSTER_ID));
+    }
+    if (properties.containsKey(ClientProperties.CLOUD_CLIENT_ID)) {
+      withClientId(properties.getProperty(ClientProperties.CLOUD_CLIENT_ID));
+    }
+    if (properties.containsKey(ClientProperties.CLOUD_CLIENT_SECRET)) {
+      withClientSecret(properties.getProperty(ClientProperties.CLOUD_CLIENT_SECRET));
+    }
+    return innerBuilder.withProperties(properties);
+  }
+
+  @Override
+  public ZeebeClientBuilder defaultJobWorkerMaxJobsActive(final int maxJobsActive) {
+    return innerBuilder.defaultJobWorkerMaxJobsActive(maxJobsActive);
+  }
+
+  @Override
+  public ZeebeClientBuilder numJobWorkerExecutionThreads(final int numThreads) {
+    return innerBuilder.numJobWorkerExecutionThreads(numThreads);
+  }
+
+  @Override
+  public ZeebeClientBuilder defaultJobWorkerName(final String workerName) {
+    return innerBuilder.defaultJobWorkerName(workerName);
+  }
+
+  @Override
+  public ZeebeClientBuilder defaultJobTimeout(final Duration timeout) {
+    return innerBuilder.defaultJobTimeout(timeout);
+  }
+
+  @Override
+  public ZeebeClientBuilder defaultJobPollInterval(final Duration pollInterval) {
+    return innerBuilder.defaultJobPollInterval(pollInterval);
+  }
+
+  @Override
+  public ZeebeClientBuilder defaultMessageTimeToLive(final Duration timeToLive) {
+    return innerBuilder.defaultMessageTimeToLive(timeToLive);
+  }
+
+  @Override
+  public ZeebeClientBuilder defaultRequestTimeout(final Duration requestTimeout) {
+    return innerBuilder.defaultRequestTimeout(requestTimeout);
+  }
+
+  @Override
+  public ZeebeClientBuilder caCertificatePath(final String certificatePath) {
+    return innerBuilder.caCertificatePath(certificatePath);
+  }
+
+  @Override
+  public ZeebeClientBuilder keepAlive(final Duration keepAlive) {
+    return innerBuilder.keepAlive(keepAlive);
+  }
+
+  @Override
+  public ZeebeClientBuilder withInterceptors(final ClientInterceptor... interceptor) {
+    return innerBuilder.withInterceptors(interceptor);
+  }
+
+  @Override
+  public ZeebeClientBuilder withJsonMapper(final JsonMapper jsonMapper) {
+    return innerBuilder.withJsonMapper(jsonMapper);
+  }
+
+  @Override
+  public ZeebeClient build() {
+    innerBuilder.gatewayAddress(determineGatewayAddress());
+    innerBuilder.credentialsProvider(determineCredentialsProvider());
+    return innerBuilder.build();
+  }
+
+  private String determineGatewayAddress() {
+    if (isNeedToSetCloudGatewayAddress()) {
+      ensureNotNull("cluster id", clusterId);
+      return String.format("%s.%s:443", clusterId, BASE_ADDRESS);
+    } else {
+      Loggers.LOGGER.debug(
+          "Expected to use 'cluster id' to set gateway address in the client cloud builder, "
+              + "but overwriting with explicitly defined gateway address: {}.",
+          innerBuilder.getGatewayAddress());
+      return innerBuilder.getGatewayAddress();
+    }
+  }
+
+  private CredentialsProvider determineCredentialsProvider() {
+    final CredentialsProvider provider = innerBuilder.getCredentialsProvider();
+    if (provider == null) {
+      ensureNotNull("cluster id", clusterId);
+      ensureNotNull("client id", clientId);
+      ensureNotNull("client secret", clientSecret);
+      final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
+      return builder
+          .audience(String.format("%s.%s", clusterId, BASE_ADDRESS))
+          .clientId(clientId)
+          .clientSecret(clientSecret)
+          .authorizationServerUrl(BASE_AUTH_URL)
+          .build();
+    } else {
+      Loggers.LOGGER.debug(
+          "Expected to use 'cluster id', 'client id' and 'client secret' to set credentials provider in the client cloud builder, "
+              + "but overwriting with explicitly defined credentials provider.");
+      return provider;
+    }
+  }
+
+  private boolean isNeedToSetCloudGatewayAddress() {
+    return innerBuilder.getGatewayAddress() == null
+        || Objects.equals(
+            innerBuilder.getGatewayAddress(), ZeebeClientBuilderImpl.DEFAULT_GATEWAY_ADDRESS);
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder(innerBuilder.toString());
+    appendProperty(sb, "clusterId", clusterId);
+    appendProperty(sb, "clientId", clientId);
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
## Description

This request contains the new client builder, which is convenient to use with Camunda Cloud.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3932 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
