### PR TITLE
Apply event sourcing to the incident create and created processors

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/incident/CreateIncidentProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/incident/CreateIncidentProcessor.java
@@ -11,10 +11,10 @@ import io.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.immutable.ElementInstanceState;
+import io.zeebe.engine.state.immutable.IncidentState;
 import io.zeebe.engine.state.immutable.JobState;
 import io.zeebe.engine.state.immutable.JobState.State;
 import io.zeebe.engine.state.instance.IndexedRecord;
-import io.zeebe.engine.state.mutable.MutableIncidentState;
 import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.IncidentIntent;
@@ -31,7 +31,7 @@ public final class CreateIncidentProcessor implements CommandProcessor<IncidentR
 
   private final ElementInstanceState elementInstanceState;
   private final JobState jobState;
-  private final MutableIncidentState incidentState;
+  private final IncidentState incidentState;
 
   public CreateIncidentProcessor(final ZeebeState zeebeState) {
     jobState = zeebeState.getJobState();
@@ -48,8 +48,7 @@ public final class CreateIncidentProcessor implements CommandProcessor<IncidentR
     final boolean incidentIsNotRejected = !tryRejectIncidentCreation(incidentEvent, commandControl);
 
     if (incidentIsNotRejected) {
-      final long incidentKey = commandControl.accept(IncidentIntent.CREATED, incidentEvent);
-      incidentState.createIncident(incidentKey, incidentEvent);
+      commandControl.accept(IncidentIntent.CREATED, incidentEvent);
     }
 
     return true;

--- a/engine/src/main/java/io/zeebe/engine/processing/incident/CreateIncidentProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/incident/CreateIncidentProcessor.java
@@ -11,10 +11,10 @@ import io.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.engine.state.immutable.ElementInstanceState;
-import io.zeebe.engine.state.immutable.IncidentState;
 import io.zeebe.engine.state.immutable.JobState;
 import io.zeebe.engine.state.immutable.JobState.State;
 import io.zeebe.engine.state.instance.IndexedRecord;
+import io.zeebe.engine.state.mutable.MutableIncidentState;
 import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.IncidentIntent;
@@ -29,10 +29,14 @@ public final class CreateIncidentProcessor implements CommandProcessor<IncidentR
   private static final String NO_FAILED_JOB_MESSAGE =
       "Expected to create incident for failed job with key '%d', but no such job was found";
 
-  private final ZeebeState zeebeState;
+  private final ElementInstanceState elementInstanceState;
+  private final JobState jobState;
+  private final MutableIncidentState incidentState;
 
   public CreateIncidentProcessor(final ZeebeState zeebeState) {
-    this.zeebeState = zeebeState;
+    jobState = zeebeState.getJobState();
+    elementInstanceState = zeebeState.getElementInstanceState();
+    incidentState = zeebeState.getIncidentState();
   }
 
   @Override
@@ -41,51 +45,53 @@ public final class CreateIncidentProcessor implements CommandProcessor<IncidentR
       final CommandControl<IncidentRecord> commandControl) {
     final IncidentRecord incidentEvent = command.getValue();
 
-    final boolean incidentIsNotRejected = !rejectIncidentCreation(incidentEvent, commandControl);
+    final boolean incidentIsNotRejected = !tryRejectIncidentCreation(incidentEvent, commandControl);
 
     if (incidentIsNotRejected) {
       final long incidentKey = commandControl.accept(IncidentIntent.CREATED, incidentEvent);
-      zeebeState.getIncidentState().createIncident(incidentKey, incidentEvent);
+      incidentState.createIncident(incidentKey, incidentEvent);
     }
 
     return true;
   }
 
-  public boolean rejectIncidentCreation(
+  /** @return true if rejected, otherwise false */
+  public boolean tryRejectIncidentCreation(
       final IncidentRecord incidentEvent, final CommandControl<IncidentRecord> commandControl) {
-    final IncidentState incidentState = zeebeState.getIncidentState();
 
     final boolean isJobIncident = incidentState.isJobIncident(incidentEvent);
 
     if (isJobIncident) {
-      return rejectJobIncident(incidentEvent.getJobKey(), commandControl);
+      return tryRejectJobIncident(incidentEvent.getJobKey(), commandControl);
     } else {
-      return rejectWorkflowInstanceIncident(incidentEvent.getElementInstanceKey(), commandControl);
+      return tryRejectWorkflowInstanceIncident(
+          incidentEvent.getElementInstanceKey(), commandControl);
     }
   }
 
-  private boolean rejectJobIncident(
+  /** @return true if rejected, otherwise false */
+  private boolean tryRejectJobIncident(
       final long jobKey, final CommandControl<IncidentRecord> commandControl) {
-    final JobState state = zeebeState.getJobState();
-    final JobState.State jobState = state.getState(jobKey);
 
-    if (jobState == State.NOT_FOUND) {
+    final JobState.State currentJobState = jobState.getState(jobKey);
+
+    if (currentJobState == State.NOT_FOUND) {
       commandControl.reject(RejectionType.NOT_FOUND, String.format(NO_FAILED_JOB_MESSAGE, jobKey));
       return true;
 
-    } else if (jobState != State.FAILED && jobState != State.ERROR_THROWN) {
+    } else if (currentJobState != State.FAILED && currentJobState != State.ERROR_THROWN) {
       commandControl.reject(
-          RejectionType.INVALID_STATE, String.format(INVALID_JOB_STATE_MESSAGE, jobKey, jobState));
+          RejectionType.INVALID_STATE,
+          String.format(INVALID_JOB_STATE_MESSAGE, jobKey, currentJobState));
       return true;
     }
 
     return false;
   }
 
-  private boolean rejectWorkflowInstanceIncident(
+  /** @return true if rejected, otherwise false */
+  private boolean tryRejectWorkflowInstanceIncident(
       final long elementInstanceKey, final CommandControl<IncidentRecord> commandControl) {
-    final ElementInstanceState elementInstanceState = zeebeState.getElementInstanceState();
-
     final IndexedRecord failedRecord = elementInstanceState.getFailedRecord(elementInstanceKey);
     final boolean noFailedRecord = failedRecord == null;
     if (noFailedRecord) {

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.processing.streamprocessor;
 
 import io.zeebe.protocol.impl.record.value.workflowinstance.WorkflowInstanceRecord;
 import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.intent.IncidentIntent;
 import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
@@ -87,6 +88,11 @@ public final class MigratedStreamProcessors {
 
     MIGRATED_VALUE_TYPES.put(ValueType.VARIABLE_DOCUMENT, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.VARIABLE, MIGRATED);
+
+    MIGRATED_VALUE_TYPES.put(
+        ValueType.INCIDENT,
+        MIGRATED_INTENT_FILTER_FACTORY.apply(
+            List.of(IncidentIntent.CREATE, IncidentIntent.CREATED)));
   }
 
   private MigratedStreamProcessors() {}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -14,6 +14,7 @@ import io.zeebe.engine.state.ZeebeState;
 import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.zeebe.protocol.record.intent.DeploymentIntent;
+import io.zeebe.protocol.record.intent.IncidentIntent;
 import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.intent.MessageIntent;
@@ -76,6 +77,7 @@ public final class EventAppliers implements EventApplier {
 
     registerJobIntentEventAppliers(state);
     registerVariableEventAppliers(state);
+    registerIncidentEventAppliers(state);
   }
 
   private void registerVariableEventAppliers(final ZeebeState state) {
@@ -135,6 +137,10 @@ public final class EventAppliers implements EventApplier {
     register(
         MessageSubscriptionIntent.DELETED,
         new MessageSubscriptionDeletedApplier(state.getMessageSubscriptionState()));
+  }
+
+  private void registerIncidentEventAppliers(final ZeebeState state) {
+    register(IncidentIntent.CREATED, new IncidentCreatedApplier(state.getIncidentState()));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/IncidentCreatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/IncidentCreatedApplier.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.mutable.MutableIncidentState;
+import io.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import io.zeebe.protocol.record.intent.IncidentIntent;
+
+final class IncidentCreatedApplier implements TypedEventApplier<IncidentIntent, IncidentRecord> {
+
+  private final MutableIncidentState incidentState;
+
+  public IncidentCreatedApplier(final MutableIncidentState incidentState) {
+    this.incidentState = incidentState;
+  }
+
+  @Override
+  public void applyState(final long incidentKey, final IncidentRecord value) {
+    incidentState.createIncident(incidentKey, value);
+  }
+}


### PR DESCRIPTION
## Description

- introduces `IncidentCreatedEventApplier`
- removes state changes from `CreateIncidentProcesssor`
- migrates `Create` and `Created` Incident records

For the reviewer: 
- I've split up the commits into 2 commits: 1 for refactoring and 1 for the logic change
- this does not yet close the issue, incident:resolve and resolved also need to be migrated still

## Related issues

relates #6174 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
