### PR TITLE
Migrate activate child instance

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -47,7 +47,11 @@ public final class BpmnStateBehavior {
   }
 
   public ElementInstance getElementInstance(final BpmnElementContext context) {
-    return elementInstanceState.getInstance(context.getElementInstanceKey());
+    return getElementInstance(context.getElementInstanceKey());
+  }
+
+  public ElementInstance getElementInstance(final long elementInstanceKey) {
+    return elementInstanceState.getInstance(elementInstanceKey);
   }
 
   public void updateElementInstance(final ElementInstance elementInstance) {

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -194,7 +194,7 @@ public final class BpmnStateTransitionBehavior {
     }
   }
 
-  public ElementInstance activateChildInstance(
+  public long activateChildInstance(
       final BpmnElementContext context, final ExecutableFlowElement childElement) {
 
     final var childInstanceRecord =
@@ -206,12 +206,10 @@ public final class BpmnStateTransitionBehavior {
 
     final var childInstanceKey = keyGenerator.nextKey();
 
-    streamWriter.appendFollowUpEvent(
+    stateWriter.appendFollowUpEvent(
         childInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATING, childInstanceRecord);
 
-    stateBehavior.updateElementInstance(context, ElementInstance::spawnToken);
-
-    return stateBehavior.createChildElementInstance(context, childInstanceKey, childInstanceRecord);
+    return childInstanceKey;
   }
 
   public void activateElementInstanceInFlowScope(
@@ -290,6 +288,7 @@ public final class BpmnStateTransitionBehavior {
     final var outgoingSequenceFlows = element.getOutgoing();
     if (outgoingSequenceFlows.isEmpty()) {
       // behaves like an implicit end event
+
       onElementCompleted(element, context);
 
     } else {

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -231,13 +231,16 @@ public final class MultiInstanceBodyProcessor
       final BpmnElementContext context,
       final DirectBuffer item) {
 
-    final var innerInstance =
+    final var innerInstanceKey =
         stateTransitionBehavior.activateChildInstance(
             context, multiInstanceBody.getInnerActivity());
+
+    final var innerInstance = stateBehavior.getElementInstance(innerInstanceKey);
     final var innerInstanceContext =
-        context.copy(innerInstance.getKey(), innerInstance.getValue(), innerInstance.getState());
+        context.copy(innerInstanceKey, innerInstance.getValue(), innerInstance.getState());
 
     // update loop counters
+    // todo(zell): updating the elemint instance can be moved in the activating of the child
     final var bodyInstance = stateBehavior.getElementInstance(context);
     bodyInstance.incrementMultiInstanceLoopCounter();
     stateBehavior.updateElementInstance(bodyInstance);

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -64,11 +64,12 @@ public final class SubProcessProcessor
     } else {
       // event sub-process is activated
       final var startEvent = element.getStartEvents().get(0);
-      final var childInstance = stateTransitionBehavior.activateChildInstance(context, startEvent);
+      final var childInstanceKey =
+          stateTransitionBehavior.activateChildInstance(context, startEvent);
 
       // the event variables are stored as temporary variables in the scope of the subprocess
       // - move them to the scope of the start event to apply the output variable mappings
-      stateBehavior.transferTemporaryVariables(context, childInstance.getKey());
+      stateBehavior.transferTemporaryVariables(context, childInstanceKey);
     }
   }
 


### PR DESCRIPTION
## Description

Migrates activating of child instances. It will spawn for container elements new tokens. This is necessary for migrating sub process and multi instance.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #6195 
related #6198 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
