### PR TITLE
Migrate transfer variables on sub process

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -249,16 +249,4 @@ public final class BpmnStateBehavior {
         variablesState.getVariablesAsDocument(sourceContext.getElementInstanceKey());
     variablesState.setTemporaryVariables(targetContext.getElementInstanceKey(), variables);
   }
-
-  public void transferTemporaryVariables(
-      final BpmnElementContext sourceContext, final long targetElementInstanceKey) {
-
-    final var variables =
-        variablesState.getTemporaryVariables(sourceContext.getElementInstanceKey());
-
-    if (variables != null) {
-      variablesState.setTemporaryVariables(targetElementInstanceKey, variables);
-      variablesState.removeTemporaryVariables(sourceContext.getElementInstanceKey());
-    }
-  }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -16,6 +16,7 @@ import io.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 
 public final class SubProcessProcessor
@@ -56,21 +57,16 @@ public final class SubProcessProcessor
   public void onActivated(
       final ExecutableFlowElementContainer element, final BpmnElementContext context) {
 
+    final ExecutableStartEvent startEvent;
     if (element.hasNoneStartEvent()) {
       // embedded sub-process is activated
-      final var noneStartEvent = element.getNoneStartEvent();
-      stateTransitionBehavior.activateChildInstance(context, noneStartEvent);
-
+      startEvent = element.getNoneStartEvent();
     } else {
       // event sub-process is activated
-      final var startEvent = element.getStartEvents().get(0);
-      final var childInstanceKey =
-          stateTransitionBehavior.activateChildInstance(context, startEvent);
-
-      // the event variables are stored as temporary variables in the scope of the subprocess
-      // - move them to the scope of the start event to apply the output variable mappings
-      stateBehavior.transferTemporaryVariables(context, childInstanceKey);
+      startEvent = element.getStartEvents().get(0);
     }
+
+    stateTransitionBehavior.activateChildInstance(context, startEvent);
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -97,9 +97,11 @@ public final class EventAppliers implements EventApplier {
     final var elementInstanceState = state.getElementInstanceState();
     final var eventScopeInstanceState = state.getEventScopeInstanceState();
     final var processState = state.getProcessState();
+    final var variableState = state.getVariableState();
     register(
         ProcessInstanceIntent.ELEMENT_ACTIVATING,
-        new ProcessInstanceElementActivatingApplier(elementInstanceState));
+        new ProcessInstanceElementActivatingApplier(
+            elementInstanceState, processState, variableState));
     register(
         ProcessInstanceIntent.ELEMENT_ACTIVATED,
         new ProcessInstanceElementActivatedApplier(

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -7,10 +7,13 @@
  */
 package io.zeebe.engine.state.appliers;
 
+import io.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
 import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.immutable.ProcessState;
 import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.engine.state.instance.StoredRecord.Purpose;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.zeebe.engine.state.mutable.MutableVariableState;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
@@ -20,10 +23,16 @@ final class ProcessInstanceElementActivatingApplier
     implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
 
   private final MutableElementInstanceState elementInstanceState;
+  private final MutableVariableState variableState;
+  private final ProcessState processState;
 
   public ProcessInstanceElementActivatingApplier(
-      final MutableElementInstanceState elementInstanceState) {
+      final MutableElementInstanceState elementInstanceState,
+      final ProcessState processState,
+      final MutableVariableState variableState) {
     this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
+    this.variableState = variableState;
   }
 
   @Override
@@ -50,6 +59,31 @@ final class ProcessInstanceElementActivatingApplier
       // we might spawn tokens for other bpmn element types as well later, then we can improve
       // here
       elementInstanceState.spawnToken(flowScopeInstance.getKey());
+    }
+
+    if (isStartEventInSubProcess(flowScopeElementType, currentElementType)) {
+
+      final var executableStartEvent =
+          processState.getFlowElement(
+              value.getProcessDefinitionKey(),
+              value.getElementIdBuffer(),
+              ExecutableStartEvent.class);
+      if (!executableStartEvent.isNone()) {
+        // IF the current element is a start event and the flow scope is a sub process
+        // then it is either a none start event, which means it is a normal *embedded sub process*
+        // or an timer/message start event, which means it is a *event sub process*
+        // *Only for event sub processes we transfer variables*
+
+        // the event variables are stored as temporary variables in the scope of the
+        // subprocess
+        // - move them to the scope of the start event to apply the output variable mappings
+        final var variables = variableState.getTemporaryVariables(flowScopeInstance.getKey());
+
+        if (variables != null) {
+          variableState.setTemporaryVariables(elementInstanceKey, variables);
+          variableState.removeTemporaryVariables(flowScopeInstance.getKey());
+        }
+      }
     }
 
     // We store the record to use it on resolving the incident, which is no longer used after
@@ -80,6 +114,12 @@ final class ProcessInstanceElementActivatingApplier
     return elementInstance.getNumberOfActiveTokens() == 2
         && elementInstance.isInterrupted()
         && elementInstance.isActive();
+  }
+
+  private boolean isStartEventInSubProcess(
+      final BpmnElementType flowScopeElementType, final BpmnElementType currentElementType) {
+    return currentElementType == BpmnElementType.START_EVENT
+        && flowScopeElementType == BpmnElementType.SUB_PROCESS;
   }
 
   private boolean isContainerElement(


### PR DESCRIPTION
## Description

Migrates the transferring of the variables for sub processes, necessary to migrate sub process processor.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #6195 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
