### PR TITLE
Incidents on failing jobs generate a new key

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobFailProcessor.java
@@ -78,7 +78,7 @@ public final class JobFailProcessor implements CommandProcessor<JobRecord> {
           .setJobKey(key)
           .setVariableScopeKey(value.getElementInstanceKey());
 
-      commandWriter.appendFollowUpCommand(key, IncidentIntent.CREATE, incidentEvent);
+      commandWriter.appendNewCommand(IncidentIntent.CREATE, incidentEvent);
     }
   }
 }


### PR DESCRIPTION
## Description

This PR fixes a bug where on failing jobs, new incidents would always have the job key as their key, resulting in multiple incidents sharing the same key and overwriting each other. We now always use a newly generated key.

## Related issues

closes #6516 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
