### PR TITLE
Use state writer in BpmnEventSubscriptionBehavior

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -50,6 +50,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
           processorLookup,
       final Writers writers) {
 
+    final var stateWriter = writers.state();
+    final var commandWriter = writers.command();
     this.streamWriter = streamWriter;
     this.expressionBehavior = expressionBehavior;
 
@@ -71,7 +73,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             stateBehavior,
             stateTransitionBehavior,
             catchEventBehavior,
-            streamWriter,
+            stateWriter,
+            commandWriter,
             sideEffects,
             zeebeState);
     incidentBehavior = new BpmnIncidentBehavior(zeebeState, streamWriter);


### PR DESCRIPTION
## Description

Use the state writer in the BpmnEventSubscriptionBehavior.  Can be seen as good step to migrate the behavior and related processors which uses this behavior. It is used by SubProcessProcessor and others to trigger events etc.

I was first not sure whether it is good to already migrate the complete behavior, but after I managed it and all tests are green it feels better :laughing: Still I have the feeling we are not supporting all cases with that and we are limited by our tests, if we had more (broader) tests we might find some stuff.

\cc @korthout @saig0 
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #6195 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
