### PR TITLE
feat(clients/go): add the host and the port arguments

### DIFF
--- a/clients/go/cmd/zbctl/testdata/help.golden
+++ b/clients/go/cmd/zbctl/testdata/help.golden
@@ -35,6 +35,8 @@ Flags:
       --clientId string       Specify a client identifier to request an access token. If omitted, will read from the environment variable 'ZEEBE_CLIENT_ID'
       --clientSecret string   Specify a client secret to request an access token. If omitted, will read from the environment variable 'ZEEBE_CLIENT_SECRET'
   -h, --help                  help for zbctl
+      --host string           Specify the host part of the gateway address. If omitted, will read from the environment variable 'ZEEBE_HOST' (default '127.0.0.1')
       --insecure              Specify if zbctl should use an unsecured connection. If omitted, will read from the environment variable 'ZEEBE_INSECURE_CONNECTION'
+      --port string           Specify the port part of the gateway address. If omitted, will read from the environment variable 'ZEEBE_PORT' (default '26500')
 
 Use "zbctl [command] --help" for more information about a command.

--- a/clients/go/internal/containersuite/containerSuite.go
+++ b/clients/go/internal/containersuite/containerSuite.go
@@ -155,6 +155,8 @@ type ContainerSuite struct {
 	ContainerImage string
 	// GatewayAddress is the contact point of the spawned Zeebe container specified in the format 'host:port'
 	GatewayAddress string
+	GatewayHost    string
+	GatewayPort    int
 
 	suite.Suite
 	container testcontainers.Container
@@ -205,6 +207,8 @@ func (s *ContainerSuite) SetupSuite() {
 	}
 
 	s.GatewayAddress = fmt.Sprintf("%s:%d", host, port.Int())
+	s.GatewayHost = host
+	s.GatewayPort = port.Int()
 }
 
 func (s *ContainerSuite) TearDownSuite() {

--- a/clients/go/pkg/zbc/client.go
+++ b/clients/go/pkg/zbc/client.go
@@ -37,10 +37,14 @@ import (
 
 const DefaultRequestTimeout = 15 * time.Second
 const DefaultKeepAlive = 45 * time.Second
+const DefaultAddressHost = "127.0.0.1"
+const DefaultAddressPort = "26500"
 const InsecureEnvVar = "ZEEBE_INSECURE_CONNECTION"
 const CaCertificatePath = "ZEEBE_CA_CERTIFICATE_PATH"
 const KeepAliveEnvVar = "ZEEBE_KEEP_ALIVE"
 const GatewayAddressEnvVar = "ZEEBE_ADDRESS"
+const GatewayHostEnvVar = "ZEEBE_HOST"
+const GatewayPortEnvVar = "ZEEBE_PORT"
 
 type ClientImpl struct {
 	gateway             pb.GatewayClient
@@ -171,7 +175,15 @@ func applyClientEnvOverrides(config *ClientConfig) error {
 		config.CaCertificatePath = caCertificatePath
 	}
 
-	if gatewayAddress := env.get(GatewayAddressEnvVar); gatewayAddress != "" {
+	if gatewayHost := env.get(GatewayHostEnvVar); gatewayHost != "" {
+		if gatewayPort := env.get(GatewayPortEnvVar); gatewayPort != "" {
+			config.GatewayAddress = fmt.Sprintf("%s:%s", gatewayHost, gatewayPort)
+		} else {
+			config.GatewayAddress = fmt.Sprintf("%s:%s", gatewayHost, DefaultAddressPort)
+		}
+	} else if gatewayPort := env.get(GatewayPortEnvVar); gatewayPort != "" {
+		config.GatewayAddress = fmt.Sprintf("%s:%s", DefaultAddressHost, gatewayPort)
+	} else if gatewayAddress := env.get(GatewayAddressEnvVar); gatewayAddress != "" {
 		config.GatewayAddress = gatewayAddress
 	}
 


### PR DESCRIPTION
## Description

I've added the host and the port arguments.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #3104 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [X] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
