### PR TITLE
chore(snapshots): remove timestamp from snapshot id

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/InstallRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/InstallRequest.java
@@ -45,8 +45,6 @@ public class InstallRequest extends AbstractRaftRequest {
   private final long index;
   // the term associated to the snapshot
   private final long term;
-  // the timestamp when the snapshot was taken
-  private final long timestamp;
   // the version of the snapshot
   private final int version;
   // the ID of the current chunk (implementation specific)
@@ -65,7 +63,6 @@ public class InstallRequest extends AbstractRaftRequest {
       final MemberId leader,
       final long index,
       final long term,
-      final long timestamp,
       final int version,
       final ByteBuffer chunkId,
       final ByteBuffer nextChunkId,
@@ -75,7 +72,6 @@ public class InstallRequest extends AbstractRaftRequest {
     this.currentTerm = currentTerm;
     this.leader = leader;
     this.index = index;
-    this.timestamp = timestamp;
     this.version = version;
     this.chunkId = chunkId;
     this.nextChunkId = nextChunkId;
@@ -131,15 +127,6 @@ public class InstallRequest extends AbstractRaftRequest {
   }
 
   /**
-   * Returns the snapshot timestamp.
-   *
-   * @return The snapshot timestamp.
-   */
-  public long timestamp() {
-    return timestamp;
-  }
-
-  /**
    * Returns the id of the snapshot chunk.
    *
    * @return The id of the snapshot chunk.
@@ -183,17 +170,7 @@ public class InstallRequest extends AbstractRaftRequest {
   @Override
   public int hashCode() {
     return Objects.hash(
-        currentTerm,
-        leader,
-        index,
-        term,
-        timestamp,
-        version,
-        chunkId,
-        nextChunkId,
-        data,
-        initial,
-        complete);
+        currentTerm, leader, index, term, version, chunkId, nextChunkId, data, initial, complete);
   }
 
   @Override
@@ -208,7 +185,6 @@ public class InstallRequest extends AbstractRaftRequest {
     return currentTerm == that.currentTerm
         && index == that.index
         && term == that.term
-        && timestamp == that.timestamp
         && version == that.version
         && initial == that.initial
         && complete == that.complete
@@ -225,7 +201,6 @@ public class InstallRequest extends AbstractRaftRequest {
         .add("leader", leader)
         .add("index", index)
         .add("term", term)
-        .add("timestamp", timestamp)
         .add("version", version)
         .add("chunkId", StringUtils.printShortBuffer(chunkId))
         .add("nextChunkId", StringUtils.printShortBuffer(nextChunkId))
@@ -241,7 +216,6 @@ public class InstallRequest extends AbstractRaftRequest {
     private long currentTerm;
     private MemberId leader;
     private long index;
-    private long timestamp;
     private int version;
     private ByteBuffer chunkId;
     private ByteBuffer nextChunkId;
@@ -290,18 +264,6 @@ public class InstallRequest extends AbstractRaftRequest {
     public Builder withIndex(final long index) {
       checkArgument(index >= 0, "index must be positive");
       this.index = index;
-      return this;
-    }
-
-    /**
-     * Sets the request timestamp.
-     *
-     * @param timestamp The request timestamp.
-     * @return The request builder.
-     */
-    public Builder withTimestamp(final long timestamp) {
-      checkArgument(timestamp >= 0, "timestamp must be positive");
-      this.timestamp = timestamp;
       return this;
     }
 
@@ -379,17 +341,7 @@ public class InstallRequest extends AbstractRaftRequest {
     public InstallRequest build() {
       validate();
       return new InstallRequest(
-          currentTerm,
-          leader,
-          index,
-          term,
-          timestamp,
-          version,
-          chunkId,
-          nextChunkId,
-          data,
-          initial,
-          complete);
+          currentTerm, leader, index, term, version, chunkId, nextChunkId, data, initial, complete);
     }
 
     @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractAppender.java
@@ -481,7 +481,6 @@ abstract class AbstractAppender implements AutoCloseable {
               .withLeader(leader.memberId())
               .withIndex(persistedSnapshot.getIndex())
               .withTerm(persistedSnapshot.getTerm())
-              .withTimestamp(persistedSnapshot.getTimestamp().unixTimestamp())
               .withVersion(persistedSnapshot.version())
               .withData(new SnapshotChunkImpl(chunk).toByteBuffer())
               .withChunkId(ByteBuffer.wrap(chunk.getChunkName().getBytes()))

--- a/broker/src/test/java/io/zeebe/broker/logstreams/NoopSnapshotStore.java
+++ b/broker/src/test/java/io/zeebe/broker/logstreams/NoopSnapshotStore.java
@@ -7,7 +7,6 @@
  */
 package io.zeebe.broker.logstreams;
 
-import io.atomix.utils.time.WallClockTimestamp;
 import io.zeebe.snapshots.raft.PersistedSnapshot;
 import io.zeebe.snapshots.raft.PersistedSnapshotListener;
 import io.zeebe.snapshots.raft.PersistedSnapshotStore;
@@ -28,11 +27,6 @@ public class NoopSnapshotStore implements PersistedSnapshotStore {
         l ->
             l.onNewSnapshot(
                 new PersistedSnapshot() {
-                  @Override
-                  public WallClockTimestamp getTimestamp() {
-                    return null;
-                  }
-
                   @Override
                   public int version() {
                     return 0;

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/SnapshotReplicationTest.java
@@ -190,10 +190,11 @@ public final class SnapshotReplicationTest {
         FileBasedSnapshotMetadata.ofPath(validSnapshotDir.getFileName()).orElseThrow();
     final String prefix =
         String.format(
-            "%d-%d-%d",
+            "%d-%d-%d-%d",
             snapshotMetadata.getIndex(),
             snapshotMetadata.getTerm(),
-            snapshotMetadata.getTimestamp().unixTimestamp());
+            snapshotMetadata.getProcessedPosition(),
+            snapshotMetadata.getExportedPosition());
     try (final var files = Files.list(validSnapshotDir)) {
       return files.collect(
           Collectors.toMap(

--- a/snapshot/pom.xml
+++ b/snapshot/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <name>Zeebe Snapshots</name>
@@ -18,10 +20,6 @@
     <dependency>
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-util</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.zeebe</groupId>
-      <artifactId>atomix-utils</artifactId>
     </dependency>
     <dependency>
       <artifactId>simpleclient</artifactId>

--- a/snapshot/src/main/java/io/zeebe/snapshots/broker/SnapshotId.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/broker/SnapshotId.java
@@ -7,7 +7,6 @@
  */
 package io.zeebe.snapshots.broker;
 
-import io.atomix.utils.time.WallClockTimestamp;
 import io.zeebe.snapshots.raft.PersistedSnapshot;
 import java.util.Comparator;
 
@@ -26,9 +25,6 @@ public interface SnapshotId extends Comparable<SnapshotId> {
   /** @return the exported position when the snapshot was taken */
   long getExportedPosition();
 
-  /** @return the timestamp when the snapshot was taken */
-  WallClockTimestamp getTimestamp();
-
   /**
    * The string representation of the snapshot identifier, looks like 'index-term-timestamp'.
    *
@@ -39,8 +35,8 @@ public interface SnapshotId extends Comparable<SnapshotId> {
   /**
    * A snapshot is considered "lower" if its term is less than that of the other snapshot. If they
    * are the same, then it is considered "lower" if its index is less then the other, if they are
-   * equal then the timestamps are compared. If they are the same then these snapshots are the same
-   * order-wise.
+   * equal then the processed positions are compared, and then exported positions are compared. If
+   * they are the same then these snapshots are the same order-wise.
    *
    * @param other the snapshot to compare against
    * @return -1 if {@code this} is less than {@code other}, 0 if they are the same, 1 if it is

--- a/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshot.java
@@ -7,7 +7,6 @@
  */
 package io.zeebe.snapshots.broker.impl;
 
-import io.atomix.utils.time.WallClockTimestamp;
 import io.zeebe.snapshots.raft.PersistedSnapshot;
 import io.zeebe.snapshots.raft.SnapshotChunkReader;
 import io.zeebe.util.FileUtil;
@@ -38,11 +37,6 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
 
   public Path getDirectory() {
     return directory;
-  }
-
-  @Override
-  public WallClockTimestamp getTimestamp() {
-    return metadata.getTimestamp();
   }
 
   @Override

--- a/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotMetadata.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotMetadata.java
@@ -7,7 +7,6 @@
  */
 package io.zeebe.snapshots.broker.impl;
 
-import io.atomix.utils.time.WallClockTimestamp;
 import io.zeebe.snapshots.broker.SnapshotId;
 import java.nio.file.Path;
 import java.util.Objects;
@@ -17,25 +16,20 @@ import org.slf4j.LoggerFactory;
 
 public final class FileBasedSnapshotMetadata implements SnapshotId {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedSnapshotMetadata.class);
-  private static final int METADATA_PARTS = 5;
-  private static final int METADATA_PARTS_OLD_VERSION = 3;
+  private static final int METADATA_PARTS = 4;
 
   private final long index;
   private final long term;
-  private final WallClockTimestamp timestamp;
   private final long processedPosition;
   private final long exporterPosition;
 
   FileBasedSnapshotMetadata(
       final long index,
       final long term,
-      final WallClockTimestamp timestamp,
       final long processedPosition,
       final long exporterPosition) {
     this.index = index;
     this.term = term;
-    // We keep timestamp for backward compatibility
-    this.timestamp = timestamp;
     this.processedPosition = processedPosition;
     this.exporterPosition = exporterPosition;
   }
@@ -52,31 +46,12 @@ public final class FileBasedSnapshotMetadata implements SnapshotId {
       try {
         final var index = Long.parseLong(parts[0]);
         final var term = Long.parseLong(parts[1]);
-        final var timestamp = Long.parseLong(parts[2]);
-        final var processedPosition = Long.parseLong(parts[3]);
-        final var exporterPosition = Long.parseLong(parts[4]);
+        final var processedPosition = Long.parseLong(parts[2]);
+        final var exporterPosition = Long.parseLong(parts[3]);
 
         metadata =
             Optional.of(
-                new FileBasedSnapshotMetadata(
-                    index,
-                    term,
-                    WallClockTimestamp.from(timestamp),
-                    processedPosition,
-                    exporterPosition));
-      } catch (final NumberFormatException e) {
-        LOGGER.warn("Failed to parse part of snapshot metadata", e);
-      }
-    } else if (parts.length >= METADATA_PARTS_OLD_VERSION) {
-      try {
-        final var index = Long.parseLong(parts[0]);
-        final var term = Long.parseLong(parts[1]);
-        final var timestamp = Long.parseLong(parts[2]);
-
-        metadata =
-            Optional.of(
-                new FileBasedSnapshotMetadata(
-                    index, term, WallClockTimestamp.from(timestamp), 0, 0));
+                new FileBasedSnapshotMetadata(index, term, processedPosition, exporterPosition));
       } catch (final NumberFormatException e) {
         LOGGER.warn("Failed to parse part of snapshot metadata", e);
       }
@@ -105,19 +80,9 @@ public final class FileBasedSnapshotMetadata implements SnapshotId {
   }
 
   @Override
-  public WallClockTimestamp getTimestamp() {
-    return timestamp;
-  }
-
-  @Override
   public String getSnapshotIdAsString() {
     return String.format(
-        "%d-%d-%d-%d-%d",
-        getIndex(),
-        getTerm(),
-        getTimestamp().unixTimestamp(),
-        getProcessedPosition(),
-        getExportedPosition());
+        "%d-%d-%d-%d", getIndex(), getTerm(), getProcessedPosition(), getExportedPosition());
   }
 
   @Override
@@ -147,8 +112,6 @@ public final class FileBasedSnapshotMetadata implements SnapshotId {
         + index
         + ", term="
         + term
-        + ", timestamp="
-        + timestamp
         + ", processedPosition="
         + processedPosition
         + ", exporterPosition="

--- a/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStoreFactory.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStoreFactory.java
@@ -25,7 +25,7 @@ import org.agrona.collections.Int2ObjectHashMap;
  * possible skip them (and print out a warning).
  *
  * <p>The metadata extraction is done by parsing the directory name using '%d-%d-%d-%d', where in
- * order we expect: index, term, timestamp, and position.
+ * order we expect: index, term, processed position and exported position.
  */
 public final class FileBasedSnapshotStoreFactory
     implements SnapshotStoreSupplier, ReceivableSnapshotStoreFactory {

--- a/snapshot/src/main/java/io/zeebe/snapshots/raft/PersistedSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/raft/PersistedSnapshot.java
@@ -7,22 +7,11 @@
  */
 package io.zeebe.snapshots.raft;
 
-import io.atomix.utils.time.WallClockTimestamp;
 import io.zeebe.util.CloseableSilently;
 import java.nio.file.Path;
 
 /** Represents a snapshot, which was persisted at the {@link PersistedSnapshotStore}. */
 public interface PersistedSnapshot extends CloseableSilently {
-
-  /**
-   * Returns the snapshot timestamp.
-   *
-   * <p>The timestamp is the wall clock time at the {@link #getIndex()} at which the snapshot was
-   * taken.
-   *
-   * @return The snapshot timestamp.
-   */
-  WallClockTimestamp getTimestamp();
 
   /**
    * Returns the snapshot format version.
@@ -66,8 +55,8 @@ public interface PersistedSnapshot extends CloseableSilently {
   Path getPath();
 
   /**
-   * Returns an implementation specific compaction bound, e.g. a log stream position, a timestamp,
-   * etc., used during compaction
+   * Returns an implementation specific compaction bound, e.g. a log stream position, index etc.,
+   * used during compaction
    *
    * @return the compaction upper bound
    */

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedReceivedSnapshotTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import io.atomix.utils.time.WallClockTimestamp;
 import io.zeebe.snapshots.broker.ConstructableSnapshotStore;
 import io.zeebe.snapshots.raft.PersistedSnapshot;
 import io.zeebe.snapshots.raft.PersistedSnapshotListener;
@@ -78,7 +77,7 @@ public class FileBasedReceivedSnapshotTest {
     // given
 
     // when
-    receiverSnapshotStore.newReceivedSnapshot("1-0-123");
+    receiverSnapshotStore.newReceivedSnapshot("1-0-123-121");
 
     // then
     assertThat(receiverPendingSnapshotsDir.toFile().listFiles()).isEmpty();
@@ -583,7 +582,7 @@ public class FileBasedReceivedSnapshotTest {
     // given
     final var index = 1L;
     final var term = 0L;
-    final var time = WallClockTimestamp.from(123);
+
     final var transientSnapshot =
         senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
     transientSnapshot.take(

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStoreTest.java
@@ -11,7 +11,6 @@ import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-import io.atomix.utils.time.WallClockTimestamp;
 import io.zeebe.util.FileUtil;
 import io.zeebe.util.sched.ActorScheduler;
 import java.io.File;
@@ -112,11 +111,10 @@ public class FileBasedSnapshotStoreTest {
   @Test
   public void shouldLoadLatestSnapshotWhenMoreThanOneExistsAndDeleteOlder() throws IOException {
     // given
-    final var timeStamp = WallClockTimestamp.from(System.currentTimeMillis());
     final List<FileBasedSnapshotMetadata> snapshots = new ArrayList<>();
-    snapshots.add(new FileBasedSnapshotMetadata(1, 1, timeStamp, 1, 1));
-    snapshots.add(new FileBasedSnapshotMetadata(10, 1, timeStamp, 10, 10));
-    snapshots.add(new FileBasedSnapshotMetadata(2, 1, timeStamp, 2, 2));
+    snapshots.add(new FileBasedSnapshotMetadata(1, 1, 1, 1));
+    snapshots.add(new FileBasedSnapshotMetadata(10, 1, 10, 10));
+    snapshots.add(new FileBasedSnapshotMetadata(2, 1, 2, 2));
 
     // We can't use FileBasedSnapshotStore to create multiple snapshot as it always delete the
     // previous snapshot during normal execution. However, due to errors or crashes during

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/PersistedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/PersistedSnapshotStoreTest.java
@@ -9,7 +9,6 @@ package io.zeebe.snapshots.broker.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.atomix.utils.time.WallClockTimestamp;
 import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
 import io.zeebe.util.sched.ActorScheduler;
 import org.junit.Before;
@@ -96,10 +95,9 @@ public class PersistedSnapshotStoreTest {
     // given
     final var index = 1L;
     final var term = 0L;
-    final var time = WallClockTimestamp.from(123);
 
     // when
-    final var transientSnapshot = persistedSnapshotStore.newReceivedSnapshot("1-0-123");
+    final var transientSnapshot = persistedSnapshotStore.newReceivedSnapshot("1-0-123-121");
 
     // then
     assertThat(transientSnapshot.index()).isEqualTo(index);

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/ReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/ReceivedSnapshotTest.java
@@ -11,7 +11,6 @@ import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.atomix.utils.time.WallClockTimestamp;
 import io.zeebe.snapshots.broker.ConstructableSnapshotStore;
 import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
 import io.zeebe.util.FileUtil;
@@ -68,7 +67,7 @@ public class ReceivedSnapshotTest {
     // given
 
     // when
-    final var receivedSnapshot = receiverSnapshotStore.newReceivedSnapshot("1-0-123");
+    final var receivedSnapshot = receiverSnapshotStore.newReceivedSnapshot("1-0-123-121");
 
     // then
     assertThat(receivedSnapshot.index()).isEqualTo(1L);
@@ -79,7 +78,7 @@ public class ReceivedSnapshotTest {
     // given
     final var index = 1L;
     final var term = 0L;
-    final var time = WallClockTimestamp.from(123);
+
     final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).get();
     transientSnapshot.take(
         p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));
@@ -104,8 +103,6 @@ public class ReceivedSnapshotTest {
     assertThat(receivedPersistedSnapshot.getTerm()).isEqualTo(persistedSnapshot.getTerm());
     assertThat(receivedPersistedSnapshot.getCompactionBound())
         .isEqualTo(persistedSnapshot.getCompactionBound());
-    assertThat(receivedPersistedSnapshot.getTimestamp())
-        .isEqualTo(persistedSnapshot.getTimestamp());
     assertThat(receivedPersistedSnapshot.getId()).isEqualTo(persistedSnapshot.getId());
   }
 
@@ -114,7 +111,6 @@ public class ReceivedSnapshotTest {
     // given
     final var index = 1L;
     final var term = 0L;
-    final var time = WallClockTimestamp.from(123);
     final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).get();
     transientSnapshot.take(
         p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));
@@ -137,7 +133,6 @@ public class ReceivedSnapshotTest {
     // given
     final var index = 1L;
     final var term = 0L;
-    final var time = WallClockTimestamp.from(123);
     final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).get();
     transientSnapshot.take(
         p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));
@@ -162,7 +157,6 @@ public class ReceivedSnapshotTest {
     // given
     final var index = 1L;
     final var term = 0L;
-    final var time = WallClockTimestamp.from(123);
     final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).get();
     transientSnapshot.take(
         p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));
@@ -194,7 +188,6 @@ public class ReceivedSnapshotTest {
     // given
     final var index = 1L;
     final var term = 0L;
-    final var time = WallClockTimestamp.from(123);
     final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).get();
     transientSnapshot.take(
         p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));
@@ -229,7 +222,7 @@ public class ReceivedSnapshotTest {
     // given
     final var index = 1L;
     final var term = 0L;
-    final var time = WallClockTimestamp.from(123);
+
     final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).get();
     transientSnapshot.take(
         p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));
@@ -247,7 +240,7 @@ public class ReceivedSnapshotTest {
     // given
     final var index = 1L;
     final var term = 0L;
-    final var time = WallClockTimestamp.from(123);
+
     final var transientSnapshot = senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).get();
     transientSnapshot.take(
         p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/SnapshotChunkReaderTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/SnapshotChunkReaderTest.java
@@ -11,7 +11,6 @@ import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.atomix.utils.time.WallClockTimestamp;
 import io.zeebe.protocol.Protocol;
 import io.zeebe.snapshots.broker.ConstructableSnapshotStore;
 import io.zeebe.snapshots.raft.SnapshotChunk;
@@ -111,7 +110,7 @@ public class SnapshotChunkReaderTest {
     // given
     final var index = 1L;
     final var term = 0L;
-    final var time = WallClockTimestamp.from(123);
+
     final var transientSnapshot =
         persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).get();
     transientSnapshot.take(
@@ -153,7 +152,7 @@ public class SnapshotChunkReaderTest {
     // given
     final var index = 1L;
     final var term = 0L;
-    final var time = WallClockTimestamp.from(123);
+
     final var transientSnapshot =
         persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).get();
     transientSnapshot.take(


### PR DESCRIPTION
## Description

* remove timestamp from snapshot id
* remove timestamp from InstallRequest
* remove support for old snapshot id format.

New snapshotId format is `index-term-processedPosition-exportedPosition`

## Related issues

closes #4676

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
