### PR TITLE
chore(raft): fix equals implementation of RaftLogEntry

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/ConfigurationEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/ConfigurationEntry.java
@@ -21,6 +21,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.utils.misc.TimestampPrinter;
 import java.util.Collection;
+import java.util.Objects;
 
 /**
  * Stores a cluster configuration.
@@ -59,5 +60,22 @@ public class ConfigurationEntry implements RaftEntry {
         .add("timestamp", new TimestampPrinter(timestamp))
         .add("members", members)
         .toString();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ConfigurationEntry that = (ConfigurationEntry) o;
+    return timestamp == that.timestamp && Objects.equals(members, that.members);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(members, timestamp);
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/InitialEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/InitialEntry.java
@@ -23,4 +23,26 @@ package io.atomix.raft.storage.log.entry;
  * leadership change has occurred. Initialize entries are always the first entry to be committed at
  * the start of a leader's term.
  */
-public class InitialEntry implements RaftEntry {}
+public class InitialEntry implements RaftEntry {
+
+  @Override
+  public int hashCode() {
+    return 1;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "InitialEntry{}";
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/RaftLogEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/RaftLogEntry.java
@@ -19,6 +19,7 @@ package io.atomix.raft.storage.log.entry;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 import io.atomix.raft.storage.log.RaftLog;
+import java.util.Objects;
 
 /** Stores a state change in a {@link RaftLog}. */
 public class RaftLogEntry {
@@ -70,6 +71,23 @@ public class RaftLogEntry {
 
   @Override
   public String toString() {
-    return toStringHelper(this).add("term", term).toString();
+    return toStringHelper(this).add("term", term).add("entry", entry).toString();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final RaftLogEntry that = (RaftLogEntry) o;
+    return term == that.term && Objects.equals(entry, that.entry);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(term, entry);
   }
 }


### PR DESCRIPTION
## Description

The PR #6503 breaks `RaftRandomizedTest` because the `equals` method is not implemented correctly. This PR fixes it.

## Related issues

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
