### PR TITLE
chore(engine): generate key for updated variable document event

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/ProcessEventProcessors.java
@@ -72,6 +72,7 @@ public final class ProcessEventProcessors {
         typedRecordProcessors,
         variableBehavior,
         zeebeState.getElementInstanceState(),
+        zeebeState.getKeyGenerator(),
         writers.state());
     addProcessInstanceCreationStreamProcessors(
         typedRecordProcessors, zeebeState, writers, variableBehavior);
@@ -161,11 +162,13 @@ public final class ProcessEventProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final VariableBehavior variableBehavior,
       final ElementInstanceState elementInstanceState,
+      final KeyGenerator keyGenerator,
       final StateWriter stateWriter) {
     typedRecordProcessors.onCommand(
         ValueType.VARIABLE_DOCUMENT,
         VariableDocumentIntent.UPDATE,
-        new UpdateVariableDocumentProcessor(elementInstanceState, variableBehavior, stateWriter));
+        new UpdateVariableDocumentProcessor(
+            elementInstanceState, keyGenerator, variableBehavior, stateWriter));
   }
 
   private static void addProcessInstanceCreationStreamProcessors(

--- a/engine/src/main/java/io/zeebe/engine/processing/variable/UpdateVariableDocumentProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/variable/UpdateVariableDocumentProcessor.java
@@ -12,6 +12,7 @@ import io.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
+import io.zeebe.engine.state.KeyGenerator;
 import io.zeebe.engine.state.immutable.ElementInstanceState;
 import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.msgpack.spec.MsgpackReaderException;
@@ -24,14 +25,17 @@ public final class UpdateVariableDocumentProcessor
     implements TypedRecordProcessor<VariableDocumentRecord> {
 
   private final ElementInstanceState elementInstanceState;
+  private final KeyGenerator keyGenerator;
   private final VariableBehavior variableBehavior;
   private final StateWriter stateWriter;
 
   public UpdateVariableDocumentProcessor(
       final ElementInstanceState elementInstanceState,
+      final KeyGenerator keyGenerator,
       final VariableBehavior variableBehavior,
       final StateWriter stateWriter) {
     this.elementInstanceState = elementInstanceState;
+    this.keyGenerator = keyGenerator;
     this.variableBehavior = variableBehavior;
     this.stateWriter = stateWriter;
   }
@@ -74,8 +78,9 @@ public final class UpdateVariableDocumentProcessor
       return;
     }
 
-    stateWriter.appendFollowUpEvent(record.getKey(), VariableDocumentIntent.UPDATED, value);
-    responseWriter.writeEventOnCommand(
-        record.getKey(), VariableDocumentIntent.UPDATED, value, record);
+    final long key = keyGenerator.nextKey();
+
+    stateWriter.appendFollowUpEvent(key, VariableDocumentIntent.UPDATED, value);
+    responseWriter.writeEventOnCommand(key, VariableDocumentIntent.UPDATED, value, record);
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/variable/UpdateVariableDocumentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/variable/UpdateVariableDocumentTest.java
@@ -20,6 +20,7 @@ import io.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.zeebe.protocol.record.intent.VariableIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.zeebe.protocol.record.value.VariableDocumentRecordValue;
 import io.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
 import io.zeebe.test.util.collection.Maps;
 import io.zeebe.test.util.record.RecordStream;
@@ -86,6 +87,14 @@ public final class UpdateVariableDocumentTest {
                 .withVariables(document)
                 .getFirst())
         .isNotNull();
+
+    final Record<VariableDocumentRecordValue> updatedRecord =
+        records
+            .get()
+            .variableDocumentRecords()
+            .withIntent(VariableDocumentIntent.UPDATED)
+            .getFirst();
+    assertThat(updatedRecord.getKey()).isGreaterThan(0);
   }
 
   private void assertVariableRecordsProduced(


### PR DESCRIPTION
## Description

The update variable event `UPDATED` now contains a valid key `> 0`, which allows users to reference this key later in the exported records.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6543 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
