### PR TITLE
Apply event sourcing to creating a new process instance subscription

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
@@ -65,7 +65,11 @@ public final class EngineProcessors {
 
     final CatchEventBehavior catchEventBehavior =
         new CatchEventBehavior(
-            zeebeState, expressionProcessor, subscriptionCommandSender, partitionsCount);
+            zeebeState,
+            expressionProcessor,
+            subscriptionCommandSender,
+            writers.state(),
+            partitionsCount);
 
     addDeploymentRelatedProcessorAndServices(
         catchEventBehavior,

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/model/element/ExecutableBoundaryEvent.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/model/element/ExecutableBoundaryEvent.java
@@ -14,7 +14,7 @@ public class ExecutableBoundaryEvent extends ExecutableCatchEventElement {
   }
 
   @Override
-  public boolean shouldCloseMessageSubscriptionOnCorrelate() {
+  public boolean isInterrupting() {
     return interrupting();
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/model/element/ExecutableCatchEvent.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/model/element/ExecutableCatchEvent.java
@@ -27,7 +27,7 @@ public interface ExecutableCatchEvent extends ExecutableFlowElement {
 
   ExecutableMessage getMessage();
 
-  default boolean shouldCloseMessageSubscriptionOnCorrelate() {
+  default boolean isInterrupting() {
     return true;
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/model/element/ExecutableStartEvent.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/model/element/ExecutableStartEvent.java
@@ -25,7 +25,7 @@ public class ExecutableStartEvent extends ExecutableCatchEventElement {
   }
 
   @Override
-  public boolean shouldCloseMessageSubscriptionOnCorrelate() {
+  public boolean isInterrupting() {
     return interrupting();
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/message/command/SubscriptionCommandMessageHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/command/SubscriptionCommandMessageHandler.java
@@ -148,7 +148,7 @@ public final class SubscriptionCommandMessageHandler
         .setElementInstanceKey(openProcessInstanceSubscriptionCommand.getElementInstanceKey())
         .setMessageKey(-1)
         .setMessageName(openProcessInstanceSubscriptionCommand.getMessageName())
-        .setCloseOnCorrelate(openProcessInstanceSubscriptionCommand.shouldCloseOnCorrelate());
+        .setInterrupting(openProcessInstanceSubscriptionCommand.shouldCloseOnCorrelate());
 
     return writeCommand(
         processInstancePartitionId,

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -79,6 +79,7 @@ public final class MigratedStreamProcessors {
         ValueType.PROCESS_INSTANCE_SUBSCRIPTION,
         MIGRATED_INTENT_FILTER_FACTORY.apply(
             List.of(
+                ProcessInstanceSubscriptionIntent.CREATING,
                 ProcessInstanceSubscriptionIntent.CREATE,
                 ProcessInstanceSubscriptionIntent.CREATED)));
 

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -77,14 +77,11 @@ public final class EventAppliers implements EventApplier {
         new MessageStartEventSubscriptionCorrelatedApplier(
             state.getMessageState(), state.getEventScopeInstanceState()));
 
-    register(
-        ProcessInstanceSubscriptionIntent.CREATED,
-        new ProcessInstanceSubscriptionCreatedApplier(state.getProcessInstanceSubscriptionState()));
-
     registerJobIntentEventAppliers(state);
     registerVariableEventAppliers(state);
     register(JobBatchIntent.ACTIVATED, new JobBatchActivatedApplier(state));
     registerIncidentEventAppliers(state);
+    registerProcessInstanceSubscriptionEventAppliers(state);
   }
 
   private void registerVariableEventAppliers(final MutableZeebeState state) {
@@ -159,6 +156,16 @@ public final class EventAppliers implements EventApplier {
     register(
         IncidentIntent.RESOLVED,
         new IncidentResolvedApplier(state.getIncidentState(), state.getJobState()));
+  }
+
+  private void registerProcessInstanceSubscriptionEventAppliers(final MutableZeebeState state) {
+    register(
+        ProcessInstanceSubscriptionIntent.CREATING,
+        new ProcessInstanceSubscriptionCreatingApplier(
+            state.getProcessInstanceSubscriptionState()));
+    register(
+        ProcessInstanceSubscriptionIntent.CREATED,
+        new ProcessInstanceSubscriptionCreatedApplier(state.getProcessInstanceSubscriptionState()));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceSubscriptionCreatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceSubscriptionCreatingApplier.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.message.ProcessInstanceSubscription;
+import io.zeebe.engine.state.mutable.MutableProcessInstanceSubscriptionState;
+import io.zeebe.protocol.impl.record.value.message.ProcessInstanceSubscriptionRecord;
+import io.zeebe.protocol.record.intent.ProcessInstanceSubscriptionIntent;
+import io.zeebe.util.sched.clock.ActorClock;
+
+public final class ProcessInstanceSubscriptionCreatingApplier
+    implements TypedEventApplier<
+        ProcessInstanceSubscriptionIntent, ProcessInstanceSubscriptionRecord> {
+
+  private final MutableProcessInstanceSubscriptionState subscriptionState;
+
+  public ProcessInstanceSubscriptionCreatingApplier(
+      final MutableProcessInstanceSubscriptionState subscriptionState) {
+    this.subscriptionState = subscriptionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceSubscriptionRecord value) {
+    // TODO (saig0): reuse the subscription record in the state (#6533)
+    final var subscription = new ProcessInstanceSubscription();
+
+    subscription.setSubscriptionPartitionId(value.getSubscriptionPartitionId());
+    subscription.setMessageName(value.getMessageNameBuffer());
+    subscription.setElementInstanceKey(value.getElementInstanceKey());
+    subscription.setProcessInstanceKey(value.getProcessInstanceKey());
+    subscription.setBpmnProcessId(value.getBpmnProcessIdBuffer());
+    subscription.setCorrelationKey(value.getCorrelationKeyBuffer());
+    subscription.setTargetElementId(value.getElementIdBuffer());
+    subscription.setCloseOnCorrelate(value.isInterrupting());
+
+    // TODO (saig0): the send time for the retry should be deterministic (#6364)
+    final var sentTime = ActorClock.currentTimeMillis();
+    subscription.setCommandSentTime(sentTime);
+
+    if (subscriptionState.existSubscriptionForElementInstance(
+        value.getElementInstanceKey(), value.getMessageNameBuffer())) {
+      // TODO (saig0): avoid state change on reprocessing of a not yet migrated processor (#6200)
+      return;
+    }
+
+    subscriptionState.put(subscription);
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/ProcessInstanceStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/ProcessInstanceStreamProcessorRule.java
@@ -118,7 +118,11 @@ public final class ProcessInstanceStreamProcessorRule extends ExternalResource
               typedRecordProcessors,
               mockSubscriptionCommandSender,
               new CatchEventBehavior(
-                  zeebeState, expressionProcessor, mockSubscriptionCommandSender, 1),
+                  zeebeState,
+                  expressionProcessor,
+                  mockSubscriptionCommandSender,
+                  writers.state(),
+                  1),
               new DueDateTimerChecker(zeebeState.getTimerState()),
               writers);
 

--- a/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/IncidentStreamProcessorRule.java
@@ -92,7 +92,11 @@ public final class IncidentStreamProcessorRule extends ExternalResource {
                   typedRecordProcessors,
                   mockSubscriptionCommandSender,
                   new CatchEventBehavior(
-                      zeebeState, expressionProcessor, mockSubscriptionCommandSender, 1),
+                      zeebeState,
+                      expressionProcessor,
+                      mockSubscriptionCommandSender,
+                      writers.state(),
+                      1),
                   mockTimerEventScheduler,
                   writers);
 

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-subscription-template.json
@@ -32,6 +32,12 @@
             },
             "correlationKey": {
               "type": "keyword"
+            },
+            "elementId": {
+              "type": "text"
+            },
+            "interrupting": {
+              "type": "boolean"
             }
           }
         }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/ProcessInstanceSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/ProcessInstanceSubscriptionRecord.java
@@ -32,9 +32,9 @@ public final class ProcessInstanceSubscriptionRecord extends UnifiedRecordValue
   private final LongProperty messageKeyProp = new LongProperty("messageKey", -1L);
   private final StringProperty messageNameProp = new StringProperty("messageName", "");
   private final DocumentProperty variablesProp = new DocumentProperty("variables");
-  private final BooleanProperty closeOnCorrelateProp =
-      new BooleanProperty("closeOnCorrelate", true);
+  private final BooleanProperty interruptingProp = new BooleanProperty("interrupting", true);
   private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
+  private final StringProperty elementIdProp = new StringProperty("elementId", "");
 
   public ProcessInstanceSubscriptionRecord() {
     declareProperty(subscriptionPartitionIdProp)
@@ -43,13 +43,15 @@ public final class ProcessInstanceSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(messageKeyProp)
         .declareProperty(messageNameProp)
         .declareProperty(variablesProp)
-        .declareProperty(closeOnCorrelateProp)
+        .declareProperty(interruptingProp)
         .declareProperty(bpmnProcessIdProp)
-        .declareProperty(correlationKeyProp);
+        .declareProperty(correlationKeyProp)
+        .declareProperty(elementIdProp);
   }
 
-  public boolean shouldCloseOnCorrelate() {
-    return closeOnCorrelateProp.getValue();
+  @Override
+  public boolean isInterrupting() {
+    return interruptingProp.getValue();
   }
 
   @Override
@@ -147,13 +149,28 @@ public final class ProcessInstanceSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  public ProcessInstanceSubscriptionRecord setCloseOnCorrelate(final boolean closeOnCorrelate) {
-    closeOnCorrelateProp.setValue(closeOnCorrelate);
+  public ProcessInstanceSubscriptionRecord setInterrupting(final boolean interrupting) {
+    interruptingProp.setValue(interrupting);
     return this;
   }
 
   @JsonIgnore
   public DirectBuffer getCorrelationKeyBuffer() {
     return correlationKeyProp.getValue();
+  }
+
+  @Override
+  public String getElementId() {
+    return bufferAsString(getElementIdBuffer());
+  }
+
+  public ProcessInstanceSubscriptionRecord setElementId(final DirectBuffer elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getElementIdBuffer() {
+    return elementIdProp.getValue();
   }
 }

--- a/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -532,9 +532,10 @@ public final class JsonSerializableToJsonTest {
                   .setSubscriptionPartitionId(subscriptionPartitionId)
                   .setProcessInstanceKey(processInstanceKey)
                   .setVariables(VARIABLES_MSGPACK)
-                  .setCorrelationKey(wrapString(correlationKey));
+                  .setCorrelationKey(wrapString(correlationKey))
+                  .setElementId(wrapString("A"));
             },
-        "{'elementInstanceKey':123,'messageName':'test-message','processInstanceKey':1345,'variables':{'foo':'bar'},'bpmnProcessId':'process','messageKey':3,'correlationKey':'key'}"
+        "{'elementInstanceKey':123,'messageName':'test-message','processInstanceKey':1345,'variables':{'foo':'bar'},'bpmnProcessId':'process','messageKey':3,'correlationKey':'key','elementId':'A','interrupting':true}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -551,7 +552,7 @@ public final class JsonSerializableToJsonTest {
                   .setProcessInstanceKey(processInstanceKey)
                   .setElementInstanceKey(elementInstanceKey);
             },
-        "{'elementInstanceKey':123,'messageName':'','processInstanceKey':1345,'variables':{},'bpmnProcessId':'','messageKey':-1,'correlationKey':''}"
+        "{'elementInstanceKey':123,'messageName':'','processInstanceKey':1345,'variables':{},'bpmnProcessId':'','messageKey':-1,'correlationKey':'','elementId':'','interrupting':true}"
       },
 
       /////////////////////////////////////////////////////////////////////////////////////////////

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/ProcessInstanceSubscriptionIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/ProcessInstanceSubscriptionIntent.java
@@ -16,14 +16,15 @@
 package io.zeebe.protocol.record.intent;
 
 public enum ProcessInstanceSubscriptionIntent implements ProcessInstanceRelatedIntent {
-  CREATE((short) 0),
-  CREATED((short) 1),
+  CREATING((short) 0),
+  CREATE((short) 1),
+  CREATED((short) 2),
 
-  CORRELATE((short) 2),
-  CORRELATED((short) 3),
+  CORRELATE((short) 3),
+  CORRELATED((short) 4),
 
-  CLOSE((short) 4),
-  CLOSED((short) 5);
+  CLOSE((short) 5),
+  CLOSED((short) 6);
 
   private final short value;
   private final boolean shouldBlacklist;
@@ -45,16 +46,18 @@ public enum ProcessInstanceSubscriptionIntent implements ProcessInstanceRelatedI
   public static Intent from(final short value) {
     switch (value) {
       case 0:
-        return CREATE;
+        return CREATING;
       case 1:
-        return CREATED;
+        return CREATE;
       case 2:
-        return CORRELATE;
+        return CREATED;
       case 3:
-        return CORRELATED;
+        return CORRELATE;
       case 4:
-        return CLOSE;
+        return CORRELATED;
       case 5:
+        return CLOSE;
+      case 6:
         return CLOSED;
       default:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/ProcessInstanceSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/ProcessInstanceSubscriptionRecordValue.java
@@ -26,6 +26,7 @@ import io.zeebe.protocol.record.intent.ProcessInstanceSubscriptionIntent;
 public interface ProcessInstanceSubscriptionRecordValue
     extends RecordValueWithVariables, ProcessInstanceRelated {
   /** @return the process instance key */
+  @Override
   long getProcessInstanceKey();
 
   /** @return the element instance key */
@@ -42,4 +43,13 @@ public interface ProcessInstanceSubscriptionRecordValue
 
   /** @return the correlation key */
   String getCorrelationKey();
+
+  /** @return the id of the element tied to the subscription. */
+  String getElementId();
+
+  /**
+   * @return {@code true} if the event tied to the subscription is interrupting. Otherwise, it
+   *     returns {@code false} if the event is non-interrupting.
+   */
+  boolean isInterrupting();
 }


### PR DESCRIPTION
## Description

* replace the state modification on creating a new message subscription by writing a `CREATING` event
  * new intent `CREATING` for process instance subscriptions to express that a subscription is going to be created (when receiving a `CREATE` command from the message partition)
  * handle the case that the processor (e.g. for intermediate message catch events) is not yet migrated and the event applier is called again on reprocessing 
* extend and adjust the `ProcessInstanceSubscriptionRecord`
  * add the property `elementId` to the record to persist the element id that was only stored in the state
  * align the property `closeOnCorrelated` with `MessageSubscriptionRecord` and rename it to `interrupting`
  * expose both properties in the API for exporters
  * add the properties to the ES template (this record is not yet consumed by Operate)

## Related issues

Part of #6182 and #6177

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
