### PR TITLE
test(test-util): add compact logging for engine records

### DIFF
--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/util/BrokerClassRuleHelper.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/util/BrokerClassRuleHelper.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.broker.it.util;
 
+import io.zeebe.test.util.record.RecordLogger;
 import io.zeebe.test.util.record.RecordingExporter;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
@@ -21,8 +22,7 @@ public final class BrokerClassRuleHelper extends TestWatcher {
 
   @Override
   protected void failed(final Throwable e, final Description description) {
-    LOG.info("Test failed, following records were exported:");
-    RecordingExporter.getRecords().forEach(r -> LOG.info(r.toString()));
+    RecordLogger.logRecords();
   }
 
   @Override

--- a/test-util/src/main/java/io/zeebe/test/util/BrokerClassRuleHelper.java
+++ b/test-util/src/main/java/io/zeebe/test/util/BrokerClassRuleHelper.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.test.util;
 
+import io.zeebe.test.util.record.RecordLogger;
 import io.zeebe.test.util.record.RecordingExporter;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
@@ -21,8 +22,7 @@ public final class BrokerClassRuleHelper extends TestWatcher {
 
   @Override
   protected void failed(final Throwable e, final Description description) {
-    LOG.info("Test failed, following records were exported:");
-    RecordingExporter.getRecords().forEach(r -> LOG.info(r.toString()));
+    RecordLogger.logRecords();
   }
 
   @Override

--- a/test-util/src/main/java/io/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/CompactRecordLogger.java
@@ -117,23 +117,29 @@ public class CompactRecordLogger {
   }
 
   public void log() {
-    LOG.info("--------");
-    LOG.info("Compact log representation");
-    LOG.info(
-        "['C'ommand/'E'event/'R'ejection] - #[position]->#[source record position]  K[key] -  [valueType] [intent] - [summary of value]");
-    LOG.info(
-        "K999 - key; #999 - record position; \"ID\" element/process id; @\"elementid\"/[K99] - element with ID and key");
-    LOG.info(
-        "Long numbers are substituted with short numbers (e.g. 52124672368 -> 1)."
-            + " Substituted numbers are used consistently, but they might not have the same order as the numbers they substitute");
-    LOG.info(
-        "Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'");
+    final var bulkMessage = new StringBuilder().append("Compact log representation:\n");
+    bulkMessage
+        .append("--------\n")
+        .append(
+            "\t['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position]  K[key] - [summary of value]\n")
+        .append(
+            "\tK999 - key; #999 - record position; \"ID\" element/process id; @\"elementid\"/[K99] - element with ID and key\n")
+        .append(
+            "\tLong numbers are substituted with short numbers (e.g. 52124672368 -> 1). Substituted numbers are used consistently, ")
+        .append("but they might not have the same order as the numbers they substitute\n")
+        .append(
+            "\tLong IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'\n")
+        .append("--------\n");
 
-    LOG.info("--------");
-    records.forEach(this::logRecord);
+    records.forEach(
+        record -> {
+          bulkMessage.append(summarizeRecord(record)).append("\n");
+        });
+
+    LOG.info(bulkMessage.toString());
   }
 
-  private void logRecord(final Record<?> record) {
+  private StringBuilder summarizeRecord(final Record<?> record) {
     final StringBuilder message = new StringBuilder();
 
     if (record.getRecordType() != RecordType.COMMAND_REJECTION) {
@@ -145,7 +151,7 @@ public class CompactRecordLogger {
       message.append(summarizePositionFields(record));
     }
 
-    LOG.info(message.toString());
+    return message;
   }
 
   private StringBuilder summarizePositionFields(final Record<?> record) {
@@ -288,8 +294,7 @@ public class CompactRecordLogger {
         final var job = value.getJobs().get(i);
 
         result
-            .append(
-                "\n                                                                                     ")
+            .append(StringUtils.rightPad("\n", 8 + valueTypeChars))
             .append(summarizeJobRecordValue(jobKey, job));
       }
     }

--- a/test-util/src/main/java/io/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/CompactRecordLogger.java
@@ -1,0 +1,460 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.test.util.record;
+
+import static java.util.Map.entry;
+import static java.util.Map.ofEntries;
+import static org.apache.commons.lang3.StringUtils.leftPad;
+import static org.apache.commons.lang3.StringUtils.rightPad;
+
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.intent.IncidentIntent;
+import io.zeebe.protocol.record.intent.Intent;
+import io.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.zeebe.protocol.record.value.IncidentRecordValue;
+import io.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.zeebe.protocol.record.value.JobRecordValue;
+import io.zeebe.protocol.record.value.MessageRecordValue;
+import io.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
+import io.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.zeebe.protocol.record.value.ProcessInstanceSubscriptionRecordValue;
+import io.zeebe.protocol.record.value.VariableRecordValue;
+import io.zeebe.protocol.record.value.deployment.DeployedProcess;
+import io.zeebe.protocol.record.value.deployment.DeploymentResource;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CompactRecordLogger {
+
+  private static final Logger LOG = LoggerFactory.getLogger("io.zeebe.test");
+  private static final String BLOCK_SEPARATOR = " - ";
+
+  private static final Map<String, String> ABBREVIATIONS =
+      ofEntries(
+          entry("PROCESS", "PROC"),
+          entry("MESSAGE", "MSG"),
+          entry("SUBSCRIPTION", "SUB"),
+          entry("SEQUENCE", "SEQ"),
+          entry("DISTRIBUTED", "DISTR"),
+          entry("ELEMENT", "ELMNT"));
+
+  private final Map<ValueType, Function<Record<?>, String>> valueLoggers = new HashMap<>();
+
+  {
+    valueLoggers.put(ValueType.DEPLOYMENT, this::summarizeDeployment);
+    valueLoggers.put(ValueType.INCIDENT, this::summarizeIncident);
+    valueLoggers.put(ValueType.JOB, this::summarizeJob);
+    valueLoggers.put(ValueType.JOB_BATCH, this::summarizeJobBatch);
+    valueLoggers.put(ValueType.MESSAGE, this::summarizeMessage);
+    valueLoggers.put(
+        ValueType.MESSAGE_START_EVENT_SUBSCRIPTION, this::summarizeMessageStartEventSubscription);
+    valueLoggers.put(ValueType.MESSAGE_SUBSCRIPTION, this::summarizeMessageSubscription);
+    valueLoggers.put(ValueType.PROCESS, this::summarizeProcess);
+    valueLoggers.put(ValueType.PROCESS_INSTANCE, this::summarizeProcessInstance);
+    valueLoggers.put(ValueType.PROCESS_INSTANCE_CREATION, this::summarizeProcessInstanceCreation);
+    valueLoggers.put(
+        ValueType.PROCESS_INSTANCE_SUBSCRIPTION, this::summarizeProcessInstanceSubscription);
+    valueLoggers.put(ValueType.VARIABLE, this::summarizeVariable);
+    // TODO please extend list
+  }
+
+  private final int keyDigits;
+  private final int valueTypeChars;
+  private final int intentChars;
+
+  private final Map<Long, Long> substitutions = new HashMap<>();
+  private final ArrayList<Record<?>> records;
+
+  private long counter = 0;
+
+  public CompactRecordLogger(final Collection<Record<?>> records) {
+    this.records = new ArrayList<>(records);
+    final var highestPosition = this.records.get(records.size() - 1).getPosition();
+
+    int digits = 0;
+    long num = highestPosition;
+    while (num != 0) {
+      // num = num/10
+      num /= 10;
+      ++digits;
+    }
+
+    keyDigits = digits;
+
+    valueTypeChars =
+        records.stream()
+            .map(Record::getValueType)
+            .map(ValueType::name)
+            .map(this::abbreviate)
+            .mapToInt(String::length)
+            .max()
+            .orElse(0);
+
+    intentChars =
+        records.stream()
+            .map(Record::getIntent)
+            .map(Intent::name)
+            .map(this::abbreviate)
+            .mapToInt(String::length)
+            .max()
+            .orElse(0);
+  }
+
+  public void log() {
+    LOG.info("--------");
+    LOG.info("Compact log representation");
+    LOG.info(
+        "['C'ommand/'E'event/'R'ejection] - #[position]->#[source record position]  K[key] -  [valueType] [intent] - [summary of value]");
+    LOG.info(
+        "K999 - key; #999 - record position; \"ID\" element/process id; @\"elementid\"/[K99] - element with ID and key");
+    LOG.info(
+        "Long numbers are substituted with short numbers (e.g. 52124672368 -> 1)."
+            + " Substituted numbers are used consistently, but they might not have the same order as the numbers they substitute");
+    LOG.info(
+        "Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'");
+
+    LOG.info("--------");
+    records.forEach(this::logRecord);
+  }
+
+  private void logRecord(final Record<?> record) {
+    final StringBuilder message = new StringBuilder();
+
+    if (record.getRecordType() != RecordType.COMMAND_REJECTION) {
+      message.append(summarizeIntent(record));
+      message.append(summarizePositionFields(record));
+      message.append(summarizeValue(record));
+    } else {
+      message.append(summarizeRejection(record));
+      message.append(summarizePositionFields(record));
+    }
+
+    LOG.info(message.toString());
+  }
+
+  private StringBuilder summarizePositionFields(final Record<?> record) {
+    return new StringBuilder()
+        .append(formatPosition(record.getPosition()))
+        .append("->")
+        .append(formatPosition(record.getSourceRecordPosition()))
+        .append(" ")
+        .append(formatKey(record.getKey()))
+        .append(BLOCK_SEPARATOR);
+  }
+
+  private StringBuilder summarizeIntent(final Record<?> record) {
+    final var valueType = record.getValueType();
+
+    return new StringBuilder()
+        .append(record.getRecordType().toString().charAt(0))
+        .append(" ")
+        .append(rightPad(abbreviate(valueType.name()), valueTypeChars))
+        .append(" ")
+        .append(rightPad(abbreviate(record.getIntent().name()), intentChars))
+        .append(BLOCK_SEPARATOR);
+  }
+
+  private String summarizeValue(final Record<?> record) {
+    return valueLoggers.getOrDefault(record.getValueType(), this::summarizeMiscValue).apply(record);
+  }
+
+  private String summarizeMiscValue(final Record<?> record) {
+    return record.getValue().getClass().getSimpleName() + " " + record.getValue().toJson();
+  }
+
+  private String summarizeDeployment(final Record<?> record) {
+    final var value = (DeploymentRecordValue) record.getValue();
+
+    return value.getResources().stream()
+        .map(DeploymentResource::getResourceName)
+        .collect(Collectors.joining());
+  }
+
+  private String summarizeElementInformation(
+      final String elementId, final long elementInstanceKey) {
+    return String.format(" @%s[%s]", formatId(elementId), formatKey(elementInstanceKey));
+  }
+
+  private String summarizeProcessInformation(
+      final String bpmnProcessId, final long processInstancekey) {
+    if (!StringUtils.isEmpty(bpmnProcessId)) {
+      return String.format(
+          " in <process %s[%s]>", formatId(bpmnProcessId), formatKey(processInstancekey));
+    } else {
+      return " in <process ?>";
+    }
+  }
+
+  private String summarizeVariables(final Map<String, Object> variables) {
+    if (variables != null && !variables.isEmpty()) {
+      return " with variables: " + variables;
+    } else {
+      return " (no vars)";
+    }
+  }
+
+  private String summarizeIncident(final Record<?> record) {
+    final var value = (IncidentRecordValue) record.getValue();
+
+    final var result = new StringBuilder();
+
+    if (record.getIntent() != IncidentIntent.RESOLVE) {
+      result.append(value.getErrorType()).append(" ").append(value.getErrorMessage()).append(", ");
+
+      if (value.getJobKey() != -1) {
+        result.append("joBKey: ").append(formatKey(value.getJobKey())).append(" ");
+      }
+
+      result
+          .append(summarizeElementInformation(value.getElementId(), value.getElementInstanceKey()))
+          .append(
+              summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()));
+    } else {
+      result.append(formatKey(record.getKey()));
+    }
+    return result.toString();
+  }
+
+  private String summarizeJob(final Record<?> record) {
+    final var value = (JobRecordValue) record.getValue();
+
+    return summarizeJobRecordValue(record.getKey(), value);
+  }
+
+  private String summarizeJobRecordValue(final long jobKey, final JobRecordValue value) {
+    final var result = new StringBuilder();
+
+    if (jobKey != -1) {
+      result.append(formatKey(jobKey));
+    }
+    if (!StringUtils.isEmpty(value.getType())) {
+      result
+          .append(" \"")
+          .append(value.getType())
+          .append("\"")
+          .append(summarizeElementInformation(value.getElementId(), value.getElementInstanceKey()));
+    }
+
+    result.append(" ").append(value.getRetries()).append(" retries,");
+
+    if (!StringUtils.isEmpty(value.getErrorCode())) {
+      result.append(" ").append(value.getErrorCode()).append(":").append(value.getErrorMessage());
+    }
+
+    result
+        .append(
+            summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()))
+        .append(summarizeVariables(value.getVariables()));
+
+    return result.toString();
+  }
+
+  private String summarizeJobBatch(final Record<?> record) {
+    final var value = (JobBatchRecordValue) record.getValue();
+    final var jobKeys = value.getJobKeys();
+
+    final var result = new StringBuilder();
+
+    result.append("\"").append(value.getType()).append("\" ");
+    if (jobKeys != null && !jobKeys.isEmpty()) {
+      result.append(jobKeys.size()).append("/").append(value.getMaxJobsToActivate());
+    } else {
+      result.append("max: ").append(value.getMaxJobsToActivate());
+    }
+
+    if (value.isTruncated()) {
+      result.append(" (truncated)");
+    }
+
+    if (jobKeys != null && !jobKeys.isEmpty()) {
+      for (int i = 0; i < jobKeys.size(); i++) {
+        final var jobKey = jobKeys.get(i);
+        final var job = value.getJobs().get(i);
+
+        result
+            .append(
+                "\n                                                                                     ")
+            .append(summarizeJobRecordValue(jobKey, job));
+      }
+    }
+
+    return result.toString();
+  }
+
+  private String summarizeMessage(final Record<?> record) {
+    final var value = (MessageRecordValue) record.getValue();
+
+    final var result = new StringBuilder().append("\"").append(value.getName()).append("\"");
+
+    if (!StringUtils.isEmpty(value.getCorrelationKey())) {
+      result.append(" correlationKey: ").append(value.getCorrelationKey());
+    }
+
+    result.append(summarizeVariables(value.getVariables()));
+
+    return result.toString();
+  }
+
+  private String summarizeMessageStartEventSubscription(final Record<?> record) {
+    final var value = (MessageStartEventSubscriptionRecordValue) record.getValue();
+
+    return new StringBuilder()
+        .append("\"")
+        .append(value.getMessageName())
+        .append("\"")
+        .append(" starting <process ")
+        .append(formatId(value.getBpmnProcessId()))
+        .append(summarizeVariables(value.getVariables()))
+        .toString();
+  }
+
+  private String summarizeMessageSubscription(final Record<?> record) {
+    final var value = (MessageSubscriptionRecordValue) record.getValue();
+
+    final var result =
+        new StringBuilder().append("\"").append(value.getMessageName()).append("\" ");
+
+    if (value.isInterrupting()) {
+      result.append("(inter.) ");
+    }
+
+    if (!StringUtils.isEmpty(value.getCorrelationKey())) {
+      result.append("correlationKey: ").append(value.getCorrelationKey()).append(" ");
+    }
+
+    result
+        .append("@[")
+        .append(formatKey(value.getElementInstanceKey()))
+        .append("]")
+        .append(
+            summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()))
+        .append(summarizeVariables(value.getVariables()));
+    return result.toString();
+  }
+
+  private String summarizeProcess(final Record<?> record) {
+    final var value = (DeployedProcess) record.getValue();
+
+    return new StringBuilder()
+        .append(value.getResourceName())
+        .append("->")
+        .append(formatId(value.getBpmnProcessId()))
+        .append(" (version:")
+        .append(value.getVersion())
+        .append(")")
+        .toString();
+  }
+
+  private String summarizeProcessInstance(final Record<?> record) {
+    final var value = (ProcessInstanceRecordValue) record.getValue();
+    return new StringBuilder()
+        .append(value.getBpmnElementType())
+        .append(" ")
+        .append(formatId(value.getElementId()))
+        .append(
+            summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()))
+        .toString();
+  }
+
+  private String summarizeProcessInstanceCreation(final Record<?> record) {
+    final var value = (ProcessInstanceCreationRecordValue) record.getValue();
+    return new StringBuilder()
+        .append("new <process ")
+        .append(formatId(value.getBpmnProcessId()))
+        .append(">")
+        .append(summarizeVariables(value.getVariables()))
+        .toString();
+  }
+
+  private String summarizeProcessInstanceSubscription(final Record<?> record) {
+    final var value = (ProcessInstanceSubscriptionRecordValue) record.getValue();
+
+    final var result =
+        new StringBuilder().append("\"").append(value.getMessageName()).append("\" ");
+
+    if (value.isInterrupting()) {
+      result.append("(inter.) ");
+    }
+
+    if (!StringUtils.isEmpty(value.getCorrelationKey())) {
+      result.append("correlationKey: ").append(value.getCorrelationKey()).append(" ");
+    }
+
+    result
+        .append("@[")
+        .append(formatKey(value.getElementInstanceKey()))
+        .append("]")
+        .append(
+            summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()))
+        .append(summarizeVariables(value.getVariables()));
+
+    return result.toString();
+  }
+
+  private String summarizeVariable(final Record<?> record) {
+    final var value = (VariableRecordValue) record.getValue();
+
+    return new StringBuilder()
+        .append(value.getName())
+        .append("->")
+        .append(value.getValue())
+        .append(" in <process ")
+        .append("[")
+        .append(formatKey(value.getProcessInstanceKey()))
+        .append("]>")
+        .toString();
+  }
+
+  private StringBuilder summarizeRejection(final Record<?> record) {
+    return new StringBuilder()
+        .append(record.getRejectionType())
+        .append(" ")
+        .append(record.getRejectionReason());
+  }
+
+  private long substitute(final long input) {
+    if (input > 0) {
+      return substitutions.computeIfAbsent(input, key -> counter++);
+    } else {
+      return input;
+    }
+  }
+
+  private String formatKey(final long input) {
+    return "K" + leftPad(Long.toString(substitute(input)), keyDigits, '0');
+  }
+
+  private String formatPosition(final long input) {
+    return "#" + leftPad(Long.toString(input), keyDigits, '0');
+  }
+
+  private String formatId(final String input) {
+    return "\"" + StringUtils.abbreviateMiddle(input, "..", 16) + "\"";
+  }
+
+  private String abbreviate(final String input) {
+    String result = input;
+
+    for (final String longForm : ABBREVIATIONS.keySet()) {
+      result = result.replace(longForm, ABBREVIATIONS.get(longForm));
+    }
+
+    return result;
+  }
+}

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordLogger.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordLogger.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.test.util.record;
+
+import io.zeebe.protocol.record.Record;
+import java.util.Collection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RecordLogger {
+  public static final String STYLE_PROPERTY = "RECORD_LOGGER_STYLE";
+  public static final String STYLE_COMPACT = "COMPACT";
+  public static final Logger LOG = LoggerFactory.getLogger("io.zeebe.test");
+
+  public static void logRecords() {
+    LOG.info("Test failed, following records were exported:");
+    if (STYLE_COMPACT.equals(System.getenv(STYLE_PROPERTY))) {
+      logRecordsCompact(RecordingExporter.getRecords());
+    } else {
+      logRecordsRaw(RecordingExporter.getRecords());
+    }
+  }
+
+  public static void logRecordsCompact(final Collection<Record<?>> records) {
+    new CompactRecordLogger(records).log();
+  }
+
+  public static void logRecordsRaw(final Collection<Record<?>> records) {
+    records.forEach(r -> LOG.info(r.toString()));
+  }
+}

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporterTestWatcher.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordingExporterTestWatcher.java
@@ -18,8 +18,7 @@ public final class RecordingExporterTestWatcher extends TestWatcher {
 
   @Override
   protected void failed(final Throwable e, final Description description) {
-    LOG.info("Test failed, following records were exported:");
-    RecordingExporter.getRecords().forEach(r -> LOG.info(r.toString()));
+    RecordLogger.logRecords();
   }
 
   @Override


### PR DESCRIPTION
## Description

* adds a new way to log records in a compact way
* the compact style is disabled by default, but can be enabled via environment setting.

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
