### PR TITLE
Replace token count with counting of active sequence flows and element instances

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -55,8 +55,6 @@ public final class ProcessInstanceStateTransitionGuard {
 
   private Either<String, ?> checkStateTransition(final BpmnElementContext context) {
     switch (context.getIntent()) {
-      case ACTIVATE_ELEMENT:
-        return Either.right(null);
       case COMPLETE_ELEMENT:
         return hasElementInstanceWithState(context, ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .flatMap(ok -> hasActiveFlowScopeInstance(context));
@@ -84,6 +82,7 @@ public final class ProcessInstanceStateTransitionGuard {
         }
         return hasElementInstanceWithState(context, ProcessInstanceIntent.ELEMENT_ACTIVATED);
 
+      case ACTIVATE_ELEMENT:
       case SEQUENCE_FLOW_TAKEN:
         return hasActiveFlowScopeInstance(context);
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -67,7 +67,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             new ProcessEngineMetrics(zeebeState.getPartitionId()),
             stateTransitionGuard,
             processorLookup,
-            writers);
+            writers,
+            zeebeState.getElementInstanceState());
     eventSubscriptionBehavior =
         new BpmnEventSubscriptionBehavior(
             stateBehavior,

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -431,7 +431,6 @@ public final class BpmnEventSubscriptionBehavior {
     stateBehavior.updateFlowScopeInstance(
         context,
         flowScopeInstance -> {
-          flowScopeInstance.spawnToken();
           flowScopeInstance.setInterruptingEventKey(eventElementInstanceKey);
         });
   }
@@ -458,7 +457,7 @@ public final class BpmnEventSubscriptionBehavior {
   }
 
   private boolean isInterrupted(final ElementInstance elementInstance) {
-    return elementInstance.getNumberOfActiveTokens() == 2
+    return elementInstance.getNumberOfActiveElementInstances() == 1
         && elementInstance.isInterrupted()
         && elementInstance.isActive();
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -104,20 +104,6 @@ public final class BpmnStateBehavior {
     }
   }
 
-  public void consumeToken(final BpmnElementContext context) {
-    final ElementInstance flowScopeInstance = getFlowScopeInstance(context);
-    if (flowScopeInstance != null) {
-      elementInstanceState.consumeToken(flowScopeInstance.getKey());
-    }
-  }
-
-  public void spawnToken(final BpmnElementContext context) {
-    final ElementInstance flowScopeInstance = getFlowScopeInstance(context);
-    if (flowScopeInstance != null) {
-      elementInstanceState.spawnToken(flowScopeInstance.getKey());
-    }
-  }
-
   public ElementInstance getFlowScopeInstance(final BpmnElementContext context) {
     return elementInstanceState.getInstance(context.getFlowScopeKey());
   }
@@ -134,18 +120,6 @@ public final class BpmnStateBehavior {
                 context.copy(
                     childInstance.getKey(), childInstance.getValue(), childInstance.getState()))
         .collect(Collectors.toList());
-  }
-
-  public ElementInstance createChildElementInstance(
-      final BpmnElementContext context,
-      final long childInstanceKey,
-      final ProcessInstanceRecord childRecord) {
-    final var parentElementInstance = getElementInstance(context);
-    return elementInstanceState.newInstance(
-        parentElementInstance,
-        childInstanceKey,
-        childRecord,
-        ProcessInstanceIntent.ELEMENT_ACTIVATING);
   }
 
   public void createElementInstanceInFlowScope(

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -80,7 +80,7 @@ public final class BpmnStateBehavior {
       return false;
     }
 
-    final int activePaths = flowScopeInstance.getNumberOfActiveTokens();
+    final int activePaths = flowScopeInstance.getNumberOfActiveElementInstances();
     if (activePaths < 0) {
       throw new BpmnProcessingException(
           context,

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -187,7 +187,6 @@ public final class BpmnStateTransitionBehavior {
     if (!MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
       streamWriter.appendFollowUpEvent(
           keyGenerator.nextKey(), ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN, record);
-      stateBehavior.spawnToken(context);
     } else {
       stateWriter.appendFollowUpEvent(
           keyGenerator.nextKey(), ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN, record);
@@ -266,18 +265,6 @@ public final class BpmnStateTransitionBehavior {
 
     final var elementInstance = stateBehavior.getElementInstance(context);
     final var activeChildInstances = elementInstance.getNumberOfActiveElementInstances();
-
-    if (activeChildInstances > 0) {
-      // wait for child instances to be terminated
-
-      // clean up the state because some events of child instances will not be processed (e.g.
-      // element completed, sequence flow taken)
-      final int pendingTokens = elementInstance.getNumberOfActiveTokens() - activeChildInstances;
-      for (int t = 0; t < pendingTokens; t++) {
-        elementInstance.consumeToken();
-      }
-      stateBehavior.updateElementInstance(elementInstance);
-    }
 
     return activeChildInstances == 0;
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -25,6 +25,7 @@ import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.KeyGenerator;
 import io.zeebe.engine.state.deployment.DeployedProcess;
 import io.zeebe.engine.state.instance.ElementInstance;
+import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
@@ -45,6 +46,7 @@ public final class BpmnStateTransitionBehavior {
   private final ProcessInstanceRecord childInstanceRecord = new ProcessInstanceRecord();
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
+  private final MutableElementInstanceState elementInstanceState;
 
   public BpmnStateTransitionBehavior(
       final TypedStreamWriter streamWriter,
@@ -54,7 +56,8 @@ public final class BpmnStateTransitionBehavior {
       final ProcessInstanceStateTransitionGuard stateTransitionGuard,
       final Function<BpmnElementType, BpmnElementContainerProcessor<ExecutableFlowElement>>
           processorLookUp,
-      final Writers writers) {
+      final Writers writers,
+      final MutableElementInstanceState elementInstanceState) {
     // todo (@korthout): replace streamWriter by writers
     this.streamWriter = streamWriter;
     this.keyGenerator = keyGenerator;
@@ -64,6 +67,7 @@ public final class BpmnStateTransitionBehavior {
     this.processorLookUp = processorLookUp;
     stateWriter = writers.state();
     commandWriter = writers.command();
+    this.elementInstanceState = elementInstanceState;
   }
 
   /** @return context with updated intent */
@@ -184,12 +188,18 @@ public final class BpmnStateTransitionBehavior {
             .setElementId(sequenceFlow.getId())
             .setBpmnElementType(sequenceFlow.getElementType());
 
+    final var sequenceFlowKey = keyGenerator.nextKey();
+
     if (!MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
+      final var flowScopeInstance = elementInstanceState.getInstance(context.getFlowScopeKey());
+      flowScopeInstance.incrementActiveSequenceFlows();
+      elementInstanceState.updateInstance(flowScopeInstance);
+
       streamWriter.appendFollowUpEvent(
-          keyGenerator.nextKey(), ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN, record);
+          sequenceFlowKey, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN, record);
     } else {
       stateWriter.appendFollowUpEvent(
-          keyGenerator.nextKey(), ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN, record);
+          sequenceFlowKey, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN, record);
     }
   }
 
@@ -227,6 +237,14 @@ public final class BpmnStateTransitionBehavior {
       commandWriter.appendFollowUpCommand(
           elementInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, elementInstanceRecord);
     } else {
+      // For migrated processors the active sequence flow count is decremented in the
+      // *ActivatingApplier. For non migrated we do it here, otherwise we can't complete the process
+      // instance in the end. Counting the active sequence flows is necessary to not complete the
+      // process instance to early.
+      final var flowScopeInstance = elementInstanceState.getInstance(context.getFlowScopeKey());
+      flowScopeInstance.decrementActiveSequenceFlows();
+      elementInstanceState.updateInstance(flowScopeInstance);
+
       streamWriter.appendFollowUpEvent(
           elementInstanceKey, ProcessInstanceIntent.ELEMENT_ACTIVATING, elementInstanceRecord);
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -101,7 +101,6 @@ public final class CallActivityProcessor
   @Override
   public void onCompleted(final ExecutableCallActivity element, final BpmnElementContext context) {
     stateTransitionBehavior.takeOutgoingSequenceFlows(element, context);
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 
@@ -117,7 +116,6 @@ public final class CallActivityProcessor
     eventSubscriptionBehavior.publishTriggeredBoundaryEvent(context);
     incidentBehavior.resolveIncidents(context);
     stateTransitionBehavior.onElementTerminated(element, context);
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -130,7 +130,6 @@ public final class MultiInstanceBodyProcessor
 
     stateTransitionBehavior.takeOutgoingSequenceFlows(element, context);
 
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 
@@ -156,7 +155,6 @@ public final class MultiInstanceBodyProcessor
 
     stateTransitionBehavior.onElementTerminated(element, context);
 
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -197,7 +197,7 @@ public final class MultiInstanceBodyProcessor
       }
     }
 
-    if (stateBehavior.isLastActiveExecutionPathInScope(childContext)) {
+    if (stateBehavior.canBeCompleted(childContext)) {
       stateTransitionBehavior.transitionToCompleting(flowScopeContext);
     }
   }
@@ -209,7 +209,7 @@ public final class MultiInstanceBodyProcessor
       final BpmnElementContext childContext) {
 
     if (flowScopeContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING
-        && stateBehavior.isLastActiveExecutionPathInScope(childContext)) {
+        && stateBehavior.canBeTerminated(childContext)) {
       stateTransitionBehavior.transitionToTerminated(flowScopeContext);
 
     } else {

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -152,7 +152,7 @@ public final class ProcessProcessor
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext) {
 
-    if (stateBehavior.isLastActiveExecutionPathInScope(childContext)) {
+    if (stateBehavior.canBeCompleted(childContext)) {
       stateTransitionBehavior.transitionToCompleting(flowScopeContext);
     }
   }
@@ -164,7 +164,7 @@ public final class ProcessProcessor
       final BpmnElementContext childContext) {
 
     if (flowScopeContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING
-        && stateBehavior.isLastActiveExecutionPathInScope(childContext)) {
+        && stateBehavior.canBeTerminated(childContext)) {
       stateTransitionBehavior.transitionToTerminated(flowScopeContext);
 
     } else {

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -89,7 +89,6 @@ public final class SubProcessProcessor
 
     stateTransitionBehavior.takeOutgoingSequenceFlows(element, context);
 
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 
@@ -115,7 +114,6 @@ public final class SubProcessProcessor
 
     stateTransitionBehavior.onElementTerminated(element, context);
 
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -130,7 +130,7 @@ public final class SubProcessProcessor
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext) {
 
-    if (stateBehavior.isLastActiveExecutionPathInScope(childContext)) {
+    if (stateBehavior.canBeCompleted(childContext)) {
       stateTransitionBehavior.transitionToCompleting(flowScopeContext);
     }
   }
@@ -142,7 +142,7 @@ public final class SubProcessProcessor
       final BpmnElementContext childContext) {
 
     if (flowScopeContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING
-        && stateBehavior.isLastActiveExecutionPathInScope(childContext)) {
+        && stateBehavior.canBeTerminated(childContext)) {
       stateTransitionBehavior.transitionToTerminated(flowScopeContext);
 
     } else {

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
@@ -66,7 +66,6 @@ public final class BoundaryEventProcessor implements BpmnElementProcessor<Execut
 
     stateTransitionBehavior.takeOutgoingSequenceFlows(element, context);
 
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 
@@ -85,7 +84,6 @@ public final class BoundaryEventProcessor implements BpmnElementProcessor<Execut
 
     stateTransitionBehavior.onElementTerminated(element, context);
 
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -83,7 +83,6 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
   @Override
   public void onCompleted(final ExecutableEndEvent element, final BpmnElementContext context) {
     stateTransitionBehavior.onElementCompleted(element, context);
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 
@@ -96,7 +95,6 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
   public void onTerminated(final ExecutableEndEvent element, final BpmnElementContext context) {
     incidentBehavior.resolveIncidents(context);
     stateTransitionBehavior.onElementTerminated(element, context);
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
@@ -84,7 +84,6 @@ public class IntermediateCatchEventProcessor
   public void onCompleted(
       final ExecutableCatchEventElement element, final BpmnElementContext context) {
     stateTransitionBehavior.takeOutgoingSequenceFlows(element, context);
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 
@@ -101,8 +100,6 @@ public class IntermediateCatchEventProcessor
     incidentBehavior.resolveIncidents(context);
 
     stateTransitionBehavior.onElementTerminated(element, context);
-
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/StartEventProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/StartEventProcessor.java
@@ -60,7 +60,6 @@ public class StartEventProcessor implements BpmnElementProcessor<ExecutableStart
   @Override
   public void onCompleted(final ExecutableStartEvent element, final BpmnElementContext context) {
     stateTransitionBehavior.takeOutgoingSequenceFlows(element, context);
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 
@@ -73,7 +72,6 @@ public class StartEventProcessor implements BpmnElementProcessor<ExecutableStart
   public void onTerminated(final ExecutableStartEvent element, final BpmnElementContext context) {
     incidentBehavior.resolveIncidents(context);
     stateTransitionBehavior.onElementTerminated(element, context);
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
@@ -71,7 +71,6 @@ public final class EventBasedGatewayProcessor
     // according to the BPMN specification, the sequence flow to this event is not taken
     eventSubscriptionBehavior.publishTriggeredEventBasedGateway(context);
 
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 
@@ -92,7 +91,6 @@ public final class EventBasedGatewayProcessor
 
     stateTransitionBehavior.onElementTerminated(element, context);
 
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/sequenceflow/SequenceFlowProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/sequenceflow/SequenceFlowProcessor.java
@@ -124,20 +124,12 @@ public final class SequenceFlowProcessor implements BpmnElementProcessor<Executa
     if (tokensBySequenceFlow.size() == parallelGateway.getIncoming().size()) {
       // all incoming sequence flows are taken, so the gateway can be activated
 
-      final var flowScopeInstance = stateBehavior.getFlowScopeInstance(context);
-
       // consume one token per sequence flow
       tokensBySequenceFlow.forEach(
           (sequenceFlow, tokens) -> {
             final var firstToken = tokens.get(0);
             deferredRecordsBehavior.removeDeferredRecord(flowScopeContext, firstToken);
-
-            flowScopeInstance.consumeToken();
           });
-
-      // spawn a new token for the activated gateway
-      flowScopeInstance.spawnToken();
-      stateBehavior.updateElementInstance(flowScopeInstance);
 
       stateTransitionBehavior.activateElementInstanceInFlowScope(context, parallelGateway);
     }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
@@ -68,7 +68,6 @@ public final class ReceiveTaskProcessor implements BpmnElementProcessor<Executab
   @Override
   public void onCompleted(final ExecutableReceiveTask element, final BpmnElementContext context) {
     stateTransitionBehavior.takeOutgoingSequenceFlows(element, context);
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 
@@ -83,7 +82,6 @@ public final class ReceiveTaskProcessor implements BpmnElementProcessor<Executab
     eventSubscriptionBehavior.publishTriggeredBoundaryEvent(context);
     incidentBehavior.resolveIncidents(context);
     stateTransitionBehavior.onElementTerminated(element, context);
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
@@ -97,7 +97,6 @@ public final class ServiceTaskProcessor implements BpmnElementProcessor<Executab
 
     stateTransitionBehavior.takeOutgoingSequenceFlows(element, context);
 
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 
@@ -125,7 +124,6 @@ public final class ServiceTaskProcessor implements BpmnElementProcessor<Executab
 
     stateTransitionBehavior.onElementTerminated(element, context);
 
-    stateBehavior.consumeToken(context);
     stateBehavior.removeElementInstance(context);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -113,9 +113,6 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessInstanceIntent.ELEMENT_TERMINATED,
         new ProcessInstanceElementTerminatedApplier(elementInstanceState, eventScopeInstanceState));
-    register(
-        ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN,
-        new ProcessInstanceSequenceFlowTakenApplier(elementInstanceState));
   }
 
   private void registerJobIntentEventAppliers(final MutableZeebeState state) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -113,6 +113,9 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessInstanceIntent.ELEMENT_TERMINATED,
         new ProcessInstanceElementTerminatedApplier(elementInstanceState, eventScopeInstanceState));
+    register(
+        ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN,
+        new ProcessInstanceSequenceFlowTakenApplier(elementInstanceState));
   }
 
   private void registerJobIntentEventAppliers(final MutableZeebeState state) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -7,6 +7,9 @@
  */
 package io.zeebe.engine.state.appliers;
 
+import io.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
+import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
 import io.zeebe.engine.state.TypedEventApplier;
 import io.zeebe.engine.state.immutable.ProcessState;
@@ -15,6 +18,7 @@ import io.zeebe.engine.state.mutable.MutableVariableState;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
+import java.util.stream.IntStream;
 
 /** Applies state changes for `ProcessInstance:Element_Activating` */
 final class ProcessInstanceElementActivatingApplier
@@ -36,6 +40,7 @@ final class ProcessInstanceElementActivatingApplier
   @Override
   public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
     final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
+
     elementInstanceState.newInstance(
         flowScopeInstance, elementInstanceKey, value, ProcessInstanceIntent.ELEMENT_ACTIVATING);
 
@@ -46,6 +51,8 @@ final class ProcessInstanceElementActivatingApplier
 
     final var flowScopeElementType = flowScopeInstance.getValue().getBpmnElementType();
     final var currentElementType = value.getBpmnElementType();
+
+    decrementActiveSequenceFlow(value, flowScopeInstance, flowScopeElementType, currentElementType);
 
     if (isStartEventInSubProcess(flowScopeElementType, currentElementType)) {
 
@@ -71,6 +78,93 @@ final class ProcessInstanceElementActivatingApplier
         }
       }
     }
+  }
+
+  private void decrementActiveSequenceFlow(
+      final ProcessInstanceRecord value,
+      final io.zeebe.engine.state.instance.ElementInstance flowScopeInstance,
+      final BpmnElementType flowScopeElementType,
+      final BpmnElementType currentElementType) {
+
+    final boolean isEventSubProcess = isEventSubProcess(currentElementType, value);
+
+    // We don't want to decrement the active sequence flow for elements which have no incoming
+    // sequence flow and for interrupting event sub processes we reset the count completely.
+    // Furthermore some elements are special and need to be handled separately.
+
+    if (currentElementType != BpmnElementType.START_EVENT
+        && currentElementType != BpmnElementType.BOUNDARY_EVENT
+        && currentElementType != BpmnElementType.PARALLEL_GATEWAY
+        && currentElementType != BpmnElementType.INTERMEDIATE_CATCH_EVENT
+        && flowScopeElementType != BpmnElementType.MULTI_INSTANCE_BODY
+        && !isEventSubProcess) {
+      flowScopeInstance.decrementActiveSequenceFlows();
+      elementInstanceState.updateInstance(flowScopeInstance);
+    }
+
+    if (currentElementType == BpmnElementType.INTERMEDIATE_CATCH_EVENT) {
+      // If we are an intermediate catch event and our previous element is an event based gateway,
+      // then we don't want to decrement the active flow, since based on the BPMN spec we DON'T take
+      // the sequence flow.
+
+      final var executableCatchEventElement =
+          processState.getFlowElement(
+              value.getProcessDefinitionKey(),
+              value.getElementIdBuffer(),
+              ExecutableCatchEventElement.class);
+
+      final var incomingSequenceFlow = executableCatchEventElement.getIncoming().get(0);
+      final var previousElement = incomingSequenceFlow.getSource();
+      if (previousElement.getElementType() != BpmnElementType.EVENT_BASED_GATEWAY) {
+        flowScopeInstance.decrementActiveSequenceFlows();
+        elementInstanceState.updateInstance(flowScopeInstance);
+      }
+    }
+
+    if (currentElementType == BpmnElementType.PARALLEL_GATEWAY) {
+      // Parallel gateways can have more then one incoming sequence flow, we need to decrement the
+      // active sequence flows based on the incoming count.
+
+      final var executableFlowNode =
+          processState.getFlowElement(
+              value.getProcessDefinitionKey(),
+              value.getElementIdBuffer(),
+              ExecutableFlowNode.class);
+      final var size = executableFlowNode.getIncoming().size();
+      IntStream.range(0, size).forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+      elementInstanceState.updateInstance(flowScopeInstance);
+    }
+
+    if (isEventSubProcess) {
+      // For interrupting event sub processes we need to reset the active sequence flows, because
+      // we might have interrupted multiple sequence flows.
+      // For non interrupting we do nothing, since we had no incoming sequence flow.
+
+      final var executableFlowElementContainer = getExecutableFlowElementContainer(value);
+      final var executableStartEvent = executableFlowElementContainer.getStartEvents().get(0);
+      if (executableStartEvent.isInterrupting()) {
+        flowScopeInstance.resetActiveSequenceFlows();
+      }
+      elementInstanceState.updateInstance(flowScopeInstance);
+    }
+  }
+
+  private boolean isEventSubProcess(
+      final BpmnElementType currentElementType, final ProcessInstanceRecord processInstanceRecord) {
+    if (currentElementType == BpmnElementType.SUB_PROCESS) {
+      final var executableFlowElementContainer =
+          getExecutableFlowElementContainer(processInstanceRecord);
+      return !executableFlowElementContainer.hasNoneStartEvent();
+    }
+    return false;
+  }
+
+  private ExecutableFlowElementContainer getExecutableFlowElementContainer(
+      final ProcessInstanceRecord value) {
+    return processState.getFlowElement(
+        value.getProcessDefinitionKey(),
+        value.getElementIdBuffer(),
+        ExecutableFlowElementContainer.class);
   }
 
   private boolean isStartEventInSubProcess(

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementCompletedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementCompletedApplier.java
@@ -30,7 +30,6 @@ final class ProcessInstanceElementCompletedApplier
   @Override
   public void applyState(final long key, final ProcessInstanceRecord value) {
     eventScopeInstanceState.deleteInstance(key);
-    elementInstanceState.consumeToken(value.getFlowScopeKey());
     elementInstanceState.removeInstance(key);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementTerminatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementTerminatedApplier.java
@@ -29,7 +29,6 @@ final class ProcessInstanceElementTerminatedApplier
 
   @Override
   public void applyState(final long key, final ProcessInstanceRecord value) {
-    elementInstanceState.consumeToken(value.getFlowScopeKey());
     eventScopeInstanceState.deleteInstance(key);
     elementInstanceState.removeInstance(key);
   }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceSequenceFlowTakenApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceSequenceFlowTakenApplier.java
@@ -24,5 +24,18 @@ final class ProcessInstanceSequenceFlowTakenApplier
   }
 
   @Override
-  public void applyState(final long key, final ProcessInstanceRecord value) {}
+  public void applyState(final long key, final ProcessInstanceRecord value) {
+    // We need to keep track of the active sequence flows to not complete the process instances to
+    // early. On completing of the process instance we verify that we have no more active element
+    // instances and active sequence flows. Since sequence flows are no elements, we don't want to
+    // have element instances for them.
+    //
+    // This is necessary for concurrent flows, where for example the end event is reached on one
+    // path and on the other path the sequence flow is currently active.
+    //
+    // See discussion in https://github.com/camunda-cloud/zeebe/pull/6562
+    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
+    flowScopeInstance.incrementActiveSequenceFlows();
+    elementInstanceState.updateInstance(flowScopeInstance);
+  }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceSequenceFlowTakenApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceSequenceFlowTakenApplier.java
@@ -24,7 +24,5 @@ final class ProcessInstanceSequenceFlowTakenApplier
   }
 
   @Override
-  public void applyState(final long key, final ProcessInstanceRecord value) {
-    elementInstanceState.spawnToken(value.getFlowScopeKey());
-  }
+  public void applyState(final long key, final ProcessInstanceRecord value) {}
 }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -177,24 +177,6 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
-  public void consumeToken(final long scopeKey) {
-    final ElementInstance elementInstance = getInstance(scopeKey);
-    if (elementInstance != null) {
-      elementInstance.consumeToken();
-      updateInstance(elementInstance);
-    }
-  }
-
-  @Override
-  public void spawnToken(final long scopeKey) {
-    final ElementInstance elementInstance = getInstance(scopeKey);
-    if (elementInstance != null) {
-      elementInstance.spawnToken();
-      updateInstance(elementInstance);
-    }
-  }
-
-  @Override
   public void storeRecord(
       final long key,
       final long scopeKey,

--- a/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstance.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstance.java
@@ -29,6 +29,8 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
       new LongProperty("calledChildInstanceKey", -1L);
   private final ObjectProperty<IndexedRecord> recordProp =
       new ObjectProperty<>("elementRecord", new IndexedRecord());
+  private final IntegerProperty activeSequenceFlowsProp =
+      new IntegerProperty("activeSequenceFlows", 0);
 
   ElementInstance() {
     declareProperty(parentKeyProp)
@@ -37,7 +39,8 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
         .declareProperty(multiInstanceLoopCounterProp)
         .declareProperty(interruptingEventKeyProp)
         .declareProperty(calledChildInstanceKeyProp)
-        .declareProperty(recordProp);
+        .declareProperty(recordProp)
+        .declareProperty(activeSequenceFlowsProp);
   }
 
   public ElementInstance(
@@ -152,5 +155,26 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
 
   public long getParentKey() {
     return parentKeyProp.getValue();
+  }
+
+  public long getActiveSequenceFlows() {
+    return activeSequenceFlowsProp.getValue();
+  }
+
+  public void decrementActiveSequenceFlows() {
+    final var decrement = activeSequenceFlowsProp.decrement();
+
+    if (decrement < 0) {
+      throw new IllegalStateException(
+          "Not expected to have an active sequence flow count lower then zero!");
+    }
+  }
+
+  public void incrementActiveSequenceFlows() {
+    activeSequenceFlowsProp.increment();
+  }
+
+  public void resetActiveSequenceFlows() {
+    activeSequenceFlowsProp.setValue(0);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstance.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstance.java
@@ -21,7 +21,6 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
   private final LongProperty parentKeyProp = new LongProperty("parentKey", -1L);
   private final IntegerProperty childCountProp = new IntegerProperty("childCount", 0);
   private final LongProperty jobKeyProp = new LongProperty("jobKey", 0L);
-  private final IntegerProperty activeTokensProp = new IntegerProperty("activeTokens", 0);
   private final IntegerProperty multiInstanceLoopCounterProp =
       new IntegerProperty("multiInstanceLoopCounter", 0);
   private final LongProperty interruptingEventKeyProp =
@@ -35,7 +34,6 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
     declareProperty(parentKeyProp)
         .declareProperty(childCountProp)
         .declareProperty(jobKeyProp)
-        .declareProperty(activeTokensProp)
         .declareProperty(multiInstanceLoopCounterProp)
         .declareProperty(interruptingEventKeyProp)
         .declareProperty(calledChildInstanceKeyProp)
@@ -116,29 +114,8 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
     return ProcessInstanceLifecycle.isFinalState(getState());
   }
 
-  public void spawnToken() {
-    activeTokensProp.increment();
-  }
-
-  public void consumeToken() {
-    final int activeTokens = activeTokensProp.decrement();
-
-    if (activeTokens < 0) {
-      throw new IllegalStateException(
-          String.format("Expected the active token count to be positive but was %d", activeTokens));
-    }
-  }
-
-  public int getNumberOfActiveTokens() {
-    return activeTokensProp.getValue();
-  }
-
   public int getNumberOfActiveElementInstances() {
     return childCountProp.getValue();
-  }
-
-  public int getNumberOfActiveExecutionPaths() {
-    return activeTokensProp.getValue() + childCountProp.getValue();
   }
 
   public int getMultiInstanceLoopCounter() {

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableElementInstanceState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableElementInstanceState.java
@@ -28,10 +28,6 @@ public interface MutableElementInstanceState extends ElementInstanceState {
 
   void updateInstance(long key, Consumer<ElementInstance> modifier);
 
-  void consumeToken(long scopeKey);
-
-  void spawnToken(long scopeKey);
-
   void storeRecord(
       long key,
       long scopeKey,

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessConcurrencyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessConcurrencyTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.processing.bpmn.subprocess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.engine.util.RecordToWrite;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.builder.ProcessBuilder;
+import io.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.zeebe.protocol.record.intent.MessageIntent;
+import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class InterruptingEventSubprocessConcurrencyTest {
+
+  private static final String PROCESS_ID = "proc";
+  private static final String MSG_NAME = "messageName";
+
+  @Rule public final EngineRule engineRule = EngineRule.singlePartition();
+
+  @Test
+  // https://github.com/camunda-cloud/zeebe/issues/6552
+  public void shouldEndProcess() {
+    // given
+    final ProcessBuilder process = Bpmn.createExecutableProcess(PROCESS_ID);
+
+    process
+        .eventSubProcess("event_sub_proc")
+        .startEvent("event_sub_start")
+        .interrupting(true)
+        .message(b -> b.name(MSG_NAME).zeebeCorrelationKeyExpression("key"))
+        .endEvent("event_sub_end");
+
+    final BpmnModelInstance model =
+        process
+            .startEvent("start_proc")
+            .intermediateCatchEvent("catch")
+            .message(m -> m.name("msg").zeebeCorrelationKeyExpression("key"))
+            .exclusiveGateway()
+            .endEvent("end_proc")
+            .done();
+
+    engineRule.deployment().withXmlResource(model).deploy();
+
+    final long processInstanceKey =
+        engineRule
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariables(Map.of("key", 123))
+            .create();
+
+    // when
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withMessageName(MSG_NAME)
+        .await();
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withMessageName("msg")
+        .await();
+
+    engineRule.writeRecords(
+        RecordToWrite.command()
+            .message(
+                MessageIntent.PUBLISH,
+                new MessageRecord().setName("msg").setCorrelationKey("123").setTimeToLive(0)),
+        RecordToWrite.command()
+            .message(
+                MessageIntent.PUBLISH,
+                new MessageRecord().setName(MSG_NAME).setCorrelationKey("123").setTimeToLive(0)));
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
+        .containsSubsequence(
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.EVENT_OCCURRED),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  // https://github.com/camunda-cloud/zeebe/issues/6565
+  public void shouldEndProcessWithParallelFlow() {
+    // given
+    final ProcessBuilder process = Bpmn.createExecutableProcess(PROCESS_ID);
+
+    process
+        .eventSubProcess("event_sub_proc")
+        .startEvent("event_sub_start")
+        .interrupting(true)
+        .message(b -> b.name(MSG_NAME).zeebeCorrelationKeyExpression("key"))
+        .endEvent("event_sub_end");
+
+    final BpmnModelInstance model =
+        process
+            .startEvent("start_proc")
+            .sequenceFlowId("toParallel")
+            .parallelGateway("parallel")
+            .intermediateCatchEvent("catch")
+            .message(m -> m.name("msg").zeebeCorrelationKeyExpression("key"))
+            .endEvent("end_proc")
+            .moveToLastGateway()
+            .intermediateCatchEvent("catch1")
+            .message(m -> m.name("msg1").zeebeCorrelationKeyExpression("key1"))
+            .endEvent("end_proc1")
+            .done();
+
+    engineRule.deployment().withXmlResource(model).deploy();
+
+    final long processInstanceKey =
+        engineRule
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariables(Map.of("key", 123, "key1", 123))
+            .create();
+
+    // when
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withMessageName(MSG_NAME)
+        .await();
+    RecordingExporter.processInstanceRecords()
+        .withElementType(BpmnElementType.START_EVENT)
+        .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+        .withElementId("start_proc")
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    engineRule
+        .message()
+        .withName(MSG_NAME)
+        .withCorrelationKey("123")
+        .withVariables(Map.of("key", "123"))
+        .publish();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
+        .containsSubsequence(
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.EVENT_OCCURRED),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/state/instance/ElementInstanceStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/instance/ElementInstanceStateTest.java
@@ -80,41 +80,6 @@ public final class ElementInstanceStateTest {
   }
 
   @Test
-  public void shouldSpawnToken() {
-    // given
-    final ProcessInstanceRecord processInstanceRecord = createProcessInstanceRecord();
-    elementInstanceState.newInstance(
-        100, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
-
-    // when
-    elementInstanceState.spawnToken(100);
-
-    // then
-    final ElementInstance elementInstance = elementInstanceState.getInstance(100);
-    Assertions.assertThat(elementInstance.getNumberOfActiveElementInstances()).isEqualTo(0);
-    Assertions.assertThat(elementInstance.getNumberOfActiveExecutionPaths()).isEqualTo(1);
-    Assertions.assertThat(elementInstance.getNumberOfActiveTokens()).isEqualTo(1);
-  }
-
-  @Test
-  public void shouldConsumeToken() {
-    // given
-    final ProcessInstanceRecord processInstanceRecord = createProcessInstanceRecord();
-    elementInstanceState.newInstance(
-        100, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
-    elementInstanceState.spawnToken(100);
-
-    // when
-    elementInstanceState.consumeToken(100);
-
-    // then
-    final ElementInstance elementInstance = elementInstanceState.getInstance(100);
-    Assertions.assertThat(elementInstance.getNumberOfActiveElementInstances()).isEqualTo(0);
-    Assertions.assertThat(elementInstance.getNumberOfActiveExecutionPaths()).isEqualTo(0);
-    Assertions.assertThat(elementInstance.getNumberOfActiveTokens()).isEqualTo(0);
-  }
-
-  @Test
   public void shouldFindElementInstance() {
     // given
     final ProcessInstanceRecord processInstanceRecord = createProcessInstanceRecord();
@@ -230,7 +195,6 @@ public final class ElementInstanceStateTest {
             100, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
 
     // when
-    instance.spawnToken();
     instance.setState(ProcessInstanceIntent.ELEMENT_ACTIVATING);
     instance.setJobKey(5);
     elementInstanceState.updateInstance(instance);
@@ -245,8 +209,6 @@ public final class ElementInstanceStateTest {
     Assertions.assertThat(updatedInstance.canTerminate()).isTrue();
 
     Assertions.assertThat(updatedInstance.getNumberOfActiveElementInstances()).isEqualTo(0);
-    Assertions.assertThat(updatedInstance.getNumberOfActiveExecutionPaths()).isEqualTo(1);
-    Assertions.assertThat(updatedInstance.getNumberOfActiveTokens()).isEqualTo(1);
 
     final ProcessInstanceRecord record = updatedInstance.getValue();
     assertProcessInstanceRecord(record);
@@ -261,7 +223,6 @@ public final class ElementInstanceStateTest {
             100, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
 
     // when
-    instance.spawnToken();
     instance.setState(ProcessInstanceIntent.ELEMENT_ACTIVATING);
     instance.setJobKey(5);
 
@@ -275,8 +236,6 @@ public final class ElementInstanceStateTest {
     Assertions.assertThat(updatedInstance.canTerminate()).isTrue();
 
     Assertions.assertThat(updatedInstance.getNumberOfActiveElementInstances()).isEqualTo(0);
-    Assertions.assertThat(updatedInstance.getNumberOfActiveExecutionPaths()).isEqualTo(0);
-    Assertions.assertThat(updatedInstance.getNumberOfActiveTokens()).isEqualTo(0);
 
     final ProcessInstanceRecord record = updatedInstance.getValue();
     assertProcessInstanceRecord(record);
@@ -291,7 +250,6 @@ public final class ElementInstanceStateTest {
             100, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
 
     // when
-    instance.spawnToken();
     instance.setState(ProcessInstanceIntent.ELEMENT_ACTIVATING);
     instance.setJobKey(5);
 
@@ -472,8 +430,6 @@ public final class ElementInstanceStateTest {
 
     Assertions.assertThat(elementInstance.getNumberOfActiveElementInstances())
         .isEqualTo(childCount);
-    Assertions.assertThat(elementInstance.getNumberOfActiveExecutionPaths()).isEqualTo(childCount);
-    Assertions.assertThat(elementInstance.getNumberOfActiveTokens()).isEqualTo(0);
 
     final ProcessInstanceRecord record = elementInstance.getValue();
 
@@ -489,8 +445,6 @@ public final class ElementInstanceStateTest {
     Assertions.assertThat(childInstance.canTerminate()).isTrue();
 
     Assertions.assertThat(childInstance.getNumberOfActiveElementInstances()).isEqualTo(0);
-    Assertions.assertThat(childInstance.getNumberOfActiveExecutionPaths()).isEqualTo(0);
-    Assertions.assertThat(childInstance.getNumberOfActiveTokens()).isEqualTo(0);
 
     assertProcessInstanceRecord(childInstance.getValue(), wrapString(elementId));
   }

--- a/engine/src/test/java/io/zeebe/engine/util/RecordToWrite.java
+++ b/engine/src/test/java/io/zeebe/engine/util/RecordToWrite.java
@@ -11,15 +11,18 @@ import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.JobBatchIntent;
 import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.MessageIntent;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.protocol.record.intent.TimerIntent;
 import io.zeebe.protocol.record.value.JobRecordValue;
+import io.zeebe.protocol.record.value.MessageRecordValue;
 import io.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.zeebe.protocol.record.value.TimerRecordValue;
 
@@ -68,6 +71,12 @@ public final class RecordToWrite {
   public RecordToWrite job(final JobIntent intent, final JobRecordValue value) {
     recordMetadata.valueType(ValueType.JOB).intent(intent);
     unifiedRecordValue = (JobRecord) value;
+    return this;
+  }
+
+  public RecordToWrite message(final MessageIntent intent, final MessageRecordValue message) {
+    recordMetadata.valueType(ValueType.MESSAGE).intent(intent);
+    unifiedRecordValue = (MessageRecord) message;
     return this;
   }
 


### PR DESCRIPTION
## Description

> I removed the token concept completely. It was just too fragile and error prone. We now use the child count of the element instances to verify whether we can complete a process instance etc.

It was not possible to completely remove the counting. We introduce an active sequence flow counting, such that process instances are not completed to early. On process completion we check active element instances and active sequence flows and decide based on that whether we can complete the process instance.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6552
closes #6565 
closes #6539 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
