### PR TITLE
chore(test-util): log substituted numbers for debug conditions

### DIFF
--- a/protocol/src/main/java/io/zeebe/protocol/Protocol.java
+++ b/protocol/src/main/java/io/zeebe/protocol/Protocol.java
@@ -69,4 +69,10 @@ public final class Protocol {
   public static int decodePartitionId(final long key) {
     return (int) (key >> KEY_BITS);
   }
+
+  public static long decodeKeyInPartition(final long key) {
+    final long partitionId = decodePartitionId(key);
+
+    return key - ((long) partitionId << KEY_BITS);
+  }
 }


### PR DESCRIPTION
## Description

This logs the substituted numbers at the end. This was suggested by Nicolas, who uses the keys in conditional breakpoints during debugging.

```
Substituted numbers (for debugging):
K001 <-> 2251799813685249	(Partition: 1	Key: 1)
K002 <-> 2251799813685250	(Partition: 1	Key: 2)
K003 <-> 2251799813685251	(Partition: 1	Key: 3)
K004 <-> 2251799813685253	(Partition: 1	Key: 5)
K005 <-> 2251799813685252	(Partition: 1	Key: 4)
K006 <-> 2251799813685254	(Partition: 1	Key: 6)
```

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
