### PR TITLE
Avoid using the logstream writer on reprocessing

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReProcessingStateMachine.java
@@ -125,7 +125,7 @@ public final class ReProcessingStateMachine {
           );
 
   private final LogStreamReader logStreamReader;
-  private final ReprocessingStreamWriter reprocessingStreamWriter = new ReprocessingStreamWriter();
+  private final ReprocessingStreamWriter reprocessingStreamWriter;
   private final TypedResponseWriter noopResponseWriter = new NoopResponseWriter();
   private final EventApplier eventApplier;
 
@@ -167,6 +167,7 @@ public final class ReProcessingStateMachine {
     updateStateRetryStrategy = new EndlessRetryStrategy(actor);
     processRetryStrategy = new EndlessRetryStrategy(actor);
     detectReprocessingInconsistency = context.isDetectReprocessingInconsistency();
+    reprocessingStreamWriter = context.getReprocessingStreamWriter();
   }
 
   /**

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -122,6 +122,10 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
       final ReProcessingStateMachine reProcessingStateMachine =
           new ReProcessingStateMachine(processingContext);
 
+      // disable writing to the log stream but for reprocessing checks
+      processingContext.disableLogStreamWriter();
+      processingContext.enableReprocessingStreamWriter();
+
       recoverFuture = reProcessingStateMachine.startRecover(snapshotPosition);
 
       actor.runOnCompletion(
@@ -280,6 +284,10 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
 
   private void onRecovered(final long lastReprocessedPosition) {
     phase = Phase.PROCESSING;
+
+    // enable writing records to the stream
+    processingContext.enableLogStreamWriter();
+
     onCommitPositionUpdatedCondition =
         actor.onCondition(
             getName() + "-on-commit-position-updated", processingStateMachine::readNextEvent);

--- a/engine/src/test/java/io/zeebe/engine/processing/job/JobTimeoutTriggerTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/job/JobTimeoutTriggerTest.java
@@ -44,6 +44,7 @@ public final class JobTimeoutTriggerTest {
 
     final ProcessingContext processingContext =
         new ProcessingContext().actor(someActor).logStreamWriter(typedStreamWriter);
+    processingContext.enableLogStreamWriter();
     jobTimeoutTrigger.onRecovered(processingContext);
 
     jobState.activate(0, newJobRecord());

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -183,8 +183,7 @@ public class StreamProcessorHealthTest {
         streamProcessorRule.startTypedStreamProcessor(
             processingContext -> {
               final MutableZeebeState zeebeState = processingContext.getZeebeState();
-              mockedLogStreamWriter =
-                  new WrappedStreamWriter(processingContext.getLogStreamWriter());
+              mockedLogStreamWriter = new WrappedStreamWriter();
               processingContext.logStreamWriter(mockedLogStreamWriter);
               return processors(zeebeState.getKeyGenerator(), processingContext.getWriters())
                   .onEvent(
@@ -230,40 +229,27 @@ public class StreamProcessorHealthTest {
 
   private final class WrappedStreamWriter implements TypedStreamWriter {
 
-    private final TypedStreamWriter wrappedWriter;
-
-    private WrappedStreamWriter(final TypedStreamWriter wrappedWriter) {
-      this.wrappedWriter = wrappedWriter;
-    }
-
     @Override
     public void appendRejection(
         final TypedRecord<? extends RecordValue> command,
         final RejectionType type,
-        final String reason) {
-      wrappedWriter.appendRejection(command, type, reason);
-    }
+        final String reason) {}
 
     @Override
     public void appendRejection(
         final TypedRecord<? extends RecordValue> command,
         final RejectionType type,
         final String reason,
-        final UnaryOperator<RecordMetadata> modifier) {
-      wrappedWriter.appendRejection(command, type, reason, modifier);
-    }
+        final UnaryOperator<RecordMetadata> modifier) {}
 
     @Override
-    public void configureSourceContext(final long sourceRecordPosition) {
-      wrappedWriter.configureSourceContext(sourceRecordPosition);
-    }
+    public void configureSourceContext(final long sourceRecordPosition) {}
 
     @Override
     public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
       if (shouldFailErrorHandlingInTransaction.get()) {
         throw new RuntimeException("Expected failure on append followup event");
       }
-      wrappedWriter.appendFollowUpEvent(key, intent, value);
     }
 
     @Override
@@ -275,40 +261,31 @@ public class StreamProcessorHealthTest {
       if (shouldFailErrorHandlingInTransaction.get()) {
         throw new RuntimeException("Expected failure on append followup event");
       }
-      wrappedWriter.appendFollowUpEvent(key, intent, value, modifier);
     }
 
     @Override
-    public void appendNewCommand(final Intent intent, final RecordValue value) {
-      wrappedWriter.appendNewCommand(intent, value);
-    }
+    public void appendNewCommand(final Intent intent, final RecordValue value) {}
 
     @Override
     public void appendFollowUpCommand(
-        final long key, final Intent intent, final RecordValue value) {
-      wrappedWriter.appendFollowUpCommand(key, intent, value);
-    }
+        final long key, final Intent intent, final RecordValue value) {}
 
     @Override
     public void appendFollowUpCommand(
         final long key,
         final Intent intent,
         final RecordValue value,
-        final UnaryOperator<RecordMetadata> modifier) {
-      wrappedWriter.appendFollowUpCommand(key, intent, value, modifier);
-    }
+        final UnaryOperator<RecordMetadata> modifier) {}
 
     @Override
-    public void reset() {
-      wrappedWriter.reset();
-    }
+    public void reset() {}
 
     @Override
     public long flush() {
       if (shouldFlushThrowException.get()) {
         throw new RuntimeException("Expected failure on flush");
       }
-      return wrappedWriter.flush();
+      return 1L;
     }
   }
 }


### PR DESCRIPTION
## Description

* the stream processor enables writing to the log stream when start processing
* on reprocessing, it uses the reprocessing checker
* no tests to verify the behavior because we'll remove it after the migration is done

## Related issues

closes #6557

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
