### PR TITLE
chore(test-util): log substituted numbers for debug conditions

### DIFF
--- a/protocol/src/main/java/io/zeebe/protocol/Protocol.java
+++ b/protocol/src/main/java/io/zeebe/protocol/Protocol.java
@@ -69,4 +69,11 @@ public final class Protocol {
   public static int decodePartitionId(final long key) {
     return (int) (key >> KEY_BITS);
   }
+
+  public static long decodeKeyInPartition(final long key) {
+    // For comprehension, we calculate: key - ((long) partitionId << KEY_BITS);
+
+    // for efficiency we do it as a bit-wise operation
+    return key & 0x0007FFFFFFFFFFFFL;
+  }
 }

--- a/test-util/src/main/java/io/zeebe/test/util/record/RecordLogger.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/RecordLogger.java
@@ -14,15 +14,15 @@ import org.slf4j.LoggerFactory;
 
 public class RecordLogger {
   public static final String STYLE_PROPERTY = "RECORD_LOGGER_STYLE";
-  public static final String STYLE_COMPACT = "COMPACT";
+  public static final String STYLE_RAW = "RAW";
   public static final Logger LOG = LoggerFactory.getLogger("io.zeebe.test");
 
   public static void logRecords() {
     LOG.info("Test failed, following records were exported:");
-    if (STYLE_COMPACT.equals(System.getenv(STYLE_PROPERTY))) {
-      logRecordsCompact(RecordingExporter.getRecords());
-    } else {
+    if (STYLE_RAW.equals(System.getenv(STYLE_PROPERTY))) {
       logRecordsRaw(RecordingExporter.getRecords());
+    } else {
+      logRecordsCompact(RecordingExporter.getRecords());
     }
   }
 


### PR DESCRIPTION
## Description

* enable compact style by default
* decompose key into partition ID and per partition key
* print out real keys at the end (for debugging)

```
Decomposed keys (for debugging):
  -1 <-> -1
K001 <-> 2251799813685249
K002 <-> 2251799813685250
K003 <-> 2251799813685251
K004 <-> 2251799813685252
K005 <-> 2251799813685253
```

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
