### PR TITLE
Apply event sourcing to Timer.CREATE processor

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
@@ -63,6 +63,7 @@ public final class EngineProcessors {
         new ExpressionProcessor(
             ExpressionLanguageFactory.createExpressionLanguage(), variablesState::getVariable);
 
+    final DueDateTimerChecker timerChecker = new DueDateTimerChecker(zeebeState.getTimerState());
     final CatchEventBehavior catchEventBehavior =
         new CatchEventBehavior(
             zeebeState,
@@ -92,7 +93,8 @@ public final class EngineProcessors {
             typedRecordProcessors,
             subscriptionCommandSender,
             catchEventBehavior,
-            writers);
+            writers,
+            timerChecker);
 
     addJobProcessors(
         zeebeState, typedRecordProcessors, onJobsAvailableCallback, maxFragmentSize, writers);
@@ -108,8 +110,8 @@ public final class EngineProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final SubscriptionCommandSender subscriptionCommandSender,
       final CatchEventBehavior catchEventBehavior,
-      final Writers writers) {
-    final DueDateTimerChecker timerChecker = new DueDateTimerChecker(zeebeState.getTimerState());
+      final Writers writers,
+      final DueDateTimerChecker timerChecker) {
     return ProcessEventProcessors.addProcessProcessors(
         zeebeState,
         expressionProcessor,

--- a/engine/src/main/java/io/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/ProcessEventProcessors.java
@@ -68,7 +68,12 @@ public final class ProcessEventProcessors {
     addMessageStreamProcessors(
         typedRecordProcessors, subscriptionState, subscriptionCommandSender, zeebeState, writers);
     addTimerStreamProcessors(
-        typedRecordProcessors, timerChecker, zeebeState, catchEventBehavior, expressionProcessor);
+        typedRecordProcessors,
+        timerChecker,
+        zeebeState,
+        catchEventBehavior,
+        expressionProcessor,
+        writers);
     addVariableDocumentStreamProcessors(
         typedRecordProcessors,
         variableBehavior,
@@ -146,11 +151,13 @@ public final class ProcessEventProcessors {
       final DueDateTimerChecker timerChecker,
       final MutableZeebeState zeebeState,
       final CatchEventBehavior catchEventOutput,
-      final ExpressionProcessor expressionProcessor) {
-
+      final ExpressionProcessor expressionProcessor,
+      final Writers writers) {
     typedRecordProcessors
         .onCommand(
-            ValueType.TIMER, TimerIntent.CREATE, new CreateTimerProcessor(zeebeState, timerChecker))
+            ValueType.TIMER,
+            TimerIntent.CREATE,
+            new CreateTimerProcessor(writers.state(), zeebeState.getKeyGenerator(), timerChecker))
         .onCommand(
             ValueType.TIMER,
             TimerIntent.TRIGGER,

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -94,7 +94,7 @@ public final class BpmnEventSubscriptionBehavior {
       final T element, final BpmnElementContext context) {
 
     try {
-      catchEventBehavior.subscribeToEvents(context, element, commandWriter, sideEffects);
+      catchEventBehavior.subscribeToEvents(context, element, sideEffects, commandWriter);
       return Either.right(null);
 
     } catch (final MessageCorrelationKeyException e) {

--- a/engine/src/main/java/io/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -94,8 +94,8 @@ public final class CatchEventBehavior {
   public void subscribeToEvents(
       final BpmnElementContext context,
       final ExecutableCatchEventSupplier supplier,
-      final TypedCommandWriter commandWriter,
-      final SideEffects sideEffects)
+      final SideEffects sideEffects,
+      final TypedCommandWriter commandWriter)
       throws MessageCorrelationKeyException {
 
     final List<ExecutableCatchEvent> events = supplier.getEvents();
@@ -145,14 +145,16 @@ public final class CatchEventBehavior {
       final DirectBuffer handlerNodeId,
       final Timer timer,
       final TypedCommandWriter commandWriter) {
+    final long dueDate = timer.getDueDate(ActorClock.currentTimeMillis());
     timerRecord.reset();
     timerRecord
         .setRepetitions(timer.getRepetitions())
-        .setDueDate(timer.getDueDate(ActorClock.currentTimeMillis()))
+        .setDueDate(dueDate)
         .setElementInstanceKey(elementInstanceKey)
         .setProcessInstanceKey(processInstanceKey)
         .setTargetElementId(handlerNodeId)
         .setProcessDefinitionKey(processDefinitionKey);
+
     commandWriter.appendNewCommand(TimerIntent.CREATE, timerRecord);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -91,7 +91,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
       final long key = keyGenerator.nextKey();
 
       try {
-        createTimerIfTimerStartEvent(command, streamWriter);
+        createTimerIfTimerStartEvent(command, streamWriter, sideEffect);
       } catch (final RuntimeException e) {
         final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
         responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
@@ -119,7 +119,9 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
   }
 
   private void createTimerIfTimerStartEvent(
-      final TypedRecord<DeploymentRecord> record, final TypedStreamWriter streamWriter) {
+      final TypedRecord<DeploymentRecord> record,
+      final TypedStreamWriter streamWriter,
+      Consumer<SideEffectProducer> sideEffects) {
     for (final ProcessRecord processRecord : record.getValue().processes()) {
       final List<ExecutableStartEvent> startEvents =
           processState.getProcessByKey(processRecord.getKey()).getProcess().getStartEvents();

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -11,6 +11,7 @@ import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.TimerIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -76,6 +77,9 @@ public final class MigratedStreamProcessors {
     MIGRATED_VALUE_TYPES.put(ValueType.VARIABLE_DOCUMENT, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.VARIABLE, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.INCIDENT, MIGRATED);
+    MIGRATED_VALUE_TYPES.put(
+        ValueType.TIMER,
+        MIGRATED_INTENT_FILTER_FACTORY.apply(List.of(TimerIntent.CREATE, TimerIntent.CREATED)));
   }
 
   private MigratedStreamProcessors() {}

--- a/engine/src/main/java/io/zeebe/engine/processing/timer/DueDateTimerChecker.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/timer/DueDateTimerChecker.java
@@ -36,7 +36,7 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
     this.timerInstanceState = timerInstanceState;
   }
 
-  public void scheduleTimer(final TimerInstance timer) {
+  public void scheduleTimer(final long dueDate) {
 
     // We schedule only one runnable for all timers.
     // - The runnable is scheduled when the first timer is scheduled.
@@ -45,18 +45,17 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
     // - Otherwise, we don't need to cancel the runnable. It will be rescheduled when it is
     // executed.
 
-    final Duration duration =
-        Duration.ofMillis(timer.getDueDate() - ActorClock.currentTimeMillis());
+    final Duration duration = Duration.ofMillis(dueDate - ActorClock.currentTimeMillis());
 
     if (scheduledTimer == null) {
       scheduledTimer = actor.runDelayed(duration, this::triggerTimers);
-      nextDueDate = timer.getDueDate();
+      nextDueDate = dueDate;
 
-    } else if (nextDueDate - timer.getDueDate() > TIMER_RESOLUTION) {
+    } else if (nextDueDate - dueDate > TIMER_RESOLUTION) {
       scheduledTimer.cancel();
 
       scheduledTimer = actor.runDelayed(duration, this::triggerTimers);
-      nextDueDate = timer.getDueDate();
+      nextDueDate = dueDate;
     }
   }
 

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -24,6 +24,7 @@ import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.protocol.record.intent.ProcessIntent;
 import io.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.zeebe.protocol.record.intent.TimerIntent;
 import io.zeebe.protocol.record.intent.VariableIntent;
 import java.util.HashMap;
 import java.util.Map;
@@ -66,6 +67,7 @@ public final class EventAppliers implements EventApplier {
     register(JobBatchIntent.ACTIVATED, new JobBatchActivatedApplier(state));
     registerIncidentEventAppliers(state);
     registerProcessMessageSubscriptionEventAppliers(state);
+    register(TimerIntent.CREATED, new TimerCreatedApplier(state.getTimerState()));
   }
 
   private void registerDeploymentAppliers(final MutableZeebeState state) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/TimerCreatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/TimerCreatedApplier.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.instance.TimerInstance;
+import io.zeebe.engine.state.mutable.MutableTimerInstanceState;
+import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.zeebe.protocol.record.intent.TimerIntent;
+
+public final class TimerCreatedApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
+
+  private final MutableTimerInstanceState timerInstanceState;
+  private final TimerInstance timerInstance = new TimerInstance();
+
+  public TimerCreatedApplier(final MutableTimerInstanceState timerInstanceState) {
+    this.timerInstanceState = timerInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final TimerRecord value) {
+    timerInstance.setElementInstanceKey(value.getElementInstanceKey());
+    timerInstance.setDueDate(value.getDueDate());
+    timerInstance.setKey(key);
+    timerInstance.setHandlerNodeId(value.getTargetElementIdBuffer());
+    timerInstance.setRepetitions(value.getRepetitions());
+    timerInstance.setProcessDefinitionKey(value.getProcessDefinitionKey());
+    timerInstance.setProcessInstanceKey(value.getProcessInstanceKey());
+
+    timerInstanceState.put(timerInstance);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/instance/TimerInstance.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/TimerInstance.java
@@ -17,7 +17,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public final class TimerInstance extends UnpackedObject implements DbValue {
 
-  public static final int NO_ELEMENT_INSTANCE = -1;
+  public static final long NO_ELEMENT_INSTANCE = -1L;
 
   private final StringProperty handlerNodeIdProp = new StringProperty("handlerNodeId", "");
   private final LongProperty processDefinitionKeyProp =

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/ProcessInstanceStreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/ProcessInstanceStreamProcessorRule.java
@@ -112,6 +112,8 @@ public final class ProcessInstanceStreamProcessorRule extends ExternalResource
                   variablesState::getVariable);
 
           final var writers = processingContext.getWriters();
+          final DueDateTimerChecker dueDateTimerChecker =
+              new DueDateTimerChecker(zeebeState.getTimerState());
           ProcessEventProcessors.addProcessProcessors(
               zeebeState,
               expressionProcessor,
@@ -123,7 +125,7 @@ public final class ProcessInstanceStreamProcessorRule extends ExternalResource
                   mockSubscriptionCommandSender,
                   writers.state(),
                   1),
-              new DueDateTimerChecker(zeebeState.getTimerState()),
+              dueDateTimerChecker,
               writers);
 
           JobEventProcessors.addJobProcessors(

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateTest.java
@@ -19,8 +19,11 @@ import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.intent.MessageIntent;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.zeebe.protocol.record.intent.TimerIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.protocol.record.value.TimerRecordValue;
 import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
@@ -40,16 +43,19 @@ import org.junit.runners.Parameterized.Parameters;
 public final class ReplayStateTest {
 
   private static final String PROCESS_ID = "process";
+  @Parameter public TestCase testCase;
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private long lastProcessedPosition = -1L;
 
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
           .withOnProcessedCallback(record -> lastProcessedPosition = record.getPosition())
           .withOnSkippedCallback(record -> lastProcessedPosition = record.getPosition());
-
-  @Parameter public TestCase testCase;
-
-  private long lastProcessedPosition = -1L;
 
   @Parameters(name = "{0}")
   public static Collection<TestCase> testRecords() {
@@ -88,6 +94,97 @@ public final class ReplayStateTest {
                           timeToLive.plus(MessageObserver.MESSAGE_TIME_TO_LIVE_CHECK_INTERVAL));
 
                   return RecordingExporter.messageRecords(MessageIntent.EXPIRED).getFirst();
+                }),
+        // TODO(npepinpe): remove after https://github.com/camunda-cloud/zeebe/issues/6568
+        testCase("timer start event")
+            .withProcess(
+                Bpmn.createExecutableProcess(PROCESS_ID)
+                    .startEvent("timer")
+                    .timerWithCycle("R/PT1M")
+                    .endEvent()
+                    .done())
+            .withExecution(
+                engine -> RecordingExporter.timerRecords(TimerIntent.CREATED).getFirst()),
+        // TODO(npepinpe): remove after https://github.com/camunda-cloud/zeebe/issues/6568
+        testCase("intermediate timer catch event")
+            .withProcess(
+                Bpmn.createExecutableProcess(PROCESS_ID)
+                    .startEvent()
+                    .intermediateCatchEvent("timer")
+                    .timerWithDuration("PT30S")
+                    .endEvent()
+                    .done())
+            .withExecution(
+                engine -> {
+                  final long piKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+                  final Record<TimerRecordValue> timer =
+                      RecordingExporter.timerRecords(TimerIntent.CREATED)
+                          .withProcessInstanceKey(piKey)
+                          .getFirst();
+
+                  assertThat(timer).as("timer start event was created").isNotNull();
+                  engine.getClock().addTime(Duration.ofSeconds(30));
+
+                  return RecordingExporter.processInstanceRecords(
+                          ProcessInstanceIntent.ELEMENT_COMPLETED)
+                      .withProcessInstanceKey(piKey)
+                      .withElementType(BpmnElementType.PROCESS)
+                      .getFirst();
+                }),
+        // TODO(npepinpe): remove after https://github.com/camunda-cloud/zeebe/issues/6568
+        testCase("interrupting timer boundary event")
+            .withProcess(
+                Bpmn.createExecutableProcess(PROCESS_ID)
+                    .startEvent()
+                    .serviceTask("task", b -> b.zeebeJobType("type"))
+                    .boundaryEvent("timer", b -> b.cancelActivity(true))
+                    .timerWithDuration("PT30S")
+                    .endEvent("end")
+                    .done())
+            .withExecution(
+                engine -> {
+                  final long piKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+                  final Record<TimerRecordValue> timer =
+                      RecordingExporter.timerRecords(TimerIntent.CREATED)
+                          .withProcessInstanceKey(piKey)
+                          .getFirst();
+
+                  assertThat(timer).as("timer start event was created").isNotNull();
+                  engine.getClock().addTime(Duration.ofSeconds(30));
+
+                  return RecordingExporter.processInstanceRecords(
+                          ProcessInstanceIntent.ELEMENT_COMPLETED)
+                      .withProcessInstanceKey(piKey)
+                      .withElementType(BpmnElementType.PROCESS)
+                      .getFirst();
+                }),
+        // TODO(npepinpe): remove after https://github.com/camunda-cloud/zeebe/issues/6568
+        testCase("non-interrupting timer boundary event")
+            .withProcess(
+                Bpmn.createExecutableProcess(PROCESS_ID)
+                    .startEvent()
+                    .serviceTask("task", b -> b.zeebeJobType("type"))
+                    .boundaryEvent("timer", b -> b.cancelActivity(false))
+                    .timerWithCycle("R/PT30S")
+                    .endEvent("end")
+                    .done())
+            .withExecution(
+                engine -> {
+                  final long piKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+                  final Record<TimerRecordValue> timer =
+                      RecordingExporter.timerRecords(TimerIntent.CREATED)
+                          .withProcessInstanceKey(piKey)
+                          .getFirst();
+
+                  assertThat(timer).as("timer start event was created").isNotNull();
+                  engine.getClock().addTime(Duration.ofSeconds(30));
+
+                  return RecordingExporter.processInstanceRecords(
+                          ProcessInstanceIntent.ELEMENT_COMPLETED)
+                      .withProcessInstanceKey(piKey)
+                      .withElementType(BpmnElementType.END_EVENT)
+                      .withElementId("end")
+                      .getFirst();
                 }));
   }
 

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
@@ -31,14 +31,18 @@ import io.zeebe.engine.util.Records;
 import io.zeebe.engine.util.TestStreams;
 import io.zeebe.logstreams.log.LoggedEvent;
 import io.zeebe.logstreams.util.SynchronousLogStream;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.ValueType;
+import io.zeebe.protocol.record.intent.DeploymentIntent;
 import io.zeebe.protocol.record.intent.ErrorIntent;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -384,23 +388,35 @@ public final class SkipFailingEventsTest {
     // given
     when(commandResponseWriter.tryWriteResponse(anyInt(), anyLong())).thenReturn(true);
     final List<Long> processedInstances = new ArrayList<>();
-    final TypedRecordProcessor<TimerRecord> errorProneProcessor =
+    final TypedRecordProcessor<DeploymentRecord> errorProneProcessor =
         new TypedRecordProcessor<>() {
           @Override
           public void processRecord(
-              final TypedRecord<TimerRecord> record,
+              final TypedRecord<DeploymentRecord> record,
               final TypedResponseWriter responseWriter,
               final TypedStreamWriter streamWriter) {
             if (record.getKey() == 0) {
               throw new RuntimeException("expected");
             }
-            processedInstances.add(record.getValue().getProcessInstanceKey());
+            processedInstances.add(TimerInstance.NO_ELEMENT_INSTANCE);
             streamWriter.appendFollowUpEvent(
                 record.getKey(),
                 TimerIntent.CREATED,
                 Records.timer(TimerInstance.NO_ELEMENT_INSTANCE));
           }
         };
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .timerWithDuration("PT1S")
+            .endEvent()
+            .done();
+    final DeploymentRecord deploymentRecord = new DeploymentRecord();
+    deploymentRecord
+        .resources()
+        .add()
+        .setResourceName("process.bpmn")
+        .setResource(Bpmn.convertToString(process).getBytes());
 
     streams.startStreamProcessor(
         STREAM_NAME,
@@ -409,22 +425,22 @@ public final class SkipFailingEventsTest {
           zeebeState = processingContext.getZeebeState();
           return TypedRecordProcessors.processors(
                   zeebeState.getKeyGenerator(), processingContext.getWriters())
-              .onCommand(ValueType.TIMER, TimerIntent.CREATE, errorProneProcessor);
+              .onCommand(ValueType.DEPLOYMENT, DeploymentIntent.CREATE, errorProneProcessor);
         });
 
     streams
         .newRecord(STREAM_NAME)
-        .event(Records.timer(TimerInstance.NO_ELEMENT_INSTANCE))
+        .event(deploymentRecord)
         .recordType(RecordType.COMMAND)
-        .intent(TimerIntent.CREATE)
-        .key(keyGenerator.nextKey())
+        .intent(DeploymentIntent.CREATE)
+        .key(0)
         .write();
     streams
         .newRecord(STREAM_NAME)
-        .event(Records.timer(TimerInstance.NO_ELEMENT_INSTANCE))
+        .event(deploymentRecord)
         .recordType(RecordType.COMMAND)
-        .intent(TimerIntent.CREATE)
-        .key(keyGenerator.nextKey())
+        .intent(DeploymentIntent.CREATE)
+        .key(1)
         .write();
 
     // when
@@ -436,7 +452,7 @@ public final class SkipFailingEventsTest {
     final MockTypedRecord<TimerRecord> mockTypedRecord =
         new MockTypedRecord<>(0, metadata, Records.timer(TimerInstance.NO_ELEMENT_INSTANCE));
     Assertions.assertThat(zeebeState.getBlackListState().isOnBlacklist(mockTypedRecord)).isFalse();
-    assertThat(processedInstances).containsExactly((long) TimerInstance.NO_ELEMENT_INSTANCE);
+    assertThat(processedInstances).containsExactly(TimerInstance.NO_ELEMENT_INSTANCE);
   }
 
   private void waitForRecordWhichSatisfies(final Predicate<LoggedEvent> filter) {

--- a/engine/src/test/java/io/zeebe/engine/util/Records.java
+++ b/engine/src/test/java/io/zeebe/engine/util/Records.java
@@ -166,7 +166,7 @@ public final class Records {
     return event;
   }
 
-  public static TimerRecord timer(final int instanceKey) {
+  public static TimerRecord timer(final long instanceKey) {
     final TimerRecord event = new TimerRecord();
     event
         .setProcessInstanceKey(instanceKey)

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/TimerIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/TimerIntent.java
@@ -16,7 +16,10 @@
 package io.zeebe.protocol.record.intent;
 
 public enum TimerIntent implements ProcessInstanceRelatedIntent {
+  // TODO(npepinpe): remove as part of https://github.com/camunda-cloud/zeebe/issues/6589
+  @Deprecated
   CREATE((short) 0),
+
   CREATED((short) 1),
 
   TRIGGER((short) 2),


### PR DESCRIPTION
## Description

This PR migrates the `Timer.CREATE` processor to a `Timer.CREATED` event applier, and drops the old processor. Timers are now created directly during subscription by producing the follow up event, and are scheduled there as side effect.

The blacklist test was adapted to not use `Timer.CREATE` but instead use `Deployment.CREATE`, as it simulates how a timer start event is created.

The ordinals of the `TimerIntent` enum have been shifted, and the old `TimerIntent.CREATE` value dropped.

## Related issues

related to #6177

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
