### PR TITLE
Apply event sourcing to Timer.CANCEL and Timer.TRIGGER processors

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/ProcessEventProcessors.java
@@ -165,7 +165,8 @@ public final class ProcessEventProcessors {
         .onCommand(
             ValueType.TIMER,
             TimerIntent.CANCEL,
-            new CancelTimerProcessor(zeebeState.getTimerState()))
+            new CancelTimerProcessor(
+                zeebeState.getTimerState(), writers.state(), writers.rejection()))
         .withListener(timerChecker);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/ProcessEventProcessors.java
@@ -161,7 +161,12 @@ public final class ProcessEventProcessors {
         .onCommand(
             ValueType.TIMER,
             TimerIntent.TRIGGER,
-            new TriggerTimerProcessor(zeebeState, catchEventOutput, expressionProcessor))
+            new TriggerTimerProcessor(
+                zeebeState,
+                catchEventOutput,
+                expressionProcessor,
+                writers.state(),
+                writers.rejection()))
         .onCommand(
             ValueType.TIMER,
             TimerIntent.CANCEL,

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -62,7 +62,12 @@ public final class MigratedStreamProcessors {
     MIGRATED_VALUE_TYPES.put(ValueType.INCIDENT, MIGRATED);
     MIGRATED_VALUE_TYPES.put(
         ValueType.TIMER,
-        MIGRATED_INTENT_FILTER_FACTORY.apply(List.of(TimerIntent.CREATE, TimerIntent.CREATED)));
+        MIGRATED_INTENT_FILTER_FACTORY.apply(
+            List.of(
+                TimerIntent.CREATE,
+                TimerIntent.CREATED,
+                TimerIntent.CANCEL,
+                TimerIntent.CANCELED)));
   }
 
   private MigratedStreamProcessors() {}

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -10,7 +10,6 @@ package io.zeebe.engine.processing.streamprocessor;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.Intent;
-import io.zeebe.protocol.record.intent.TimerIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -60,14 +59,7 @@ public final class MigratedStreamProcessors {
     MIGRATED_VALUE_TYPES.put(ValueType.VARIABLE_DOCUMENT, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.VARIABLE, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.INCIDENT, MIGRATED);
-    MIGRATED_VALUE_TYPES.put(
-        ValueType.TIMER,
-        MIGRATED_INTENT_FILTER_FACTORY.apply(
-            List.of(
-                TimerIntent.CREATE,
-                TimerIntent.CREATED,
-                TimerIntent.CANCEL,
-                TimerIntent.CANCELED)));
+    MIGRATED_VALUE_TYPES.put(ValueType.TIMER, MIGRATED);
   }
 
   private MigratedStreamProcessors() {}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -68,6 +68,7 @@ public final class EventAppliers implements EventApplier {
     registerIncidentEventAppliers(state);
     registerProcessMessageSubscriptionEventAppliers(state);
     register(TimerIntent.CREATED, new TimerCreatedApplier(state.getTimerState()));
+    register(TimerIntent.CANCELED, new TimerCancelledApplier(state.getTimerState()));
   }
 
   private void registerDeploymentAppliers(final MutableZeebeState state) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -67,8 +67,15 @@ public final class EventAppliers implements EventApplier {
     register(JobBatchIntent.ACTIVATED, new JobBatchActivatedApplier(state));
     registerIncidentEventAppliers(state);
     registerProcessMessageSubscriptionEventAppliers(state);
+    registerTimeEventAppliers(state);
+  }
+
+  private void registerTimeEventAppliers(final MutableZeebeState state) {
     register(TimerIntent.CREATED, new TimerCreatedApplier(state.getTimerState()));
     register(TimerIntent.CANCELED, new TimerCancelledApplier(state.getTimerState()));
+    register(
+        TimerIntent.TRIGGERED,
+        new TimerTriggeredApplier(state.getEventScopeInstanceState(), state.getTimerState()));
   }
 
   private void registerDeploymentAppliers(final MutableZeebeState state) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/TimerCancelledApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/TimerCancelledApplier.java
@@ -13,25 +13,22 @@ import io.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.zeebe.protocol.record.intent.TimerIntent;
 
-final class TimerCreatedApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
+final class TimerCancelledApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
 
   private final MutableTimerInstanceState timerInstanceState;
-  private final TimerInstance timerInstance = new TimerInstance();
 
-  TimerCreatedApplier(final MutableTimerInstanceState timerInstanceState) {
+  TimerCancelledApplier(final MutableTimerInstanceState timerInstanceState) {
     this.timerInstanceState = timerInstanceState;
   }
 
   @Override
   public void applyState(final long key, final TimerRecord value) {
-    timerInstance.setElementInstanceKey(value.getElementInstanceKey());
-    timerInstance.setDueDate(value.getDueDate());
-    timerInstance.setKey(key);
-    timerInstance.setHandlerNodeId(value.getTargetElementIdBuffer());
-    timerInstance.setRepetitions(value.getRepetitions());
-    timerInstance.setProcessDefinitionKey(value.getProcessDefinitionKey());
-    timerInstance.setProcessInstanceKey(value.getProcessInstanceKey());
+    final TimerInstance timerInstance = timerInstanceState.get(value.getElementInstanceKey(), key);
 
-    timerInstanceState.put(timerInstance);
+    // if (timerInstance != null) {
+    timerInstanceState.remove(timerInstance);
+    // } else {
+    //  System.out.println("klongh");
+    // }
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/TimerCancelledApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/TimerCancelledApplier.java
@@ -24,11 +24,6 @@ final class TimerCancelledApplier implements TypedEventApplier<TimerIntent, Time
   @Override
   public void applyState(final long key, final TimerRecord value) {
     final TimerInstance timerInstance = timerInstanceState.get(value.getElementInstanceKey(), key);
-
-    // if (timerInstance != null) {
     timerInstanceState.remove(timerInstance);
-    // } else {
-    //  System.out.println("klongh");
-    // }
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/TimerTriggeredApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/TimerTriggeredApplier.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.instance.TimerInstance;
+import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.zeebe.engine.state.mutable.MutableTimerInstanceState;
+import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.zeebe.protocol.record.intent.TimerIntent;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+final class TimerTriggeredApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
+
+  private static final UnsafeBuffer NO_VARIABLES = new UnsafeBuffer();
+  private final MutableEventScopeInstanceState eventScopeInstanceState;
+  private final MutableTimerInstanceState timerInstanceState;
+
+  public TimerTriggeredApplier(
+      final MutableEventScopeInstanceState eventScopeInstanceState,
+      final MutableTimerInstanceState timerInstanceState) {
+    this.eventScopeInstanceState = eventScopeInstanceState;
+    this.timerInstanceState = timerInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final TimerRecord value) {
+    final long elementInstanceKey = value.getElementInstanceKey();
+    final TimerInstance timerInstance = timerInstanceState.get(elementInstanceKey, key);
+    final long processDefinitionKey = value.getProcessDefinitionKey();
+    final DirectBuffer targetElementId = value.getTargetElementIdBuffer();
+    final long eventScopeKey =
+        isStartEvent(elementInstanceKey) ? processDefinitionKey : elementInstanceKey;
+
+    timerInstanceState.remove(timerInstance);
+    eventScopeInstanceState.triggerEvent(eventScopeKey, key, targetElementId, NO_VARIABLES);
+  }
+
+  private boolean isStartEvent(final long elementInstanceKey) {
+    return elementInstanceKey < 0;
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
@@ -128,8 +128,8 @@ public final class BoundaryEventTest {
     assertThat(records)
         .extracting(Record::getValueType, Record::getIntent)
         .containsSequence(
-            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.EVENT_OCCURRED),
             tuple(ValueType.TIMER, TimerIntent.TRIGGERED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.EVENT_OCCURRED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(ValueType.JOB, JobIntent.CANCEL),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATED),
@@ -252,8 +252,8 @@ public final class BoundaryEventTest {
     assertThat(records)
         .extracting(Record::getValueType, Record::getIntent)
         .endsWith(
-            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.EVENT_OCCURRED),
             tuple(ValueType.TIMER, TimerIntent.TRIGGERED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.EVENT_OCCURRED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(ValueType.JOB, JobIntent.CANCEL),
@@ -299,8 +299,8 @@ public final class BoundaryEventTest {
     assertThat(records)
         .extracting(Record::getValueType, Record::getIntent)
         .containsSubsequence(
-            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.EVENT_OCCURRED),
             tuple(ValueType.TIMER, TimerIntent.TRIGGERED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.EVENT_OCCURRED),
             tuple(ValueType.TIMER, TimerIntent.CREATE),
             tuple(ValueType.JOB, JobIntent.COMPLETED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_COMPLETING),


### PR DESCRIPTION
## Description

This PR migrates the `Timer.CANCEL`, `Timer.CANCELLED`, `Timer.TRIGGER`, and `Timer.TRIGGERED` processors. The bulk of the changes is in the `TriggerTimerProcessor`, where most of the logic from `EventHandle` was pulled in (with some going into the applier). Another notable change is that `Timer.TRIGGERED` __must__ be applied _before_ `EVENT_OCCURRED`, as the applier will create the event trigger in the state which the event occurred processor needs to read. 

## Related issues

related to #6177 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
