### PR TITLE
fix(logstreams): prevent bad system clock from causing crash

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/transport/backpressure/PartitionAwareRequestLimiter.java
+++ b/broker/src/main/java/io/zeebe/broker/transport/backpressure/PartitionAwareRequestLimiter.java
@@ -130,7 +130,7 @@ public final class PartitionAwareRequestLimiter {
   }
 
   public void onResponse(final int partitionId, final int streamId, final long requestId) {
-    final RequestLimiter limiter = partitionLimiters.get(partitionId);
+    final RequestLimiter<Intent> limiter = partitionLimiters.get(partitionId);
     if (limiter != null) {
       limiter.onResponse(streamId, requestId);
     }
@@ -149,6 +149,6 @@ public final class PartitionAwareRequestLimiter {
   }
 
   private RequestLimiter<Intent> getOrCreateLimiter(final int partitionId) {
-    return partitionLimiters.computeIfAbsent(partitionId, limiterSupplier::apply);
+    return partitionLimiters.computeIfAbsent(partitionId, limiterSupplier);
   }
 }


### PR DESCRIPTION
## Description

Some systems were returning smaller values in consecutive calls to System.nanoTime() which caused the rate-limiter library to throw an exception. This fixes the issue by catching the exception, ignoring the request in the limiter and suggesting the 'fixed' bp algorithm to users.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6520

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [x] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
