### PR TITLE
Log key on blacklist process instance

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/state/processing/DbBlackListState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/processing/DbBlackListState.java
@@ -43,7 +43,7 @@ public final class DbBlackListState implements MutableBlackListState {
 
   private void blacklist(final long key) {
     if (key >= 0) {
-      LOG.warn(BLACKLIST_INSTANCE_MESSAGE, processInstanceKey);
+      LOG.warn(BLACKLIST_INSTANCE_MESSAGE, key);
 
       processInstanceKey.wrapLong(key);
       blackListColumnFamily.put(processInstanceKey, DbNil.INSTANCE);


### PR DESCRIPTION
## Description

Tiny PR that fixes printing the key of process instance when it is blacklisted. 

## Related issues

closes #6559 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
