### PR TITLE
chore(journal): add record frame with version/ignore status

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -132,7 +132,6 @@ public class RaftLog implements Closeable {
     return journal.isEmpty();
   }
 
-  @SuppressWarnings("unchecked")
   public IndexedRaftRecord append(final RaftLogEntry entry) {
     final byte[] serializedEntry = serializer.serialize(entry);
     final JournalRecord journalRecord;

--- a/journal/src/main/java/io/zeebe/journal/file/FrameUtil.java
+++ b/journal/src/main/java/io/zeebe/journal/file/FrameUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file;
+
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+public final class FrameUtil {
+
+  private static final byte VERSION = 1;
+  private static final byte IGNORE = 0;
+  private static final int LENGTH = 1;
+
+  private FrameUtil() {}
+
+  public static void writeVersion(final ByteBuffer buffer, final int offset) {
+    write(buffer, offset, VERSION);
+  }
+
+  public static void markAsIgnored(final ByteBuffer buffer, final int offset) {
+    write(buffer, offset, IGNORE);
+  }
+
+  /**
+   * If the frame is valid, returns an Optional with the frame version (which can span from 1-255)
+   * and the buffer's position in incremented. If the frame should be ignored, the returned Optional
+   * is empty and the buffer's position is the same.
+   */
+  public static Optional<Integer> readVersion(final ByteBuffer buffer) {
+    buffer.mark();
+
+    try {
+      final byte val = buffer.get();
+
+      if (val != IGNORE) {
+        return Optional.of((int) val);
+      }
+    } catch (BufferUnderflowException e) {
+      // nothing to read - reset
+    }
+
+    buffer.reset();
+    return Optional.empty();
+  }
+
+  public static int getLength() {
+    return LENGTH;
+  }
+
+  private static void write(final ByteBuffer buffer, final int offset, final byte value) {
+    buffer.put(offset, value);
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
@@ -21,6 +21,7 @@ import io.zeebe.journal.file.record.JournalRecordReaderUtil;
 import io.zeebe.journal.file.record.SBESerializer;
 import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 /** Log segment reader. */
 class MappedJournalSegmentReader {
@@ -114,6 +115,12 @@ class MappedJournalSegmentReader {
 
   /** Reads the next entry in the segment. */
   private void readNext(final long expectedIndex) {
+    final Optional<Integer> version = FrameUtil.readVersion(buffer);
+    if (version.isEmpty()) {
+      nextEntry = null;
+      return;
+    }
+
     nextEntry = recordReader.read(buffer, expectedIndex);
   }
 

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
@@ -86,6 +86,7 @@ class MappedJournalSegmentWriter {
     // TODO: Should reject append if the asqn is not greater than the previous record
 
     final int startPosition = buffer.position();
+    final int frameLength = FrameUtil.getLength();
     final int metadataLength = serializer.getMetadataLength();
 
     final RecordData indexedRecord = new RecordData(recordIndex, asqn, data);
@@ -93,20 +94,21 @@ class MappedJournalSegmentWriter {
 
     final int recordLength;
     try {
-      recordLength = writeRecord(startPosition + metadataLength, indexedRecord);
+      recordLength = writeRecord(startPosition + frameLength + metadataLength, indexedRecord);
     } catch (final BufferOverflowException boe) {
       buffer.position(startPosition);
       throw boe;
     }
 
     final long checksum =
-        checksumGenerator.compute(buffer, startPosition + metadataLength, recordLength);
+        checksumGenerator.compute(
+            buffer, startPosition + frameLength + metadataLength, recordLength);
 
-    writeMetadata(startPosition, recordLength, checksum);
+    writeMetadata(startPosition, frameLength, recordLength, checksum);
+    updateLastWrittenEntry(startPosition, frameLength, metadataLength, recordLength);
+    FrameUtil.writeVersion(buffer, startPosition);
 
-    updateLastWrittenEntry(startPosition, metadataLength, recordLength);
-
-    buffer.position(startPosition + metadataLength + recordLength);
+    buffer.position(startPosition + frameLength + metadataLength + recordLength);
     return lastEntry;
   }
 
@@ -122,6 +124,7 @@ class MappedJournalSegmentWriter {
     }
 
     final int startPosition = buffer.position();
+    final int frameLength = FrameUtil.getLength();
     final int metadataLength = serializer.getMetadataLength();
 
     final RecordData indexedRecord = new RecordData(record.index(), record.asqn(), record.data());
@@ -129,14 +132,15 @@ class MappedJournalSegmentWriter {
 
     final int recordLength;
     try {
-      recordLength = writeRecord(startPosition + metadataLength, indexedRecord);
+      recordLength = writeRecord(startPosition + frameLength + metadataLength, indexedRecord);
     } catch (final BufferOverflowException boe) {
       buffer.position(startPosition);
       throw boe;
     }
 
     final long checksum =
-        checksumGenerator.compute(buffer, startPosition + metadataLength, recordLength);
+        checksumGenerator.compute(
+            buffer, startPosition + frameLength + metadataLength, recordLength);
 
     if (record.checksum() != checksum) {
       buffer.position(startPosition);
@@ -144,25 +148,30 @@ class MappedJournalSegmentWriter {
           String.format("Failed to append record %s. Checksum does not match", record));
     }
 
-    writeMetadata(startPosition, recordLength, checksum);
+    writeMetadata(startPosition, frameLength, recordLength, checksum);
+    updateLastWrittenEntry(startPosition, frameLength, metadataLength, recordLength);
+    FrameUtil.writeVersion(buffer, startPosition);
 
-    updateLastWrittenEntry(startPosition, metadataLength, recordLength);
-
-    buffer.position(startPosition + metadataLength + recordLength);
+    buffer.position(startPosition + frameLength + metadataLength + recordLength);
   }
 
   private void updateLastWrittenEntry(
-      final int startPosition, final int metadataLength, final int recordLength) {
-    final var metadata = serializer.readMetadata(writeBuffer, startPosition);
-    final var data = serializer.readData(writeBuffer, startPosition + metadataLength, recordLength);
+      final int startPosition,
+      final int frameLength,
+      final int metadataLength,
+      final int recordLength) {
+    final var metadata = serializer.readMetadata(writeBuffer, startPosition + frameLength);
+    final var data =
+        serializer.readData(
+            writeBuffer, startPosition + frameLength + metadataLength, recordLength);
     lastEntry = new PersistedJournalRecord(metadata, data);
     index.index(lastEntry, startPosition);
   }
 
   private RecordMetadata writeMetadata(
-      final int startPosition, final int recordLength, final long checksum) {
+      final int startPosition, final int frameLength, final int recordLength, final long checksum) {
     final RecordMetadata recordMetadata = new RecordMetadata(checksum, recordLength);
-    serializer.writeMetadata(recordMetadata, writeBuffer, startPosition);
+    serializer.writeMetadata(recordMetadata, writeBuffer, startPosition + frameLength);
     return recordMetadata;
   }
 
@@ -195,12 +204,11 @@ class MappedJournalSegmentWriter {
   }
 
   private void invalidateNextEntry(final int position) {
-    if (position + (Integer.BYTES * 2) >= writeBuffer.capacity()) {
+    if (position >= buffer.capacity()) {
       return;
     }
 
-    writeBuffer.putInt(position, 0);
-    writeBuffer.putInt(position + Integer.BYTES, 0);
+    FrameUtil.markAsIgnored(buffer, position);
   }
 
   private void reset(final long index) {
@@ -210,7 +218,7 @@ class MappedJournalSegmentWriter {
     buffer.position(JournalSegmentDescriptor.BYTES);
     buffer.mark();
     try {
-      while (index == 0 || nextIndex <= index) {
+      while ((index == 0 || nextIndex <= index) && FrameUtil.readVersion(buffer).isPresent()) {
         final var nextEntry = recordUtil.read(buffer, nextIndex);
         if (nextEntry == null) {
           break;

--- a/journal/src/main/java/io/zeebe/journal/file/record/CorruptedLogException.java
+++ b/journal/src/main/java/io/zeebe/journal/file/record/CorruptedLogException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.journal.file.record;
+
+public class CorruptedLogException extends RuntimeException {
+  public CorruptedLogException(final String message) {
+    super(message);
+  }
+}

--- a/journal/src/main/java/io/zeebe/journal/file/record/JournalRecordSerializer.java
+++ b/journal/src/main/java/io/zeebe/journal/file/record/JournalRecordSerializer.java
@@ -51,14 +51,6 @@ public interface JournalRecordSerializer {
   int getMetadataLength();
 
   /**
-   * Checks if a valid metadata can be read from the buffer.
-   *
-   * @param buffer to read
-   * @return true if a valid metadata exists, false otherwise.
-   */
-  boolean hasMetadata(DirectBuffer buffer, int offset);
-
-  /**
    * Reads the {@link RecordMetadata} from the buffer at offset 0. A valid record must exist in the
    * buffer at this position.
    *

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -42,7 +42,7 @@ class SegmentedJournalReaderTest {
 
   @BeforeEach
   void setup() {
-    final int entrySize = getSerializedSize(data);
+    final int entrySize = FrameUtil.getLength() + getSerializedSize(data);
 
     journal =
         SegmentedJournal.builder()

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
@@ -330,6 +330,7 @@ class SegmentedJournalTest {
     final var serializer = new SBESerializer();
     final ByteBuffer buffer = ByteBuffer.allocate(128);
     return serializer.writeData(record, new UnsafeBuffer(buffer), 0)
+        + FrameUtil.getLength()
         + serializer.getMetadataLength();
   }
 }

--- a/journal/src/test/java/io/zeebe/journal/file/record/SBESerializerTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/record/SBESerializerTest.java
@@ -93,32 +93,14 @@ public class SBESerializerTest {
   }
 
   @Test
-  public void shouldReturnFalseWhenInvalidMetadata() {
+  public void shouldThrowCorruptLogExceptionIfMetadataIsInvalid() {
     // given
     serializer.writeMetadata(metadata, writeBuffer, 0);
-    writeBuffer.putLong(0, 0);
-
-    // when - then
-    assertThat(serializer.hasMetadata(writeBuffer, 0)).isFalse();
-  }
-
-  @Test
-  public void shouldReturnTrueWhenValidMetadata() {
-    // given
-    serializer.writeMetadata(metadata, writeBuffer, 0);
-
-    // when - then
-    assertThat(serializer.hasMetadata(writeBuffer, 0)).isTrue();
-  }
-
-  @Test
-  public void shouldThrowExceptionWhenInvalidMetadata() {
-    // given
     writeBuffer.putLong(0, 0);
 
     // when - then
     assertThatThrownBy(() -> serializer.readMetadata(writeBuffer, 0))
-        .isInstanceOf(InvalidRecordException.class);
+        .isInstanceOf(CorruptedLogException.class);
   }
 
   @Test
@@ -128,7 +110,7 @@ public class SBESerializerTest {
 
     // when - then
     assertThatThrownBy(() -> serializer.readData(writeBuffer, 0, 1))
-        .isInstanceOf(InvalidRecordException.class);
+        .isInstanceOf(CorruptedLogException.class);
   }
 
   @Test


### PR DESCRIPTION
## Description

* Adds a frame to the records
* The frame value can be 0, meaning the record should be ignored, or a number from 1-255 that is interpreted as the frame's version
* By marking truncated records as ignored, we can distinguish truncated and corrupted records
* In case of log corruption, an exception is thrown in the journal. Improving the how we handle this is left for another PR

@deepthidevaki I didn't split this up in multiple PRs/commits with because the PR is small as it is and separating them into would increase the review burden overall

## Related issues
closes #6579

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
