### PR TITLE
chore(journal): use a shared mapped buffer among writer and readers 

### DIFF
--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
@@ -19,15 +19,13 @@ package io.zeebe.journal.file;
 import io.zeebe.journal.JournalRecord;
 import io.zeebe.journal.file.record.JournalRecordReaderUtil;
 import io.zeebe.journal.file.record.SBESerializer;
-import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel.MapMode;
+import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
-import org.agrona.IoUtil;
 
 /** Log segment reader. */
 class MappedJournalSegmentReader {
 
-  private final MappedByteBuffer buffer;
+  private final ByteBuffer buffer;
   private final JournalIndex index;
   private final JournalSegment segment;
   private JournalRecord currentEntry;
@@ -35,13 +33,11 @@ class MappedJournalSegmentReader {
   private final JournalRecordReaderUtil recordReader;
 
   MappedJournalSegmentReader(
-      final JournalSegmentFile file, final JournalSegment segment, final JournalIndex index) {
+      final ByteBuffer buffer, final JournalSegment segment, final JournalIndex index) {
     this.index = index;
     this.segment = segment;
     recordReader = new JournalRecordReaderUtil(new SBESerializer());
-    buffer =
-        IoUtil.mapExistingFile(
-            file.file(), MapMode.READ_ONLY, file.name(), 0, segment.descriptor().maxSegmentSize());
+    this.buffer = buffer;
     reset();
   }
 
@@ -109,7 +105,6 @@ class MappedJournalSegmentReader {
   }
 
   public void close() {
-    IoUtil.unmap(buffer);
     segment.onReaderClosed(this);
   }
 

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
@@ -30,7 +30,6 @@ import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.MappedByteBuffer;
 import org.agrona.DirectBuffer;
-import org.agrona.IoUtil;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -50,7 +49,7 @@ class MappedJournalSegmentWriter {
   private final MutableDirectBuffer writeBuffer = new UnsafeBuffer();
 
   MappedJournalSegmentWriter(
-      final JournalSegmentFile file,
+      final MappedByteBuffer buffer,
       final JournalSegment segment,
       final int maxEntrySize,
       final JournalIndex index) {
@@ -59,16 +58,9 @@ class MappedJournalSegmentWriter {
     recordUtil = new JournalRecordReaderUtil(serializer);
     this.index = index;
     firstIndex = segment.index();
-    buffer = mapFile(file, segment);
+    this.buffer = buffer;
     writeBuffer.wrap(buffer);
     reset(0);
-  }
-
-  private static MappedByteBuffer mapFile(
-      final JournalSegmentFile file, final JournalSegment segment) {
-    // map existing file, because file is already created by SegmentedJournal
-    return IoUtil.mapExistingFile(
-        file.file(), file.name(), 0, segment.descriptor().maxSegmentSize());
   }
 
   public long getLastIndex() {
@@ -263,7 +255,6 @@ class MappedJournalSegmentWriter {
     if (isOpen) {
       isOpen = false;
       flush();
-      IoUtil.unmap(buffer);
     }
   }
 


### PR DESCRIPTION
## Description

* Mapped buffer of the file is managed by the segment
* Writer and readers share the same mapped buffer, but have access to different view which they can independently modify.

## Related issues

closes #6580 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
