### PR TITLE
Temporary fix for SBE compilation step

### DIFF
--- a/journal/pom.xml
+++ b/journal/pom.xml
@@ -48,6 +48,11 @@
       <artifactId>sbe-tool</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+
   </dependencies>
 
 
@@ -125,6 +130,11 @@
           <usedDependencies>
             <!-- dependency used but plugin seems to report a false positive here -->
             <dependency>uk.co.real-logic:sbe-tool</dependency>
+            <!--
+              ensures that zeebe-protocol is built first, preventing concurrent executions
+              of the sbe-tool
+            -->
+            <dependency>io.zeebe:zeebe-protocol</dependency>
           </usedDependencies>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Description

This PR provides a temporary fix to build issues when concurrently building modules using exec-maven-plugin to generate source code. It seems the maven properties (e.g. project.build.outputDirectory) are sometimes mixed, and then all generated files end up in one module (instead of some in each).

By enforcing a dependency between the two modules we can control this, but a better fix should be incoming soon.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
