### PR TITLE
chore(benchmark): build project on create

### DIFF
--- a/createBenchmark.sh
+++ b/createBenchmark.sh
@@ -13,7 +13,7 @@ set -exo pipefail
 # 6. Deploy's the benchmark
 
 # Contains OS specific sed function
-. benchmarks/setup/utils.sh
+source benchmarks/setup/utils.sh
 
 if [ -z $1 ]
 then
@@ -22,12 +22,25 @@ then
 fi
 benchmark=$1
 
+# Check if docker daemon is running
+if ! docker info >/dev/null 2>&1; then
+    echo "Docker daemon does not seem to be running, make sure it's running and retry"
+    exit 1
+fi
+
 mvn clean install -DskipTests -T1C
 
 docker build --build-arg DISTBALL=dist/target/zeebe-distribution-*.tar.gz --build-arg APP_ENV=dev -t "gcr.io/zeebe-io/zeebe:$benchmark" .
 docker push "gcr.io/zeebe-io/zeebe:$benchmark"
 
-cd benchmarks/setup/
+cd benchmarks/project
+
+sed_inplace "s/:SNAPSHOT/:$benchmark/" docker-compose.yml
+docker-compose build
+docker-compose push
+git restore -- docker-compose.yml
+
+cd ../setup/
 
 ./newBenchmark.sh "$benchmark"
 
@@ -36,5 +49,9 @@ cd "$benchmark"
 # calls OS specific sed inplace function
 sed_inplace 's/camunda\/zeebe/gcr.io\/zeebe-io\/zeebe/' zeebe-values.yaml
 sed_inplace "s/SNAPSHOT/$benchmark/" zeebe-values.yaml
+sed_inplace "s/starter:zeebe/starter:$benchmark/" starter.yaml
+sed_inplace "s/starter:zeebe/starter:$benchmark/" simpleStarter.yaml
+sed_inplace "s/starter:zeebe/starter:$benchmark/" timer.yaml
+sed_inplace "s/worker:zeebe/worker:$benchmark/" worker.yaml
 
 make zeebe starter worker


### PR DESCRIPTION
## Description

This PR updates `createBenchmark.sh` to automatically build the benchmark project for the specific custom Zeebe version you want to benchmark, including the specific zeebe client version used by the worker and starter.

tested automatic run of `make zeebe starter worker`, as well as manual `make simpleStarter timer`

## Related issues

closes #6564

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
