### PR TITLE
Add TestWatcher to other PropertyBasedTest

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/FailedPropertyBasedTestDataPrinter.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/FailedPropertyBasedTestDataPrinter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.processing.streamprocessor;
+
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.test.util.bpmn.random.AbstractExecutionStep;
+import java.util.stream.Collectors;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class FailedPropertyBasedTestDataPrinter extends TestWatcher {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(FailedPropertyBasedTestDataPrinter.class);
+
+  private final PropertyBasedTest propertyBasedTest;
+
+  public FailedPropertyBasedTestDataPrinter(final PropertyBasedTest propertyBasedTest) {
+    this.propertyBasedTest = propertyBasedTest;
+  }
+
+  @Override
+  protected void failed(final Throwable e, final Description description) {
+    LOGGER.info("Data of failed test case: {}", propertyBasedTest.getDataRecord());
+    LOGGER.info(
+        "Process of failed test case:{}{}",
+        System.lineSeparator(),
+        Bpmn.convertToString(propertyBasedTest.getDataRecord().getBpmnModel()));
+    LOGGER.info(
+        "Execution path of failed test case:{}{}",
+        System.lineSeparator(),
+        propertyBasedTest.getDataRecord().getExecutionPath().getSteps().stream()
+            .map(AbstractExecutionStep::toString)
+            .collect(Collectors.joining(System.lineSeparator())));
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ProcessExecutionRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ProcessExecutionRandomizedPropertyTest.java
@@ -19,13 +19,14 @@ import io.zeebe.test.util.record.RecordingExporter;
 import java.util.Collection;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestWatcher;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
-public class ProcessExecutionRandomizedPropertyTest {
+public class ProcessExecutionRandomizedPropertyTest implements PropertyBasedTest {
 
   /*
    * Some notes on scaling of these tests:
@@ -43,11 +44,17 @@ public class ProcessExecutionRandomizedPropertyTest {
   private static final int PROCESS_COUNT = 10;
   private static final int EXECUTION_PATH_COUNT = 100;
 
+  @Rule public TestWatcher failedTestDataPrinter = new FailedPropertyBasedTestDataPrinter(this);
   @Rule public final EngineRule engineRule = EngineRule.singlePartition();
 
   @Parameter public TestDataRecord record;
 
   private final ProcessExecutor processExecutor = new ProcessExecutor(engineRule);
+
+  @Override
+  public TestDataRecord getDataRecord() {
+    return record;
+  }
 
   /**
    * This test takes a random process and execution path in that process. A process instance is

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/PropertyBasedTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/PropertyBasedTest.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.processing.streamprocessor;
+
+import io.zeebe.test.util.bpmn.random.TestDataGenerator.TestDataRecord;
+
+public interface PropertyBasedTest {
+
+  TestDataRecord getDataRecord();
+}


### PR DESCRIPTION
## Description

Adds a test watcher to the other property based test, which will print the seeds, deployment etc on failure.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->


## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
