### PR TITLE
Terminate boundary event correctly

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
@@ -73,7 +73,7 @@ public final class BoundaryEventProcessor implements BpmnElementProcessor<Execut
   public void onTerminating(
       final ExecutableBoundaryEvent element, final BpmnElementContext context) {
 
-    stateTransitionBehavior.onElementTerminated(element, context);
+    stateTransitionBehavior.transitionToTerminated(context);
   }
 
   @Override


### PR DESCRIPTION
## Description

Terminates the boundary event correctly. I tried to find a sufficient test for it, it was not that easy since it is a special race condition, but least locally it fails if the fix is removed.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6587 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
