### PR TITLE
Remove test watcher from StreamProcessorRule

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/StreamProcessorRule.java
@@ -40,7 +40,6 @@ import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
@@ -103,8 +102,7 @@ public final class StreamProcessorRule implements TestRule {
             .around(actorSchedulerRule)
             .around(new CleanUpRule(tempFolder::getRoot))
             .around(closeables)
-            .around(rule)
-            .around(new FailedTestRecordPrinter());
+            .around(rule);
   }
 
   public ActorSchedulerRule getActorSchedulerRule() {
@@ -319,15 +317,6 @@ public final class StreamProcessorRule implements TestRule {
     protected void after() {
       streams = null;
       streamProcessingComposite = null;
-    }
-  }
-
-  private class FailedTestRecordPrinter extends TestWatcher {
-
-    @Override
-    protected void failed(final Throwable e, final Description description) {
-      LOG.info("Test failed, following records were exported:");
-      printAllRecords();
     }
   }
 


### PR DESCRIPTION
## Description

The test watcher in the stream processor rule was just annoying left over, which caused on failing tests to spam the log twice with not so nice formatted records.

<!-- Please explain the changes you made here. -->

## Related issues


## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
