### PR TITLE
fix(engine): fix terminate xor incident terminating

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -435,10 +435,11 @@ public final class BpmnEventSubscriptionBehavior {
         });
   }
 
-  public void publishTriggeredEventSubProcess(final BpmnElementContext context) {
+  public void publishTriggeredEventSubProcess(
+      final boolean isChildMigrated, final BpmnElementContext context) {
     final var elementInstance = stateBehavior.getElementInstance(context);
 
-    if (isInterrupted(elementInstance)) {
+    if (isInterrupted(isChildMigrated, elementInstance)) {
       elementInstanceState.getDeferredRecords(context.getElementInstanceKey()).stream()
           .filter(record -> record.getKey() == elementInstance.getInterruptingEventKey())
           .filter(record -> record.getValue().getBpmnElementType() == BpmnElementType.SUB_PROCESS)
@@ -456,8 +457,10 @@ public final class BpmnEventSubscriptionBehavior {
     }
   }
 
-  private boolean isInterrupted(final ElementInstance elementInstance) {
-    return elementInstance.getNumberOfActiveElementInstances() == 1
+  private boolean isInterrupted(
+      final boolean isChildMigrated, final ElementInstance elementInstance) {
+    final int expectedActiveInstanceCount = isChildMigrated ? 0 : 1;
+    return elementInstance.getNumberOfActiveElementInstances() == expectedActiveInstanceCount
         && elementInstance.isInterrupted()
         && elementInstance.isActive();
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -18,6 +18,7 @@ import io.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.zeebe.engine.processing.common.ExpressionProcessor;
 import io.zeebe.engine.processing.common.Failure;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
+import io.zeebe.engine.processing.streamprocessor.MigratedStreamProcessors;
 import io.zeebe.msgpack.spec.MsgPackHelper;
 import io.zeebe.msgpack.spec.MsgPackReader;
 import io.zeebe.msgpack.spec.MsgPackWriter;
@@ -213,7 +214,8 @@ public final class MultiInstanceBodyProcessor
       stateTransitionBehavior.transitionToTerminated(flowScopeContext);
 
     } else {
-      eventSubscriptionBehavior.publishTriggeredEventSubProcess(flowScopeContext);
+      eventSubscriptionBehavior.publishTriggeredEventSubProcess(
+          MigratedStreamProcessors.isMigrated(childContext.getBpmnElementType()), flowScopeContext);
     }
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -18,6 +18,7 @@ import io.zeebe.engine.processing.bpmn.behavior.BpmnProcessResultSenderBehavior;
 import io.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.zeebe.engine.processing.streamprocessor.MigratedStreamProcessors;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 
 public final class ProcessProcessor
@@ -168,7 +169,8 @@ public final class ProcessProcessor
       stateTransitionBehavior.transitionToTerminated(flowScopeContext);
 
     } else {
-      eventSubscriptionBehavior.publishTriggeredEventSubProcess(flowScopeContext);
+      eventSubscriptionBehavior.publishTriggeredEventSubProcess(
+          MigratedStreamProcessors.isMigrated(childContext.getBpmnElementType()), flowScopeContext);
     }
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -17,6 +17,7 @@ import io.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
+import io.zeebe.engine.processing.streamprocessor.MigratedStreamProcessors;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 
 public final class SubProcessProcessor
@@ -146,7 +147,8 @@ public final class SubProcessProcessor
       stateTransitionBehavior.transitionToTerminated(flowScopeContext);
 
     } else {
-      eventSubscriptionBehavior.publishTriggeredEventSubProcess(flowScopeContext);
+      eventSubscriptionBehavior.publishTriggeredEventSubProcess(
+          MigratedStreamProcessors.isMigrated(childContext.getBpmnElementType()), flowScopeContext);
     }
   }
 }


### PR DESCRIPTION
## Description

We now decide based on whether the child is migrated or not what element instance count we check.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda-cloud/zeebe/issues/6593

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
