### PR TITLE
chore(ci): run nightly only on latest stable/0.26

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,8 @@ def masterBranchName = 'master'
 def isMasterBranch = env.BRANCH_NAME == masterBranchName
 def developBranchName = 'develop'
 def isDevelopBranch = env.BRANCH_NAME == developBranchName
+def latestStableBranchName = 'stable/0.26'
+def isLatestStable = env.BRANCH_NAME == latestStableBranchName
 
 //for develop branch keep builds for 7 days to be able to analyse build errors, for all other branches, keep the last 10 builds
 def daysToKeep = isDevelopBranch ? '7' : '-1'
@@ -25,8 +27,9 @@ def longTimeoutMinutes = 45
 itAgentUnstashDirectory = '.tmp/it'
 itFlakyTestStashName = 'it-flakyTests'
 
-//the develop branch should be run at midnight to do a nightly build including QA test run
-def cronTrigger = isDevelopBranch ? '0 0 * * *' : ''
+// the latest stable branch should be run at midnight to do a nightly build including QA test run
+// todo: run develop branch at midnight using new testbench version
+def cronTrigger = isLatestStable ? '0 0 * * *' : ''
 
 pipeline {
     agent {
@@ -312,7 +315,7 @@ pipeline {
                 anyOf {
                     expression { params.RUN_QA }
                     allOf {
-                        branch developBranchName
+                        branch latestStableBranchName
                         triggeredBy 'TimerTrigger'
                     }
                 }


### PR DESCRIPTION
## Description

Since `develop` is currently working towards `1.0.0` and there are breaking changes, testbench is currently not able to QA test the latest versions. However, we also still support `0.26` for some time, so it makes sense to run the nightly build for the latest version of the `stable/0.26` branch.

## Related issues

closes https://github.com/zeebe-io/zeebe-cluster-testbench/issues/254

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
