### PR TITLE
Generate event sub for property based tests

### DIFF
--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ExecutionPathSegment.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ExecutionPathSegment.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.test.util.bpmn.random;
 
+import io.zeebe.test.util.bpmn.random.blocks.IntermediateMessageCatchEventBlockBuilder.StepPublishMessage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,6 +32,15 @@ public final class ExecutionPathSegment {
 
   public void append(final ExecutionPathSegment pathToAdd) {
     steps.addAll(pathToAdd.getSteps());
+  }
+
+  public void replace(final int index, final AbstractExecutionStep executionStep) {
+    steps.subList(index, steps.size()).clear();
+    steps.add(executionStep);
+  }
+
+  public void insert(final int index, final StepPublishMessage stepPublishMessage) {
+    steps.add(index, stepPublishMessage);
   }
 
   public List<AbstractExecutionStep> getSteps() {

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
@@ -7,6 +7,8 @@
  */
 package io.zeebe.test.util.bpmn.random.blocks;
 
+import static io.zeebe.test.util.bpmn.random.blocks.IntermediateMessageCatchEventBlockBuilder.CORRELATION_KEY_VALUE;
+
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
@@ -14,6 +16,7 @@ import io.zeebe.test.util.bpmn.random.BlockBuilder;
 import io.zeebe.test.util.bpmn.random.ConstructionContext;
 import io.zeebe.test.util.bpmn.random.ExecutionPath;
 import io.zeebe.test.util.bpmn.random.StartEventBlockBuilder;
+import io.zeebe.test.util.bpmn.random.blocks.IntermediateMessageCatchEventBlockBuilder.StepPublishMessage;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Function;
@@ -29,13 +32,17 @@ public final class ProcessBuilder {
 
   private final String processId;
   private final String endEventId;
+  private final boolean hasEventSubProcess;
+  private String eventSubProcessId = null;
+  private boolean isEventSubProcessInterrupting;
+  private String eventSubProcessMessageName;
 
   public ProcessBuilder(final ConstructionContext context) {
     blockBuilder = context.getBlockSequenceBuilderFactory().createBlockSequenceBuilder(context);
 
     final var idGenerator = context.getIdGenerator();
     processId = "process_" + idGenerator.nextId();
-
+    hasEventSubProcess = initEventSubProcess(context, idGenerator);
     final var random = context.getRandom();
     final var startEventBuilderFactory =
         START_EVENT_BUILDER_FACTORIES.get(random.nextInt(START_EVENT_BUILDER_FACTORIES.size()));
@@ -44,10 +51,27 @@ public final class ProcessBuilder {
     endEventId = idGenerator.nextId();
   }
 
+  private boolean initEventSubProcess(
+      final ConstructionContext context,
+      final io.zeebe.test.util.bpmn.random.IDGenerator idGenerator) {
+    final boolean hasEventSubProcess = context.getRandom().nextBoolean();
+    if (hasEventSubProcess) {
+      eventSubProcessId = "eventSubProcess_" + idGenerator.nextId();
+      isEventSubProcessInterrupting = context.getRandom().nextBoolean();
+      eventSubProcessMessageName = "message_" + eventSubProcessId;
+    }
+    return hasEventSubProcess;
+  }
+
   public BpmnModelInstance buildProcess() {
 
     final io.zeebe.model.bpmn.builder.ProcessBuilder processBuilder =
         Bpmn.createExecutableProcess(processId);
+
+    if (hasEventSubProcess) {
+      buildEventSubProcess(processBuilder);
+    }
+
     AbstractFlowNodeBuilder<?, ?> processWorkInProgress =
         startEventBuilder.buildStartEvent(processBuilder);
 
@@ -56,12 +80,63 @@ public final class ProcessBuilder {
     return processWorkInProgress.endEvent(endEventId).done();
   }
 
+  private void buildEventSubProcess(
+      final io.zeebe.model.bpmn.builder.ProcessBuilder processBuilder) {
+    processBuilder
+        .eventSubProcess(eventSubProcessId)
+        .startEvent("start_event_" + eventSubProcessId)
+        .interrupting(isEventSubProcessInterrupting)
+        .message(
+            b ->
+                // When we have a message start event then variables are not correctly copied,
+                // which will not trigger the event sub process then. We use here a static value to
+                // trigger the event sub process.
+                //
+                // See https://github.com/camunda-cloud/zeebe/issues/4099
+                b.name(eventSubProcessMessageName)
+                    .zeebeCorrelationKeyExpression('\"' + CORRELATION_KEY_VALUE + '\"'))
+        .endEvent("end_event_" + eventSubProcessId);
+  }
+
   public ExecutionPath findRandomExecutionPath(final Random random) {
     final var followingPath = blockBuilder.findRandomExecutionPath(random);
+
+    if (hasEventSubProcess) {
+      final var shouldTriggerEventSubProcess = random.nextBoolean();
+      if (shouldTriggerEventSubProcess) {
+        executionPathForEventSubProcess(random, followingPath);
+      }
+    }
+
     final var startPath =
         startEventBuilder.findRandomExecutionPath(processId, followingPath.collectVariables());
     startPath.append(followingPath);
 
     return new ExecutionPath(processId, startPath);
+  }
+
+  private void executionPathForEventSubProcess(
+      final Random random,
+      final io.zeebe.test.util.bpmn.random.ExecutionPathSegment followingPath) {
+    // We don't want to trigger the event sub process at the end of the process instance execution,
+    // which is the reason why we decrement by one. With that we avoid a race condition, which can
+    // happen on triggering the event sub process and completing the process instance.
+    final var size = followingPath.getSteps().size() - 1;
+
+    if (size < 1) {
+      // empty execution path
+      // We will not add here an event sub process execution, since the likelihood that the event
+      // sub process is triggered in time, before the process is completed, is quite low.
+      // This can cause flaky tests.
+      return;
+    }
+
+    final var index = random.nextInt(size);
+    if (isEventSubProcessInterrupting) {
+      // if it is interrupting we remove the other execution path
+      followingPath.replace(index, new StepPublishMessage(eventSubProcessMessageName));
+    } else {
+      followingPath.insert(index, new StepPublishMessage(eventSubProcessMessageName));
+    }
   }
 }


### PR DESCRIPTION
## Description
After fixing several bugs we are finally able to have the first iteration of generating and executing property based tests with event sub processes. In this first iteration we have simple event processes with start and end event only. Furthermore event sub processes are only added on root level.

I was able to run ~2k runs without any issues.
![tests](https://user-images.githubusercontent.com/2758593/111831013-1244eb80-88ef-11eb-9d55-120d39405598.png)

Example models which are generated:


![diagram_3](https://user-images.githubusercontent.com/2758593/111323006-cb928f80-8669-11eb-8568-cc1e69862572.png)
![diagram_6](https://user-images.githubusercontent.com/2758593/111372127-86d31c80-869a-11eb-8f02-ed565edca14e.png)
![diagram_5](https://user-images.githubusercontent.com/2758593/111372141-8b97d080-869a-11eb-8854-1eb677e25bfd.png)

![111050744-bee61f80-844e-11eb-8bd8-50a733234c76](https://user-images.githubusercontent.com/2758593/112264937-ea98af00-8c71-11eb-8907-7ac985db91fd.png)
![111768838-b9526480-88a8-11eb-9adc-f0c7baa2ef49](https://user-images.githubusercontent.com/2758593/112264939-ebc9dc00-8c71-11eb-8b11-7b534ae58fda.png)
![111803822-bae35300-88cf-11eb-9708-d908a69ecfc7](https://user-images.githubusercontent.com/2758593/112264942-ecfb0900-8c71-11eb-996c-787bb2256b53.png)


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #6195 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
