### PR TITLE
Remove the job activated intent

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -10,7 +10,6 @@ package io.zeebe.engine.processing.streamprocessor;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.Intent;
-import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.intent.TimerIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import java.util.ArrayList;
@@ -41,28 +40,12 @@ public final class MigratedStreamProcessors {
           final var bpmnElementType = recordValue.getBpmnElementType();
           return MIGRATED_BPMN_PROCESSORS.contains(bpmnElementType);
         });
-    MIGRATED_VALUE_TYPES.put(
-        ValueType.JOB,
-        MIGRATED_INTENT_FILTER_FACTORY.apply(
-            List.of(
-                JobIntent.CREATE,
-                JobIntent.CREATED,
-                JobIntent.COMPLETE,
-                JobIntent.COMPLETED,
-                JobIntent.FAIL,
-                JobIntent.FAILED,
-                JobIntent.THROW_ERROR,
-                JobIntent.ERROR_THROWN,
-                JobIntent.TIME_OUT,
-                JobIntent.TIMED_OUT,
-                JobIntent.UPDATE_RETRIES,
-                JobIntent.RETRIES_UPDATED,
-                JobIntent.CANCEL,
-                JobIntent.CANCELED)));
-    MIGRATED_VALUE_TYPES.put(ValueType.JOB_BATCH, MIGRATED);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.TESTING_ONLY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.EXCLUSIVE_GATEWAY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.PARALLEL_GATEWAY);
+
+    MIGRATED_VALUE_TYPES.put(ValueType.JOB, MIGRATED);
+    MIGRATED_VALUE_TYPES.put(ValueType.JOB_BATCH, MIGRATED);
 
     MIGRATED_VALUE_TYPES.put(ValueType.ERROR, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.PROCESS, MIGRATED);

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/BlacklistInstanceTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/BlacklistInstanceTest.java
@@ -91,7 +91,6 @@ public final class BlacklistInstanceTest {
       ////////////////////////////////////////
       {ValueType.JOB, JobIntent.CREATE, true},
       {ValueType.JOB, JobIntent.CREATED, true},
-      {ValueType.JOB, JobIntent.ACTIVATED, true},
       {ValueType.JOB, JobIntent.COMPLETED, true},
       {ValueType.JOB, JobIntent.TIME_OUT, true},
       {ValueType.JOB, JobIntent.TIMED_OUT, true},

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/SkipFailingEventsTest.java
@@ -259,7 +259,7 @@ public final class SkipFailingEventsTest {
             .newRecord(STREAM_NAME)
             .event(Records.job(1))
             .recordType(RecordType.EVENT)
-            .intent(JobIntent.ACTIVATED)
+            .intent(JobIntent.CREATED)
             .key(keyGenerator.nextKey())
             .write();
     streams
@@ -286,7 +286,7 @@ public final class SkipFailingEventsTest {
                       latch.countDown();
                     }
                   })
-              .onEvent(ValueType.JOB, JobIntent.ACTIVATED, new DumpProcessor());
+              .onEvent(ValueType.JOB, JobIntent.CREATED, new DumpProcessor());
         });
 
     // when
@@ -339,7 +339,7 @@ public final class SkipFailingEventsTest {
           return TypedRecordProcessors.processors(
                   zeebeState.getKeyGenerator(), processingContext.getWriters())
               .onCommand(ValueType.JOB, JobIntent.COMPLETE, errorProneProcessor)
-              .onEvent(ValueType.JOB, JobIntent.ACTIVATED, dumpProcessor);
+              .onCommand(ValueType.JOB, JobIntent.THROW_ERROR, dumpProcessor);
         });
 
     streams
@@ -352,8 +352,8 @@ public final class SkipFailingEventsTest {
     streams
         .newRecord(STREAM_NAME)
         .event(Records.job(1))
-        .recordType(RecordType.EVENT)
-        .intent(JobIntent.ACTIVATED)
+        .recordType(RecordType.COMMAND)
+        .intent(JobIntent.THROW_ERROR)
         .key(keyGenerator.nextKey())
         .write();
 
@@ -361,8 +361,8 @@ public final class SkipFailingEventsTest {
     streams
         .newRecord(STREAM_NAME)
         .event(Records.job(2))
-        .recordType(RecordType.EVENT)
-        .intent(JobIntent.ACTIVATED)
+        .recordType(RecordType.COMMAND)
+        .intent(JobIntent.THROW_ERROR)
         .key(keyGenerator.nextKey())
         .write();
 

--- a/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/commandapi/PartitionTestClient.java
+++ b/protocol-test-util/src/main/java/io/zeebe/test/broker/protocol/commandapi/PartitionTestClient.java
@@ -7,7 +7,7 @@
  */
 package io.zeebe.test.broker.protocol.commandapi;
 
-import static io.zeebe.protocol.record.intent.JobIntent.ACTIVATED;
+import static io.zeebe.protocol.record.intent.JobIntent.CREATED;
 import static io.zeebe.test.util.TestUtil.doRepeatedly;
 import static io.zeebe.util.buffer.BufferUtil.bufferAsString;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -367,11 +367,11 @@ public final class PartitionTestClient {
 
     final Record<JobRecordValue> jobEvent =
         receiveJobs()
-            .withIntent(ACTIVATED)
+            .withIntent(CREATED)
             .withType(jobType)
             .filter(jobEventFilter)
             .findFirst()
-            .orElseThrow(() -> new AssertionError("Expected job locked event but not found."));
+            .orElseThrow(() -> new AssertionError("Expected job to be created but not found."));
 
     final ExecuteCommandResponse response = completeJob(jobEvent.getKey(), variables);
 

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/JobIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/JobIntent.java
@@ -24,25 +24,23 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
   CREATE((short) 0),
   CREATED((short) 1),
 
-  ACTIVATED((short) 2),
+  COMPLETE((short) 2, false),
+  COMPLETED((short) 3),
 
-  COMPLETE((short) 3, false),
-  COMPLETED((short) 4),
+  TIME_OUT((short) 4),
+  TIMED_OUT((short) 5),
 
-  TIME_OUT((short) 5),
-  TIMED_OUT((short) 6),
+  FAIL((short) 6, false),
+  FAILED((short) 7),
 
-  FAIL((short) 7, false),
-  FAILED((short) 8),
+  UPDATE_RETRIES((short) 8, false),
+  RETRIES_UPDATED((short) 9),
 
-  UPDATE_RETRIES((short) 9, false),
-  RETRIES_UPDATED((short) 10),
+  CANCEL((short) 10),
+  CANCELED((short) 11),
 
-  CANCEL((short) 11),
-  CANCELED((short) 12),
-
-  THROW_ERROR((short) 13, false),
-  ERROR_THROWN((short) 14);
+  THROW_ERROR((short) 12, false),
+  ERROR_THROWN((short) 13);
 
   private final short value;
   private final boolean shouldBlacklist;
@@ -67,30 +65,28 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
       case 1:
         return CREATED;
       case 2:
-        return ACTIVATED;
-      case 3:
         return COMPLETE;
-      case 4:
+      case 3:
         return COMPLETED;
-      case 5:
+      case 4:
         return TIME_OUT;
-      case 6:
+      case 5:
         return TIMED_OUT;
-      case 7:
+      case 6:
         return FAIL;
-      case 8:
+      case 7:
         return FAILED;
-      case 9:
+      case 8:
         return UPDATE_RETRIES;
-      case 10:
+      case 9:
         return RETRIES_UPDATED;
-      case 11:
+      case 10:
         return CANCEL;
-      case 12:
+      case 11:
         return CANCELED;
-      case 13:
+      case 12:
         return THROW_ERROR;
-      case 14:
+      case 13:
         return ERROR_THROWN;
       default:
         return UNKNOWN;


### PR DESCRIPTION
## Description

* the job activated intent is not used anymore
* remove the intent and adjust the ordinals

## Related issues

Follow-up of #5991

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
