### PR TITLE
Print record metadata on (re)processing failure

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingException.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.processing.streamprocessor;
+
+import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+
+public final class ProcessingException extends RuntimeException {
+
+  public ProcessingException(
+      final String message,
+      final LoggedEvent event,
+      final RecordMetadata metadata,
+      final Throwable cause) {
+    super(formatMessage(message, event, metadata), cause);
+  }
+
+  private static String formatMessage(
+      final String message, final LoggedEvent event, final RecordMetadata metadata) {
+    return String.format("%s [%s %s]", message, formatEvent(event), formatMetadata(metadata));
+  }
+
+  private static String formatEvent(final LoggedEvent event) {
+    if (event == null) {
+      return "LoggedEvent [null]";
+    }
+    return event.toString();
+  }
+
+  private static String formatMetadata(final RecordMetadata metadata) {
+    if (metadata == null) {
+      return "RecordMetadata{null}";
+    }
+    return metadata.toString();
+  }
+}


### PR DESCRIPTION
## Description

This PR adds record metadata to the error logging of failures during both processing and reprocessing.

I've introduced a ProcessingException, because it was necessary for the ReprocessingStateMachine to complete the future exceptionally with a throwable. This mechanism is not used by the ProcessingStateMachine, so I was not able to reuse it.

Some of the messages did not require changing, since they print the typedrecord, which already contains the metadata.
I've also taken the liberty to make small changes (change visibility of a message constant, remove an unnecessary whitespace, etc).

## Related issues

closes #6518 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
