### PR TITLE
chore(atomix): add sbe schema and serializer for raft types

### DIFF
--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -216,6 +216,7 @@
           <mainClass>uk.co.real_logic.sbe.SbeTool</mainClass>
           <arguments>
             <argument>${project.build.resources[0].directory}/snapshot-schema.xml</argument>
+            <argument>${project.build.resources[0].directory}/raft-entry-schema.xml</argument>
           </arguments>
           <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
           <!-- system properties defined in zeebe-parent -->

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -234,7 +234,6 @@ public final class RaftStorage {
     return RaftLog.builder()
         .withName(prefix)
         .withDirectory(directory)
-        .withNamespace(namespace)
         .withMaxSegmentSize(maxSegmentSize)
         .withMaxEntrySize(maxEntrySize)
         .withFreeDiskSpace(freeDiskSpace)

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftEntrySBESerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftEntrySBESerializer.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.storage.log;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.RaftMember;
+import io.atomix.raft.cluster.impl.DefaultRaftMember;
+import io.atomix.raft.storage.log.entry.ApplicationEntry;
+import io.atomix.raft.storage.log.entry.ApplicationEntryDecoder;
+import io.atomix.raft.storage.log.entry.ApplicationEntryEncoder;
+import io.atomix.raft.storage.log.entry.ConfigurationEntry;
+import io.atomix.raft.storage.log.entry.ConfigurationEntryDecoder;
+import io.atomix.raft.storage.log.entry.ConfigurationEntryDecoder.RaftMemberDecoder;
+import io.atomix.raft.storage.log.entry.ConfigurationEntryEncoder;
+import io.atomix.raft.storage.log.entry.EntryType;
+import io.atomix.raft.storage.log.entry.InitialEntry;
+import io.atomix.raft.storage.log.entry.MemberType;
+import io.atomix.raft.storage.log.entry.MessageHeaderDecoder;
+import io.atomix.raft.storage.log.entry.MessageHeaderEncoder;
+import io.atomix.raft.storage.log.entry.RaftEntry;
+import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.storage.log.entry.RaftLogEntryDecoder;
+import io.atomix.raft.storage.log.entry.RaftLogEntryEncoder;
+import java.time.Instant;
+import java.util.ArrayList;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public class RaftEntrySBESerializer implements RaftEntrySerializer {
+  final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  final RaftLogEntryEncoder raftLogEntryEncoder = new RaftLogEntryEncoder();
+  final ApplicationEntryEncoder applicationEntryEncoder = new ApplicationEntryEncoder();
+  final ConfigurationEntryEncoder configurationEntryEncoder = new ConfigurationEntryEncoder();
+
+  final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+  final RaftLogEntryDecoder raftLogEntryDecoder = new RaftLogEntryDecoder();
+  final ApplicationEntryDecoder applicationEntryDecoder = new ApplicationEntryDecoder();
+  final ConfigurationEntryDecoder configurationEntryDecoder = new ConfigurationEntryDecoder();
+
+  @Override
+  public int writeApplicationEntry(
+      final long term,
+      final ApplicationEntry entry,
+      final MutableDirectBuffer buffer,
+      final int offset) {
+
+    final int entryOffset = writeRaftFrame(term, EntryType.ApplicationEntry, buffer, offset);
+
+    headerEncoder
+        .wrap(buffer, offset + entryOffset)
+        .blockLength(applicationEntryEncoder.sbeBlockLength())
+        .templateId(applicationEntryEncoder.sbeTemplateId())
+        .schemaId(applicationEntryEncoder.sbeSchemaId())
+        .version(applicationEntryEncoder.sbeSchemaVersion());
+    applicationEntryEncoder.wrap(buffer, offset + entryOffset + headerEncoder.encodedLength());
+    applicationEntryEncoder
+        .lowestAsqn(entry.lowestPosition())
+        .highestAsqn(entry.highestPosition())
+        .putApplicationData(new UnsafeBuffer(entry.data()), 0, entry.data().capacity());
+
+    return entryOffset + headerEncoder.encodedLength() + applicationEntryEncoder.encodedLength();
+  }
+
+  @Override
+  public int writeInitialEntry(
+      final long term,
+      final InitialEntry entry,
+      final MutableDirectBuffer buffer,
+      final int offset) {
+
+    return writeRaftFrame(term, EntryType.InitialEntry, buffer, offset);
+  }
+
+  @Override
+  public int writeConfigurationEntry(
+      final long term,
+      final ConfigurationEntry entry,
+      final MutableDirectBuffer buffer,
+      final int offset) {
+    final int entryOffset = writeRaftFrame(term, EntryType.ConfigurationEntry, buffer, offset);
+
+    headerEncoder
+        .wrap(buffer, offset + entryOffset)
+        .blockLength(configurationEntryEncoder.sbeBlockLength())
+        .templateId(configurationEntryEncoder.sbeTemplateId())
+        .schemaId(configurationEntryEncoder.sbeSchemaId())
+        .version(configurationEntryEncoder.sbeSchemaVersion());
+
+    configurationEntryEncoder.wrap(buffer, offset + entryOffset + headerEncoder.encodedLength());
+
+    configurationEntryEncoder.timestamp(entry.timestamp());
+
+    final var raftMemberEncoder = configurationEntryEncoder.raftMemberCount(entry.members().size());
+    for (final RaftMember member : entry.members()) {
+      final var memberId = member.memberId().id();
+      raftMemberEncoder
+          .next()
+          .type(getSBEType(member.getType()))
+          .updated(member.getLastUpdated().toEpochMilli())
+          .memberId(memberId);
+    }
+
+    return entryOffset + headerEncoder.encodedLength() + configurationEntryEncoder.encodedLength();
+  }
+
+  @Override
+  public RaftLogEntry readRaftLogEntry(final DirectBuffer buffer) {
+    headerDecoder.wrap(buffer, 0);
+    raftLogEntryDecoder.wrap(
+        buffer,
+        headerDecoder.encodedLength(),
+        headerDecoder.blockLength(),
+        headerDecoder.version());
+    final long term = raftLogEntryDecoder.term();
+    final EntryType type = raftLogEntryDecoder.type();
+
+    final RaftEntry entry;
+    final int entryOffset = headerDecoder.encodedLength() + raftLogEntryDecoder.encodedLength();
+
+    switch (type) {
+      case ApplicationEntry:
+        headerDecoder.wrap(buffer, entryOffset);
+        entry = readApplicationEntry(buffer, entryOffset);
+        break;
+      case ConfigurationEntry:
+        headerDecoder.wrap(buffer, entryOffset);
+        entry = readConfigurationEntry(buffer, entryOffset);
+        break;
+      case InitialEntry:
+        entry = new InitialEntry();
+        break;
+      default:
+        throw new IllegalStateException("Unexpected entry type " + type);
+    }
+
+    return new RaftLogEntry(term, entry);
+  }
+
+  private int writeRaftFrame(
+      final long term,
+      final EntryType entryType,
+      final MutableDirectBuffer buffer,
+      final int offset) {
+    headerEncoder
+        .wrap(buffer, offset)
+        .blockLength(raftLogEntryEncoder.sbeBlockLength())
+        .templateId(raftLogEntryEncoder.sbeTemplateId())
+        .schemaId(raftLogEntryEncoder.sbeSchemaId())
+        .version(raftLogEntryEncoder.sbeSchemaVersion());
+    raftLogEntryEncoder.wrap(buffer, offset + headerEncoder.encodedLength());
+    raftLogEntryEncoder.term(term);
+    raftLogEntryEncoder.type(entryType);
+
+    return headerEncoder.encodedLength() + raftLogEntryEncoder.encodedLength();
+  }
+
+  private MemberType getSBEType(final RaftMember.Type type) {
+    switch (type) {
+      case ACTIVE:
+        return MemberType.ACTIVE;
+      case PASSIVE:
+        return MemberType.PASSIVE;
+      case INACTIVE:
+        return MemberType.INACTIVE;
+      case PROMOTABLE:
+        return MemberType.PROMOTABLE;
+      default:
+        throw new IllegalStateException("Unexpected member type");
+    }
+  }
+
+  private RaftMember.Type getRaftMemberType(final MemberType type) {
+    switch (type) {
+      case ACTIVE:
+        return RaftMember.Type.ACTIVE;
+      case PASSIVE:
+        return RaftMember.Type.PASSIVE;
+      case INACTIVE:
+        return RaftMember.Type.INACTIVE;
+      case PROMOTABLE:
+        return RaftMember.Type.PROMOTABLE;
+      default:
+        throw new IllegalStateException("Unexpected member type " + type);
+    }
+  }
+
+  private ApplicationEntry readApplicationEntry(final DirectBuffer buffer, final int entryOffset) {
+    applicationEntryDecoder.wrap(
+        buffer,
+        entryOffset + headerDecoder.encodedLength(),
+        headerDecoder.blockLength(),
+        headerDecoder.version());
+
+    final DirectBuffer data = new UnsafeBuffer();
+    applicationEntryDecoder.wrapApplicationData(data);
+
+    return new ApplicationEntry(
+        applicationEntryDecoder.lowestAsqn(), applicationEntryDecoder.highestAsqn(), data);
+  }
+
+  private ConfigurationEntry readConfigurationEntry(
+      final DirectBuffer buffer, final int entryOffset) {
+
+    configurationEntryDecoder.wrap(
+        buffer,
+        entryOffset + headerDecoder.encodedLength(),
+        headerDecoder.blockLength(),
+        headerDecoder.version());
+
+    final long timestamp = configurationEntryDecoder.timestamp();
+
+    final RaftMemberDecoder memberDecoder = configurationEntryDecoder.raftMember();
+    final ArrayList<RaftMember> members = new ArrayList<>(memberDecoder.count());
+    for (final RaftMemberDecoder member : memberDecoder) {
+      final RaftMember.Type type = getRaftMemberType(member.type());
+      final Instant updated = Instant.ofEpochMilli(member.updated());
+      final var memberId = member.memberId();
+      members.add(new DefaultRaftMember(MemberId.from(memberId), type, updated));
+    }
+
+    return new ConfigurationEntry(timestamp, members);
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftEntrySerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftEntrySerializer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.storage.log;
+
+import io.atomix.raft.storage.log.entry.ApplicationEntry;
+import io.atomix.raft.storage.log.entry.ConfigurationEntry;
+import io.atomix.raft.storage.log.entry.InitialEntry;
+import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public interface RaftEntrySerializer {
+
+  /**
+   * Writes the term and entry into given buffer at the given offset
+   *
+   * @param term the term of the entry
+   * @param entry the ApplicationEntry to write
+   * @param buffer the buffer to write to
+   * @param offset the offset in the buffer at which the term and entry will be written
+   * @return the number of bytes written
+   */
+  int writeApplicationEntry(
+      long term, ApplicationEntry entry, MutableDirectBuffer buffer, int offset);
+
+  /**
+   * Writes the term and entry into given buffer at the given offset
+   *
+   * @param term the term of the entry
+   * @param entry the InitialEntry to write
+   * @param buffer the buffer to write to
+   * @param offset the offset in the buffer at which the term and entry will be written
+   * @return the number of bytes written
+   */
+  int writeInitialEntry(long term, InitialEntry entry, MutableDirectBuffer buffer, int offset);
+
+  /**
+   * Writes the term and entry into given buffer at the given offset
+   *
+   * @param term the term of the entry
+   * @param entry the ApplicationEntry to write
+   * @param buffer the buffer to write to
+   * @param offset the offset in the buffer at which the term and entry will be written
+   * @return the number of bytes written
+   */
+  int writeConfigurationEntry(
+      long term, ConfigurationEntry entry, MutableDirectBuffer buffer, int offset);
+
+  /**
+   * Read the raft log entry from the buffer
+   *
+   * @param buffer
+   * @return RaftLogEntry
+   */
+  RaftLogEntry readRaftLogEntry(DirectBuffer buffer);
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/ApplicationEntry.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/entry/ApplicationEntry.java
@@ -19,6 +19,8 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 /**
  * Stores an entry that contains serialized records, ordered by their position; the lowestPosition
@@ -29,13 +31,20 @@ public class ApplicationEntry implements RaftEntry {
 
   private final long lowestPosition;
   private final long highestPosition;
-  private final ByteBuffer data;
+  private final DirectBuffer data = new UnsafeBuffer();
 
   public ApplicationEntry(
       final long lowestPosition, final long highestPosition, final ByteBuffer data) {
     this.lowestPosition = lowestPosition;
     this.highestPosition = highestPosition;
-    this.data = data;
+    this.data.wrap(data);
+  }
+
+  public ApplicationEntry(
+      final long lowestPosition, final long highestPosition, final DirectBuffer data) {
+    this.lowestPosition = lowestPosition;
+    this.highestPosition = highestPosition;
+    this.data.wrap(data);
   }
 
   public long lowestPosition() {
@@ -46,7 +55,7 @@ public class ApplicationEntry implements RaftEntry {
     return highestPosition;
   }
 
-  public ByteBuffer data() {
+  public DirectBuffer data() {
     return data;
   }
 

--- a/atomix/cluster/src/main/resources/raft-entry-schema.xml
+++ b/atomix/cluster/src/main/resources/raft-entry-schema.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  package="io.atomix.raft.storage.log.entry" id="8" version="1"
+  semanticVersion="0.1.0" description="Raft Entry" byteOrder="littleEndian">
+
+  <xi:include href="../../../../../protocol/src/main/resources/common-types.xml"/>
+
+  <types>
+    <enum name="MemberType" encodingType="uint8">
+      <validValue name="INACTIVE">0</validValue>
+      <validValue name="PASSIVE">1</validValue>
+      <validValue name="PROMOTABLE">2</validValue>
+      <validValue name="ACTIVE">3</validValue>
+    </enum>
+  </types>
+
+  <types>
+    <enum name="EntryType" encodingType="uint8">
+      <validValue name="ApplicationEntry">0</validValue>
+      <validValue name="ConfigurationEntry">1</validValue>
+      <validValue name="InitialEntry">2</validValue>
+    </enum>
+  </types>
+
+  <types>
+    <!-- binary data -->
+    <composite name="blob">
+      <type name="length" primitiveType="uint32" maxValue="2147483647"/>
+      <type name="varData" primitiveType="uint8" length="0"/>
+    </composite>
+
+  </types>
+
+  <sbe:message name="RaftLogEntry" id="1">
+    <field name="term" id="0" type="uint64"/>
+    <field name="type" id="1" type="EntryType"/>
+  </sbe:message>
+
+  <sbe:message name="ApplicationEntry" id="2">
+    <field name="lowestAsqn" id="0" type="uint64"/>
+    <field name="highestAsqn" id="1" type="uint64"/>
+    <data name="applicationData" id="2" type="blob"/>
+  </sbe:message>
+
+  <sbe:message name="ConfigurationEntry" id="4">
+    <field name="timestamp" id="1" type="uint64"/>
+    <group name="RaftMember" id="2">
+      <field name="type" id="1" type="MemberType"/>
+      <field name="updated" id="2" type="int64"/>
+      <data name="memberId" id="3" type="varDataEncoding"/>
+    </group>
+  </sbe:message>
+</sbe:messageSchema>

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -348,9 +348,6 @@ public class LeaderRoleTest {
                 assertThat(lastEntry.highestPosition()).isEqualTo(7);
                 assertThat(entry.lowestPosition()).isEqualTo(9);
                 assertThat(entry.highestPosition()).isEqualTo(9);
-                entry.data().rewind();
-                data.rewind();
-                assertThat(entry.data()).isEqualTo(data);
                 latch.countDown();
                 return ValidationResult.failure("expected");
               }

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftEntrySBESerializerTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftEntrySBESerializerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.storage.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.RaftMember;
+import io.atomix.raft.cluster.RaftMember.Type;
+import io.atomix.raft.cluster.impl.DefaultRaftMember;
+import io.atomix.raft.storage.log.entry.ApplicationEntry;
+import io.atomix.raft.storage.log.entry.ConfigurationEntry;
+import io.atomix.raft.storage.log.entry.InitialEntry;
+import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import java.time.Instant;
+import java.util.Set;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+
+public class RaftEntrySBESerializerTest {
+
+  final RaftEntrySerializer serializer = new RaftEntrySBESerializer();
+  final MutableDirectBuffer buffer = new ExpandableArrayBuffer();
+
+  @Test
+  public void shouldWriteApplicationEntry() {
+    // given
+    final byte[] data = "Test".getBytes();
+    final ApplicationEntry applicationEntryWritten =
+        new ApplicationEntry(1, 2, new UnsafeBuffer(data));
+    final RaftLogEntry raftLogEntryExpected = new RaftLogEntry(5, applicationEntryWritten);
+
+    // when
+    serializer.writeApplicationEntry(5, applicationEntryWritten, buffer, 0);
+    final RaftLogEntry raftLogEntryRead = serializer.readRaftLogEntry(buffer);
+
+    assertThat(raftLogEntryRead.isApplicationEntry()).isTrue();
+
+    final ApplicationEntry applicationEntryRead = raftLogEntryRead.getApplicationEntry();
+
+    // then
+    assertThat(applicationEntryRead).isEqualTo(applicationEntryWritten);
+    assertThat(raftLogEntryRead).isEqualTo(raftLogEntryExpected);
+  }
+
+  @Test
+  public void shouldWriteApplicationEntryAtAnyOffset() {
+    // given
+    final int offset = 10;
+    final byte[] data = "Test".getBytes();
+    final ApplicationEntry applicationEntryWritten =
+        new ApplicationEntry(1, 2, new UnsafeBuffer(data));
+    final RaftLogEntry raftLogEntryExpected = new RaftLogEntry(5, applicationEntryWritten);
+
+    // when
+    final var length = serializer.writeApplicationEntry(5, applicationEntryWritten, buffer, offset);
+    final RaftLogEntry raftLogEntryRead =
+        serializer.readRaftLogEntry(new UnsafeBuffer(buffer, offset, length));
+
+    assertThat(raftLogEntryRead.isApplicationEntry()).isTrue();
+
+    final ApplicationEntry applicationEntryRead = raftLogEntryRead.getApplicationEntry();
+
+    // then
+    assertThat(applicationEntryRead).isEqualTo(applicationEntryWritten);
+    assertThat(raftLogEntryRead).isEqualTo(raftLogEntryExpected);
+  }
+
+  @Test
+  public void shouldWriteInitialEntry() {
+    // given
+    final InitialEntry initialEntryWritten = new InitialEntry();
+    final RaftLogEntry raftLogEntryExpected = new RaftLogEntry(5, initialEntryWritten);
+
+    // when
+    serializer.writeInitialEntry(5, initialEntryWritten, buffer, 0);
+    final RaftLogEntry raftLogEntryRead = serializer.readRaftLogEntry(buffer);
+
+    assertThat(raftLogEntryRead.isInitialEntry()).isTrue();
+    assertThat(raftLogEntryRead).isEqualTo(raftLogEntryExpected);
+  }
+
+  @Test
+  public void shouldWriteInitialEntryAtAnyOffset() {
+    // given
+    final int offset = 10;
+    final InitialEntry initialEntryWritten = new InitialEntry();
+    final RaftLogEntry raftLogEntryExpected = new RaftLogEntry(5, initialEntryWritten);
+
+    // when
+    final var length = serializer.writeInitialEntry(5, initialEntryWritten, buffer, offset);
+    final RaftLogEntry raftLogEntryRead =
+        serializer.readRaftLogEntry(new UnsafeBuffer(buffer, offset, length));
+
+    assertThat(raftLogEntryRead.isInitialEntry()).isTrue();
+    assertThat(raftLogEntryExpected).isEqualTo(raftLogEntryRead);
+  }
+
+  @Test
+  public void shouldWriteConfigurationEntry() {
+    // given
+    final Set<RaftMember> members =
+        Set.of(
+            new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.ofEpochMilli(123456L)),
+            new DefaultRaftMember(MemberId.from("2"), Type.PASSIVE, Instant.ofEpochMilli(123457L)),
+            new DefaultRaftMember(
+                MemberId.from("3"), Type.PROMOTABLE, Instant.ofEpochMilli(123458L)));
+    final ConfigurationEntry configurationEntryWritten = new ConfigurationEntry(1234L, members);
+
+    // when
+    serializer.writeConfigurationEntry(5, configurationEntryWritten, buffer, 0);
+    final RaftLogEntry entryRead = serializer.readRaftLogEntry(buffer);
+
+    // then
+    assertThat(entryRead.isConfigurationEntry()).isTrue();
+    final var configurationEntryRead = entryRead.getConfigurationEntry();
+    assertThat(configurationEntryRead.timestamp()).isEqualTo(configurationEntryWritten.timestamp());
+    assertThat(configurationEntryRead.toString()).isEqualTo(configurationEntryWritten.toString());
+  }
+
+  @Test
+  public void shouldWriteConfigurationEntryAtAnyOffset() {
+    // given
+    final int offset = 10;
+    final Set<RaftMember> members =
+        Set.of(
+            new DefaultRaftMember(MemberId.from("1"), Type.ACTIVE, Instant.ofEpochMilli(123456L)),
+            new DefaultRaftMember(MemberId.from("2"), Type.PASSIVE, Instant.ofEpochMilli(123457L)),
+            new DefaultRaftMember(
+                MemberId.from("3"), Type.PROMOTABLE, Instant.ofEpochMilli(123458L)));
+    final ConfigurationEntry configurationEntryWritten = new ConfigurationEntry(1234L, members);
+
+    // when
+    final var length =
+        serializer.writeConfigurationEntry(5, configurationEntryWritten, buffer, offset);
+    final RaftLogEntry entryRead =
+        serializer.readRaftLogEntry(new UnsafeBuffer(buffer, offset, length));
+
+    // then
+    assertThat(entryRead.isConfigurationEntry()).isTrue();
+    final var configurationEntryRead = entryRead.getConfigurationEntry();
+    assertThat(configurationEntryRead.timestamp()).isEqualTo(configurationEntryWritten.timestamp());
+    assertThat(configurationEntryRead.toString()).isEqualTo(configurationEntryWritten.toString());
+  }
+}

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
@@ -38,6 +38,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -81,7 +82,8 @@ public final class AsyncSnapshotingTest {
             new NoneSnapshotReplication(),
             l ->
                 Optional.of(
-                    new TestIndexedRaftLogEntry(l + 100, 1, new ApplicationEntry(1, 10, null))),
+                    new TestIndexedRaftLogEntry(
+                        l + 100, 1, new ApplicationEntry(1, 10, new UnsafeBuffer()))),
             db -> Long.MAX_VALUE);
 
     snapshotController.openDb();

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -61,7 +62,10 @@ public final class FailingSnapshotChunkReplicationTest {
             senderFactory.getReceivableSnapshotStore(1),
             senderRoot.resolve("runtime"),
             replicator,
-            l -> Optional.of(new TestIndexedRaftLogEntry(l, 1, new ApplicationEntry(1, 10, null))),
+            l ->
+                Optional.of(
+                    new TestIndexedRaftLogEntry(
+                        l, 1, new ApplicationEntry(1, 10, new UnsafeBuffer()))),
             db -> Long.MAX_VALUE);
     senderStore.addSnapshotListener(replicatorSnapshotController);
 
@@ -73,7 +77,10 @@ public final class FailingSnapshotChunkReplicationTest {
             receiverFactory.getReceivableSnapshotStore(1),
             receiverRoot.resolve("runtime"),
             replicator,
-            l -> Optional.of(new TestIndexedRaftLogEntry(l, 1, new ApplicationEntry(1, 10, null))),
+            l ->
+                Optional.of(
+                    new TestIndexedRaftLogEntry(
+                        l, 1, new ApplicationEntry(1, 10, new UnsafeBuffer()))),
             db -> Long.MAX_VALUE);
     receiverStore.addSnapshotListener(receiverSnapshotController);
 

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.zip.CRC32;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
@@ -71,7 +72,10 @@ public final class ReplicateStateControllerTest {
             senderFactory.getReceivableSnapshotStore(1),
             senderRoot.resolve("runtime"),
             replicator,
-            l -> Optional.of(new TestIndexedRaftLogEntry(l, 1, new ApplicationEntry(1, 10, null))),
+            l ->
+                Optional.of(
+                    new TestIndexedRaftLogEntry(
+                        l, 1, new ApplicationEntry(1, 10, new UnsafeBuffer()))),
             db -> Long.MAX_VALUE);
     senderStore.addSnapshotListener(replicatorSnapshotController);
 
@@ -83,7 +87,10 @@ public final class ReplicateStateControllerTest {
             receiverStore,
             receiverRoot.resolve("runtime"),
             replicator,
-            l -> Optional.of(new TestIndexedRaftLogEntry(l, 1, new ApplicationEntry(1, 10, null))),
+            l ->
+                Optional.of(
+                    new TestIndexedRaftLogEntry(
+                        l, 1, new ApplicationEntry(1, 10, new UnsafeBuffer()))),
             db -> Long.MAX_VALUE);
     receiverStore.addSnapshotListener(receiverSnapshotController);
 

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -30,6 +30,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
 import java.util.Optional;
 import org.agrona.collections.MutableLong;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,7 +63,10 @@ public final class StateControllerImplTest {
             factory.getReceivableSnapshotStore(1),
             rootDirectory.resolve("runtime"),
             new NoneSnapshotReplication(),
-            l -> Optional.of(new TestIndexedRaftLogEntry(l, 1, new ApplicationEntry(1, 10, null))),
+            l ->
+                Optional.of(
+                    new TestIndexedRaftLogEntry(
+                        l, 1, new ApplicationEntry(1, 10, new UnsafeBuffer()))),
             db -> exporterPosition.get());
 
     autoCloseableRule.manage(snapshotController);


### PR DESCRIPTION
## Description

* Introduce sbe schema for raft entries
* Remove Kryo and use SBE for serializing raft entries that are written to the log

## Related issues

closes #6310 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
