### PR TITLE
[Backport 0.26] Print record metadata on (re)processing failure

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingException.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.processing.streamprocessor;
+
+import io.zeebe.logstreams.log.LoggedEvent;
+import io.zeebe.protocol.impl.record.RecordMetadata;
+
+public final class ProcessingException extends RuntimeException {
+
+  public ProcessingException(
+      final String message,
+      final LoggedEvent event,
+      final RecordMetadata metadata,
+      final Throwable cause) {
+    super(formatMessage(message, event, metadata), cause);
+  }
+
+  private static String formatMessage(
+      final String message, final LoggedEvent event, final RecordMetadata metadata) {
+    return String.format("%s [%s %s]", message, formatEvent(event), formatMetadata(metadata));
+  }
+
+  private static String formatEvent(final LoggedEvent event) {
+    if (event == null) {
+      return "LoggedEvent [null]";
+    }
+    return event.toString();
+  }
+
+  private static String formatMetadata(final RecordMetadata metadata) {
+    if (metadata == null) {
+      return "RecordMetadata{null}";
+    }
+    return metadata.toString();
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingException.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingException.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.1. You may not use this file
- * except in compliance with the Zeebe Community License 1.1.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
  */
 package io.zeebe.engine.processing.streamprocessor;
 

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -77,23 +77,23 @@ import org.slf4j.Logger;
  */
 public final class ProcessingStateMachine {
 
-  public static final String ERROR_MESSAGE_WRITE_EVENT_ABORTED =
-      "Expected to write one or more follow up events for event '{}' without errors, but exception was thrown.";
   private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
+  private static final String ERROR_MESSAGE_WRITE_EVENT_ABORTED =
+      "Expected to write one or more follow up events for event '{} {}' without errors, but exception was thrown.";
   private static final String ERROR_MESSAGE_ROLLBACK_ABORTED =
-      "Expected to roll back the current transaction for event '{}' successfully, but exception was thrown.";
+      "Expected to roll back the current transaction for event '{} {}' successfully, but exception was thrown.";
   private static final String ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED =
-      "Expected to execute side effects for event '{}' successfully, but exception was thrown.";
+      "Expected to execute side effects for event '{} {}' successfully, but exception was thrown.";
   private static final String ERROR_MESSAGE_UPDATE_STATE_FAILED =
-      "Expected to successfully update state for event '{}', but caught an exception. Retry.";
+      "Expected to successfully update state for event '{} {}', but caught an exception. Retry.";
   private static final String ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT =
-      "Expected to find event processor for event '{}', but caught an exception. Skip this event.";
+      "Expected to find event processor for event '{} {}', but caught an exception. Skip this event.";
   private static final String ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT =
-      "Expected to successfully process event '{}' with processor, but caught an exception. Skip this event.";
+      "Expected to successfully process event '{} {}' with processor, but caught an exception. Skip this event.";
   private static final String ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING =
-      "Expected to process event '{}' successfully on stream processor, but caught recoverable exception. Retry processing.";
+      "Expected to process event '{} {}' successfully on stream processor, but caught recoverable exception. Retry processing.";
   private static final String PROCESSING_ERROR_MESSAGE =
-      "Expected to process event '%s' without errors, but exception occurred with message '%s' .";
+      "Expected to process event '%s' without errors, but exception occurred with message '%s'.";
   private static final String NOTIFY_LISTENER_ERROR_MESSAGE =
       "Expected to invoke processed listener for event {} successfully, but exception was thrown.";
 
@@ -233,10 +233,11 @@ public final class ProcessingStateMachine {
       writeEvent();
     } catch (final RecoverableException recoverableException) {
       // recoverable
-      LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING, event, recoverableException);
+      LOG.error(
+          ERROR_MESSAGE_PROCESSING_FAILED_RETRY_PROCESSING, event, metadata, recoverableException);
       actor.runDelayed(PROCESSING_RETRY_DELAY, () -> processEvent(currentEvent));
     } catch (final Exception e) {
-      LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT, event, e);
+      LOG.error(ERROR_MESSAGE_PROCESSING_FAILED_SKIP_EVENT, event, metadata, e);
       onError(e, this::writeEvent);
     }
   }
@@ -249,7 +250,7 @@ public final class ProcessingStateMachine {
           recordProcessorMap.get(
               metadata.getRecordType(), metadata.getValueType(), metadata.getIntent().value());
     } catch (final Exception e) {
-      LOG.error(ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT, event, e);
+      LOG.error(ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT, event, metadata, e);
     }
 
     return typedRecordProcessor;
@@ -305,7 +306,7 @@ public final class ProcessingStateMachine {
         retryFuture,
         (bool, throwable) -> {
           if (throwable != null) {
-            LOG.error(ERROR_MESSAGE_ROLLBACK_ABORTED, currentEvent, throwable);
+            LOG.error(ERROR_MESSAGE_ROLLBACK_ABORTED, currentEvent, metadata, throwable);
           }
           try {
             errorHandlingInTransaction(processingException);
@@ -366,7 +367,7 @@ public final class ProcessingStateMachine {
         retryFuture,
         (bool, t) -> {
           if (t != null) {
-            LOG.error(ERROR_MESSAGE_WRITE_EVENT_ABORTED, currentEvent, t);
+            LOG.error(ERROR_MESSAGE_WRITE_EVENT_ABORTED, currentEvent, metadata, t);
             onError(t, this::writeEvent);
           } else {
             updateState();
@@ -405,7 +406,7 @@ public final class ProcessingStateMachine {
         retryFuture,
         (bool, throwable) -> {
           if (throwable != null) {
-            LOG.error(ERROR_MESSAGE_UPDATE_STATE_FAILED, currentEvent, throwable);
+            LOG.error(ERROR_MESSAGE_UPDATE_STATE_FAILED, currentEvent, metadata, throwable);
             onError(throwable, this::updateState);
           } else {
             executeSideEffects();
@@ -417,7 +418,7 @@ public final class ProcessingStateMachine {
     try {
       onProcessed.accept(typedEvent);
     } catch (final Exception e) {
-      LOG.error(NOTIFY_LISTENER_ERROR_MESSAGE, currentEvent, e);
+      LOG.error(NOTIFY_LISTENER_ERROR_MESSAGE, typedEvent, e);
     }
   }
 
@@ -429,7 +430,7 @@ public final class ProcessingStateMachine {
         retryFuture,
         (bool, throwable) -> {
           if (throwable != null) {
-            LOG.error(ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED, currentEvent, throwable);
+            LOG.error(ERROR_MESSAGE_EXECUTE_SIDE_EFFECT_ABORTED, currentEvent, metadata, throwable);
           }
 
           notifyListener();

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ReProcessingStateMachine.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.processing.streamprocessor;
 import io.zeebe.db.DbContext;
 import io.zeebe.db.TransactionOperation;
 import io.zeebe.db.ZeebeDbTransaction;
+import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
 import io.zeebe.engine.processing.streamprocessor.writers.NoopResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.ReprocessingStreamWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -70,10 +71,9 @@ import org.slf4j.Logger;
  */
 public final class ReProcessingStateMachine {
 
-  public static final Consumer NOOP_SIDE_EFFECT_CONSUMER = (sideEffect) -> {};
   private static final Logger LOG = Loggers.PROCESSOR_LOGGER;
   private static final String ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT =
-      "Expected to find event processor for event '{}', but caught an exception. Skip this event.";
+      "Expected to find event processor for event '{} {}', but caught an exception. Skip this event.";
   private static final String ERROR_MESSAGE_REPROCESSING_NO_FOLLOW_UP_EVENT =
       "Expected to find last follow-up event position '%d', but last position was '%d'. Failed to reprocess on processor";
   private static final String ERROR_MESSAGE_REPROCESSING_NO_NEXT_EVENT =
@@ -82,10 +82,10 @@ public final class ReProcessingStateMachine {
       "Processor finished reprocessing at event position {}";
   private static final String LOG_STMT_FAILED_ON_PROCESSING =
       "Event {} failed on processing last time, will call #onError to update workflow instance blacklist.";
-
   private static final String ERROR_INCONSISTENT_LOG =
       "Expected that position '%d' of current event is higher then position '%d' of last event, but was not. Inconsistent log detected!";
 
+  private static final Consumer<SideEffectProducer> NOOP_SIDE_EFFECT_CONSUMER = (sideEffect) -> {};
   private static final Consumer<Long> NOOP_LONG_CONSUMER = (instanceKey) -> {};
   protected final RecordMetadata metadata = new RecordMetadata();
   private final ZeebeState zeebeState;
@@ -116,7 +116,7 @@ public final class ReProcessingStateMachine {
   private LoggedEvent currentEvent;
   private TypedRecordProcessor eventProcessor;
   private ZeebeDbTransaction zeebeDbTransaction;
-  private boolean detectReprocessingInconsistency;
+  private final boolean detectReprocessingInconsistency;
 
   public ReProcessingStateMachine(final ProcessingContext context) {
     actor = context.getActor();
@@ -242,7 +242,9 @@ public final class ReProcessingStateMachine {
       }
 
     } catch (final RuntimeException e) {
-      recoveryFuture.completeExceptionally(e);
+      final var processingException =
+          new ProcessingException("Unable to reprocess record", currentEvent, metadata, e);
+      recoveryFuture.completeExceptionally(processingException);
     }
   }
 
@@ -256,7 +258,7 @@ public final class ReProcessingStateMachine {
           recordProcessorMap.get(
               metadata.getRecordType(), metadata.getValueType(), metadata.getIntent().value());
     } catch (final Exception e) {
-      LOG.error(ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT, currentEvent, e);
+      LOG.error(ERROR_MESSAGE_ON_EVENT_FAILED_SKIP_EVENT, currentEvent, metadata, e);
     }
 
     if (eventProcessor == null) {


### PR DESCRIPTION
## Description

Backport of #6604 

## Related issues

closes #6518
