### PR TITLE
fix(clients/go): remove leading '\' from test

### DIFF
--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -1,4 +1,4 @@
-\// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

Removes a leading '\\' from a test file that was causing a compiler error.

## Related issues

closes #6613 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
