### PR TITLE
chore(ci): adjust seedjobs for multi env

### DIFF
--- a/.ci/jobs/github_camunda_cloud.dsl
+++ b/.ci/jobs/github_camunda_cloud.dsl
@@ -16,8 +16,10 @@ organizationFolder('camunda-cloud') {
                         deleteUntrackedNestedRepositories(false)
                     }
                 }
+                // Discover branches.
+                // Strategy ID 3 => Discover all branches.
                 gitHubBranchDiscovery {
-                    strategyId(3)
+                    strategyId 3
                 }
                 pruneStaleBranchTrait()
                 localBranchTrait()
@@ -25,25 +27,42 @@ organizationFolder('camunda-cloud') {
                   includes('zeebe*')
                   excludes('')
                 }
+
+                // Disable sending Github status notifications in non-prod envs.
+                if (ENVIRONMENT != 'prod') {
+                    notificationsSkip()
+                }
             }
+        }
+    }
+
+    buildStrategies {
+        // Don't auto build discovered branches for non prod envs.
+        if (ENVIRONMENT == 'prod') {
+            // Builds regular branches whenever a change is detected.
+            buildRegularBranches()
         }
     }
 
     orphanedItemStrategy {
         discardOldItems {
-            numToKeep(10)
+            numToKeep 10
         }
     }
 
     triggers {
         periodicFolderTrigger {
-            interval('8h')
+            interval '8h'
         }
     }
 
-    configure {
-        def traits = it / navigators / 'org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator' / traits
-        // Note: the 'traits' variable can be used to configure options that are
-        // not exposed via normal Jenkins API like above 'gitHubBranchDiscovery'
+    properties {
+        // Avoid automatically build jobs on non-prod envs by org indexing.
+        // Note: The DSL name here is misleading. This config is for the branches that WILL be built automatically.
+        // So on prod env all branches will be built automatically but for non-prod no automatic builds.
+        noTriggerOrganizationFolderProperty {
+            branches (ENVIRONMENT == 'prod' ? '.*' : '')
+        } 
     }
+
 }

--- a/.ci/jobs/github_zeebe_io.dsl
+++ b/.ci/jobs/github_zeebe_io.dsl
@@ -16,8 +16,10 @@ organizationFolder('zeebe-io') {
                         deleteUntrackedNestedRepositories(false)
                     }
                 }
+                // Discover branches.
+                // Strategy ID 3 => Discover all branches.
                 gitHubBranchDiscovery {
-                    strategyId(3)
+                    strategyId 3
                 }
                 pruneStaleBranchTrait()
                 localBranchTrait()
@@ -25,25 +27,42 @@ organizationFolder('zeebe-io') {
                   includes('*')
                   excludes('zeebe-tasklist')
                 }
+
+                // Disable sending Github status notifications in non-prod envs.
+                if (ENVIRONMENT != 'prod') {
+                    notificationsSkip()
+                }
             }
+        }
+    }
+
+    buildStrategies {
+        // Don't auto build discovered for non prod envs.
+        if (ENVIRONMENT == 'prod') {
+            // Builds regular branches whenever a change is detected.
+            buildRegularBranches()
         }
     }
 
     orphanedItemStrategy {
         discardOldItems {
-            numToKeep(10)
+            numToKeep 10
         }
     }
 
     triggers {
         periodicFolderTrigger {
-            interval('8h')
+            interval '8h'
         }
     }
 
-    configure {
-        def traits = it / navigators / 'org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator' / traits
-        // Note: the 'traits' variable can be used to configure options that are
-        // not exposed via normal Jenkins API like above 'gitHubBranchDiscovery'
+    properties {
+        // Avoid automatically build jobs on non-prod envs by org indexing.
+        // Note: The DSL name here is misleading. This config is for the branches that WILL be built automatically.
+        // So on prod env all branches will be built automatically but for non-prod no automatic builds.
+        noTriggerOrganizationFolderProperty {
+            branches (ENVIRONMENT == 'prod' ? '.*' : '')
+        } 
     }
+
 }

--- a/.ci/seed.dsl
+++ b/.ci/seed.dsl
@@ -31,8 +31,10 @@ def seedJob = job('seed-job-zeebe') {
     }
   }
 
-  triggers {
-    githubPush()
+  if (ENVIRONMENT == 'prod') {
+    triggers {
+      githubPush()
+    }
   }
 
   label 'master'


### PR DESCRIPTION
## Description

As an outcome of [INFRA-2300](https://jira.camunda.com/browse/INFRA-2300), we are adjusting seed jobs to be more compatible with having multiple Jenkins environments. This includes no automatic triggering and reporting for e.g. multibranchjobs or organization folders on staging/dev.
In the past whenever someone wanted to test something on the staging instance all current Jenkins status reports were overwritten with the staging instance.

## Related issues

[INFRA-2300](https://jira.camunda.com/browse/INFRA-2300)

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
