### PR TITLE
add definition of ready to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,18 @@
 
 closes #
 
+## Definition of Ready
+
+Please check the items that apply, before requesting a review.
+
+* [ ] I've reviewed my own code
+* [ ] I've written a clear changelist description
+* [ ] I've narrowly scoped my changes
+* [ ] I've separated structural from behavioural changes
+
 ## Definition of Done
+
+Please the items that apply, before merging or (if possible) before requesting a review.
 
 _Not all items need to be done depending on the issue and the pull request._
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,18 +8,22 @@
 
 closes #
 
+<!--
 ## Definition of Ready
 
 Please check the items that apply, before requesting a review.
+
+You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).
 
 * [ ] I've reviewed my own code
 * [ ] I've written a clear changelist description
 * [ ] I've narrowly scoped my changes
 * [ ] I've separated structural from behavioural changes
+-->
 
 ## Definition of Done
 
-Please the items that apply, before merging or (if possible) before requesting a review.
+<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->
 
 _Not all items need to be done depending on the issue and the pull request._
 


### PR DESCRIPTION
## Description

During the `PR Reviews` sharpen the axe session, the group discussed ideas on how to improve the pull request process. This first session specifically discussed improvements to benefit the reviewer. This PR adds a checklist to help author's to improve their pull requests.

The main ideas of this checklist are discussed in our wiki page on [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews). That page should be considered part of this PR.

## Related issues

NA

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
