### PR TITLE
Avoid duplicate terminating

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
@@ -71,12 +71,10 @@ public class IntermediateCatchEventProcessor
   public void onTerminate(
       final ExecutableCatchEventElement element, final BpmnElementContext context) {
 
-    final var terminating = stateTransitionBehavior.transitionToTerminating(context);
+    eventSubscriptionBehavior.unsubscribeFromEvents(context);
+    incidentBehavior.resolveIncidents(context);
 
-    eventSubscriptionBehavior.unsubscribeFromEvents(terminating);
-    incidentBehavior.resolveIncidents(terminating);
-
-    final var terminated = stateTransitionBehavior.transitionToTerminated(terminating);
+    final var terminated = stateTransitionBehavior.transitionToTerminated(context);
     stateTransitionBehavior.onElementTerminated(element, terminated);
   }
 


### PR DESCRIPTION
## Description
The transition to terminating is already done in BpmnStreamProcessor https://github.com/camunda-cloud/zeebe/blob/develop/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java#L134 for migrated processors, in the `IntermediateCatchEventProcessor#onTerminate` was it done another time.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6643 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
