### PR TITLE
Disallow multiple same transition

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
@@ -38,10 +38,7 @@ public class IntermediateCatchEventProcessor
 
   @Override
   public void onActivate(
-      final ExecutableCatchEventElement element, final BpmnElementContext context) {
-
-    final var activating = stateTransitionBehavior.transitionToActivating(context);
-
+      final ExecutableCatchEventElement element, final BpmnElementContext activating) {
     variableMappingBehavior
         .applyInputMappings(activating, element)
         .flatMap(ok -> eventSubscriptionBehavior.subscribeToEvents(element, activating))
@@ -52,10 +49,7 @@ public class IntermediateCatchEventProcessor
 
   @Override
   public void onComplete(
-      final ExecutableCatchEventElement element, final BpmnElementContext context) {
-
-    final var completing = stateTransitionBehavior.transitionToCompleting(context);
-
+      final ExecutableCatchEventElement element, final BpmnElementContext completing) {
     variableMappingBehavior
         .applyOutputMappings(completing, element)
         .ifRightOrLeft(
@@ -69,12 +63,11 @@ public class IntermediateCatchEventProcessor
 
   @Override
   public void onTerminate(
-      final ExecutableCatchEventElement element, final BpmnElementContext context) {
+      final ExecutableCatchEventElement element, final BpmnElementContext terminating) {
+    eventSubscriptionBehavior.unsubscribeFromEvents(terminating);
+    incidentBehavior.resolveIncidents(terminating);
 
-    eventSubscriptionBehavior.unsubscribeFromEvents(context);
-    incidentBehavior.resolveIncidents(context);
-
-    final var terminated = stateTransitionBehavior.transitionToTerminated(context);
+    final var terminated = stateTransitionBehavior.transitionToTerminated(terminating);
     stateTransitionBehavior.onElementTerminated(element, terminated);
   }
 


### PR DESCRIPTION
## Description

Since we had some cases recently, I would like to have an intermediate solution as a reminder to not transition again on migrated processors. This allows us to have the same way of doing it (consistency). We should remove it after we migrated all. I can create a follow up issue if you want.

Ideally we wouldn't have the possibility in the processors to transition again, but it think this can only be changed after we merged all.

<!-- Please explain the changes you made here. -->

## Related issues


## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
