### PR TITLE
Add user task support

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/Bpmn.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/Bpmn.java
@@ -212,6 +212,7 @@ import io.zeebe.model.bpmn.impl.instance.di.ShapeImpl;
 import io.zeebe.model.bpmn.impl.instance.di.StyleImpl;
 import io.zeebe.model.bpmn.impl.instance.di.WaypointImpl;
 import io.zeebe.model.bpmn.impl.instance.zeebe.ZeebeCalledElementImpl;
+import io.zeebe.model.bpmn.impl.instance.zeebe.ZeebeFormDefinitionImpl;
 import io.zeebe.model.bpmn.impl.instance.zeebe.ZeebeHeaderImpl;
 import io.zeebe.model.bpmn.impl.instance.zeebe.ZeebeInputImpl;
 import io.zeebe.model.bpmn.impl.instance.zeebe.ZeebeIoMappingImpl;
@@ -220,6 +221,7 @@ import io.zeebe.model.bpmn.impl.instance.zeebe.ZeebeOutputImpl;
 import io.zeebe.model.bpmn.impl.instance.zeebe.ZeebeSubscriptionImpl;
 import io.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskDefinitionImpl;
 import io.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskHeadersImpl;
+import io.zeebe.model.bpmn.impl.instance.zeebe.ZeebeUserTaskFormImpl;
 import io.zeebe.model.bpmn.instance.Definitions;
 import io.zeebe.model.bpmn.instance.Process;
 import io.zeebe.model.bpmn.instance.bpmndi.BpmnDiagram;
@@ -635,6 +637,8 @@ public class Bpmn {
     ZeebeTaskHeadersImpl.registerType(bpmnModelBuilder);
     ZeebeLoopCharacteristicsImpl.registerType(bpmnModelBuilder);
     ZeebeCalledElementImpl.registerType(bpmnModelBuilder);
+    ZeebeFormDefinitionImpl.registerType(bpmnModelBuilder);
+    ZeebeUserTaskFormImpl.registerType(bpmnModelBuilder);
   }
 
   /** @return the {@link Model} instance to use */

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractBaseElementBuilder.java
@@ -36,6 +36,7 @@ import io.zeebe.model.bpmn.instance.FlowNode;
 import io.zeebe.model.bpmn.instance.Gateway;
 import io.zeebe.model.bpmn.instance.Message;
 import io.zeebe.model.bpmn.instance.MessageEventDefinition;
+import io.zeebe.model.bpmn.instance.Process;
 import io.zeebe.model.bpmn.instance.SequenceFlow;
 import io.zeebe.model.bpmn.instance.Signal;
 import io.zeebe.model.bpmn.instance.SignalEventDefinition;
@@ -45,6 +46,7 @@ import io.zeebe.model.bpmn.instance.bpmndi.BpmnPlane;
 import io.zeebe.model.bpmn.instance.bpmndi.BpmnShape;
 import io.zeebe.model.bpmn.instance.dc.Bounds;
 import io.zeebe.model.bpmn.instance.di.Waypoint;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.function.Consumer;
@@ -274,6 +276,26 @@ public abstract class AbstractBaseElementBuilder<
     final CompensateEventDefinition compensateEventDefinition =
         createInstance(CompensateEventDefinition.class);
     return compensateEventDefinition;
+  }
+
+  protected Process findProcess() {
+    ModelElementInstance parentElement;
+    do {
+      parentElement = element.getParentElement();
+    } while (!(parentElement == null || parentElement instanceof Process));
+
+    if (parentElement == null) {
+      throw new RuntimeException("Unable to find process parent for element " + element);
+    }
+
+    return (Process) parentElement;
+  }
+
+  protected ZeebeUserTaskForm createZeebeUserTaskForm() {
+    final Process process = findProcess();
+    final ExtensionElements extensionElements =
+        getCreateSingleChild(process, ExtensionElements.class);
+    return createChild(extensionElements, ZeebeUserTaskForm.class);
   }
 
   /**

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
@@ -16,8 +16,15 @@
 
 package io.zeebe.model.bpmn.builder;
 
+import static io.zeebe.model.bpmn.impl.ZeebeConstants.USER_TASK_FORM_KEY_BPMN_LOCATION;
+import static io.zeebe.model.bpmn.impl.ZeebeConstants.USER_TASK_FORM_KEY_CAMUNDA_FORMS_FORMAT;
+
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.model.bpmn.instance.UserTask;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
 
 /** @author Sebastian Menski */
 public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<B>>
@@ -40,4 +47,70 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
   }
 
   /** camunda extensions */
+
+  /**
+   * Sets the form key with the format 'format:location:id' of the build user task.
+   *
+   * @param format the format of the reference form
+   * @param location the location where the form is available
+   * @param id the id of the form
+   * @return the builder object
+   */
+  public B zeebeFormKey(final String format, final String location, final String id) {
+    return zeebeFormKey(String.format("%s:%s:%s", format, location, id));
+  }
+
+  /**
+   * Sets the form key of the build user task.
+   *
+   * @param formKey the form key to set
+   * @return the builder object
+   */
+  public B zeebeFormKey(final String formKey) {
+    final ZeebeFormDefinition formDefinition =
+        getCreateSingleExtensionElement(ZeebeFormDefinition.class);
+    formDefinition.setFormKey(formKey);
+    return myself;
+  }
+
+  /**
+   * Creates an new user task form with the given context, assuming it is of the format
+   * camunda-forms and embedded inside the diagram.
+   *
+   * @param userTaskForm the XML encoded user task form json in the camunda-forms format
+   * @return the builder object
+   */
+  public B zeebeUserTaskForm(final String userTaskForm) {
+    final ZeebeUserTaskForm zeebeUserTaskForm = createZeebeUserTaskForm();
+    zeebeUserTaskForm.setTextContent(userTaskForm);
+    return zeebeFormKey(
+        USER_TASK_FORM_KEY_CAMUNDA_FORMS_FORMAT,
+        USER_TASK_FORM_KEY_BPMN_LOCATION,
+        zeebeUserTaskForm.getId());
+  }
+
+  /**
+   * Creates an new user task form with the given context, assuming it is of the format
+   * camunda-forms and embedded inside the diagram.
+   *
+   * @param id the unique identifier of the user task form element
+   * @param userTaskForm the XML encoded user task form json in the camunda-forms format
+   * @return the builder object
+   */
+  public B zeebeUserTaskForm(final String id, final String userTaskForm) {
+    final ZeebeUserTaskForm zeebeUserTaskForm = createZeebeUserTaskForm();
+    zeebeUserTaskForm.setId(id);
+    zeebeUserTaskForm.setTextContent(userTaskForm);
+    return zeebeFormKey(
+        USER_TASK_FORM_KEY_CAMUNDA_FORMS_FORMAT, USER_TASK_FORM_KEY_BPMN_LOCATION, id);
+  }
+
+  public B zeebeTaskHeader(final String key, final String value) {
+    final ZeebeTaskHeaders taskHeaders = getCreateSingleExtensionElement(ZeebeTaskHeaders.class);
+    final ZeebeHeader header = createChild(taskHeaders, ZeebeHeader.class);
+    header.setKey(key);
+    header.setValue(value);
+
+    return myself;
+  }
 }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -36,6 +36,8 @@ public class ZeebeConstants {
   public static final String ATTRIBUTE_PROCESS_ID = "processId";
   public static final String ATTRIBUTE_PROPAGATE_ALL_CHILD_VARIABLES = "propagateAllChildVariables";
 
+  public static final String ATTRIBUTE_FORM_KEY = "formKey";
+
   public static final String ELEMENT_HEADER = "header";
   public static final String ELEMENT_INPUT = "input";
   public static final String ELEMENT_IO_MAPPING = "ioMapping";
@@ -46,7 +48,15 @@ public class ZeebeConstants {
   public static final String ELEMENT_TASK_DEFINITION = "taskDefinition";
   public static final String ELEMENT_TASK_HEADERS = "taskHeaders";
 
+  public static final String ELEMENT_FORM_DEFINITION = "formDefinition";
+  public static final String ELEMENT_USER_TASK_FORM = "userTaskForm";
+
   public static final String ELEMENT_LOOP_CHARACTERISTICS = "loopCharacteristics";
 
   public static final String ELEMENT_CALLED_ELEMENT = "calledElement";
+
+  /** Form key format used for camunda-forms format */
+  public static final String USER_TASK_FORM_KEY_CAMUNDA_FORMS_FORMAT = "camunda-forms";
+  /** Form key location used for forms embedded in the same BPMN file, i.e. zeebeUserTaskForm */
+  public static final String USER_TASK_FORM_KEY_BPMN_LOCATION = "bpmn";
 }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/zeebe/ZeebeFormDefinitionImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/zeebe/ZeebeFormDefinitionImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+
+public class ZeebeFormDefinitionImpl extends BpmnModelElementInstanceImpl
+    implements ZeebeFormDefinition {
+
+  protected static Attribute<String> formKeyAttribute;
+
+  public ZeebeFormDefinitionImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  @Override
+  public String getFormKey() {
+    return formKeyAttribute.getValue(this);
+  }
+
+  @Override
+  public void setFormKey(final String formKey) {
+    formKeyAttribute.setValue(this, formKey);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebeFormDefinition.class, ZeebeConstants.ELEMENT_FORM_DEFINITION)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeFormDefinitionImpl::new);
+
+    formKeyAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_FORM_KEY)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .required()
+            .build();
+
+    typeBuilder.build();
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/zeebe/ZeebeUserTaskFormImpl.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/impl/instance/zeebe/ZeebeUserTaskFormImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.zeebe.model.bpmn.impl.instance.BaseElementImpl;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+
+public class ZeebeUserTaskFormImpl extends BaseElementImpl implements ZeebeUserTaskForm {
+
+  public ZeebeUserTaskFormImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebeUserTaskForm.class, ZeebeConstants.ELEMENT_USER_TASK_FORM)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeUserTaskFormImpl::new);
+
+    typeBuilder.build();
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinition.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinition.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.instance.zeebe;
+
+import io.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+
+public interface ZeebeFormDefinition extends BpmnModelElementInstance {
+
+  String getFormKey();
+
+  void setFormKey(String formKey);
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeUserTaskForm.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeUserTaskForm.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.instance.zeebe;
+
+import io.zeebe.model.bpmn.instance.BaseElement;
+
+public interface ZeebeUserTaskForm extends BaseElement {}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/FlowElementValidator.java
@@ -31,6 +31,7 @@ import io.zeebe.model.bpmn.instance.SequenceFlow;
 import io.zeebe.model.bpmn.instance.ServiceTask;
 import io.zeebe.model.bpmn.instance.StartEvent;
 import io.zeebe.model.bpmn.instance.SubProcess;
+import io.zeebe.model.bpmn.instance.UserTask;
 import java.util.HashSet;
 import java.util.Set;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
@@ -55,6 +56,7 @@ public class FlowElementValidator implements ModelElementValidator<FlowElement> 
     SUPPORTED_ELEMENT_TYPES.add(StartEvent.class);
     SUPPORTED_ELEMENT_TYPES.add(SubProcess.class);
     SUPPORTED_ELEMENT_TYPES.add(CallActivity.class);
+    SUPPORTED_ELEMENT_TYPES.add(UserTask.class);
 
     NON_EXECUTABLE_ELEMENT_TYPES.add(DataObject.class);
     NON_EXECUTABLE_ELEMENT_TYPES.add(DataObjectReference.class);

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -70,6 +70,8 @@ public final class ZeebeDesignTimeValidators {
     validators.add(new ZeebeLoopCharacteristicsValidator());
     validators.add(new ZeebeTaskDefinitionValidator());
     validators.add(new ZeebeSubscriptionValidator());
+    validators.add(new ZeebeFormDefinitionValidator());
+    validators.add(new ZeebeUserTaskFormValidator());
 
     VALIDATORS = Collections.unmodifiableList(validators);
   }

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeFormDefinitionValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeFormDefinitionValidator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.validation.zeebe;
+
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ZeebeFormDefinitionValidator implements ModelElementValidator<ZeebeFormDefinition> {
+
+  @Override
+  public Class<ZeebeFormDefinition> getElementType() {
+    return ZeebeFormDefinition.class;
+  }
+
+  @Override
+  public void validate(
+      final ZeebeFormDefinition element,
+      final ValidationResultCollector validationResultCollector) {
+    final String formKey = element.getFormKey();
+
+    if (formKey == null || formKey.isEmpty()) {
+      validationResultCollector.addError(0, "Form key must be present and not empty");
+    }
+  }
+}

--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeUserTaskFormValidator.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/validation/zeebe/ZeebeUserTaskFormValidator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.validation.zeebe;
+
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ZeebeUserTaskFormValidator implements ModelElementValidator<ZeebeUserTaskForm> {
+
+  @Override
+  public Class<ZeebeUserTaskForm> getElementType() {
+    return ZeebeUserTaskForm.class;
+  }
+
+  @Override
+  public void validate(
+      final ZeebeUserTaskForm element, final ValidationResultCollector validationResultCollector) {
+    final String textContent = element.getTextContent();
+
+    if (textContent == null || textContent.isEmpty()) {
+      validationResultCollector.addError(
+          0, "User task form text content has to be present and not empty");
+    }
+  }
+}

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinitionTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinitionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.instance.zeebe;
+
+import io.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import java.util.Collection;
+import java.util.Collections;
+
+public class ZeebeFormDefinitionTest extends BpmnModelElementInstanceTest {
+
+  @Override
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(BpmnModelConstants.ZEEBE_NS, false);
+  }
+
+  @Override
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Collections.singletonList(
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "formKey", false, true));
+  }
+}

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeUserTaskFormTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/instance/zeebe/ZeebeUserTaskFormTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.instance.zeebe;
+
+import io.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import java.util.Collection;
+import java.util.Collections;
+
+public class ZeebeUserTaskFormTest extends BpmnModelElementInstanceTest {
+
+  @Override
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(BpmnModelConstants.ZEEBE_NS, false);
+  }
+
+  @Override
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Collections.emptyList();
+  }
+}

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeUserTaskValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeUserTaskValidationTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.model.bpmn.validation;
+
+import static io.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+import static java.util.Collections.singletonList;
+
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
+import org.junit.runners.Parameterized.Parameters;
+
+public class ZeebeUserTaskValidationTest extends AbstractZeebeValidationTest {
+
+  @Parameters(name = "{index}: {1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task")
+            .zeebeFormKey("")
+            .endEvent()
+            .done(),
+        singletonList(expect(ZeebeFormDefinition.class, "Form key must be present and not empty"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task")
+            .zeebeUserTaskForm("")
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeUserTaskForm.class,
+                "User task form text content has to be present and not empty"))
+      }
+    };
+  }
+}

--- a/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
+++ b/bpmn-model/src/test/java/io/zeebe/model/bpmn/validation/ZeebeValidationTest.java
@@ -39,10 +39,6 @@ public class ZeebeValidationTest extends AbstractZeebeValidationTest {
         singletonList(expect("process", "Must have at least one start event"))
       },
       {
-        Bpmn.createExecutableProcess("process").startEvent().userTask("task").endEvent().done(),
-        singletonList(expect("task", "Elements of this type are not supported"))
-      },
-      {
         Bpmn.createExecutableProcess("process")
             .startEvent()
             .endEvent("end")

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -36,6 +36,7 @@ public final class BpmnElementProcessors {
     // tasks
     processors.put(BpmnElementType.SERVICE_TASK, new ServiceTaskProcessor(bpmnBehaviors));
     processors.put(BpmnElementType.RECEIVE_TASK, new ReceiveTaskProcessor(bpmnBehaviors));
+    processors.put(BpmnElementType.USER_TASK, new ServiceTaskProcessor(bpmnBehaviors));
 
     // gateways
     processors.put(BpmnElementType.EXCLUSIVE_GATEWAY, new ExclusiveGatewayProcessor(bpmnBehaviors));

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformation/BpmnTransformer.java
@@ -28,6 +28,7 @@ import io.zeebe.engine.processing.deployment.model.transformer.SequenceFlowTrans
 import io.zeebe.engine.processing.deployment.model.transformer.ServiceTaskTransformer;
 import io.zeebe.engine.processing.deployment.model.transformer.StartEventTransformer;
 import io.zeebe.engine.processing.deployment.model.transformer.SubProcessTransformer;
+import io.zeebe.engine.processing.deployment.model.transformer.UserTaskTransformer;
 import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.model.bpmn.traversal.ModelWalker;
 import java.util.List;
@@ -75,6 +76,7 @@ public final class BpmnTransformer {
     step2Visitor.registerHandler(new SequenceFlowTransformer());
     step2Visitor.registerHandler(new ServiceTaskTransformer());
     step2Visitor.registerHandler(new ReceiveTaskTransformer());
+    step2Visitor.registerHandler(new UserTaskTransformer());
     step2Visitor.registerHandler(new StartEventTransformer());
 
     step3Visitor = new TransformationVisitor();

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformer/FlowElementInstantiationTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformer/FlowElementInstantiationTransformer.java
@@ -38,6 +38,7 @@ import io.zeebe.model.bpmn.instance.SequenceFlow;
 import io.zeebe.model.bpmn.instance.ServiceTask;
 import io.zeebe.model.bpmn.instance.StartEvent;
 import io.zeebe.model.bpmn.instance.SubProcess;
+import io.zeebe.model.bpmn.instance.UserTask;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,6 +62,7 @@ public final class FlowElementInstantiationTransformer
     ELEMENT_FACTORIES.put(ParallelGateway.class, ExecutableFlowNode::new);
     ELEMENT_FACTORIES.put(SequenceFlow.class, ExecutableSequenceFlow::new);
     ELEMENT_FACTORIES.put(ServiceTask.class, ExecutableServiceTask::new);
+    ELEMENT_FACTORIES.put(UserTask.class, ExecutableServiceTask::new);
     ELEMENT_FACTORIES.put(ReceiveTask.class, ExecutableReceiveTask::new);
     ELEMENT_FACTORIES.put(StartEvent.class, ExecutableStartEvent::new);
     ELEMENT_FACTORIES.put(SubProcess.class, ExecutableFlowElementContainer::new);

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.processing.deployment.model.transformer;
+
+import static io.zeebe.util.buffer.BufferUtil.wrapString;
+
+import io.zeebe.el.impl.StaticExpression;
+import io.zeebe.engine.Loggers;
+import io.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.zeebe.engine.processing.deployment.model.element.ExecutableServiceTask;
+import io.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
+import io.zeebe.engine.processing.deployment.model.transformation.TransformContext;
+import io.zeebe.model.bpmn.instance.UserTask;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
+import io.zeebe.msgpack.spec.MsgPackWriter;
+import io.zeebe.protocol.Protocol;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.slf4j.Logger;
+
+public final class UserTaskTransformer implements ModelElementTransformer<UserTask> {
+
+  private static final Logger LOG = Loggers.STREAM_PROCESSING;
+
+  private static final int INITIAL_SIZE_KEY_VALUE_PAIR = 128;
+
+  private final MsgPackWriter msgPackWriter = new MsgPackWriter();
+
+  @Override
+  public Class<UserTask> getType() {
+    return UserTask.class;
+  }
+
+  @Override
+  public void transform(final UserTask element, final TransformContext context) {
+
+    final ExecutableProcess process = context.getCurrentProcess();
+    final ExecutableServiceTask userTask =
+        process.getElementById(element.getId(), ExecutableServiceTask.class);
+
+    transformTaskDefinition(element, userTask, context);
+
+    transformTaskHeaders(element, userTask);
+  }
+
+  private void transformTaskDefinition(
+      final UserTask element,
+      final ExecutableServiceTask userTask,
+      final TransformContext context) {
+    userTask.setType(new StaticExpression(Protocol.USER_TASK_JOB_TYPE));
+    userTask.setRetries(new StaticExpression("1"));
+  }
+
+  private void transformTaskHeaders(final UserTask element, final ExecutableServiceTask userTask) {
+    final ZeebeTaskHeaders taskHeaders = element.getSingleExtensionElement(ZeebeTaskHeaders.class);
+
+    addZeebeUserTaskFormKeyHeader(element, taskHeaders);
+
+    if (taskHeaders != null) {
+      final List<ZeebeHeader> validHeaders =
+          taskHeaders.getHeaders().stream()
+              .filter(this::isValidHeader)
+              .collect(Collectors.toList());
+
+      if (validHeaders.size() < taskHeaders.getHeaders().size()) {
+        LOG.warn(
+            "Ignoring invalid headers for task '{}'. Must have non-empty key and value.",
+            element.getName());
+      }
+
+      if (!validHeaders.isEmpty()) {
+        final DirectBuffer encodedHeaders = encode(validHeaders);
+        userTask.setEncodedHeaders(encodedHeaders);
+      }
+    }
+  }
+
+  private DirectBuffer encode(final List<ZeebeHeader> taskHeaders) {
+    final MutableDirectBuffer buffer = new UnsafeBuffer(0, 0);
+
+    final ExpandableArrayBuffer expandableBuffer =
+        new ExpandableArrayBuffer(INITIAL_SIZE_KEY_VALUE_PAIR * taskHeaders.size());
+
+    msgPackWriter.wrap(expandableBuffer, 0);
+    msgPackWriter.writeMapHeader(taskHeaders.size());
+
+    taskHeaders.forEach(
+        h -> {
+          if (isValidHeader(h)) {
+            final DirectBuffer key = wrapString(h.getKey());
+            msgPackWriter.writeString(key);
+
+            final DirectBuffer value = wrapString(h.getValue());
+            msgPackWriter.writeString(value);
+          }
+        });
+
+    buffer.wrap(expandableBuffer.byteArray(), 0, msgPackWriter.getOffset());
+
+    return buffer;
+  }
+
+  private void addZeebeUserTaskFormKeyHeader(
+      final UserTask element, final ZeebeTaskHeaders taskHeaders) {
+    final ZeebeFormDefinition formDefinition =
+        element.getSingleExtensionElement(ZeebeFormDefinition.class);
+
+    if (formDefinition != null) {
+      final ZeebeHeader zeebeHeader = element.getModelInstance().newInstance(ZeebeHeader.class);
+      zeebeHeader.setKey(Protocol.USER_TASK_FORM_KEY_HEADER_NAME);
+      zeebeHeader.setValue(formDefinition.getFormKey());
+      taskHeaders.getHeaders().add(zeebeHeader);
+    }
+  }
+
+  private boolean isValidHeader(final ZeebeHeader header) {
+    return header != null
+        && header.getValue() != null
+        && !header.getValue().isEmpty()
+        && header.getKey() != null
+        && !header.getKey().isEmpty();
+  }
+}

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/BpmnElementTypeTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/BpmnElementTypeTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.zeebe.engine.util.EngineRule;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.Protocol;
 import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
@@ -199,6 +200,25 @@ public final class BpmnElementTypeTest {
             void test() {
               final long processInstanceKey = super.executeInstance();
               ENGINE.job().ofInstance(processInstanceKey).withType(taskType()).complete();
+            }
+          },
+          new BpmnElementTypeScenario("User Task", BpmnElementType.USER_TASK) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .userTask(elementId())
+                  .done();
+            }
+
+            @Override
+            void test() {
+              final long processInstanceKey = super.executeInstance();
+              ENGINE
+                  .job()
+                  .ofInstance(processInstanceKey)
+                  .withType(Protocol.USER_TASK_JOB_TYPE)
+                  .complete();
             }
           },
           new BpmnElementTypeScenario("Receive Task", BpmnElementType.RECEIVE_TASK) {

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/activity/UserTaskTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/activity/UserTaskTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.processing.bpmn.activity;
+
+import static io.zeebe.model.bpmn.impl.ZeebeConstants.USER_TASK_FORM_KEY_BPMN_LOCATION;
+import static io.zeebe.model.bpmn.impl.ZeebeConstants.USER_TASK_FORM_KEY_CAMUNDA_FORMS_FORMAT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.builder.UserTaskBuilder;
+import io.zeebe.protocol.Protocol;
+import io.zeebe.protocol.record.Assertions;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.intent.IncidentIntent;
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.protocol.record.value.JobRecordValue;
+import io.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.zeebe.test.util.Strings;
+import io.zeebe.test.util.record.RecordingExporter;
+import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class UserTaskTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private static BpmnModelInstance process() {
+    return process(b -> {});
+  }
+
+  private static BpmnModelInstance process(final Consumer<UserTaskBuilder> consumer) {
+    final var builder = Bpmn.createExecutableProcess(PROCESS_ID).startEvent().userTask("task");
+
+    consumer.accept(builder);
+
+    return builder.endEvent().done();
+  }
+
+  @Test
+  public void shouldActivateUserTask() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.USER_TASK)
+                .limit(2))
+        .extracting(Record::getIntent)
+        .containsSequence(
+            ProcessInstanceIntent.ELEMENT_ACTIVATING, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    final Record<ProcessInstanceRecordValue> userTask =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.USER_TASK)
+            .getFirst();
+
+    Assertions.assertThat(userTask.getValue())
+        .hasElementId("task")
+        .hasBpmnElementType(BpmnElementType.USER_TASK)
+        .hasFlowScopeKey(processInstanceKey)
+        .hasBpmnProcessId(PROCESS_ID)
+        .hasProcessInstanceKey(processInstanceKey);
+  }
+
+  @Test
+  public void shouldCreateJob() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<ProcessInstanceRecordValue> taskActivated =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withElementType(BpmnElementType.USER_TASK)
+            .getFirst();
+
+    final Record<JobRecordValue> job =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(job.getValue())
+        .hasType(Protocol.USER_TASK_JOB_TYPE)
+        .hasRetries(1)
+        .hasElementInstanceKey(taskActivated.getKey())
+        .hasElementId(taskActivated.getValue().getElementId())
+        .hasProcessDefinitionKey(taskActivated.getValue().getProcessDefinitionKey())
+        .hasBpmnProcessId(taskActivated.getValue().getBpmnProcessId())
+        .hasProcessDefinitionVersion(taskActivated.getValue().getVersion());
+  }
+
+  @Test
+  public void shouldCreateJobWithVariables() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(process(t -> t.zeebeInputExpression("processVariable", "taskVariable")))
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("processVariable", "processValue")
+            .create();
+
+    // then
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    final Optional<JobRecordValue> jobRecordValue =
+        ENGINE
+            .jobs()
+            .withType(Protocol.USER_TASK_JOB_TYPE)
+            .withMaxJobsToActivate(Integer.MAX_VALUE)
+            .withTimeout(200)
+            .activate()
+            .getValue()
+            .getJobs()
+            .stream()
+            .filter(j -> j.getProcessInstanceKey() == processInstanceKey)
+            .findFirst();
+
+    assertThat(jobRecordValue)
+        .hasValueSatisfying(
+            v ->
+                assertThat(v.getVariables())
+                    .containsEntry("processVariable", "processValue")
+                    .containsEntry("taskVariable", "processValue"));
+  }
+
+  @Test
+  public void shouldCreateJobWithProcessInstanceAndCustomHeaders() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(process(t -> t.zeebeTaskHeader("a", "b").zeebeTaskHeader("c", "d")))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<JobRecordValue> job =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final Map<String, String> customHeaders = job.getValue().getCustomHeaders();
+    assertThat(customHeaders).hasSize(2).containsEntry("a", "b").containsEntry("c", "d");
+  }
+
+  @Test
+  public void shouldCreateJobWithFormKeyHeaderAndCustomHeaders() {
+    // given
+    final String formKey = Strings.newRandomValidBpmnId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            process(
+                t ->
+                    t.zeebeUserTaskForm(formKey, "User Task Form")
+                        .zeebeTaskHeader("a", "b")
+                        .zeebeTaskHeader("c", "d")))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<JobRecordValue> job =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final Map<String, String> customHeaders = job.getValue().getCustomHeaders();
+    assertThat(customHeaders)
+        .hasSize(3)
+        .containsEntry(
+            Protocol.USER_TASK_FORM_KEY_HEADER_NAME,
+            String.format(
+                "%s:%s:%s",
+                USER_TASK_FORM_KEY_CAMUNDA_FORMS_FORMAT, USER_TASK_FORM_KEY_BPMN_LOCATION, formKey))
+        .containsEntry("a", "b")
+        .containsEntry("c", "d");
+  }
+
+  @Test
+  public void shouldCompleteUserTask() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType(Protocol.USER_TASK_JOB_TYPE).complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
+        .containsSubsequence(
+            tuple(BpmnElementType.USER_TASK, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.USER_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.SEQUENCE_FLOW, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldResolveIncidentsWhenTerminating() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(process(t -> t.zeebeInputExpression("nonexisting_variable", "target")))
+        .deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("foo", 10).create();
+    assertThat(
+            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(2))
+        .extracting(Record::getIntent)
+        .containsExactly(IncidentIntent.CREATE, IncidentIntent.CREATED);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.USER_TASK, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.USER_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
+
+    assertThat(
+            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(3))
+        .extracting(Record::getIntent)
+        .containsExactly(IncidentIntent.CREATE, IncidentIntent.CREATED, IncidentIntent.RESOLVED);
+  }
+}

--- a/protocol/src/main/java/io/zeebe/protocol/Protocol.java
+++ b/protocol/src/main/java/io/zeebe/protocol/Protocol.java
@@ -62,6 +62,12 @@ public final class Protocol {
    */
   public static final int KEY_BITS = 51;
 
+  /** Job typ used for user tasks handled by Camunda Cloud Tasklist */
+  public static final String USER_TASK_JOB_TYPE = "humanTask";
+
+  /** Task header key used for user tasks to contain form key from BPMN XML */
+  public static final String USER_TASK_FORM_KEY_HEADER_NAME = "io.camunda.zeebe:formKey";
+
   public static long encodePartitionId(final int partitionId, final long key) {
     return ((long) partitionId << KEY_BITS) + key;
   }

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/BpmnElementType.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/BpmnElementType.java
@@ -33,6 +33,7 @@ public enum BpmnElementType {
   // Tasks
   SERVICE_TASK,
   RECEIVE_TASK,
+  USER_TASK,
 
   // Gateways
   EXCLUSIVE_GATEWAY,
@@ -75,6 +76,8 @@ public enum BpmnElementType {
         return BpmnElementType.SEQUENCE_FLOW;
       case "callActivity":
         return BpmnElementType.CALL_ACTIVITY;
+      case "userTask":
+        return BpmnElementType.USER_TASK;
       default:
         throw new RuntimeException("Unsupported BPMN element of type " + elementTypeName);
     }


### PR DESCRIPTION
## Description

Add support for BPMN User Task symbol in deployment. The user task has the same behavior as the service task internally. The job type will be set to `humanTask` and if an `formKey` is present it will be attached as task header with the name `io.camunda.zeebe::formKey`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6116 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
