### PR TITLE
Disable event sub processes

### DIFF
--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
@@ -32,8 +32,8 @@ public final class ProcessBuilder {
 
   private final String processId;
   private final String endEventId;
-  private final boolean hasEventSubProcess;
-  private String eventSubProcessId = null;
+  private boolean hasEventSubProcess;
+  private String eventSubProcessId;
   private boolean isEventSubProcessInterrupting;
   private String eventSubProcessMessageName;
 
@@ -42,7 +42,9 @@ public final class ProcessBuilder {
 
     final var idGenerator = context.getIdGenerator();
     processId = "process_" + idGenerator.nextId();
-    hasEventSubProcess = initEventSubProcess(context, idGenerator);
+    // todo enable when sub processes are migrated
+    // https://github.com/camunda-cloud/zeebe/issues/6195
+    // hasEventSubProcess = initEventSubProcess(context, idGenerator);
     final var random = context.getRandom();
     final var startEventBuilderFactory =
         START_EVENT_BUILDER_FACTORIES.get(random.nextInt(START_EVENT_BUILDER_FACTORIES.size()));
@@ -68,9 +70,11 @@ public final class ProcessBuilder {
     final io.zeebe.model.bpmn.builder.ProcessBuilder processBuilder =
         Bpmn.createExecutableProcess(processId);
 
-    if (hasEventSubProcess) {
-      buildEventSubProcess(processBuilder);
-    }
+    // todo enable when sub processes are migrated
+    // https://github.com/camunda-cloud/zeebe/issues/6195
+    //    if (hasEventSubProcess) {
+    //      buildEventSubProcess(processBuilder);
+    //    }
 
     AbstractFlowNodeBuilder<?, ?> processWorkInProgress =
         startEventBuilder.buildStartEvent(processBuilder);
@@ -102,12 +106,14 @@ public final class ProcessBuilder {
   public ExecutionPath findRandomExecutionPath(final Random random) {
     final var followingPath = blockBuilder.findRandomExecutionPath(random);
 
-    if (hasEventSubProcess) {
-      final var shouldTriggerEventSubProcess = random.nextBoolean();
-      if (shouldTriggerEventSubProcess) {
-        executionPathForEventSubProcess(random, followingPath);
-      }
-    }
+    // todo enable when sub processes are migrated
+    // https://github.com/camunda-cloud/zeebe/issues/6195
+    //    if (hasEventSubProcess) {
+    //      final var shouldTriggerEventSubProcess = random.nextBoolean();
+    //      if (shouldTriggerEventSubProcess) {
+    //        executionPathForEventSubProcess(random, followingPath);
+    //      }
+    //    }
 
     final var startPath =
         startEventBuilder.findRandomExecutionPath(processId, followingPath.collectVariables());


### PR DESCRIPTION

## Description
 Currently event sub processes in the process property test can cause problems, since sub processes are not yet migrated. We should enable it after we migrated sub processes.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda-cloud/zeebe/issues/6652

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
