### PR TITLE
Generate key for activating element

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -82,6 +82,22 @@ public final class BpmnStateTransitionBehavior {
             context.getRecordValue(),
             ProcessInstanceIntent.ELEMENT_ACTIVATING);
       }
+
+      // When the element instance key is not set (-1), then we process the ACTIVATE_ELEMENT
+      // command. We need to generate a new key in order to transition to ELEMENT_ACTIVATING, such
+      // that we can assign the new create element instance a correct key. It is expected that on
+      // the command the key is not set. But some elements (such as multi instance), need to
+      // generate the key before they write ACTIVATE command, to prepare the state (e.g. set
+      // variables) for the upcoming element instance.
+      if (context.getElementInstanceKey() == -1) {
+        final var newElementInstanceKey = keyGenerator.nextKey();
+        final var newContext =
+            context.copy(
+                newElementInstanceKey,
+                context.getRecordValue(),
+                ProcessInstanceIntent.ELEMENT_ACTIVATING);
+        return transitionTo(newContext, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+      }
     }
     return transitionTo(context, ProcessInstanceIntent.ELEMENT_ACTIVATING);
   }


### PR DESCRIPTION

## Description
 We have two options to write an ACTIVATE ELEMENT command, as follow up
 command, where the key was already generated. Used in multi instances
 and other processors, to use the key for further work.

 Normally we would write an ACTIVATE ELEMENT as new command, without an
 key since no element instance is generated and no key for it. Currently
 this will end problems, since the key is set to -1. This means that the
 new element instance is stored under -1 in the state.

This problem came up on migrating start events.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #6184 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
