### PR TITLE
Fix race condition on creation compact logger

### DIFF
--- a/test-util/src/main/java/io/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/zeebe/test/util/record/CompactRecordLogger.java
@@ -93,14 +93,14 @@ public class CompactRecordLogger {
     this.records = new ArrayList<>(records);
 
     singlePartition =
-        records.stream()
+        this.records.stream()
                 .mapToLong(Record::getKey)
                 .filter(key -> key != -1)
                 .map(Protocol::decodePartitionId)
                 .distinct()
                 .count()
             < 2;
-    final var highestPosition = this.records.get(records.size() - 1).getPosition();
+    final var highestPosition = this.records.get(this.records.size() - 1).getPosition();
 
     int digits = 0;
     long num = highestPosition;
@@ -113,7 +113,7 @@ public class CompactRecordLogger {
     keyDigits = digits;
 
     valueTypeChars =
-        records.stream()
+        this.records.stream()
             .map(Record::getValueType)
             .map(ValueType::name)
             .map(this::abbreviate)
@@ -122,7 +122,7 @@ public class CompactRecordLogger {
             .orElse(0);
 
     intentChars =
-        records.stream()
+        this.records.stream()
             .map(Record::getIntent)
             .map(Intent::name)
             .map(this::abbreviate)


### PR DESCRIPTION
## Description
 Fixes race condition which occurred when record list got new entries, an array out of bounce exception was thrown, since the size of the record list was bigger then the own record list.

<!-- Please explain the changes you made here. -->

## Related issues


## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
