### PR TITLE
fix(journal): use signed integer for asqn in sbe schema

### DIFF
--- a/journal/src/main/resources/journal-record-schema.xml
+++ b/journal/src/main/resources/journal-record-schema.xml
@@ -22,7 +22,7 @@
 
   <sbe:message name="RecordData" id="2">
     <field name="index" id="1" type="uint64"/>
-    <field name="asqn" id="2" type="uint64"/>
+    <field name="asqn" id="2" type="int64"/>
     <data name="data" id="3" type="blob"/>
   </sbe:message>
 </sbe:messageSchema>


### PR DESCRIPTION
## Description

The sbe schema for journal record defines asqn to be of type uint64. However, -1 is a valid value to asqn if the record does not have an asqn. Hence the type should be signed integer.

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
