### PR TITLE
chore(journal): remove check for entry size in journal

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -521,12 +521,6 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
       raft.getReplicationMetrics().setAppendIndex(indexedEntry.index());
       log.trace("Appended {}", indexedEntry);
       resultingFuture = CompletableFuture.completedFuture(indexedEntry);
-    } catch (final JournalException.TooLarge e) {
-
-      // the entry was to large, we can't handle this case
-      log.error("Failed to append entry {}, because it was to large.", entry, e);
-      resultingFuture = Futures.exceptionalFuture(e);
-
     } catch (final JournalException.OutOfDiskSpace e) {
 
       // if this happens then compact will also not help, since we need to create a snapshot

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -651,10 +651,6 @@ public class PassiveRole extends InactiveRole {
 
       log.trace("Appended {}", indexed);
       raft.getReplicationMetrics().setAppendIndex(indexed.index());
-    } catch (final JournalException.TooLarge e) {
-      log.warn(
-          "Entry size exceeds maximum allowed bytes. Ensure Raft storage configuration is consistent on all nodes!");
-      return false;
     } catch (final JournalException.OutOfDiskSpace e) {
       log.trace("Append failed: ", e);
       raft.getLogCompactor().compact();

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -204,34 +204,6 @@ public class LeaderRoleTest {
   }
 
   @Test
-  public void shouldStopAppendEntryOnToLargeEntry() throws InterruptedException {
-    // given
-    when(log.append(any(RaftLogEntry.class)))
-        .thenThrow(new JournalException.TooLarge("Too large entry"));
-
-    final AtomicReference<Throwable> caughtError = new AtomicReference<>();
-    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
-    final CountDownLatch latch = new CountDownLatch(1);
-    final AppendListener listener =
-        new AppendListener() {
-          @Override
-          public void onWriteError(final Throwable error) {
-            caughtError.set(error);
-            latch.countDown();
-          }
-        };
-
-    // when
-    leaderRole.appendEntry(0, 1, data, listener);
-
-    // then
-    assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
-    verify(log, timeout(1000)).append(any(RaftLogEntry.class));
-
-    assertThat(caughtError.get()).isInstanceOf(JournalException.TooLarge.class);
-  }
-
-  @Test
   public void shouldTransitionToFollowerWhenAppendEntryException() throws InterruptedException {
     // given
     when(log.append(any(RaftLogEntry.class))).thenThrow(new RuntimeException("expected"));

--- a/journal/src/main/java/io/zeebe/journal/JournalException.java
+++ b/journal/src/main/java/io/zeebe/journal/JournalException.java
@@ -31,13 +31,6 @@ public class JournalException extends RuntimeException {
     super(cause);
   }
 
-  /** Exception thrown when an entry being stored is too large. */
-  public static class TooLarge extends JournalException {
-    public TooLarge(final String message) {
-      super(message);
-    }
-  }
-
   /** Exception thrown when storage runs out of disk space. */
   public static class OutOfDiskSpace extends JournalException {
     public OutOfDiskSpace(final String message) {


### PR DESCRIPTION
## Description

The size of the entry is checked in the dispatcher already and rejected if it is too large. It is not necessary to check it again in the journal. The previous check was also incorrect because it uses the same limit as the dispatcher. An entry that passes the dispatcher size check can be rejected by the journal because of the additional fields added by the raft and journal. Hence this check is removed and journal accepts entries of any size as long as it fits in a segment.
 
## Related issues

closes #6318 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
