### PR TITLE
chore(broker): use crc32c for checksums in journal and snapshot

### DIFF
--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
-import java.util.zip.CRC32;
+import java.util.zip.CRC32C;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.awaitility.Awaitility;
 import org.junit.Before;
@@ -143,7 +143,7 @@ public final class ReplicateStateControllerTest {
 
     replicatedChunks.forEach(
         chunk -> {
-          final CRC32 crc32 = new CRC32();
+          final CRC32C crc32 = new CRC32C();
           crc32.update(chunk.getContent());
           assertThat(chunk.getChecksum()).isEqualTo(crc32.getValue());
         });

--- a/journal/src/main/java/io/zeebe/journal/file/ChecksumGenerator.java
+++ b/journal/src/main/java/io/zeebe/journal/file/ChecksumGenerator.java
@@ -16,11 +16,11 @@
 package io.zeebe.journal.file;
 
 import java.nio.ByteBuffer;
-import java.util.zip.CRC32;
+import java.util.zip.CRC32C;
 
 public final class ChecksumGenerator {
 
-  private final CRC32 crc32 = new CRC32();
+  private final CRC32C crc32 = new CRC32C();
 
   /** Compute checksum of given ByteBuffer */
   public long compute(final ByteBuffer buffer, final int offset, final int length) {

--- a/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/SnapshotChunkUtil.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/SnapshotChunkUtil.java
@@ -11,14 +11,14 @@ import io.zeebe.snapshots.raft.SnapshotChunk;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.zip.CRC32;
+import java.util.zip.CRC32C;
 
 final class SnapshotChunkUtil {
 
   private SnapshotChunkUtil() {}
 
   static long createChecksum(final byte[] content) {
-    final CRC32 crc32 = new CRC32();
+    final CRC32C crc32 = new CRC32C();
     crc32.update(content);
     return crc32.getValue();
   }

--- a/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/SnapshotChunkReaderTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/broker/impl/SnapshotChunkReaderTest.java
@@ -26,7 +26,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.zip.CRC32;
+import java.util.zip.CRC32C;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -182,9 +182,9 @@ public class SnapshotChunkReaderTest {
     assertThat(snapshotChunk.getChunkName()).isEqualTo(fileName);
     assertThat(snapshotChunk.getContent()).isEqualTo(chunkContent.getBytes());
     assertThat(snapshotChunk.getTotalCount()).isEqualTo(4);
-    final var crc32 = new CRC32();
-    crc32.update(asByteBuffer(chunkContent));
-    assertThat(snapshotChunk.getChecksum()).isEqualTo(crc32.getValue());
+    final var crc32c = new CRC32C();
+    crc32c.update(asByteBuffer(chunkContent));
+    assertThat(snapshotChunk.getChecksum()).isEqualTo(crc32c.getValue());
 
     assertThat(snapshotChunk.getSnapshotChecksum()).isEqualTo(expectedSnapshotChecksum);
   }


### PR DESCRIPTION
## Description

Replace all CRC32 with CRC32C

## Related issues

closes #6422 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [x] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
