### PR TITLE
Support call activity in randomized processes

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/FailedPropertyBasedTestDataPrinter.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/FailedPropertyBasedTestDataPrinter.java
@@ -30,9 +30,11 @@ final class FailedPropertyBasedTestDataPrinter extends TestWatcher {
   protected void failed(final Throwable e, final Description description) {
     LOGGER.info("Data of failed test case: {}", propertyBasedTest.getDataRecord());
     LOGGER.info(
-        "Process of failed test case:{}{}",
+        "Process(es) of failed test case:{}{}",
         System.lineSeparator(),
-        Bpmn.convertToString(propertyBasedTest.getDataRecord().getBpmnModel()));
+        propertyBasedTest.getDataRecord().getBpmnModels().stream()
+            .map(Bpmn::convertToString)
+            .collect(Collectors.joining(System.lineSeparator())));
     LOGGER.info(
         "Execution path of failed test case:{}{}",
         System.lineSeparator(),

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ProcessExecutionRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ProcessExecutionRandomizedPropertyTest.java
@@ -17,6 +17,7 @@ import io.zeebe.test.util.bpmn.random.TestDataGenerator;
 import io.zeebe.test.util.bpmn.random.TestDataGenerator.TestDataRecord;
 import io.zeebe.test.util.record.RecordingExporter;
 import java.util.Collection;
+import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -63,8 +64,8 @@ public class ProcessExecutionRandomizedPropertyTest implements PropertyBasedTest
    */
   @Test
   public void shouldExecuteProcessToEnd() {
-    final BpmnModelInstance model = record.getBpmnModel();
-    engineRule.deployment().withXmlResource(model).deploy();
+    final List<BpmnModelInstance> models = record.getBpmnModels();
+    models.forEach(model -> engineRule.deployment().withXmlResource(model).deploy());
 
     final ExecutionPath path = record.getExecutionPath();
 

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ProcessExecutionRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ProcessExecutionRandomizedPropertyTest.java
@@ -9,7 +9,6 @@ package io.zeebe.engine.processing.streamprocessor;
 
 import io.zeebe.engine.util.EngineRule;
 import io.zeebe.engine.util.ProcessExecutor;
-import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.test.util.bpmn.random.ExecutionPath;
@@ -17,7 +16,6 @@ import io.zeebe.test.util.bpmn.random.TestDataGenerator;
 import io.zeebe.test.util.bpmn.random.TestDataGenerator.TestDataRecord;
 import io.zeebe.test.util.record.RecordingExporter;
 import java.util.Collection;
-import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -64,8 +62,9 @@ public class ProcessExecutionRandomizedPropertyTest implements PropertyBasedTest
    */
   @Test
   public void shouldExecuteProcessToEnd() {
-    final List<BpmnModelInstance> models = record.getBpmnModels();
-    models.forEach(model -> engineRule.deployment().withXmlResource(model).deploy());
+    final var deployment = engineRule.deployment();
+    record.getBpmnModels().forEach(deployment::withXmlResource);
+    deployment.deploy();
 
     final ExecutionPath path = record.getExecutionPath();
 

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java
@@ -13,7 +13,6 @@ import io.zeebe.engine.processing.streamprocessor.StreamProcessor.Phase;
 import io.zeebe.engine.state.ZbColumnFamilies;
 import io.zeebe.engine.util.EngineRule;
 import io.zeebe.engine.util.ProcessExecutor;
-import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.test.util.bpmn.random.ExecutionPath;
@@ -22,7 +21,6 @@ import io.zeebe.test.util.bpmn.random.TestDataGenerator.TestDataRecord;
 import io.zeebe.test.util.bpmn.random.steps.AbstractExecutionStep;
 import io.zeebe.test.util.record.RecordingExporter;
 import java.util.Collection;
-import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.awaitility.Awaitility;
 import org.junit.Before;
@@ -79,8 +77,9 @@ public class ReplayStateRandomizedPropertyTest implements PropertyBasedTest {
    */
   @Test
   public void shouldRestoreStateAtEachStepInExecution() {
-    final List<BpmnModelInstance> models = record.getBpmnModels();
-    models.forEach(model -> engineRule.deployment().withXmlResource(model).deploy());
+    final var deployment = engineRule.deployment();
+    record.getBpmnModels().forEach(deployment::withXmlResource);
+    deployment.deploy();
 
     final ExecutionPath path = record.getExecutionPath();
 

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateRandomizedPropertyTest.java
@@ -22,6 +22,7 @@ import io.zeebe.test.util.bpmn.random.TestDataGenerator.TestDataRecord;
 import io.zeebe.test.util.bpmn.random.steps.AbstractExecutionStep;
 import io.zeebe.test.util.record.RecordingExporter;
 import java.util.Collection;
+import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.awaitility.Awaitility;
 import org.junit.Before;
@@ -78,8 +79,8 @@ public class ReplayStateRandomizedPropertyTest implements PropertyBasedTest {
    */
   @Test
   public void shouldRestoreStateAtEachStepInExecution() {
-    final BpmnModelInstance model = record.getBpmnModel();
-    engineRule.deployment().withXmlResource(model).deploy();
+    final List<BpmnModelInstance> models = record.getBpmnModels();
+    models.forEach(model -> engineRule.deployment().withXmlResource(model).deploy());
 
     final ExecutionPath path = record.getExecutionPath();
 

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ConstructionContext.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ConstructionContext.java
@@ -7,11 +7,15 @@
  */
 package io.zeebe.test.util.bpmn.random;
 
+import io.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.test.util.bpmn.random.blocks.BlockSequenceBuilder.BlockSequenceBuilderFactory;
 import java.util.Random;
+import java.util.function.Consumer;
 
 /** This class captures information that are needed during the construction of a random process */
 public final class ConstructionContext {
+
+  private static final Consumer<BpmnModelInstance> NOOP = x -> {};
 
   private final Random random;
   private final IDGenerator idGenerator;
@@ -20,6 +24,7 @@ public final class ConstructionContext {
   private final int maxDepth;
   private final int maxBranches;
   private final int currentDepth;
+  private final Consumer<BpmnModelInstance> onAddCalledChildProcessCallback;
 
   /**
    * Create a construction context
@@ -31,6 +36,8 @@ public final class ConstructionContext {
    * @param maxDepth the maximum level of depth for nested elements
    * @param maxBranches the maximum number of outgoing branches from a given node
    * @param currentDepth the current level of depth in the construction process
+   * @param onAddCalledChildProcessCallback consumer that is called for every child process that is
+   *     called from the main process
    */
   ConstructionContext(
       final Random random,
@@ -39,7 +46,8 @@ public final class ConstructionContext {
       final int maxBlocks,
       final int maxDepth,
       final int maxBranches,
-      final int currentDepth) {
+      final int currentDepth,
+      final Consumer<BpmnModelInstance> onAddCalledChildProcessCallback) {
     this.random = random;
     this.idGenerator = idGenerator;
     this.blockSequenceBuilderFactory = blockSequenceBuilderFactory;
@@ -47,6 +55,18 @@ public final class ConstructionContext {
     this.maxDepth = maxDepth;
     this.maxBranches = maxBranches;
     this.currentDepth = currentDepth;
+    this.onAddCalledChildProcessCallback = onAddCalledChildProcessCallback;
+  }
+
+  public ConstructionContext(
+      final Random random,
+      final IDGenerator idGenerator,
+      final BlockSequenceBuilderFactory factory,
+      final Integer maxBlocks,
+      final Integer maxDepth,
+      final Integer maxBranches,
+      final int currentDepth) {
+    this(random, idGenerator, factory, maxBlocks, maxDepth, maxBranches, currentDepth, NOOP);
   }
 
   public Random getRandom() {
@@ -90,6 +110,20 @@ public final class ConstructionContext {
         maxBlocks,
         maxDepth,
         maxBranches,
-        currentDepth + 1);
+        currentDepth + 1,
+        onAddCalledChildProcessCallback);
+  }
+
+  public ConstructionContext withAddCalledChildProcessCallback(
+      final Consumer<BpmnModelInstance> callback) {
+    return new ConstructionContext(
+        random,
+        idGenerator,
+        blockSequenceBuilderFactory,
+        maxBlocks,
+        maxDepth,
+        maxBranches,
+        currentDepth,
+        callback);
   }
 }

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ConstructionContext.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ConstructionContext.java
@@ -39,7 +39,7 @@ public final class ConstructionContext {
    * @param onAddCalledChildProcessCallback consumer that is called for every child process that is
    *     called from the main process
    */
-  ConstructionContext(
+  private ConstructionContext(
       final Random random,
       final IDGenerator idGenerator,
       final BlockSequenceBuilderFactory blockSequenceBuilderFactory,
@@ -58,7 +58,7 @@ public final class ConstructionContext {
     this.onAddCalledChildProcessCallback = onAddCalledChildProcessCallback;
   }
 
-  public ConstructionContext(
+  ConstructionContext(
       final Random random,
       final IDGenerator idGenerator,
       final BlockSequenceBuilderFactory factory,

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ConstructionContext.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ConstructionContext.java
@@ -69,6 +69,10 @@ public final class ConstructionContext {
     this(random, idGenerator, factory, maxBlocks, maxDepth, maxBranches, currentDepth, NOOP);
   }
 
+  public void addCalledChildProcess(final BpmnModelInstance childModelInstance) {
+    onAddCalledChildProcessCallback.accept(childModelInstance);
+  }
+
   public Random getRandom() {
     return random;
   }

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/RandomProcessGenerator.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/RandomProcessGenerator.java
@@ -55,7 +55,7 @@ public final class RandomProcessGenerator {
   }
 
   /** @return the build process and any potentially called child processes */
-  public List<BpmnModelInstance> buildProcess() {
+  public List<BpmnModelInstance> buildProcesses() {
     return processBuilder.buildProcess();
   }
 
@@ -73,7 +73,7 @@ public final class RandomProcessGenerator {
 
       final RandomProcessGenerator builder = new RandomProcessGenerator(random.nextLong(), 5, 3, 3);
 
-      final var bpmnModelInstances = builder.buildProcess();
+      final var bpmnModelInstances = builder.buildProcesses();
 
       bpmnModelInstances.stream()
           .map(modelInstance -> new Tuple<>(createFile(modelInstance, index), modelInstance))

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/RandomProcessGenerator.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/RandomProcessGenerator.java
@@ -9,9 +9,13 @@ package io.zeebe.test.util.bpmn.random;
 
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.instance.BaseElement;
+import io.zeebe.model.bpmn.instance.Process;
 import io.zeebe.test.util.bpmn.random.blocks.BlockSequenceBuilder.BlockSequenceBuilderFactory;
 import io.zeebe.test.util.bpmn.random.blocks.ProcessBuilder;
+import io.zeebe.util.collection.Tuple;
 import java.io.File;
+import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
@@ -50,7 +54,8 @@ public final class RandomProcessGenerator {
     processBuilder = new ProcessBuilder(context);
   }
 
-  public BpmnModelInstance buildProcess() {
+  /** @return the build process and any potentially called child processes */
+  public List<BpmnModelInstance> buildProcess() {
     return processBuilder.buildProcess();
   }
 
@@ -63,13 +68,16 @@ public final class RandomProcessGenerator {
     final Random random = new Random();
 
     for (int i = 0; i < 10; i++) {
-      System.out.println("Generating process " + i);
-
-      final String id = "process" + i;
+      final int index = i;
+      System.out.println("Generating process " + index);
 
       final RandomProcessGenerator builder = new RandomProcessGenerator(random.nextLong(), 5, 3, 3);
 
-      Bpmn.writeModelToFile(new File(id + ".bpmn"), builder.buildProcess());
+      final var bpmnModelInstances = builder.buildProcess();
+
+      bpmnModelInstances.stream()
+          .map(modelInstance -> new Tuple<>(createFile(modelInstance, index), modelInstance))
+          .forEach(tuple -> Bpmn.writeModelToFile(tuple.getLeft(), tuple.getRight()));
 
       for (int p = 0; p < 5; p++) {
         final ExecutionPath path = builder.findRandomExecutionPath(random.nextLong());
@@ -77,5 +85,14 @@ public final class RandomProcessGenerator {
         System.out.println("Execution path " + p + " :" + path);
       }
     }
+  }
+
+  private static File createFile(final BpmnModelInstance bpmnModelInstance, final int index) {
+    return bpmnModelInstance.getDefinitions().getChildElementsByType(Process.class).stream()
+        .map(BaseElement::getId)
+        .map(id -> index + "-" + id + ".bpmn")
+        .map(File::new)
+        .findFirst()
+        .orElseThrow();
   }
 }

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/TestDataGenerator.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/TestDataGenerator.java
@@ -29,7 +29,7 @@ public class TestDataGenerator {
       final RandomProcessGenerator generator =
           new RandomProcessGenerator(processSeed, null, null, null);
 
-      final List<BpmnModelInstance> bpmnModelInstances = generator.buildProcess();
+      final List<BpmnModelInstance> bpmnModelInstances = generator.buildProcesses();
 
       final Set<ExecutionPath> paths = new HashSet<>();
       for (int pathIndex = 0; pathIndex < pathsPerProcess; pathIndex++) {
@@ -53,7 +53,7 @@ public class TestDataGenerator {
     final RandomProcessGenerator generator =
         new RandomProcessGenerator(processSeed, null, null, null);
 
-    final List<BpmnModelInstance> bpmnModelInstances = generator.buildProcess();
+    final List<BpmnModelInstance> bpmnModelInstances = generator.buildProcesses();
 
     final ExecutionPath path = generator.findRandomExecutionPath(executionPathSeed);
 

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/TestDataGenerator.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/TestDataGenerator.java
@@ -29,7 +29,7 @@ public class TestDataGenerator {
       final RandomProcessGenerator generator =
           new RandomProcessGenerator(processSeed, null, null, null);
 
-      final BpmnModelInstance bpmnModelInstance = generator.buildProcess();
+      final List<BpmnModelInstance> bpmnModelInstances = generator.buildProcess();
 
       final Set<ExecutionPath> paths = new HashSet<>();
       for (int pathIndex = 0; pathIndex < pathsPerProcess; pathIndex++) {
@@ -40,7 +40,7 @@ public class TestDataGenerator {
         final boolean isDifferentPath = paths.add(path);
 
         if (isDifferentPath) {
-          records.add(new TestDataRecord(processSeed, pathSeed, bpmnModelInstance, path));
+          records.add(new TestDataRecord(processSeed, pathSeed, bpmnModelInstances, path));
         }
       }
     }
@@ -53,33 +53,33 @@ public class TestDataGenerator {
     final RandomProcessGenerator generator =
         new RandomProcessGenerator(processSeed, null, null, null);
 
-    final BpmnModelInstance bpmnModelInstance = generator.buildProcess();
+    final List<BpmnModelInstance> bpmnModelInstances = generator.buildProcess();
 
     final ExecutionPath path = generator.findRandomExecutionPath(executionPathSeed);
 
-    return new TestDataRecord(processSeed, executionPathSeed, bpmnModelInstance, path);
+    return new TestDataRecord(processSeed, executionPathSeed, bpmnModelInstances, path);
   }
 
   public static final class TestDataRecord {
     private final long processSeed;
     private final long executionPathSeed;
 
-    private final BpmnModelInstance bpmnModel;
+    private final List<BpmnModelInstance> bpmnModels;
     private final ExecutionPath executionPath;
 
     private TestDataRecord(
         final long processSeed,
         final long executionPathSeed,
-        final BpmnModelInstance bpmnModel,
+        final List<BpmnModelInstance> bpmnModels,
         final ExecutionPath executionPath) {
       this.processSeed = processSeed;
       this.executionPathSeed = executionPathSeed;
-      this.bpmnModel = bpmnModel;
+      this.bpmnModels = bpmnModels;
       this.executionPath = executionPath;
     }
 
-    public BpmnModelInstance getBpmnModel() {
-      return bpmnModel;
+    public List<BpmnModelInstance> getBpmnModels() {
+      return bpmnModels;
     }
 
     public ExecutionPath getExecutionPath() {

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -32,7 +32,8 @@ public class BlockSequenceBuilder implements BlockBuilder {
           new SubProcessBlockBuilder.Factory(),
           new ExclusiveGatewayBlockBuilder.Factory(),
           new ParallelGatewayBlockBuilder.Factory(),
-          new ReceiveTaskBlockBuilder.Factory());
+          new ReceiveTaskBlockBuilder.Factory(),
+          new CallActivityBlockBuilder.Factory());
 
   private final List<BlockBuilder> blockBuilders = new ArrayList<>();
 

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
@@ -56,12 +56,10 @@ public class CallActivityBlockBuilder implements BlockBuilder {
 
     buildChildProcess();
 
-    final var callActivityBuilder = nodeBuilder.callActivity(callActivityId);
-
-    callActivityBuilder.zeebeProcessId(calledProcessId);
-    callActivityBuilder.zeebePropagateAllChildVariables(shouldPropagateAllChildVariables);
-
-    return callActivityBuilder;
+    return nodeBuilder
+        .callActivity(callActivityId)
+        .zeebeProcessId(calledProcessId)
+        .zeebePropagateAllChildVariables(shouldPropagateAllChildVariables);
   }
 
   @Override

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/CallActivityBlockBuilder.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.test.util.bpmn.random.blocks;
+
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.zeebe.test.util.bpmn.random.BlockBuilder;
+import io.zeebe.test.util.bpmn.random.BlockBuilderFactory;
+import io.zeebe.test.util.bpmn.random.ConstructionContext;
+import io.zeebe.test.util.bpmn.random.ExecutionPathSegment;
+import io.zeebe.test.util.bpmn.random.IDGenerator;
+import java.util.Random;
+
+/** Generates a call activity. The called process is a Process that contains any block sequence. */
+public class CallActivityBlockBuilder implements BlockBuilder {
+
+  private final boolean shouldPropagateAllChildVariables;
+  private final String calledProcessId;
+  private final BlockSequenceBuilder calledProcessBuilder;
+  private final ConstructionContext context;
+  private final String callActivityId;
+
+  public CallActivityBlockBuilder(final ConstructionContext context) {
+    final Random random = context.getRandom();
+    final IDGenerator idGenerator = context.getIdGenerator();
+    final int maxDepth = context.getMaxDepth();
+    final int currentDepth = context.getCurrentDepth();
+    final boolean goDeeper = random.nextInt(maxDepth) > currentDepth;
+
+    this.context = context;
+    shouldPropagateAllChildVariables = random.nextBoolean();
+
+    final var reusableId = idGenerator.nextId();
+    calledProcessId = "process_child_" + reusableId;
+    callActivityId = "call_activity_" + reusableId;
+
+    if (goDeeper) {
+      calledProcessBuilder =
+          context
+              .getBlockSequenceBuilderFactory()
+              .createBlockSequenceBuilder(context.withIncrementedDepth());
+    } else {
+      calledProcessBuilder = null;
+    }
+  }
+
+  @Override
+  public AbstractFlowNodeBuilder<?, ?> buildFlowNodes(
+      final AbstractFlowNodeBuilder<?, ?> nodeBuilder) {
+
+    buildChildProcess();
+
+    final var callActivityBuilder = nodeBuilder.callActivity(callActivityId);
+
+    callActivityBuilder.zeebeProcessId(calledProcessId);
+    callActivityBuilder.zeebePropagateAllChildVariables(shouldPropagateAllChildVariables);
+
+    return callActivityBuilder;
+  }
+
+  @Override
+  public ExecutionPathSegment findRandomExecutionPath(final Random random) {
+    final ExecutionPathSegment result = new ExecutionPathSegment();
+
+    if (calledProcessBuilder != null) {
+      result.append(calledProcessBuilder.findRandomExecutionPath(random));
+    }
+
+    return result;
+  }
+
+  private void buildChildProcess() {
+    AbstractFlowNodeBuilder<?, ?> workInProgress =
+        Bpmn.createExecutableProcess(calledProcessId).startEvent();
+
+    if (calledProcessBuilder != null) {
+      workInProgress = calledProcessBuilder.buildFlowNodes(workInProgress);
+    }
+
+    final BpmnModelInstance childModelInstance = workInProgress.endEvent().done();
+    context.addCalledChildProcess(childModelInstance);
+  }
+
+  public static class Factory implements BlockBuilderFactory {
+
+    @Override
+    public BlockBuilder createBlockBuilder(final ConstructionContext context) {
+      return new CallActivityBlockBuilder(context);
+    }
+
+    @Override
+    public boolean isAddingDepth() {
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds call activities to the randomly generated processes. Each child process is individually deployed and each can contain a block sequence. This supports generating called child processes that themselves call other child processes. 
The id of the child process is shared for both the child as well as the call activity's id, each prefixed by their type.

Note, it's easiest to read this PR through the individual commits and their respective commit messages.

## Example
In this generated example, the main process calls this child process at `call_activity_id_18`.
<img width="1806" alt="Screen Shot 2021-03-29 at 15 40 16" src="https://user-images.githubusercontent.com/3511026/112849218-20da9200-90a9-11eb-97e3-dc58114be02b.png">
That child process itself contains a call activity `call_activity_id_20` to a child process.
<img width="33%" alt="Screen Shot 2021-03-29 at 15 40 52" src="https://user-images.githubusercontent.com/3511026/112849225-220bbf00-90a9-11eb-8397-541f7ca6a251.png">

## Related issues

relates #6197 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
