### PR TITLE
Add timer start event to random process generation

### DIFF
--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/StartEventBlockBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/StartEventBlockBuilder.java
@@ -7,8 +7,8 @@
  */
 package io.zeebe.test.util.bpmn.random;
 
+import io.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
 import io.zeebe.model.bpmn.builder.ProcessBuilder;
-import io.zeebe.model.bpmn.builder.StartEventBuilder;
 import java.util.Map;
 
 /**
@@ -33,7 +33,8 @@ public interface StartEventBlockBuilder {
    * <p><strong>Contract: </strong> this method must be deterministic. It must not have any random
    * behavior.
    */
-  StartEventBuilder buildStartEvent(final ProcessBuilder processBuilder);
+  @SuppressWarnings("java:S1452")
+  AbstractFlowNodeBuilder<?, ?> buildStartEvent(final ProcessBuilder processBuilder);
 
   /** Creates a random execution path segment. */
   ExecutionPathSegment findRandomExecutionPath(String processId, Map<String, Object> variables);

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ProcessBuilder.java
@@ -25,7 +25,10 @@ public final class ProcessBuilder {
 
   private static final List<Function<ConstructionContext, StartEventBlockBuilder>>
       START_EVENT_BUILDER_FACTORIES =
-          List.of(NoneStartEventBuilder::new, MessageStartEventBuilder::new);
+          List.of(
+              NoneStartEventBuilder::new,
+              MessageStartEventBuilder::new,
+              TimerStartEventBuilder::new);
 
   private final BlockBuilder blockBuilder;
   private final StartEventBlockBuilder startEventBuilder;

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/TimerStartEventBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/TimerStartEventBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.test.util.bpmn.random.blocks;
+
+import io.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.zeebe.model.bpmn.builder.ProcessBuilder;
+import io.zeebe.test.util.bpmn.random.ConstructionContext;
+import io.zeebe.test.util.bpmn.random.ExecutionPathSegment;
+import io.zeebe.test.util.bpmn.random.StartEventBlockBuilder;
+import io.zeebe.test.util.bpmn.random.steps.StepActivateAndCompleteJob;
+import io.zeebe.test.util.bpmn.random.steps.StepTriggerTimer;
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * NOTE: as we cannot set variables on a timer start event - variables which may be necessary to
+ * take the right execution path - every timer start event is followed by a service task where the
+ * variables are set. These steps cannot be separated, as otherwise any execution which requires
+ * variables will fail.
+ */
+public class TimerStartEventBuilder implements StartEventBlockBuilder {
+
+  private static final String VARIABLES_JOB_TYPE_SUFFIX = "_variables";
+  private final String startEventId;
+  private final Duration timeToAdd;
+
+  public TimerStartEventBuilder(final ConstructionContext context) {
+    final var idGenerator = context.getIdGenerator();
+    startEventId = idGenerator.nextId();
+    timeToAdd = Duration.ofMinutes(context.getRandom().nextInt(60) + 5L);
+  }
+
+  @Override
+  public AbstractFlowNodeBuilder<?, ?> buildStartEvent(final ProcessBuilder processBuilder) {
+    final String dateExpression = String.format("now() + duration(\"%s\")", timeToAdd);
+    return processBuilder
+        .startEvent(startEventId)
+        .timerWithDateExpression(dateExpression)
+        .serviceTask(
+            startEventId + "_variables_task",
+            b -> b.zeebeJobType(startEventId + VARIABLES_JOB_TYPE_SUFFIX));
+  }
+
+  @Override
+  public ExecutionPathSegment findRandomExecutionPath(
+      final String processId, final Map<String, Object> variables) {
+    final ExecutionPathSegment pathSegment = new ExecutionPathSegment();
+    pathSegment.append(new StepTriggerTimer(timeToAdd));
+    pathSegment.append(
+        new StepActivateAndCompleteJob(startEventId + VARIABLES_JOB_TYPE_SUFFIX, variables));
+    return pathSegment;
+  }
+}

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/steps/StepTriggerTimer.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/steps/StepTriggerTimer.java
@@ -7,24 +7,18 @@
  */
 package io.zeebe.test.util.bpmn.random.steps;
 
-import java.util.Collections;
-import java.util.Map;
+import java.time.Duration;
 
-public final class StepActivateAndCompleteJob extends AbstractExecutionStep {
+public final class StepTriggerTimer extends AbstractExecutionStep {
 
-  private final String jobType;
+  private final Duration timeToAdd;
 
-  public StepActivateAndCompleteJob(final String jobType) {
-    this(jobType, Collections.emptyMap());
+  public StepTriggerTimer(final Duration timeToAdd) {
+    this.timeToAdd = timeToAdd;
   }
 
-  public StepActivateAndCompleteJob(final String jobType, final Map<String, Object> variables) {
-    this.jobType = jobType;
-    this.variables.putAll(variables);
-  }
-
-  public String getJobType() {
-    return jobType;
+  public Duration getTimeToAdd() {
+    return timeToAdd;
   }
 
   @Override
@@ -36,9 +30,9 @@ public final class StepActivateAndCompleteJob extends AbstractExecutionStep {
       return false;
     }
 
-    final StepActivateAndCompleteJob that = (StepActivateAndCompleteJob) o;
+    final StepTriggerTimer that = (StepTriggerTimer) o;
 
-    if (jobType != null ? !jobType.equals(that.jobType) : that.jobType != null) {
+    if (timeToAdd != null ? !timeToAdd.equals(that.timeToAdd) : that.timeToAdd != null) {
       return false;
     }
     return variables.equals(that.variables);
@@ -46,7 +40,7 @@ public final class StepActivateAndCompleteJob extends AbstractExecutionStep {
 
   @Override
   public int hashCode() {
-    int result = jobType != null ? jobType.hashCode() : 0;
+    int result = timeToAdd != null ? timeToAdd.hashCode() : 0;
     result = 31 * result + variables.hashCode();
     return result;
   }


### PR DESCRIPTION
## Description

This PR extends capabilities of the random process generator to also generate processes with timer start events. This will increase the test coverage for all our property tests.

Since variables are crucial to execute the right path, but timer start events do not support variables, they are always linked to a service task which will set the right variables.

The PR also extends the `StepActivateAndCompleteJob` to take in arbitrary variables and set them on completion.

## Related issues

related to #6177 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
