### PR TITLE
Seek to asqn with in committed index

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -192,21 +192,15 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     return future;
   }
 
-  // TODO: good candidate to use a seekToLastASQN()
   private ApplicationEntry findLastZeebeEntry() {
-    long index = raft.getLog().getLastIndex();
     final RaftLogReader reader = raft.getLogReader();
+    reader.seekToAsqn(Long.MAX_VALUE);
 
-    while (index > 0) {
-      reader.reset(index);
-      if (reader.hasNext()) {
-        final IndexedRaftLogEntry lastEntry = reader.next();
-        if (lastEntry != null && lastEntry.isApplicationEntry()) {
-          return lastEntry.getApplicationEntry();
-        }
+    if (reader.hasNext()) {
+      final IndexedRaftLogEntry lastEntry = reader.next();
+      if (lastEntry != null && lastEntry.isApplicationEntry()) {
+        return lastEntry.getApplicationEntry();
       }
-
-      index--;
     }
 
     return null;

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
@@ -92,12 +92,11 @@ public class RaftLogReader implements java.util.Iterator<IndexedRaftLogEntry>, A
   }
 
   public long seekToAsqn(final long asqn) {
-    nextIndex = journalReader.seekToAsqn(asqn);
-
-    if (nextIndex > log.getCommitIndex() && !log.isEmpty()) {
-      throw new UnsupportedOperationException("Cannot seek to an ASQN that is not yet committed");
+    if (mode == Mode.COMMITS) {
+      nextIndex = journalReader.seekToAsqn(asqn, log.getCommitIndex());
+    } else {
+      nextIndex = journalReader.seekToAsqn(asqn);
     }
-
     return nextIndex;
   }
 

--- a/journal/src/main/java/io/zeebe/journal/JournalReader.java
+++ b/journal/src/main/java/io/zeebe/journal/JournalReader.java
@@ -91,6 +91,19 @@ public interface JournalReader extends Iterator<JournalRecord>, AutoCloseable {
    */
   long seekToAsqn(long asqn);
 
+  /**
+   * Seek to a record with the highest ASQN less than or equal to the given {@code asqn}, with the
+   * restriction that it seeks to a record with index less than or equal to the given
+   * indexUpperBound.
+   *
+   * <p>Otherwise, the semantics is similar to {@code seekToAsqn(asqn)}
+   *
+   * @param asqn application sequence number to seek
+   * @param indexUpperBound the index until which it seeks
+   * @return the index of the record that will be returned by {@link #next()}
+   */
+  long seekToAsqn(long asqn, long indexUpperBound);
+
   @Override
   void close();
 }

--- a/journal/src/main/java/io/zeebe/journal/file/JournalIndex.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalIndex.java
@@ -42,10 +42,21 @@ interface JournalIndex {
   /**
    * Look up the index for the given application sequence number.
    *
-   * @param asqn
+   * @param asqn asqn to lookup
    * @return the index of a record with asqn less than or equal to the given asqn.
    */
   Long lookupAsqn(long asqn);
+
+  /**
+   * Look up the index for the given application sequence number. Same as {code lookupAsqn(asqn)},
+   * but the returned index will be less than or equal to the given indexUpperBound.
+   *
+   * @param asqn asqn to lookup
+   * @param indexUpperBound the upper bound of the index that will be returned
+   * @return the index (<= indexUpperBound) of a record with asqn less than or equal to the given
+   *     asqn.
+   */
+  Long lookupAsqn(long asqn, long indexUpperBound);
 
   /**
    * Delete all entries after the given index.

--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalReader.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalReader.java
@@ -120,8 +120,13 @@ class SegmentedJournalReader implements JournalReader {
 
   @Override
   public long seekToAsqn(final long asqn) {
+    return seekToAsqn(asqn, journal.getLastIndex());
+  }
+
+  @Override
+  public long seekToAsqn(final long asqn, final long indexUpperBound) {
     final var journalIndex = journal.getJournalIndex();
-    final var index = journalIndex.lookupAsqn(asqn);
+    final var index = journalIndex.lookupAsqn(asqn, indexUpperBound);
 
     // depending on the type of index, it's possible there is no ASQN indexed, in which case start
     // from the beginning
@@ -136,6 +141,9 @@ class SegmentedJournalReader implements JournalReader {
     JournalRecord record = null;
     while (hasNext()) {
       final var currentRecord = next();
+      if (currentRecord.index() > indexUpperBound) {
+        break;
+      }
       if (currentRecord.asqn() <= asqn && currentRecord.asqn() != ASQN_IGNORE) {
         record = currentRecord;
       } else if (currentRecord.asqn() >= asqn) {

--- a/journal/src/main/java/io/zeebe/journal/file/SparseJournalIndex.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SparseJournalIndex.java
@@ -53,8 +53,20 @@ class SparseJournalIndex implements JournalIndex {
 
   @Override
   public Long lookupAsqn(final long asqn) {
+    return lookupAsqn(asqn, Long.MAX_VALUE);
+  }
+
+  @Override
+  public Long lookupAsqn(final long asqn, final long indexUpperBound) {
     final Map.Entry<Long, Long> entry = asqnToIndex.floorEntry(asqn);
-    return entry != null ? entry.getValue() : null;
+    if (entry != null) {
+      if (entry.getValue() <= indexUpperBound) {
+        return entry.getValue();
+      } else {
+        return indexToAsqn.floorKey(indexUpperBound);
+      }
+    }
+    return null;
   }
 
   @Override

--- a/journal/src/test/java/io/zeebe/journal/file/JournalReaderTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/JournalReaderTest.java
@@ -172,6 +172,43 @@ class JournalReaderTest {
   }
 
   @Test
+  void shouldSeekToHighestAsqnWithinBoundIndex() {
+    // given
+    final var firstIndex = journal.append(1, data).index();
+    final var secondIndex = journal.append(4, data).index();
+    final var thirdIndex = journal.append(data).index();
+    final var fourthIndex = journal.append(5, data).index();
+    journal.append(data).index();
+
+    // when - then
+    assertThat(reader.seekToAsqn(5, firstIndex)).isEqualTo(firstIndex);
+    assertThat(reader.next().asqn()).isEqualTo(1);
+
+    assertThat(reader.seekToAsqn(5, secondIndex)).isEqualTo(secondIndex);
+    assertThat(reader.next().asqn()).isEqualTo(4);
+
+    assertThat(reader.seekToAsqn(5, thirdIndex)).isEqualTo(secondIndex);
+    assertThat(reader.next().asqn()).isEqualTo(4);
+
+    assertThat(reader.seekToAsqn(5, fourthIndex)).isEqualTo(fourthIndex);
+    assertThat(reader.next().asqn()).isEqualTo(5);
+
+    assertThat(reader.seekToAsqn(Long.MAX_VALUE)).isEqualTo(fourthIndex);
+    assertThat(reader.next().asqn()).isEqualTo(5);
+  }
+
+  @Test
+  void shouldSeekToLastAsqn() {
+    // given
+    final var expectedRecord = journal.append(5, data);
+    journal.append(data);
+
+    // when - then
+    assertThat(reader.seekToAsqn(Long.MAX_VALUE)).isEqualTo(expectedRecord.index());
+    assertThat(reader.next()).isEqualTo(expectedRecord);
+  }
+
+  @Test
   void shouldSeekToHighestLowerAsqnSkippingRecordsWithNoAsqn() {
     // given
     final var expectedRecord = journal.append(1, data);

--- a/journal/src/test/java/io/zeebe/journal/file/SparseJournalIndexTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SparseJournalIndexTest.java
@@ -56,6 +56,7 @@ public class SparseJournalIndexTest {
     // then
     assertEquals(5, index.lookup(5).index());
     assertEquals(10, index.lookup(5).position());
+    assertEquals(5, index.lookupAsqn(5));
   }
 
   @Test
@@ -77,6 +78,7 @@ public class SparseJournalIndexTest {
     // then
     assertEquals(5, index.lookup(8).index());
     assertEquals(10, index.lookup(8).position());
+    assertEquals(5, index.lookupAsqn(8));
   }
 
   @Test
@@ -100,6 +102,7 @@ public class SparseJournalIndexTest {
     // then
     assertEquals(10, index.lookup(10).index());
     assertEquals(20, index.lookup(10).position());
+    assertEquals(10, index.lookupAsqn(10));
   }
 
   @Test
@@ -211,5 +214,28 @@ public class SparseJournalIndexTest {
     assertNull(index.lookupAsqn(40));
     assertNull(index.lookupAsqn(50));
     assertNull(index.lookupAsqn(80));
+  }
+
+  @Test
+  public void shouldFindAsqnWithInBound() {
+    // given - every 2nd index is added
+    final JournalIndex index = new SparseJournalIndex(2);
+
+    // when
+    index.index(asJournalRecord(1, 1), 2);
+    index.index(asJournalRecord(2, 2), 4);
+    index.index(asJournalRecord(3, 3), 6);
+    index.index(asJournalRecord(4, 4), 8);
+    index.index(asJournalRecord(5, 5), 10);
+    index.index(asJournalRecord(6, 6), 10);
+
+    // then
+    assertNull(index.lookupAsqn(5, 1));
+    assertEquals(2, index.lookupAsqn(5, 3));
+    assertEquals(2, index.lookupAsqn(5, 3));
+    assertEquals(4, index.lookupAsqn(5, 4));
+    assertEquals(4, index.lookupAsqn(5, 5));
+    assertEquals(4, index.lookupAsqn(Long.MAX_VALUE, 5));
+    assertEquals(6, index.lookupAsqn(Long.MAX_VALUE, 6));
   }
 }


### PR DESCRIPTION
## Description

* JournalReader seekToAsqn accepts an upperbound index to seek to so that readers with mode COMMITS can bound the seek to the committed index. 
* Update RaftLogReader to use the new api
* Use seekToAsqn to find the last applicationEntry for entry validation in LeaderRole

## Related issues

closes #6343

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
