### PR TITLE
fix(atomix): fix race condition in raft test

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/SingleRaftEntryValidationTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/SingleRaftEntryValidationTest.java
@@ -19,9 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
+import io.atomix.raft.storage.log.entry.InitialEntry;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.ValidationResult;
-import java.util.List;
+import io.zeebe.test.util.TestUtil;
+import java.util.Collection;
 import java.util.function.BiFunction;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,17 +52,19 @@ public class SingleRaftEntryValidationTest {
     // when
     assertThatThrownBy(() -> raftRule.appendEntry()).hasMessageContaining("invalid");
     entryValidator.validation = (last, current) -> ValidationResult.success();
-    raftRule.awaitNewLeader();
-    final var commitIndex =
-        raftRule.appendEntry(); // append another entry to await the commit index
+    TestUtil.waitUntil(() -> getEntryTypeCount(InitialEntry.class) == 2);
+    raftRule.appendEntry();
 
     // then
-    raftRule.awaitCommit(commitIndex);
-    raftRule.awaitSameLogSizeOnAllNodes(commitIndex);
-    final var memberLog = raftRule.getMemberLogs();
+    assertThat(getEntryTypeCount(ApplicationEntry.class)).isOne();
+  }
 
-    final var logLength = memberLog.values().stream().map(List::size).findFirst().orElseThrow();
-    assertThat(logLength).withFailMessage(memberLog.toString()).isEqualTo(3);
+  private int getEntryTypeCount(final Class type) {
+    return (int)
+        raftRule.getMemberLogs().values().stream()
+            .flatMap(Collection::stream)
+            .filter(e -> e.entry().getClass().isAssignableFrom(type))
+            .count();
   }
 
   private static class TestEntryValidator implements EntryValidator {


### PR DESCRIPTION
## Description

Fixes the test by removing a race condition between the node failing and waiting for a new leader. Also improves the assertion part to be more robust. In the previous state I had to run this 2 times to get a failure and with the current state it didn't fail after 7500+ runs.

## Related issues

closes #6672

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
