### PR TITLE
fix(clients/go): fix status cmd's human-readable output

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/status.go
+++ b/clients/go/cmd/zbctl/internal/commands/status.go
@@ -47,7 +47,7 @@ func (s StatusResponseWrapper) human() (string, error) {
 
 	sort.Sort(ByNodeID(resp.Brokers))
 
-	for _, broker := range resp.Brokers {
+	for b, broker := range resp.Brokers {
 		stringBuilder.WriteString(fmt.Sprintf("  Broker %d - %s:%d\n", broker.NodeId, broker.Host, broker.Port))
 
 		version := "unavailable"
@@ -58,13 +58,13 @@ func (s StatusResponseWrapper) human() (string, error) {
 		stringBuilder.WriteString(fmt.Sprintf("    Version: %s\n", version))
 
 		sort.Sort(ByPartitionID(broker.Partitions))
-		for i, partition := range broker.Partitions {
+		for p, partition := range broker.Partitions {
 			stringBuilder.WriteString(fmt.Sprintf("    Partition %d : %s, %s",
 				partition.PartitionId,
 				roleToString(partition.Role),
 				healthToString(partition.Health)))
 
-			if i < len(broker.Partitions)-1 {
+			if p < len(broker.Partitions)-1 || b < len(broker.Partitions)-1 {
 				stringBuilder.WriteRune('\n')
 			}
 		}


### PR DESCRIPTION
## Description

Fixes zbctl's human-readable output for the status command:
```
Cluster size: 3
Partitions count: 3
Replication factor: 3
Gateway version: 0.27.0-SNAPSHOT
Brokers:
  Broker 0 - mp-spike-zeebe-0.mp-spike-zeebe.mp-spike.svc.cluster.local:26501
    Version: 0.27.0-SNAPSHOT
    Partition 1 : Follower, Healthy
    Partition 2 : Follower, Healthy
    Partition 3 : Follower, Healthy
  Broker 1 - mp-spike-zeebe-1.mp-spike-zeebe.mp-spike.svc.cluster.local:26501
    Version: 0.27.0-SNAPSHOT
    Partition 1 : Leader, Healthy
    Partition 2 : Leader, Healthy
    Partition 3 : Leader, Healthy
  Broker 2 - mp-spike-zeebe-2.mp-spike-zeebe.mp-spike.svc.cluster.local:26501
    Version: 0.27.0-SNAPSHOT
    Partition 1 : Follower, Healthy
    Partition 2 : Follower, Healthy
    Partition 3 : Follower, Healthy
```


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6692

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
