### PR TITLE
Fix user task with form key but no other task headers

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -21,7 +21,9 @@ import io.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
 import io.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
 import io.zeebe.msgpack.spec.MsgPackWriter;
 import io.zeebe.protocol.Protocol;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
@@ -49,44 +51,30 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
     final ExecutableServiceTask userTask =
         process.getElementById(element.getId(), ExecutableServiceTask.class);
 
-    transformTaskDefinition(element, userTask, context);
+    transformTaskDefinition(userTask);
 
     transformTaskHeaders(element, userTask);
   }
 
-  private void transformTaskDefinition(
-      final UserTask element,
-      final ExecutableServiceTask userTask,
-      final TransformContext context) {
+  private void transformTaskDefinition(final ExecutableServiceTask userTask) {
     userTask.setType(new StaticExpression(Protocol.USER_TASK_JOB_TYPE));
     userTask.setRetries(new StaticExpression("1"));
   }
 
   private void transformTaskHeaders(final UserTask element, final ExecutableServiceTask userTask) {
-    final ZeebeTaskHeaders taskHeaders = element.getSingleExtensionElement(ZeebeTaskHeaders.class);
+    final Map<String, String> taskHeaders = new HashMap<>();
+
+    collectModelTaskHeaders(element, taskHeaders);
 
     addZeebeUserTaskFormKeyHeader(element, taskHeaders);
 
-    if (taskHeaders != null) {
-      final List<ZeebeHeader> validHeaders =
-          taskHeaders.getHeaders().stream()
-              .filter(this::isValidHeader)
-              .collect(Collectors.toList());
-
-      if (validHeaders.size() < taskHeaders.getHeaders().size()) {
-        LOG.warn(
-            "Ignoring invalid headers for task '{}'. Must have non-empty key and value.",
-            element.getName());
-      }
-
-      if (!validHeaders.isEmpty()) {
-        final DirectBuffer encodedHeaders = encode(validHeaders);
-        userTask.setEncodedHeaders(encodedHeaders);
-      }
+    if (!taskHeaders.isEmpty()) {
+      final DirectBuffer encodedHeaders = encode(taskHeaders);
+      userTask.setEncodedHeaders(encodedHeaders);
     }
   }
 
-  private DirectBuffer encode(final List<ZeebeHeader> taskHeaders) {
+  private DirectBuffer encode(final Map<String, String> taskHeaders) {
     final MutableDirectBuffer buffer = new UnsafeBuffer(0, 0);
 
     final ExpandableArrayBuffer expandableBuffer =
@@ -96,12 +84,12 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
     msgPackWriter.writeMapHeader(taskHeaders.size());
 
     taskHeaders.forEach(
-        h -> {
-          if (isValidHeader(h)) {
-            final DirectBuffer key = wrapString(h.getKey());
+        (k, v) -> {
+          if (isValidHeader(k, v)) {
+            final DirectBuffer key = wrapString(k);
             msgPackWriter.writeString(key);
 
-            final DirectBuffer value = wrapString(h.getValue());
+            final DirectBuffer value = wrapString(v);
             msgPackWriter.writeString(value);
           }
         });
@@ -112,23 +100,41 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
   }
 
   private void addZeebeUserTaskFormKeyHeader(
-      final UserTask element, final ZeebeTaskHeaders taskHeaders) {
+      final UserTask element, final Map<String, String> taskHeaders) {
     final ZeebeFormDefinition formDefinition =
         element.getSingleExtensionElement(ZeebeFormDefinition.class);
 
     if (formDefinition != null) {
-      final ZeebeHeader zeebeHeader = element.getModelInstance().newInstance(ZeebeHeader.class);
-      zeebeHeader.setKey(Protocol.USER_TASK_FORM_KEY_HEADER_NAME);
-      zeebeHeader.setValue(formDefinition.getFormKey());
-      taskHeaders.getHeaders().add(zeebeHeader);
+      taskHeaders.put(Protocol.USER_TASK_FORM_KEY_HEADER_NAME, formDefinition.getFormKey());
+    }
+  }
+
+  private void collectModelTaskHeaders(
+      final UserTask element, final Map<String, String> taskHeaders) {
+    final ZeebeTaskHeaders modelTaskHeaders =
+        element.getSingleExtensionElement(ZeebeTaskHeaders.class);
+
+    if (modelTaskHeaders != null) {
+      final List<ZeebeHeader> validHeaders =
+          modelTaskHeaders.getHeaders().stream()
+              .filter(this::isValidHeader)
+              .collect(Collectors.toList());
+
+      if (validHeaders.size() < modelTaskHeaders.getHeaders().size()) {
+        LOG.warn(
+            "Ignoring invalid headers for task '{}'. Must have non-empty key and value.",
+            element.getName());
+      }
+
+      validHeaders.forEach(h -> taskHeaders.put(h.getKey(), h.getValue()));
     }
   }
 
   private boolean isValidHeader(final ZeebeHeader header) {
-    return header != null
-        && header.getValue() != null
-        && !header.getValue().isEmpty()
-        && header.getKey() != null
-        && !header.getKey().isEmpty();
+    return header != null && isValidHeader(header.getKey(), header.getValue());
+  }
+
+  private boolean isValidHeader(final String key, final String value) {
+    return key != null && !key.isEmpty() && value != null && !value.isEmpty();
   }
 }


### PR DESCRIPTION
## Description

The user task #6667 support contains a bug where if no task headers are specified but a form definition extension elements. This PR fixes the bug

## Related issues

related #6667 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
