### PR TITLE
Ignore development only modules in release

### DIFF
--- a/.ci/scripts/release/build-java.sh
+++ b/.ci/scripts/release/build-java.sh
@@ -2,4 +2,5 @@
 
 export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -XX:MaxRAMFraction=$((LIMITS_CPU))"
 
-mvn -B -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pchecks,prepare-offline
+# single quote the !development profile as this can cause issues with shell substitution
+mvn -B -s ${MAVEN_SETTINGS_XML} -DskipTests clean install -Pchecks,prepare-offline -P '!development'

--- a/.ci/scripts/release/maven-release.sh
+++ b/.ci/scripts/release/maven-release.sh
@@ -2,7 +2,9 @@
 
 export ZBCTL_ROOT_DIR=${PWD}
 
+# single quote the !development profile as this can cause issues with shell substitution
 mvn -s ${MAVEN_SETTINGS_XML} release:prepare release:perform -B \
+    -P '!development' \
     -Dgpg.passphrase="${GPG_PASS}" \
     -Dresume=false \
     -Dtag=${RELEASE_VERSION} \

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
     <module>parent</module>
     <module>atomix</module>
     <module>broker</module>
-    <module>qa</module>
     <module>protocol-test-util</module>
     <module>samples</module>
     <module>dist</module>
@@ -43,12 +42,25 @@
     <module>exporters/elasticsearch-exporter</module>
     <module>protocol-impl</module>
     <module>zb-db</module>
-    <module>update-tests</module>
     <module>expression-language</module>
     <module>snapshot</module>
-    <module>benchmarks/project</module>
     <module>journal</module>
   </modules>
+
+  <profiles>
+    <profile>
+      <id>development</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+
+      <modules>
+        <module>qa</module>
+        <module>update-tests</module>
+        <module>benchmarks/project</module>
+      </modules>
+    </profile>
+  </profiles>
 
   <scm>
     <url>https://github.com/camunda-cloud/zeebe</url>


### PR DESCRIPTION
## Description

Introduces an active-by-default development profile which includes development modules (benchmarks/project, qa tests, update tests) and updates the release scripts to disable this profile such that the development only modules are ignored during release. Future development only modules should be added to this profile as well.

NOTE: this means development modules will not be released to maven central, which I think is totally fine as we don't want these to be public, nor do we ever pull these as dependencies. This should help lighten the release process (the benchmark project always took forever to deploy).

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
