### PR TITLE
Fix race condition in random replay test

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/zeebe/engine/util/EngineRule.java
@@ -168,12 +168,12 @@ public final class EngineRule extends ExternalResource {
   }
 
   public EngineRule withOnProcessedCallback(final Consumer<TypedRecord> onProcessedCallback) {
-    this.onProcessedCallback = onProcessedCallback;
+    this.onProcessedCallback = this.onProcessedCallback.andThen(onProcessedCallback);
     return this;
   }
 
   public EngineRule withOnSkippedCallback(final Consumer<LoggedEvent> onSkippedCallback) {
-    this.onSkippedCallback = onSkippedCallback;
+    this.onSkippedCallback = this.onSkippedCallback.andThen(onSkippedCallback);
     return this;
   }
 

--- a/engine/src/test/java/io/zeebe/engine/util/ProcessExecutor.java
+++ b/engine/src/test/java/io/zeebe/engine/util/ProcessExecutor.java
@@ -238,6 +238,13 @@ public class ProcessExecutor {
     waitUntilRecordIsProcessed("until start timer is scheduled", timerSchedulingRecord);
 
     engineRule.increaseTime(timerStep.getTimeToAdd());
+
+    // await that the timer is triggered or otherwise there may be a race condition where a test may
+    // think we've already reached a wait state, when in truth the timer trigger hasn't even been
+    // processed and so we haven't actually moved on from the previous wait state
+    // TODO(npepinpe): if reused for other timers than start event, modify so we filter and await
+    // the right timer, not just any timer
+    RecordingExporter.timerRecords(TimerIntent.TRIGGERED).await();
   }
 
   private void resolveExpressionIncident(final StepExpressionIncidentCase expressionIncident) {

--- a/engine/src/test/java/io/zeebe/engine/util/ProcessExecutor.java
+++ b/engine/src/test/java/io/zeebe/engine/util/ProcessExecutor.java
@@ -27,7 +27,7 @@ import io.zeebe.test.util.bpmn.random.steps.StepPickDefaultCase;
 import io.zeebe.test.util.bpmn.random.steps.StepPublishMessage;
 import io.zeebe.test.util.bpmn.random.steps.StepPublishStartMessage;
 import io.zeebe.test.util.bpmn.random.steps.StepStartProcessInstance;
-import io.zeebe.test.util.bpmn.random.steps.StepTriggerTimer;
+import io.zeebe.test.util.bpmn.random.steps.StepTriggerTimerStartEvent;
 import io.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import java.util.Map;
@@ -81,9 +81,9 @@ public class ProcessExecutor {
     } else if (step instanceof StepExpressionIncidentCase) {
       final var expressionIncident = (StepExpressionIncidentCase) step;
       resolveExpressionIncident(expressionIncident);
-    } else if (step instanceof StepTriggerTimer) {
-      final StepTriggerTimer timerStep = (StepTriggerTimer) step;
-      triggerTimer(timerStep);
+    } else if (step instanceof StepTriggerTimerStartEvent) {
+      final StepTriggerTimerStartEvent timerStep = (StepTriggerTimerStartEvent) step;
+      triggerTimerStartEvent(timerStep);
     } else {
       throw new IllegalStateException("Not yet implemented: " + step);
     }
@@ -232,7 +232,7 @@ public class ProcessExecutor {
         .create();
   }
 
-  private void triggerTimer(final StepTriggerTimer timerStep) {
+  private void triggerTimerStartEvent(final StepTriggerTimerStartEvent timerStep) {
     final Record<TimerRecordValue> timerSchedulingRecord =
         RecordingExporter.timerRecords(TimerIntent.CREATE).getFirst();
     waitUntilRecordIsProcessed("until start timer is scheduled", timerSchedulingRecord);
@@ -242,8 +242,6 @@ public class ProcessExecutor {
     // await that the timer is triggered or otherwise there may be a race condition where a test may
     // think we've already reached a wait state, when in truth the timer trigger hasn't even been
     // processed and so we haven't actually moved on from the previous wait state
-    // TODO(npepinpe): if reused for other timers than start event, modify so we filter and await
-    // the right timer, not just any timer
     RecordingExporter.timerRecords(TimerIntent.TRIGGERED).await();
   }
 

--- a/engine/src/test/java/io/zeebe/engine/util/ProcessExecutor.java
+++ b/engine/src/test/java/io/zeebe/engine/util/ProcessExecutor.java
@@ -7,10 +7,13 @@
  */
 package io.zeebe.engine.util;
 
+import io.zeebe.protocol.record.Record;
 import io.zeebe.protocol.record.intent.IncidentIntent;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.zeebe.protocol.record.intent.TimerIntent;
+import io.zeebe.protocol.record.value.TimerRecordValue;
 import io.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
 import io.zeebe.test.util.MsgPackUtil;
 import io.zeebe.test.util.bpmn.random.steps.AbstractExecutionStep;
@@ -28,14 +31,19 @@ import io.zeebe.test.util.bpmn.random.steps.StepTriggerTimer;
 import io.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import java.util.Map;
+import org.awaitility.Awaitility;
 
 /** This class executes individual {@link AbstractExecutionStep} for a given process */
 public class ProcessExecutor {
 
   private final EngineRule engineRule;
+  private long lastProcessedPosition = -1L;
 
   public ProcessExecutor(final EngineRule engineRule) {
-    this.engineRule = engineRule;
+    this.engineRule =
+        engineRule
+            .withOnProcessedCallback(r -> lastProcessedPosition = r.getPosition())
+            .withOnSkippedCallback(r -> lastProcessedPosition = r.getPosition());
   }
 
   public void applyStep(final AbstractExecutionStep step) {
@@ -225,6 +233,10 @@ public class ProcessExecutor {
   }
 
   private void triggerTimer(final StepTriggerTimer timerStep) {
+    final Record<TimerRecordValue> timerSchedulingRecord =
+        RecordingExporter.timerRecords(TimerIntent.CREATE).getFirst();
+    waitUntilRecordIsProcessed("until start timer is scheduled", timerSchedulingRecord);
+
     engineRule.increaseTime(timerStep.getTimeToAdd());
   }
 
@@ -254,5 +266,9 @@ public class ProcessExecutor {
     RecordingExporter.incidentRecords(IncidentIntent.RESOLVED)
         .withElementId(expressionIncident.getGatewayElementId())
         .await();
+  }
+
+  private void waitUntilRecordIsProcessed(final String condition, final Record<?> record) {
+    Awaitility.await(condition).until(() -> lastProcessedPosition >= record.getPosition());
   }
 }

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/TimerStartEventBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/TimerStartEventBuilder.java
@@ -13,7 +13,7 @@ import io.zeebe.test.util.bpmn.random.ConstructionContext;
 import io.zeebe.test.util.bpmn.random.ExecutionPathSegment;
 import io.zeebe.test.util.bpmn.random.StartEventBlockBuilder;
 import io.zeebe.test.util.bpmn.random.steps.StepActivateAndCompleteJob;
-import io.zeebe.test.util.bpmn.random.steps.StepTriggerTimer;
+import io.zeebe.test.util.bpmn.random.steps.StepTriggerTimerStartEvent;
 import java.time.Duration;
 import java.util.Map;
 
@@ -50,7 +50,7 @@ public class TimerStartEventBuilder implements StartEventBlockBuilder {
   public ExecutionPathSegment findRandomExecutionPath(
       final String processId, final Map<String, Object> variables) {
     final ExecutionPathSegment pathSegment = new ExecutionPathSegment();
-    pathSegment.append(new StepTriggerTimer(timeToAdd));
+    pathSegment.append(new StepTriggerTimerStartEvent(timeToAdd));
     pathSegment.append(
         new StepActivateAndCompleteJob(startEventId + VARIABLES_JOB_TYPE_SUFFIX, variables));
     return pathSegment;

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/steps/StepTriggerTimer.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/steps/StepTriggerTimer.java
@@ -32,16 +32,13 @@ public final class StepTriggerTimer extends AbstractExecutionStep {
 
     final StepTriggerTimer that = (StepTriggerTimer) o;
 
-    if (timeToAdd != null ? !timeToAdd.equals(that.timeToAdd) : that.timeToAdd != null) {
-      return false;
-    }
-    return variables.equals(that.variables);
+    return getTimeToAdd() != null
+        ? getTimeToAdd().equals(that.getTimeToAdd())
+        : that.getTimeToAdd() == null;
   }
 
   @Override
   public int hashCode() {
-    int result = timeToAdd != null ? timeToAdd.hashCode() : 0;
-    result = 31 * result + variables.hashCode();
-    return result;
+    return getTimeToAdd() != null ? getTimeToAdd().hashCode() : 0;
   }
 }

--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/steps/StepTriggerTimerStartEvent.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/steps/StepTriggerTimerStartEvent.java
@@ -9,11 +9,11 @@ package io.zeebe.test.util.bpmn.random.steps;
 
 import java.time.Duration;
 
-public final class StepTriggerTimer extends AbstractExecutionStep {
+public final class StepTriggerTimerStartEvent extends AbstractExecutionStep {
 
   private final Duration timeToAdd;
 
-  public StepTriggerTimer(final Duration timeToAdd) {
+  public StepTriggerTimerStartEvent(final Duration timeToAdd) {
     this.timeToAdd = timeToAdd;
   }
 
@@ -30,7 +30,7 @@ public final class StepTriggerTimer extends AbstractExecutionStep {
       return false;
     }
 
-    final StepTriggerTimer that = (StepTriggerTimer) o;
+    final StepTriggerTimerStartEvent that = (StepTriggerTimerStartEvent) o;
 
     return getTimeToAdd() != null
         ? getTimeToAdd().equals(that.getTimeToAdd())


### PR DESCRIPTION
## Description

This PR fixes a potential race condition with timer start event where we increased the clock before the timer was created. We now wait for the the Timer.CREATE has been processed and its state changes applied, since we're guaranteed at that point that the timer has been scheduled.

Adds new helper in ProcessExecutor to await until a record has been processed, helping avoid race conditions with things such as timer scheduling Additionally await until the TRIGGER command has been processed, as otherwise there may be a race condition in certain tests (e.g. ReplayStateTest) where we want to apply the step and then stop the engine at the next wait state. It could be that we immediately think we're in a wait state BEFORE the timer is actually triggered if we don't wait for the command to be processed, and thus have different processing/reprocessing states.

Adds a new helper in TestStreams to get the last processed position for a given log.

## Related issues

closes #6710 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
