### PR TITLE
Adds blacklisting metric

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/metrics/BlacklistMetrics.java
+++ b/engine/src/main/java/io/zeebe/engine/metrics/BlacklistMetrics.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.metrics;
+
+import io.prometheus.client.Counter;
+
+public final class BlacklistMetrics {
+
+  private static final Counter BLACKLISTED_INSTANCES_COUNTER =
+      Counter.build()
+          .namespace("zeebe")
+          .name("blacklisted_instances_total")
+          .help("Number of blacklisted instances")
+          .labelNames("partition")
+          .register();
+
+  private final String partitionIdLabel;
+
+  public BlacklistMetrics(final int partitionId) {
+    partitionIdLabel = String.valueOf(partitionId);
+  }
+
+  public void countBlacklistedInstance() {
+    BLACKLISTED_INSTANCES_COUNTER.labels(partitionIdLabel).inc();
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/ZeebeDbState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/ZeebeDbState.java
@@ -95,7 +95,7 @@ public class ZeebeDbState implements MutableZeebeState {
     processMessageSubscriptionState =
         new DbProcessMessageSubscriptionState(zeebeDb, transactionContext);
     incidentState = new DbIncidentState(zeebeDb, transactionContext, partitionId);
-    blackListState = new DbBlackListState(zeebeDb, transactionContext);
+    blackListState = new DbBlackListState(zeebeDb, transactionContext, partitionId);
     lastProcessedPositionState = new DbLastProcessedPositionState(zeebeDb, transactionContext);
   }
 


### PR DESCRIPTION
## Description

We had in the past problems to see whether instances are blacklist or not. This information can be found in the log, but can be also overseen and it would be nice if we can make this available as metric, where we can also create alerts for. Currently operate is not able to show blacklisted instances, which it makes more urgent that we need to see whether blacklisted instances exist.
<!-- Please explain the changes you made here. -->


## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
