### PR TITLE
chore(benchmarks): Reduce exports and PVC claims

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -13,7 +13,7 @@ gatewayMetrics: true
 
 podSecurityContext:
   capabilities:
-        add: ["NET_ADMIN"]
+    add: [ "NET_ADMIN" ]
 
 gateway:
   replicas: 1
@@ -82,6 +82,11 @@ env:
     value: "0.8"
   - name: ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
     value: "0.9"
+  - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_JOB
+    value: "false"
+  - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_VARIABLE
+    value: "false"
+
 
 # RESOURCES
 resources:
@@ -93,8 +98,8 @@ resources:
     memory: 12Gi
 
 # PVC
-pvcAccessMode: ["ReadWriteOnce"]
-pvcSize: 128Gi
+pvcAccessMode: [ "ReadWriteOnce" ]
+pvcSize: 64Gi
 pvcStorageClassName: ssd
 
 
@@ -111,7 +116,7 @@ elasticsearch:
     storageClassName: "ssd"
     resources:
       requests:
-        storage: 600Gi
+        storage: 200Gi
 
   esJavaOpts: "-Xmx4g -Xms4g"
 


### PR DESCRIPTION
## Description

This PR introduces the following changes to the benchmark configuration:
* Disable exporting of variables and job records - because those come with a heavy payload which fills up the disk
* Reduce disk size of Broker and Elasticsearch

This change is not necessary. Depending on what we want to test with our benchmarks this change could go into the right or the wrong direction.

The purpose of this change is to be able to run benchmarks without allocating huge PVC to store all the data that accumulates. There are probably other ways to achieve the same goal, so see this is a proposal.

A benchmark with this configuration has been started and is running smoothly: http://34.77.165.228/d/I4lo7_EZk/zeebe?orgId=1&var-DS_PROMETHEUS=Prometheus&var-namespace=experiment-export-less&var-pod=All&var-partition=All&from=now-24h&to=now

Note that the PVC was chosen arbitrarily and could be reduced even further. The minimum judging by the experiment would be 50 GB for Elasticsearch and 10 GB for Zeebe Broker. However, Chris mentioned that smaller disks will give less performance.


## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [X] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
