### PR TITLE
chore(broker): handle unrecoverable failures during transitions

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/partitions/PartitionHealthBroadcaster.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/PartitionHealthBroadcaster.java
@@ -32,6 +32,11 @@ public final class PartitionHealthBroadcaster implements FailureListener {
     delegate.onHealthChanged(partitionId, HealthStatus.HEALTHY);
   }
 
+  @Override
+  public void onUnrecoverableFailure() {
+    delegate.onHealthChanged(partitionId, HealthStatus.DEAD);
+  }
+
   @FunctionalInterface
   public interface PartitionHealthListener {
 

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartitionHealth.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartitionHealth.java
@@ -16,6 +16,7 @@ import io.zeebe.util.health.HealthStatus;
  * transitions either succeeded or failed.
  */
 class ZeebePartitionHealth implements HealthMonitorable {
+
   private HealthStatus healthStatus = HealthStatus.UNHEALTHY;
   private final String name;
   private FailureListener failureListener;
@@ -25,7 +26,7 @@ class ZeebePartitionHealth implements HealthMonitorable {
   * - diskSpaceAvailable
   */
   private boolean servicesInstalled;
-  // We assume diskspace is available until otherwise notified
+  // We assume disk space is available until otherwise notified
   private boolean diskSpaceAvailable = true;
 
   public ZeebePartitionHealth(final int partitionId) {
@@ -43,8 +44,12 @@ class ZeebePartitionHealth implements HealthMonitorable {
   }
 
   private void updateHealthStatus() {
-    final boolean healthy = diskSpaceAvailable && servicesInstalled;
     final var previousStatus = healthStatus;
+    if (previousStatus == HealthStatus.DEAD) {
+      return;
+    }
+
+    final boolean healthy = diskSpaceAvailable && servicesInstalled;
     if (healthy) {
       healthStatus = HealthStatus.HEALTHY;
     } else {
@@ -73,6 +78,10 @@ class ZeebePartitionHealth implements HealthMonitorable {
   void setDiskSpaceAvailable(final boolean diskSpaceAvailable) {
     this.diskSpaceAvailable = diskSpaceAvailable;
     updateHealthStatus();
+  }
+
+  void onUnrecoverableFailure() {
+    healthStatus = HealthStatus.DEAD;
   }
 
   public String getName() {

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/RaftLogReaderPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/RaftLogReaderPartitionStep.java
@@ -30,6 +30,7 @@ public class RaftLogReaderPartitionStep implements PartitionStep {
     } catch (final Exception e) {
       Loggers.SYSTEM_LOGGER.error(
           "Unexpected error closing Raft log reader for partition {}", context.getPartitionId(), e);
+      return CompletableActorFuture.completedExceptionally(e);
     } finally {
       context.setRaftLogReader(null);
     }

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StreamProcessorPartitionStep.java
@@ -63,7 +63,6 @@ public class StreamProcessorPartitionStep implements PartitionStep {
   }
 
   private StreamProcessor createStreamProcessor(final PartitionContext state) {
-
     return StreamProcessor.builder()
         .logStream(state.getLogStream())
         .actorScheduler(state.getScheduler())

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -18,6 +18,7 @@ import io.zeebe.logstreams.impl.Loggers;
 import io.zeebe.logstreams.log.LogStream;
 import io.zeebe.logstreams.log.LogStreamBatchWriter;
 import io.zeebe.logstreams.log.LogStreamReader;
+import io.zeebe.util.exception.UnrecoverableException;
 import io.zeebe.util.health.FailureListener;
 import io.zeebe.util.health.HealthMonitorable;
 import io.zeebe.util.health.HealthStatus;
@@ -307,8 +308,13 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
     if (!openFuture.isDone()) {
       openFuture.completeExceptionally(throwable);
     }
+
     if (failureListener != null) {
-      failureListener.onFailure();
+      if (throwable instanceof UnrecoverableException) {
+        failureListener.onUnrecoverableFailure();
+      } else {
+        failureListener.onFailure();
+      }
     }
   }
 

--- a/journal/pom.xml
+++ b/journal/pom.xml
@@ -53,6 +53,10 @@
       <artifactId>zeebe-protocol</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
   </dependencies>
 
 

--- a/journal/src/main/java/io/zeebe/journal/file/JournalSegmentDescriptor.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalSegmentDescriptor.java
@@ -58,7 +58,7 @@ import java.nio.ByteBuffer;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-final class JournalSegmentDescriptor {
+public final class JournalSegmentDescriptor {
   public static final int BYTES = 64;
 
   // Current segment version.

--- a/journal/src/main/java/io/zeebe/journal/file/record/CorruptedLogException.java
+++ b/journal/src/main/java/io/zeebe/journal/file/record/CorruptedLogException.java
@@ -15,7 +15,9 @@
  */
 package io.zeebe.journal.file.record;
 
-public class CorruptedLogException extends RuntimeException {
+import io.zeebe.util.exception.UnrecoverableException;
+
+public class CorruptedLogException extends UnrecoverableException {
   public CorruptedLogException(final String message) {
     super(message);
   }

--- a/journal/src/test/java/io/zeebe/journal/file/JournalTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/JournalTest.java
@@ -23,23 +23,14 @@ import io.zeebe.journal.JournalException.InvalidChecksum;
 import io.zeebe.journal.JournalException.InvalidIndex;
 import io.zeebe.journal.JournalReader;
 import io.zeebe.journal.JournalRecord;
-import io.zeebe.journal.file.record.JournalRecordReaderUtil;
 import io.zeebe.journal.file.record.PersistedJournalRecord;
 import io.zeebe.journal.file.record.RecordData;
 import io.zeebe.journal.file.record.RecordMetadata;
-import io.zeebe.journal.file.record.SBESerializer;
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,7 +40,6 @@ import org.junit.jupiter.api.io.TempDir;
 class JournalTest {
 
   @TempDir Path directory;
-  @TempDir Path temp;
 
   private byte[] entry;
   private final DirectBuffer data = new UnsafeBuffer();
@@ -522,12 +512,9 @@ class JournalTest {
     assertThat(directory.toFile().listFiles()[0].listFiles()).hasSize(1);
     final File log = directory.toFile().listFiles()[0].listFiles()[0];
 
-    final File tempFile = new File(temp.toFile(), "rand");
-    assertThat(tempFile.createNewFile()).isTrue();
-
     // when
     journal.close();
-    assertThat(corruptFile(tempFile, log, secondRecord.index())).isTrue();
+    assertThat(LogCorrupter.corruptRecord(log, secondRecord.index())).isTrue();
     journal = openJournal();
     final var reader = journal.openReader();
 
@@ -547,12 +534,9 @@ class JournalTest {
     assertThat(directory.toFile().listFiles()[0].listFiles()).hasSize(1);
     final File log = directory.toFile().listFiles()[0].listFiles()[0];
 
-    final File tempFile = new File(temp.toFile(), "rand");
-    assertThat(tempFile.createNewFile()).isTrue();
-
     // when
     journal.close();
-    assertThat(corruptFile(tempFile, log, secondRecord.index())).isTrue();
+    assertThat(LogCorrupter.corruptRecord(log, secondRecord.index())).isTrue();
     journal = openJournal();
     data.wrap("111".getBytes(StandardCharsets.UTF_8));
     final var lastRecord = journal.append(data);
@@ -561,51 +545,6 @@ class JournalTest {
     // then
     assertThat(reader.next()).isEqualTo(firstRecord);
     assertThat(reader.next()).isEqualTo(lastRecord);
-  }
-
-  static boolean corruptFile(final File temp, final File file, final long index)
-      throws IOException {
-    final byte[] bytes = new byte[1024];
-    int read = 0;
-
-    try (final BufferedInputStream in = new BufferedInputStream(new FileInputStream(file))) {
-      while (in.available() > 0 && read < 1024) {
-        read += in.read(bytes, read, Math.min(1024, in.available()) - read);
-      }
-    }
-
-    if (!corruptRecord(bytes, index)) {
-      return false;
-    }
-
-    try (final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(temp))) {
-      out.write(bytes, 0, read);
-    }
-
-    return temp.renameTo(file);
-  }
-
-  private static boolean corruptRecord(final byte[] bytes, final long targetIndex) {
-    final JournalRecordReaderUtil reader = new JournalRecordReaderUtil(new SBESerializer());
-    final ByteBuffer buffer = ByteBuffer.wrap(bytes);
-    buffer.position(JournalSegmentDescriptor.BYTES);
-
-    Optional<Integer> version = FrameUtil.readVersion(buffer);
-    for (long index = 1; version.isPresent() && version.get() == 1; index++) {
-      final var record = reader.read(buffer, index);
-
-      if (record == null || record.index() > targetIndex) {
-        break;
-      } else if (record.index() == targetIndex) {
-        final int lastPos = buffer.position() - 1;
-        buffer.put(lastPos, (byte) ~buffer.get(lastPos));
-        return true;
-      }
-
-      version = FrameUtil.readVersion(buffer);
-    }
-
-    return false;
   }
 
   private PersistedJournalRecord copyRecord(final JournalRecord record) {

--- a/journal/src/test/java/io/zeebe/journal/file/LogCorrupter.java
+++ b/journal/src/test/java/io/zeebe/journal/file/LogCorrupter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.journal.file;
+
+import io.zeebe.journal.file.record.JournalRecordReaderUtil;
+import io.zeebe.journal.file.record.SBESerializer;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+public class LogCorrupter {
+
+  /**
+   * Corrupts the record associated with the specified index, if it's present in the file.
+   *
+   * @param file file where the record is persisted
+   * @param index index of record to be corrupted
+   * @return true if the specified record was successfully corrupted; otherwise, returns false
+   */
+  public static boolean corruptRecord(final File file, final long index) throws IOException {
+    final byte[] bytes = new byte[1024];
+    int read = 0;
+
+    try (final BufferedInputStream in = new BufferedInputStream(new FileInputStream(file))) {
+      while (in.available() > 0 && read < 1024) {
+        read += in.read(bytes, read, Math.min(1024, in.available()) - read);
+      }
+    }
+
+    if (!corruptRecord(bytes, index)) {
+      return false;
+    }
+
+    try (final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(file))) {
+      out.write(bytes, 0, read);
+    }
+
+    return true;
+  }
+
+  private static boolean corruptRecord(final byte[] bytes, final long targetIndex) {
+    final JournalRecordReaderUtil reader = new JournalRecordReaderUtil(new SBESerializer());
+    final ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    buffer.position(JournalSegmentDescriptor.BYTES);
+
+    Optional<Integer> version = FrameUtil.readVersion(buffer);
+    for (long index = 1; version.isPresent() && version.get() == 1; index++) {
+      final var record = reader.read(buffer, index);
+
+      if (record == null || record.index() > targetIndex) {
+        break;
+      } else if (record.index() == targetIndex) {
+        final int lastPos = buffer.position() - 1;
+        buffer.put(lastPos, (byte) ~buffer.get(lastPos));
+        return true;
+      }
+
+      version = FrameUtil.readVersion(buffer);
+    }
+
+    return false;
+  }
+}

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/clustering/ClusteringRule.java
@@ -235,7 +235,15 @@ public final class ClusteringRule extends ExternalResource {
   @Override
   protected void after() {
     LOG.debug("Closing ClusteringRule...");
-    brokers.values().parallelStream().forEach(Broker::close);
+    brokers.values().parallelStream()
+        .forEach(
+            b -> {
+              try {
+                b.close();
+              } catch (final Exception e) {
+                LOG.error("Failed to close broker: ", e);
+              }
+            });
     brokers.clear();
     brokerCfgs.clear();
     logstreams.clear();

--- a/util/src/main/java/io/zeebe/util/exception/UnrecoverableException.java
+++ b/util/src/main/java/io/zeebe/util/exception/UnrecoverableException.java
@@ -5,10 +5,11 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.zeebe.util.health;
+package io.zeebe.util.exception;
 
-public enum HealthStatus {
-  UNHEALTHY,
-  HEALTHY,
-  DEAD
+public class UnrecoverableException extends RuntimeException {
+
+  public UnrecoverableException(final String message) {
+    super(message);
+  }
 }

--- a/util/src/main/java/io/zeebe/util/health/FailureListener.java
+++ b/util/src/main/java/io/zeebe/util/health/FailureListener.java
@@ -19,4 +19,10 @@ public interface FailureListener {
    * expected to call {#onRecovered} when it is marked as healthy.
    */
   void onRecovered();
+
+  /**
+   * Invoked when the health status becomes dead and the system can't becomes healthy again without
+   * external intervention.
+   */
+  void onUnrecoverableFailure();
 }


### PR DESCRIPTION
## Description

Handle unrecoverable exceptions in the transition logic by going inactive.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6677, #6391

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
