### PR TITLE
chore(test-util): log deployed processes in compact log

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/FailedPropertyBasedTestDataPrinter.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/FailedPropertyBasedTestDataPrinter.java
@@ -7,7 +7,6 @@
  */
 package io.zeebe.engine.processing.streamprocessor;
 
-import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.test.util.bpmn.random.TestDataGenerator.TestDataRecord;
 import io.zeebe.test.util.bpmn.random.steps.AbstractExecutionStep;
 import java.util.function.Supplier;
@@ -33,13 +32,6 @@ final class FailedPropertyBasedTestDataPrinter extends TestWatcher {
     final var record = testDataRecordSupplier.get();
 
     LOGGER.info("Data of failed test case: {}", record);
-
-    LOGGER.info(
-        "Process(es) of failed test case:{}{}",
-        System.lineSeparator(),
-        record.getBpmnModels().stream()
-            .map(Bpmn::convertToString)
-            .collect(Collectors.joining(System.lineSeparator())));
 
     LOGGER.info(
         "Execution path of failed test case:{}{}",


### PR DESCRIPTION
## Description

This adds logic to the `CompactRecordLogger` to log out all processes which have been deployed as part of the run.

It also removes the logging of processes from the `FailedPropertyBasedTestDataPrinter` to avoid redundancy.  


## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
