### PR TITLE
New BPMN element type for event subprocesses

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -47,6 +47,8 @@ public final class BpmnElementProcessors {
     // containers
     processors.put(BpmnElementType.PROCESS, new ProcessProcessor(bpmnBehaviors));
     processors.put(BpmnElementType.SUB_PROCESS, new SubProcessProcessor(bpmnBehaviors));
+    // TODO (saig0): extract the logic for event subprocesses into its own processor (#6196)
+    processors.put(BpmnElementType.EVENT_SUB_PROCESS, new SubProcessProcessor(bpmnBehaviors));
     processors.put(
         BpmnElementType.MULTI_INSTANCE_BODY, new MultiInstanceBodyProcessor(bpmnBehaviors));
     processors.put(BpmnElementType.CALL_ACTIVITY, new CallActivityProcessor(bpmnBehaviors));

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -386,7 +386,8 @@ public final class BpmnEventSubscriptionBehavior {
         eventTrigger -> {
           final var eventSubProcessElementId = startEvent.getEventSubProcess();
           final var record =
-              getEventRecord(context.getRecordValue(), eventTrigger, BpmnElementType.SUB_PROCESS)
+              getEventRecord(
+                      context.getRecordValue(), eventTrigger, BpmnElementType.EVENT_SUB_PROCESS)
                   .setElementId(eventSubProcessElementId);
 
           final long eventElementInstanceKey = keyGenerator.nextKey();
@@ -437,7 +438,8 @@ public final class BpmnEventSubscriptionBehavior {
     if (isInterrupted(isChildMigrated, elementInstance)) {
       elementInstanceState.getDeferredRecords(context.getElementInstanceKey()).stream()
           .filter(record -> record.getKey() == elementInstance.getInterruptingEventKey())
-          .filter(record -> record.getValue().getBpmnElementType() == BpmnElementType.SUB_PROCESS)
+          .filter(
+              record -> record.getValue().getBpmnElementType() == BpmnElementType.EVENT_SUB_PROCESS)
           .findFirst()
           .ifPresent(
               record -> {

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformer/SubProcessTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformer/SubProcessTransformer.java
@@ -14,6 +14,7 @@ import io.zeebe.engine.processing.deployment.model.transformation.ModelElementTr
 import io.zeebe.engine.processing.deployment.model.transformation.TransformContext;
 import io.zeebe.model.bpmn.instance.FlowNode;
 import io.zeebe.model.bpmn.instance.SubProcess;
+import io.zeebe.protocol.record.value.BpmnElementType;
 
 public final class SubProcessTransformer implements ModelElementTransformer<SubProcess> {
 
@@ -37,6 +38,9 @@ public final class SubProcessTransformer implements ModelElementTransformer<SubP
       final SubProcess element,
       final ExecutableProcess currentProcess,
       final ExecutableFlowElementContainer subprocess) {
+
+    // set the element type explicitly because the element name is equal to an embedded subprocess
+    subprocess.setElementType(BpmnElementType.EVENT_SUB_PROCESS);
 
     if (element.getScope() instanceof FlowNode) {
       final FlowNode scope = (FlowNode) element.getScope();

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -109,8 +109,7 @@ public final class EventAppliers implements EventApplier {
             elementInstanceState, processState, variableState, eventScopeInstanceState));
     register(
         ProcessInstanceIntent.ELEMENT_ACTIVATED,
-        new ProcessInstanceElementActivatedApplier(
-            elementInstanceState, processState, eventScopeInstanceState));
+        new ProcessInstanceElementActivatedApplier(elementInstanceState));
     register(
         ProcessInstanceIntent.ELEMENT_COMPLETING,
         new ProcessInstanceElementCompletingApplier(elementInstanceState));

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatedApplier.java
@@ -7,50 +7,25 @@
  */
 package io.zeebe.engine.state.appliers;
 
-import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
 import io.zeebe.engine.state.TypedEventApplier;
-import io.zeebe.engine.state.immutable.ProcessState;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
-import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.zeebe.protocol.record.value.BpmnElementType;
 
 /** Applies state changes for `ProcessInstance:Element_Activated` */
 final class ProcessInstanceElementActivatedApplier
     implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
 
   private final MutableElementInstanceState elementInstanceState;
-  private final ProcessState processState;
-  private final MutableEventScopeInstanceState eventScopeInstanceState;
 
   public ProcessInstanceElementActivatedApplier(
-      final MutableElementInstanceState elementInstanceState,
-      final ProcessState processState,
-      final MutableEventScopeInstanceState eventScopeInstanceState) {
+      final MutableElementInstanceState elementInstanceState) {
     this.elementInstanceState = elementInstanceState;
-    this.processState = processState;
-    this.eventScopeInstanceState = eventScopeInstanceState;
   }
 
   @Override
   public void applyState(final long key, final ProcessInstanceRecord value) {
     elementInstanceState.updateInstance(
         key, instance -> instance.setState(ProcessInstanceIntent.ELEMENT_ACTIVATED));
-
-    if (value.getBpmnElementType() == BpmnElementType.SUB_PROCESS) {
-
-      final var executableFlowElementContainer =
-          processState.getFlowElement(
-              value.getProcessDefinitionKey(),
-              value.getElementIdBuffer(),
-              ExecutableFlowElementContainer.class);
-
-      final var events = executableFlowElementContainer.getEvents();
-      if (!events.isEmpty()) {
-        eventScopeInstanceState.createIfNotExists(
-            key, executableFlowElementContainer.getInterruptingElementIds());
-      }
-    }
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -11,7 +11,6 @@ import io.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventE
 import io.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
-import io.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
 import io.zeebe.engine.state.TypedEventApplier;
 import io.zeebe.engine.state.immutable.ProcessState;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
@@ -61,28 +60,15 @@ final class ProcessInstanceElementActivatingApplier
 
     decrementActiveSequenceFlow(value, flowScopeInstance, flowScopeElementType, currentElementType);
 
-    if (isStartEventInSubProcess(flowScopeElementType, currentElementType)) {
+    if (currentElementType == BpmnElementType.START_EVENT
+        && flowScopeElementType == BpmnElementType.EVENT_SUB_PROCESS) {
+      // the event variables are stored as temporary variables in the scope of the subprocess
+      // - move them to the scope of the start event to apply the output variable mappings
+      final var variables = variableState.getTemporaryVariables(flowScopeInstance.getKey());
 
-      final var executableStartEvent =
-          processState.getFlowElement(
-              value.getProcessDefinitionKey(),
-              value.getElementIdBuffer(),
-              ExecutableStartEvent.class);
-      if (!executableStartEvent.isNone()) {
-        // IF the current element is a start event and the flow scope is a sub process
-        // then it is either a none start event, which means it is a normal *embedded sub process*
-        // or an timer/message start event, which means it is a *event sub process*
-        // *Only for event sub processes we transfer variables*
-
-        // the event variables are stored as temporary variables in the scope of the
-        // subprocess
-        // - move them to the scope of the start event to apply the output variable mappings
-        final var variables = variableState.getTemporaryVariables(flowScopeInstance.getKey());
-
-        if (variables != null) {
-          variableState.setTemporaryVariables(elementInstanceKey, variables);
-          variableState.removeTemporaryVariables(flowScopeInstance.getKey());
-        }
+      if (variables != null) {
+        variableState.setTemporaryVariables(elementInstanceKey, variables);
+        variableState.removeTemporaryVariables(flowScopeInstance.getKey());
       }
     }
   }
@@ -93,7 +79,7 @@ final class ProcessInstanceElementActivatingApplier
       final BpmnElementType flowScopeElementType,
       final BpmnElementType currentElementType) {
 
-    final boolean isEventSubProcess = isEventSubProcess(currentElementType, value);
+    final boolean isEventSubProcess = currentElementType == BpmnElementType.EVENT_SUB_PROCESS;
 
     // We don't want to decrement the active sequence flow for elements which have no incoming
     // sequence flow and for interrupting event sub processes we reset the count completely.
@@ -156,28 +142,12 @@ final class ProcessInstanceElementActivatingApplier
     }
   }
 
-  private boolean isEventSubProcess(
-      final BpmnElementType currentElementType, final ProcessInstanceRecord processInstanceRecord) {
-    if (currentElementType == BpmnElementType.SUB_PROCESS) {
-      final var executableFlowElementContainer =
-          getExecutableFlowElementContainer(processInstanceRecord);
-      return !executableFlowElementContainer.hasNoneStartEvent();
-    }
-    return false;
-  }
-
   private ExecutableFlowElementContainer getExecutableFlowElementContainer(
       final ProcessInstanceRecord value) {
     return processState.getFlowElement(
         value.getProcessDefinitionKey(),
         value.getElementIdBuffer(),
         ExecutableFlowElementContainer.class);
-  }
-
-  private boolean isStartEventInSubProcess(
-      final BpmnElementType flowScopeElementType, final BpmnElementType currentElementType) {
-    return currentElementType == BpmnElementType.START_EVENT
-        && flowScopeElementType == BpmnElementType.SUB_PROCESS;
   }
 
   private void createEventScope(

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/BpmnElementTypeTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/BpmnElementTypeTest.java
@@ -303,6 +303,20 @@ public final class BpmnElementTypeTest {
                   .endEvent()
                   .done();
             }
+          },
+          new BpmnElementTypeScenario("Event Subprocess", BpmnElementType.EVENT_SUB_PROCESS) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .eventSubProcess(
+                      elementId(),
+                      eventSubProcess ->
+                          eventSubProcess.startEvent().timerWithDuration("PT0S").endEvent())
+                  .startEvent()
+                  .serviceTask("task", t -> t.zeebeJobType("test"))
+                  .endEvent()
+                  .done();
+            }
           });
 
   @Rule

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessConcurrencyTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessConcurrencyTest.java
@@ -92,8 +92,8 @@ public class InterruptingEventSubprocessConcurrencyTest {
         .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
         .containsSubsequence(
             tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.EVENT_OCCURRED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
@@ -160,8 +160,8 @@ public class InterruptingEventSubprocessConcurrencyTest {
         .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
         .containsSubsequence(
             tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.EVENT_OCCURRED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
@@ -232,8 +232,8 @@ public class InterruptingEventSubprocessConcurrencyTest {
         .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
         .containsSubsequence(
             tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.EVENT_OCCURRED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
@@ -287,8 +287,8 @@ public class InterruptingEventSubprocessConcurrencyTest {
         .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
         .containsSubsequence(
             tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.EVENT_OCCURRED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
@@ -154,8 +154,8 @@ public class InterruptingEventSubprocessTest {
         .containsSubsequence(
             tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.EVENT_OCCURRED),
             tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
@@ -196,8 +196,8 @@ public class InterruptingEventSubprocessTest {
         .containsSubsequence(
             tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.EVENT_OCCURRED),
             tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
@@ -295,7 +295,7 @@ public class InterruptingEventSubprocessTest {
     final long eventSubprocKey =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .withProcessInstanceKey(wfInstanceKey)
-            .withElementType(BpmnElementType.SUB_PROCESS)
+            .withElementType(BpmnElementType.EVENT_SUB_PROCESS)
             .getFirst()
             .getKey();
 

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/MultipleEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/MultipleEventSubprocessTest.java
@@ -49,7 +49,7 @@ public final class MultipleEventSubprocessTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(wfInstanceKey)
-                .withElementType(BpmnElementType.SUB_PROCESS)
+                .withElementType(BpmnElementType.EVENT_SUB_PROCESS)
                 .limit(8))
         .extracting(r -> tuple(r.getValue().getElementId(), r.getIntent()))
         .containsSubsequence(
@@ -209,10 +209,10 @@ public final class MultipleEventSubprocessTest {
         .containsSubsequence(
             tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
   }
 
@@ -246,7 +246,7 @@ public final class MultipleEventSubprocessTest {
                 .withProcessInstanceKey(wfInstanceKey)
                 .limitToProcessInstanceCompleted()
                 .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-                .withElementType(BpmnElementType.SUB_PROCESS))
+                .withElementType(BpmnElementType.EVENT_SUB_PROCESS))
         .extracting(r -> r.getValue().getElementId())
         .containsExactly("event_sub_proc_timer");
   }

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/NonInterruptingEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/NonInterruptingEventSubprocessTest.java
@@ -146,8 +146,8 @@ public class NonInterruptingEventSubprocessTest {
         .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
         .containsSubsequence(
             tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.EVENT_OCCURRED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.EVENT_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
@@ -161,7 +161,7 @@ public class NonInterruptingEventSubprocessTest {
     final long eventSubprocKey =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .withProcessInstanceKey(wfInstanceKey)
-            .withElementType(BpmnElementType.SUB_PROCESS)
+            .withElementType(BpmnElementType.EVENT_SUB_PROCESS)
             .getFirst()
             .getKey();
 

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/BpmnElementType.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/BpmnElementType.java
@@ -23,6 +23,7 @@ public enum BpmnElementType {
   // Containers
   PROCESS,
   SUB_PROCESS,
+  EVENT_SUB_PROCESS,
 
   // Events
   START_EVENT,


### PR DESCRIPTION
## Description

* introduce a new BPMN element type `EVENT_SUB_PROCESS` to distinguish between embedded and event subprocesses
* delegate the logic for event subprocesses to the existing subprocess processor because it can handle both cases at the moment
  * we can extract/move the logic from the subprocess processor in a further issue  

## Related issues

closes #6542 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
