### PR TITLE
Call activity boundary event replay test case

### DIFF
--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateTest.java
@@ -22,9 +22,9 @@ import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import org.assertj.core.api.SoftAssertions;
 import org.awaitility.Awaitility;
@@ -170,7 +170,7 @@ public final class ReplayStateTest {
   @Test
   public void shouldRestoreState() {
     // given
-    testCase.process.ifPresent(process -> engine.deployment().withXmlResource(process).deploy());
+    testCase.processes.forEach(process -> engine.deployment().withXmlResource(process).deploy());
 
     final Record<?> finalRecord = testCase.execution.apply(engine);
 
@@ -227,7 +227,7 @@ public final class ReplayStateTest {
 
   private static final class TestCase {
     private final String description;
-    private Optional<BpmnModelInstance> process = Optional.empty();
+    private final List<BpmnModelInstance> processes = new ArrayList<>();
     private Function<EngineRule, Record<?>> execution =
         engine -> RecordingExporter.records().getFirst();
 
@@ -236,7 +236,7 @@ public final class ReplayStateTest {
     }
 
     private TestCase withProcess(final BpmnModelInstance process) {
-      this.process = Optional.of(process);
+      processes.add(process);
       return this;
     }
 


### PR DESCRIPTION
## Description

To further cover replay state test cases, this PR adds an example-based test case for call activity with an interrupting boundary event. Adding this case to the randomized test cases was not trivial, while an example is.

## Related issues

relates #6197 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
