### PR TITLE
Use SBE in raft metastore

### DIFF
--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -14,7 +14,9 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <artifactId>atomix-cluster</artifactId>
 
   <dependencies>

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
@@ -88,29 +88,5 @@ public final class RaftNamespaces {
           .name("RaftProtocol")
           .build();
 
-  /**
-   * Raft storage namespace.
-   *
-   * <p>*Be aware* we use the Void type for replaced/removed types to keep the id's of used types,
-   * otherwise we break compatibility.
-   */
-  public static final Namespace RAFT_STORAGE =
-      new Builder()
-          .register(Namespaces.BASIC)
-          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID + 100)
-          .register(ConfigurationEntry.class)
-          .register(InitialEntry.class)
-          .register(ArrayList.class)
-          .register(HashSet.class)
-          .register(DefaultRaftMember.class)
-          .register(MemberId.class)
-          .register(RaftMember.Type.class)
-          .register(Instant.class)
-          .register(Configuration.class)
-          .register(ApplicationEntry.class)
-          .register(RaftLogEntry.class)
-          .name("RaftStorage")
-          .build();
-
   private RaftNamespaces() {}
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -286,7 +286,6 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
         .withMaxEntrySize((int) storageConfig.getMaxEntrySize().bytes())
         .withFlushExplicitly(storageConfig.shouldFlushExplicitly())
         .withFreeDiskSpace(storageConfig.getFreeDiskSpace())
-        .withNamespace(RaftNamespaces.RAFT_STORAGE)
         .withSnapshotStore(persistedSnapshotStore)
         .withJournalIndexDensity(storageConfig.getJournalIndexDensity())
         .build();

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -24,8 +24,6 @@ import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.system.MetaStore;
 import io.atomix.storage.StorageException;
 import io.atomix.storage.buffer.FileBuffer;
-import io.atomix.utils.serializer.Namespace;
-import io.atomix.utils.serializer.Serializer;
 import io.zeebe.snapshots.raft.PersistedSnapshotStore;
 import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
 import java.io.File;
@@ -55,7 +53,6 @@ public final class RaftStorage {
 
   private final String prefix;
   private final File directory;
-  private final Namespace namespace;
   private final int maxSegmentSize;
   private final int maxEntrySize;
   private final long freeDiskSpace;
@@ -66,7 +63,6 @@ public final class RaftStorage {
   private RaftStorage(
       final String prefix,
       final File directory,
-      final Namespace namespace,
       final int maxSegmentSize,
       final int maxEntrySize,
       final long freeDiskSpace,
@@ -75,7 +71,6 @@ public final class RaftStorage {
       final int journalIndexDensity) {
     this.prefix = prefix;
     this.directory = directory;
-    this.namespace = namespace;
     this.maxSegmentSize = maxSegmentSize;
     this.maxEntrySize = maxEntrySize;
     this.freeDiskSpace = freeDiskSpace;
@@ -102,15 +97,6 @@ public final class RaftStorage {
    */
   public String prefix() {
     return prefix;
-  }
-
-  /**
-   * Returns the storage serializer.
-   *
-   * @return The storage serializer.
-   */
-  public Namespace namespace() {
-    return namespace;
   }
 
   /**
@@ -187,7 +173,7 @@ public final class RaftStorage {
    */
   public MetaStore openMetaStore() {
     try {
-      return new MetaStore(this, Serializer.using(namespace));
+      return new MetaStore(this);
     } catch (final IOException e) {
       throw new StorageException("Failed to open metastore", e);
     }
@@ -302,7 +288,6 @@ public final class RaftStorage {
 
     private String prefix = DEFAULT_PREFIX;
     private File directory = new File(DEFAULT_DIRECTORY);
-    private Namespace namespace;
     private int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
     private int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
     private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
@@ -351,18 +336,6 @@ public final class RaftStorage {
      */
     public Builder withDirectory(final File directory) {
       this.directory = checkNotNull(directory, "directory");
-      return this;
-    }
-
-    /**
-     * Sets the storage namespace.
-     *
-     * @param namespace The storage namespace.
-     * @return The storage builder.
-     * @throws NullPointerException If the {@code namespace} is {@code null}
-     */
-    public Builder withNamespace(final Namespace namespace) {
-      this.namespace = checkNotNull(namespace, "namespace cannot be null");
       return this;
     }
 
@@ -449,7 +422,6 @@ public final class RaftStorage {
       return new RaftStorage(
           prefix,
           directory,
-          namespace,
           maxSegmentSize,
           maxEntrySize,
           freeDiskSpace,

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -186,7 +186,11 @@ public final class RaftStorage {
    * @return The metastore.
    */
   public MetaStore openMetaStore() {
-    return new MetaStore(this, Serializer.using(namespace));
+    try {
+      return new MetaStore(this, Serializer.using(namespace));
+    } catch (final IOException e) {
+      throw new StorageException("Failed to open metastore", e);
+    }
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -21,6 +21,8 @@ import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.log.entry.InitialEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.storage.serializer.RaftEntrySBESerializer;
+import io.atomix.raft.storage.serializer.RaftEntrySerializer;
 import io.zeebe.journal.Journal;
 import io.zeebe.journal.JournalRecord;
 import io.zeebe.journal.file.SegmentedJournal;

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
@@ -17,6 +17,8 @@
 package io.atomix.raft.storage.log;
 
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.storage.serializer.RaftEntrySBESerializer;
+import io.atomix.raft.storage.serializer.RaftEntrySerializer;
 import io.zeebe.journal.JournalReader;
 import io.zeebe.journal.JournalRecord;
 import java.util.NoSuchElementException;

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.storage.serializer;
+
+import static io.atomix.raft.storage.serializer.SerializerUtil.getRaftMemberType;
+import static io.atomix.raft.storage.serializer.SerializerUtil.getSBEType;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.RaftMember;
+import io.atomix.raft.cluster.impl.DefaultRaftMember;
+import io.atomix.raft.storage.serializer.ConfigurationDecoder.RaftMemberDecoder;
+import io.atomix.raft.storage.system.Configuration;
+import java.time.Instant;
+import java.util.ArrayList;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+
+public class MetaStoreSerializer {
+
+  private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final ConfigurationEncoder configurationEncoder = new ConfigurationEncoder();
+  private final MetaEncoder metaEncoder = new MetaEncoder();
+
+  private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
+  private final ConfigurationDecoder configurationDecoder = new ConfigurationDecoder();
+  private final MetaDecoder metaDecoder = new MetaDecoder();
+
+  public int writeConfiguration(
+      final Configuration configuration, final MutableDirectBuffer buffer, final int offset) {
+
+    headerEncoder
+        .wrap(buffer, offset)
+        .blockLength(configurationEncoder.sbeBlockLength())
+        .templateId(configurationEncoder.sbeTemplateId())
+        .schemaId(configurationEncoder.sbeSchemaId())
+        .version(configurationEncoder.sbeSchemaVersion());
+
+    configurationEncoder.wrap(buffer, offset + headerEncoder.encodedLength());
+
+    configurationEncoder
+        .index(configuration.index())
+        .term(configuration.term())
+        .timestamp(configuration.time());
+
+    final var raftMemberEncoder =
+        configurationEncoder.raftMemberCount(configuration.members().size());
+    for (final RaftMember member : configuration.members()) {
+      final var memberId = member.memberId().id();
+      raftMemberEncoder
+          .next()
+          .type(getSBEType(member.getType()))
+          .updated(member.getLastUpdated().toEpochMilli())
+          .memberId(memberId);
+    }
+
+    return headerEncoder.encodedLength() + configurationEncoder.encodedLength();
+  }
+
+  public Configuration readConfiguration(final DirectBuffer buffer, final int offset) {
+    headerDecoder.wrap(buffer, offset);
+    if (headerDecoder.version() != configurationEncoder.sbeSchemaVersion()
+        || headerDecoder.templateId() != configurationEncoder.sbeTemplateId()) {
+      return null;
+    }
+    configurationDecoder.wrap(
+        buffer,
+        offset + headerDecoder.encodedLength(),
+        headerDecoder.blockLength(),
+        headerDecoder.version());
+
+    final long index = configurationDecoder.index();
+    final long term = configurationDecoder.term();
+    final long timestamp = configurationDecoder.timestamp();
+
+    final RaftMemberDecoder memberDecoder = configurationDecoder.raftMember();
+    final ArrayList<RaftMember> members = new ArrayList<>(memberDecoder.count());
+    for (final RaftMemberDecoder member : memberDecoder) {
+      final RaftMember.Type type = getRaftMemberType(member.type());
+      final Instant updated = Instant.ofEpochMilli(member.updated());
+      final var memberId = member.memberId();
+      members.add(new DefaultRaftMember(MemberId.from(memberId), type, updated));
+    }
+
+    return new Configuration(index, term, timestamp, members);
+  }
+
+  public void writeTerm(final long term, final MutableDirectBuffer buffer) {
+    headerEncoder
+        .wrap(buffer, 0)
+        .blockLength(metaEncoder.sbeBlockLength())
+        .templateId(metaEncoder.sbeTemplateId())
+        .schemaId(metaEncoder.sbeSchemaId())
+        .version(metaEncoder.sbeSchemaVersion());
+
+    metaEncoder.wrap(buffer, headerEncoder.encodedLength());
+    metaEncoder.term(term);
+  }
+
+  public long readTerm(final MutableDirectBuffer buffer) {
+    headerDecoder.wrap(buffer, 0);
+    metaDecoder.wrap(
+        buffer,
+        headerDecoder.encodedLength(),
+        headerDecoder.blockLength(),
+        headerDecoder.version());
+
+    return metaDecoder.term();
+  }
+
+  public void writeVotedFor(final String memberId, final MutableDirectBuffer buffer) {
+    headerEncoder
+        .wrap(buffer, 0)
+        .blockLength(metaEncoder.sbeBlockLength())
+        .templateId(metaEncoder.sbeTemplateId())
+        .schemaId(metaEncoder.sbeSchemaId())
+        .version(metaEncoder.sbeSchemaVersion());
+
+    metaEncoder.wrap(buffer, headerEncoder.encodedLength());
+    metaEncoder.votedFor(memberId);
+  }
+
+  public String readVotedFor(final MutableDirectBuffer buffer) {
+    headerDecoder.wrap(buffer, 0);
+    metaDecoder.wrap(
+        buffer,
+        headerDecoder.encodedLength(),
+        headerDecoder.blockLength(),
+        headerDecoder.version());
+
+    return metaDecoder.votedFor();
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySBESerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySBESerializer.java
@@ -13,27 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.raft.storage.log;
+package io.atomix.raft.storage.serializer;
+
+import static io.atomix.raft.storage.serializer.SerializerUtil.getRaftMemberType;
+import static io.atomix.raft.storage.serializer.SerializerUtil.getSBEType;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
-import io.atomix.raft.storage.log.entry.ApplicationEntryDecoder;
-import io.atomix.raft.storage.log.entry.ApplicationEntryEncoder;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;
-import io.atomix.raft.storage.log.entry.ConfigurationEntryDecoder;
-import io.atomix.raft.storage.log.entry.ConfigurationEntryDecoder.RaftMemberDecoder;
-import io.atomix.raft.storage.log.entry.ConfigurationEntryEncoder;
-import io.atomix.raft.storage.log.entry.EntryType;
 import io.atomix.raft.storage.log.entry.InitialEntry;
-import io.atomix.raft.storage.log.entry.MemberType;
-import io.atomix.raft.storage.log.entry.MessageHeaderDecoder;
-import io.atomix.raft.storage.log.entry.MessageHeaderEncoder;
 import io.atomix.raft.storage.log.entry.RaftEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
-import io.atomix.raft.storage.log.entry.RaftLogEntryDecoder;
-import io.atomix.raft.storage.log.entry.RaftLogEntryEncoder;
+import io.atomix.raft.storage.serializer.ConfigurationEntryDecoder.RaftMemberDecoder;
 import java.time.Instant;
 import java.util.ArrayList;
 import org.agrona.DirectBuffer;
@@ -166,36 +159,6 @@ public class RaftEntrySBESerializer implements RaftEntrySerializer {
     raftLogEntryEncoder.type(entryType);
 
     return headerEncoder.encodedLength() + raftLogEntryEncoder.encodedLength();
-  }
-
-  private MemberType getSBEType(final RaftMember.Type type) {
-    switch (type) {
-      case ACTIVE:
-        return MemberType.ACTIVE;
-      case PASSIVE:
-        return MemberType.PASSIVE;
-      case INACTIVE:
-        return MemberType.INACTIVE;
-      case PROMOTABLE:
-        return MemberType.PROMOTABLE;
-      default:
-        throw new IllegalStateException("Unexpected member type");
-    }
-  }
-
-  private RaftMember.Type getRaftMemberType(final MemberType type) {
-    switch (type) {
-      case ACTIVE:
-        return RaftMember.Type.ACTIVE;
-      case PASSIVE:
-        return RaftMember.Type.PASSIVE;
-      case INACTIVE:
-        return RaftMember.Type.INACTIVE;
-      case PROMOTABLE:
-        return RaftMember.Type.PROMOTABLE;
-      default:
-        throw new IllegalStateException("Unexpected member type " + type);
-    }
   }
 
   private ApplicationEntry readApplicationEntry(final DirectBuffer buffer, final int entryOffset) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/RaftEntrySerializer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.raft.storage.log;
+package io.atomix.raft.storage.serializer;
 
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.ConfigurationEntry;

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/SerializerUtil.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/SerializerUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.storage.serializer;
+
+import io.atomix.raft.cluster.RaftMember;
+
+public class SerializerUtil {
+
+  static MemberType getSBEType(final RaftMember.Type type) {
+    switch (type) {
+      case ACTIVE:
+        return MemberType.ACTIVE;
+      case PASSIVE:
+        return MemberType.PASSIVE;
+      case INACTIVE:
+        return MemberType.INACTIVE;
+      case PROMOTABLE:
+        return MemberType.PROMOTABLE;
+      default:
+        throw new IllegalStateException("Unexpected member type");
+    }
+  }
+
+  static RaftMember.Type getRaftMemberType(final MemberType type) {
+    switch (type) {
+      case ACTIVE:
+        return RaftMember.Type.ACTIVE;
+      case PASSIVE:
+        return RaftMember.Type.PASSIVE;
+      case INACTIVE:
+        return RaftMember.Type.INACTIVE;
+      case PROMOTABLE:
+        return RaftMember.Type.PROMOTABLE;
+      default:
+        throw new IllegalStateException("Unexpected member type " + type);
+    }
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
@@ -22,7 +22,6 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.serializer.MetaStoreSerializer;
 import io.atomix.storage.StorageException;
-import io.atomix.utils.serializer.Serializer;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -53,7 +52,7 @@ public class MetaStore implements AutoCloseable {
   private final File confFile;
   private final MetaStoreSerializer serializer = new MetaStoreSerializer();
 
-  public MetaStore(final RaftStorage storage, final Serializer serializer) throws IOException {
+  public MetaStore(final RaftStorage storage) throws IOException {
     if (!(storage.directory().isDirectory() || storage.directory().mkdirs())) {
       throw new IllegalArgumentException(
           String.format("Can't create storage directory [%s].", storage.directory()));

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
@@ -17,14 +17,20 @@
 package io.atomix.raft.storage.system;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.storage.RaftStorage;
-import io.atomix.storage.buffer.Buffer;
-import io.atomix.storage.buffer.FileBuffer;
+import io.atomix.raft.storage.serializer.MetaStoreSerializer;
+import io.atomix.storage.StorageException;
 import io.atomix.utils.serializer.Serializer;
 import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.IoUtil;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,13 +46,14 @@ import org.slf4j.LoggerFactory;
 public class MetaStore implements AutoCloseable {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
-  private final Serializer serializer;
-  private final FileBuffer metadataBuffer;
-  private final Buffer configurationBuffer;
+  private final FileChannel metaFileChannel;
+  private final ByteBuffer metaBuffer = ByteBuffer.allocate(256);
+  private final FileChannel configurationChannel;
+  private final File metaFile;
+  private final File confFile;
+  private final MetaStoreSerializer serializer = new MetaStoreSerializer();
 
-  public MetaStore(final RaftStorage storage, final Serializer serializer) {
-    this.serializer = checkNotNull(serializer, "serializer cannot be null");
-
+  public MetaStore(final RaftStorage storage, final Serializer serializer) throws IOException {
     if (!(storage.directory().isDirectory() || storage.directory().mkdirs())) {
       throw new IllegalArgumentException(
           String.format("Can't create storage directory [%s].", storage.directory()));
@@ -54,11 +61,22 @@ public class MetaStore implements AutoCloseable {
 
     // Note that for raft safety, irrespective of the storage level, <term, vote> metadata is always
     // persisted on disk.
-    final File metaFile = new File(storage.directory(), String.format("%s.meta", storage.prefix()));
-    metadataBuffer = FileBuffer.allocate(metaFile, 12);
+    metaFile = new File(storage.directory(), String.format("%s.meta", storage.prefix()));
+    if (!metaFile.exists()) {
+      metaFileChannel = IoUtil.createEmptyFile(metaFile, 32, true);
+    } else {
+      metaFileChannel =
+          FileChannel.open(metaFile.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE);
+    }
 
-    final File confFile = new File(storage.directory(), String.format("%s.conf", storage.prefix()));
-    configurationBuffer = FileBuffer.allocate(confFile, 32);
+    confFile = new File(storage.directory(), String.format("%s.conf", storage.prefix()));
+
+    if (!confFile.exists()) {
+      configurationChannel = IoUtil.createEmptyFile(confFile, 32, true);
+    } else {
+      configurationChannel =
+          FileChannel.open(confFile.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE);
+    }
   }
 
   /**
@@ -68,7 +86,13 @@ public class MetaStore implements AutoCloseable {
    */
   public synchronized void storeTerm(final long term) {
     log.trace("Store term {}", term);
-    metadataBuffer.writeLong(0, term).flush();
+    serializer.writeTerm(term, new UnsafeBuffer(metaBuffer));
+    try {
+      metaFileChannel.write(metaBuffer, 0);
+      metaFileChannel.force(true);
+    } catch (final IOException e) {
+      throw new StorageException(e);
+    }
   }
 
   /**
@@ -77,7 +101,12 @@ public class MetaStore implements AutoCloseable {
    * @return The stored server term.
    */
   public synchronized long loadTerm() {
-    return metadataBuffer.readLong(0);
+    try {
+      metaFileChannel.read(metaBuffer, 0);
+    } catch (final IOException e) {
+      throw new StorageException(e);
+    }
+    return serializer.readTerm(new UnsafeBuffer(metaBuffer));
   }
 
   /**
@@ -87,7 +116,14 @@ public class MetaStore implements AutoCloseable {
    */
   public synchronized void storeVote(final MemberId vote) {
     log.trace("Store vote {}", vote);
-    metadataBuffer.writeString(8, vote != null ? vote.id() : null).flush();
+    try {
+      final String id = vote == null ? null : vote.id();
+      serializer.writeVotedFor(id, new UnsafeBuffer(metaBuffer));
+      metaFileChannel.write(metaBuffer, 0);
+      metaFileChannel.force(true);
+    } catch (final IOException e) {
+      throw new StorageException(e);
+    }
   }
 
   /**
@@ -96,8 +132,13 @@ public class MetaStore implements AutoCloseable {
    * @return The last vote for the server.
    */
   public synchronized MemberId loadVote() {
-    final String id = metadataBuffer.readString(8);
-    return id != null ? MemberId.from(id) : null;
+    try {
+      metaFileChannel.read(metaBuffer, 0);
+    } catch (final IOException e) {
+      throw new StorageException(e);
+    }
+    final String id = serializer.readVotedFor(new UnsafeBuffer(metaBuffer));
+    return id.isEmpty() ? null : MemberId.from(id);
   }
 
   /**
@@ -107,9 +148,17 @@ public class MetaStore implements AutoCloseable {
    */
   public synchronized void storeConfiguration(final Configuration configuration) {
     log.trace("Store configuration {}", configuration);
-    final byte[] bytes = serializer.encode(configuration);
-    configurationBuffer.position(0).writeByte(1).writeInt(bytes.length).write(bytes);
-    configurationBuffer.flush();
+    final ExpandableArrayBuffer serializedBuffer = new ExpandableArrayBuffer();
+    final var serializedLength = serializer.writeConfiguration(configuration, serializedBuffer, 0);
+
+    final ByteBuffer buffer = ByteBuffer.allocate(serializedLength);
+    serializedBuffer.getBytes(0, buffer, 0, serializedLength);
+    try {
+      configurationChannel.write(buffer, 0);
+      configurationChannel.force(true);
+    } catch (final IOException e) {
+      throw new StorageException(e);
+    }
   }
 
   /**
@@ -118,20 +167,25 @@ public class MetaStore implements AutoCloseable {
    * @return The current cluster configuration.
    */
   public synchronized Configuration loadConfiguration() {
-    if (configurationBuffer.position(0).readByte() == 1) {
-      final int bytesLength = configurationBuffer.readInt();
-      if (bytesLength == 0) {
-        return null;
-      }
-      return serializer.decode(configurationBuffer.readBytes(bytesLength));
+    try {
+      configurationChannel.position(0);
+      final ByteBuffer buffer = ByteBuffer.allocate((int) confFile.length());
+      configurationChannel.read(buffer);
+      buffer.position(0);
+      return serializer.readConfiguration(new UnsafeBuffer(buffer), 0);
+    } catch (final IOException e) {
+      throw new StorageException(e);
     }
-    return null;
   }
 
   @Override
   public synchronized void close() {
-    metadataBuffer.close();
-    configurationBuffer.close();
+    try {
+      metaFileChannel.close();
+      configurationChannel.close();
+    } catch (final IOException e) {
+      log.warn("Failed to close metastore", e);
+    }
   }
 
   @Override

--- a/atomix/cluster/src/main/resources/raft-entry-schema.xml
+++ b/atomix/cluster/src/main/resources/raft-entry-schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude"
-  package="io.atomix.raft.storage.log.entry" id="8" version="1"
+  package="io.atomix.raft.storage.serializer" id="8" version="1"
   semanticVersion="0.1.0" description="Raft Entry" byteOrder="littleEndian">
 
   <xi:include href="../../../../../protocol/src/main/resources/common-types.xml"/>
@@ -15,6 +15,7 @@
     </enum>
   </types>
 
+  <!--  Raft log entries -->
   <types>
     <enum name="EntryType" encodingType="uint8">
       <validValue name="ApplicationEntry">0</validValue>
@@ -51,4 +52,22 @@
       <data name="memberId" id="3" type="varDataEncoding"/>
     </group>
   </sbe:message>
+
+  <!-- MetaStore -->
+  <sbe:message name="Configuration" id="5">
+    <field name="index" id="0" type="uint64"/>
+    <field name="term" id="1" type="uint64"/>
+    <field name="timestamp" id="2" type="uint64"/>
+    <group name="RaftMember" id="3">
+      <field name="type" id="1" type="MemberType"/>
+      <field name="updated" id="2" type="int64"/>
+      <data name="memberId" id="3" type="varDataEncoding"/>
+    </group>
+  </sbe:message>
+
+  <sbe:message name="Meta" id="6">
+    <field name="term" id="0" type="uint64"/>
+    <data name="votedFor" id="1" type="varDataEncoding"/>
+  </sbe:message>
+
 </sbe:messageSchema>

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.mock;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.partition.impl.RaftNamespaces;
 import io.atomix.raft.protocol.ControllableRaftServerProtocol;
 import io.atomix.raft.roles.LeaderRole;
 import io.atomix.raft.snapshot.TestSnapshotStore;
@@ -187,8 +186,7 @@ public final class ControllableRaftContexts {
             .withDirectory(memberDirectory)
             .withMaxSegmentSize(1024 * 10)
             .withFreeDiskSpace(100)
-            .withSnapshotStore(new TestSnapshotStore(new AtomicReference<>()))
-            .withNamespace(RaftNamespaces.RAFT_STORAGE);
+            .withSnapshotStore(new TestSnapshotStore(new AtomicReference<>()));
     return configurator.apply(defaults).build();
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -24,7 +24,6 @@ import io.atomix.raft.RaftServer.Builder;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.partition.impl.RaftNamespaces;
 import io.atomix.raft.primitive.TestMember;
 import io.atomix.raft.protocol.TestRaftProtocolFactory;
 import io.atomix.raft.protocol.TestRaftServerProtocol;
@@ -483,8 +482,7 @@ public final class RaftRule extends ExternalResource {
             .withSnapshotStore(
                 snapshotStores.compute(
                     memberId.id(),
-                    (k, v) -> new TestSnapshotStore(getOrCreatePersistedSnapshot(memberId.id()))))
-            .withNamespace(RaftNamespaces.RAFT_STORAGE);
+                    (k, v) -> new TestSnapshotStore(getOrCreatePersistedSnapshot(memberId.id()))));
     return configurator.apply(defaults).build();
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -35,7 +35,6 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.metrics.RaftRoleMetrics;
-import io.atomix.raft.partition.impl.RaftNamespaces;
 import io.atomix.raft.primitive.TestMember;
 import io.atomix.raft.protocol.TestRaftProtocolFactory;
 import io.atomix.raft.protocol.TestRaftServerProtocol;
@@ -191,8 +190,7 @@ public class RaftTest extends ConcurrentTestCase {
         RaftStorage.builder()
             .withDirectory(directory)
             .withSnapshotStore(new TestSnapshotStore(new AtomicReference<>()))
-            .withMaxSegmentSize(1024 * 10)
-            .withNamespace(RaftNamespaces.RAFT_STORAGE);
+            .withMaxSegmentSize(1024 * 10);
     return configurator.apply(defaults).build();
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -26,10 +26,6 @@ import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.PersistedRaftRecord;
 import io.atomix.raft.storage.log.RaftLog;
-import io.atomix.raft.storage.log.entry.ApplicationEntry;
-import io.atomix.utils.serializer.Namespace;
-import io.atomix.utils.serializer.Namespace.Builder;
-import io.atomix.utils.serializer.Namespaces;
 import io.zeebe.snapshots.raft.PersistedSnapshot;
 import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
 import java.io.IOException;
@@ -45,8 +41,6 @@ import org.junit.rules.Timeout;
 
 public class PassiveRoleTest {
 
-  private static final Namespace NAMESPACE =
-      new Builder().register(Namespaces.BASIC).register(ApplicationEntry.class).build();
   @Rule public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private RaftLog log;
@@ -55,7 +49,6 @@ public class PassiveRoleTest {
   @Before
   public void setup() throws IOException {
     final RaftStorage storage = mock(RaftStorage.class);
-    when(storage.namespace()).thenReturn(NAMESPACE);
 
     log = RaftLog.builder().withDirectory(temporaryFolder.newFolder("data")).build();
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/serializer/RaftEntrySBESerializerTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/serializer/RaftEntrySBESerializerTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.raft.storage.log;
+package io.atomix.raft.storage.serializer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -21,9 +21,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
-import io.atomix.raft.partition.impl.RaftNamespaces;
 import io.atomix.raft.storage.RaftStorage;
-import io.atomix.utils.serializer.Serializer;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -42,7 +40,7 @@ public class MetaStoreTest {
   @Before
   public void setup() throws IOException {
     storage = RaftStorage.builder().withDirectory(temporaryFolder.newFolder("store")).build();
-    metaStore = new MetaStore(storage, Serializer.using(RaftNamespaces.RAFT_STORAGE));
+    metaStore = new MetaStore(storage);
   }
 
   @Test
@@ -100,7 +98,7 @@ public class MetaStoreTest {
 
     // when
     metaStore.close();
-    metaStore = new MetaStore(storage, Serializer.using(RaftNamespaces.RAFT_STORAGE));
+    metaStore = new MetaStore(storage);
 
     // then
     final Configuration readConfig = metaStore.loadConfiguration();
@@ -119,7 +117,7 @@ public class MetaStoreTest {
 
     // when
     metaStore.close();
-    metaStore = new MetaStore(storage, Serializer.using(RaftNamespaces.RAFT_STORAGE));
+    metaStore = new MetaStore(storage);
 
     // then
     assertThat(metaStore.loadTerm()).isEqualTo(2L);
@@ -132,7 +130,7 @@ public class MetaStoreTest {
 
     // when
     metaStore.close();
-    metaStore = new MetaStore(storage, Serializer.using(RaftNamespaces.RAFT_STORAGE));
+    metaStore = new MetaStore(storage);
 
     // then
     assertThat(metaStore.loadVote().id()).isEqualTo("id");

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.storage.system;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.RaftMember;
+import io.atomix.raft.cluster.RaftMember.Type;
+import io.atomix.raft.cluster.impl.DefaultRaftMember;
+import io.atomix.raft.partition.impl.RaftNamespaces;
+import io.atomix.raft.storage.RaftStorage;
+import io.atomix.utils.serializer.Serializer;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class MetaStoreTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private MetaStore metaStore;
+  private RaftStorage storage;
+
+  @Before
+  public void setup() throws IOException {
+    storage = RaftStorage.builder().withDirectory(temporaryFolder.newFolder("store")).build();
+    metaStore = new MetaStore(storage, Serializer.using(RaftNamespaces.RAFT_STORAGE));
+  }
+
+  @Test
+  public void shouldStoreAndLoadConfiguration() throws IOException {
+    // given
+    final Configuration config = getConfiguration();
+    metaStore.storeConfiguration(config);
+
+    // when
+    final Configuration readConfig = metaStore.loadConfiguration();
+
+    // then
+    assertThat(readConfig.index()).isEqualTo(config.index());
+    assertThat(readConfig.term()).isEqualTo(config.term());
+    assertThat(readConfig.time()).isEqualTo(config.time());
+    assertThat(readConfig.members())
+        .containsExactlyInAnyOrder(config.members().toArray(new RaftMember[0]));
+  }
+
+  private Configuration getConfiguration() {
+    return new Configuration(
+        1,
+        2,
+        1234L,
+        new ArrayList<>(
+            Set.of(
+                new DefaultRaftMember(MemberId.from("0"), Type.ACTIVE, Instant.ofEpochMilli(12345)),
+                new DefaultRaftMember(
+                    MemberId.from("2"), Type.PASSIVE, Instant.ofEpochMilli(12346)))));
+  }
+
+  @Test
+  public void shouldStoreAndLoadTerm() throws IOException {
+    // when
+    metaStore.storeTerm(2L);
+
+    // then
+    assertThat(metaStore.loadTerm()).isEqualTo(2L);
+  }
+
+  @Test
+  public void shouldStoreAndLoadVote() throws IOException {
+    // when
+    metaStore.storeVote(new MemberId("id"));
+
+    // then
+    assertThat(metaStore.loadVote().id()).isEqualTo("id");
+  }
+
+  @Test
+  public void shouldLoadExistingConfiguration() throws IOException {
+    // given
+    final Configuration config = getConfiguration();
+    metaStore.storeConfiguration(config);
+
+    // when
+    metaStore.close();
+    metaStore = new MetaStore(storage, Serializer.using(RaftNamespaces.RAFT_STORAGE));
+
+    // then
+    final Configuration readConfig = metaStore.loadConfiguration();
+
+    assertThat(readConfig.index()).isEqualTo(config.index());
+    assertThat(readConfig.term()).isEqualTo(config.term());
+    assertThat(readConfig.time()).isEqualTo(config.time());
+    assertThat(readConfig.members())
+        .containsExactlyInAnyOrder(config.members().toArray(new RaftMember[0]));
+  }
+
+  @Test
+  public void shouldLoadExistingTerm() throws IOException {
+    // given
+    metaStore.storeTerm(2L);
+
+    // when
+    metaStore.close();
+    metaStore = new MetaStore(storage, Serializer.using(RaftNamespaces.RAFT_STORAGE));
+
+    // then
+    assertThat(metaStore.loadTerm()).isEqualTo(2L);
+  }
+
+  @Test
+  public void shouldLoadExistingVote() throws IOException {
+    // given
+    metaStore.storeVote(new MemberId("id"));
+
+    // when
+    metaStore.close();
+    metaStore = new MetaStore(storage, Serializer.using(RaftNamespaces.RAFT_STORAGE));
+
+    // then
+    assertThat(metaStore.loadVote().id()).isEqualTo("id");
+  }
+
+  @Test
+  public void shouldLoadEmptyMeta() {
+    // when -then
+    assertThat(metaStore.loadVote()).isNull();
+
+    // when - then
+    assertThat(metaStore.loadTerm()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldLoadEmptyVoteWhenTermExists() {
+    // given
+    metaStore.storeTerm(1);
+
+    // when - then
+    assertThat(metaStore.loadVote()).isNull();
+  }
+
+  @Test
+  public void shouldLoadEmptyConfig() {
+    // when -then
+    assertThat(metaStore.loadConfiguration()).isNull();
+  }
+}

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
@@ -9,7 +9,6 @@ package io.zeebe.logstreams.util;
 
 import static org.mockito.Mockito.spy;
 
-import io.atomix.raft.partition.impl.RaftNamespaces;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
@@ -237,10 +236,7 @@ public final class AtomixLogStorageRule extends ExternalResource
   }
 
   private RaftStorage.Builder buildDefaultStorage() {
-    return RaftStorage.builder()
-        .withFlushExplicitly(true)
-        .withNamespace(RaftNamespaces.RAFT_STORAGE)
-        .withJournalIndexDensity(1);
+    return RaftStorage.builder().withFlushExplicitly(true).withJournalIndexDensity(1);
   }
 
   private static final class NoopListener implements AppendListener {


### PR DESCRIPTION
## Description

* Use sbe in metastore
   * Define sbe templates for meta data (term, lastVoted) stored in Metastore
   * Define sbe templates for configuration stored in metastore
   * Added a serializer class
* Add test for Metastore
* Remove Kryo namespace from Raft storage, as it is no longer used in storage.

## Related issues

closes #6680 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
