### PR TITLE
Support Elasticsearch 7

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -101,7 +101,7 @@ pvcStorageClassName: ssd
 # ELASTIC
 elasticsearch:
   enabled: true
-  imageTag: 6.8.5
+  imageTag: 7.12.0
 
   replicas: 3
   minimumMasterNodes: 2

--- a/exporters/elasticsearch-exporter/docker-compose.yml
+++ b/exporters/elasticsearch-exporter/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         environment:
             - discovery.type=single-node
             - cluster.name=test
+            - ES_JAVA_OPTS=-Xmx750m -Xms750m
 
     kibana:
         image: docker.elastic.co/kibana/kibana:7.12.0

--- a/exporters/elasticsearch-exporter/docker-compose.yml
+++ b/exporters/elasticsearch-exporter/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.12.0
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.12.0
         ports:
             - "9200:9200"
             - "9300:9300"
@@ -11,7 +11,7 @@ services:
             - cluster.name=test
 
     kibana:
-        image: docker.elastic.co/kibana/kibana-oss:7.12.0
+        image: docker.elastic.co/kibana/kibana:7.12.0
         ports:
             - "5601:5601"
         links:

--- a/exporters/elasticsearch-exporter/docker-compose.yml
+++ b/exporters/elasticsearch-exporter/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.14
+        image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.12.0
         ports:
             - "9200:9200"
             - "9300:9300"
@@ -11,7 +11,7 @@ services:
             - cluster.name=test
 
     kibana:
-        image: docker.elastic.co/kibana/kibana-oss:6.8.14
+        image: docker.elastic.co/kibana/kibana-oss:7.12.0
         ports:
             - "5601:5601"
         links:

--- a/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
@@ -48,7 +48,7 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
 
   @Before
   public void setUp() {
-    elastic = new ElasticsearchContainer();
+    elastic = new ElasticsearchContainer().withEnv("ES_JAVA_OPTS", "-Xms750m -Xmx750m");
   }
 
   @After

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,7 +45,7 @@
     <version.commons-math>3.6.1</version.commons-math>
     <version.commons-codec>1.15</version.commons-codec>
     <version.docker-java-api>3.2.8</version.docker-java-api>
-    <version.elasticsearch>6.8.15</version.elasticsearch>
+    <version.elasticsearch>7.12.0</version.elasticsearch>
     <version.error-prone>2.6.0</version.error-prone>
     <version.grpc>1.37.0</version.grpc>
     <version.gson>2.8.6</version.gson>


### PR DESCRIPTION
## Description

This change updates the used Elasticsearch version to 7.

## Related issues

closes #3445 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
