### PR TITLE
Introduce ProcessEvent record

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -62,6 +62,7 @@ public final class MigratedStreamProcessors {
     MIGRATED_VALUE_TYPES.put(ValueType.VARIABLE, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.INCIDENT, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.TIMER, MIGRATED);
+    MIGRATED_VALUE_TYPES.put(ValueType.PROCESS_EVENT, MIGRATED);
   }
 
   private MigratedStreamProcessors() {}

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/TypedEventRegistry.java
@@ -19,6 +19,7 @@ import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import io.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
@@ -55,6 +56,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.PROCESS_INSTANCE_RESULT, ProcessInstanceResultRecord.class);
     registry.put(ValueType.PROCESS, ProcessRecord.class);
     registry.put(ValueType.DEPLOYMENT_DISTRIBUTION, DeploymentDistributionRecord.class);
+    registry.put(ValueType.PROCESS_EVENT, ProcessEventRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
   }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -21,6 +21,7 @@ import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.protocol.record.intent.MessageIntent;
 import io.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.protocol.record.intent.ProcessIntent;
 import io.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
@@ -68,6 +69,7 @@ public final class EventAppliers implements EventApplier {
     registerIncidentEventAppliers(state);
     registerProcessMessageSubscriptionEventAppliers(state);
     registerTimeEventAppliers(state);
+    registerProcessEventAppliers(state);
   }
 
   private void registerTimeEventAppliers(final MutableZeebeState state) {
@@ -202,6 +204,12 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessMessageSubscriptionIntent.DELETED,
         new ProcessMessageSubscriptionDeletedApplier(state.getProcessMessageSubscriptionState()));
+  }
+
+  private void registerProcessEventAppliers(final MutableZeebeState state) {
+    register(
+        ProcessEventIntent.TRIGGERED,
+        new ProcessEventTriggeredApplier(state.getEventScopeInstanceState()));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessEventTriggeredApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessEventTriggeredApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
+import io.zeebe.protocol.record.intent.ProcessEventIntent;
+
+final class ProcessEventTriggeredApplier
+    implements TypedEventApplier<ProcessEventIntent, ProcessEventRecord> {
+  private final MutableEventScopeInstanceState eventScopeState;
+
+  public ProcessEventTriggeredApplier(final MutableEventScopeInstanceState eventScopeState) {
+    this.eventScopeState = eventScopeState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessEventRecord value) {
+    eventScopeState.triggerEvent(
+        value.getScopeKey(), key, value.getTargetElementIdBuffer(), value.getVariablesBuffer());
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableEventScopeInstanceState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableEventScopeInstanceState.java
@@ -61,6 +61,8 @@ public interface MutableEventScopeInstanceState extends EventScopeInstanceState 
    * @param variables the variables of the occurred event, i.e. message variables
    * @return true if the event was accepted by the event scope, false otherwise
    */
+  // TODO: once only the event appliers are calling this, change signature to void as the processors
+  // should have checked that the event could be triggered (#6202)
   boolean triggerEvent(
       long eventScopeKey, long eventKey, DirectBuffer elementId, DirectBuffer variables);
 

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/processinstance/ProcessEventRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/processinstance/ProcessEventRecord.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.protocol.impl.record.value.processinstance;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.zeebe.msgpack.property.DocumentProperty;
+import io.zeebe.msgpack.property.LongProperty;
+import io.zeebe.msgpack.property.StringProperty;
+import io.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.zeebe.protocol.record.value.ProcessEventRecordValue;
+import io.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+
+@SuppressWarnings("java:S2160")
+public final class ProcessEventRecord extends UnifiedRecordValue
+    implements ProcessEventRecordValue {
+  private final LongProperty scopeKeyProperty = new LongProperty("scopeKey");
+  private final StringProperty targetElementIdProperty = new StringProperty("targetElementId");
+  private final DocumentProperty variablesProperty = new DocumentProperty("variables");
+  private final LongProperty processDefinitionKeyProperty =
+      new LongProperty("processDefinitionKey", -1);
+  private final LongProperty processInstanceKeyProperty =
+      new LongProperty("processInstanceKey", -1);
+
+  public ProcessEventRecord() {
+    declareProperty(scopeKeyProperty)
+        .declareProperty(targetElementIdProperty)
+        .declareProperty(variablesProperty)
+        .declareProperty(processDefinitionKeyProperty)
+        .declareProperty(processInstanceKeyProperty);
+  }
+
+  public ProcessEventRecord wrap(final ProcessEventRecord record) {
+    scopeKeyProperty.setValue(record.getScopeKey());
+    targetElementIdProperty.setValue(record.getTargetElementIdBuffer());
+    variablesProperty.setValue(record.getVariablesBuffer());
+    processDefinitionKeyProperty.setValue(record.getProcessDefinitionKey());
+    processInstanceKeyProperty.setValue(record.getProcessInstanceKey());
+
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getTargetElementIdBuffer() {
+    return targetElementIdProperty.getValue();
+  }
+
+  public ProcessEventRecord setTargetElementIdBuffer(final DirectBuffer targetElementIdBuffer) {
+    targetElementIdProperty.setValue(targetElementIdBuffer);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variablesProperty.getValue();
+  }
+
+  public ProcessEventRecord setVariablesBuffer(final DirectBuffer variablesBuffer) {
+    variablesProperty.setValue(variablesBuffer);
+    return this;
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return MsgPackConverter.convertToMap(getVariablesBuffer());
+  }
+
+  @Override
+  public long getScopeKey() {
+    return scopeKeyProperty.getValue();
+  }
+
+  public ProcessEventRecord setScopeKey(final long scopeKey) {
+    scopeKeyProperty.setValue(scopeKey);
+    return this;
+  }
+
+  @Override
+  public String getTargetElementId() {
+    return BufferUtil.bufferAsString(getTargetElementIdBuffer());
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProperty.getValue();
+  }
+
+  public ProcessEventRecord setProcessDefinitionKey(final long processDefinitionKey) {
+    processDefinitionKeyProperty.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  public ProcessEventRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
+  }
+}

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/Intent.java
@@ -36,7 +36,8 @@ public interface Intent {
           ProcessInstanceCreationIntent.class,
           ErrorIntent.class,
           ProcessIntent.class,
-          DeploymentDistributionIntent.class);
+          DeploymentDistributionIntent.class,
+          ProcessEventIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN =
       new Intent() {
@@ -91,6 +92,8 @@ public interface Intent {
         return ProcessIntent.from(intent);
       case DEPLOYMENT_DISTRIBUTION:
         return DeploymentDistributionIntent.from(intent);
+      case PROCESS_EVENT:
+        return ProcessEventIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -138,6 +141,8 @@ public interface Intent {
         return ProcessIntent.valueOf(intent);
       case DEPLOYMENT_DISTRIBUTION:
         return DeploymentDistributionIntent.valueOf(intent);
+      case PROCESS_EVENT:
+        return ProcessEventIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/ProcessEventIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/ProcessEventIntent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.protocol.record.intent;
+
+public enum ProcessEventIntent implements ProcessInstanceRelatedIntent {
+  TRIGGERED((short) 0);
+
+  private final short value;
+
+  ProcessEventIntent(final short value) {
+    this.value = value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  // suppress as it's simpler to have a short switch for extension later
+  @SuppressWarnings({"SwitchStatementWithTooFewBranches", "java:S1301"})
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return TRIGGERED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+
+  @Override
+  public boolean shouldBlacklistInstanceOnError() {
+    return true;
+  }
+}

--- a/protocol/src/main/java/io/zeebe/protocol/record/value/ProcessEventRecordValue.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/value/ProcessEventRecordValue.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.protocol.record.value;
+
+import io.zeebe.protocol.record.RecordValueWithVariables;
+
+/**
+ * Represents a signal that an event was triggered in a process instance, within a given scope, and
+ * targeting a particular element identified by its ID.
+ *
+ * <p>The scope here can refer to a process definition (for start events), or to a specific element
+ * instance, e.g. an activity. Note that the scope may be (and usually is) a different element
+ * instance than the one identified by the {@link #getTargetElementId()}.
+ *
+ * <p>The target element ID refer to the element which should receive the payload of the event, e.g.
+ * the boundary event, or the start event. For example, if the scope is a sub process, then the
+ * target element ID could refer to one of its boundary events.
+ *
+ * <p>NOTE: this record is optional, and events can be triggered without this record being emitted.
+ * It's meant to be used mostly when the scope and/or target element of the event is far removed
+ * from the emitter (e.g. error throw end event, escalation), and there is no special purpose entity
+ * associated with the emitter (e.g. timer, message).
+ */
+public interface ProcessEventRecordValue extends RecordValueWithVariables, ProcessInstanceRelated {
+
+  /** @return the key identifying the event's scope */
+  long getScopeKey();
+
+  /** @return the ID of the element which should react to the event */
+  String getTargetElementId();
+
+  /** @return the key of the deployed process this instance belongs to. */
+  long getProcessDefinitionKey();
+}

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -38,6 +38,7 @@
       <validValue name="PROCESS_INSTANCE_RESULT">21</validValue>
       <validValue name="PROCESS">22</validValue>
       <validValue name="DEPLOYMENT_DISTRIBUTION">23</validValue>
+      <validValue name="PROCESS_EVENT">24</validValue>
     </enum>
 
     <enum name="RecordType" encodingType="uint8">


### PR DESCRIPTION
## Description

This PR introduces a new `ProcessEvent`. Please read the original issue for motivation. While the new record isn't used in this PR, I decided to split it off from #6716. You can see how it will be used in that PR, specifically in [ba94d20c09a2f98860d02cbc49b925fa6a5ef07a](https://github.com/camunda-cloud/zeebe/pull/6716/commits/ba94d20c09a2f98860d02cbc49b925fa6a5ef07a).

Example of the compacted log:

```
E PROC_EVNT          TRIGGERED      - #24->#21 K11 -  @"errorCatchEvent"[K07] in <process K01[K03]> (no vars)
```

## Related issues

closes #6737 

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
