### PR TITLE
chore(benchmarks): run curator on space

### DIFF
--- a/benchmarks/setup/default/curator-configmap.yaml
+++ b/benchmarks/setup/default/curator-configmap.yaml
@@ -23,16 +23,10 @@ data:
           disable_action: False
           ignore_empty_list: True
         filters:
-        - filtertype: age
+        - filtertype: space
+          disk_space: 10
           source: name
-          direction: older
           timestring: '%Y-%m-%d'
-          unit: days
-          unit_count: 1
-          field:
-          stats_result:
-          epoch:
-          exclude: False
   config.yml: |-
     ---
     # Remember, leave a key empty if there is no value.  None will be a string,

--- a/benchmarks/setup/default/curator-configmap.yaml
+++ b/benchmarks/setup/default/curator-configmap.yaml
@@ -14,7 +14,28 @@ data:
     # want to use this action as a template, be sure to set this to False after
     # copying it.
     actions:
+      # delete indicies which are older then one day
       1:
+        action: delete_indices
+        description: "Clean up ES by deleting old indices"
+        options:
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+          ignore_empty_list: True
+        filters:
+        - filtertype: age
+          source: name
+          direction: older
+          timestring: '%Y-%m-%d'
+          unit: days
+          unit_count: 1
+          field:
+          stats_result:
+          epoch:
+          exclude: False
+      # or delete indicies which exceed the total size of 10 gig
+      2:
         action: delete_indices
         description: "Clean up ES by deleting old indices"
         options:

--- a/benchmarks/setup/default/curator-cronjob.yaml
+++ b/benchmarks/setup/default/curator-cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: curator
 spec:
-  schedule: "0 3 * * *" # run every 03:00 AM daily
+  schedule: "*/15 * * * *" # at every 15th minute
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid

--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -111,7 +111,7 @@ elasticsearch:
     storageClassName: "ssd"
     resources:
       requests:
-        storage: 600Gi
+        storage: 50Gi
 
   esJavaOpts: "-Xmx4g -Xms4g"
 


### PR DESCRIPTION
## Description

 Runs curator based on space instead of time. Will trigger the curator every 15 minutes and delete the indices if they are larger then 10 gigs. Reduces the elastic disk size by factor 12.

![perf2](https://user-images.githubusercontent.com/2758593/113916388-32761500-97e0-11eb-9651-253f7dd86d70.png)
![perf](https://user-images.githubusercontent.com/2758593/113916389-33a74200-97e0-11eb-9d68-645888f1ac7d.png)
![elastic](https://user-images.githubusercontent.com/2758593/113916390-33a74200-97e0-11eb-94c4-ecd9c47b2888.png)

Fixes the problems of going out of disk with elastic in our benchmarks
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6720

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
