### PR TITLE
Use SBE in journal segment descriptor

### DIFF
--- a/journal/pom.xml
+++ b/journal/pom.xml
@@ -114,7 +114,7 @@
           </executableDependency>
           <mainClass>uk.co.real_logic.sbe.SbeTool</mainClass>
           <arguments>
-            <argument>${project.build.resources[0].directory}/journal-record-schema.xml</argument>
+            <argument>${project.build.resources[0].directory}/journal-schema.xml</argument>
           </arguments>
           <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
           <!-- system properties defined in zeebe-parent -->

--- a/journal/src/main/java/io/zeebe/journal/file/JournalSegment.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalSegment.java
@@ -67,15 +67,6 @@ class JournalSegment implements AutoCloseable {
   }
 
   /**
-   * Returns the segment version.
-   *
-   * @return The segment version.
-   */
-  public long version() {
-    return descriptor.version();
-  }
-
-  /**
    * Returns the segment's starting index.
    *
    * @return The segment's starting index.
@@ -196,10 +187,6 @@ class JournalSegment implements AutoCloseable {
 
   @Override
   public String toString() {
-    return toStringHelper(this)
-        .add("id", id())
-        .add("version", version())
-        .add("index", index())
-        .toString();
+    return toStringHelper(this).add("id", id()).add("index", index()).toString();
   }
 }

--- a/journal/src/main/java/io/zeebe/journal/file/JournalSegmentDescriptor.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalSegmentDescriptor.java
@@ -16,118 +16,105 @@
  */
 package io.zeebe.journal.file;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.nio.ByteBuffer;
+import java.util.Objects;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 /**
- * Stores information about a {@link JournalSegment} of the log.
+ * The segment descriptor stores the metadata of a single segment {@link JournalSegment} of a {@link
+ * SegmentedJournal}. The descriptor is stored in the first bytes of the segment. The number of
+ * bytes requires for the descriptor is dependent on the encoding used. The first byte of the
+ * segment contains the version of the descriptor. The subsequent bytes contains the following
+ * fields encoded using the SBE schema.
  *
- * <p>The segment descriptor manages metadata related to a single segment of the log. Descriptors
- * are stored within the first {@code 64} bytes of each segment in the following order:
+ * <p>{@code id} (64-bit signed integer) - A unique segment identifier. This is a monotonically
+ * increasing number within each journal. Segments with in-sequence identifiers should contain
+ * in-sequence indices.
  *
- * <ul>
- *   <li>{@code id} (64-bit signed integer) - A unique segment identifier. This is a monotonically
- *       increasing number within each log. Segments with in-sequence identifiers should contain
- *       in-sequence indexes.
- *   <li>{@code index} (64-bit signed integer) - The effective first index of the segment. This
- *       indicates the index at which the first entry should be written to the segment. Indexes are
- *       monotonically increasing thereafter.
- *   <li>{@code version} (64-bit signed integer) - The version of the segment. Versions are
- *       monotonically increasing starting at {@code 1}. Versions will only be incremented whenever
- *       the segment is rewritten to another memory/disk space, e.g. after log compaction.
- *   <li>{@code maxSegmentSize} (32-bit unsigned integer) - The maximum number of bytes allowed in
- *       the segment.
- *   <li>{@code maxEntries} (32-bit signed integer) - The total number of expected entries in the
- *       segment. This is the final number of entries allowed within the segment both before and
- *       after compaction. This entry count is used to determine the count of internal indexing and
- *       deduplication facilities.
- *   <li>{@code updated} (64-bit signed integer) - The last update to the segment in terms of
- *       milliseconds since the epoch. When the segment is first constructed, the {@code updated}
- *       time is {@code 0}. Once all entries in the segment have been committed, the {@code updated}
- *       time should be set to the current time. Log compaction should not result in a change to
- *       {@code updated}.
- *   <li>{@code locked} (8-bit boolean) - A boolean indicating whether the segment is locked.
- *       Segments will be locked once all entries have been committed to the segment. The lock state
- *       of each segment is used to determine log compaction and recovery behavior.
- * </ul>
+ * <p><{@code index} (64-bit signed integer) - The effective first index of the segment. This
+ * indicates the index at which the first entry should be written to the segment. Indices are
+ * monotonically increasing thereafter.
  *
- * The remainder of the 64 segment header bytes are reserved for future metadata.
- *
- * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
+ * <p>{@code maxSegmentSize} (32-bit unsigned integer) - The maximum number of bytes allowed in the
+ * segment.
  */
-public final class JournalSegmentDescriptor {
-  public static final int BYTES = 64;
+final class JournalSegmentDescriptor {
 
-  // Current segment version.
-  @VisibleForTesting static final int VERSION = 1;
+  private static final byte VERSION = 1;
+  private static final int VERSION_LENGTH = Byte.BYTES;
 
-  // The lengths of each field in the header.
-  private static final int VERSION_LENGTH = Integer.BYTES; // 32-bit signed integer
-  private static final int ID_LENGTH = Long.BYTES; // 64-bit signed integer
-  private static final int INDEX_LENGTH = Long.BYTES; // 64-bit signed integer
-  private static final int MAX_SIZE_LENGTH = Integer.BYTES; // 32-bit signed integer
-  private static final int MAX_ENTRIES_LENGTH = Integer.BYTES; // 32-bit signed integer
-  private static final int UPDATED_LENGTH = Long.BYTES; // 64-bit signed integer
-
-  // The positions of each field in the header.
-  private static final int VERSION_POSITION = 0; // 0
-  private static final int ID_POSITION = VERSION_POSITION + VERSION_LENGTH; // 4
-  private static final int INDEX_POSITION = ID_POSITION + ID_LENGTH; // 12
-  private static final int MAX_SIZE_POSITION = INDEX_POSITION + INDEX_LENGTH; // 20
-  private static final int MAX_ENTRIES_POSITION = MAX_SIZE_POSITION + MAX_SIZE_LENGTH; // 24
-  private static final int UPDATED_POSITION = MAX_ENTRIES_POSITION + MAX_ENTRIES_LENGTH; // 28
-  private final ByteBuffer buffer;
-  private final int version;
   private final long id;
   private final long index;
   private final int maxSegmentSize;
-  private volatile long updated;
-  private final boolean locked;
-  /** @throws NullPointerException if {@code buffer} is null */
+  private final int encodedLength;
+
+  private final SegmentDescriptorDecoder segmentDescriptorDecoder = new SegmentDescriptorDecoder();
+  private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
+  private final MutableDirectBuffer directBuffer = new UnsafeBuffer();
+
+  private final SegmentDescriptorEncoder segmentDescriptorEncoder = new SegmentDescriptorEncoder();
+  private final MessageHeaderEncoder messageHeaderEncoder = new MessageHeaderEncoder();
+
   public JournalSegmentDescriptor(final ByteBuffer buffer) {
-    this.buffer = buffer;
-    version = buffer.getInt();
-    id = buffer.getLong();
-    index = buffer.getLong();
-    maxSegmentSize = buffer.getInt();
-    updated = buffer.getLong();
-    locked = buffer.get() == 1;
+    directBuffer.wrap(buffer);
+
+    /* The first byte of the buffer contains the version at which the descriptor is written.
+     Currently we have only one version, so we can ignore it. We can use this version in future
+    when needed. Note that we can add fields to SBE schema of the descriptor without changing this version. */
+    messageHeaderDecoder.wrap(directBuffer, VERSION_LENGTH);
+    segmentDescriptorDecoder.wrap(
+        directBuffer,
+        VERSION_LENGTH + messageHeaderDecoder.encodedLength(),
+        messageHeaderDecoder.blockLength(),
+        messageHeaderDecoder.version());
+
+    id = segmentDescriptorDecoder.id();
+    index = segmentDescriptorDecoder.index();
+    maxSegmentSize = segmentDescriptorDecoder.maxSegmentSize();
+    encodedLength =
+        VERSION_LENGTH
+            + messageHeaderDecoder.encodedLength()
+            + segmentDescriptorDecoder.encodedLength();
+  }
+
+  private JournalSegmentDescriptor(final long id, final long index, final int maxSegmentSize) {
+    this.id = id;
+    this.index = index;
+    this.maxSegmentSize = maxSegmentSize;
+    encodedLength = getEncodingLength();
+  }
+
+  /**
+   * The number of bytes taken by the descriptor in the segment is dependent on the encoding used.
+   * The length represents this number of bytes.
+   *
+   * @return the number of bytes taken by this descriptor in the segment.
+   */
+  public int length() {
+    return encodedLength;
+  }
+
+  /**
+   * The number of bytes required to write a descriptor to the segment.
+   *
+   * @return the encoding length
+   */
+  public static int getEncodingLength() {
+    return VERSION_LENGTH
+        + MessageHeaderEncoder.ENCODED_LENGTH
+        + SegmentDescriptorEncoder.BLOCK_LENGTH;
   }
 
   /**
    * Returns a descriptor builder.
    *
-   * <p>The descriptor builder will write segment metadata to a {@code 48} byte in-memory buffer.
-   *
    * @return The descriptor builder.
    */
   public static Builder builder() {
-    return new Builder(ByteBuffer.allocate(BYTES));
-  }
-
-  /**
-   * Returns a descriptor builder for the given descriptor buffer.
-   *
-   * @param buffer The descriptor buffer.
-   * @return The descriptor builder.
-   * @throws NullPointerException if {@code buffer} is null
-   */
-  public static Builder builder(final ByteBuffer buffer) {
-    return new Builder(buffer);
-  }
-
-  /**
-   * Returns the segment version.
-   *
-   * <p>Versions are monotonically increasing starting at {@code 1}.
-   *
-   * @return The segment version.
-   */
-  public int version() {
-    return version;
+    return new Builder();
   }
 
   /**
@@ -155,64 +142,73 @@ public final class JournalSegmentDescriptor {
   }
 
   /**
-   * Returns the maximum count of the segment.
+   * Returns the maximum allowed number of bytes in the segment.
    *
-   * @return The maximum allowed count of the segment.
+   * @return The maximum allowed number of bytes in the segment.
    */
   public int maxSegmentSize() {
     return maxSegmentSize;
   }
 
   /**
-   * Returns last time the segment was updated.
-   *
-   * <p>When the segment is first constructed, the {@code updated} time is {@code 0}. Once all
-   * entries in the segment have been committed, the {@code updated} time should be set to the
-   * current time. Log compaction should not result in a change to {@code updated}.
-   *
-   * @return The last time the segment was updated in terms of milliseconds since the epoch.
+   * Copies the descriptor to a new buffer. The number of bytes written will be equal to {@link
+   * JournalSegmentDescriptor#getEncodingLength()}
    */
-  public long updated() {
-    return updated;
-  }
-
-  /** Writes an update to the descriptor. */
-  public void update(final long timestamp) {
-    if (!locked) {
-      buffer.putLong(UPDATED_POSITION, timestamp);
-      updated = timestamp;
-    }
-  }
-
-  /** Copies the segment to a new buffer. */
   JournalSegmentDescriptor copyTo(final ByteBuffer buffer) {
-    buffer.putInt(version);
-    buffer.putLong(id);
-    buffer.putLong(index);
-    buffer.putInt(maxSegmentSize);
-    buffer.putLong(updated);
-    buffer.put(locked ? (byte) 1 : (byte) 0);
+    directBuffer.wrap(buffer);
+    directBuffer.putByte(0, VERSION);
+
+    messageHeaderEncoder
+        .wrap(directBuffer, VERSION_LENGTH)
+        .blockLength(segmentDescriptorEncoder.sbeBlockLength())
+        .templateId(segmentDescriptorEncoder.sbeTemplateId())
+        .schemaId(segmentDescriptorEncoder.sbeSchemaId())
+        .version(segmentDescriptorEncoder.sbeSchemaVersion());
+
+    segmentDescriptorEncoder
+        .wrap(directBuffer, VERSION_LENGTH + messageHeaderEncoder.encodedLength())
+        .id(id)
+        .index(index)
+        .maxSegmentSize(maxSegmentSize);
+
     return this;
   }
 
   @Override
+  public int hashCode() {
+    return Objects.hash(id, index, maxSegmentSize);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final JournalSegmentDescriptor that = (JournalSegmentDescriptor) o;
+    return id == that.id && index == that.index && maxSegmentSize == that.maxSegmentSize;
+  }
+
+  @Override
   public String toString() {
-    return toStringHelper(this)
-        .add("version", version)
-        .add("id", id)
-        .add("index", index)
-        .add("updated", updated)
-        .toString();
+    return "JournalSegmentDescriptor{"
+        + "id="
+        + id
+        + ", index="
+        + index
+        + ", maxSegmentSize="
+        + maxSegmentSize
+        + '}';
   }
 
   /** Segment descriptor builder. */
   public static final class Builder {
-    private final ByteBuffer buffer;
 
-    private Builder(final ByteBuffer buffer) {
-      this.buffer = checkNotNull(buffer, "buffer cannot be null");
-      buffer.putInt(VERSION_POSITION, VERSION);
-    }
+    private long id;
+    private long index;
+    private int maxSegmentSize;
 
     /**
      * Sets the segment identifier.
@@ -221,7 +217,8 @@ public final class JournalSegmentDescriptor {
      * @return The segment descriptor builder.
      */
     public Builder withId(final long id) {
-      buffer.putLong(ID_POSITION, id);
+      checkArgument(id > 0, "id must be positive");
+      this.id = id;
       return this;
     }
 
@@ -232,18 +229,20 @@ public final class JournalSegmentDescriptor {
      * @return The segment descriptor builder.
      */
     public Builder withIndex(final long index) {
-      buffer.putLong(INDEX_POSITION, index);
+      checkArgument(index > 0, "index must be positive");
+      this.index = index;
       return this;
     }
 
     /**
-     * Sets maximum count of the segment.
+     * Sets maximum number of bytes of the segment.
      *
      * @param maxSegmentSize The maximum count of the segment.
      * @return The segment descriptor builder.
      */
     public Builder withMaxSegmentSize(final int maxSegmentSize) {
-      buffer.putInt(MAX_SIZE_POSITION, maxSegmentSize);
+      checkArgument(maxSegmentSize > 0, "maxSegmentSize must be positive");
+      this.maxSegmentSize = maxSegmentSize;
       return this;
     }
 
@@ -253,8 +252,7 @@ public final class JournalSegmentDescriptor {
      * @return The built segment descriptor.
      */
     public JournalSegmentDescriptor build() {
-      buffer.rewind();
-      return new JournalSegmentDescriptor(buffer);
+      return new JournalSegmentDescriptor(id, index, maxSegmentSize);
     }
   }
 }

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
@@ -32,11 +32,13 @@ class MappedJournalSegmentReader {
   private JournalRecord currentEntry;
   private JournalRecord nextEntry;
   private final JournalRecordReaderUtil recordReader;
+  private final int descriptorLength;
 
   MappedJournalSegmentReader(
       final ByteBuffer buffer, final JournalSegment segment, final JournalIndex index) {
     this.index = index;
     this.segment = segment;
+    descriptorLength = segment.descriptor().length();
     recordReader = new JournalRecordReaderUtil(new SBESerializer());
     this.buffer = buffer;
     reset();
@@ -77,7 +79,7 @@ class MappedJournalSegmentReader {
   }
 
   public void reset() {
-    buffer.position(JournalSegmentDescriptor.BYTES);
+    buffer.position(descriptorLength);
     currentEntry = null;
     nextEntry = null;
     readNext(getNextIndex());

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
@@ -47,6 +47,7 @@ class MappedJournalSegmentWriter {
   private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
   private final JournalRecordSerializer serializer = new SBESerializer();
   private final MutableDirectBuffer writeBuffer = new UnsafeBuffer();
+  private final int descriptorLength;
 
   MappedJournalSegmentWriter(
       final MappedByteBuffer buffer,
@@ -54,6 +55,7 @@ class MappedJournalSegmentWriter {
       final int maxEntrySize,
       final JournalIndex index) {
     this.segment = segment;
+    descriptorLength = segment.descriptor().length();
     this.maxEntrySize = maxEntrySize;
     recordUtil = new JournalRecordReaderUtil(serializer);
     this.index = index;
@@ -196,7 +198,7 @@ class MappedJournalSegmentWriter {
     long nextIndex = firstIndex;
 
     // Clear the buffer indexes.
-    buffer.position(JournalSegmentDescriptor.BYTES);
+    buffer.position(descriptorLength);
     buffer.mark();
     int position = buffer.position();
     try {
@@ -239,8 +241,8 @@ class MappedJournalSegmentWriter {
     this.index.deleteAfter(index);
 
     if (index < segment.index()) {
-      buffer.position(JournalSegmentDescriptor.BYTES);
-      invalidateNextEntry(JournalSegmentDescriptor.BYTES);
+      buffer.position(descriptorLength);
+      invalidateNextEntry(descriptorLength);
     } else {
       reset(index);
       invalidateNextEntry(buffer.position());

--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -94,8 +94,8 @@ public class SegmentedJournalBuilder {
    */
   public SegmentedJournalBuilder withMaxSegmentSize(final int maxSegmentSize) {
     checkArgument(
-        maxSegmentSize > JournalSegmentDescriptor.BYTES,
-        "maxSegmentSize must be greater than " + JournalSegmentDescriptor.BYTES);
+        maxSegmentSize > JournalSegmentDescriptor.getEncodingLength(),
+        "maxSegmentSize must be greater than " + JournalSegmentDescriptor.getEncodingLength());
     this.maxSegmentSize = maxSegmentSize;
     return this;
   }

--- a/journal/src/main/resources/journal-schema.xml
+++ b/journal/src/main/resources/journal-schema.xml
@@ -25,4 +25,11 @@
     <field name="asqn" id="2" type="int64"/>
     <data name="data" id="3" type="blob"/>
   </sbe:message>
+
+
+  <sbe:message name="SegmentDescriptor" id="3">
+    <field name="id" id="1" type="int64"/>
+    <field name="index" id="2" type="int64"/>
+    <field name="maxSegmentSize" id="3" type="int32"/>
+  </sbe:message>
 </sbe:messageSchema>

--- a/journal/src/test/java/io/zeebe/journal/file/JournalSegmentDescriptorTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/JournalSegmentDescriptorTest.java
@@ -16,58 +16,33 @@
  */
 package io.zeebe.journal.file;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
 import org.junit.jupiter.api.Test;
 
-/**
- * Segment descriptor test.
- *
- * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
- */
 public class JournalSegmentDescriptorTest {
 
-  /** Tests the segment descriptor builder. */
   @Test
-  public void shouldBuildDescriptor() {
-    final JournalSegmentDescriptor descriptor =
-        JournalSegmentDescriptor.builder(ByteBuffer.allocate(JournalSegmentDescriptor.BYTES))
-            .withId(2)
-            .withIndex(1025)
-            .withMaxSegmentSize(1024 * 1024)
-            .build();
-
-    assertEquals(2, descriptor.id());
-    assertEquals(JournalSegmentDescriptor.VERSION, descriptor.version());
-    assertEquals(1025, descriptor.index());
-    assertEquals(1024 * 1024, descriptor.maxSegmentSize());
-
-    assertEquals(0, descriptor.updated());
-    final long time = System.currentTimeMillis();
-    descriptor.update(time);
-    assertEquals(time, descriptor.updated());
-  }
-
-  /** Tests copying the segment descriptor. */
-  @Test
-  public void shouldCopyDescriptor() {
+  public void shouldWriteAndReadDescriptor() {
+    // given
     JournalSegmentDescriptor descriptor =
         JournalSegmentDescriptor.builder()
             .withId(2)
-            .withIndex(1025)
-            .withMaxSegmentSize(1024 * 1024)
+            .withIndex(100)
+            .withMaxSegmentSize(1024)
             .build();
+    final ByteBuffer buffer = ByteBuffer.allocate(JournalSegmentDescriptor.getEncodingLength());
+    descriptor = descriptor.copyTo(buffer);
 
-    final long time = System.currentTimeMillis();
-    descriptor.update(time);
+    // when
+    final JournalSegmentDescriptor descriptorRead = new JournalSegmentDescriptor(buffer);
 
-    descriptor = descriptor.copyTo(ByteBuffer.allocate(JournalSegmentDescriptor.BYTES));
-
-    assertEquals(2, descriptor.id());
-    assertEquals(JournalSegmentDescriptor.VERSION, descriptor.version());
-    assertEquals(1025, descriptor.index());
-    assertEquals(1024 * 1024, descriptor.maxSegmentSize());
-    assertEquals(time, descriptor.updated());
+    // then
+    assertThat(descriptorRead).isEqualTo(descriptor);
+    assertThat(descriptorRead.id()).isEqualTo(2);
+    assertThat(descriptorRead.index()).isEqualTo(100);
+    assertThat(descriptorRead.maxSegmentSize()).isEqualTo(1024);
+    assertThat(descriptorRead.length()).isEqualTo(JournalSegmentDescriptor.getEncodingLength());
   }
 }

--- a/journal/src/test/java/io/zeebe/journal/file/LogCorrupter.java
+++ b/journal/src/test/java/io/zeebe/journal/file/LogCorrupter.java
@@ -51,7 +51,7 @@ public class LogCorrupter {
   private static boolean corruptRecord(final byte[] bytes, final long targetIndex) {
     final JournalRecordReaderUtil reader = new JournalRecordReaderUtil(new SBESerializer());
     final ByteBuffer buffer = ByteBuffer.wrap(bytes);
-    buffer.position(JournalSegmentDescriptor.BYTES);
+    buffer.position(JournalSegmentDescriptor.getEncodingLength());
 
     Optional<Integer> version = FrameUtil.readVersion(buffer);
     for (long index = 1; version.isPresent() && version.get() == 1; index++) {

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -47,7 +47,8 @@ class SegmentedJournalReaderTest {
     journal =
         SegmentedJournal.builder()
             .withDirectory(directory.resolve("data").toFile())
-            .withMaxSegmentSize(entrySize * ENTRIES_PER_SEGMENT + JournalSegmentDescriptor.BYTES)
+            .withMaxSegmentSize(
+                entrySize * ENTRIES_PER_SEGMENT + JournalSegmentDescriptor.getEncodingLength())
             .withMaxEntrySize(entrySize)
             .withJournalIndexDensity(5)
             .build();

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
@@ -338,7 +338,8 @@ class SegmentedJournalTest {
   private SegmentedJournal openJournal(final float entriesPerSegment, final int entrySize) {
     return SegmentedJournal.builder()
         .withDirectory(directory.resolve("data").toFile())
-        .withMaxSegmentSize((int) (entrySize * entriesPerSegment) + JournalSegmentDescriptor.BYTES)
+        .withMaxSegmentSize(
+            (int) (entrySize * entriesPerSegment) + JournalSegmentDescriptor.getEncodingLength())
         .withMaxEntrySize(entrySize)
         .withJournalIndexDensity(journalIndexDensity)
         .build();


### PR DESCRIPTION
## Description

* Use sbe to encode journal descriptor.
* Also add a 1 byte header to encode the version, similar to the frame in a journal record.

## Related issues

closes #6224

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
