### PR TITLE
Activate inner instances of a multi-instance activity for elements that are migrated

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementContainerProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementContainerProcessor.java
@@ -22,6 +22,19 @@ public interface BpmnElementContainerProcessor<T extends ExecutableFlowElement>
     extends BpmnElementProcessor<T> {
 
   /**
+   * A child element is on activating (but not yet activated). Perform additional logic for the new
+   * child element, like setting variables.
+   *
+   * @param element the instance of the BPMN element container
+   * @param flowScopeContext process instance-related data of the element container
+   * @param childContext process instance-related data of the child element that is on activating
+   */
+  void onChildActivating(
+      final T element,
+      final BpmnElementContext flowScopeContext,
+      final BpmnElementContext childContext);
+
+  /**
    * A child element is completed. Leave the element container if it has no more active child
    * elements.
    *

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -147,6 +147,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
       case ACTIVATE_ELEMENT:
         if (MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
           final var activatingContext = stateTransitionBehavior.transitionToActivating(context);
+          stateTransitionBehavior.onElementActivating(element, activatingContext);
           processor.onActivate(element, activatingContext);
         } else {
           processor.onActivating(element, context);

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -126,6 +126,12 @@ public final class CallActivityProcessor
   }
 
   @Override
+  public void onChildActivating(
+      final ExecutableCallActivity element,
+      final BpmnElementContext flowScopeContext,
+      final BpmnElementContext childContext) {}
+
+  @Override
   public void onChildCompleted(
       final ExecutableCallActivity element,
       final BpmnElementContext callActivityContext,

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -160,6 +160,12 @@ public final class ProcessProcessor
   }
 
   @Override
+  public void onChildActivating(
+      final ExecutableFlowElementContainer element,
+      final BpmnElementContext flowScopeContext,
+      final BpmnElementContext childContext) {}
+
+  @Override
   public void onChildCompleted(
       final ExecutableFlowElementContainer element,
       final BpmnElementContext flowScopeContext,

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -126,6 +126,12 @@ public final class SubProcessProcessor
   }
 
   @Override
+  public void onChildActivating(
+      final ExecutableFlowElementContainer element,
+      final BpmnElementContext flowScopeContext,
+      final BpmnElementContext childContext) {}
+
+  @Override
   public void onChildCompleted(
       final ExecutableFlowElementContainer element,
       final BpmnElementContext flowScopeContext,


### PR DESCRIPTION
## Description

* activate inner instances of a multi-instance activity for elements that are already migrated by writing a `ACTIVATE` command instead of a `ACTIVATING` event
* apply the state changes for managing the loop counter in the `ACTIVATING` event applier

**Hints for the reviewer**
* the new behavior is not used yet because no processor of an inner instance is migrated 
* however, I tested it locally with the receive task that I'm currently migrating

## Related issues

contribute to #6198

## Definition of Done

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
