### PR TITLE
Fix current benchmarks

### DIFF
--- a/benchmarks/setup/cloud-default/simpleStarter.yaml
+++ b/benchmarks/setup/cloud-default/simpleStarter.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: simple
-        image: gcr.io/zeebe-io/starter:zeebe
+        image: gcr.io/zeebe-io/starter:SNAPSHOT
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS

--- a/benchmarks/setup/cloud-default/starter.yaml
+++ b/benchmarks/setup/cloud-default/starter.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: starter
-        image: gcr.io/zeebe-io/starter:zeebe
+        image: gcr.io/zeebe-io/starter:SNAPSHOT
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS

--- a/benchmarks/setup/cloud-default/timer.yaml
+++ b/benchmarks/setup/cloud-default/timer.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: timer
-        image: gcr.io/zeebe-io/starter:zeebe
+        image: gcr.io/zeebe-io/starter:SNAPSHOT
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS

--- a/benchmarks/setup/cloud-default/worker.yaml
+++ b/benchmarks/setup/cloud-default/worker.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: worker
-        image: gcr.io/zeebe-io/worker:zeebe
+        image: gcr.io/zeebe-io/worker:SNAPSHOT
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS

--- a/benchmarks/setup/default/simpleStarter.yaml
+++ b/benchmarks/setup/default/simpleStarter.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: simple
-        image: gcr.io/zeebe-io/starter:zeebe
+        image: gcr.io/zeebe-io/starter:SNAPSHOT
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS

--- a/benchmarks/setup/default/starter.yaml
+++ b/benchmarks/setup/default/starter.yaml
@@ -22,7 +22,7 @@ spec:
           - name: JAVA_OPTIONS
             value: >-
               -Dapp.brokerUrl=default-zeebe-gateway:26500
-              -Dapp.starter.rate=300
+              -Dapp.starter.rate=200
               -Dapp.starter.durationLimit=0
               -Dzeebe.client.requestTimeout=62000
               -XX:+HeapDumpOnOutOfMemoryError

--- a/benchmarks/setup/default/starter.yaml
+++ b/benchmarks/setup/default/starter.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: starter
-        image: gcr.io/zeebe-io/starter:zeebe
+        image: gcr.io/zeebe-io/starter:SNAPSHOT
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS

--- a/benchmarks/setup/default/timer.yaml
+++ b/benchmarks/setup/default/timer.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: timer
-        image: gcr.io/zeebe-io/starter:zeebe
+        image: gcr.io/zeebe-io/starter:SNAPSHOT
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS

--- a/benchmarks/setup/default/worker.yaml
+++ b/benchmarks/setup/default/worker.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: worker
-        image: gcr.io/zeebe-io/worker:zeebe
+        image: gcr.io/zeebe-io/worker:SNAPSHOT
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS

--- a/benchmarks/setup/operate/starter.yaml
+++ b/benchmarks/setup/operate/starter.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: starter
-        image: gcr.io/zeebe-io/starter:zeebe
+        image: gcr.io/zeebe-io/starter:SNAPSHOT
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS

--- a/benchmarks/setup/operate/worker.yaml
+++ b/benchmarks/setup/operate/worker.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: worker
-        image: gcr.io/zeebe-io/worker:zeebe
+        image: gcr.io/zeebe-io/worker:SNAPSHOT
         imagePullPolicy: Always
         env:
           - name: JAVA_OPTIONS

--- a/createBenchmark.sh
+++ b/createBenchmark.sh
@@ -49,9 +49,9 @@ cd "$benchmark"
 # calls OS specific sed inplace function
 sed_inplace 's/camunda\/zeebe/gcr.io\/zeebe-io\/zeebe/' zeebe-values.yaml
 sed_inplace "s/SNAPSHOT/$benchmark/" zeebe-values.yaml
-sed_inplace "s/starter:zeebe/starter:$benchmark/" starter.yaml
-sed_inplace "s/starter:zeebe/starter:$benchmark/" simpleStarter.yaml
-sed_inplace "s/starter:zeebe/starter:$benchmark/" timer.yaml
-sed_inplace "s/worker:zeebe/worker:$benchmark/" worker.yaml
+sed_inplace "s/starter:SNAPSHOT/starter:$benchmark/" starter.yaml
+sed_inplace "s/starter:SNAPSHOT/starter:$benchmark/" simpleStarter.yaml
+sed_inplace "s/starter:SNAPSHOT/starter:$benchmark/" timer.yaml
+sed_inplace "s/worker:SNAPSHOT/worker:$benchmark/" worker.yaml
 
 make zeebe starter worker


### PR DESCRIPTION
## Description

Mitigates the issue we have seen in our current benchmarks #6747 that we overwhelm the exporters, which cause at the end that zeebe goes out of disk space on high load. The load is reduced to 200, which seems to work for now.

The tags have been set to SNAPSHOT instead of zeebe, because these tags are builds from 0.24.x which are not working anymore without current grpc protocol. SNAPSHOT seem to work, but idk when this was build. It is currently also not build by our pipeline. https://github.com/camunda-cloud/zeebe/issues/5608
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->



<!--
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
