### PR TITLE
Cut off pr body in bors merge commit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,9 @@
 
 closes #
 
-<!--
+<!-- Cut-off marker
+_All lines under and including the cut-off marker will be removed from the merge commit message_
+
 ## Definition of Ready
 
 Please check the items that apply, before requesting a review.

--- a/bors.toml
+++ b/bors.toml
@@ -8,4 +8,5 @@ delete_merged_branches = true
 
 commit_title = "merge: ${PR_REFS}"
 
-cut_body_after = "# Pull Request Checklist"
+# Also cuts the marker, not just after
+cut_body_after = "<!-- Cut-off marker"


### PR DESCRIPTION
## Description

This adds a specific marker to cut off the merge commit body.

The definition of ready and definition of done checklists add a lot of
unnecessary volume to merge commits, because bors copies the pr
description into the merge commit body. We already instructed bors to
cut off these bodies at a marker, but the marker has been removed at
some point. Having a specific marker for it reduces the change we remove
it by accident.

## Related issues

closes #6756

<!--
## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
