### PR TITLE
Apply event sourcing to the receive task

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -9,7 +9,6 @@ package io.zeebe.engine.processing.streamprocessor;
 
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.zeebe.protocol.record.ValueType;
-import io.zeebe.protocol.record.intent.Intent;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -27,10 +26,6 @@ public final class MigratedStreamProcessors {
   private static final Map<ValueType, Function<TypedRecord<?>, Boolean>> MIGRATED_VALUE_TYPES =
       new EnumMap<>(ValueType.class);
 
-  private static final Function<List<Intent>, Function<TypedRecord<?>, Boolean>>
-      MIGRATED_INTENT_FILTER_FACTORY =
-          (intents) -> (record) -> intents.contains(record.getIntent());
-
   static {
     MIGRATED_VALUE_TYPES.put(
         ValueType.PROCESS_INSTANCE,
@@ -45,6 +40,7 @@ public final class MigratedStreamProcessors {
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.INTERMEDIATE_CATCH_EVENT);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.EVENT_BASED_GATEWAY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.START_EVENT);
+    MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.RECEIVE_TASK);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.END_EVENT);
 
     MIGRATED_VALUE_TYPES.put(ValueType.JOB, MIGRATED);

--- a/engine/src/test/java/io/zeebe/engine/processing/message/MessageCorrelationTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/message/MessageCorrelationTest.java
@@ -750,9 +750,10 @@ public final class MessageCorrelationTest {
         .filteredOn(r -> r.getValue().getElementId().equals("receive-message"))
         .extracting(Record::getIntent)
         .containsExactly(
+            ProcessInstanceIntent.ACTIVATE_ELEMENT,
             ProcessInstanceIntent.ELEMENT_ACTIVATING,
             ProcessInstanceIntent.ELEMENT_ACTIVATED,
-            ProcessInstanceIntent.EVENT_OCCURRED,
+            ProcessInstanceIntent.COMPLETE_ELEMENT,
             ProcessInstanceIntent.ELEMENT_COMPLETING,
             ProcessInstanceIntent.ELEMENT_COMPLETED);
   }
@@ -773,13 +774,13 @@ public final class MessageCorrelationTest {
     assertThat(events)
         .extracting(r -> tuple(r.getValue().getElementId(), r.getIntent()))
         .containsSequence(
-            tuple("task", ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple("task", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple("task", ProcessInstanceIntent.EVENT_OCCURRED),
+            tuple("task", ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple("task", ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple("task", ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple("msg1", ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple("msg1", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("msg1", ProcessInstanceIntent.COMPLETE_ELEMENT),
             tuple("msg1", ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple("msg1", ProcessInstanceIntent.ELEMENT_COMPLETED));
   }


### PR DESCRIPTION
## Description

* avoid writing an EVENT_OCCURRED event to continue the processing of the receive task because it is not a command
  * trigger the receive task by writing a COMPLETE command
  * trigger an attached non-interrupting boundary event by writing a ACTIVATE command for the boundary event
  * trigger an attached interrupting boundary event by writing a TERMINATE command for the receive task. When the receive task is terminated then activate the boundary event using the data of the event trigger.

## Related issues

closes #6188 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
