### PR TITLE
chore(atomix): use version header in metastore 

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
@@ -97,46 +97,47 @@ public class MetaStoreSerializer {
     return new Configuration(index, term, timestamp, members);
   }
 
-  public void writeTerm(final long term, final MutableDirectBuffer buffer) {
+  public void writeTerm(final long term, final MutableDirectBuffer buffer, final int offset) {
     headerEncoder
-        .wrap(buffer, 0)
+        .wrap(buffer, offset)
         .blockLength(metaEncoder.sbeBlockLength())
         .templateId(metaEncoder.sbeTemplateId())
         .schemaId(metaEncoder.sbeSchemaId())
         .version(metaEncoder.sbeSchemaVersion());
 
-    metaEncoder.wrap(buffer, headerEncoder.encodedLength());
+    metaEncoder.wrap(buffer, offset + headerEncoder.encodedLength());
     metaEncoder.term(term);
   }
 
-  public long readTerm(final MutableDirectBuffer buffer) {
-    headerDecoder.wrap(buffer, 0);
+  public long readTerm(final MutableDirectBuffer buffer, final int offset) {
+    headerDecoder.wrap(buffer, offset);
     metaDecoder.wrap(
         buffer,
-        headerDecoder.encodedLength(),
+        offset + headerDecoder.encodedLength(),
         headerDecoder.blockLength(),
         headerDecoder.version());
 
     return metaDecoder.term();
   }
 
-  public void writeVotedFor(final String memberId, final MutableDirectBuffer buffer) {
+  public void writeVotedFor(
+      final String memberId, final MutableDirectBuffer buffer, final int offset) {
     headerEncoder
-        .wrap(buffer, 0)
+        .wrap(buffer, offset)
         .blockLength(metaEncoder.sbeBlockLength())
         .templateId(metaEncoder.sbeTemplateId())
         .schemaId(metaEncoder.sbeSchemaId())
         .version(metaEncoder.sbeSchemaVersion());
 
-    metaEncoder.wrap(buffer, headerEncoder.encodedLength());
+    metaEncoder.wrap(buffer, offset + headerEncoder.encodedLength());
     metaEncoder.votedFor(memberId);
   }
 
-  public String readVotedFor(final MutableDirectBuffer buffer) {
-    headerDecoder.wrap(buffer, 0);
+  public String readVotedFor(final MutableDirectBuffer buffer, final int offset) {
+    headerDecoder.wrap(buffer, offset);
     metaDecoder.wrap(
         buffer,
-        headerDecoder.encodedLength(),
+        offset + headerDecoder.encodedLength(),
         headerDecoder.blockLength(),
         headerDecoder.version());
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -46,7 +46,7 @@ public class MetaStoreTest {
   @Test
   public void shouldStoreAndLoadConfiguration() throws IOException {
     // given
-    final Configuration config = getConfiguration();
+    final Configuration config = getConfiguration(1, 2);
     metaStore.storeConfiguration(config);
 
     // when
@@ -60,10 +60,10 @@ public class MetaStoreTest {
         .containsExactlyInAnyOrder(config.members().toArray(new RaftMember[0]));
   }
 
-  private Configuration getConfiguration() {
+  private Configuration getConfiguration(final long index, final long term) {
     return new Configuration(
-        1,
-        2,
+        index,
+        term,
         1234L,
         new ArrayList<>(
             Set.of(
@@ -93,7 +93,7 @@ public class MetaStoreTest {
   @Test
   public void shouldLoadExistingConfiguration() throws IOException {
     // given
-    final Configuration config = getConfiguration();
+    final Configuration config = getConfiguration(1, 2);
     metaStore.storeConfiguration(config);
 
     // when
@@ -158,5 +158,62 @@ public class MetaStoreTest {
   public void shouldLoadEmptyConfig() {
     // when -then
     assertThat(metaStore.loadConfiguration()).isNull();
+  }
+
+  @Test
+  public void shouldLoadLatestTermAndVoteAfterRestart() throws IOException {
+    //  given
+    metaStore.storeTerm(2L);
+    metaStore.storeVote(MemberId.from("0"));
+    metaStore.storeTerm(3L);
+    metaStore.storeVote(MemberId.from("1"));
+
+    // when
+    metaStore.close();
+    metaStore = new MetaStore(storage);
+
+    // then
+    assertThat(metaStore.loadTerm()).isEqualTo(3L);
+    assertThat(metaStore.loadVote().id()).isEqualTo("1");
+  }
+
+  @Test
+  public void shouldStoreConfigurationMultipleTimes() throws IOException {
+    // given
+    final Configuration firstConfig = getConfiguration(1, 2);
+    metaStore.storeConfiguration(firstConfig);
+    final Configuration secondConfig = getConfiguration(3, 4);
+    metaStore.storeConfiguration(secondConfig);
+
+    // when
+    final Configuration readConfig = metaStore.loadConfiguration();
+
+    // then
+    assertThat(readConfig.index()).isEqualTo(secondConfig.index());
+    assertThat(readConfig.term()).isEqualTo(secondConfig.term());
+    assertThat(readConfig.time()).isEqualTo(secondConfig.time());
+    assertThat(readConfig.members())
+        .containsExactlyInAnyOrder(secondConfig.members().toArray(new RaftMember[0]));
+  }
+
+  @Test
+  public void shouldLoadLatestConfigurationAfterRestart() throws IOException {
+    // given
+    final Configuration firstConfig = getConfiguration(1, 2);
+    metaStore.storeConfiguration(firstConfig);
+    final Configuration secondConfig = getConfiguration(3, 4);
+    metaStore.storeConfiguration(secondConfig);
+
+    // when
+    metaStore.close();
+    metaStore = new MetaStore(storage);
+    final Configuration readConfig = metaStore.loadConfiguration();
+
+    // then
+    assertThat(readConfig.index()).isEqualTo(secondConfig.index());
+    assertThat(readConfig.term()).isEqualTo(secondConfig.term());
+    assertThat(readConfig.time()).isEqualTo(secondConfig.time());
+    assertThat(readConfig.members())
+        .containsExactlyInAnyOrder(secondConfig.members().toArray(new RaftMember[0]));
   }
 }


### PR DESCRIPTION
## Description

Added a one byte header before the sbe messages similar to journal records. This header can be used to represent the version if we ever migrate away from sbe and use a different encoding. Note that sbe can handle versioning itself and we can add or remove fields without changing this version header.

## Related issues

closes #6764 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
