### PR TITLE
Switch QA to new testbench-1.x-prod

### DIFF
--- a/.ci/scripts/distribution/qa-testbench.sh
+++ b/.ci/scripts/distribution/qa-testbench.sh
@@ -13,7 +13,7 @@ jobKey=""
 
 while true; do
     "${zbctl}" activate jobs "$businessKey" > activationresponse.txt 2>/dev/null
-    jobKey=$(jq -r '.[0].key' < activationresponse.txt)
+    jobKey=$(jq -r '.jobs[0].key' < activationresponse.txt)
 
     if [[ -z "$jobKey" || "$jobKey" == "null" ]]; then
         echo "Still waiting"
@@ -25,7 +25,7 @@ while true; do
 done
 
 echo "Job key is: $jobKey"
-variables=$(jq -r '.[0].variables' < activationresponse.txt)
+variables=$(jq -r '.jobs[0].variables' < activationresponse.txt)
 echo "Job variables are: $variables"
 
 testResult=$(echo "$variables" | jq -r '.aggregatedTestResult')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ def masterBranchName = 'master'
 def isMasterBranch = env.BRANCH_NAME == masterBranchName
 def developBranchName = 'develop'
 def isDevelopBranch = env.BRANCH_NAME == developBranchName
-def latestStableBranchName = 'stable/0.26'
+def latestStableBranchName = 'stable/1.0'
 def isLatestStable = env.BRANCH_NAME == latestStableBranchName
 
 //for develop branch keep builds for 7 days to be able to analyse build errors, for all other branches, keep the last 10 builds

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,9 @@ def longTimeoutMinutes = 45
 itAgentUnstashDirectory = '.tmp/it'
 itFlakyTestStashName = 'it-flakyTests'
 
-// the latest stable branch should be run at midnight to do a nightly build including QA test run
-// todo: run develop branch at midnight using new testbench version
-def cronTrigger = isLatestStable ? '0 0 * * *' : ''
+// the develop branch should be run at midnight to do a nightly build including QA test run
+// the latest stable branch is run an hour later at 01:00 AM.
+def cronTrigger = isDevelopBranch ? '0 0 * * *' : isLatestStable ? '0 1 * * *' : ''
 
 pipeline {
     agent {
@@ -315,7 +315,10 @@ pipeline {
                 anyOf {
                     expression { params.RUN_QA }
                     allOf {
-                        branch latestStableBranchName
+                        anyOf {
+                            branch developBranchName
+                            branch latestStableBranchName
+                        }
                         triggeredBy 'TimerTrigger'
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -326,7 +326,7 @@ pipeline {
                 TAG = "${env.VERSION}-${env.GIT_COMMIT}"
                 DOCKER_GCR = credentials("zeebe-gcr-serviceaccount-json")
                 ZEEBE_AUTHORIZATION_SERVER_URL = 'https://login.cloud.ultrawombat.com/oauth/token'
-                ZEEBE_CLIENT_ID = 'W5a4JUc3I1NIetNnodo3YTvdsRIFb12w'
+                ZEEBE_CLIENT_ID = 'ELL8eP0qDkl6dxXVps0t51x2VkCkWf~p'
                 QA_RUN_VARIABLES = "{\"zeebeImage\": \"${env.IMAGE}:${env.TAG}\", \"generationTemplate\": \"${params.GENERATION_TEMPLATE}\", " +
                                     "\"channel\": \"Internal Dev\", \"branch\": \"${env.BRANCH_NAME}\", \"build\": \"${currentBuild.absoluteUrl}\", " +
                                     "\"businessKey\": \"${currentBuild.absoluteUrl}\", \"processId\": \"qa-protocol\"}"
@@ -341,7 +341,7 @@ pipeline {
                     withVault(
                         [vaultSecrets:
                              [
-                                 [path        : 'secret/common/ci-zeebe/testbench-secrets-int',
+                                 [path        : 'secret/common/ci-zeebe/testbench-secrets-1.x-prod',
                                   secretValues:
                                       [
                                           [envVar: 'ZEEBE_CLIENT_SECRET', vaultKey: 'clientSecret'],


### PR DESCRIPTION
## Description

In order to use the new Testbench that is compatible with Zeebe 1.x
versions, this switches the client id and secrets used by the QA stage.

It also re-enables develop for nightly QA runs.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [x] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
