### PR TITLE
Replace writing of EVENT_OCCURRED with migrated event code for JobThrowErrorProcessor

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.processing;
 import static io.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 
 import io.zeebe.el.ExpressionLanguageFactory;
+import io.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
 import io.zeebe.engine.processing.common.CatchEventBehavior;
 import io.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.zeebe.engine.processing.common.ExpressionProcessor;
@@ -77,6 +78,9 @@ public final class EngineProcessors {
         new EventTriggerBehavior(
             zeebeState.getKeyGenerator(), catchEventBehavior, writers, zeebeState);
 
+    final var eventPublicationBehavior =
+        new BpmnEventPublicationBehavior(zeebeState, eventTriggerBehavior, writers);
+
     addDeploymentRelatedProcessorAndServices(
         catchEventBehavior,
         partitionId,
@@ -107,11 +111,12 @@ public final class EngineProcessors {
             writers,
             timerChecker);
 
-    addJobProcessors(
-        zeebeState,
+    JobEventProcessors.addJobProcessors(
         typedRecordProcessors,
+        zeebeState,
         onJobsAvailableCallback,
         eventTriggerBehavior,
+        eventPublicationBehavior,
         maxFragmentSize,
         writers);
 
@@ -196,22 +201,6 @@ public final class EngineProcessors {
       final Writers writers) {
     IncidentEventProcessors.addProcessors(
         typedRecordProcessors, zeebeState, bpmnStreamProcessor, writers);
-  }
-
-  private static void addJobProcessors(
-      final MutableZeebeState zeebeState,
-      final TypedRecordProcessors typedRecordProcessors,
-      final Consumer<String> onJobsAvailableCallback,
-      final EventTriggerBehavior eventTriggerBehavior,
-      final int maxFragmentSize,
-      final Writers writers) {
-    JobEventProcessors.addJobProcessors(
-        typedRecordProcessors,
-        zeebeState,
-        onJobsAvailableCallback,
-        eventTriggerBehavior,
-        maxFragmentSize,
-        writers);
   }
 
   private static void addMessageProcessors(

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.engine.processing.job;
 
+import io.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
 import io.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
 import io.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
@@ -25,6 +26,7 @@ public final class JobEventProcessors {
       final MutableZeebeState zeebeState,
       final Consumer<String> onJobsAvailableCallback,
       final EventTriggerBehavior eventTriggerBehavior,
+      final BpmnEventPublicationBehavior eventPublicationBehavior,
       final int maxRecordSize,
       final Writers writers) {
 
@@ -38,7 +40,8 @@ public final class JobEventProcessors {
         .onCommand(
             ValueType.JOB,
             JobIntent.THROW_ERROR,
-            new JobThrowErrorProcessor(zeebeState, eventTriggerBehavior, keyGenerator))
+            new JobThrowErrorProcessor(
+                zeebeState, eventTriggerBehavior, eventPublicationBehavior, keyGenerator))
         .onCommand(ValueType.JOB, JobIntent.TIME_OUT, new JobTimeOutProcessor(zeebeState))
         .onCommand(
             ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(zeebeState))

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/JobErrorThrownApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/JobErrorThrownApplier.java
@@ -47,9 +47,6 @@ public class JobErrorThrownApplier implements TypedEventApplier<JobIntent, JobRe
       final var serviceTaskInstance = elementInstanceState.getInstance(job.getElementInstanceKey());
 
       removeJobReference(jobKey, job, serviceTaskInstance);
-
-      // TODO (#6472) remove this after the right event is being written
-      triggerEvent(jobKey, job, serviceTaskInstance);
     }
   }
 
@@ -60,17 +57,5 @@ public class JobErrorThrownApplier implements TypedEventApplier<JobIntent, JobRe
     elementInstanceState.updateInstance(serviceTaskInstance);
 
     jobState.delete(jobKey, job);
-  }
-
-  private void triggerEvent(
-      final long jobKey, final JobRecord job, final ElementInstance serviceTaskInstance) {
-    final var foundCatchEvent =
-        stateAnalyzer.findCatchEvent(job.getErrorCodeBuffer(), serviceTaskInstance);
-
-    final var eventScopeInstance = foundCatchEvent.getElementInstance();
-    final var catchEvent = foundCatchEvent.getCatchEvent();
-
-    eventScopeInstanceState.triggerEvent(
-        eventScopeInstance.getKey(), jobKey, catchEvent.getId(), NO_VARIABLES);
   }
 }


### PR DESCRIPTION
## Description

Removes logic to write legacy `EVENT_OCCURED` record from `JobErrorThrownProcessor`
Use the migrated logic instead.

## Related issues

relates #6172 
relates #6472 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
