### PR TITLE
Rename RaftLog api and Refactor openReader method

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -437,7 +437,7 @@ public final class RaftMemberContext {
   }
 
   public void reset(final long index) {
-    final var nextIndex = reader.reset(index - 1);
+    final var nextIndex = reader.seek(index - 1);
     if (nextIndex == index - 1) {
       currentEntry = reader.next();
     } else {

--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -95,7 +95,8 @@ public final class RaftMemberContext {
   }
 
   private void openReaderAtEndOfLog(final RaftLog log, final Mode all) {
-    reader = log.openReader(log.getLastIndex(), all);
+    reader = log.openReader(all);
+    reader.seekToLast();
     if (reader.hasNext()) {
       currentEntry = reader.next();
     }

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -153,7 +153,7 @@ public class RaftContext implements AutoCloseable {
 
     // Construct the core log, reader, writer, and compactor.
     raftLog = storage.openLog();
-    logReader = raftLog.openReader(1, RaftLogReader.Mode.ALL);
+    logReader = raftLog.openReader(RaftLogReader.Mode.ALL);
 
     // Open the snapshot store.
     persistedSnapshotStore = storage.getPersistedSnapshotStore();

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/zeebe/LogCompactor.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/zeebe/LogCompactor.java
@@ -50,7 +50,7 @@ public final class LogCompactor {
     final CompletableFuture<Void> result = new CompletableFuture<>();
     try {
       final var startTime = System.currentTimeMillis();
-      raft.getLog().compact(compactableIndex);
+      raft.getLog().deleteUntil(compactableIndex);
       metrics.compactionTime(System.currentTimeMillis() - startTime);
       result.complete(null);
     } catch (final Exception e) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -192,8 +192,8 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
     server.getContext().getLogCompactor().setCompactableIndex(index);
   }
 
-  public RaftLogReader openReader(final long index, final Mode mode) {
-    return server.getContext().getLog().openReader(index, mode);
+  public RaftLogReader openReader(final Mode mode) {
+    return server.getContext().getLog().openReader(mode);
   }
 
   public void addRoleChangeListener(final RaftRoleChangeListener listener) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -25,10 +25,7 @@ import io.atomix.raft.storage.serializer.RaftEntrySBESerializer;
 import io.atomix.raft.storage.serializer.RaftEntrySerializer;
 import io.zeebe.journal.Journal;
 import io.zeebe.journal.JournalRecord;
-import io.zeebe.journal.file.SegmentedJournal;
-import io.zeebe.journal.file.SegmentedJournalBuilder;
 import java.io.Closeable;
-import java.io.File;
 import org.agrona.CloseHelper;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -55,8 +52,8 @@ public class RaftLog implements Closeable {
    *
    * @return A new Raft log builder.
    */
-  public static Builder builder() {
-    return new Builder();
+  public static RaftLogBuilder builder() {
+    return new RaftLogBuilder();
   }
 
   /**
@@ -221,130 +218,4 @@ public class RaftLog implements Closeable {
         + '}';
   }
 
-  public static class Builder implements io.atomix.utils.Builder<RaftLog> {
-
-    private final SegmentedJournalBuilder journalBuilder = SegmentedJournal.builder();
-    private boolean flushExplicitly = true;
-
-    protected Builder() {}
-
-    /**
-     * Sets the storage name.
-     *
-     * @param name The storage name.
-     * @return The storage builder.
-     */
-    public Builder withName(final String name) {
-      journalBuilder.withName(name);
-      return this;
-    }
-
-    /**
-     * Sets the log directory, returning the builder for method chaining.
-     *
-     * <p>The log will write segment files into the provided directory.
-     *
-     * @param directory The log directory.
-     * @return The storage builder.
-     * @throws NullPointerException If the {@code directory} is {@code null}
-     */
-    public Builder withDirectory(final String directory) {
-      journalBuilder.withDirectory(directory);
-      return this;
-    }
-
-    /**
-     * Sets the log directory, returning the builder for method chaining.
-     *
-     * <p>The log will write segment files into the provided directory.
-     *
-     * @param directory The log directory.
-     * @return The storage builder.
-     * @throws NullPointerException If the {@code directory} is {@code null}
-     */
-    public Builder withDirectory(final File directory) {
-      journalBuilder.withDirectory(directory);
-      return this;
-    }
-
-    /**
-     * Sets the maximum segment size in bytes, returning the builder for method chaining.
-     *
-     * <p>The maximum segment size dictates when logs should roll over to new segments. As entries
-     * are written to a segment of the log, once the size of the segment surpasses the configured
-     * maximum segment size, the log will create a new segment and append new entries to that
-     * segment.
-     *
-     * <p>By default, the maximum segment size is {@code 1024 * 1024 * 32}.
-     *
-     * @param maxSegmentSize The maximum segment size in bytes.
-     * @return The storage builder.
-     * @throws IllegalArgumentException If the {@code maxSegmentSize} is not positive
-     */
-    public Builder withMaxSegmentSize(final int maxSegmentSize) {
-      journalBuilder.withMaxSegmentSize(maxSegmentSize);
-      return this;
-    }
-
-    /**
-     * Sets the maximum entry size in bytes, returning the builder for method chaining.
-     *
-     * @param maxEntrySize the maximum entry size in bytes
-     * @return the storage builder
-     * @throws IllegalArgumentException if the {@code maxEntrySize} is not positive
-     */
-    public Builder withMaxEntrySize(final int maxEntrySize) {
-      journalBuilder.withMaxEntrySize(maxEntrySize);
-      return this;
-    }
-
-    /**
-     * Sets the minimum free disk space to leave when allocating a new segment
-     *
-     * @param freeDiskSpace free disk space in bytes
-     * @return the storage builder
-     * @throws IllegalArgumentException if the {@code freeDiskSpace} is not positive
-     */
-    public Builder withFreeDiskSpace(final long freeDiskSpace) {
-      journalBuilder.withFreeDiskSpace(freeDiskSpace);
-      return this;
-    }
-
-    /**
-     * Sets whether or not to flush buffered I/O explicitly at various points, returning the builder
-     * for chaining.
-     *
-     * <p>Enabling this ensures that entries are flushed on followers before acknowledging a write,
-     * and are flushed on the leader before marking an entry as committed. This guarantees the
-     * correctness of various Raft properties.
-     *
-     * @param flushExplicitly whether to flush explicitly or not
-     * @return this builder for chaining
-     */
-    public Builder withFlushExplicitly(final boolean flushExplicitly) {
-      this.flushExplicitly = flushExplicitly;
-      return this;
-    }
-
-    /**
-     * Sets the index density of the journal.
-     *
-     * <p>When journalIndexDensity is set to n, every n'th record is indexed. So higher this value,
-     * longer a seek operation takes. Lower this value more memory is required to store the index
-     * mappings.
-     *
-     * @param journalIndexDensity
-     * @return this builder for chaining
-     */
-    public Builder withJournalIndexDensity(final int journalIndexDensity) {
-      journalBuilder.withJournalIndexDensity(journalIndexDensity);
-      return this;
-    }
-
-    @Override
-    public RaftLog build() {
-      final Journal journal = journalBuilder.build();
-      return new RaftLog(journal, flushExplicitly);
-    }
-  }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -57,26 +57,22 @@ public class RaftLog implements Closeable {
   }
 
   /**
-   * Opens the reader with {@link Mode} ALL and seek to the given index.
+   * Opens the reader with {@link Mode} ALL.
    *
-   * @param index index at which the reader starts
    * @return the reader
    */
-  public RaftLogReader openReader(final long index) {
-    return openReader(index, Mode.ALL);
+  public RaftLogReader openReader() {
+    return openReader(Mode.ALL);
   }
 
   /**
-   * Opens the reader with given {@link Mode} and seek to the given index.
+   * Opens the reader with given {@link Mode}.
    *
-   * @param index index at which the reader starts
    * @param mode the mode of the reader
    * @return the reader
    */
-  public RaftLogReader openReader(final long index, final Mode mode) {
+  public RaftLogReader openReader(final Mode mode) {
     final RaftLogReader reader = new RaftLogReader(this, journal.openReader(), mode);
-    reader.seek(index);
-
     return reader;
   }
 
@@ -134,7 +130,8 @@ public class RaftLog implements Closeable {
   }
 
   private void readLastEntry() {
-    try (final var reader = openReader(journal.getLastIndex())) {
+    try (final var reader = openReader()) {
+      reader.seekToLast();
       if (reader.hasNext()) {
         lastAppendedEntry = reader.next();
       }
@@ -217,5 +214,4 @@ public class RaftLog implements Closeable {
         + commitIndex
         + '}';
   }
-
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -1,0 +1,134 @@
+package io.atomix.raft.storage.log;
+
+import io.zeebe.journal.Journal;
+import io.zeebe.journal.file.SegmentedJournal;
+import io.zeebe.journal.file.SegmentedJournalBuilder;
+import java.io.File;
+
+public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
+
+  private final SegmentedJournalBuilder journalBuilder = SegmentedJournal.builder();
+  private boolean flushExplicitly = true;
+
+  protected RaftLogBuilder() {
+  }
+
+  /**
+   * Sets the storage name.
+   *
+   * @param name The storage name.
+   * @return The storage builder.
+   */
+  public RaftLogBuilder withName(final String name) {
+    journalBuilder.withName(name);
+    return this;
+  }
+
+  /**
+   * Sets the log directory, returning the builder for method chaining.
+   *
+   * <p>The log will write segment files into the provided directory.
+   *
+   * @param directory The log directory.
+   * @return The storage builder.
+   * @throws NullPointerException If the {@code directory} is {@code null}
+   */
+  public RaftLogBuilder withDirectory(final String directory) {
+    journalBuilder.withDirectory(directory);
+    return this;
+  }
+
+  /**
+   * Sets the log directory, returning the builder for method chaining.
+   *
+   * <p>The log will write segment files into the provided directory.
+   *
+   * @param directory The log directory.
+   * @return The storage builder.
+   * @throws NullPointerException If the {@code directory} is {@code null}
+   */
+  public RaftLogBuilder withDirectory(final File directory) {
+    journalBuilder.withDirectory(directory);
+    return this;
+  }
+
+  /**
+   * Sets the maximum segment size in bytes, returning the builder for method chaining.
+   *
+   * <p>The maximum segment size dictates when logs should roll over to new segments. As entries
+   * are written to a segment of the log, once the size of the segment surpasses the configured
+   * maximum segment size, the log will create a new segment and append new entries to that
+   * segment.
+   *
+   * <p>By default, the maximum segment size is {@code 1024 * 1024 * 32}.
+   *
+   * @param maxSegmentSize The maximum segment size in bytes.
+   * @return The storage builder.
+   * @throws IllegalArgumentException If the {@code maxSegmentSize} is not positive
+   */
+  public RaftLogBuilder withMaxSegmentSize(final int maxSegmentSize) {
+    journalBuilder.withMaxSegmentSize(maxSegmentSize);
+    return this;
+  }
+
+  /**
+   * Sets the maximum entry size in bytes, returning the builder for method chaining.
+   *
+   * @param maxEntrySize the maximum entry size in bytes
+   * @return the storage builder
+   * @throws IllegalArgumentException if the {@code maxEntrySize} is not positive
+   */
+  public RaftLogBuilder withMaxEntrySize(final int maxEntrySize) {
+    journalBuilder.withMaxEntrySize(maxEntrySize);
+    return this;
+  }
+
+  /**
+   * Sets the minimum free disk space to leave when allocating a new segment
+   *
+   * @param freeDiskSpace free disk space in bytes
+   * @return the storage builder
+   * @throws IllegalArgumentException if the {@code freeDiskSpace} is not positive
+   */
+  public RaftLogBuilder withFreeDiskSpace(final long freeDiskSpace) {
+    journalBuilder.withFreeDiskSpace(freeDiskSpace);
+    return this;
+  }
+
+  /**
+   * Sets whether or not to flush buffered I/O explicitly at various points, returning the builder
+   * for chaining.
+   *
+   * <p>Enabling this ensures that entries are flushed on followers before acknowledging a write,
+   * and are flushed on the leader before marking an entry as committed. This guarantees the
+   * correctness of various Raft properties.
+   *
+   * @param flushExplicitly whether to flush explicitly or not
+   * @return this builder for chaining
+   */
+  public RaftLogBuilder withFlushExplicitly(final boolean flushExplicitly) {
+    this.flushExplicitly = flushExplicitly;
+    return this;
+  }
+
+  /**
+   * Sets the index density of the journal.
+   *
+   * <p>When journalIndexDensity is set to n, every n'th record is indexed. So higher this value,
+   * longer a seek operation takes. Lower this value more memory is required to store the index
+   * mappings.
+   *
+   * @param journalIndexDensity the journal index density
+   * @return this builder for chaining
+   */
+  public RaftLogBuilder withJournalIndexDensity(final int journalIndexDensity) {
+    journalBuilder.withJournalIndexDensity(journalIndexDensity);
+    return this;
+  }
+
+  @Override
+  public RaftLog build() {
+    final Journal journal = journalBuilder.build();
+    return new RaftLog(journal, flushExplicitly);
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.atomix.raft.storage.log;
 
 import io.zeebe.journal.Journal;
@@ -10,8 +25,7 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
   private final SegmentedJournalBuilder journalBuilder = SegmentedJournal.builder();
   private boolean flushExplicitly = true;
 
-  protected RaftLogBuilder() {
-  }
+  protected RaftLogBuilder() {}
 
   /**
    * Sets the storage name.
@@ -55,10 +69,9 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
   /**
    * Sets the maximum segment size in bytes, returning the builder for method chaining.
    *
-   * <p>The maximum segment size dictates when logs should roll over to new segments. As entries
-   * are written to a segment of the log, once the size of the segment surpasses the configured
-   * maximum segment size, the log will create a new segment and append new entries to that
-   * segment.
+   * <p>The maximum segment size dictates when logs should roll over to new segments. As entries are
+   * written to a segment of the log, once the size of the segment surpasses the configured maximum
+   * segment size, the log will create a new segment and append new entries to that segment.
    *
    * <p>By default, the maximum segment size is {@code 1024 * 1024 * 32}.
    *

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
@@ -66,7 +66,7 @@ public class RaftLogReader implements java.util.Iterator<IndexedRaftLogEntry>, A
     return nextIndex;
   }
 
-  public long reset(final long index) {
+  public long seek(final long index) {
     if (nextIndex == index) {
       return nextIndex;
     }
@@ -87,7 +87,7 @@ public class RaftLogReader implements java.util.Iterator<IndexedRaftLogEntry>, A
     if (mode == Mode.ALL) {
       nextIndex = journalReader.seekToLast();
     } else {
-      reset(log.getCommitIndex());
+      seek(log.getCommitIndex());
     }
 
     return nextIndex;

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -299,7 +299,7 @@ public final class ControllableRaftContexts {
     final var readers =
         raftServers.values().stream()
             .collect(
-                Collectors.toMap(Function.identity(), s -> s.getLog().openReader(0, Mode.COMMITS)));
+                Collectors.toMap(Function.identity(), s -> s.getLog().openReader(Mode.COMMITS)));
     long index = 0;
     while (true) {
       final var entries =

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -376,8 +376,7 @@ public final class RaftRule extends ExternalResource {
 
         final var log = server.getContext().getLog();
         final List<IndexedRaftLogEntry> entryList = new ArrayList<>();
-        try (final var raftLogReader = log.openReader(1, Mode.ALL)) {
-
+        try (final var raftLogReader = log.openReader(Mode.ALL)) {
           while (raftLogReader.hasNext()) {
             final var indexedEntry = raftLogReader.next();
             entryList.add(indexedEntry);

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -369,7 +369,7 @@ public class RaftTest extends ConcurrentTestCase {
     if (role == Role.LEADER) {
       final RaftLog raftLog = server.getContext().getLog();
       final RaftLogReader raftLogReader = raftLog.openReader(0, Mode.COMMITS);
-      raftLogReader.reset(raftLog.getLastIndex());
+      raftLogReader.seek(raftLog.getLastIndex());
       final IndexedRaftLogEntry entry = raftLogReader.next();
 
       assertThat(entry.entry()).isInstanceOf(InitialEntry.class);

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -368,7 +368,7 @@ public class RaftTest extends ConcurrentTestCase {
       final CountDownLatch transitionCompleted) {
     if (role == Role.LEADER) {
       final RaftLog raftLog = server.getContext().getLog();
-      final RaftLogReader raftLogReader = raftLog.openReader(0, Mode.COMMITS);
+      final RaftLogReader raftLogReader = raftLog.openReader(Mode.COMMITS);
       raftLogReader.seek(raftLog.getLastIndex());
       final IndexedRaftLogEntry entry = raftLogReader.next();
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestHelper.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestHelper.java
@@ -89,7 +89,8 @@ public class ZeebeTestHelper {
 
   public boolean containsIndexed(
       final RaftPartitionServer partition, final IndexedRaftLogEntry indexed) {
-    try (final RaftLogReader reader = partition.openReader(indexed.index(), Mode.COMMITS)) {
+    try (final RaftLogReader reader = partition.openReader(Mode.COMMITS)) {
+      reader.seek(indexed.index());
 
       if (reader.hasNext()) {
         final IndexedRaftLogEntry entry = reader.next();

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/AtomixRecordEntrySupplierImpl.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/AtomixRecordEntrySupplierImpl.java
@@ -25,7 +25,7 @@ public final class AtomixRecordEntrySupplierImpl implements AtomixRecordEntrySup
     // to be not very efficient.
     final long recordIndex = reader.seekToAsqn(position);
     final long prevIndex = recordIndex - 1;
-    if (reader.reset(prevIndex) == prevIndex) {
+    if (reader.seek(prevIndex) == prevIndex) {
       return Optional.of(reader.next());
     }
 

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/RaftLogReaderPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/RaftLogReaderPartitionStep.java
@@ -18,7 +18,7 @@ public class RaftLogReaderPartitionStep implements PartitionStep {
 
   @Override
   public ActorFuture<Void> open(final PartitionContext context) {
-    final var reader = context.getRaftPartition().getServer().openReader(-1, Mode.COMMITS);
+    final var reader = context.getRaftPartition().getServer().openReader(Mode.COMMITS);
     context.setRaftLogReader(reader);
     return CompletableActorFuture.completed(null);
   }

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/BrokerSnapshotTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/BrokerSnapshotTest.java
@@ -49,7 +49,7 @@ public class BrokerSnapshotTest {
                 .getPartitionService()
                 .getPartitionGroup(AtomixFactory.GROUP_NAME)
                 .getPartition(PartitionId.from(AtomixFactory.GROUP_NAME, PARTITION_ID));
-    journalReader = raftPartition.getServer().openReader(1, Mode.COMMITS);
+    journalReader = raftPartition.getServer().openReader(Mode.COMMITS);
     brokerAdminService = brokerRule.getBroker().getBrokerAdminService();
 
     final String contactPoint =

--- a/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixReaderFactory.java
+++ b/logstreams/src/main/java/io/zeebe/logstreams/storage/atomix/AtomixReaderFactory.java
@@ -12,13 +12,9 @@ import io.atomix.raft.storage.log.RaftLogReader.Mode;
 
 @FunctionalInterface
 public interface AtomixReaderFactory {
-  RaftLogReader create(long index, Mode mode);
-
-  default RaftLogReader create(final long index) {
-    return create(index, Mode.COMMITS);
-  }
+  RaftLogReader create(Mode mode);
 
   default RaftLogReader create() {
-    return create(0);
+    return create(Mode.COMMITS);
   }
 }

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
@@ -156,7 +156,7 @@ public final class AtomixLogStorageRule extends ExternalResource
   }
 
   public CompletableFuture<Void> compact(final long index) {
-    raftLog.compact(index);
+    raftLog.deleteUntil(index);
     return CompletableFuture.completedFuture(null);
   }
 

--- a/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/util/AtomixLogStorageRule.java
@@ -161,8 +161,8 @@ public final class AtomixLogStorageRule extends ExternalResource
   }
 
   @Override
-  public RaftLogReader create(final long index, final Mode mode) {
-    return raftLog.openReader(index, mode);
+  public RaftLogReader create(final Mode mode) {
+    return raftLog.openReader(mode);
   }
 
   public void setPositionListener(final LongConsumer positionListener) {


### PR DESCRIPTION
## Description

This PR has following changes:
* Rename compact/truncate to deleteUntil/deleteAfter to match with journal api
* Rename reset(index) to seek(index)
* Move RaftLogBuilder to own class because SonarLint complaints that the RaftLog class is too big.
* Refactor RaftLog::openReader - don't specify the index when opening a reader. Reader always starts at first index. The creator of the reader can seek to any specific index.

## Related issues

closes #6311 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
