### PR TITLE
chore(journal): use little endian in mapped segment buffer

### DIFF
--- a/journal/src/main/java/io/zeebe/journal/file/JournalSegment.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalSegment.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.collect.Sets;
 import io.zeebe.journal.JournalException;
 import java.io.IOException;
+import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel.MapMode;
 import java.nio.file.Files;
@@ -34,6 +35,7 @@ import org.agrona.IoUtil;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 class JournalSegment implements AutoCloseable {
+  private static final ByteOrder ENDIANNESS = ByteOrder.LITTLE_ENDIAN;
 
   private final JournalSegmentFile file;
   private final JournalSegmentDescriptor descriptor;
@@ -54,6 +56,7 @@ class JournalSegment implements AutoCloseable {
     buffer =
         IoUtil.mapExistingFile(
             file.file(), MapMode.READ_WRITE, file.name(), 0, descriptor.maxSegmentSize());
+    buffer.order(ENDIANNESS);
     writer = createWriter(maxEntrySize);
   }
 
@@ -146,7 +149,8 @@ class JournalSegment implements AutoCloseable {
    */
   MappedJournalSegmentReader createReader() {
     checkOpen();
-    return new MappedJournalSegmentReader(buffer.asReadOnlyBuffer().position(0), this, index);
+    return new MappedJournalSegmentReader(
+        buffer.asReadOnlyBuffer().position(0).order(ENDIANNESS), this, index);
   }
 
   private MappedJournalSegmentWriter createWriter(final int maxEntrySize) {


### PR DESCRIPTION
## Description

By default ByteBuffer uses BIG_ENDIAN. SBE uses LITTLE_ENDIAN. To make it consistent across the journal, set the endiannes of the mapped bytebuffer to LITTLE_ENDIAN immediately after it is mapped. The endianness has to be set again when a new view is created via `buffer.asReadOnly()`.

## Related issues

closes #6669 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
