### PR TITLE
Split up BPMNElementContainerProcessor.onElementCompleted into two methods

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementContainerProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementContainerProcessor.java
@@ -35,14 +35,27 @@ public interface BpmnElementContainerProcessor<T extends ExecutableFlowElement>
       final BpmnElementContext childContext);
 
   /**
-   * A child element is completed. Leave the element container if it has no more active child
-   * elements.
+   * The execution path of a child element is about to be completed.
    *
    * @param element the instance of the BPMN element container
    * @param flowScopeContext process instance-related data of the element container
-   * @param childContext process instance-related data of the child element that is completed
+   * @param childContext process instance-related data of the child element that is completed. At
+   *     this point in time the element is still present in the state
    */
-  void onChildCompleted(
+  void beforeExecutionPathCompleted(
+      final T element,
+      final BpmnElementContext flowScopeContext,
+      final BpmnElementContext childContext);
+
+  /**
+   * The execution path of a child element has completed.
+   *
+   * @param element the instance of the BPMN element container
+   * @param flowScopeContext process instance-related data of the element container
+   * @param childContext process instance-related data of the child element that is completed. At
+   *     this point in time the element has already been removed from the state.
+   */
+  void afterExecutionPathCompleted(
       final T element,
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext);

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -94,7 +94,8 @@ public final class ProcessProcessor
     final var parentProcessInstanceKey = context.getParentProcessInstanceKey();
     if (parentProcessInstanceKey > 0) {
       // process instance is created by a call activity
-      stateTransitionBehavior.onElementCompleted(element, context);
+      stateTransitionBehavior.beforeExecutionPathCompleted(element, context);
+      stateTransitionBehavior.afterExecutionPathCompleted(element, context);
     }
 
     if (element.hasNoneStartEvent()) {
@@ -166,11 +167,16 @@ public final class ProcessProcessor
       final BpmnElementContext childContext) {}
 
   @Override
-  public void onChildCompleted(
+  public void beforeExecutionPathCompleted(
+      final ExecutableFlowElementContainer element,
+      final BpmnElementContext flowScopeContext,
+      final BpmnElementContext childContext) {}
+
+  @Override
+  public void afterExecutionPathCompleted(
       final ExecutableFlowElementContainer element,
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext) {
-
     if (stateBehavior.canBeCompleted(childContext)) {
       stateTransitionBehavior.transitionToCompleting(flowScopeContext);
     }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
@@ -57,13 +57,19 @@ public final class BoundaryEventProcessor implements BpmnElementProcessor<Execut
     variableMappingBehavior
         .applyOutputMappings(context, element)
         .ifRightOrLeft(
-            ok -> stateTransitionBehavior.transitionToCompleted(context),
+            ok ->
+                stateTransitionBehavior.transitionToCompletedWithParentNotification(
+                    element, context),
             failure -> incidentBehavior.createIncident(failure, context));
   }
 
   @Override
   public void onCompleted(final ExecutableBoundaryEvent element, final BpmnElementContext context) {
-
+    if (element.getOutgoing().isEmpty()) {
+      /* can be dropped during migration; after migration this is done as part of
+      stateTransitionBehavior.transitionToCompletedWithParentNotification(...)*/
+      stateTransitionBehavior.afterExecutionPathCompleted(element, context);
+    }
     stateTransitionBehavior.takeOutgoingSequenceFlows(element, context);
 
     stateBehavior.removeElementInstance(context);

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -83,8 +83,7 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
 
     final var activated = stateTransitionBehavior.transitionToActivated(activating);
     final var completing = stateTransitionBehavior.transitionToCompleting(activated);
-    final var completed = stateTransitionBehavior.transitionToCompleted(completing);
 
-    stateTransitionBehavior.onElementCompleted(element, completed);
+    stateTransitionBehavior.transitionToCompletedWithParentNotification(element, completing);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
@@ -55,7 +55,9 @@ public class IntermediateCatchEventProcessor
         .ifRightOrLeft(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(completing);
-              final var completed = stateTransitionBehavior.transitionToCompleted(completing);
+              final var completed =
+                  stateTransitionBehavior.transitionToCompletedWithParentNotification(
+                      element, completing);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             },
             failure -> incidentBehavior.createIncident(failure, completing));

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/StartEventProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/event/StartEventProcessor.java
@@ -42,7 +42,10 @@ public class StartEventProcessor implements BpmnElementProcessor<ExecutableStart
   public void onComplete(final ExecutableStartEvent element, final BpmnElementContext context) {
     variableMappingBehavior
         .applyOutputMappings(context, element)
-        .map(c -> stateTransitionBehavior.transitionToCompleted(context))
+        .map(
+            c ->
+                stateTransitionBehavior.transitionToCompletedWithParentNotification(
+                    element, context))
         .ifRightOrLeft(
             completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
             failure -> incidentBehavior.createIncident(failure, context));

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/gateway/ParallelGatewayProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/gateway/ParallelGatewayProcessor.java
@@ -34,7 +34,8 @@ public final class ParallelGatewayProcessor implements BpmnElementProcessor<Exec
     // incoming sequence flows are taken
     final var activated = stateTransitionBehavior.transitionToActivated(context);
     final var completing = stateTransitionBehavior.transitionToCompleting(activated);
-    final var completed = stateTransitionBehavior.transitionToCompleted(completing);
+    final var completed =
+        stateTransitionBehavior.transitionToCompletedWithParentNotification(element, completing);
     // fork the process processing by taking all outgoing sequence flows of the parallel gateway
     stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
@@ -54,7 +54,9 @@ public final class ReceiveTaskProcessor implements BpmnElementProcessor<Executab
         .ifRightOrLeft(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
-              final var completed = stateTransitionBehavior.transitionToCompleted(context);
+              final var completed =
+                  stateTransitionBehavior.transitionToCompletedWithParentNotification(
+                      element, context);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             },
             failure -> incidentBehavior.createIncident(failure, context));

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
@@ -87,14 +87,18 @@ public final class ServiceTaskProcessor implements BpmnElementProcessor<Executab
         .ifRightOrLeft(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
-              stateTransitionBehavior.transitionToCompleted(context);
+              stateTransitionBehavior.transitionToCompletedWithParentNotification(element, context);
             },
             failure -> incidentBehavior.createIncident(failure, context));
   }
 
   @Override
   public void onCompleted(final ExecutableServiceTask element, final BpmnElementContext context) {
-
+    if (element.getOutgoing().isEmpty()) {
+      /* can be dropped during migration; after migration this is done as part of
+      stateTransitionBehavior.transitionToCompletedWithParentNotification(...)*/
+      stateTransitionBehavior.afterExecutionPathCompleted(element, context);
+    }
     stateTransitionBehavior.takeOutgoingSequenceFlows(element, context);
 
     stateBehavior.removeElementInstance(context);

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayTest.java
@@ -308,14 +308,14 @@ public final class ExclusiveGatewayTest {
             .collect(Collectors.toList());
 
     assertThat(completedEvents)
-        .extracting(Record::getIntent)
+        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
         .containsExactly(
-            ProcessInstanceIntent.ELEMENT_ACTIVATING,
-            ProcessInstanceIntent.ELEMENT_ACTIVATED,
-            ProcessInstanceIntent.ELEMENT_COMPLETING,
-            ProcessInstanceIntent.ELEMENT_COMPLETED,
-            ProcessInstanceIntent.ELEMENT_COMPLETING,
-            ProcessInstanceIntent.ELEMENT_COMPLETED);
+            tuple(BpmnElementType.EXCLUSIVE_GATEWAY, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.EXCLUSIVE_GATEWAY, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.EXCLUSIVE_GATEWAY, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.EXCLUSIVE_GATEWAY, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
   @Test


### PR DESCRIPTION
## Description

The problem with the code was that this method was called after the element had already completed.
Therefore, the element and all its variables were already removed from storage.
The change introduces two methods before/after completion of the element. This allows to separate steps
that need to happen before the element is deleted from the steps that can happen after the element is deleted.

The method was also renamed from onChildCompleted which sournds like it should be called whenever an
element was completed - which was not the case - to before/AfterExecutionPathCompleting which better
reflects the semantics of the method.


## Related issues

related to #6172 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [?] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [-] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
