### PR TITLE
chore(engine): add value metric about root process instances

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -114,7 +114,7 @@ public final class BpmnStateTransitionBehavior {
       stateTransitionGuard.registerStateTransition(
           context, ProcessInstanceIntent.ELEMENT_ACTIVATED);
     }
-    metrics.elementInstanceActivated(context.getBpmnElementType());
+    metrics.elementInstanceActivated(context);
     return transitionedContext;
   }
 
@@ -171,7 +171,7 @@ public final class BpmnStateTransitionBehavior {
       stateTransitionGuard.registerStateTransition(
           context, ProcessInstanceIntent.ELEMENT_COMPLETED);
     }
-    metrics.elementInstanceCompleted(context.getBpmnElementType());
+    metrics.elementInstanceCompleted(context);
     return transitionedContext;
   }
 
@@ -201,7 +201,7 @@ public final class BpmnStateTransitionBehavior {
       stateTransitionGuard.registerStateTransition(
           context, ProcessInstanceIntent.ELEMENT_TERMINATED);
     }
-    metrics.elementInstanceTerminated(context.getBpmnElementType());
+    metrics.elementInstanceTerminated(context);
     return transitionedContext;
   }
 


### PR DESCRIPTION
## Description

The new metric "zeebe_executed_instances_total" counts executed root process instances, and can be extend for other use cases. The metric exposes a organization label which can be used to aggregate these values over an organization in Camunda Cloud. The organization is set to "null" in case the env variable "CAMUNDA_CLOUD_ORGANIZATION_ID" is not set.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to https://github.com/camunda-cloud/console/issues/1757

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
