### PR TITLE
fix(engine): set inner instance loop counter correctly

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -14,7 +14,6 @@ import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.zeebe.engine.processing.streamprocessor.MigratedStreamProcessors;
 import io.zeebe.engine.state.TypedEventApplier;
 import io.zeebe.engine.state.immutable.ProcessState;
-import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.zeebe.engine.state.mutable.MutableVariableState;
@@ -78,8 +77,8 @@ final class ProcessInstanceElementActivatingApplier
     if (flowScopeElementType == BpmnElementType.MULTI_INSTANCE_BODY
         && MigratedStreamProcessors.isMigrated(currentElementType)) {
       // update the loop counter of the multi-instance body (starting by 1)
-      elementInstanceState.updateInstance(
-          value.getFlowScopeKey(), ElementInstance::incrementMultiInstanceLoopCounter);
+      flowScopeInstance.incrementMultiInstanceLoopCounter();
+      elementInstanceState.updateInstance(flowScopeInstance);
 
       // set the loop counter of the inner instance
       final var loopCounter = flowScopeInstance.getMultiInstanceLoopCounter();


### PR DESCRIPTION
## Description

Update the loop counter on the element instance object
(flowscopeInstance in this code) when incrementing the loop counter in
the state. Only necessary for the event applier.

This is necessary because: When a migrated element type is the inner
instance of a multi instance body, the loop counter on the inner
instance is set to the unincremented value, i.e. the loop counter is
incremented in the state on the multi-instance body, but then the loop
counter value is taken from the multi-instance body element instance
that is kept in memory which was not modified by the increment method.
I ran into this while migrating the call activity processor.

A test is added to show the problem (test case fails without the fix).

## Related issues

relates #6197 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
