### PR TITLE
Apply event sourcing to the boundary event

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementContext.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementContext.java
@@ -41,4 +41,7 @@ public interface BpmnElementContext {
 
   BpmnElementContext copy(
       long elementInstanceKey, ProcessInstanceRecord recordValue, ProcessInstanceIntent intent);
+
+  // TODO (saig0): remove when all processors are migrated (#6202)
+  boolean isInReprocessingMode();
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementContextImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementContextImpl.java
@@ -20,6 +20,8 @@ public final class BpmnElementContextImpl implements BpmnElementContext {
   private ProcessInstanceRecord recordValue;
   private ProcessInstanceIntent intent;
 
+  private boolean reprocessingMode = false;
+
   @Override
   public long getElementInstanceKey() {
     return elementInstanceKey;
@@ -88,6 +90,7 @@ public final class BpmnElementContextImpl implements BpmnElementContext {
 
     final var copy = new BpmnElementContextImpl();
     copy.init(elementInstanceKey, recordValue, intent);
+    copy.reprocessingMode = reprocessingMode;
     return copy;
   }
 
@@ -98,6 +101,15 @@ public final class BpmnElementContextImpl implements BpmnElementContext {
     this.elementInstanceKey = elementInstanceKey;
     this.recordValue = recordValue;
     this.intent = intent;
+  }
+
+  public void setReprocessingMode(final boolean reprocessingMode) {
+    this.reprocessingMode = reprocessingMode;
+  }
+
+  @Override
+  public boolean isInReprocessingMode() {
+    return reprocessingMode;
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -18,6 +18,7 @@ import io.zeebe.engine.state.immutable.ElementInstanceState;
 import io.zeebe.engine.state.mutable.MutableVariableState;
 import io.zeebe.engine.state.mutable.MutableZeebeState;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.util.Either;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -110,7 +111,8 @@ public final class BpmnVariableMappingBehavior {
 
       variablesState.removeTemporaryVariables(elementInstanceKey);
 
-    } else if (isConnectedToEventBasedGateway(element)) {
+    } else if (isConnectedToEventBasedGateway(element)
+        || element.getElementType() == BpmnElementType.BOUNDARY_EVENT) {
       // event variables are set local variables instead of temporary variables
       final var localVariables = variablesState.getVariablesLocalAsDocument(elementInstanceKey);
       variableBehavior.mergeDocument(

--- a/engine/src/main/java/io/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -114,7 +114,11 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
 
         final var catchEvent =
             getCatchEvent(elementInstance.getValue(), subscriptionRecord.getElementIdBuffer());
-        eventHandle.activateElement(catchEvent, elementInstanceKey, elementInstance.getValue());
+        eventHandle.activateElement(
+            catchEvent,
+            elementInstanceKey,
+            elementInstance.getValue(),
+            subscriptionRecord.getVariablesBuffer());
 
         sendAcknowledgeCommand(subscriptionRecord);
       }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -42,6 +42,7 @@ public final class MigratedStreamProcessors {
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.START_EVENT);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.RECEIVE_TASK);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.END_EVENT);
+    MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.BOUNDARY_EVENT);
 
     MIGRATED_VALUE_TYPES.put(ValueType.JOB, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.JOB_BATCH, MIGRATED);

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessEventTriggeredApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessEventTriggeredApplier.java
@@ -9,11 +9,15 @@ package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
 import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.zeebe.msgpack.value.DocumentValue;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
 import io.zeebe.protocol.record.intent.ProcessEventIntent;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 final class ProcessEventTriggeredApplier
     implements TypedEventApplier<ProcessEventIntent, ProcessEventRecord> {
+  private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
   private final MutableEventScopeInstanceState eventScopeState;
 
   public ProcessEventTriggeredApplier(final MutableEventScopeInstanceState eventScopeState) {
@@ -22,7 +26,13 @@ final class ProcessEventTriggeredApplier
 
   @Override
   public void applyState(final long key, final ProcessEventRecord value) {
+    var variables = value.getVariablesBuffer();
+    if (variables.equals(DocumentValue.EMPTY_DOCUMENT)) {
+      // avoid storing an empty document
+      variables = NO_VARIABLES;
+    }
+
     eventScopeState.triggerEvent(
-        value.getScopeKey(), key, value.getTargetElementIdBuffer(), value.getVariablesBuffer());
+        value.getScopeKey(), key, value.getTargetElementIdBuffer(), variables);
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
@@ -262,6 +262,7 @@ public final class BoundaryEventTest {
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.COMPLETE_ELEMENT),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
@@ -81,6 +81,7 @@ public class ErrorEventTest {
             tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.COMPLETE_ELEMENT),
             tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.SEQUENCE_FLOW, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),

--- a/engine/src/test/java/io/zeebe/engine/processing/message/MessageCorrelationTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/message/MessageCorrelationTest.java
@@ -800,7 +800,9 @@ public final class MessageCorrelationTest {
             .endEvent("taskEnd")
             .done();
     engine.deployment().withXmlResource(process).deploy();
-    engine.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("key", "123").create();
+
+    final var processInstanceKey =
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("key", "123").create();
 
     // when
     final PublishMessageClient messageClient =
@@ -820,7 +822,11 @@ public final class MessageCorrelationTest {
                 .count())
         .isEqualTo(3);
 
-    assertThat(RecordingExporter.variableRecords().withName("foo").limit(3))
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withName("foo")
+                .withScopeKey(processInstanceKey)
+                .limit(3))
         .extracting(r -> r.getValue().getValue())
         .containsExactly("0", "1", "2");
   }

--- a/engine/src/test/java/io/zeebe/engine/processing/variable/mapping/MessageCatchElementOutputMappingTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/variable/mapping/MessageCatchElementOutputMappingTest.java
@@ -134,6 +134,32 @@ public final class MessageCatchElementOutputMappingTest {
           .endEvent()
           .done();
 
+  private static final BpmnModelInstance INTERRUPTING_BOUNDARY_EVENT_ON_RECEIVE_TASK_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .receiveTask(
+              "task",
+              t ->
+                  t.message(
+                      m -> m.name("other").zeebeCorrelationKeyExpression(CORRELATION_VARIABLE)))
+          .boundaryEvent(MAPPING_ELEMENT_ID)
+          .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKeyExpression(CORRELATION_VARIABLE))
+          .endEvent()
+          .done();
+
+  private static final BpmnModelInstance NON_INTERRUPTING_BOUNDARY_EVENT_ON_RECEIVE_TASK_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .receiveTask(
+              "task",
+              t ->
+                  t.message(
+                      m -> m.name("other").zeebeCorrelationKeyExpression(CORRELATION_VARIABLE)))
+          .boundaryEvent(MAPPING_ELEMENT_ID, b -> b.cancelActivity(false))
+          .message(m -> m.name(MESSAGE_NAME).zeebeCorrelationKeyExpression(CORRELATION_VARIABLE))
+          .endEvent()
+          .done();
+
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
@@ -155,7 +181,15 @@ public final class MessageCatchElementOutputMappingTest {
       {"interrupting boundary event", INTERRUPTING_BOUNDARY_EVENT_PROCESS},
       {"non-interrupting boundary event", NON_INTERRUPTING_BOUNDARY_EVENT_PROCESS},
       {"interrupting event subprocess", INTERRUPTING_EVENT_SUBPROCESS_PROCESS},
-      {"non-interrupting event subprocess", NON_INTERRUPTING_EVENT_SUBPROCESS_PROCESS}
+      {"non-interrupting event subprocess", NON_INTERRUPTING_EVENT_SUBPROCESS_PROCESS},
+      {
+        "interrupting boundary event on receive task",
+        INTERRUPTING_BOUNDARY_EVENT_ON_RECEIVE_TASK_PROCESS
+      },
+      {
+        "non-interrupting boundary event on receive task",
+        NON_INTERRUPTING_BOUNDARY_EVENT_ON_RECEIVE_TASK_PROCESS
+      }
     };
   }
 


### PR DESCRIPTION
## Description

* activate the boundary event by writing an ACTIVATING and an ACTIVATED event to pass the variables for the output mapping (similar to event-based gateways)
* introduce a marker in the context to distinguish between processing and reprocessing
  * use the marker to avoid writing events and commands on reprocessing for migrated element processors
  * otherwise, the boundary events are applied twice, for example, if it is attached on a service task

## Related issues

closes #6187

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
