### PR TITLE
Apply event sourcing to call activity

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -150,11 +150,23 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
       }
 
       final var flowScopeInstance = elementInstanceState.getInstance(context.getFlowScopeKey());
-      elementInstanceState.newInstance(
-          flowScopeInstance,
-          context.getElementInstanceKey(),
-          context.getRecordValue(),
-          ProcessInstanceIntent.ELEMENT_ACTIVATING);
+      final var elementInstance =
+          elementInstanceState.newInstance(
+              flowScopeInstance,
+              context.getElementInstanceKey(),
+              context.getRecordValue(),
+              ProcessInstanceIntent.ELEMENT_ACTIVATING);
+
+      final var parentElementInstance =
+          elementInstanceState.getInstance(context.getRecordValue().getParentElementInstanceKey());
+      if (parentElementInstance == null
+          || context.getBpmnElementType() != BpmnElementType.PROCESS) {
+        // only connect to call activity for child processes
+        return;
+      }
+
+      parentElementInstance.setCalledChildInstanceKey(elementInstance.getKey());
+      elementInstanceState.updateInstance(parentElementInstance);
       return;
     }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -114,29 +114,8 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
     final var processor = processors.getProcessor(bpmnElementType);
     final ExecutableFlowElement element = getElement(recordValue, processor);
 
-    // On migrating processors we saw issues on replay, where element instances are not existing on
-    // replay/reprocessing. You need to know that migrated processors are only replayed, which means
-    // the events are applied to the state and non migrated are reprocessed, so the processor is
-    // called.
-    //
-    // If we have a non migrated type and reprocess that, we expect an existing element instance.
-    // On normal processing this element instance was created by using the state writer of the
-    // previous command/event most likely by an already migrated type. On replay this state writer
-    // is not called which causes issues, like non existing element instance.
-    //
-    // To cover the gap between migrated and non migrated processors we need to re-create an element
-    // instance here, such that we can continue in migrate the processors individually and still
-    // are able to run the replay tests.
-    final var instance = elementInstanceState.getInstance(context.getElementInstanceKey());
-    if (instance == null
-        && context.getIntent() == ProcessInstanceIntent.ELEMENT_ACTIVATING
-        && !MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
-      final var flowScopeInstance = elementInstanceState.getInstance(context.getFlowScopeKey());
-      elementInstanceState.newInstance(
-          flowScopeInstance,
-          context.getElementInstanceKey(),
-          context.getRecordValue(),
-          ProcessInstanceIntent.ELEMENT_ACTIVATING);
+    if (!MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
+      relieveReprocessingStateProblems();
     }
 
     // process the record
@@ -144,6 +123,45 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
       LOGGER.trace("Process process instance event [context: {}]", context);
 
       processEvent(intent, processor, element);
+    }
+  }
+
+  /**
+   * On migrating processors we saw issues on replay, where element instances are not existing on
+   * replay/reprocessing. You need to know that migrated processors are only replayed, which means
+   * the events are applied to the state and non migrated are reprocessed, so the processor is
+   * called.
+   *
+   * <p>If we have a non migrated type and reprocess that, we expect an existing element instance.
+   * On normal processing this element instance was created by using the state writer of the
+   * previous command/event most likely by an already migrated type. On replay this state writer is
+   * not called which causes issues, like non existing element instance.
+   *
+   * <p>To cover the gap between migrated and non migrated processors we need to re-create an
+   * element instance here, such that we can continue in migrate the processors individually and
+   * still are able to run the replay tests.
+   */
+  private void relieveReprocessingStateProblems() {
+    final var instance = elementInstanceState.getInstance(context.getElementInstanceKey());
+    if (instance == null) {
+      if (context.getIntent() != ProcessInstanceIntent.ELEMENT_ACTIVATING) {
+        // only create new instance for elements that are activating
+        return;
+      }
+
+      final var flowScopeInstance = elementInstanceState.getInstance(context.getFlowScopeKey());
+      elementInstanceState.newInstance(
+          flowScopeInstance,
+          context.getElementInstanceKey(),
+          context.getRecordValue(),
+          ProcessInstanceIntent.ELEMENT_ACTIVATING);
+      return;
+    }
+
+    if (context.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING
+        && context.getBpmnElementType() == BpmnElementType.PROCESS) {
+      instance.setState(ProcessInstanceIntent.ELEMENT_TERMINATING);
+      elementInstanceState.updateInstance(instance);
     }
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -59,9 +59,9 @@ public final class ProcessInstanceStateTransitionGuard {
     // processors in the processor. this means that ELEMENT_COMPLETING of a migrated processor will
     // set the element state to ELEMENT_COMPLETING on replay, but ELEMENT_COMPLETING of a non
     // migrated will expect its state to ALREADY be ELEMENT_COMPLETING. To avoid too much
-    // complexity, when reprocessing events for non migrated processors, just set their state as
-    // expected; this could in the future be a source of error, but as its only temporary until
-    // all processors are migrated, it's OK for now
+    // complexity, when reprocessing events for non migrated processors, just allow allow the
+    // transition as well; this could in the future be a source of error, but as its only
+    // temporary until all processors are migrated, it's OK for now
     // TODO(npepinpe): remove as part of https://github.com/camunda-cloud/zeebe/issues/6202
     if (!MigratedStreamProcessors.isMigrated(context.getBpmnElementType())) {
       if (context.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETING) {

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -539,14 +539,17 @@ public final class BpmnStateTransitionBehavior {
     return processInstanceKey;
   }
 
-  public void terminateChildProcessInstance(final BpmnElementContext context) {
+  public <T extends ExecutableFlowElement> void terminateChildProcessInstance(
+      final BpmnElementContainerProcessor<T> containerProcessor,
+      final T element,
+      final BpmnElementContext context) {
     stateBehavior
         .getCalledChildInstance(context)
         .filter(ElementInstance::canTerminate)
-        .map(instance -> context.copy(instance.getKey(), instance.getValue(), instance.getState()))
+        .map(child -> context.copy(child.getKey(), child.getValue(), child.getState()))
         .ifPresentOrElse(
             childInstanceContext -> terminate(childInstanceContext),
-            () -> transitionToTerminated(context));
+            () -> containerProcessor.onChildTerminated(element, context, null));
   }
 
   @FunctionalInterface

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -112,7 +112,7 @@ public final class CallActivityProcessor
   @Override
   public void onTerminating(
       final ExecutableCallActivity element, final BpmnElementContext context) {
-    stateTransitionBehavior.terminateChildProcessInstance(context);
+    stateTransitionBehavior.terminateChildProcessInstance(this, element, context);
     eventSubscriptionBehavior.unsubscribeFromEvents(context);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -56,7 +56,7 @@ public final class CallActivityProcessor
   }
 
   @Override
-  public void onActivating(final ExecutableCallActivity element, final BpmnElementContext context) {
+  public void onActivate(final ExecutableCallActivity element, final BpmnElementContext context) {
     variableMappingBehavior
         .applyInputMappings(context, element)
         .flatMap(ok -> eventSubscriptionBehavior.subscribeToEvents(element, context))
@@ -65,16 +65,12 @@ public final class CallActivityProcessor
         .flatMap(this::checkProcessHasNoneStartEvent)
         .ifRightOrLeft(
             process -> {
-              stateTransitionBehavior.transitionToActivated(context);
+              final var activated = stateTransitionBehavior.transitionToActivated(context);
 
               final var childProcessInstanceKey =
                   stateTransitionBehavior.createChildProcessInstance(process, context);
 
-              final var callActivityInstance = stateBehavior.getElementInstance(context);
-              callActivityInstance.setCalledChildInstanceKey(childProcessInstanceKey);
-              stateBehavior.updateElementInstance(callActivityInstance);
-
-              final var callActivityInstanceKey = context.getElementInstanceKey();
+              final var callActivityInstanceKey = activated.getElementInstanceKey();
               stateBehavior.copyVariablesToProcessInstance(
                   callActivityInstanceKey, childProcessInstanceKey, process);
             },
@@ -82,46 +78,25 @@ public final class CallActivityProcessor
   }
 
   @Override
-  public void onActivated(final ExecutableCallActivity element, final BpmnElementContext context) {
-    // Nothing to do but wait until the child process has completed
-  }
-
-  @Override
-  public void onCompleting(final ExecutableCallActivity element, final BpmnElementContext context) {
+  public void onComplete(final ExecutableCallActivity element, final BpmnElementContext context) {
     variableMappingBehavior
         .applyOutputMappings(context, element)
         .ifRightOrLeft(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
-              stateTransitionBehavior.transitionToCompletedWithParentNotification(element, context);
+              final var completed =
+                  stateTransitionBehavior.transitionToCompletedWithParentNotification(
+                      element, context);
+              stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             },
             failure -> incidentBehavior.createIncident(failure, context));
   }
 
   @Override
-  public void onCompleted(final ExecutableCallActivity element, final BpmnElementContext context) {
-    if (element.getOutgoing().isEmpty()) {
-      /* can be dropped during migration; after migration this is done as part of
-      stateTransitionBehavior.transitionToCompletedWithParentNotification(...)*/
-      stateTransitionBehavior.afterExecutionPathCompleted(element, context);
-    }
-    stateTransitionBehavior.takeOutgoingSequenceFlows(element, context);
-    stateBehavior.removeElementInstance(context);
-  }
-
-  @Override
-  public void onTerminating(
-      final ExecutableCallActivity element, final BpmnElementContext context) {
-    stateTransitionBehavior.terminateChildProcessInstance(this, element, context);
+  public void onTerminate(final ExecutableCallActivity element, final BpmnElementContext context) {
     eventSubscriptionBehavior.unsubscribeFromEvents(context);
-  }
-
-  @Override
-  public void onTerminated(final ExecutableCallActivity element, final BpmnElementContext context) {
-    eventSubscriptionBehavior.publishTriggeredBoundaryEvent(context);
     incidentBehavior.resolveIncidents(context);
-    stateTransitionBehavior.onElementTerminated(element, context);
-    stateBehavior.removeElementInstance(context);
+    stateTransitionBehavior.terminateChildProcessInstance(this, element, context);
   }
 
   @Override
@@ -144,7 +119,7 @@ public final class CallActivityProcessor
     final var currentState = callActivityContext.getIntent();
     switch (currentState) {
       case ELEMENT_ACTIVATED:
-        stateTransitionBehavior.transitionToCompleting(callActivityContext);
+        // nothing to do any more
         break;
       case ELEMENT_TERMINATING:
         // the call activity is already terminating, it doesn't matter that the child completed
@@ -159,8 +134,10 @@ public final class CallActivityProcessor
   @Override
   public void afterExecutionPathCompleted(
       final ExecutableCallActivity element,
-      final BpmnElementContext flowScopeContext,
-      final BpmnElementContext childContext) {}
+      final BpmnElementContext callActivityContext,
+      final BpmnElementContext childContext) {
+    stateTransitionBehavior.completeElement(callActivityContext);
+  }
 
   @Override
   public void onChildTerminated(
@@ -168,12 +145,24 @@ public final class CallActivityProcessor
       final BpmnElementContext callActivityContext,
       final BpmnElementContext childContext) {
     final var currentState = callActivityContext.getIntent();
-    if (currentState == ProcessInstanceIntent.ELEMENT_TERMINATING) {
-      stateTransitionBehavior.transitionToTerminated(callActivityContext);
-    } else {
+    if (currentState != ProcessInstanceIntent.ELEMENT_TERMINATING) {
       final var message = String.format(UNABLE_TO_TERMINATE_FROM_STATE_MESSAGE, currentState);
       throw new BpmnProcessingException(callActivityContext, message);
     }
+
+    eventSubscriptionBehavior
+        .findEventTrigger(callActivityContext)
+        .ifPresentOrElse(
+            eventTrigger -> {
+              final var terminated =
+                  stateTransitionBehavior.transitionToTerminated(callActivityContext);
+              eventSubscriptionBehavior.activateTriggeredEvent(terminated, eventTrigger);
+            },
+            () -> {
+              final var terminated =
+                  stateTransitionBehavior.transitionToTerminated(callActivityContext);
+              stateTransitionBehavior.onElementTerminated(element, terminated);
+            });
   }
 
   private Either<Failure, DirectBuffer> evaluateProcessId(

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -44,6 +44,7 @@ public final class MigratedStreamProcessors {
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.END_EVENT);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.BOUNDARY_EVENT);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.PROCESS);
+    MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.CALL_ACTIVITY);
 
     MIGRATED_VALUE_TYPES.put(ValueType.JOB, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.JOB_BATCH, MIGRATED);

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -60,6 +60,21 @@ final class ProcessInstanceElementActivatingApplier
 
     if (flowScopeInstance == null) {
       // process instance level
+      final var parentElementInstance =
+          elementInstanceState.getInstance(value.getParentElementInstanceKey());
+      if (parentElementInstance == null) {
+        // root process (not a child process)
+        return;
+      }
+
+      // this check is not really necessary: if parentElementInstance exists,
+      // it should always be a call-activity, but let's try to be safe
+      final var parentElementType = parentElementInstance.getValue().getBpmnElementType();
+      if (parentElementType == BpmnElementType.CALL_ACTIVITY) {
+        parentElementInstance.setCalledChildInstanceKey(elementInstanceKey);
+        elementInstanceState.updateInstance(parentElementInstance);
+      }
+
       return;
     }
 

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -82,6 +82,7 @@ public final class CallActivityTest {
     // then
     assertThat(
             RecordingExporter.processInstanceRecords()
+                .onlyEvents()
                 .withProcessInstanceKey(processInstanceKey)
                 .withElementId("call")
                 .limit(2))
@@ -392,7 +393,7 @@ public final class CallActivityTest {
                 .processInstanceRecords())
         .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
         .containsSubsequence(
-            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.EVENT_OCCURRED),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
@@ -224,7 +224,7 @@ public class ErrorEventTest {
                 .limitToProcessInstanceCompleted())
         .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
         .containsSubsequence(
-            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.EVENT_OCCURRED),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),

--- a/engine/src/test/java/io/zeebe/engine/processing/incident/CallActivityIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/CallActivityIncidentTest.java
@@ -198,6 +198,7 @@ public final class CallActivityIncidentTest {
     // then
     assertThat(
             RecordingExporter.processInstanceRecords()
+                .onlyEvents()
                 .withRecordKey(incident.getValue().getElementInstanceKey())
                 .limit(2))
         .extracting(Record::getIntent)

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/ReplayStateTest.java
@@ -154,12 +154,14 @@ public final class ReplayStateTest {
                     .startEvent()
                     .callActivity("call-child", b -> b.zeebeProcessId(PROCESS_CHILD_ID))
                     .boundaryEvent("timer", b -> b.cancelActivity(true))
-                    .timerWithDuration("PT0S")
+                    .timerWithDuration("PT1M")
                     .endEvent("end")
                     .done())
             .withExecution(
                 engine -> {
                   final long piKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+                  RecordingExporter.jobRecords(JobIntent.CREATED).await();
+                  engine.getClock().addTime(Duration.ofMinutes(1));
                   return RecordingExporter.processInstanceRecords(
                           ProcessInstanceIntent.ELEMENT_COMPLETED)
                       .withProcessInstanceKey(piKey)


### PR DESCRIPTION
## Description

This PR migrates call activity elements to the event sourcing model.

For call activity elements only commands are processed: 
`activate_element`, `complete_element` and `terminate_element`.

For call activity elements events are no longer processed:
`element_activating`, `element_activated`, 
`element_completing`, `element_completed`, 
`element_terminating`, `element_terminated`, 
`event_occurred`.

I recommend reviewing this PR by reading the commits individually.

## Related issues

closes #6197

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
