### PR TITLE
fix(broker): flush write if any entry was appended

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -16,7 +16,10 @@
 package io.atomix.raft.roles;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.raft.impl.RaftContext;
@@ -24,33 +27,37 @@ import io.atomix.raft.metrics.RaftReplicationMetrics;
 import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.storage.RaftStorage;
+import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.PersistedRaftRecord;
 import io.atomix.raft.storage.log.RaftLog;
+import io.zeebe.journal.JournalException;
+import io.zeebe.journal.JournalException.InvalidChecksum;
 import io.zeebe.snapshots.raft.PersistedSnapshot;
 import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.junit.rules.Timeout;
 
 public class PassiveRoleTest {
 
   @Rule public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private RaftLog log;
   private PassiveRole role;
 
   @Before
   public void setup() throws IOException {
+
+    final RaftContext ctx = mock(RaftContext.class);
     final RaftStorage storage = mock(RaftStorage.class);
 
-    log = RaftLog.builder().withDirectory(temporaryFolder.newFolder("data")).build();
+    log = mock(RaftLog.class);
+    when(log.shouldFlushExplicitly()).thenReturn(true);
+    when(ctx.getLog()).thenReturn(log);
 
     final PersistedSnapshot snapshot = mock(PersistedSnapshot.class);
     when(snapshot.getIndex()).thenReturn(1L);
@@ -59,7 +66,6 @@ public class PassiveRoleTest {
     final ReceivableSnapshotStore store = mock(ReceivableSnapshotStore.class);
     when(store.getLatestSnapshot()).thenReturn(Optional.of(snapshot));
 
-    final RaftContext ctx = mock(RaftContext.class);
     when(ctx.getStorage()).thenReturn(storage);
     when(ctx.getLog()).thenReturn(log);
     when(ctx.getPersistedSnapshotStore()).thenReturn(store);
@@ -72,14 +78,77 @@ public class PassiveRoleTest {
   @Test
   public void shouldFailAppendWithIncorrectChecksum() {
     // given
-    final List<PersistedRaftRecord> entries = new ArrayList<>();
-    entries.add(new PersistedRaftRecord(1, 1, 1, 12345, new byte[1]));
+    final List<PersistedRaftRecord> entries =
+        List.of(new PersistedRaftRecord(1, 1, 1, 12345, new byte[1]));
     final AppendRequest request = new AppendRequest(2, "", 0, 0, entries, 1);
+
+    when(log.append(any(PersistedRaftRecord.class)))
+        .thenThrow(new JournalException.InvalidChecksum("expected"));
 
     // when
     final AppendResponse response = role.handleAppend(request).join();
 
     // then
     assertThat(response.succeeded()).isFalse();
+  }
+
+  @Test
+  public void shouldFlushAfterAppendRequest() {
+    // given
+    final List<PersistedRaftRecord> entries =
+        List.of(
+            new PersistedRaftRecord(1, 1, 1, 1, new byte[1]),
+            new PersistedRaftRecord(1, 2, 2, 1, new byte[1]));
+    final AppendRequest request = new AppendRequest(1, "", 0, 0, entries, 2);
+
+    when(log.append(any(PersistedRaftRecord.class)))
+        .thenReturn(mock(IndexedRaftLogEntry.class))
+        .thenReturn(mock(IndexedRaftLogEntry.class));
+
+    // when
+    final AppendResponse response = role.handleAppend(request).join();
+
+    // then
+    verify(log).flush();
+    assertThat(response.lastLogIndex()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldFlushAfterPartiallyAppendedRequest() {
+    // given
+    final List<PersistedRaftRecord> entries =
+        List.of(
+            new PersistedRaftRecord(1, 1, 1, 1, new byte[1]),
+            new PersistedRaftRecord(1, 2, 2, 1, new byte[1]));
+    final AppendRequest request = new AppendRequest(1, "", 0, 0, entries, 2);
+
+    when(log.append(any(PersistedRaftRecord.class)))
+        .thenReturn(mock(IndexedRaftLogEntry.class))
+        .thenThrow(new InvalidChecksum.InvalidChecksum("expected"));
+
+    // when
+    final AppendResponse response = role.handleAppend(request).join();
+
+    // then
+    verify(log).flush();
+    assertThat(response.lastLogIndex()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldNotFlushIfNoEntryIsAppended() {
+    // given
+    final List<PersistedRaftRecord> entries =
+        List.of(new PersistedRaftRecord(1, 1, 1, 1, new byte[1]));
+    final AppendRequest request = new AppendRequest(1, "", 0, 0, entries, 2);
+
+    when(log.append(any(PersistedRaftRecord.class)))
+        .thenThrow(new InvalidChecksum.InvalidChecksum("expected"));
+
+    // when
+    final AppendResponse response = role.handleAppend(request).join();
+
+    // then
+    verify(log, never()).flush();
+    assertThat(response.lastLogIndex()).isEqualTo(0);
   }
 }


### PR DESCRIPTION
## Description

The follower only flushed the appended entries if every entry in the AppendRequest was written. This commit makes the follower flush if any entry was written.

## Related issues

closes #6784 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
