### PR TITLE
Ignore checksum files when loading snapshots on startup

### DIFF
--- a/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/broker/impl/FileBasedSnapshotStore.java
@@ -82,7 +82,9 @@ public final class FileBasedSnapshotStore extends Actor
   private FileBasedSnapshot loadLatestSnapshot(final Path snapshotDirectory) {
     FileBasedSnapshot latestPersistedSnapshot = null;
     final List<FileBasedSnapshot> snapshots = new ArrayList<>();
-    try (final var stream = Files.newDirectoryStream(snapshotDirectory)) {
+    try (final var stream =
+        Files.newDirectoryStream(
+            snapshotDirectory, path -> !path.toString().endsWith(CHECKSUM_SUFFIX))) {
       for (final var path : stream) {
         final var snapshot = collectSnapshot(path);
         if (snapshot != null) {
@@ -93,6 +95,7 @@ public final class FileBasedSnapshotStore extends Actor
           }
         }
       }
+
       // Delete older snapshots
       if (latestPersistedSnapshot != null) {
         snapshots.remove(latestPersistedSnapshot);


### PR DESCRIPTION
## Description

As the checksum file is now a sibling file of the snapshot, it gets picked up during startup as a potential snapshot itself, resulting in weird warnings that it's not a valid snapshot.

The simplest fix is to ignore checksum files when loading the latest snapshot, as we expect that file to be present.

## Related issues

closes #6793 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
