### PR TITLE
Persist the index of the last entry to be flushed

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -373,6 +373,7 @@ public class RaftContext implements AutoCloseable {
       if (raftLog.shouldFlushExplicitly() && isLeader()) {
         // leader counts itself in quorum, so in order to commit the leader must persist
         raftLog.flush();
+        setFlushedIndex(commitIndex);
       }
       final long configurationIndex = cluster.getConfiguration().index();
       if (configurationIndex > previousCommitIndex && configurationIndex <= commitIndex) {
@@ -898,6 +899,10 @@ public class RaftContext implements AutoCloseable {
       meta.storeVote(lastVotedFor);
       log.debug("Set term {}", term);
     }
+  }
+
+  public void setFlushedIndex(final long index) {
+    meta.storeFlushedIndex(index);
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -373,7 +373,7 @@ public class RaftContext implements AutoCloseable {
       if (raftLog.shouldFlushExplicitly() && isLeader()) {
         // leader counts itself in quorum, so in order to commit the leader must persist
         raftLog.flush();
-        setFlushedIndex(commitIndex);
+        setLastWrittenIndex(commitIndex);
       }
       final long configurationIndex = cluster.getConfiguration().index();
       if (configurationIndex > previousCommitIndex && configurationIndex <= commitIndex) {
@@ -901,8 +901,8 @@ public class RaftContext implements AutoCloseable {
     }
   }
 
-  public void setFlushedIndex(final long index) {
-    meta.storeFlushedIndex(index);
+  public void setLastWrittenIndex(final long index) {
+    meta.storeLastWrittenIndex(index);
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -562,7 +562,7 @@ public class PassiveRole extends InactiveRole {
   private void flush(final long lastWrittenIndex, final long previousEntryIndex) {
     if (raft.getLog().shouldFlushExplicitly() && lastWrittenIndex > previousEntryIndex) {
       raft.getLog().flush();
-      raft.setFlushedIndex(lastWrittenIndex);
+      raft.setLastWrittenIndex(lastWrittenIndex);
     }
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -522,9 +522,8 @@ public class PassiveRole extends InactiveRole {
       }
 
       // Iterate through entries and append them.
-      for (int i = 0; i < request.entries().size(); ++i) {
+      for (final PersistedRaftRecord entry : request.entries()) {
         final long index = ++lastLogIndex;
-        final PersistedRaftRecord entry = request.entries().get(i);
 
         // Get the last entry written to the log by the writer.
         final IndexedRaftLogEntry lastEntry = raft.getLog().getLastEntry();
@@ -563,6 +562,7 @@ public class PassiveRole extends InactiveRole {
   private void flush(final long lastWrittenIndex, final long previousEntryIndex) {
     if (raft.getLog().shouldFlushExplicitly() && lastWrittenIndex > previousEntryIndex) {
       raft.getLog().flush();
+      raft.setFlushedIndex(lastWrittenIndex);
     }
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
@@ -148,7 +148,7 @@ public class MetaStoreSerializer {
     headerDecoder.wrap(buffer, offset);
     metaDecoder.wrap(
         buffer,
-        headerDecoder.encodedLength(),
+        offset + headerDecoder.encodedLength(),
         headerDecoder.blockLength(),
         headerDecoder.version());
 
@@ -164,7 +164,7 @@ public class MetaStoreSerializer {
         .schemaId(metaEncoder.sbeSchemaId())
         .version(metaEncoder.sbeSchemaVersion());
 
-    metaEncoder.wrap(buffer, headerEncoder.encodedLength());
+    metaEncoder.wrap(buffer, offset + headerEncoder.encodedLength());
     metaEncoder.lastWrittenIndex(index);
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
@@ -144,7 +144,7 @@ public class MetaStoreSerializer {
     return metaDecoder.votedFor();
   }
 
-  public long readFlushedIndex(final MutableDirectBuffer buffer, final int offset) {
+  public long readLastWrittenIndex(final MutableDirectBuffer buffer, final int offset) {
     headerDecoder.wrap(buffer, offset);
     metaDecoder.wrap(
         buffer,
@@ -152,10 +152,10 @@ public class MetaStoreSerializer {
         headerDecoder.blockLength(),
         headerDecoder.version());
 
-    return metaDecoder.flushedIndex();
+    return metaDecoder.lastWrittenIndex();
   }
 
-  public void writeFlushedIndex(
+  public void writeLastWrittenIndex(
       final long index, final MutableDirectBuffer buffer, final int offset) {
     headerEncoder
         .wrap(buffer, offset)
@@ -165,6 +165,6 @@ public class MetaStoreSerializer {
         .version(metaEncoder.sbeSchemaVersion());
 
     metaEncoder.wrap(buffer, headerEncoder.encodedLength());
-    metaEncoder.flushedIndex(index);
+    metaEncoder.lastWrittenIndex(index);
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
@@ -143,4 +143,28 @@ public class MetaStoreSerializer {
 
     return metaDecoder.votedFor();
   }
+
+  public long readFlushedIndex(final MutableDirectBuffer buffer, final int offset) {
+    headerDecoder.wrap(buffer, offset);
+    metaDecoder.wrap(
+        buffer,
+        headerDecoder.encodedLength(),
+        headerDecoder.blockLength(),
+        headerDecoder.version());
+
+    return metaDecoder.flushedIndex();
+  }
+
+  public void writeFlushedIndex(
+      final long index, final MutableDirectBuffer buffer, final int offset) {
+    headerEncoder
+        .wrap(buffer, offset)
+        .blockLength(metaEncoder.sbeBlockLength())
+        .templateId(metaEncoder.sbeTemplateId())
+        .schemaId(metaEncoder.sbeSchemaId())
+        .version(metaEncoder.sbeSchemaVersion());
+
+    metaEncoder.wrap(buffer, headerEncoder.encodedLength());
+    metaEncoder.flushedIndex(index);
+  }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
@@ -50,12 +50,11 @@ public class MetaStore implements AutoCloseable {
   private static final int VERSION_LENGTH = Byte.BYTES;
 
   private final Logger log = LoggerFactory.getLogger(getClass());
-  private final FileChannel metaFileChannel;
   private final ByteBuffer metaBuffer = ByteBuffer.allocate(256).order(ByteOrder.LITTLE_ENDIAN);
   private final FileChannel configurationChannel;
-  private final File metaFile;
   private final File confFile;
   private final MetaStoreSerializer serializer = new MetaStoreSerializer();
+  private FileChannel metaFileChannel;
 
   public MetaStore(final RaftStorage storage) throws IOException {
     if (!(storage.directory().isDirectory() || storage.directory().mkdirs())) {
@@ -65,13 +64,18 @@ public class MetaStore implements AutoCloseable {
 
     // Note that for raft safety, irrespective of the storage level, <term, vote> metadata is always
     // persisted on disk.
-    metaFile = new File(storage.directory(), String.format("%s.meta", storage.prefix()));
+    final File metaFile = new File(storage.directory(), String.format("%s.meta", storage.prefix()));
     if (!metaFile.exists()) {
       metaFileChannel = IoUtil.createEmptyFile(metaFile, 32, true);
-    } else {
-      metaFileChannel =
-          FileChannel.open(metaFile.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE);
+      metaFileChannel.close();
     }
+
+    metaFileChannel =
+        FileChannel.open(
+            metaFile.toPath(),
+            StandardOpenOption.READ,
+            StandardOpenOption.WRITE,
+            StandardOpenOption.SYNC);
 
     confFile = new File(storage.directory(), String.format("%s.conf", storage.prefix()));
 
@@ -108,7 +112,6 @@ public class MetaStore implements AutoCloseable {
     try {
       metaFileChannel.write(metaBuffer, 0);
       metaBuffer.position(0);
-      metaFileChannel.force(true);
     } catch (final IOException e) {
       throw new StorageException(e);
     }
@@ -140,7 +143,6 @@ public class MetaStore implements AutoCloseable {
       final String id = vote == null ? null : vote.id();
       serializer.writeVotedFor(id, new UnsafeBuffer(metaBuffer), VERSION_LENGTH);
       metaFileChannel.write(metaBuffer, 0);
-      metaFileChannel.force(true);
       metaBuffer.position(0);
     } catch (final IOException e) {
       throw new StorageException(e);
@@ -166,6 +168,7 @@ public class MetaStore implements AutoCloseable {
   public synchronized long loadLastWrittenIndex() {
     try {
       metaFileChannel.read(metaBuffer, 0);
+      metaBuffer.position(0);
     } catch (final IOException e) {
       throw new StorageException(e);
     }
@@ -178,7 +181,7 @@ public class MetaStore implements AutoCloseable {
     try {
       serializer.writeLastWrittenIndex(index, new UnsafeBuffer(metaBuffer), VERSION_LENGTH);
       metaFileChannel.write(metaBuffer, 0);
-      metaFileChannel.force(true);
+      metaBuffer.position(0);
     } catch (final IOException e) {
       throw new StorageException(e);
     }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
@@ -88,11 +88,11 @@ public class MetaStore implements AutoCloseable {
 
   private void initializeMetaBuffer() {
     final var term = loadTerm();
-    final long index = loadFlushedIndex();
+    final long index = loadLastWrittenIndex();
     final var voted = loadVote();
     metaBuffer.put(0, VERSION);
     storeTerm(term);
-    storeFlushedIndex(index);
+    storeLastWrittenIndex(index);
     storeVote(voted);
   }
 
@@ -163,20 +163,20 @@ public class MetaStore implements AutoCloseable {
     return id.isEmpty() ? null : MemberId.from(id);
   }
 
-  public synchronized long loadFlushedIndex() {
+  public synchronized long loadLastWrittenIndex() {
     try {
       metaFileChannel.read(metaBuffer, 0);
     } catch (final IOException e) {
       throw new StorageException(e);
     }
-    return serializer.readFlushedIndex(new UnsafeBuffer(metaBuffer), VERSION_LENGTH);
+    return serializer.readLastWrittenIndex(new UnsafeBuffer(metaBuffer), VERSION_LENGTH);
   }
 
-  public synchronized void storeFlushedIndex(final long index) {
+  public synchronized void storeLastWrittenIndex(final long index) {
     log.trace("Store last flushed index {}", index);
 
     try {
-      serializer.writeFlushedIndex(index, new UnsafeBuffer(metaBuffer), VERSION_LENGTH);
+      serializer.writeLastWrittenIndex(index, new UnsafeBuffer(metaBuffer), VERSION_LENGTH);
       metaFileChannel.write(metaBuffer, 0);
       metaFileChannel.force(true);
     } catch (final IOException e) {

--- a/atomix/cluster/src/main/resources/raft-entry-schema.xml
+++ b/atomix/cluster/src/main/resources/raft-entry-schema.xml
@@ -67,7 +67,7 @@
 
   <sbe:message name="Meta" id="6">
     <field name="term" id="0" type="uint64"/>
-    <field name="flushedIndex" id="1" type="uint64"/>
+    <field name="lastWrittenIndex" id="1" type="uint64"/>
     <data name="votedFor" id="2" type="varDataEncoding"/>
   </sbe:message>
 

--- a/atomix/cluster/src/main/resources/raft-entry-schema.xml
+++ b/atomix/cluster/src/main/resources/raft-entry-schema.xml
@@ -67,7 +67,8 @@
 
   <sbe:message name="Meta" id="6">
     <field name="term" id="0" type="uint64"/>
-    <data name="votedFor" id="1" type="varDataEncoding"/>
+    <field name="flushedIndex" id="1" type="uint64"/>
+    <data name="votedFor" id="2" type="varDataEncoding"/>
   </sbe:message>
 
 </sbe:messageSchema>

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer.Role;
-import io.atomix.raft.cluster.impl.RaftClusterContext;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.metrics.RaftReplicationMetrics;
 import io.atomix.raft.storage.RaftStorage;
@@ -46,7 +45,6 @@ import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -54,7 +52,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 public class LeaderRoleTest {
@@ -345,32 +342,6 @@ public class LeaderRoleTest {
     // then
     assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
     verify(leaderRole.raft, timeout(2000).atLeast(1)).transition(Role.FOLLOWER);
-  }
-
-  @Test
-  public void shouldSetCommitIndexOnSingleNode() throws InterruptedException {
-    // given
-    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
-    final CountDownLatch latch = new CountDownLatch(1);
-    final var cluster = mock(RaftClusterContext.class);
-    when(cluster.getActiveMemberStates()).thenReturn(Collections.emptyList());
-    when(context.getCluster()).thenReturn(cluster);
-
-    // when
-    leaderRole.appendEntry(
-        1,
-        1,
-        data,
-        new AppendListener() {
-          @Override
-          public void onCommit(final IndexedRaftLogEntry indexed) {
-            latch.countDown();
-          }
-        });
-
-    // then
-    assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
-    verify(context).setCommitIndex(ArgumentMatchers.eq(1L));
   }
 
   private static class TestIndexedRaftLogEntry implements IndexedRaftLogEntry {

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.raft.RaftException.NoLeader;
 import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.cluster.impl.RaftClusterContext;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.metrics.RaftReplicationMetrics;
 import io.atomix.raft.storage.RaftStorage;
@@ -45,6 +46,7 @@ import io.zeebe.snapshots.raft.ReceivableSnapshotStore;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -52,6 +54,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 public class LeaderRoleTest {
@@ -342,6 +345,32 @@ public class LeaderRoleTest {
     // then
     assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
     verify(leaderRole.raft, timeout(2000).atLeast(1)).transition(Role.FOLLOWER);
+  }
+
+  @Test
+  public void shouldSetCommitIndexOnSingleNode() throws InterruptedException {
+    // given
+    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
+    final CountDownLatch latch = new CountDownLatch(1);
+    final var cluster = mock(RaftClusterContext.class);
+    when(cluster.getActiveMemberStates()).thenReturn(Collections.emptyList());
+    when(context.getCluster()).thenReturn(cluster);
+
+    // when
+    leaderRole.appendEntry(
+        1,
+        1,
+        data,
+        new AppendListener() {
+          @Override
+          public void onCommit(final IndexedRaftLogEntry indexed) {
+            latch.countDown();
+          }
+        });
+
+    // then
+    assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+    verify(context).setCommitIndex(ArgumentMatchers.eq(1L));
   }
 
   private static class TestIndexedRaftLogEntry implements IndexedRaftLogEntry {

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -154,7 +154,7 @@ public class PassiveRoleTest {
   }
 
   @Test
-  public void shouldStoreLastFlushedIndex() {
+  public void shouldStoreLastWrittenIndex() {
     // given
     final List<PersistedRaftRecord> entries =
         List.of(new PersistedRaftRecord(1, 1, 1, 1, new byte[1]));
@@ -167,11 +167,11 @@ public class PassiveRoleTest {
     role.handleAppend(request).join();
 
     // then
-    verify(ctx).setFlushedIndex(eq(1L));
+    verify(ctx).setLastWrittenIndex(eq(1L));
   }
 
   @Test
-  public void shouldStoreLastFlushedWithSomeFailure() {
+  public void shouldStoreLastWrittenEvenWithFailure() {
     // given
     final List<PersistedRaftRecord> entries =
         List.of(
@@ -190,6 +190,6 @@ public class PassiveRoleTest {
     role.handleAppend(request).join();
 
     // then
-    verify(ctx).setFlushedIndex(eq(2L));
+    verify(ctx).setLastWrittenIndex(eq(2L));
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -220,22 +220,22 @@ public class MetaStoreTest {
   @Test
   public void shouldStoreAndLastFlushedIndex() {
     // given
-    metaStore.storeFlushedIndex(5L);
+    metaStore.storeLastWrittenIndex(5L);
 
     // when/then
-    assertThat(metaStore.loadFlushedIndex()).isEqualTo(5L);
+    assertThat(metaStore.loadLastWrittenIndex()).isEqualTo(5L);
   }
 
   @Test
   public void shouldStoreAndLoadLastFlushedIndexAfterRestart() throws IOException {
     // given
-    metaStore.storeFlushedIndex(5L);
+    metaStore.storeLastWrittenIndex(5L);
 
     // when
     metaStore.close();
     metaStore = new MetaStore(storage);
 
     // then
-    assertThat(metaStore.loadFlushedIndex()).isEqualTo(5L);
+    assertThat(metaStore.loadLastWrittenIndex()).isEqualTo(5L);
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -44,7 +44,7 @@ public class MetaStoreTest {
   }
 
   @Test
-  public void shouldStoreAndLoadConfiguration() throws IOException {
+  public void shouldStoreAndLoadConfiguration() {
     // given
     final Configuration config = getConfiguration(1, 2);
     metaStore.storeConfiguration(config);
@@ -82,7 +82,7 @@ public class MetaStoreTest {
   }
 
   @Test
-  public void shouldStoreAndLoadVote() throws IOException {
+  public void shouldStoreAndLoadVote() {
     // when
     metaStore.storeVote(new MemberId("id"));
 
@@ -178,7 +178,7 @@ public class MetaStoreTest {
   }
 
   @Test
-  public void shouldStoreConfigurationMultipleTimes() throws IOException {
+  public void shouldStoreConfigurationMultipleTimes() {
     // given
     final Configuration firstConfig = getConfiguration(1, 2);
     metaStore.storeConfiguration(firstConfig);
@@ -215,5 +215,27 @@ public class MetaStoreTest {
     assertThat(readConfig.time()).isEqualTo(secondConfig.time());
     assertThat(readConfig.members())
         .containsExactlyInAnyOrder(secondConfig.members().toArray(new RaftMember[0]));
+  }
+
+  @Test
+  public void shouldStoreAndLastFlushedIndex() {
+    // given
+    metaStore.storeFlushedIndex(5L);
+
+    // when/then
+    assertThat(metaStore.loadFlushedIndex()).isEqualTo(5L);
+  }
+
+  @Test
+  public void shouldStoreAndLoadLastFlushedIndexAfterRestart() throws IOException {
+    // given
+    metaStore.storeFlushedIndex(5L);
+
+    // when
+    metaStore.close();
+    metaStore = new MetaStore(storage);
+
+    // then
+    assertThat(metaStore.loadFlushedIndex()).isEqualTo(5L);
   }
 }

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -218,7 +218,7 @@ public class MetaStoreTest {
   }
 
   @Test
-  public void shouldStoreAndLastFlushedIndex() {
+  public void shouldStoreAndLoadLastWrittenIndex() {
     // given
     metaStore.storeLastWrittenIndex(5L);
 
@@ -227,7 +227,7 @@ public class MetaStoreTest {
   }
 
   @Test
-  public void shouldStoreAndLoadLastFlushedIndexAfterRestart() throws IOException {
+  public void shouldStoreAndLoadLastWrittenIndexAfterRestart() throws IOException {
     // given
     metaStore.storeLastWrittenIndex(5L);
 
@@ -237,5 +237,39 @@ public class MetaStoreTest {
 
     // then
     assertThat(metaStore.loadLastWrittenIndex()).isEqualTo(5L);
+  }
+
+  @Test
+  public void shouldLoadLatestWrittenIndex() throws IOException {
+    // given
+    metaStore.storeLastWrittenIndex(5L);
+
+    // when
+    metaStore.storeLastWrittenIndex(7L);
+
+    // then
+    assertThat(metaStore.loadLastWrittenIndex()).isEqualTo(7L);
+
+    // when
+    metaStore.storeLastWrittenIndex(8L);
+
+    metaStore.close();
+    metaStore = new MetaStore(storage);
+
+    // then
+    assertThat(metaStore.loadLastWrittenIndex()).isEqualTo(8L);
+  }
+
+  @Test
+  public void shouldStoreAndLoadAllMetadata() {
+    // when
+    metaStore.storeTerm(1L);
+    metaStore.storeLastWrittenIndex(2L);
+    metaStore.storeVote(MemberId.from("a"));
+
+    // then
+    assertThat(metaStore.loadTerm()).isEqualTo(1L);
+    assertThat(metaStore.loadLastWrittenIndex()).isEqualTo(2L);
+    assertThat(metaStore.loadVote()).isEqualTo(MemberId.from("a"));
   }
 }


### PR DESCRIPTION
## Description

This PR prepares the solution to the partial write issue by persisting the index of the last entry to be flushed. Since this adds
 a new write+flush every appendRequest on the follower and every commit on the leader, there are a couple of benchmarks to investigate the performance impact. They're in the `mp-meta-*` namespaces. So far I didn't observe any impact. Opening as draft until #6789 is merged since this is based off that branch

## Related issues

blocked by #6789
closes #6790

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
