### PR TITLE
Migrate Process processor

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/ProcessEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/ProcessEventProcessors.java
@@ -213,11 +213,7 @@ public final class ProcessEventProcessors {
 
     final CreateProcessInstanceProcessor createProcessor =
         new CreateProcessInstanceProcessor(
-            zeebeState.getProcessState(),
-            elementInstanceState,
-            keyGenerator,
-            writers,
-            variableBehavior);
+            zeebeState.getProcessState(), keyGenerator, writers, variableBehavior);
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATE, createProcessor);
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -545,8 +545,8 @@ public final class BpmnStateTransitionBehavior {
         .filter(ElementInstance::canTerminate)
         .map(instance -> context.copy(instance.getKey(), instance.getValue(), instance.getState()))
         .ifPresentOrElse(
-            childInstanceContext -> terminate(childInstanceContext) /* TERMINATING */,
-            () -> transitionToTerminated(context) /* TERMINATED */);
+            childInstanceContext -> terminate(childInstanceContext),
+            () -> transitionToTerminated(context));
   }
 
   @FunctionalInterface

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -145,12 +145,6 @@ public final class CallActivityProcessor
     switch (currentState) {
       case ELEMENT_ACTIVATED:
         stateTransitionBehavior.transitionToCompleting(callActivityContext);
-
-        if (element.getOutputMappings().isPresent()
-            || element.isPropagateAllChildVariablesEnabled()) {
-          stateBehavior.propagateTemporaryVariables(childContext, callActivityContext);
-        }
-
         break;
       case ELEMENT_TERMINATING:
         // the call activity is already terminating, it doesn't matter that the child completed

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -53,19 +53,7 @@ public final class ProcessProcessor
         .subscribeToEvents(element, context)
         .map(o -> stateTransitionBehavior.transitionToActivated(context))
         .ifRightOrLeft(
-            activated -> {
-              if (element.hasMessageStartEvent() || element.hasTimerStartEvent()) {
-                eventSubscriptionBehavior
-                    .getEventTriggerForProcessDefinition(context.getProcessDefinitionKey())
-                    .ifPresentOrElse(
-                        eventTrigger ->
-                            eventSubscriptionBehavior.activateTriggeredStartEvent(
-                                context, eventTrigger),
-                        () -> activateNoneStartEvent(element, context));
-              } else {
-                activateNoneStartEvent(element, context);
-              }
-            },
+            activated -> activateStartEvent(element, activated),
             failure -> incidentBehavior.createIncident(failure, context));
   }
 
@@ -125,6 +113,20 @@ public final class ProcessProcessor
 
     if (element.hasMessageStartEvent()) {
       bufferedMessageStartEventBehavior.correlateMessage(context);
+    }
+  }
+
+  private void activateStartEvent(
+      final ExecutableFlowElementContainer element, final BpmnElementContext activated) {
+    if (element.hasMessageStartEvent() || element.hasTimerStartEvent()) {
+      eventSubscriptionBehavior
+          .getEventTriggerForProcessDefinition(activated.getProcessDefinitionKey())
+          .ifPresentOrElse(
+              eventTrigger ->
+                  eventSubscriptionBehavior.activateTriggeredStartEvent(activated, eventTrigger),
+              () -> activateNoneStartEvent(element, activated));
+    } else {
+      activateNoneStartEvent(element, activated);
     }
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/processinstance/CancelProcessInstanceHandler.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/processinstance/CancelProcessInstanceHandler.java
@@ -39,10 +39,7 @@ public final class CancelProcessInstanceHandler implements ProcessInstanceComman
 
     commandContext
         .getStreamWriter()
-        .appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.ELEMENT_TERMINATING, value);
-
-    elementInstance.setState(ProcessInstanceIntent.ELEMENT_TERMINATING);
-    commandContext.getElementInstanceState().updateInstance(elementInstance);
+        .appendFollowUpCommand(command.getKey(), ProcessInstanceIntent.TERMINATE_ELEMENT, value);
 
     commandContext
         .getResponseWriter()

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -43,6 +43,7 @@ public final class MigratedStreamProcessors {
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.RECEIVE_TASK);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.END_EVENT);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.BOUNDARY_EVENT);
+    MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.PROCESS);
 
     MIGRATED_VALUE_TYPES.put(ValueType.JOB, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.JOB_BATCH, MIGRATED);

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -118,7 +118,7 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessInstanceIntent.ELEMENT_COMPLETED,
         new ProcessInstanceElementCompletedApplier(
-            elementInstanceState, eventScopeInstanceState, variableState));
+            elementInstanceState, eventScopeInstanceState, variableState, processState));
     register(
         ProcessInstanceIntent.ELEMENT_TERMINATING,
         new ProcessInstanceElementTerminatingApplier(elementInstanceState));

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -47,6 +47,13 @@ final class ProcessInstanceElementActivatingApplier
 
     createEventScope(elementInstanceKey, value);
 
+    final var processDefinitionKey = value.getProcessDefinitionKey();
+    final var eventTrigger = eventScopeInstanceState.peekEventTrigger(processDefinitionKey);
+    if (eventTrigger != null && value.getElementIdBuffer().equals(eventTrigger.getElementId())) {
+      variableState.setTemporaryVariables(elementInstanceKey, eventTrigger.getVariables());
+      eventScopeInstanceState.deleteTrigger(processDefinitionKey, eventTrigger.getEventKey());
+    }
+
     final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
     elementInstanceState.newInstance(
         flowScopeInstance, elementInstanceKey, value, ProcessInstanceIntent.ELEMENT_ACTIVATING);

--- a/engine/src/main/java/io/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -154,9 +154,14 @@ public final class DbElementInstanceState implements MutableElementInstanceState
       if (parentKey > 0) {
         final ElementInstance parentInstance = getInstance(parentKey);
         if (parentInstance == null) {
-          final var errorMsg =
-              "Expected to find parent instance for element instance with key %d, but none was found.";
-          throw new IllegalStateException(String.format(errorMsg, parentKey));
+          /// todo(zell): bring it back https://github.com/camunda-cloud/zeebe/issues/6202
+          // For now it is fine that parents might be not existing since they are already deleted,
+          // due to the migration
+          return;
+          //          final var errorMsg =
+          //              "Expected to find parent instance for element instance with key %d, but
+          // none was found.";
+          //          throw new IllegalStateException(String.format(errorMsg, parentKey));
         }
         parentInstance.decrementChildCount();
         updateInstance(parentInstance);

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -101,9 +101,10 @@ public final class CallActivityTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withParentProcessInstanceKey(processInstanceKey)
-                .limit(5))
+                .limit(6))
         .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
         .containsExactly(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ACTIVATE_ELEMENT),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ACTIVATE_ELEMENT),
@@ -168,6 +169,8 @@ public final class CallActivityTest {
         .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
         .containsSubsequence(
             tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_ELEMENT),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_COMPLETED),
@@ -391,6 +394,7 @@ public final class CallActivityTest {
         .containsSubsequence(
             tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.EVENT_OCCURRED),
             tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATED),

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
@@ -90,6 +90,7 @@ public class ErrorEventTest {
             tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_ELEMENT),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayTest.java
@@ -248,6 +248,7 @@ public final class ExclusiveGatewayTest {
             ProcessInstanceIntent.ELEMENT_ACTIVATED,
             ProcessInstanceIntent.ELEMENT_COMPLETING,
             ProcessInstanceIntent.ELEMENT_COMPLETED,
+            ProcessInstanceIntent.COMPLETE_ELEMENT,
             ProcessInstanceIntent.ELEMENT_COMPLETING,
             ProcessInstanceIntent.ELEMENT_COMPLETED);
   }

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/gateway/ParallelGatewayTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/gateway/ParallelGatewayTest.java
@@ -172,6 +172,7 @@ public final class ParallelGatewayTest {
             tuple("end", ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple("end", ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple("end", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.COMPLETE_ELEMENT),
             tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
@@ -201,7 +202,7 @@ public final class ParallelGatewayTest {
         .extracting(e -> e.getValue().getElementId(), Record::getIntent)
         .containsSequence(
             tuple("fork", ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETING));
+            tuple(PROCESS_ID, ProcessInstanceIntent.COMPLETE_ELEMENT));
   }
 
   @Test

--- a/engine/src/test/java/io/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
@@ -115,10 +115,11 @@ public final class CancelProcessInstanceTest {
             .asList();
 
     assertThat(processEvents)
-        .hasSize(5)
+        .hasSize(6)
         .extracting(e -> e.getValue().getElementId(), e -> e.getIntent())
         .containsSequence(
             tuple("", CANCEL),
+            tuple("PROCESS", ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple("PROCESS", ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple("task", ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple("task", ELEMENT_TERMINATED),
@@ -178,10 +179,11 @@ public final class CancelProcessInstanceTest {
             .asList();
 
     assertThat(processEvents)
-        .hasSize(7)
+        .hasSize(8)
         .extracting(e -> e.getValue().getElementId(), e -> e.getIntent())
         .containsSequence(
             tuple("", ProcessInstanceIntent.CANCEL),
+            tuple("SUB_PROCESS_PROCESS", ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple("SUB_PROCESS_PROCESS", ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple("subProcess", ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple("task", ProcessInstanceIntent.ELEMENT_TERMINATING),

--- a/engine/src/test/java/io/zeebe/engine/processing/timer/TimerStartEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/timer/TimerStartEventTest.java
@@ -230,9 +230,10 @@ public final class TimerStartEventTest {
             RecordingExporter.processInstanceRecords()
                 .withProcessDefinitionKey(processDefinitionKey)
                 .skipUntil(r -> r.getPosition() >= triggerRecordPosition)
-                .limit(3))
+                .limit(4))
         .extracting(Record::getIntent)
         .containsExactly(
+            ProcessInstanceIntent.ACTIVATE_ELEMENT, // causes the flow node activation
             ProcessInstanceIntent.ELEMENT_ACTIVATING, // causes the flow node activation
             ProcessInstanceIntent.ELEMENT_ACTIVATED, // input mappings applied
             ProcessInstanceIntent.ACTIVATE_ELEMENT); // triggers the start event


### PR DESCRIPTION
## Description

Applies the event sourcing to the process processor. It adds new commands (Activate, Complete and Terminate) for the Process, which are written on several places. I did that migration to the best of my knowledge and time I had :see_no_evil:  , but I assume that something might be not the optimum, like the parent removed check. Happy to get your feedback.

Since it contains some touch points with call activity might make sense that you also look at it @korthout 
I probably have to anyway rework some stuff after yours is merged. It seems boundary event migration has also changed something :sweat_smile: :see_no_evil: 

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6194, #6199

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
