### PR TITLE
[Backport 0.26] fix(broker): flush write if any entry was appended

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/zeebe/LogCompactor.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/zeebe/LogCompactor.java
@@ -16,7 +16,7 @@ import io.atomix.utils.logging.LoggerContext;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 
-public final class LogCompactor {
+public class LogCompactor {
   private final RaftContext raft;
 
   // hard coupled state

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.roles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.impl.zeebe.LogCompactor;
+import io.atomix.raft.metrics.RaftReplicationMetrics;
+import io.atomix.raft.protocol.AppendRequest;
+import io.atomix.raft.protocol.AppendResponse;
+import io.atomix.raft.storage.log.RaftLog;
+import io.atomix.raft.storage.log.RaftLogWriter;
+import io.atomix.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.raft.zeebe.ZeebeEntry;
+import io.atomix.storage.StorageException.OutOfDiskSpace;
+import io.atomix.storage.journal.Indexed;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+public class PassiveRoleTest {
+
+  @Rule public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
+  private PassiveRole role;
+  private RaftLogWriter writer;
+
+  @Before
+  public void setup() throws IOException {
+    writer = mock(RaftLogWriter.class);
+    when(writer.getNextIndex()).thenReturn(1L);
+
+    final RaftLog log = mock(RaftLog.class);
+    when(log.shouldFlushExplicitly()).thenReturn(true);
+    when(log.writer()).thenReturn(writer);
+
+    final RaftContext ctx = mock(RaftContext.class);
+    when(ctx.getLog()).thenReturn(log);
+    when(ctx.getLogWriter()).thenReturn(writer);
+    when(ctx.getTerm()).thenReturn(1L);
+    when(ctx.getReplicationMetrics()).thenReturn(mock(RaftReplicationMetrics.class));
+    when(ctx.getLogCompactor()).thenReturn(mock(LogCompactor.class));
+
+    role = new PassiveRole(ctx);
+  }
+
+  @Test
+  public void shouldFlushAfterAppendRequest() {
+    // given
+    final List<RaftLogEntry> entries =
+        List.of(
+            new ZeebeEntry(1, 1, 1, 12345, ByteBuffer.allocate(1)),
+            new ZeebeEntry(1, 2, 2, 1, ByteBuffer.allocate(1)));
+    final AppendRequest request = new AppendRequest(1, "", 0, 0, entries, 2);
+
+    when(writer.append(any(RaftLogEntry.class)))
+        .thenReturn(mock(Indexed.class))
+        .thenReturn(mock(Indexed.class));
+
+    // when
+    final AppendResponse response = role.handleAppend(request).join();
+
+    // then
+    verify(writer).flush();
+    assertThat(response.lastLogIndex()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldFlushAfterPartiallyAppendedRequest() {
+    // given
+    final List<RaftLogEntry> entries =
+        List.of(
+            new ZeebeEntry(1, 1, 1, 1, ByteBuffer.allocate(1)),
+            new ZeebeEntry(1, 2, 2, 1, ByteBuffer.allocate(1)));
+    final AppendRequest request = new AppendRequest(1, "", 0, 0, entries, 2);
+
+    when(writer.append(any(RaftLogEntry.class)))
+        .thenReturn(mock(Indexed.class))
+        .thenThrow(new OutOfDiskSpace("expected"));
+
+    // when
+    final AppendResponse response = role.handleAppend(request).join();
+
+    // then
+    verify(writer).flush();
+    assertThat(response.lastLogIndex()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldNotFlushIfNoEntryIsAppended() {
+    // given
+    final List<RaftLogEntry> entries = List.of(new ZeebeEntry(1, 1, 1, 1, ByteBuffer.allocate(1)));
+    final AppendRequest request = new AppendRequest(1, "", 0, 0, entries, 2);
+
+    when(writer.append(any(RaftLogEntry.class))).thenThrow(new OutOfDiskSpace("expected"));
+
+    // when
+    final AppendResponse response = role.handleAppend(request).join();
+
+    // then
+    verify(writer, never()).flush();
+    assertThat(response.lastLogIndex()).isEqualTo(0);
+  }
+}


### PR DESCRIPTION
## Description
The follower only flushed the appended entries if every entry in the AppendRequest was written. This commit makes the follower flush if any entry was written.

This PR backports #6789. There were some small changes necessary in the PassiveRole but most changes happened in the FollowerRoleTest since it didn't exist in the 0.26 branch and it needed to be adapted.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6784 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
