### PR TITLE
Split SubProcessProcessor for event subprocess

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.processing.bpmn;
 
 import io.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.zeebe.engine.processing.bpmn.container.CallActivityProcessor;
+import io.zeebe.engine.processing.bpmn.container.EventSubProcessProcessor;
 import io.zeebe.engine.processing.bpmn.container.MultiInstanceBodyProcessor;
 import io.zeebe.engine.processing.bpmn.container.ProcessProcessor;
 import io.zeebe.engine.processing.bpmn.container.SubProcessProcessor;
@@ -47,8 +48,7 @@ public final class BpmnElementProcessors {
     // containers
     processors.put(BpmnElementType.PROCESS, new ProcessProcessor(bpmnBehaviors));
     processors.put(BpmnElementType.SUB_PROCESS, new SubProcessProcessor(bpmnBehaviors));
-    // TODO (saig0): extract the logic for event subprocesses into its own processor (#6196)
-    processors.put(BpmnElementType.EVENT_SUB_PROCESS, new SubProcessProcessor(bpmnBehaviors));
+    processors.put(BpmnElementType.EVENT_SUB_PROCESS, new EventSubProcessProcessor(bpmnBehaviors));
     processors.put(
         BpmnElementType.MULTI_INSTANCE_BODY, new MultiInstanceBodyProcessor(bpmnBehaviors));
     processors.put(BpmnElementType.CALL_ACTIVITY, new CallActivityProcessor(bpmnBehaviors));

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.processing.bpmn.container;
+
+import io.zeebe.engine.processing.bpmn.BpmnElementContainerProcessor;
+import io.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.zeebe.engine.processing.bpmn.behavior.BpmnEventSubscriptionBehavior;
+import io.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
+import io.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
+import io.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
+import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
+import io.zeebe.engine.processing.streamprocessor.MigratedStreamProcessors;
+import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+public final class EventSubProcessProcessor
+    implements BpmnElementContainerProcessor<ExecutableFlowElementContainer> {
+
+  private final BpmnStateBehavior stateBehavior;
+  private final BpmnStateTransitionBehavior stateTransitionBehavior;
+  private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
+  private final BpmnVariableMappingBehavior variableMappingBehavior;
+  private final BpmnIncidentBehavior incidentBehavior;
+
+  public EventSubProcessProcessor(final BpmnBehaviors bpmnBehaviors) {
+    stateBehavior = bpmnBehaviors.stateBehavior();
+    stateTransitionBehavior = bpmnBehaviors.stateTransitionBehavior();
+    eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();
+    variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
+    incidentBehavior = bpmnBehaviors.incidentBehavior();
+  }
+
+  @Override
+  public Class<ExecutableFlowElementContainer> getType() {
+    return ExecutableFlowElementContainer.class;
+  }
+
+  @Override
+  public void onActivating(
+      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+
+    variableMappingBehavior
+        .applyInputMappings(context, element)
+        .flatMap(ok -> eventSubscriptionBehavior.subscribeToEvents(element, context))
+        .ifRightOrLeft(
+            ok -> stateTransitionBehavior.transitionToActivated(context),
+            failure -> incidentBehavior.createIncident(failure, context));
+  }
+
+  @Override
+  public void onActivated(
+      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+
+    final ExecutableStartEvent startEvent;
+    if (element.hasNoneStartEvent()) {
+      // embedded sub-process is activated
+      startEvent = element.getNoneStartEvent();
+    } else {
+      // event sub-process is activated
+      startEvent = element.getStartEvents().get(0);
+    }
+
+    stateTransitionBehavior.activateChildInstance(context, startEvent);
+  }
+
+  @Override
+  public void onCompleting(
+      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+
+    variableMappingBehavior
+        .applyOutputMappings(context, element)
+        .ifRightOrLeft(
+            ok -> {
+              eventSubscriptionBehavior.unsubscribeFromEvents(context);
+              stateTransitionBehavior.transitionToCompletedWithParentNotification(element, context);
+            },
+            failure -> incidentBehavior.createIncident(failure, context));
+  }
+
+  @Override
+  public void onCompleted(
+      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+    if (element.getOutgoing().isEmpty()) {
+      /* can be dropped during migration; after migration this is done as part of
+      stateTransitionBehavior.transitionToCompletedWithParentNotification(...)*/
+      stateTransitionBehavior.afterExecutionPathCompleted(element, context);
+    }
+    // call after here (unmigrated processor)
+    stateTransitionBehavior.takeOutgoingSequenceFlows(element, context);
+
+    stateBehavior.removeElementInstance(context);
+  }
+
+  @Override
+  public void onTerminating(
+      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+
+    eventSubscriptionBehavior.unsubscribeFromEvents(context);
+
+    final var noActiveChildInstances = stateTransitionBehavior.terminateChildInstances(context);
+    if (noActiveChildInstances) {
+      stateTransitionBehavior.transitionToTerminated(context);
+    }
+  }
+
+  @Override
+  public void onTerminated(
+      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+
+    eventSubscriptionBehavior.publishTriggeredBoundaryEvent(context);
+
+    incidentBehavior.resolveIncidents(context);
+
+    stateTransitionBehavior.onElementTerminated(element, context);
+
+    stateBehavior.removeElementInstance(context);
+  }
+
+  @Override
+  public void onEventOccurred(
+      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+
+    eventSubscriptionBehavior.triggerBoundaryEvent(element, context);
+  }
+
+  @Override
+  public void onChildActivating(
+      final ExecutableFlowElementContainer element,
+      final BpmnElementContext flowScopeContext,
+      final BpmnElementContext childContext) {}
+
+  @Override
+  public void beforeExecutionPathCompleted(
+      final ExecutableFlowElementContainer element,
+      final BpmnElementContext flowScopeContext,
+      final BpmnElementContext childContext) {}
+
+  @Override
+  public void afterExecutionPathCompleted(
+      final ExecutableFlowElementContainer element,
+      final BpmnElementContext flowScopeContext,
+      final BpmnElementContext childContext) {
+    if (stateBehavior.canBeCompleted(childContext)) {
+      stateTransitionBehavior.transitionToCompleting(flowScopeContext);
+    }
+  }
+
+  @Override
+  public void onChildTerminated(
+      final ExecutableFlowElementContainer element,
+      final BpmnElementContext flowScopeContext,
+      final BpmnElementContext childContext) {
+
+    if (flowScopeContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING
+        && stateBehavior.canBeTerminated(childContext)) {
+      stateTransitionBehavior.transitionToTerminated(flowScopeContext);
+
+    } else {
+      eventSubscriptionBehavior.publishTriggeredEventSubProcess(
+          MigratedStreamProcessors.isMigrated(childContext.getBpmnElementType()), flowScopeContext);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This makes migrating the processors individually a lot easier.

## Related issues

relates #6195
relates #6196

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
