### PR TITLE
Remove in-memory reader state

### DIFF
--- a/journal/src/main/java/io/zeebe/journal/file/FrameUtil.java
+++ b/journal/src/main/java/io/zeebe/journal/file/FrameUtil.java
@@ -15,9 +15,7 @@
  */
 package io.zeebe.journal.file;
 
-import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
-import java.util.Optional;
 
 public final class FrameUtil {
 
@@ -36,25 +34,21 @@ public final class FrameUtil {
   }
 
   /**
-   * If the frame is valid, returns an Optional with the frame version (which can span from 1-255)
-   * and the buffer's position in incremented. If the frame should be ignored, the returned Optional
-   * is empty and the buffer's position is the same.
+   * Reads the version at buffer's current position. The position of the buffer will be advanced.
    */
-  public static Optional<Integer> readVersion(final ByteBuffer buffer) {
-    buffer.mark();
+  public static int readVersion(final ByteBuffer buffer) {
+    return buffer.get();
+  }
 
-    try {
-      final byte val = buffer.get();
-
-      if (val != IGNORE) {
-        return Optional.of((int) val);
-      }
-    } catch (BufferUnderflowException e) {
-      // nothing to read - reset
+  /**
+   * Returns true if there is a valid version at buffer's current position. The position of the
+   * buffer will be unchanged.
+   */
+  public static boolean hasValidVersion(final ByteBuffer buffer) {
+    if (buffer.capacity() < buffer.position() + LENGTH) {
+      return false;
     }
-
-    buffer.reset();
-    return Optional.empty();
+    return buffer.get(buffer.position()) != IGNORE;
   }
 
   public static int getLength() {

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
@@ -125,8 +125,4 @@ class MappedJournalSegmentReader {
 
     nextEntry = recordReader.read(buffer, expectedIndex);
   }
-
-  long getCurrentIndex() {
-    return currentEntry != null ? currentEntry.index() : 0;
-  }
 }

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentReader.java
@@ -21,7 +21,6 @@ import io.zeebe.journal.file.record.JournalRecordReaderUtil;
 import io.zeebe.journal.file.record.SBESerializer;
 import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 /** Log segment reader. */
 class MappedJournalSegmentReader {
@@ -29,8 +28,7 @@ class MappedJournalSegmentReader {
   private final ByteBuffer buffer;
   private final JournalIndex index;
   private final JournalSegment segment;
-  private JournalRecord currentEntry;
-  private JournalRecord nextEntry;
+  private long currentIndex;
   private final JournalRecordReaderUtil recordReader;
   private final int descriptorLength;
 
@@ -44,20 +42,9 @@ class MappedJournalSegmentReader {
     reset();
   }
 
-  public JournalRecord getCurrentEntry() {
-    return currentEntry;
-  }
-
-  public JournalRecord getNextEntry() {
-    return nextEntry;
-  }
-
   public boolean hasNext() {
-    // If the next entry is null, check whether a next entry exists.
-    if (nextEntry == null) {
-      readNext(getNextIndex());
-    }
-    return nextEntry != null;
+    // if the next entry exists the version would be non-zero
+    return FrameUtil.hasValidVersion(buffer);
   }
 
   public JournalRecord next() {
@@ -65,27 +52,21 @@ class MappedJournalSegmentReader {
       throw new NoSuchElementException();
     }
 
-    // Set the current entry to the next entry.
-    currentEntry = nextEntry;
+    // Read version so that buffer's position is advanced.
+    FrameUtil.readVersion(buffer);
 
-    // Reset the next entry to null.
-    nextEntry = null;
-
-    // Read the next entry in the segment.
-    readNext(getNextIndex());
-
-    // Return the current entry.
+    final var currentEntry = recordReader.read(buffer, getNextIndex());
+    // currentEntry should not be null as hasNext returns true
+    currentIndex = currentEntry.index();
     return currentEntry;
   }
 
   public void reset() {
     buffer.position(descriptorLength);
-    currentEntry = null;
-    nextEntry = null;
-    readNext(getNextIndex());
+    currentIndex = segment.index() - 1;
   }
 
-  public boolean seek(final long index) {
+  public void seek(final long index) {
     final long firstIndex = segment.index();
     final long lastIndex = segment.lastIndex();
 
@@ -93,18 +74,13 @@ class MappedJournalSegmentReader {
 
     final var position = this.index.lookup(index - 1);
     if (position != null && position.index() >= firstIndex && position.index() <= lastIndex) {
-      currentEntry = null;
       buffer.position(position.position());
-
-      nextEntry = null;
-      readNext(position.index());
+      currentIndex = position.index() - 1;
     }
 
     while (getNextIndex() < index && hasNext()) {
       next();
     }
-
-    return nextEntry != null && nextEntry.index() == index;
   }
 
   public void close() {
@@ -112,17 +88,6 @@ class MappedJournalSegmentReader {
   }
 
   long getNextIndex() {
-    return currentEntry == null ? segment.index() : currentEntry.index() + 1;
-  }
-
-  /** Reads the next entry in the segment. */
-  private void readNext(final long expectedIndex) {
-    final Optional<Integer> version = FrameUtil.readVersion(buffer);
-    if (version.isEmpty()) {
-      nextEntry = null;
-      return;
-    }
-
-    nextEntry = recordReader.read(buffer, expectedIndex);
+    return currentIndex + 1;
   }
 }

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
@@ -202,12 +202,10 @@ class MappedJournalSegmentWriter {
     buffer.mark();
     int position = buffer.position();
     try {
-      while ((index == 0 || nextIndex <= index) && FrameUtil.readVersion(buffer).isPresent()) {
-        final var nextEntry = recordUtil.read(buffer, nextIndex);
-        if (nextEntry == null) {
-          break;
-        }
-        lastEntry = nextEntry;
+      while ((index == 0 || nextIndex <= index) && FrameUtil.hasValidVersion(buffer)) {
+        // read version so that buffer's position is advanced
+        FrameUtil.readVersion(buffer);
+        lastEntry = recordUtil.read(buffer, nextIndex);
         nextIndex++;
         buffer.mark();
         position = buffer.position();


### PR DESCRIPTION
## Description

This PR has 3 commits which adds the following changes:
* Remove keeping track of `previousEntry` in SegmentedJournalReader. It was never used and incorrectly updated.
* Remove caching nextEntry in MappedSegmentedReader, instead use the frame to check if next entry exists.
* Since we use frame for `hasNext()`, it is important that the nextEntry is never null. Hence the reader util thrown exception if it is not able to read a valid record.

## Related issues

closes #6803 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
