### PR TITLE
fix(journal): update journal index after restart

### DIFF
--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
@@ -209,6 +209,7 @@ class MappedJournalSegmentWriter {
         }
         lastEntry = nextEntry;
         nextIndex++;
+        this.index.index(lastEntry, position);
         buffer.mark();
         position = buffer.position();
       }

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
@@ -331,6 +331,36 @@ class SegmentedJournalTest {
     assertThat(reader.hasNext()).isFalse();
   }
 
+  @Test
+  void shouldUpdateIndexMappingsAfterRestart() {
+    // given
+    final int entriesPerSegment = 10;
+    long asqn = 1;
+    SegmentedJournal journal = openJournal(entriesPerSegment);
+    for (int i = 0; i < 2 * journalIndexDensity; i++) {
+      journal.append(asqn++, data);
+    }
+    final var indexBeforeClose = journal.getJournalIndex();
+
+    // when
+    journal.close();
+    journal = openJournal(entriesPerSegment);
+
+    // then
+    final var firstIndexedPosition = journalIndexDensity;
+    final var secondIndexedPosition = 2 * journalIndexDensity;
+    final JournalIndex indexAfterRestart = journal.getJournalIndex();
+
+    assertThat(indexAfterRestart.lookup(firstIndexedPosition).index())
+        .isEqualTo(firstIndexedPosition);
+    assertThat(indexAfterRestart.lookup(secondIndexedPosition).index())
+        .isEqualTo(secondIndexedPosition);
+    assertThat(indexAfterRestart.lookup(firstIndexedPosition).position())
+        .isEqualTo(indexBeforeClose.lookup(firstIndexedPosition).position());
+    assertThat(indexAfterRestart.lookup(secondIndexedPosition).position())
+        .isEqualTo(indexBeforeClose.lookup(secondIndexedPosition).position());
+  }
+
   private SegmentedJournal openJournal(final float entriesPerSegment) {
     return openJournal(entriesPerSegment, entrySize);
   }


### PR DESCRIPTION
## Description

When the index is not updated, seek operations can take long time as it has to iterate over all records.

## Related issues

closes #6786 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
