### PR TITLE
Apply event sourcing to multi instance

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -27,6 +27,7 @@ import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.processing.variable.VariableBehavior;
 import io.zeebe.engine.state.immutable.ProcessState;
+import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.engine.state.mutable.MutableZeebeState;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -210,6 +211,28 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         break;
         // legacy behavior for not migrated processors
       case ELEMENT_ACTIVATING:
+        // manage the multi-instance loop counter and input variable BEFORE calling the non migrated
+        // processor, otherwise these will not be available for IO mapping
+        if (context.getFlowScopeKey() > 0) {
+          final ElementInstance flowScopeInstance =
+              elementInstanceState.getInstance(context.getFlowScopeKey());
+          if (flowScopeInstance.getValue().getBpmnElementType()
+              == BpmnElementType.MULTI_INSTANCE_BODY) {
+            // update the loop counter of the multi-instance body (starting by 1)
+            flowScopeInstance.incrementMultiInstanceLoopCounter();
+            elementInstanceState.updateInstance(flowScopeInstance);
+
+            // set the loop counter of the inner instance
+            final var loopCounter = flowScopeInstance.getMultiInstanceLoopCounter();
+            elementInstanceState.updateInstance(
+                context.getElementInstanceKey(),
+                instance -> instance.setMultiInstanceLoopCounter(loopCounter));
+
+            // will call onChildActivating of the multi instance, thereby setting the loop variables
+            stateTransitionBehavior.onElementActivating(element, context);
+          }
+        }
+
         processor.onActivating(element, context);
         break;
       case ELEMENT_ACTIVATED:

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
@@ -65,6 +65,7 @@ public final class MultiInstanceActivityTransformer implements ModelElementTrans
 
       // attach incoming and outgoing sequence flows to the multi-instance body
       innerActivity.getIncoming().forEach(flow -> flow.setTarget(multiInstanceBody));
+      innerActivity.getOutgoing().forEach(flow -> flow.setSource(multiInstanceBody));
 
       multiInstanceBody
           .getOutgoing()

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -47,6 +47,7 @@ public final class MigratedStreamProcessors {
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.CALL_ACTIVITY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.SERVICE_TASK);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.USER_TASK);
+    MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.MULTI_INSTANCE_BODY);
 
     MIGRATED_VALUE_TYPES.put(ValueType.JOB, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.JOB_BATCH, MIGRATED);

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
@@ -319,7 +319,6 @@ public class ErrorEventTest {
                 .limitToProcessInstanceCompleted())
         .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
         .containsSubsequence(
-            tuple(BpmnElementType.MULTI_INSTANCE_BODY, ProcessInstanceIntent.EVENT_OCCURRED),
             tuple(BpmnElementType.MULTI_INSTANCE_BODY, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_TERMINATING),

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceActivityTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/multiinstance/MultiInstanceActivityTest.java
@@ -260,6 +260,7 @@ public final class MultiInstanceActivityTest {
             tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.MULTI_INSTANCE_BODY, ProcessInstanceIntent.COMPLETE_ELEMENT),
             tuple(BpmnElementType.MULTI_INSTANCE_BODY, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(BpmnElementType.MULTI_INSTANCE_BODY, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
@@ -445,11 +446,13 @@ public final class MultiInstanceActivityTest {
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
                 .withElementId(ELEMENT_ID)
-                .limit(4))
+                .limit(6))
         .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
         .containsExactly(
+            tuple(BpmnElementType.MULTI_INSTANCE_BODY, ProcessInstanceIntent.ACTIVATE_ELEMENT),
             tuple(BpmnElementType.MULTI_INSTANCE_BODY, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(BpmnElementType.MULTI_INSTANCE_BODY, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.MULTI_INSTANCE_BODY, ProcessInstanceIntent.COMPLETE_ELEMENT),
             tuple(BpmnElementType.MULTI_INSTANCE_BODY, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(BpmnElementType.MULTI_INSTANCE_BODY, ProcessInstanceIntent.ELEMENT_COMPLETED));
 
@@ -977,7 +980,7 @@ public final class MultiInstanceActivityTest {
             tuple(
                 ELEMENT_ID,
                 BpmnElementType.MULTI_INSTANCE_BODY,
-                ProcessInstanceIntent.EVENT_OCCURRED),
+                ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(
                 ELEMENT_ID,
                 BpmnElementType.MULTI_INSTANCE_BODY,
@@ -1056,10 +1059,6 @@ public final class MultiInstanceActivityTest {
                 tuple(
                     r.getValue().getElementId(), r.getValue().getBpmnElementType(), r.getIntent()))
         .containsSubsequence(
-            tuple(
-                ELEMENT_ID,
-                BpmnElementType.MULTI_INSTANCE_BODY,
-                ProcessInstanceIntent.EVENT_OCCURRED),
             tuple(
                 "to-notified",
                 BpmnElementType.SEQUENCE_FLOW,

--- a/engine/src/test/java/io/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
@@ -187,7 +187,7 @@ public final class MultiInstanceIncidentTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withRecordKey(incident.getValue().getElementInstanceKey())
-                .limit(2))
+                .limit(3))
         .extracting(Record::getIntent)
         .contains(ProcessInstanceIntent.ELEMENT_ACTIVATED);
   }


### PR DESCRIPTION
## Description

This PR applies event sourcing principles to the multi instance, by moving out all state changes to appliers (or temporarily to non-migrated elements' ELEMENT_ACTIVATING). The only difference in output is the new ACTIVATE, COMPLETE, and TERMINATE commands when dealing with multi instance bodies - other outputs are the same as before.

I had to fix a few issues, one related to the dirty hack in the reprocessing state machines (to correctly identify if a source of a sequence flow is migrated), and one related to finding the right event supplier (as the inner activity is always picked up instead of the multi instance on generic lookups).

NOTE: might be easier to look at the commits.

## Related issues

closes #6198 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
