### PR TITLE
Truncate log if checksum mismatch was caused by partial write

### DIFF
--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -171,6 +171,13 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-journal</artifactId>
+      <scope>test</scope>
+      <version>${parent.version}</version>
+      <type>test-jar</type>
+    </dependency>
   </dependencies>
 
   <modelVersion>4.0.0</modelVersion>

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -216,6 +216,11 @@ public final class RaftStorage {
    * @return The opened log.
    */
   public RaftLog openLog() {
+    final long lastWrittenIndex;
+    try (final MetaStore metaStore = openMetaStore()) {
+      lastWrittenIndex = metaStore.loadLastWrittenIndex();
+    }
+
     return RaftLog.builder()
         .withName(prefix)
         .withDirectory(directory)
@@ -224,6 +229,7 @@ public final class RaftStorage {
         .withFreeDiskSpace(freeDiskSpace)
         .withFlushExplicitly(flushExplicitly)
         .withJournalIndexDensity(journalIndexDensity)
+        .withLastWrittenIndex(lastWrittenIndex)
         .build();
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -139,6 +139,11 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
     return this;
   }
 
+  public RaftLogBuilder withLastWrittenIndex(final long lastWrittenIndex) {
+    journalBuilder.withLastWrittenIndex(lastWrittenIndex);
+    return this;
+  }
+
   @Override
   public RaftLog build() {
     final Journal journal = journalBuilder.build();

--- a/journal/pom.xml
+++ b/journal/pom.xml
@@ -142,7 +142,17 @@
           </usedDependencies>
         </configuration>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/journal/src/main/java/io/zeebe/journal/file/JournalSegment.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalSegment.java
@@ -35,6 +35,7 @@ import org.agrona.IoUtil;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 class JournalSegment implements AutoCloseable {
+
   private static final ByteOrder ENDIANNESS = ByteOrder.LITTLE_ENDIAN;
 
   private final JournalSegmentFile file;
@@ -49,6 +50,7 @@ class JournalSegment implements AutoCloseable {
       final JournalSegmentFile file,
       final JournalSegmentDescriptor descriptor,
       final int maxEntrySize,
+      final long maxWrittenIndex,
       final JournalIndex journalIndex) {
     this.file = file;
     this.descriptor = descriptor;
@@ -57,7 +59,7 @@ class JournalSegment implements AutoCloseable {
         IoUtil.mapExistingFile(
             file.file(), MapMode.READ_WRITE, file.name(), 0, descriptor.maxSegmentSize());
     buffer.order(ENDIANNESS);
-    writer = createWriter(maxEntrySize);
+    writer = createWriter(maxEntrySize, maxWrittenIndex);
   }
 
   /**
@@ -144,8 +146,9 @@ class JournalSegment implements AutoCloseable {
         buffer.asReadOnlyBuffer().position(0).order(ENDIANNESS), this, index);
   }
 
-  private MappedJournalSegmentWriter createWriter(final int maxEntrySize) {
-    return new MappedJournalSegmentWriter(buffer, this, maxEntrySize, index);
+  private MappedJournalSegmentWriter createWriter(
+      final int maxEntrySize, final long lastWrittenIndex) {
+    return new MappedJournalSegmentWriter(buffer, this, maxEntrySize, index, lastWrittenIndex);
   }
 
   /**

--- a/journal/src/main/java/io/zeebe/journal/file/JournalSegmentDescriptor.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalSegmentDescriptor.java
@@ -41,7 +41,7 @@ import org.agrona.concurrent.UnsafeBuffer;
  * <p>{@code maxSegmentSize} (32-bit unsigned integer) - The maximum number of bytes allowed in the
  * segment.
  */
-final class JournalSegmentDescriptor {
+public final class JournalSegmentDescriptor {
 
   private static final byte VERSION = 1;
   private static final int VERSION_LENGTH = Byte.BYTES;

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
@@ -53,7 +53,8 @@ class MappedJournalSegmentWriter {
       final MappedByteBuffer buffer,
       final JournalSegment segment,
       final int maxEntrySize,
-      final JournalIndex index) {
+      final JournalIndex index,
+      final long lastWrittenIndex) {
     this.segment = segment;
     descriptorLength = segment.descriptor().length();
     this.maxEntrySize = maxEntrySize;
@@ -62,7 +63,7 @@ class MappedJournalSegmentWriter {
     firstIndex = segment.index();
     this.buffer = buffer;
     writeBuffer.wrap(buffer);
-    reset(0, true);
+    reset(0, lastWrittenIndex);
   }
 
   public long getLastIndex() {
@@ -191,10 +192,10 @@ class MappedJournalSegmentWriter {
   }
 
   private void reset(final long index) {
-    reset(index, false);
+    reset(index, -1);
   }
 
-  private void reset(final long index, final boolean startup) {
+  private void reset(final long index, final long lastWrittenIndex) {
     long nextIndex = firstIndex;
 
     // Clear the buffer indexes.
@@ -214,17 +215,26 @@ class MappedJournalSegmentWriter {
     } catch (final BufferUnderflowException e) {
       // Reached end of the segment
     } catch (final CorruptedLogException e) {
-      // if at startup, assume record was partially written due to crash and mark as ignored
-      if (!startup) {
-        throw e;
-      }
-
-      FrameUtil.markAsIgnored(buffer, position);
-      buffer.position(position);
-      buffer.mark();
+      handleChecksumMismatch(e, nextIndex, lastWrittenIndex, position);
     } finally {
       buffer.reset();
     }
+  }
+
+  private void handleChecksumMismatch(
+      final CorruptedLogException e,
+      final long nextIndex,
+      final long lastWrittenIndex,
+      final int position) {
+    // entry wasn't acked (likely a partial write): it's safe to delete it
+    if (nextIndex > lastWrittenIndex) {
+      FrameUtil.markAsIgnored(buffer, position);
+      buffer.position(position);
+      buffer.mark();
+      return;
+    }
+
+    throw e;
   }
 
   public void truncate(final long index) {

--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournal.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 /** A file based journal. The journal is split into multiple segments files. */
 public class SegmentedJournal implements Journal {
+
   public static final long ASQN_IGNORE = -1;
   private static final int SEGMENT_BUFFER_FACTOR = 3;
   private static final int FIRST_SEGMENT_ID = 1;
@@ -61,6 +62,7 @@ public class SegmentedJournal implements Journal {
   private final long minFreeDiskSpace;
   private final JournalIndex journalIndex;
   private final SegmentedJournalWriter writer;
+  private final long lastWrittenIndex;
 
   public SegmentedJournal(
       final String name,
@@ -68,7 +70,8 @@ public class SegmentedJournal implements Journal {
       final int maxSegmentSize,
       final int maxEntrySize,
       final long minFreeSpace,
-      final JournalIndex journalIndex) {
+      final JournalIndex journalIndex,
+      final long lastWrittenIndex) {
     this.name = checkNotNull(name, "name cannot be null");
     this.directory = checkNotNull(directory, "directory cannot be null");
     this.maxSegmentSize = maxSegmentSize;
@@ -76,6 +79,7 @@ public class SegmentedJournal implements Journal {
     journalMetrics = new JournalMetrics(name);
     minFreeDiskSpace = minFreeSpace;
     this.journalIndex = journalIndex;
+    this.lastWrittenIndex = lastWrittenIndex;
     open();
     writer = new SegmentedJournalWriter(this);
   }
@@ -441,7 +445,8 @@ public class SegmentedJournal implements Journal {
    */
   protected JournalSegment newSegment(
       final JournalSegmentFile segmentFile, final JournalSegmentDescriptor descriptor) {
-    return new JournalSegment(segmentFile, descriptor, maxEntrySize, journalIndex);
+    return new JournalSegment(
+        segmentFile, descriptor, maxEntrySize, lastWrittenIndex, journalIndex);
   }
 
   /** Loads a segment. */

--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -38,6 +38,7 @@ public class SegmentedJournalBuilder {
 
   private long freeDiskSpace = DEFAULT_MIN_FREE_DISK_SPACE;
   private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
+  private long lastWrittenIndex = -1L;
 
   protected SegmentedJournalBuilder() {}
 
@@ -131,9 +132,26 @@ public class SegmentedJournalBuilder {
     return this;
   }
 
+  /**
+   * Writes the last index to have been persisted to the metastore.
+   *
+   * @param lastWrittenIndex last index to have been persisted in the log
+   * @return the storage builder
+   */
+  public SegmentedJournalBuilder withLastWrittenIndex(final long lastWrittenIndex) {
+    this.lastWrittenIndex = lastWrittenIndex;
+    return this;
+  }
+
   public SegmentedJournal build() {
     final JournalIndex journalIndex = new SparseJournalIndex(journalIndexDensity);
     return new SegmentedJournal(
-        name, directory, maxSegmentSize, maxEntrySize, freeDiskSpace, journalIndex);
+        name,
+        directory,
+        maxSegmentSize,
+        maxEntrySize,
+        freeDiskSpace,
+        journalIndex,
+        lastWrittenIndex);
   }
 }

--- a/journal/src/main/java/io/zeebe/journal/file/record/CorruptedLogException.java
+++ b/journal/src/main/java/io/zeebe/journal/file/record/CorruptedLogException.java
@@ -17,7 +17,8 @@ package io.zeebe.journal.file.record;
 
 import io.zeebe.util.exception.UnrecoverableException;
 
-public class CorruptedLogException extends UnrecoverableException {
+public final class CorruptedLogException extends UnrecoverableException {
+
   public CorruptedLogException(final String message) {
     super(message);
   }

--- a/journal/src/test/java/io/zeebe/journal/file/LogCorrupter.java
+++ b/journal/src/test/java/io/zeebe/journal/file/LogCorrupter.java
@@ -19,6 +19,8 @@ import java.nio.ByteBuffer;
 
 public class LogCorrupter {
 
+  private static final int BUFFER_SIZE = 8 * 1024;
+
   /**
    * Corrupts the record associated with the specified index, if it's present in the file.
    *
@@ -27,12 +29,12 @@ public class LogCorrupter {
    * @return true if the specified record was successfully corrupted; otherwise, returns false
    */
   public static boolean corruptRecord(final File file, final long index) throws IOException {
-    final byte[] bytes = new byte[1024];
+    final byte[] bytes = new byte[BUFFER_SIZE];
     int read = 0;
 
     try (final BufferedInputStream in = new BufferedInputStream(new FileInputStream(file))) {
-      while (in.available() > 0 && read < 1024) {
-        read += in.read(bytes, read, Math.min(1024, in.available()) - read);
+      while (in.available() > 0 && read < bytes.length) {
+        read += in.read(bytes, read, Math.min(bytes.length, in.available()) - read);
       }
     }
 

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -246,7 +246,6 @@
       <artifactId>agrona</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Description

Use written index in the persisted in the metastore to distinguish between log corruption and partial writes caused by a broker crashing. Also adds an integration test that had to be removed due to the partial write issue as well as a new test for the partial write case.
 
## Related issues

closes #6744 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
