### PR TITLE
Migrate interrupting event sub marker

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -14,6 +14,7 @@ import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
 import io.zeebe.util.Either;
+import io.zeebe.util.buffer.BufferUtil;
 import java.util.Arrays;
 import org.slf4j.Logger;
 
@@ -193,12 +194,13 @@ public final class ProcessInstanceStateTransitionGuard {
 
   private Either<String, ElementInstance> hasNonInterruptedFlowScope(
       final ElementInstance flowScopeInstance, final BpmnElementContext context) {
-    final var interruptingEventKey = flowScopeInstance.getInterruptingEventKey();
-    if (interruptingEventKey > 0 && interruptingEventKey != context.getElementInstanceKey()) {
+    final var interruptingElementId = flowScopeInstance.getInterruptingElementId();
+    if (flowScopeInstance.isInterrupted()
+        && !interruptingElementId.equals(context.getElementId())) {
       return Either.left(
           String.format(
-              "Expected flow scope instance to be not interrupted but was interrupted by an event with key '%d'.",
-              interruptingEventKey));
+              "Expected flow scope instance to be not interrupted but was interrupted by an event with id '%s'.",
+              BufferUtil.bufferAsString(interruptingElementId)));
 
     } else {
       return Either.right(flowScopeInstance);

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -314,7 +314,12 @@ public final class BpmnEventSubscriptionBehavior {
 
     if (isInterrupted(isChildMigrated, elementInstance)) {
       elementInstanceState.getDeferredRecords(context.getElementInstanceKey()).stream()
-          .filter(record -> record.getKey() == elementInstance.getInterruptingEventKey())
+          .filter(
+              record ->
+                  record
+                      .getValue()
+                      .getElementIdBuffer()
+                      .equals(elementInstance.getInterruptingElementId()))
           .filter(
               record -> record.getValue().getBpmnElementType() == BpmnElementType.EVENT_SUB_PROCESS)
           .findFirst()

--- a/engine/src/main/java/io/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -111,7 +111,10 @@ public class EventTriggerBehavior {
     final var flowScopeElementInstance =
         elementInstanceState.getInstance(flowScopeElementInstanceKey);
 
-    if (flowScopeElementInstance.getInterruptingEventKey() > 0) {
+    if (flowScopeElementInstance.isInterrupted()
+        && !flowScopeElementInstance
+            .getInterruptingElementId()
+            .equals(startEvent.getEventSubProcess())) {
       // the flow scope is already interrupted - discard this event
       return;
     }
@@ -163,10 +166,6 @@ public class EventTriggerBehavior {
       deferActivatingEvent(
           flowScopeContext.getElementInstanceKey(), eventElementInstanceKey, eventRecord);
     }
-
-    elementInstanceState.updateInstance(
-        flowScopeContext.getElementInstanceKey(),
-        flowScopeInstance -> flowScopeInstance.setInterruptingEventKey(eventElementInstanceKey));
   }
 
   private boolean terminateChildInstances(final BpmnElementContext flowScopeContext) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -77,7 +77,11 @@ public final class EventAppliers implements EventApplier {
     register(TimerIntent.CANCELED, new TimerCancelledApplier(state.getTimerState()));
     register(
         TimerIntent.TRIGGERED,
-        new TimerTriggeredApplier(state.getEventScopeInstanceState(), state.getTimerState()));
+        new TimerTriggeredApplier(
+            state.getEventScopeInstanceState(),
+            state.getTimerState(),
+            state.getElementInstanceState(),
+            state.getProcessState()));
   }
 
   private void registerDeploymentAppliers(final MutableZeebeState state) {
@@ -200,7 +204,9 @@ public final class EventAppliers implements EventApplier {
         new ProcessMessageSubscriptionCorrelatedApplier(
             state.getProcessMessageSubscriptionState(),
             state.getEventScopeInstanceState(),
-            state.getVariableState()));
+            state.getVariableState(),
+            state.getElementInstanceState(),
+            state.getProcessState()));
     register(
         ProcessMessageSubscriptionIntent.DELETED,
         new ProcessMessageSubscriptionDeletedApplier(state.getProcessMessageSubscriptionState()));
@@ -209,7 +215,10 @@ public final class EventAppliers implements EventApplier {
   private void registerProcessEventAppliers(final MutableZeebeState state) {
     register(
         ProcessEventIntent.TRIGGERED,
-        new ProcessEventTriggeredApplier(state.getEventScopeInstanceState()));
+        new ProcessEventTriggeredApplier(
+            state.getEventScopeInstanceState(),
+            state.getElementInstanceState(),
+            state.getProcessState()));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventSubProcessInterruptionMarker.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventSubProcessInterruptionMarker.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
+import io.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
+import io.zeebe.engine.state.immutable.ProcessState;
+import io.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.zeebe.protocol.record.value.BpmnElementType;
+import org.agrona.DirectBuffer;
+
+public class EventSubProcessInterruptionMarker {
+
+  private final ProcessState processState;
+  private final MutableElementInstanceState elementInstanceState;
+
+  public EventSubProcessInterruptionMarker(
+      final ProcessState processState, final MutableElementInstanceState elementInstanceState) {
+    this.processState = processState;
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  /**
+   * Marks the flow scope as interrupted, if the triggered element id, corresponds to an
+   * interrupting event sub process.
+   *
+   * @param flowScopeElementInstanceKey the key of the flow scope, which should be marked as
+   *     interrupted
+   * @param processDefinitionKey the corresponding process definition key
+   * @param elementId the id of the element which was triggered
+   */
+  public void markInstanceIfInterrupted(
+      final long flowScopeElementInstanceKey,
+      final long processDefinitionKey,
+      final DirectBuffer elementId) {
+    final var catchEvent =
+        processState.getFlowElement(processDefinitionKey, elementId, ExecutableCatchEvent.class);
+    if (!isRootStartEvent(flowScopeElementInstanceKey)
+        && catchEvent.getFlowScope().getElementType() == BpmnElementType.EVENT_SUB_PROCESS
+        && catchEvent instanceof ExecutableStartEvent
+        && catchEvent.isInterrupting()) {
+      final var executableStartEvent = (ExecutableStartEvent) catchEvent;
+
+      // interrupting event sub process
+      elementInstanceState.updateInstance(
+          flowScopeElementInstanceKey,
+          flowScopeElementInstance ->
+              flowScopeElementInstance.setInterruptingElementId(
+                  executableStartEvent.getEventSubProcess()));
+    }
+  }
+
+  private boolean isRootStartEvent(final long elementInstanceKey) {
+    return elementInstanceKey < 0;
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/JobErrorThrownApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/JobErrorThrownApplier.java
@@ -9,33 +9,21 @@ package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.processing.job.JobThrowErrorProcessor;
 import io.zeebe.engine.state.TypedEventApplier;
-import io.zeebe.engine.state.analyzers.CatchEventAnalyzer;
 import io.zeebe.engine.state.instance.ElementInstance;
 import io.zeebe.engine.state.mutable.MutableElementInstanceState;
-import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.zeebe.engine.state.mutable.MutableJobState;
 import io.zeebe.engine.state.mutable.MutableZeebeState;
 import io.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.zeebe.protocol.record.intent.JobIntent;
-import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
 
 public class JobErrorThrownApplier implements TypedEventApplier<JobIntent, JobRecord> {
 
-  private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
-
   private final MutableJobState jobState;
   private final MutableElementInstanceState elementInstanceState;
-  private final MutableEventScopeInstanceState eventScopeInstanceState;
-  private final CatchEventAnalyzer stateAnalyzer;
 
   JobErrorThrownApplier(final MutableZeebeState state) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
-    eventScopeInstanceState = state.getEventScopeInstanceState();
-
-    stateAnalyzer =
-        new CatchEventAnalyzer(state.getProcessState(), state.getElementInstanceState());
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessEventTriggeredApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessEventTriggeredApplier.java
@@ -8,7 +8,9 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.zeebe.engine.state.mutable.MutableProcessState;
 import io.zeebe.msgpack.value.DocumentValue;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
 import io.zeebe.protocol.record.intent.ProcessEventIntent;
@@ -19,9 +21,15 @@ final class ProcessEventTriggeredApplier
     implements TypedEventApplier<ProcessEventIntent, ProcessEventRecord> {
   private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
   private final MutableEventScopeInstanceState eventScopeState;
+  private final EventSubProcessInterruptionMarker eventSubProcessInterruptionMarker;
 
-  public ProcessEventTriggeredApplier(final MutableEventScopeInstanceState eventScopeState) {
+  public ProcessEventTriggeredApplier(
+      final MutableEventScopeInstanceState eventScopeState,
+      final MutableElementInstanceState elementInstanceState,
+      final MutableProcessState processState) {
     this.eventScopeState = eventScopeState;
+    eventSubProcessInterruptionMarker =
+        new EventSubProcessInterruptionMarker(processState, elementInstanceState);
   }
 
   @Override
@@ -32,7 +40,11 @@ final class ProcessEventTriggeredApplier
       variables = NO_VARIABLES;
     }
 
-    eventScopeState.triggerEvent(
-        value.getScopeKey(), key, value.getTargetElementIdBuffer(), variables);
+    final var targetElementIdBuffer = value.getTargetElementIdBuffer();
+    final var scopeKey = value.getScopeKey();
+
+    eventScopeState.triggerEvent(scopeKey, key, targetElementIdBuffer, variables);
+    eventSubProcessInterruptionMarker.markInstanceIfInterrupted(
+        scopeKey, value.getProcessDefinitionKey(), targetElementIdBuffer);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstance.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/ElementInstance.java
@@ -13,8 +13,10 @@ import io.zeebe.msgpack.UnpackedObject;
 import io.zeebe.msgpack.property.IntegerProperty;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.ObjectProperty;
+import io.zeebe.msgpack.property.StringProperty;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import org.agrona.DirectBuffer;
 
 public final class ElementInstance extends UnpackedObject implements DbValue {
 
@@ -23,8 +25,8 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
   private final LongProperty jobKeyProp = new LongProperty("jobKey", 0L);
   private final IntegerProperty multiInstanceLoopCounterProp =
       new IntegerProperty("multiInstanceLoopCounter", 0);
-  private final LongProperty interruptingEventKeyProp =
-      new LongProperty("interruptingEventKey", -1L);
+  private final StringProperty interruptingEventKeyProp =
+      new StringProperty("interruptingElementId", "");
   private final LongProperty calledChildInstanceKeyProp =
       new LongProperty("calledChildInstanceKey", -1L);
   private final ObjectProperty<IndexedRecord> recordProp =
@@ -141,16 +143,16 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
     calledChildInstanceKeyProp.setValue(calledChildInstanceKey);
   }
 
-  public long getInterruptingEventKey() {
+  public DirectBuffer getInterruptingElementId() {
     return interruptingEventKeyProp.getValue();
   }
 
-  public void setInterruptingEventKey(final long key) {
-    interruptingEventKeyProp.setValue(key);
+  public void setInterruptingElementId(final DirectBuffer elementId) {
+    interruptingEventKeyProp.setValue(elementId);
   }
 
   public boolean isInterrupted() {
-    return getInterruptingEventKey() > 0;
+    return getInterruptingElementId().capacity() > 0;
   }
 
   public long getParentKey() {


### PR DESCRIPTION
## Description


 * Moves the event sub process interruption marker to related EventAppliers, in order to have no longer state changes in the processing (updating the flow scope element instance). 
 * The logic of marking the flow scope is encapsulated by a helper class
 * The interruption marker is changed from the element instance key to the corresponding element id, since this the available information we have in the applier. This change allows to migrate the event sub processes.
 * Some unused code is removed

<!-- Please explain the changes you made here. -->

Who ever has time first @npepinpe @saig0 We need that for continuing on migration of event and embedded sub process

## Related issues

related #6195 
related #6196  

<!-- Which issues are closed by this PR or are related -->


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
