### PR TITLE
Do not reset reader's if they are behind the truncated index

### DIFF
--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalWriter.java
@@ -79,21 +79,15 @@ class SegmentedJournalWriter {
   }
 
   public void deleteAfter(final long index) {
-    journalMetrics.observeSegmentTruncation(
-        () -> {
-          // Delete all segments with first indexes greater than the given index.
-          while (index < currentSegment.index() && currentSegment != journal.getFirstSegment()) {
-            journal.removeSegment(currentSegment);
-            currentSegment = journal.getLastSegment();
-            currentWriter = currentSegment.writer();
-          }
+    // Delete all segments with first indexes greater than the given index.
+    while (index < currentSegment.index() && currentSegment != journal.getFirstSegment()) {
+      journal.removeSegment(currentSegment);
+      currentSegment = journal.getLastSegment();
+      currentWriter = currentSegment.writer();
+    }
 
-          // Truncate the current index.
-          currentWriter.truncate(index);
-
-          // Reset segment readers.
-          journal.resetTail(index + 1);
-        });
+    // Truncate the current index.
+    currentWriter.truncate(index);
   }
 
   public void flush() {

--- a/journal/src/test/java/io/zeebe/journal/file/JournalTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/JournalTest.java
@@ -299,6 +299,66 @@ class JournalTest {
   }
 
   @Test
+  void shouldNotReadTruncatedEntriesWhenReaderPastTruncateIndex() {
+    // given
+    final var reader = journal.openReader();
+    assertThat(journal.getLastIndex()).isEqualTo(0);
+    journal.append(1, data);
+    journal.append(2, data);
+    journal.append(3, data);
+    reader.next();
+    reader.next();
+    assertThat(reader.hasNext()).isTrue();
+
+    // when
+    journal.deleteAfter(1);
+
+    // then
+    assertThat(journal.getLastIndex()).isEqualTo(1);
+    assertThat(reader.hasNext()).isFalse();
+  }
+
+  @Test
+  void shouldNotReadTruncatedEntriesWhenReaderAtTruncateIndex() {
+    // given
+    final var reader = journal.openReader();
+    assertThat(journal.getLastIndex()).isEqualTo(0);
+    journal.append(1, data);
+    journal.append(2, data);
+    journal.append(3, data);
+    reader.next();
+    reader.next();
+    assertThat(reader.hasNext()).isTrue();
+
+    // when
+    journal.deleteAfter(2);
+
+    // then
+    assertThat(journal.getLastIndex()).isEqualTo(2);
+    assertThat(reader.hasNext()).isFalse();
+  }
+
+  @Test
+  void shouldNotReadTruncatedEntriesWhenReaderBeforeTruncateIndex() {
+    // given
+    final var reader = journal.openReader();
+    assertThat(journal.getLastIndex()).isEqualTo(0);
+    journal.append(1, data);
+    journal.append(2, data);
+    journal.append(3, data);
+    reader.next();
+    assertThat(reader.hasNext()).isTrue();
+
+    // when
+    journal.deleteAfter(2);
+
+    // then
+    assertThat(journal.getLastIndex()).isEqualTo(2);
+    reader.next();
+    assertThat(reader.hasNext()).isFalse();
+  }
+
+  @Test
   void shouldAppendJournalRecord() {
     // given
     final var receiverJournal =


### PR DESCRIPTION
## Description

This PR is in preparation to #4198. After #6804, the readers are not reading ahead. Hence during the truncation the reader's has to be reset only if they are ahead of the truncated index. 

## Related issues

Related #4198
Blocked by #6804

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
