### PR TITLE
Make truncate and reset safe with concurrent readers

### DIFF
--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalReader.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalReader.java
@@ -45,11 +45,25 @@ class SegmentedJournalReader implements JournalReader {
 
   @Override
   public boolean hasNext() {
-    return hasNextEntry();
+    final var stamp = journal.acquireReadlock();
+    try {
+      return unsafeHasNext();
+    } finally {
+      journal.releaseReadlock(stamp);
+    }
   }
 
   @Override
   public JournalRecord next() {
+    final var stamp = journal.acquireReadlock();
+    try {
+      return unsafeNext();
+    } finally {
+      journal.releaseReadlock(stamp);
+    }
+  }
+
+  private JournalRecord unsafeNext() throws NoSuchElementException {
     if (!currentReader.hasNext()) {
       final JournalSegment nextSegment = journal.getNextSegment(currentSegment.index());
       if (nextSegment != null && nextSegment.index() == getNextIndex()) {
@@ -65,13 +79,94 @@ class SegmentedJournalReader implements JournalReader {
 
   @Override
   public long seek(final long index) {
-    // If the current segment is not open, it has been replaced. Reset the segments.
-    if (!currentSegment.isOpen()) {
-      seekToFirst();
+    final var stamp = journal.acquireReadlock();
+    try {
+      // If the current segment is not open, it has been replaced. Reset the segments.
+      return unsafeSeek(index);
+    } finally {
+      journal.releaseReadlock(stamp);
     }
+  }
 
-    if (currentReader.getNextIndex() == index) {
-      return index;
+  @Override
+  public long seekToFirst() {
+    final var stamp = journal.acquireReadlock();
+    try {
+      return unsafeSeekToFirst();
+    } finally {
+      journal.releaseReadlock(stamp);
+    }
+  }
+
+  @Override
+  public long seekToLast() {
+    final var stamp = journal.acquireReadlock();
+    try {
+      return unsafeSeekToLast();
+    } finally {
+      journal.releaseReadlock(stamp);
+    }
+  }
+
+  @Override
+  public long seekToAsqn(final long asqn) {
+    return seekToAsqn(asqn, journal.getLastIndex());
+  }
+
+  @Override
+  public long seekToAsqn(final long asqn, final long indexUpperBound) {
+    final var stamp = journal.acquireReadlock();
+    try {
+      final var journalIndex = journal.getJournalIndex();
+      final var index = journalIndex.lookupAsqn(asqn, indexUpperBound);
+
+      // depending on the type of index, it's possible there is no ASQN indexed, in which case start
+      // from the beginning
+      if (index == null) {
+        unsafeSeekToFirst();
+      } else {
+        unsafeSeek(index);
+      }
+
+      // potential beneficiary of a peek() call, which would avoid the duplicate seek or
+      // being at the second position if the first entry has a greater ASQN
+      JournalRecord record = null;
+      while (unsafeHasNext()) {
+        final var currentRecord = next();
+        if (currentRecord.index() > indexUpperBound) {
+          break;
+        }
+        if (currentRecord.asqn() <= asqn && currentRecord.asqn() != ASQN_IGNORE) {
+          record = currentRecord;
+        } else if (currentRecord.asqn() >= asqn) {
+          break;
+        }
+      }
+
+      // if the journal was empty, the reader will be at the beginning of the log
+      // if the journal only contained entries with ASQN greater than the one requested, then seek
+      // back to the beginning
+      if (record == null) {
+        return unsafeSeekToFirst();
+      }
+
+      // This is needed so that the next() returns the correct record
+      // TODO: Remove the duplicate seek. https://github.com/zeebe-io/zeebe/issues/6223
+      return unsafeSeek(record.index());
+    } finally {
+      journal.releaseReadlock(stamp);
+    }
+  }
+
+  @Override
+  public void close() {
+    currentReader.close();
+    journal.closeReader(this);
+  }
+
+  long unsafeSeek(final long index) {
+    if (!currentSegment.isOpen()) {
+      unsafeSeekToFirst();
     }
 
     if (index < currentReader.getNextIndex()) {
@@ -85,69 +180,16 @@ class SegmentedJournalReader implements JournalReader {
     return getNextIndex();
   }
 
-  @Override
-  public long seekToFirst() {
+  private long unsafeSeekToFirst() {
     replaceCurrentSegment(journal.getFirstSegment());
     return journal.getFirstIndex();
   }
 
-  @Override
-  public long seekToLast() {
+  private long unsafeSeekToLast() {
     replaceCurrentSegment(journal.getLastSegment());
-    seek(journal.getLastIndex());
+    unsafeSeek(journal.getLastIndex());
 
     return journal.getLastIndex();
-  }
-
-  @Override
-  public long seekToAsqn(final long asqn) {
-    return seekToAsqn(asqn, journal.getLastIndex());
-  }
-
-  @Override
-  public long seekToAsqn(final long asqn, final long indexUpperBound) {
-    final var journalIndex = journal.getJournalIndex();
-    final var index = journalIndex.lookupAsqn(asqn, indexUpperBound);
-
-    // depending on the type of index, it's possible there is no ASQN indexed, in which case start
-    // from the beginning
-    if (index == null) {
-      seekToFirst();
-    } else {
-      seek(index);
-    }
-
-    // potential beneficiary of a peek() call, which would avoid the duplicate seek or
-    // being at the second position if the first entry has a greater ASQN
-    JournalRecord record = null;
-    while (hasNext()) {
-      final var currentRecord = next();
-      if (currentRecord.index() > indexUpperBound) {
-        break;
-      }
-      if (currentRecord.asqn() <= asqn && currentRecord.asqn() != ASQN_IGNORE) {
-        record = currentRecord;
-      } else if (currentRecord.asqn() >= asqn) {
-        break;
-      }
-    }
-
-    // if the journal was empty, the reader will be at the beginning of the log
-    // if the journal only contained entries with ASQN greater than the one requested, then seek
-    // back to the beginning
-    if (record == null) {
-      return seekToFirst();
-    }
-
-    // This is needed so that the next() returns the correct record
-    // TODO: Remove the duplicate seek. https://github.com/zeebe-io/zeebe/issues/6223
-    return seek(record.index());
-  }
-
-  @Override
-  public void close() {
-    currentReader.close();
-    journal.closeReader(this);
   }
 
   /** Rewinds the journal to the given index. */
@@ -176,7 +218,7 @@ class SegmentedJournalReader implements JournalReader {
     currentReader.seek(index);
   }
 
-  private boolean hasNextEntry() {
+  private boolean unsafeHasNext() {
     if (!currentReader.hasNext()) {
       final JournalSegment nextSegment = journal.getNextSegment(currentSegment.index());
       if (nextSegment != null && nextSegment.index() == getNextIndex()) {

--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalWriter.java
@@ -75,7 +75,6 @@ class SegmentedJournalWriter {
   public void reset(final long index) {
     currentSegment = journal.resetSegments(index);
     currentWriter = currentSegment.writer();
-    journal.resetHead(index);
   }
 
   public void deleteAfter(final long index) {


### PR DESCRIPTION
## Description

Use ReadWriteLock for concurrency control between deleteAfter/reset operation by a writer and all operations by readers. It is not necessary for append to acquire lock, as it is does not cause an inconsistent state observed by the reader. As a result, this is read heavy workload because `deleteUntil` and `reset` are only called infrequently.

Blocked by #6814 

## Related issues

closes #4198 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x ] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
