### PR TITLE
Apply event sourcing on SubProcessProcessor

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -213,13 +213,18 @@ public final class BpmnEventSubscriptionBehavior {
 
   /**
    * Activates the element that was triggered by an event and pass in the variables of the event.
-   * Should be called after {@link #findEventTrigger(BpmnElementContext)}.
+   * Should be called after {@link #findEventTrigger(BpmnElementContext)}. Depending on the event
+   * type we need to give different flow scope key, e. g. for EventSubProcess the container
+   * triggers/activates the EventSubProcess, while for boundary events the attached element triggers
+   * that event which is not the flow scope.
    *
-   * @param context the element instance that was triggered
+   * @param flowScopeKey the flow scope of event element to activate, which can be different based
+   *     on the event type
+   * @param context the current processing context
    * @param eventTrigger the event data returned by {@link #findEventTrigger(BpmnElementContext)}
    */
   public void activateTriggeredEvent(
-      final BpmnElementContext context, final EventTrigger eventTrigger) {
+      final long flowScopeKey, final BpmnElementContext context, final EventTrigger eventTrigger) {
 
     final var triggeredEvent =
         processState.getFlowElement(
@@ -228,10 +233,7 @@ public final class BpmnEventSubscriptionBehavior {
             ExecutableFlowElement.class);
 
     eventTriggerBehavior.activateTriggeredEvent(
-        triggeredEvent,
-        context.getFlowScopeKey(),
-        context.getRecordValue(),
-        eventTrigger.getVariables());
+        triggeredEvent, flowScopeKey, context.getRecordValue(), eventTrigger.getVariables());
   }
 
   private void publishTriggeredEvent(

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -144,6 +144,7 @@ public final class BpmnEventSubscriptionBehavior {
     } else {
       // copy temporary variables here because they are read in publishActivatingEvent()
       if (eventTrigger.getVariables() != null && eventTrigger.getVariables().capacity() > 0) {
+        // todo (@korthout/zell): look at this again
         variablesState.setTemporaryVariables(
             boundaryElementInstanceKey, eventTrigger.getVariables());
       }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -390,7 +390,8 @@ public final class BpmnStateTransitionBehavior {
               childInstanceContext.getRecordValue());
         }
 
-      } else if (childInstanceContext.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED) {
+      } else if (childInstanceContext.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED
+          && !MigratedStreamProcessors.isMigrated(childInstanceContext.getBpmnElementType())) {
         // clean up the state because the completed event will not be processed
         stateBehavior.removeElementInstance(childInstanceContext);
       }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -156,7 +156,8 @@ public final class CallActivityProcessor
             eventTrigger -> {
               final var terminated =
                   stateTransitionBehavior.transitionToTerminated(callActivityContext);
-              eventSubscriptionBehavior.activateTriggeredEvent(terminated, eventTrigger);
+              eventSubscriptionBehavior.activateTriggeredEvent(
+                  terminated.getFlowScopeKey(), terminated, eventTrigger);
             },
             () -> {
               final var terminated =

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -237,7 +237,8 @@ public final class MultiInstanceBodyProcessor
             eventTrigger -> {
               final var terminated =
                   stateTransitionBehavior.transitionToTerminated(flowScopeContext);
-              eventSubscriptionBehavior.activateTriggeredEvent(terminated, eventTrigger);
+              eventSubscriptionBehavior.activateTriggeredEvent(
+                  terminated.getFlowScopeKey(), terminated, eventTrigger);
               stateTransitionBehavior.onElementTerminated(element, terminated);
             },
             () -> {

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -18,7 +18,6 @@ import io.zeebe.engine.processing.bpmn.behavior.BpmnProcessResultSenderBehavior;
 import io.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
-import io.zeebe.engine.processing.streamprocessor.MigratedStreamProcessors;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 
 public final class ProcessProcessor
@@ -189,8 +188,13 @@ public final class ProcessProcessor
             flowScopeContext, parentElementInstanceContext);
       }
     } else {
-      eventSubscriptionBehavior.publishTriggeredEventSubProcess(
-          MigratedStreamProcessors.isMigrated(childContext.getBpmnElementType()), flowScopeContext);
+
+      eventSubscriptionBehavior
+          .findEventTrigger(flowScopeContext)
+          .ifPresent(
+              eventTrigger ->
+                  eventSubscriptionBehavior.activateTriggeredEvent(
+                      flowScopeContext.getElementInstanceKey(), flowScopeContext, eventTrigger));
     }
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
@@ -63,7 +63,8 @@ public final class EventBasedGatewayProcessor
     // transition to completed and continue on the event of the gateway that was triggered
     // - according to the BPMN specification, the sequence flow to this event is not taken
     final var completed = stateTransitionBehavior.transitionToCompleted(context);
-    eventSubscriptionBehavior.activateTriggeredEvent(completed, eventTrigger);
+    eventSubscriptionBehavior.activateTriggeredEvent(
+        completed.getFlowScopeKey(), completed, eventTrigger);
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
@@ -73,7 +73,8 @@ public final class ReceiveTaskProcessor implements BpmnElementProcessor<Executab
         .ifPresentOrElse(
             eventTrigger -> {
               final var terminated = stateTransitionBehavior.transitionToTerminated(context);
-              eventSubscriptionBehavior.activateTriggeredEvent(terminated, eventTrigger);
+              eventSubscriptionBehavior.activateTriggeredEvent(
+                  terminated.getFlowScopeKey(), terminated, eventTrigger);
             },
             () -> {
               final var terminated = stateTransitionBehavior.transitionToTerminated(context);

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
@@ -65,19 +65,6 @@ public final class ServiceTaskProcessor implements BpmnElementProcessor<Executab
             failure -> incidentBehavior.createIncident(failure, context));
   }
 
-  private Either<Failure, Tuple<String, Long>> evaluateJobExpressions(
-      final ExecutableServiceTask element, final BpmnElementContext context) {
-    final var scopeKey = context.getElementInstanceKey();
-
-    return expressionBehavior
-        .evaluateStringExpression(element.getType(), scopeKey)
-        .flatMap(
-            jobType ->
-                expressionBehavior
-                    .evaluateLongExpression(element.getRetries(), scopeKey)
-                    .map(retries -> new Tuple<>(jobType, retries)));
-  }
-
   @Override
   public void onComplete(final ExecutableServiceTask element, final BpmnElementContext context) {
     variableMappingBehavior
@@ -118,5 +105,18 @@ public final class ServiceTaskProcessor implements BpmnElementProcessor<Executab
               final var terminated = stateTransitionBehavior.transitionToTerminated(context);
               stateTransitionBehavior.onElementTerminated(element, terminated);
             });
+  }
+
+  private Either<Failure, Tuple<String, Long>> evaluateJobExpressions(
+      final ExecutableServiceTask element, final BpmnElementContext context) {
+    final var scopeKey = context.getElementInstanceKey();
+
+    return expressionBehavior
+        .evaluateStringExpression(element.getType(), scopeKey)
+        .flatMap(
+            jobType ->
+                expressionBehavior
+                    .evaluateLongExpression(element.getRetries(), scopeKey)
+                    .map(retries -> new Tuple<>(jobType, retries)));
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
@@ -111,7 +111,8 @@ public final class ServiceTaskProcessor implements BpmnElementProcessor<Executab
         .ifPresentOrElse(
             eventTrigger -> {
               final var terminated = stateTransitionBehavior.transitionToTerminated(context);
-              eventSubscriptionBehavior.activateTriggeredEvent(terminated, eventTrigger);
+              eventSubscriptionBehavior.activateTriggeredEvent(
+                  terminated.getFlowScopeKey(), terminated, eventTrigger);
             },
             () -> {
               final var terminated = stateTransitionBehavior.transitionToTerminated(context);

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -48,6 +48,7 @@ public final class MigratedStreamProcessors {
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.SERVICE_TASK);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.USER_TASK);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.MULTI_INSTANCE_BODY);
+    MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.SUB_PROCESS);
 
     MIGRATED_VALUE_TYPES.put(ValueType.JOB, MIGRATED);
     MIGRATED_VALUE_TYPES.put(ValueType.JOB_BATCH, MIGRATED);

--- a/engine/src/main/java/io/zeebe/engine/state/instance/DbEventScopeInstanceState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/DbEventScopeInstanceState.java
@@ -86,13 +86,6 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
-  public EventScopeInstance getInstance(final long eventScopeKey) {
-    this.eventScopeKey.wrapLong(eventScopeKey);
-    final EventScopeInstance instance = eventScopeInstanceColumnFamily.get(this.eventScopeKey);
-    return instance != null ? new EventScopeInstance(instance) : null;
-  }
-
-  @Override
   public void deleteInstance(final long eventScopeKey) {
     eventTriggerScopeKey.wrapLong(eventScopeKey);
 
@@ -106,11 +99,18 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
-  public boolean isAcceptingEvent(final long eventScopeKey) {
-    this.eventScopeKey.wrapLong(eventScopeKey);
-    final EventScopeInstance instance = eventScopeInstanceColumnFamily.get(this.eventScopeKey);
+  public EventTrigger pollEventTrigger(final long eventScopeKey) {
+    eventTriggerScopeKey.wrapLong(eventScopeKey);
+    final EventTrigger[] next = new EventTrigger[1];
+    eventTriggerColumnFamily.whileEqualPrefix(
+        eventTriggerScopeKey,
+        (key, value) -> {
+          next[0] = new EventTrigger(value);
+          eventTriggerColumnFamily.delete(key);
+          return false;
+        });
 
-    return isAcceptingEvent(instance);
+    return next[0];
   }
 
   @Override
@@ -136,21 +136,18 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
     }
   }
 
-  private boolean isAcceptingEvent(final EventScopeInstance instance) {
-    return instance != null && instance.isAccepting();
-  }
-
-  private void createTrigger(
-      final long eventScopeKey,
-      final long eventKey,
-      final DirectBuffer elementId,
-      final DirectBuffer variables) {
+  @Override
+  public void deleteTrigger(final long eventScopeKey, final long eventKey) {
     eventTriggerScopeKey.wrapLong(eventScopeKey);
     eventTriggerEventKey.wrapLong(eventKey);
+    deleteTrigger(eventTriggerKey);
+  }
 
-    eventTrigger.setElementId(elementId).setVariables(variables).setEventKey(eventKey);
-
-    eventTriggerColumnFamily.put(eventTriggerKey, eventTrigger);
+  @Override
+  public EventScopeInstance getInstance(final long eventScopeKey) {
+    this.eventScopeKey.wrapLong(eventScopeKey);
+    final EventScopeInstance instance = eventScopeInstanceColumnFamily.get(this.eventScopeKey);
+    return instance != null ? new EventScopeInstance(instance) : null;
   }
 
   @Override
@@ -168,25 +165,28 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
-  public EventTrigger pollEventTrigger(final long eventScopeKey) {
-    eventTriggerScopeKey.wrapLong(eventScopeKey);
-    final EventTrigger[] next = new EventTrigger[1];
-    eventTriggerColumnFamily.whileEqualPrefix(
-        eventTriggerScopeKey,
-        (key, value) -> {
-          next[0] = new EventTrigger(value);
-          eventTriggerColumnFamily.delete(key);
-          return false;
-        });
+  public boolean isAcceptingEvent(final long eventScopeKey) {
+    this.eventScopeKey.wrapLong(eventScopeKey);
+    final EventScopeInstance instance = eventScopeInstanceColumnFamily.get(this.eventScopeKey);
 
-    return next[0];
+    return isAcceptingEvent(instance);
   }
 
-  @Override
-  public void deleteTrigger(final long eventScopeKey, final long eventKey) {
+  private boolean isAcceptingEvent(final EventScopeInstance instance) {
+    return instance != null && instance.isAccepting();
+  }
+
+  private void createTrigger(
+      final long eventScopeKey,
+      final long eventKey,
+      final DirectBuffer elementId,
+      final DirectBuffer variables) {
     eventTriggerScopeKey.wrapLong(eventScopeKey);
     eventTriggerEventKey.wrapLong(eventKey);
-    deleteTrigger(eventTriggerKey);
+
+    eventTrigger.setElementId(elementId).setVariables(variables).setEventKey(eventKey);
+
+    eventTriggerColumnFamily.put(eventTriggerKey, eventTrigger);
   }
 
   private void deleteTrigger(final DbCompositeKey<DbLong, DbLong> triggerKey) {

--- a/engine/src/main/java/io/zeebe/engine/state/instance/DbEventScopeInstanceState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/instance/DbEventScopeInstanceState.java
@@ -106,7 +106,7 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
         eventTriggerScopeKey,
         (key, value) -> {
           next[0] = new EventTrigger(value);
-          eventTriggerColumnFamily.delete(key);
+          deleteTrigger(key);
           return false;
         });
 

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
@@ -251,17 +251,17 @@ public final class BoundaryEventTest {
         .extracting(Record::getValueType, Record::getIntent)
         .endsWith(
             tuple(ValueType.TIMER, TimerIntent.TRIGGERED),
-            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.EVENT_OCCURRED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(ValueType.JOB, JobIntent.CANCEL),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(ValueType.JOB, JobIntent.CANCELED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.COMPLETE_ELEMENT),
+            tuple(ValueType.JOB, JobIntent.CANCELED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/error/ErrorEventTest.java
@@ -357,11 +357,11 @@ public class ErrorEventTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceCompleted())
+                .limitToProcessInstanceCompleted()
+                .onlyEvents())
         .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
         .containsSubsequence(
             tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.EVENT_OCCURRED),
             tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_TERMINATED),

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessTest.java
@@ -85,7 +85,7 @@ public final class EmbeddedSubProcessTest {
                 .withProcessInstanceKey(processInstanceKey)
                 .limitToProcessInstanceCompleted())
         .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
-        .containsSequence(
+        .containsSubsequence(
             tuple(BpmnElementType.SEQUENCE_FLOW, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
             tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
@@ -119,7 +119,7 @@ public final class EmbeddedSubProcessTest {
                 .withProcessInstanceKey(processInstanceKey)
                 .limitToProcessInstanceCompleted())
         .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
-        .containsSequence(
+        .containsSubsequence(
             tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
@@ -350,6 +350,7 @@ public final class EmbeddedSubProcessTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
+                .onlyEvents()
                 .limitToProcessInstanceTerminated())
         .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
         .containsSubsequence(
@@ -386,6 +387,7 @@ public final class EmbeddedSubProcessTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
+                .onlyEvents()
                 .limitToProcessInstanceTerminated())
         .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
         .containsSubsequence(

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
@@ -237,7 +237,7 @@ public class InterruptingEventSubprocessTest {
 
     // then
     final Record<ProcessInstanceRecordValue> subProcess =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETING)
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.COMPLETE_ELEMENT)
             .withProcessInstanceKey(wfInstanceKey)
             .withElementId("sub_proc")
             .getFirst();

--- a/engine/src/test/java/io/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
@@ -177,11 +177,14 @@ public final class CancelProcessInstanceTest {
             .asList();
 
     assertThat(processEvents)
+        .hasSize(10)
         .extracting(e -> e.getValue().getElementId(), e -> e.getIntent())
         .containsSubsequence(
             tuple("", ProcessInstanceIntent.CANCEL),
             tuple("SUB_PROCESS_PROCESS", ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple("subProcess", ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple("subProcess", ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple("task", ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple("task", ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple("task", ELEMENT_TERMINATED),
             tuple("subProcess", ELEMENT_TERMINATED),


### PR DESCRIPTION
## Description

* Introduce the flowScopeKey on the `activateTriggeredEvent` method 
* Apply event sourcing to the SubProcessProcessor.
* Fix how temp vars are set on event sub processes

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6195 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
