### PR TITLE
Apply event sourcing to the buffered start message events

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -91,7 +91,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
         new BpmnEventPublicationBehavior(zeebeState, eventTriggerBehavior, writers);
     processResultSenderBehavior = new BpmnProcessResultSenderBehavior(zeebeState, responseWriter);
     bufferedMessageStartEventBehavior =
-        new BpmnBufferedMessageStartEventBehavior(zeebeState, eventTriggerBehavior, writers);
+        new BpmnBufferedMessageStartEventBehavior(
+            zeebeState, zeebeState.getKeyGenerator(), eventTriggerBehavior, writers);
     jobBehavior =
         new BpmnJobBehavior(zeebeState.getKeyGenerator(), zeebeState.getJobState(), writers);
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -19,9 +19,13 @@ import io.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 
 public final class ProcessProcessor
     implements BpmnElementContainerProcessor<ExecutableFlowElementContainer> {
+
+  private static final Consumer<BpmnElementContext> NOOP = context -> {};
 
   private final BpmnStateBehavior stateBehavior;
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
@@ -62,56 +66,24 @@ public final class ProcessProcessor
 
     eventSubscriptionBehavior.unsubscribeFromEvents(context);
 
-    final var parentProcessInstanceKey = context.getParentProcessInstanceKey();
-    BpmnElementContext parentElementInstanceContext = null;
-    if (parentProcessInstanceKey > 0) {
-      // needs to be done before we delete the Process element instance
-      parentElementInstanceContext = stateBehavior.getParentElementInstanceContext(context);
-    }
-
     // we need to send the result before we transition to completed, since the
     // event applier will delete the element instance
     processResultSenderBehavior.sendResult(context);
 
-    final var completed = stateTransitionBehavior.transitionToCompleted(context);
-
-    if (parentElementInstanceContext != null) {
-      stateTransitionBehavior.onCalledProcessCompleted(completed, parentElementInstanceContext);
-    }
-
-    if (element.hasMessageStartEvent()) {
-      bufferedMessageStartEventBehavior.correlateMessage(completed);
-    }
+    transitionTo(element, context, stateTransitionBehavior::transitionToCompleted);
   }
 
   @Override
   public void onTerminate(
       final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+
     eventSubscriptionBehavior.unsubscribeFromEvents(context);
+    incidentBehavior.resolveIncidents(context);
 
     final var noActiveChildInstances = stateTransitionBehavior.terminateChildInstances(context);
 
     if (noActiveChildInstances) {
-
-      final var parentProcessInstanceKey = context.getParentProcessInstanceKey();
-      BpmnElementContext parentElementInstanceContext = null;
-      if (parentProcessInstanceKey > 0) {
-        // needs to be done before we delete the Process element instance
-        parentElementInstanceContext = stateBehavior.getParentElementInstanceContext(context);
-      }
-
-      final var terminated = stateTransitionBehavior.transitionToTerminated(context);
-      incidentBehavior.resolveIncidents(terminated);
-
-      if (parentElementInstanceContext != null) {
-        stateTransitionBehavior.onCalledProcessTerminated(terminated, parentElementInstanceContext);
-      }
-    } else {
-      incidentBehavior.resolveIncidents(context);
-    }
-
-    if (element.hasMessageStartEvent()) {
-      bufferedMessageStartEventBehavior.correlateMessage(context);
+      transitionTo(element, context, stateTransitionBehavior::transitionToTerminated);
     }
   }
 
@@ -157,6 +129,7 @@ public final class ProcessProcessor
       final ExecutableFlowElementContainer element,
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext) {
+
     if (stateBehavior.canBeCompleted(childContext)) {
       stateTransitionBehavior.completeElement(flowScopeContext);
     }
@@ -171,30 +144,59 @@ public final class ProcessProcessor
     if (flowScopeContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING
         && stateBehavior.canBeTerminated(childContext)) {
 
-      final var parentProcessInstanceKey = flowScopeContext.getParentProcessInstanceKey();
-      BpmnElementContext parentElementInstanceContext = null;
-      if (parentProcessInstanceKey > 0) {
-        // needs to be done before we delete the Process element instance
-        parentElementInstanceContext =
-            stateBehavior.getParentElementInstanceContext(flowScopeContext);
-      }
+      transitionTo(element, flowScopeContext, stateTransitionBehavior::transitionToTerminated);
 
-      // the event appliers will remove the process instance, this is the reason
-      // why we need to extract the parent element instance before the reference is deleted
-      stateTransitionBehavior.transitionToTerminated(flowScopeContext);
-
-      if (parentElementInstanceContext != null) {
-        stateTransitionBehavior.onCalledProcessTerminated(
-            flowScopeContext, parentElementInstanceContext);
-      }
     } else {
-
       eventSubscriptionBehavior
           .findEventTrigger(flowScopeContext)
           .ifPresent(
               eventTrigger ->
                   eventSubscriptionBehavior.activateTriggeredEvent(
                       flowScopeContext.getElementInstanceKey(), flowScopeContext, eventTrigger));
+    }
+  }
+
+  private void transitionTo(
+      final ExecutableFlowElementContainer element,
+      final BpmnElementContext context,
+      final UnaryOperator<BpmnElementContext> transitionOperation) {
+
+    final var action = getPostTransitionAction(element, context);
+    final var afterTransition = transitionOperation.apply(context);
+
+    action.accept(afterTransition);
+  }
+
+  private Consumer<BpmnElementContext> getPostTransitionAction(
+      final ExecutableFlowElementContainer processElement, final BpmnElementContext context) {
+
+    // fetch the data before the element instance is removed while performing the transition
+    final var parentProcessInstanceKey = context.getParentProcessInstanceKey();
+    if (parentProcessInstanceKey > 0) {
+      // the process was created by a call activity
+      final var parentInstanceContext = stateBehavior.getParentElementInstanceContext(context);
+
+      return postTransitionContext -> {
+        if (postTransitionContext.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED) {
+          stateTransitionBehavior.onCalledProcessCompleted(
+              postTransitionContext, parentInstanceContext);
+        } else {
+          stateTransitionBehavior.onCalledProcessTerminated(
+              postTransitionContext, parentInstanceContext);
+        }
+      };
+
+    } else if (processElement.hasMessageStartEvent()) {
+      // the process might be created by a message (but not by a call activity)
+      final var correlationKey = bufferedMessageStartEventBehavior.findCorrelationKey(context);
+
+      return postTransitionContext ->
+          correlationKey.ifPresent(
+              key ->
+                  bufferedMessageStartEventBehavior.correlateMessage(postTransitionContext, key));
+
+    } else {
+      return NOOP;
     }
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
@@ -15,9 +15,9 @@ import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.KeyGenerator;
+import io.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.zeebe.engine.state.immutable.ProcessState;
 import io.zeebe.engine.state.instance.ElementInstance;
-import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
@@ -40,25 +40,24 @@ public final class EventHandle {
       new MessageStartEventSubscriptionRecord();
 
   private final KeyGenerator keyGenerator;
-  private final MutableEventScopeInstanceState eventScopeInstanceState;
+  private final EventScopeInstanceState eventScopeInstanceState;
+  private final ProcessState processState;
 
   private final TypedCommandWriter commandWriter;
   private final StateWriter stateWriter;
-  private final ProcessState processState;
   private final EventTriggerBehavior eventTriggerBehavior;
 
-  // TODO (saig0): use immutable states only (#6200)
   public EventHandle(
       final KeyGenerator keyGenerator,
-      final MutableEventScopeInstanceState eventScopeInstanceState,
+      final EventScopeInstanceState eventScopeInstanceState,
       final Writers writers,
       final ProcessState processState,
       final EventTriggerBehavior eventTriggerBehavior) {
     this.keyGenerator = keyGenerator;
     this.eventScopeInstanceState = eventScopeInstanceState;
+    this.processState = processState;
     commandWriter = writers.command();
     stateWriter = writers.state();
-    this.processState = processState;
     this.eventTriggerBehavior = eventTriggerBehavior;
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -20,13 +20,11 @@ import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.KeyGenerator;
+import io.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
 import io.zeebe.engine.state.immutable.MessageState;
 import io.zeebe.engine.state.immutable.MessageSubscriptionState;
-import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
-import io.zeebe.engine.state.mutable.MutableMessageState;
-import io.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
-import io.zeebe.engine.state.mutable.MutableProcessState;
+import io.zeebe.engine.state.immutable.ProcessState;
 import io.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.MessageIntent;
@@ -53,14 +51,14 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
   private long messageKey;
 
   public MessagePublishProcessor(
-      final MutableMessageState messageState,
-      final MutableMessageSubscriptionState subscriptionState,
+      final MessageState messageState,
+      final MessageSubscriptionState subscriptionState,
       final MessageStartEventSubscriptionState startEventSubscriptionState,
-      final MutableEventScopeInstanceState eventScopeInstanceState,
+      final EventScopeInstanceState eventScopeInstanceState,
       final SubscriptionCommandSender commandSender,
       final KeyGenerator keyGenerator,
       final Writers writers,
-      final MutableProcessState processState,
+      final ProcessState processState,
       final EventTriggerBehavior eventTriggerBehavior) {
     this.messageState = messageState;
     this.subscriptionState = subscriptionState;

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/BufferedStartMessageEventStateApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/BufferedStartMessageEventStateApplier.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.zeebe.engine.state.immutable.ProcessState;
+import io.zeebe.engine.state.mutable.MutableMessageState;
+import io.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.zeebe.protocol.record.value.BpmnElementType;
+
+public final class BufferedStartMessageEventStateApplier {
+
+  private final ProcessState processState;
+  private final MutableMessageState messageState;
+
+  public BufferedStartMessageEventStateApplier(
+      final ProcessState processState, final MutableMessageState messageState) {
+    this.processState = processState;
+    this.messageState = messageState;
+  }
+
+  /**
+   * If a process instance is created by a message then it creates a lock for the instance to avoid
+   * that another instance can be created for the same message name and correlation key. This method
+   * removes the lock. It should be called when the process instance transitions to completed or
+   * terminated.
+   *
+   * @param record the record of the process instance that has ended
+   */
+  public void removeMessageLock(final ProcessInstanceRecord record) {
+
+    if (record.getBpmnElementType() == BpmnElementType.PROCESS) {
+      final var processElement = getProcessElement(record);
+
+      if (processElement.hasMessageStartEvent()) {
+        removeProcessInstanceMessageLock(record);
+      }
+    }
+  }
+
+  private ExecutableFlowElementContainer getProcessElement(final ProcessInstanceRecord record) {
+    return processState.getFlowElement(
+        record.getProcessDefinitionKey(),
+        record.getElementIdBuffer(),
+        ExecutableFlowElementContainer.class);
+  }
+
+  private void removeProcessInstanceMessageLock(final ProcessInstanceRecord record) {
+
+    final var processInstanceKey = record.getProcessInstanceKey();
+    final var correlationKey = messageState.getProcessInstanceCorrelationKey(processInstanceKey);
+
+    if (correlationKey != null) {
+      messageState.removeProcessInstanceCorrelationKey(processInstanceKey);
+      messageState.removeActiveProcessInstance(record.getBpmnProcessIdBuffer(), correlationKey);
+    }
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -109,6 +109,9 @@ public final class EventAppliers implements EventApplier {
     final var eventScopeInstanceState = state.getEventScopeInstanceState();
     final var processState = state.getProcessState();
     final var variableState = state.getVariableState();
+    final var bufferedStartMessageEventStateApplier =
+        new BufferedStartMessageEventStateApplier(processState, state.getMessageState());
+
     register(
         ProcessInstanceIntent.ELEMENT_ACTIVATING,
         new ProcessInstanceElementActivatingApplier(
@@ -122,13 +125,18 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessInstanceIntent.ELEMENT_COMPLETED,
         new ProcessInstanceElementCompletedApplier(
-            elementInstanceState, eventScopeInstanceState, variableState, processState));
+            elementInstanceState,
+            eventScopeInstanceState,
+            variableState,
+            processState,
+            bufferedStartMessageEventStateApplier));
     register(
         ProcessInstanceIntent.ELEMENT_TERMINATING,
         new ProcessInstanceElementTerminatingApplier(elementInstanceState));
     register(
         ProcessInstanceIntent.ELEMENT_TERMINATED,
-        new ProcessInstanceElementTerminatedApplier(elementInstanceState, eventScopeInstanceState));
+        new ProcessInstanceElementTerminatedApplier(
+            elementInstanceState, eventScopeInstanceState, bufferedStartMessageEventStateApplier));
     register(
         ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN,
         new ProcessInstanceSequenceFlowTakenApplier(elementInstanceState));

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementCompletedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementCompletedApplier.java
@@ -25,16 +25,19 @@ final class ProcessInstanceElementCompletedApplier
   private final MutableEventScopeInstanceState eventScopeInstanceState;
   private final MutableVariableState variableState;
   private final ProcessState processState;
+  private final BufferedStartMessageEventStateApplier bufferedStartMessageEventStateApplier;
 
   public ProcessInstanceElementCompletedApplier(
       final MutableElementInstanceState elementInstanceState,
       final MutableEventScopeInstanceState eventScopeInstanceState,
       final MutableVariableState variableState,
-      final ProcessState processState) {
+      final ProcessState processState,
+      final BufferedStartMessageEventStateApplier bufferedStartMessageEventStateApplier) {
     this.elementInstanceState = elementInstanceState;
     this.eventScopeInstanceState = eventScopeInstanceState;
     this.variableState = variableState;
     this.processState = processState;
+    this.bufferedStartMessageEventStateApplier = bufferedStartMessageEventStateApplier;
   }
 
   @Override
@@ -61,6 +64,8 @@ final class ProcessInstanceElementCompletedApplier
         variableState.setTemporaryVariables(parentElementInstanceKey, variables);
       }
     }
+
+    bufferedStartMessageEventStateApplier.removeMessageLock(value);
 
     eventScopeInstanceState.deleteInstance(key);
     elementInstanceState.removeInstance(key);

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementTerminatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementTerminatedApplier.java
@@ -19,16 +19,22 @@ final class ProcessInstanceElementTerminatedApplier
 
   private final MutableElementInstanceState elementInstanceState;
   private final MutableEventScopeInstanceState eventScopeInstanceState;
+  private final BufferedStartMessageEventStateApplier bufferedStartMessageEventStateApplier;
 
   public ProcessInstanceElementTerminatedApplier(
       final MutableElementInstanceState elementInstanceState,
-      final MutableEventScopeInstanceState eventScopeInstanceState) {
+      final MutableEventScopeInstanceState eventScopeInstanceState,
+      final BufferedStartMessageEventStateApplier bufferedStartMessageEventStateApplier) {
     this.elementInstanceState = elementInstanceState;
     this.eventScopeInstanceState = eventScopeInstanceState;
+    this.bufferedStartMessageEventStateApplier = bufferedStartMessageEventStateApplier;
   }
 
   @Override
   public void applyState(final long key, final ProcessInstanceRecord value) {
+
+    bufferedStartMessageEventStateApplier.removeMessageLock(value);
+
     eventScopeInstanceState.deleteInstance(key);
     elementInstanceState.removeInstance(key);
   }

--- a/engine/src/test/java/io/zeebe/engine/processing/message/MessageStartEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/message/MessageStartEventTest.java
@@ -22,11 +22,13 @@ import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
+import io.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
 import io.zeebe.protocol.record.value.VariableRecordValue;
 import io.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,7 +57,7 @@ public final class MessageStartEventTest {
   private static BpmnModelInstance singleStartEvent(
       final Consumer<StartEventBuilder> customizer, final String messageName) {
     final var startEventBuilder =
-        Bpmn.createExecutableProcess("wf").startEvent().message(messageName);
+        Bpmn.createExecutableProcess("wf").startEvent("start").message(messageName);
 
     customizer.accept(startEventBuilder);
 
@@ -604,6 +606,65 @@ public final class MessageStartEventTest {
         .extracting(r -> r.getValue().getValue())
         .describedAs("Expected messages [1,2,3] to be correlated")
         .containsExactly("1", "2", "3");
+  }
+
+  @Test
+  public void shouldWriteCorrelatedEventsForBufferedMessages() {
+    // given
+    final var instanceCount = 3;
+    engine.deployment().withXmlResource(SINGLE_START_EVENT_1).deploy();
+
+    // when
+    final var expectedSubscriptionTuples =
+        IntStream.range(0, instanceCount)
+            .mapToObj(
+                i -> {
+                  final Map<String, Object> variables = Map.of("x", i);
+
+                  final var messagePublished =
+                      engine
+                          .message()
+                          .withName(MESSAGE_NAME_1)
+                          .withCorrelationKey(CORRELATION_KEY_1)
+                          .withVariables(variables)
+                          .publish();
+
+                  final var jobCreated =
+                      RecordingExporter.jobRecords(JobIntent.CREATED).skip(i).getFirst();
+                  engine.job().withKey(jobCreated.getKey()).complete();
+
+                  final var processInstanceKey = jobCreated.getValue().getProcessInstanceKey();
+                  return tuple(messagePublished.getKey(), processInstanceKey, variables);
+                })
+            .collect(Collectors.toList());
+
+    // then
+    final var process = RecordingExporter.processRecords().getFirst().getValue();
+
+    final var subscriptionRecords =
+        RecordingExporter.messageStartEventSubscriptionRecords(
+                MessageStartEventSubscriptionIntent.CORRELATED)
+            .limit(instanceCount)
+            .map(Record::getValue)
+            .collect(Collectors.toList());
+
+    assertThat(subscriptionRecords)
+        .allSatisfy(
+            value -> {
+              assertThat(value.getMessageName()).isEqualTo(MESSAGE_NAME_1);
+              assertThat(value.getCorrelationKey()).isEqualTo(CORRELATION_KEY_1);
+              assertThat(value.getProcessDefinitionKey())
+                  .isEqualTo(process.getProcessDefinitionKey());
+              assertThat(value.getBpmnProcessId()).isEqualTo(process.getBpmnProcessId());
+              assertThat(value.getStartEventId()).isEqualTo("start");
+            });
+
+    assertThat(subscriptionRecords)
+        .extracting(
+            MessageStartEventSubscriptionRecordValue::getMessageKey,
+            MessageStartEventSubscriptionRecordValue::getProcessInstanceKey,
+            MessageStartEventSubscriptionRecordValue::getVariables)
+        .containsSequence(expectedSubscriptionTuples);
   }
 
   @Test


### PR DESCRIPTION
## Description

* replace the state changes in `BpmnBufferedMessageStartEventBehavior` by 
  * writing a message start event subscription `correlated` event in `EventHandle` (like it was done in the `MessagePublishedProcessor` before)
  * extending the `completed` and `terminated` event appliers of the process instance to clean up the state 

_I recommend reviewing the PR commit-by-commit and look at the commit comments._

## Related issues

closes #6816 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
