### PR TITLE
docs(benchmark): update Helm repo URL

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -40,7 +40,7 @@ chmod 700 get_helm.sh
 
 ## add zeebe as helm repo
 helm version
-helm repo add zeebe https://helm.zeebe.io
+helm repo add zeebe https://helm.camunda.io
 helm repo add stable https://kubernetes-charts.storage.googleapis.com
 helm repo update
 


### PR DESCRIPTION
The old URL doesn't work anymore.