### PR TITLE
Add null check on SubProcessProcessor

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -128,7 +128,8 @@ public final class SubProcessProcessor
         .ifPresentOrElse(
             eventTrigger -> {
               if (subProcessContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING
-                  && stateBehavior.canBeTerminated(childContext)) {
+                  // child context can be null if no child's exist on termination
+                  && (childContext == null || stateBehavior.canBeTerminated(childContext))) {
                 final var terminated =
                     stateTransitionBehavior.transitionToTerminated(subProcessContext);
                 eventSubscriptionBehavior.activateTriggeredEvent(
@@ -140,7 +141,8 @@ public final class SubProcessProcessor
             },
             () -> {
               if (subProcessContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING
-                  && stateBehavior.canBeTerminated(childContext)) {
+                  // child context can be null if no child's exist on termination
+                  && (childContext == null || stateBehavior.canBeTerminated(childContext))) {
                 final var terminated =
                     stateTransitionBehavior.transitionToTerminated(subProcessContext);
                 stateTransitionBehavior.onElementTerminated(element, terminated);


### PR DESCRIPTION
## Description

The child context can be null on SubProcess termination, if no child's exist which need to be terminated. In this case we want to immediately terminate and call `onChildTerminated`, to respect DRY, with childContext = null. In order to handle this we need to check for null.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6829 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
