### PR TITLE
Reuse ProcessMessageSubscriptionRecord in ProcessMessageSubscription state

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -245,15 +245,13 @@ public final class CatchEventBehavior {
   private boolean unsubscribeFromMessageEvent(
       final ProcessMessageSubscription subscription, final SideEffects sideEffects) {
 
-    final DirectBuffer messageName = cloneBuffer(subscription.getMessageName());
-    final int subscriptionPartitionId = subscription.getSubscriptionPartitionId();
-    final long processInstanceKey = subscription.getProcessInstanceKey();
-    final long elementInstanceKey = subscription.getElementInstanceKey();
+    final DirectBuffer messageName = cloneBuffer(subscription.getRecord().getMessageNameBuffer());
+    final int subscriptionPartitionId = subscription.getRecord().getSubscriptionPartitionId();
+    final long processInstanceKey = subscription.getRecord().getProcessInstanceKey();
+    final long elementInstanceKey = subscription.getRecord().getElementInstanceKey();
 
-    subscription.setClosing();
     processMessageSubscriptionState.updateToClosingState(
-        subscription, ActorClock.currentTimeMillis());
-
+        subscription.getRecord(), ActorClock.currentTimeMillis());
     sideEffects.add(
         () ->
             sendCloseMessageSubscriptionCommand(

--- a/engine/src/main/java/io/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
@@ -103,20 +103,20 @@ public final class PendingProcessMessageSubscriptionChecker
 
   private boolean sendOpenCommand(final ProcessMessageSubscription subscription) {
     return commandSender.openMessageSubscription(
-        subscription.getSubscriptionPartitionId(),
-        subscription.getProcessInstanceKey(),
-        subscription.getElementInstanceKey(),
-        subscription.getBpmnProcessId(),
-        subscription.getMessageName(),
-        subscription.getCorrelationKey(),
-        subscription.shouldCloseOnCorrelate());
+        subscription.getRecord().getSubscriptionPartitionId(),
+        subscription.getRecord().getProcessInstanceKey(),
+        subscription.getRecord().getElementInstanceKey(),
+        subscription.getRecord().getBpmnProcessIdBuffer(),
+        subscription.getRecord().getMessageNameBuffer(),
+        subscription.getRecord().getCorrelationKeyBuffer(),
+        subscription.getRecord().isInterrupting());
   }
 
   private boolean sendCloseCommand(final ProcessMessageSubscription subscription) {
     return commandSender.closeMessageSubscription(
-        subscription.getSubscriptionPartitionId(),
-        subscription.getProcessInstanceKey(),
-        subscription.getElementInstanceKey(),
-        subscription.getMessageName());
+        subscription.getRecord().getSubscriptionPartitionId(),
+        subscription.getRecord().getProcessInstanceKey(),
+        subscription.getRecord().getElementInstanceKey(),
+        subscription.getRecord().getMessageNameBuffer());
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -83,12 +83,11 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
       final TypedStreamWriter streamWriter,
       final Consumer<SideEffectProducer> sideEffect) {
 
-    final var subscriptionRecord = command.getValue();
-    final var elementInstanceKey = subscriptionRecord.getElementInstanceKey();
+    final var record = command.getValue();
+    final var elementInstanceKey = record.getElementInstanceKey();
 
     final ProcessMessageSubscription subscription =
-        subscriptionState.getSubscription(
-            elementInstanceKey, subscriptionRecord.getMessageNameBuffer());
+        subscriptionState.getSubscription(elementInstanceKey, record.getMessageNameBuffer());
 
     if (subscription == null) {
       rejectCommand(command, RejectionType.NOT_FOUND, NO_SUBSCRIPTION_FOUND_MESSAGE);
@@ -104,23 +103,25 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
         rejectCommand(command, RejectionType.INVALID_STATE, NO_EVENT_OCCURRED_MESSAGE);
 
       } else {
-        // TODO (saig0): reuse the subscription record in the state (#6533)
-        subscriptionRecord
-            .setElementId(subscription.getTargetElementId())
-            .setInterrupting(subscription.shouldCloseOnCorrelate());
+        // avoid reusing the subscription record directly as any access to the state (e.g. as #get)
+        // will overwrite it - safer to just copy its values into an one-time-use record
+        final ProcessMessageSubscriptionRecord subscriptionRecord = subscription.getRecord();
+        record
+            .setElementId(subscriptionRecord.getElementIdBuffer())
+            .setInterrupting(subscriptionRecord.isInterrupting());
 
         stateWriter.appendFollowUpEvent(
-            command.getKey(), ProcessMessageSubscriptionIntent.CORRELATED, subscriptionRecord);
+            command.getKey(), ProcessMessageSubscriptionIntent.CORRELATED, record);
 
         final var catchEvent =
-            getCatchEvent(elementInstance.getValue(), subscriptionRecord.getElementIdBuffer());
+            getCatchEvent(elementInstance.getValue(), record.getElementIdBuffer());
         eventHandle.activateElement(
             catchEvent,
             elementInstanceKey,
             elementInstance.getValue(),
-            subscriptionRecord.getVariablesBuffer());
+            record.getVariablesBuffer());
 
-        sendAcknowledgeCommand(subscriptionRecord);
+        sendAcknowledgeCommand(record);
       }
     }
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
@@ -56,7 +56,7 @@ public final class ProcessMessageSubscriptionCreateProcessor
     if (subscription != null && subscription.isOpening()) {
       // TODO (saig0): the subscription should have a key (#2805)
       stateWriter.appendFollowUpEvent(
-          command.getKey(), ProcessMessageSubscriptionIntent.CREATED, subscriptionRecord);
+          command.getKey(), ProcessMessageSubscriptionIntent.CREATED, subscription.getRecord());
 
     } else {
       rejectCommand(command, subscription);

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionCorrelatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionCorrelatedApplier.java
@@ -42,7 +42,6 @@ public final class ProcessMessageSubscriptionCorrelatedApplier
 
   @Override
   public void applyState(final long key, final ProcessMessageSubscriptionRecord value) {
-
     if (value.isInterrupting()) {
       subscriptionState.remove(value.getElementInstanceKey(), value.getMessageNameBuffer());
     }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionCreatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionCreatedApplier.java
@@ -25,12 +25,6 @@ public final class ProcessMessageSubscriptionCreatedApplier
 
   @Override
   public void applyState(final long key, final ProcessMessageSubscriptionRecord value) {
-
-    // TODO (saig0): reuse the subscription record in the state (#6533)
-    final var subscription =
-        subscriptionState.getSubscription(
-            value.getElementInstanceKey(), value.getMessageNameBuffer());
-
-    subscriptionState.updateToOpenedState(subscription, subscription.getSubscriptionPartitionId());
+    subscriptionState.updateToOpenedState(value);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionCreatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionCreatingApplier.java
@@ -8,7 +8,6 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
-import io.zeebe.engine.state.message.ProcessMessageSubscription;
 import io.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
@@ -27,21 +26,8 @@ public final class ProcessMessageSubscriptionCreatingApplier
 
   @Override
   public void applyState(final long key, final ProcessMessageSubscriptionRecord value) {
-    // TODO (saig0): reuse the subscription record in the state (#6533)
-    final var subscription = new ProcessMessageSubscription();
-
-    subscription.setSubscriptionPartitionId(value.getSubscriptionPartitionId());
-    subscription.setMessageName(value.getMessageNameBuffer());
-    subscription.setElementInstanceKey(value.getElementInstanceKey());
-    subscription.setProcessInstanceKey(value.getProcessInstanceKey());
-    subscription.setBpmnProcessId(value.getBpmnProcessIdBuffer());
-    subscription.setCorrelationKey(value.getCorrelationKeyBuffer());
-    subscription.setTargetElementId(value.getElementIdBuffer());
-    subscription.setCloseOnCorrelate(value.isInterrupting());
-
     // TODO (saig0): the send time for the retry should be deterministic (#6364)
     final var sentTime = ActorClock.currentTimeMillis();
-    subscription.setCommandSentTime(sentTime);
 
     if (subscriptionState.existSubscriptionForElementInstance(
         value.getElementInstanceKey(), value.getMessageNameBuffer())) {
@@ -49,6 +35,6 @@ public final class ProcessMessageSubscriptionCreatingApplier
       return;
     }
 
-    subscriptionState.put(subscription);
+    subscriptionState.put(value, sentTime);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
@@ -16,6 +16,8 @@ import io.zeebe.db.impl.DbNil;
 import io.zeebe.db.impl.DbString;
 import io.zeebe.engine.state.ZbColumnFamilies;
 import io.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
+import io.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 
 public final class DbProcessMessageSubscriptionState
@@ -63,12 +65,15 @@ public final class DbProcessMessageSubscriptionState
   }
 
   @Override
-  public void put(final ProcessMessageSubscription subscription) {
-    wrapSubscriptionKeys(subscription.getElementInstanceKey(), subscription.getMessageName());
+  public void put(final ProcessMessageSubscriptionRecord record, final long commandSentTime) {
+    wrapSubscriptionKeys(record.getElementInstanceKey(), record.getMessageNameBuffer());
 
-    subscriptionColumnFamily.put(elementKeyAndMessageName, subscription);
+    processMessageSubscription.reset();
+    processMessageSubscription.setRecord(record).setCommandSentTime(commandSentTime);
 
-    sentTime.wrapLong(subscription.getCommandSentTime());
+    subscriptionColumnFamily.put(elementKeyAndMessageName, processMessageSubscription);
+
+    sentTime.wrapLong(commandSentTime);
     sentTimeColumnFamily.put(sentTimeCompositeKey, DbNil.INSTANCE);
   }
 
@@ -98,54 +103,32 @@ public final class DbProcessMessageSubscriptionState
 
     sentTimeColumnFamily.whileTrue(
         (compositeKey, nil) -> {
-          final long sentTime = compositeKey.getFirst().getValue();
-          if (sentTime < deadline) {
-            final ProcessMessageSubscription processMessageSubscription =
+          final long commandSentTime = compositeKey.getFirst().getValue();
+          if (commandSentTime < deadline) {
+            final ProcessMessageSubscription subscription =
                 subscriptionColumnFamily.get(compositeKey.getSecond());
 
-            return visitor.visit(processMessageSubscription);
+            return visitor.visit(subscription);
           }
           return false;
         });
   }
 
-  @Override
-  public void updateToOpenedState(
-      final ProcessMessageSubscription subscription, final int subscriptionPartitionId) {
-    subscription.setOpened();
-    subscription.setSubscriptionPartitionId(subscriptionPartitionId);
-    updateSentTime(subscription, 0);
+  public void updateToOpenedState(final ProcessMessageSubscriptionRecord record) {
+    update(record, s -> s.setRecord(record).setCommandSentTime(0).setOpened());
   }
 
   @Override
   public void updateToClosingState(
-      final ProcessMessageSubscription subscription, final long sentTime) {
-    subscription.setClosing();
-    updateSentTime(subscription, sentTime);
+      final ProcessMessageSubscriptionRecord record, final long commandSentTime) {
+    update(record, s -> s.setRecord(record).setCommandSentTime(commandSentTime).setClosing());
   }
 
   @Override
   public void updateSentTimeInTransaction(
-      final ProcessMessageSubscription subscription, final long sentTime) {
-    transactionContext.runInTransaction(() -> updateSentTime(subscription, sentTime));
-  }
-
-  @Override
-  public void updateSentTime(final ProcessMessageSubscription subscription, final long sentTime) {
-    wrapSubscriptionKeys(subscription.getElementInstanceKey(), subscription.getMessageName());
-
-    if (subscription.getCommandSentTime() > 0) {
-      this.sentTime.wrapLong(subscription.getCommandSentTime());
-      sentTimeColumnFamily.delete(sentTimeCompositeKey);
-    }
-
-    subscription.setCommandSentTime(sentTime);
-    subscriptionColumnFamily.put(elementKeyAndMessageName, subscription);
-
-    if (sentTime > 0) {
-      this.sentTime.wrapLong(sentTime);
-      sentTimeColumnFamily.put(sentTimeCompositeKey, DbNil.INSTANCE);
-    }
+      final ProcessMessageSubscription subscription, final long commandSentTime) {
+    transactionContext.runInTransaction(
+        () -> update(subscription, s -> s.setCommandSentTime(commandSentTime)));
   }
 
   @Override
@@ -167,9 +150,47 @@ public final class DbProcessMessageSubscriptionState
     return found;
   }
 
-  @Override
-  public void remove(final ProcessMessageSubscription subscription) {
-    wrapSubscriptionKeys(subscription.getElementInstanceKey(), subscription.getMessageName());
+  private void update(
+      final ProcessMessageSubscriptionRecord record,
+      final Consumer<ProcessMessageSubscription> modifier) {
+    final ProcessMessageSubscription subscription =
+        getSubscription(record.getElementInstanceKey(), record.getMessageNameBuffer());
+    if (subscription == null) {
+      return;
+    }
+
+    update(subscription, modifier);
+  }
+
+  private void update(
+      final ProcessMessageSubscription subscription,
+      final Consumer<ProcessMessageSubscription> modifier) {
+    final long previousSentTime = subscription.getCommandSentTime();
+    modifier.accept(subscription);
+
+    wrapSubscriptionKeys(
+        subscription.getRecord().getElementInstanceKey(),
+        subscription.getRecord().getMessageNameBuffer());
+    subscriptionColumnFamily.put(elementKeyAndMessageName, subscription);
+
+    final long updatedSentTime = subscription.getCommandSentTime();
+    if (updatedSentTime != previousSentTime) {
+      if (previousSentTime > 0) {
+        sentTime.wrapLong(previousSentTime);
+        sentTimeColumnFamily.delete(sentTimeCompositeKey);
+      }
+
+      if (updatedSentTime > 0) {
+        sentTime.wrapLong(updatedSentTime);
+        sentTimeColumnFamily.put(sentTimeCompositeKey, DbNil.INSTANCE);
+      }
+    }
+  }
+
+  private void remove(final ProcessMessageSubscription subscription) {
+    wrapSubscriptionKeys(
+        subscription.getRecord().getElementInstanceKey(),
+        subscription.getRecord().getMessageNameBuffer());
 
     subscriptionColumnFamily.delete(elementKeyAndMessageName);
 

--- a/engine/src/main/java/io/zeebe/engine/state/message/ProcessMessageSubscription.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/ProcessMessageSubscription.java
@@ -9,149 +9,58 @@ package io.zeebe.engine.state.message;
 
 import io.zeebe.db.DbValue;
 import io.zeebe.msgpack.UnpackedObject;
-import io.zeebe.msgpack.property.BooleanProperty;
 import io.zeebe.msgpack.property.EnumProperty;
-import io.zeebe.msgpack.property.IntegerProperty;
 import io.zeebe.msgpack.property.LongProperty;
-import io.zeebe.msgpack.property.StringProperty;
-import org.agrona.DirectBuffer;
+import io.zeebe.msgpack.property.ObjectProperty;
+import io.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 
+@SuppressWarnings({"java:S2160", "UnusedReturnValue"})
 public final class ProcessMessageSubscription extends UnpackedObject implements DbValue {
 
-  private final StringProperty messageNameProp = new StringProperty("messageName", "");
-  private final StringProperty correlationKeyProp = new StringProperty("correlationKey", "");
-  private final StringProperty targetElementIdProp = new StringProperty("targetElementId", "");
-  private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
-  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
-  private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
-  private final IntegerProperty subscriptionPartitionIdProp =
-      new IntegerProperty("subscriptionPartitionId", -1);
+  private final ObjectProperty<ProcessMessageSubscriptionRecord> recordProp =
+      new ObjectProperty<>("record", new ProcessMessageSubscriptionRecord());
   private final LongProperty commandSentTimeProp = new LongProperty("commandSentTime", 0);
-  private final BooleanProperty closeOnCorrelateProp =
-      new BooleanProperty("closeOnCorrelate", true);
   private final EnumProperty<State> stateProp =
       new EnumProperty<>("state", State.class, State.STATE_OPENING);
 
   public ProcessMessageSubscription() {
-    declareProperty(messageNameProp)
-        .declareProperty(correlationKeyProp)
-        .declareProperty(targetElementIdProp)
-        .declareProperty(bpmnProcessIdProp)
-        .declareProperty(processInstanceKeyProp)
-        .declareProperty(elementInstanceKeyProp)
-        .declareProperty(subscriptionPartitionIdProp)
-        .declareProperty(commandSentTimeProp)
-        .declareProperty(closeOnCorrelateProp)
-        .declareProperty(stateProp);
+    declareProperty(recordProp).declareProperty(commandSentTimeProp).declareProperty(stateProp);
   }
 
-  public ProcessMessageSubscription(
-      final long processInstanceKey,
-      final long elementInstanceKey,
-      final DirectBuffer targetElementId,
-      final DirectBuffer bpmnProcessId,
-      final DirectBuffer messageName,
-      final DirectBuffer correlationKey,
-      final long commandSentTime,
-      final boolean closeOnCorrelate) {
-    this();
-
-    processInstanceKeyProp.setValue(processInstanceKey);
-    elementInstanceKeyProp.setValue(elementInstanceKey);
-    bpmnProcessIdProp.setValue(bpmnProcessId);
-    targetElementIdProp.setValue(targetElementId);
-    commandSentTimeProp.setValue(commandSentTime);
-    messageNameProp.setValue(messageName);
-    correlationKeyProp.setValue(correlationKey);
-    closeOnCorrelateProp.setValue(closeOnCorrelate);
+  public ProcessMessageSubscriptionRecord getRecord() {
+    return recordProp.getValue();
   }
 
-  public DirectBuffer getMessageName() {
-    return messageNameProp.getValue();
-  }
-
-  public void setMessageName(final DirectBuffer messageName) {
-    messageNameProp.setValue(messageName);
-  }
-
-  public DirectBuffer getCorrelationKey() {
-    return correlationKeyProp.getValue();
-  }
-
-  public void setCorrelationKey(final DirectBuffer correlationKey) {
-    correlationKeyProp.setValue(correlationKey);
-  }
-
-  public DirectBuffer getTargetElementId() {
-    return targetElementIdProp.getValue();
-  }
-
-  public void setTargetElementId(final DirectBuffer targetElementId) {
-    targetElementIdProp.setValue(targetElementId);
-  }
-
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProp.getValue();
-  }
-
-  public void setProcessInstanceKey(final long processInstanceKey) {
-    processInstanceKeyProp.setValue(processInstanceKey);
-  }
-
-  public long getElementInstanceKey() {
-    return elementInstanceKeyProp.getValue();
-  }
-
-  public void setElementInstanceKey(final long elementInstanceKey) {
-    elementInstanceKeyProp.setValue(elementInstanceKey);
-  }
-
-  public DirectBuffer getBpmnProcessId() {
-    return bpmnProcessIdProp.getValue();
-  }
-
-  public void setBpmnProcessId(final DirectBuffer bpmnProcessId) {
-    bpmnProcessIdProp.setValue(bpmnProcessId);
+  public ProcessMessageSubscription setRecord(final ProcessMessageSubscriptionRecord record) {
+    recordProp.getValue().wrap(record);
+    return this;
   }
 
   public long getCommandSentTime() {
     return commandSentTimeProp.getValue();
   }
 
-  public void setCommandSentTime(final long commandSentTime) {
+  public ProcessMessageSubscription setCommandSentTime(final long commandSentTime) {
     commandSentTimeProp.setValue(commandSentTime);
-  }
-
-  public int getSubscriptionPartitionId() {
-    return subscriptionPartitionIdProp.getValue();
-  }
-
-  public void setSubscriptionPartitionId(final int subscriptionPartitionId) {
-    subscriptionPartitionIdProp.setValue(subscriptionPartitionId);
-  }
-
-  public boolean shouldCloseOnCorrelate() {
-    return closeOnCorrelateProp.getValue();
-  }
-
-  public void setCloseOnCorrelate(final boolean closeOnCorrelate) {
-    closeOnCorrelateProp.setValue(closeOnCorrelate);
+    return this;
   }
 
   public boolean isOpening() {
     return stateProp.getValue() == State.STATE_OPENING;
   }
 
+  public ProcessMessageSubscription setOpened() {
+    stateProp.setValue(State.STATE_OPENED);
+    return this;
+  }
+
   public boolean isClosing() {
     return stateProp.getValue() == State.STATE_CLOSING;
   }
 
-  public void setOpened() {
-    stateProp.setValue(State.STATE_OPENED);
-  }
-
-  public void setClosing() {
+  public ProcessMessageSubscription setClosing() {
     stateProp.setValue(State.STATE_CLOSING);
+    return this;
   }
 
   private enum State {

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableProcessMessageSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableProcessMessageSubscriptionState.java
@@ -9,21 +9,18 @@ package io.zeebe.engine.state.mutable;
 
 import io.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.zeebe.engine.state.message.ProcessMessageSubscription;
+import io.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import org.agrona.DirectBuffer;
 
 public interface MutableProcessMessageSubscriptionState extends ProcessMessageSubscriptionState {
 
-  void put(ProcessMessageSubscription subscription);
+  void put(ProcessMessageSubscriptionRecord record, final long commandSentTime);
 
-  void updateToOpenedState(ProcessMessageSubscription subscription, int subscriptionPartitionId);
+  void updateToOpenedState(ProcessMessageSubscriptionRecord record);
 
-  void updateToClosingState(ProcessMessageSubscription subscription, long sentTime);
+  void updateToClosingState(ProcessMessageSubscriptionRecord record, long commandSentTime);
 
-  void updateSentTimeInTransaction(ProcessMessageSubscription subscription, long sentTime);
-
-  void updateSentTime(ProcessMessageSubscription subscription, long sentTime);
+  void updateSentTimeInTransaction(ProcessMessageSubscription subscription, long commandSentTime);
 
   boolean remove(long elementInstanceKey, DirectBuffer messageName);
-
-  void remove(ProcessMessageSubscription subscription);
 }

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -21,6 +21,7 @@ import io.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 
+@SuppressWarnings("java:S2160")
 public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     implements ProcessMessageSubscriptionRecordValue {
 
@@ -47,6 +48,19 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(correlationKeyProp)
         .declareProperty(elementIdProp);
+  }
+
+  public void wrap(final ProcessMessageSubscriptionRecord record) {
+    setSubscriptionPartitionId(record.getSubscriptionPartitionId());
+    setProcessInstanceKey(record.getProcessInstanceKey());
+    setElementInstanceKey(record.getElementInstanceKey());
+    setMessageKey(record.getMessageKey());
+    setMessageName(record.getMessageNameBuffer());
+    setVariables(record.getVariablesBuffer());
+    setInterrupting(record.isInterrupting());
+    setBpmnProcessId(record.getBpmnProcessIdBuffer());
+    setCorrelationKey(record.getCorrelationKeyBuffer());
+    setElementId(record.getElementIdBuffer());
   }
 
   @Override

--- a/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -63,9 +63,44 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setElementId(record.getElementIdBuffer());
   }
 
+  @JsonIgnore
+  public DirectBuffer getBpmnProcessIdBuffer() {
+    return bpmnProcessIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getMessageNameBuffer() {
+    return messageNameProp.getValue();
+  }
+
+  @JsonIgnore
+  public int getSubscriptionPartitionId() {
+    return subscriptionPartitionIdProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setSubscriptionPartitionId(final int partitionId) {
+    subscriptionPartitionIdProp.setValue(partitionId);
+    return this;
+  }
+
   @Override
-  public boolean isInterrupting() {
-    return interruptingProp.getValue();
+  public Map<String, Object> getVariables() {
+    return MsgPackConverter.convertToMap(variablesProp.getValue());
+  }
+
+  public ProcessMessageSubscriptionRecord setVariables(final DirectBuffer variables) {
+    variablesProp.setValue(variables);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variablesProp.getValue();
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
   }
 
   @Override
@@ -108,6 +143,26 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public String getElementId() {
+    return bufferAsString(getElementIdBuffer());
+  }
+
+  @Override
+  public boolean isInterrupting() {
+    return interruptingProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setInterrupting(final boolean interrupting) {
+    interruptingProp.setValue(interrupting);
+    return this;
+  }
+
+  public ProcessMessageSubscriptionRecord setElementId(final DirectBuffer elementId) {
+    elementIdProp.setValue(elementId);
+    return this;
+  }
+
   public ProcessMessageSubscriptionRecord setMessageName(final DirectBuffer messageName) {
     messageNameProp.setValue(messageName);
     return this;
@@ -118,69 +173,14 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  @JsonIgnore
-  public DirectBuffer getBpmnProcessIdBuffer() {
-    return bpmnProcessIdProp.getValue();
-  }
-
-  @JsonIgnore
-  public DirectBuffer getMessageNameBuffer() {
-    return messageNameProp.getValue();
-  }
-
-  @JsonIgnore
-  public int getSubscriptionPartitionId() {
-    return subscriptionPartitionIdProp.getValue();
-  }
-
-  public ProcessMessageSubscriptionRecord setSubscriptionPartitionId(final int partitionId) {
-    subscriptionPartitionIdProp.setValue(partitionId);
-    return this;
-  }
-
-  @Override
-  public Map<String, Object> getVariables() {
-    return MsgPackConverter.convertToMap(variablesProp.getValue());
-  }
-
-  public ProcessMessageSubscriptionRecord setVariables(final DirectBuffer variables) {
-    variablesProp.setValue(variables);
-    return this;
-  }
-
-  @JsonIgnore
-  public DirectBuffer getVariablesBuffer() {
-    return variablesProp.getValue();
-  }
-
-  @Override
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProp.getValue();
-  }
-
   public ProcessMessageSubscriptionRecord setProcessInstanceKey(final long key) {
     processInstanceKeyProp.setValue(key);
-    return this;
-  }
-
-  public ProcessMessageSubscriptionRecord setInterrupting(final boolean interrupting) {
-    interruptingProp.setValue(interrupting);
     return this;
   }
 
   @JsonIgnore
   public DirectBuffer getCorrelationKeyBuffer() {
     return correlationKeyProp.getValue();
-  }
-
-  @Override
-  public String getElementId() {
-    return bufferAsString(getElementIdBuffer());
-  }
-
-  public ProcessMessageSubscriptionRecord setElementId(final DirectBuffer elementId) {
-    elementIdProp.setValue(elementId);
-    return this;
   }
 
   @JsonIgnore


### PR DESCRIPTION
## Description

This PR reduces duplication between `ProcessMessageSubscription` and `ProcessMessageSubscriptionRecord`. It does so by embedding the record into the subscription object.

Additionally, it reduces the API surface of the `MutableProcessMessageSubscriptionState`, which is possible due to the way we now embed the record into the state object.

NOTE: there are two formatting commits which are plain automated formatting according to the ZeebeStyle, you can skip those. As well there is one commit which is just updating the test to the new object format, but the tests themselves weren't changed. The interesting commits are then, in order: 
- https://github.com/camunda-cloud/zeebe/commit/a249792ea57202227cef4f1abbdffd14b2e1cf53 (new subscription object)
- https://github.com/camunda-cloud/zeebe/commit/5d0060a8e3f7437a5bf59bfcaf146877d873b737 (refactor state to use new object)
- https://github.com/camunda-cloud/zeebe/commit/a4ec51617c4913d7d1ea54a15e1a0c9e42bec5b7 (update usages of the state and the object)

## Related issues

closes #6533

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
