### PR TITLE
Apply event sourcing to closing process message subscriptions 

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -10,6 +10,7 @@ package io.zeebe.engine.state.appliers;
 import io.zeebe.engine.Loggers;
 import io.zeebe.engine.state.EventApplier;
 import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.zeebe.engine.state.mutable.MutableZeebeState;
 import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.intent.DeploymentDistributionIntent;
@@ -201,23 +202,29 @@ public final class EventAppliers implements EventApplier {
   }
 
   private void registerProcessMessageSubscriptionEventAppliers(final MutableZeebeState state) {
+    final MutableProcessMessageSubscriptionState subscriptionState =
+        state.getProcessMessageSubscriptionState();
+
     register(
         ProcessMessageSubscriptionIntent.CREATING,
-        new ProcessMessageSubscriptionCreatingApplier(state.getProcessMessageSubscriptionState()));
+        new ProcessMessageSubscriptionCreatingApplier(subscriptionState));
     register(
         ProcessMessageSubscriptionIntent.CREATED,
-        new ProcessMessageSubscriptionCreatedApplier(state.getProcessMessageSubscriptionState()));
+        new ProcessMessageSubscriptionCreatedApplier(subscriptionState));
     register(
         ProcessMessageSubscriptionIntent.CORRELATED,
         new ProcessMessageSubscriptionCorrelatedApplier(
-            state.getProcessMessageSubscriptionState(),
+            subscriptionState,
             state.getEventScopeInstanceState(),
             state.getVariableState(),
             state.getElementInstanceState(),
             state.getProcessState()));
     register(
+        ProcessMessageSubscriptionIntent.DELETING,
+        new ProcessMessageSubscriptionDeletingApplier(subscriptionState));
+    register(
         ProcessMessageSubscriptionIntent.DELETED,
-        new ProcessMessageSubscriptionDeletedApplier(state.getProcessMessageSubscriptionState()));
+        new ProcessMessageSubscriptionDeletedApplier(subscriptionState));
   }
 
   private void registerProcessEventAppliers(final MutableZeebeState state) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionDeletingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionDeletingApplier.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
+import io.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import io.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.zeebe.util.sched.clock.ActorClock;
+
+final class ProcessMessageSubscriptionDeletingApplier
+    implements TypedEventApplier<
+        ProcessMessageSubscriptionIntent, ProcessMessageSubscriptionRecord> {
+  private final MutableProcessMessageSubscriptionState state;
+
+  public ProcessMessageSubscriptionDeletingApplier(
+      final MutableProcessMessageSubscriptionState state) {
+    this.state = state;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessMessageSubscriptionRecord value) {
+    // TODO (npepinpe): the send time for the retry should be deterministic (#6364)
+    // TODO (npepinpe): the subscription should have a key (#2805)
+    state.updateToClosingState(value, ActorClock.currentTimeMillis());
+  }
+}

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
@@ -23,8 +23,9 @@ public enum ProcessMessageSubscriptionIntent implements ProcessInstanceRelatedIn
   CORRELATE((short) 3),
   CORRELATED((short) 4),
 
-  DELETE((short) 5),
-  DELETED((short) 6);
+  DELETING((short) 5),
+  DELETE((short) 6),
+  DELETED((short) 7);
 
   private final short value;
   private final boolean shouldBlacklist;
@@ -56,8 +57,10 @@ public enum ProcessMessageSubscriptionIntent implements ProcessInstanceRelatedIn
       case 4:
         return CORRELATED;
       case 5:
-        return DELETE;
+        return DELETING;
       case 6:
+        return DELETE;
+      case 7:
         return DELETED;
       default:
         return Intent.UNKNOWN;


### PR DESCRIPTION
## Description

This PR introduces a new `ProcessMessageSubscriptionIntent.DELETING` intent which represents the closing state of the subscription, and removes the last state changes that occur in processing when closing the subscription. This is moved to a new applier, which is also processed on replay. One caveat, the command sent time is now also not deterministic as it's calculated in the applier, which will be addressed in #6364.

## Related issues

closes #6200 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
