### PR TITLE
New event sub process tests

### DIFF
--- a/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractEventSubProcessBuilder.java
+++ b/bpmn-model/src/main/java/io/zeebe/model/bpmn/builder/AbstractEventSubProcessBuilder.java
@@ -21,10 +21,13 @@ import io.zeebe.model.bpmn.instance.StartEvent;
 import io.zeebe.model.bpmn.instance.SubProcess;
 import io.zeebe.model.bpmn.instance.bpmndi.BpmnShape;
 import io.zeebe.model.bpmn.instance.dc.Bounds;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeIoMapping;
+import io.zeebe.model.bpmn.instance.zeebe.ZeebeOutput;
 import java.util.function.Consumer;
 
 public class AbstractEventSubProcessBuilder<B extends AbstractEventSubProcessBuilder<B>>
-    extends AbstractFlowElementBuilder<B, SubProcess> {
+    extends AbstractFlowElementBuilder<B, SubProcess> implements ZeebeVariablesMappingBuilder<B> {
 
   protected AbstractEventSubProcessBuilder(
       final BpmnModelInstance modelInstance, final SubProcess element, final Class<?> selfType) {
@@ -61,5 +64,37 @@ public class AbstractEventSubProcessBuilder<B extends AbstractEventSubProcessBui
     final StartEventBuilder builder = startEvent(id);
     consumer.accept(builder);
     return builder;
+  }
+
+  @Override
+  public B zeebeInputExpression(final String sourceExpression, final String target) {
+    final String expression = asZeebeExpression(sourceExpression);
+    return zeebeInput(expression, target);
+  }
+
+  @Override
+  public B zeebeOutputExpression(final String sourceExpression, final String target) {
+    final String expression = asZeebeExpression(sourceExpression);
+    return zeebeOutput(expression, target);
+  }
+
+  @Override
+  public B zeebeInput(final String source, final String target) {
+    final ZeebeIoMapping ioMapping = getCreateSingleExtensionElement(ZeebeIoMapping.class);
+    final ZeebeInput input = createChild(ioMapping, ZeebeInput.class);
+    input.setSource(source);
+    input.setTarget(target);
+
+    return myself;
+  }
+
+  @Override
+  public B zeebeOutput(final String source, final String target) {
+    final ZeebeIoMapping ioMapping = getCreateSingleExtensionElement(ZeebeIoMapping.class);
+    final ZeebeOutput input = createChild(ioMapping, ZeebeOutput.class);
+    input.setSource(source);
+    input.setTarget(target);
+
+    return myself;
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/incident/EventSubProcessIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/EventSubProcessIncidentTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.processing.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.engine.util.EngineRule;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.model.bpmn.builder.ProcessBuilder;
+import io.zeebe.model.bpmn.builder.StartEventBuilder;
+import io.zeebe.protocol.record.Assertions;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.intent.IncidentIntent;
+import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.zeebe.protocol.record.intent.TimerIntent;
+import io.zeebe.protocol.record.value.ErrorType;
+import io.zeebe.protocol.record.value.IncidentRecordValue;
+import io.zeebe.protocol.record.value.deployment.DeployedProcess;
+import io.zeebe.test.util.BrokerClassRuleHelper;
+import io.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class EventSubProcessIncidentTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "proc";
+  private static final String JOB_TYPE = "type";
+  private static String messageName;
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+  @Parameterized.Parameter public String testName;
+
+  @Parameterized.Parameter(1)
+  public Function<StartEventBuilder, StartEventBuilder> builder;
+
+  @Parameterized.Parameter(2)
+  public Consumer<Long> triggerEventSubprocess;
+
+  private DeployedProcess currentProcess;
+
+  @Parameterized.Parameters(name = "{0} event subprocess")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        "timer",
+        eventSubprocess(s -> s.timerWithDuration("PT60S")),
+        eventTrigger(
+            key -> {
+              assertThat(
+                      RecordingExporter.timerRecords(TimerIntent.CREATED)
+                          .withProcessInstanceKey(key)
+                          .exists())
+                  .describedAs("Expected timer to exist")
+                  .isTrue();
+              ENGINE.increaseTime(Duration.ofSeconds(60));
+            })
+      },
+      {
+        "message",
+        eventSubprocess(
+            s -> s.message(b -> b.name(messageName).zeebeCorrelationKeyExpression("key"))),
+        eventTrigger(
+            key -> {
+              RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+                  .withProcessInstanceKey(key)
+                  .withMessageName(messageName)
+                  .await();
+              ENGINE.message().withName(messageName).withCorrelationKey("123").publish();
+            })
+      },
+      {
+        "error",
+        eventSubprocess(s -> s.error("ERROR")),
+        eventTrigger(
+            key ->
+                ENGINE.job().ofInstance(key).withType(JOB_TYPE).withErrorCode("ERROR").throwError())
+      },
+    };
+  }
+
+  private static Function<StartEventBuilder, StartEventBuilder> eventSubprocess(
+      final Function<StartEventBuilder, StartEventBuilder> consumer) {
+    return consumer;
+  }
+
+  private static Consumer<Long> eventTrigger(final Consumer<Long> eventTrigger) {
+    return eventTrigger;
+  }
+
+  @Before
+  public void init() {
+    messageName = helper.getMessageName();
+  }
+
+  @Test
+  public void shouldCreateIncidentForInputMappingFailure() {
+    // given
+    final BpmnModelInstance model = process(withEventSubprocessAndInputMapping(builder));
+
+    // when
+    final long processInstanceKey = createInstanceAndTriggerEvent(model);
+
+    // then
+    final Record<?> failureEvent =
+        RecordingExporter.processInstanceRecords()
+            .withElementId("event_sub_proc")
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final Record<IncidentRecordValue> incidentEvent =
+        RecordingExporter.incidentRecords()
+            .onlyEvents()
+            .withIntent(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(incidentEvent.getValue().getVariableScopeKey()).isEqualTo(failureEvent.getKey());
+
+    final IncidentRecordValue incidentEventValue = incidentEvent.getValue();
+    Assertions.assertThat(incidentEventValue)
+        .hasErrorType(ErrorType.IO_MAPPING_ERROR)
+        .hasBpmnProcessId(PROCESS_ID)
+        .hasProcessDefinitionKey(currentProcess.getProcessDefinitionKey())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasElementId("event_sub_proc")
+        .hasElementInstanceKey(failureEvent.getKey())
+        .hasVariableScopeKey(failureEvent.getKey());
+
+    assertThat(incidentEventValue.getErrorMessage())
+        .contains("no variable found for name 'source'");
+  }
+
+  @Test
+  public void shouldResolveIncidentForInputMappingFailure() {
+    // given
+    final BpmnModelInstance model = process(withEventSubprocessAndInputMapping(builder));
+    final long processInstanceKey = createInstanceAndTriggerEvent(model);
+
+    final Record<IncidentRecordValue> incidentEvent =
+        RecordingExporter.incidentRecords()
+            .onlyEvents()
+            .withIntent(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when
+    ENGINE
+        .variables()
+        .ofScope(incidentEvent.getValue().getVariableScopeKey())
+        .withDocument(Map.of("source", "null"))
+        .update();
+
+    // then
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incidentEvent.getKey()).resolve();
+
+    RecordingExporter.processInstanceRecords()
+        .withElementId("event_sub_start")
+        .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+  }
+
+  private long createInstanceAndTriggerEvent(final BpmnModelInstance model) {
+    final long wfInstanceKey = createInstanceAndWaitForTask(model);
+    triggerEventSubprocess.accept(wfInstanceKey);
+    return wfInstanceKey;
+  }
+
+  private long createInstanceAndWaitForTask(final BpmnModelInstance model) {
+    currentProcess =
+        ENGINE
+            .deployment()
+            .withXmlResource(model)
+            .deploy()
+            .getValue()
+            .getDeployedProcesses()
+            .get(0);
+
+    final long wfInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariables(Map.of("key", 123))
+            .create();
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(wfInstanceKey)
+                .exists())
+        .describedAs("Expected job to be created")
+        .isTrue();
+    return wfInstanceKey;
+  }
+
+  private static BpmnModelInstance process(final ProcessBuilder processBuilder) {
+    return processBuilder
+        .startEvent("start_proc")
+        .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+        .endEvent("end_proc")
+        .done();
+  }
+
+  private static ProcessBuilder withEventSubprocessAndInputMapping(
+      final Function<StartEventBuilder, StartEventBuilder> builder) {
+    final ProcessBuilder process = Bpmn.createExecutableProcess(PROCESS_ID);
+
+    builder
+        .apply(
+            process
+                .eventSubProcess("event_sub_proc")
+                .zeebeInputExpression("=source", "localScope")
+                .startEvent("event_sub_start")
+                .interrupting(true))
+        .endEvent("event_sub_end");
+
+    return process;
+  }
+}


### PR DESCRIPTION
## Description

* Adds support for input output mapping on event sub processes to the BPMN model API
* Adds tests for input mappings on event sub process to create local scopes
* Add tests for non interrupting event sub process which can be triggered twice
* Add tests for incident creation when input mapping fails

This should increase our confidence in migrating the event sub processor, that we not accidentally break something.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #6196 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
