### PR TITLE
Fixes an IllegalArgumentException when finding a cut off point for an execution segment path

### DIFF
--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ExecutionPathSegment.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/ExecutionPathSegment.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -158,6 +159,10 @@ public final class ExecutionPathSegment {
     }
 
     // find a random position between these two cutoff points
+    if (Objects.equals(firstCutOffPoint, lastCutOffPoint)) {
+      return firstCutOffPoint;
+    }
+
     final int initialCutOffPoint =
         firstCutOffPoint + random.nextInt(lastCutOffPoint - firstCutOffPoint);
 


### PR DESCRIPTION
## Description

This PR fixes an IllegalArgumentException when finding a cut off point for a path segment which could occur if there was only one step in the segment, resulting passing 0 to the random number generator as a positive bound.

If there is only on element in the path, then we just return an empty segment such that it can be immediately interrupted. If there is more than one element, but only one point where we can cut off, just return that point.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
