### PR TITLE
Apply event sourcing to event sub process processor

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementContainerProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementContainerProcessor.java
@@ -7,7 +7,9 @@
  */
 package io.zeebe.engine.processing.bpmn;
 
+import io.zeebe.engine.processing.common.Failure;
 import io.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.zeebe.util.Either;
 
 /**
  * The business logic of an BPMN element container (e.g. a sub-process).
@@ -28,11 +30,14 @@ public interface BpmnElementContainerProcessor<T extends ExecutableFlowElement>
    * @param element the instance of the BPMN element container
    * @param flowScopeContext process instance-related data of the element container
    * @param childContext process instance-related data of the child element that is on activating
+   * @return either a failure (Left) or any success value (Right)
    */
-  void onChildActivating(
+  default Either<Failure, ?> onChildActivating(
       final T element,
       final BpmnElementContext flowScopeContext,
-      final BpmnElementContext childContext);
+      final BpmnElementContext childContext) {
+    return Either.right(null); // im always right
+  }
 
   /**
    * The execution path of a child element is about to be completed.

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -116,13 +116,6 @@ public final class BpmnEventSubscriptionBehavior {
     catchEventBehavior.unsubscribeFromEvents(context, commandWriter, sideEffects);
   }
 
-  // TODO (saig0): replace by findEventTrigger + activateTriggeredEvent (#6202)
-  public void triggerBoundaryEvent(
-      final ExecutableActivity element, final BpmnElementContext context) {
-    eventTriggerBehavior.triggerEvent(
-        context, eventTrigger -> triggerBoundaryEvent(element, context, eventTrigger));
-  }
-
   private long triggerBoundaryEvent(
       final ExecutableActivity element,
       final BpmnElementContext context,

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -54,17 +54,6 @@ public final class BpmnVariableMappingBehavior {
     final long processInstanceKey = context.getProcessInstanceKey();
     final Optional<Expression> inputMappingExpression = element.getInputMappings();
 
-    if (context.getBpmnElementType() == BpmnElementType.EVENT_SUB_PROCESS) {
-      // copy temp variables into local scope (necessary for start/boundary event to apply output
-      // mappings)
-      // todo (#6196): move into event applier
-      final var temporaryVariables =
-          variablesState.getTemporaryVariables(context.getFlowScopeKey());
-      if (temporaryVariables != null) {
-        variablesState.setTemporaryVariables(scopeKey, temporaryVariables);
-      }
-    }
-
     if (inputMappingExpression.isPresent()) {
       return expressionProcessor
           .evaluateVariableMappingExpression(inputMappingExpression.get(), scopeKey)

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -100,12 +100,6 @@ public final class CallActivityProcessor
   }
 
   @Override
-  public void onChildActivating(
-      final ExecutableCallActivity element,
-      final BpmnElementContext flowScopeContext,
-      final BpmnElementContext childContext) {}
-
-  @Override
   public void beforeExecutionPathCompleted(
       final ExecutableCallActivity element,
       final BpmnElementContext callActivityContext,

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
@@ -52,31 +52,16 @@ public final class EventSubProcessProcessor
   }
 
   @Override
-  public void onCompleting(
-      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+  public void onComplete(
+      final ExecutableFlowElementContainer element, final BpmnElementContext completing) {
 
     variableMappingBehavior
-        .applyOutputMappings(context, element)
+        .applyOutputMappings(completing, element)
         .ifRightOrLeft(
-            ok -> {
-              eventSubscriptionBehavior.unsubscribeFromEvents(context);
-              stateTransitionBehavior.transitionToCompletedWithParentNotification(element, context);
-            },
-            failure -> incidentBehavior.createIncident(failure, context));
-  }
-
-  @Override
-  public void onCompleted(
-      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
-    if (element.getOutgoing().isEmpty()) {
-      /* can be dropped during migration; after migration this is done as part of
-      stateTransitionBehavior.transitionToCompletedWithParentNotification(...)*/
-      stateTransitionBehavior.afterExecutionPathCompleted(element, context);
-    }
-    // call after here (unmigrated processor)
-    stateTransitionBehavior.takeOutgoingSequenceFlows(element, context);
-
-    stateBehavior.removeElementInstance(context);
+            ok ->
+                stateTransitionBehavior.transitionToCompletedWithParentNotification(
+                    element, completing),
+            failure -> incidentBehavior.createIncident(failure, completing));
   }
 
   @Override
@@ -130,7 +115,7 @@ public final class EventSubProcessProcessor
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext) {
     if (stateBehavior.canBeCompleted(childContext)) {
-      stateTransitionBehavior.transitionToCompleting(flowScopeContext);
+      stateTransitionBehavior.completeElement(flowScopeContext);
     }
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -110,7 +110,7 @@ public final class MultiInstanceBodyProcessor
   }
 
   @Override
-  public void onChildActivating(
+  public Either<Failure, ?> onChildActivating(
       final ExecutableMultiInstanceBody multiInstanceBody,
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext) {
@@ -118,7 +118,7 @@ public final class MultiInstanceBodyProcessor
     final var bodyInstance = stateBehavior.getElementInstance(flowScopeContext);
     final var loopCounter = bodyInstance.getMultiInstanceLoopCounter();
 
-    readInputCollectionVariable(multiInstanceBody, childContext)
+    return readInputCollectionVariable(multiInstanceBody, childContext)
         .flatMap(
             collection -> {
               // the loop counter starts by 1
@@ -135,10 +135,11 @@ public final class MultiInstanceBodyProcessor
                 return Either.left(failure);
               }
             })
-        .ifRightOrLeft(
-            inputElement ->
-                setLoopVariables(multiInstanceBody, childContext, loopCounter, inputElement),
-            failure -> incidentBehavior.createIncident(failure, childContext));
+        .map(
+            inputElement -> {
+              setLoopVariables(multiInstanceBody, childContext, loopCounter, inputElement);
+              return null;
+            });
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -113,12 +113,6 @@ public final class ProcessProcessor
   }
 
   @Override
-  public void onChildActivating(
-      final ExecutableFlowElementContainer element,
-      final BpmnElementContext flowScopeContext,
-      final BpmnElementContext childContext) {}
-
-  @Override
   public void beforeExecutionPathCompleted(
       final ExecutableFlowElementContainer element,
       final BpmnElementContext flowScopeContext,

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -141,18 +141,15 @@ public final class ProcessProcessor
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext) {
 
-    if (flowScopeContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING
-        && stateBehavior.canBeTerminated(childContext)) {
-
-      transitionTo(element, flowScopeContext, stateTransitionBehavior::transitionToTerminated);
-
-    } else {
+    if (flowScopeContext.getIntent() != ProcessInstanceIntent.ELEMENT_TERMINATING) {
       eventSubscriptionBehavior
           .findEventTrigger(flowScopeContext)
           .ifPresent(
               eventTrigger ->
                   eventSubscriptionBehavior.activateTriggeredEvent(
                       flowScopeContext.getElementInstanceKey(), flowScopeContext, eventTrigger));
+    } else if (stateBehavior.canBeTerminated(childContext)) {
+      transitionTo(element, flowScopeContext, stateTransitionBehavior::transitionToTerminated);
     }
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -96,12 +96,6 @@ public final class SubProcessProcessor
   }
 
   @Override
-  public void onChildActivating(
-      final ExecutableFlowElementContainer element,
-      final BpmnElementContext flowScopeContext,
-      final BpmnElementContext childContext) {}
-
-  @Override
   public void beforeExecutionPathCompleted(
       final ExecutableFlowElementContainer element,
       final BpmnElementContext flowScopeContext,

--- a/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
@@ -112,15 +112,14 @@ public final class EventHandle {
         commandWriter.appendFollowUpCommand(
             eventScopeKey, ProcessInstanceIntent.COMPLETE_ELEMENT, elementRecord);
       } else if (catchEvent.getFlowScope().getElementType() == BpmnElementType.EVENT_SUB_PROCESS) {
-        final var executableStartEvent = (ExecutableStartEvent) catchEvent;
-
+        final var startEvent = (ExecutableStartEvent) catchEvent;
         eventTriggerBehavior.triggerEventSubProcess(
-            executableStartEvent, eventScopeKey, elementRecord);
+            startEvent, eventScopeKey, elementRecord, variables);
+
       } else if (isInterrupting(catchEvent)) {
         // terminate the activated element and then activate the triggered catch event
         commandWriter.appendFollowUpCommand(
             eventScopeKey, ProcessInstanceIntent.TERMINATE_ELEMENT, elementRecord);
-
       } else {
         eventTriggerBehavior.activateTriggeredEvent(
             catchEvent, elementRecord.getFlowScopeKey(), elementRecord, variables);

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/MigratedStreamProcessors.java
@@ -49,6 +49,7 @@ public final class MigratedStreamProcessors {
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.USER_TASK);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.MULTI_INSTANCE_BODY);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.SUB_PROCESS);
+    MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.EVENT_SUB_PROCESS);
     MIGRATED_BPMN_PROCESSORS.add(BpmnElementType.SEQUENCE_FLOW);
 
     MIGRATED_VALUE_TYPES.put(ValueType.JOB, MIGRATED);

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -89,6 +89,16 @@ final class ProcessInstanceElementActivatingApplier
 
     decrementActiveSequenceFlow(value, flowScopeInstance, flowScopeElementType, currentElementType);
 
+    if (currentElementType == BpmnElementType.EVENT_SUB_PROCESS) {
+      // copy temp variables into local scope (necessary for start event to apply output mappings)
+      final var temporaryVariables =
+          variableState.getTemporaryVariables(flowScopeInstance.getKey());
+      if (temporaryVariables != null) {
+        variableState.setTemporaryVariables(elementInstanceKey, temporaryVariables);
+        variableState.removeTemporaryVariables(flowScopeInstance.getKey());
+      }
+    }
+
     if (currentElementType == BpmnElementType.START_EVENT
         && flowScopeElementType == BpmnElementType.EVENT_SUB_PROCESS) {
       // the event variables are stored as temporary variables in the scope of the subprocess

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
@@ -268,7 +268,7 @@ public class InterruptingEventSubprocessTest {
             .getFirst();
 
     final Record<ProcessInstanceRecordValue> eventSubproc =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.COMPLETE_ELEMENT)
             .withProcessInstanceKey(processInstanceKey)
             .withElementId("event_sub_proc")
             .getFirst();
@@ -399,8 +399,12 @@ public class InterruptingEventSubprocessTest {
     final List<Record<ProcessInstanceRecordValue>> events =
         RecordingExporter.processInstanceRecords()
             .withProcessInstanceKey(processInstanceKey)
+            .onlyEvents()
             .filter(r -> r.getValue().getElementId().startsWith("event_sub_"))
-            .limit(15)
+            .limit(
+                r ->
+                    r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED
+                        && r.getValue().getBpmnElementType() == BpmnElementType.EVENT_SUB_PROCESS)
             .asList();
 
     assertThat(events)
@@ -408,13 +412,10 @@ public class InterruptingEventSubprocessTest {
         .containsExactly(
             tuple(ProcessInstanceIntent.ELEMENT_ACTIVATING, "event_sub_proc"),
             tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, "event_sub_proc"),
-            tuple(ProcessInstanceIntent.ACTIVATE_ELEMENT, "event_sub_start"),
             tuple(ProcessInstanceIntent.ELEMENT_ACTIVATING, "event_sub_start"),
             tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, "event_sub_start"),
-            tuple(ProcessInstanceIntent.COMPLETE_ELEMENT, "event_sub_start"),
             tuple(ProcessInstanceIntent.ELEMENT_COMPLETING, "event_sub_start"),
             tuple(ProcessInstanceIntent.ELEMENT_COMPLETED, "event_sub_start"),
-            tuple(ProcessInstanceIntent.ACTIVATE_ELEMENT, "event_sub_end"),
             tuple(ProcessInstanceIntent.ELEMENT_ACTIVATING, "event_sub_end"),
             tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, "event_sub_end"),
             tuple(ProcessInstanceIntent.ELEMENT_COMPLETING, "event_sub_end"),

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/MultipleEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/MultipleEventSubprocessTest.java
@@ -46,18 +46,16 @@ public final class MultipleEventSubprocessTest {
     triggerMessageStart(processInstanceKey, helper.getMessageName());
 
     // then
-    assertThat(
-            RecordingExporter.processInstanceRecords()
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementType(BpmnElementType.EVENT_SUB_PROCESS)
-                .limit(8))
-        .extracting(r -> tuple(r.getValue().getElementId(), r.getIntent()))
-        .containsSubsequence(
-            tuple("event_sub_proc_timer", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple("event_sub_proc_timer", ProcessInstanceIntent.ELEMENT_COMPLETED))
-        .containsSubsequence(
-            tuple("event_sub_proc_msg", ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple("event_sub_proc_msg", ProcessInstanceIntent.ELEMENT_COMPLETED));
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.EVENT_SUB_PROCESS)
+        .withElementId("event_sub_proc_timer")
+        .await();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.EVENT_SUB_PROCESS)
+        .withElementId("event_sub_proc_msg")
+        .await();
   }
 
   @Test
@@ -85,6 +83,7 @@ public final class MultipleEventSubprocessTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
+                .onlyEvents()
                 .limitToProcessInstanceCompleted())
         .extracting(r -> tuple(r.getValue().getElementId(), r.getIntent()))
         .containsSubsequence(

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/NonInterruptingEventSubprocessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/NonInterruptingEventSubprocessTest.java
@@ -282,7 +282,11 @@ public class NonInterruptingEventSubprocessTest {
         RecordingExporter.processInstanceRecords()
             .withProcessInstanceKey(processInstanceKey)
             .filter(r -> r.getValue().getElementId().startsWith("event_sub_"))
-            .limit(15)
+            .onlyEvents()
+            .limit(
+                r ->
+                    r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED
+                        && r.getValue().getBpmnElementType() == BpmnElementType.EVENT_SUB_PROCESS)
             .asList();
 
     assertThat(events)
@@ -290,13 +294,10 @@ public class NonInterruptingEventSubprocessTest {
         .containsExactly(
             tuple(ProcessInstanceIntent.ELEMENT_ACTIVATING, "event_sub_proc"),
             tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, "event_sub_proc"),
-            tuple(ProcessInstanceIntent.ACTIVATE_ELEMENT, "event_sub_start"),
             tuple(ProcessInstanceIntent.ELEMENT_ACTIVATING, "event_sub_start"),
             tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, "event_sub_start"),
-            tuple(ProcessInstanceIntent.COMPLETE_ELEMENT, "event_sub_start"),
             tuple(ProcessInstanceIntent.ELEMENT_COMPLETING, "event_sub_start"),
             tuple(ProcessInstanceIntent.ELEMENT_COMPLETED, "event_sub_start"),
-            tuple(ProcessInstanceIntent.ACTIVATE_ELEMENT, "event_sub_end"),
             tuple(ProcessInstanceIntent.ELEMENT_ACTIVATING, "event_sub_end"),
             tuple(ProcessInstanceIntent.ELEMENT_ACTIVATED, "event_sub_end"),
             tuple(ProcessInstanceIntent.ELEMENT_COMPLETING, "event_sub_end"),

--- a/engine/src/test/java/io/zeebe/engine/processing/incident/EventSubProcessIncidentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/incident/EventSubProcessIncidentTest.java
@@ -23,6 +23,7 @@ import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.protocol.record.intent.TimerIntent;
 import io.zeebe.protocol.record.value.ErrorType;
 import io.zeebe.protocol.record.value.IncidentRecordValue;
+import io.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.zeebe.protocol.record.value.deployment.DeployedProcess;
 import io.zeebe.test.util.BrokerClassRuleHelper;
 import io.zeebe.test.util.record.RecordingExporter;
@@ -119,9 +120,9 @@ public class EventSubProcessIncidentTest {
     final long processInstanceKey = createInstanceAndTriggerEvent(model);
 
     // then
-    final Record<?> failureEvent =
+    final Record<ProcessInstanceRecordValue> failureEvent =
         RecordingExporter.processInstanceRecords()
-            .withElementId("event_sub_proc")
+            .withElementId("event_sub_start")
             .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
             .withProcessInstanceKey(processInstanceKey)
             .getFirst();
@@ -133,17 +134,15 @@ public class EventSubProcessIncidentTest {
             .withProcessInstanceKey(processInstanceKey)
             .getFirst();
 
-    assertThat(incidentEvent.getValue().getVariableScopeKey()).isEqualTo(failureEvent.getKey());
-
     final IncidentRecordValue incidentEventValue = incidentEvent.getValue();
     Assertions.assertThat(incidentEventValue)
         .hasErrorType(ErrorType.IO_MAPPING_ERROR)
         .hasBpmnProcessId(PROCESS_ID)
         .hasProcessDefinitionKey(currentProcess.getProcessDefinitionKey())
         .hasProcessInstanceKey(processInstanceKey)
-        .hasElementId("event_sub_proc")
+        .hasElementId("event_sub_start")
         .hasElementInstanceKey(failureEvent.getKey())
-        .hasVariableScopeKey(failureEvent.getKey());
+        .hasVariableScopeKey(failureEvent.getValue().getFlowScopeKey());
 
     assertThat(incidentEventValue.getErrorMessage())
         .contains("no variable found for name 'source'");

--- a/util/src/main/java/io/zeebe/util/Either.java
+++ b/util/src/main/java/io/zeebe/util/Either.java
@@ -64,7 +64,7 @@ public interface Either<L, R> {
    * @param <R> the type of the right value
    * @return a {@link Right} of the value
    */
-  static <L, R> Either<L, R> right(R right) {
+  static <L, R> Either<L, R> right(final R right) {
     return new Right<>(right);
   }
 
@@ -76,7 +76,7 @@ public interface Either<L, R> {
    * @param <R> the type of the right value
    * @return a {@link Left} of the value
    */
-  static <L, R> Either<L, R> left(L left) {
+  static <L, R> Either<L, R> left(final L left) {
     return new Left<>(left);
   }
 


### PR DESCRIPTION
## Description

Migrates the event sub process processor.

When an event triggers, it now activates the event sub process by writing the `activating` and `activated` event records directly, instead of writing the `activate` command. This is necessary to correctly copy the variables of the triggered event into the event sub process' scope. To continue the execution, the start event is activated by writing the `activate` command for it.

Since the activation of the event sub process is not processed by the `EventSubProcessProcessor`, the input mappings of the event sub process are evaluated on the processing of the start event `activate` command. 

> Note, it would not have been possible to evaluate this as part of the event trigger processing, because input mappings can cause incidents and incidents can only exist on elements. For example, it would not be possible to resolve an incident for a failure during Timer:Trigger processing.

Incidents due to the evaluation of the input mappings of the event sub process are thus created on the start event, to allow the start event `activate` command to be retried when resolving the incident.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6196

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
