### PR TITLE
Add reasoning for Event sub process processor implementation

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
@@ -84,6 +84,10 @@ public final class EventSubProcessProcessor
       return Either.right(null);
     }
 
+    // The input mapping for the event sub process need to happen here, since we immediately moved
+    // the event sub process to ACTIVATED on event triggering. This is done to make sure that we
+    // copy temporary variables (for messages) to the correct scope already on triggering the event,
+    // otherwise we will have issues on concurrent incoming events.
     return variableMappingBehavior.applyInputMappings(flowScopeContext, element);
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -256,7 +256,7 @@ public class EventTriggerBehavior {
   }
 
   private void activateEventSubProcess(
-      final ExecutableFlowElement triggeredEvent, final ExecutableFlowElement flowScope) {
+      final ExecutableFlowElement triggeredStartEvent, final ExecutableFlowElement flowScope) {
     // First we move the event sub process immediately to ACTIVATED,
     // to make sure that we can copy the temp variables from the flow scope directly to the
     // event sub process scope. This is done in the ACTIVATING applier of the event sub process.
@@ -274,8 +274,8 @@ public class EventTriggerBehavior {
     // we can apply the output mappings.
     eventRecord
         .setFlowScopeKey(eventSubProcessKey)
-        .setBpmnElementType(triggeredEvent.getElementType())
-        .setElementId(triggeredEvent.getId());
+        .setBpmnElementType(triggeredStartEvent.getElementType())
+        .setElementId(triggeredStartEvent.getId());
 
     commandWriter.appendNewCommand(ProcessInstanceIntent.ACTIVATE_ELEMENT, eventRecord);
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/common/EventTriggerBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/EventTriggerBehavior.java
@@ -257,7 +257,9 @@ public class EventTriggerBehavior {
 
   private void activateEventSubProcess(
       final ExecutableFlowElement triggeredEvent, final ExecutableFlowElement flowScope) {
-    // first activate the event sub process
+    // First we move the event sub process immediately to ACTIVATED,
+    // to make sure that we can copy the temp variables from the flow scope directly to the
+    // event sub process scope. This is done in the ACTIVATING applier of the event sub process.
     eventRecord
         .setBpmnElementType(BpmnElementType.EVENT_SUB_PROCESS)
         .setElementId(flowScope.getId());
@@ -268,6 +270,8 @@ public class EventTriggerBehavior {
     stateWriter.appendFollowUpEvent(
         eventSubProcessKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, eventRecord);
 
+    // Then we ACTIVATE the start event and copy the temporary variables further down, such that
+    // we can apply the output mappings.
     eventRecord
         .setFlowScopeKey(eventSubProcessKey)
         .setBpmnElementType(triggeredEvent.getElementType())


### PR DESCRIPTION
## Description

Add reasoning why we need to do the input mapping for event sub process
later and why we not write an ACTIVATE command for the event sub
process.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->



<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
