### PR TITLE
Avoid re-activation of EventSubProcess 

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -116,31 +116,40 @@ public final class SubProcessProcessor
       final ExecutableFlowElementContainer element,
       final BpmnElementContext subProcessContext,
       final BpmnElementContext childContext) {
+    if (subProcessContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING) {
 
-    eventSubscriptionBehavior
-        .findEventTrigger(subProcessContext)
-        .ifPresentOrElse(
-            eventTrigger -> {
-              if (subProcessContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING
-                  // child context can be null if no child's exist on termination
-                  && (childContext == null || stateBehavior.canBeTerminated(childContext))) {
-                final var terminated =
-                    stateTransitionBehavior.transitionToTerminated(subProcessContext);
-                eventSubscriptionBehavior.activateTriggeredEvent(
-                    subProcessContext.getFlowScopeKey(), terminated, eventTrigger);
-              } else {
-                eventSubscriptionBehavior.activateTriggeredEvent(
-                    subProcessContext.getElementInstanceKey(), subProcessContext, eventTrigger);
-              }
-            },
-            () -> {
-              if (subProcessContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING
-                  // child context can be null if no child's exist on termination
-                  && (childContext == null || stateBehavior.canBeTerminated(childContext))) {
-                final var terminated =
-                    stateTransitionBehavior.transitionToTerminated(subProcessContext);
-                stateTransitionBehavior.onElementTerminated(element, terminated);
-              }
-            });
+      if (childContext == null || stateBehavior.canBeTerminated(childContext)) {
+        // if we are able to terminate we try to trigger boundary events
+        eventSubscriptionBehavior
+            .findEventTrigger(subProcessContext)
+            .filter(
+                eventTrigger ->
+                    element.getBoundaryEvents().stream()
+                        .anyMatch(b -> b.getId().equals(eventTrigger.getElementId())))
+            .ifPresentOrElse(
+                eventTrigger -> {
+                  final var terminated =
+                      stateTransitionBehavior.transitionToTerminated(subProcessContext);
+                  eventSubscriptionBehavior.activateTriggeredEvent(
+                      subProcessContext.getFlowScopeKey(), terminated, eventTrigger);
+                },
+                () -> {
+                  final var terminated =
+                      stateTransitionBehavior.transitionToTerminated(subProcessContext);
+                  stateTransitionBehavior.onElementTerminated(element, terminated);
+                });
+      }
+
+    } else {
+      // if the flow scope is not terminating we allow
+      // * interrupting event sub processes
+      // * non interrupting boundary events
+      eventSubscriptionBehavior
+          .findEventTrigger(subProcessContext)
+          .ifPresent(
+              eventTrigger ->
+                  eventSubscriptionBehavior.activateTriggeredEvent(
+                      subProcessContext.getElementInstanceKey(), subProcessContext, eventTrigger));
+    }
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/subprocess/EmbeddedSubProcessTest.java
@@ -26,6 +26,7 @@ import io.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.function.Consumer;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -107,6 +108,7 @@ public final class EmbeddedSubProcessTest {
   }
 
   @Test
+  @Ignore("https://github.com/camunda-cloud/zeebe/issues/6850")
   public void shouldTerminateSubProcessWithNonInterruptingBoundaryEvent() {
     // given
     final var model =


### PR DESCRIPTION
## Description

Non interrupting event sub processes  have been triggered wrongly, if the flow scope was on terminating state
and a child was terminated it was activated again. The same is happening for non interrupting boundary events. https://github.com/camunda-cloud/zeebe/issues/6850 Turns out this is another bug.

This fix contains:

 a) event sub processes are only triggered if the flow scope is not in
 terminating state
 b) boundary events are triggered if
   * the flow scope is in terminating state
     AND can be terminated
     AND the event trigger element id corresponds to a boundary event
         element id
   * the flow scope is not terminating, but there exist an event trigger
     for it

Plus it add two new tests to verify the behavior.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6846

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
