### PR TITLE
Add startup endpoint and include the startup state in ready check

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/zeebe/broker/Broker.java
@@ -179,6 +179,7 @@ public final class Broker implements AutoCloseable {
     try {
       closeProcess = startProcess.start();
       startFuture.complete(this);
+      healthCheckService.setBrokerStarted();
     } catch (final Exception bootStrapException) {
       final BrokerCfg brokerCfg = getConfig();
       LOG.error(

--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/MonitoringRestController.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/MonitoringRestController.java
@@ -19,6 +19,7 @@ import org.springframework.web.servlet.ModelAndView;
 public class MonitoringRestController {
 
   private static final String BROKER_READY_STATUS_URI = "/ready";
+  private static final String BROKER_STARTUP_STATUS_URI = "/startup";
   private static final String METRICS_URI = "/metrics";
   private static final String BROKER_HEALTH_STATUS_URI = "/health";
 
@@ -56,6 +57,23 @@ public class MonitoringRestController {
 
     final HttpStatus status;
     if (brokerReady) {
+      status = HttpStatus.NO_CONTENT;
+    } else {
+      status = HttpStatus.SERVICE_UNAVAILABLE;
+    }
+    return new ResponseEntity<>(status);
+  }
+
+  @GetMapping(value = BROKER_STARTUP_STATUS_URI)
+  public ResponseEntity<String> startup() {
+    final boolean brokerStarted =
+        springBrokerBridge
+            .getBrokerHealthCheckService()
+            .map(BrokerHealthCheckService::isBrokerStarted)
+            .orElse(false);
+
+    final HttpStatus status;
+    if (brokerStarted) {
       status = HttpStatus.NO_CONTENT;
     } else {
       status = HttpStatus.SERVICE_UNAVAILABLE;

--- a/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/BrokerMonitoringEndpointTest.java
+++ b/qa/integration-tests/src/test/java/io/zeebe/broker/it/health/BrokerMonitoringEndpointTest.java
@@ -87,4 +87,14 @@ public final class BrokerMonitoringEndpointTest {
         .then() //
         .statusCode(204);
   }
+
+  @Test
+  public void shouldGetStartupStatus() {
+    given()
+        .spec(brokerServerSpec)
+        .when()
+        .get("startup")
+        .then() //
+        .statusCode(204);
+  }
 }


### PR DESCRIPTION
## Description

* Add a startup endpoint which returns success only after all startup steps in the broker is completed
* Update ready check to include the startup state

## Related issues

closes #6134 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
