### PR TITLE
Rework EventTrigger handling

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -59,7 +59,6 @@ public final class BpmnEventPublicationBehavior {
     final ExecutableCatchEvent catchEvent = catchEventTuple.getCatchEvent();
 
     if (eventHandle.canTriggerElement(eventScopeInstance)) {
-      eventHandle.triggerProcessEvent(eventScopeInstance, catchEvent.getId(), NO_VARIABLES);
       eventHandle.activateElement(
           catchEvent, eventScopeInstance.getKey(), eventScopeInstance.getValue());
     }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -101,7 +101,7 @@ public final class BpmnEventSubscriptionBehavior {
 
   /**
    * Checks if the given element instance was triggered by an event. Should be used in combination
-   * with {@link #activateTriggeredEvent(long, BpmnElementContext, EventTrigger)}.
+   * with {@link #activateTriggeredEvent(long, long, EventTrigger, BpmnElementContext)}.
    *
    * @param context the element instance to check
    * @return the event data if the element instance was triggered. Otherwise, it returns {@link
@@ -119,13 +119,18 @@ public final class BpmnEventSubscriptionBehavior {
    * triggers/activates the EventSubProcess, while for boundary events the attached element triggers
    * that event which is not the flow scope.
    *
+   * @param eventScopeKey the event scope key of the triggered event, can be the same as the flow
+   *     scope key depending of the type of event
    * @param flowScopeKey the flow scope of event element to activate, which can be different based
    *     on the event type
-   * @param context the current processing context
    * @param eventTrigger the event data returned by {@link #findEventTrigger(BpmnElementContext)}
+   * @param context the current processing context
    */
   public void activateTriggeredEvent(
-      final long flowScopeKey, final BpmnElementContext context, final EventTrigger eventTrigger) {
+      final long eventScopeKey,
+      final long flowScopeKey,
+      final EventTrigger eventTrigger,
+      final BpmnElementContext context) {
 
     final var triggeredEvent =
         processState.getFlowElement(
@@ -134,7 +139,12 @@ public final class BpmnEventSubscriptionBehavior {
             ExecutableFlowElement.class);
 
     eventTriggerBehavior.activateTriggeredEvent(
-        triggeredEvent, flowScopeKey, context.getRecordValue(), eventTrigger.getVariables());
+        eventTrigger.getEventKey(),
+        triggeredEvent,
+        eventScopeKey,
+        flowScopeKey,
+        context.getRecordValue(),
+        eventTrigger.getVariables());
   }
 
   public Optional<EventTrigger> getEventTriggerForProcessDefinition(
@@ -154,6 +164,13 @@ public final class BpmnEventSubscriptionBehavior {
       throw new BpmnProcessingException(
           context, String.format(NO_PROCESS_FOUND_MESSAGE, processDefinitionKey));
     }
+
+    eventTriggerBehavior.processEventTriggered(
+        triggeredEvent.getEventKey(),
+        processDefinitionKey,
+        processInstanceKey,
+        processDefinitionKey, /* the event scope for the start event is the process definition */
+        triggeredEvent.getElementId());
 
     eventRecord.reset();
     eventRecord.wrap(context.getRecordValue());

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -255,4 +255,12 @@ public final class BpmnStateBehavior {
         variablesState.getVariablesAsDocument(sourceContext.getElementInstanceKey());
     variablesState.setTemporaryVariables(targetContext.getElementInstanceKey(), variables);
   }
+
+  public boolean isInterrupted(final BpmnElementContext flowScopeContext) {
+    final var flowScopeInstance =
+        elementInstanceState.getInstance(flowScopeContext.getElementInstanceKey());
+    return flowScopeInstance.getNumberOfActiveElementInstances() == 0
+        && flowScopeInstance.isInterrupted()
+        && flowScopeInstance.isActive();
+  }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -145,7 +145,10 @@ public final class CallActivityProcessor
               final var terminated =
                   stateTransitionBehavior.transitionToTerminated(callActivityContext);
               eventSubscriptionBehavior.activateTriggeredEvent(
-                  terminated.getFlowScopeKey(), terminated, eventTrigger);
+                  callActivityContext.getElementInstanceKey(),
+                  terminated.getFlowScopeKey(),
+                  eventTrigger,
+                  terminated);
             },
             () -> {
               final var terminated =

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -239,7 +239,10 @@ public final class MultiInstanceBodyProcessor
               final var terminated =
                   stateTransitionBehavior.transitionToTerminated(flowScopeContext);
               eventSubscriptionBehavior.activateTriggeredEvent(
-                  terminated.getFlowScopeKey(), terminated, eventTrigger);
+                  flowScopeContext.getElementInstanceKey(),
+                  terminated.getFlowScopeKey(),
+                  eventTrigger,
+                  terminated);
               stateTransitionBehavior.onElementTerminated(element, terminated);
             },
             () -> {

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -135,7 +135,8 @@ public final class ProcessProcessor
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext) {
 
-    if (flowScopeContext.getIntent() != ProcessInstanceIntent.ELEMENT_TERMINATING) {
+    if (flowScopeContext.getIntent() != ProcessInstanceIntent.ELEMENT_TERMINATING
+        && stateBehavior.isInterrupted(flowScopeContext)) {
       eventSubscriptionBehavior
           .findEventTrigger(flowScopeContext)
           .ifPresent(

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -141,7 +141,10 @@ public final class ProcessProcessor
           .ifPresent(
               eventTrigger ->
                   eventSubscriptionBehavior.activateTriggeredEvent(
-                      flowScopeContext.getElementInstanceKey(), flowScopeContext, eventTrigger));
+                      flowScopeContext.getElementInstanceKey(),
+                      flowScopeContext.getElementInstanceKey(),
+                      eventTrigger,
+                      flowScopeContext));
     } else if (stateBehavior.canBeTerminated(childContext)) {
       transitionTo(element, flowScopeContext, stateTransitionBehavior::transitionToTerminated);
     }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -122,10 +122,6 @@ public final class SubProcessProcessor
         // if we are able to terminate we try to trigger boundary events
         eventSubscriptionBehavior
             .findEventTrigger(subProcessContext)
-            .filter(
-                eventTrigger ->
-                    element.getBoundaryEvents().stream()
-                        .anyMatch(b -> b.getId().equals(eventTrigger.getElementId())))
             .ifPresentOrElse(
                 eventTrigger -> {
                   final var terminated =

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -116,31 +116,40 @@ public final class SubProcessProcessor
       final ExecutableFlowElementContainer element,
       final BpmnElementContext subProcessContext,
       final BpmnElementContext childContext) {
+    if (subProcessContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING) {
 
-    eventSubscriptionBehavior
-        .findEventTrigger(subProcessContext)
-        .ifPresentOrElse(
-            eventTrigger -> {
-              if (subProcessContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING
-                  // child context can be null if no child's exist on termination
-                  && (childContext == null || stateBehavior.canBeTerminated(childContext))) {
-                final var terminated =
-                    stateTransitionBehavior.transitionToTerminated(subProcessContext);
-                eventSubscriptionBehavior.activateTriggeredEvent(
-                    subProcessContext.getFlowScopeKey(), terminated, eventTrigger);
-              } else {
-                eventSubscriptionBehavior.activateTriggeredEvent(
-                    subProcessContext.getElementInstanceKey(), subProcessContext, eventTrigger);
-              }
-            },
-            () -> {
-              if (subProcessContext.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATING
-                  // child context can be null if no child's exist on termination
-                  && (childContext == null || stateBehavior.canBeTerminated(childContext))) {
-                final var terminated =
-                    stateTransitionBehavior.transitionToTerminated(subProcessContext);
-                stateTransitionBehavior.onElementTerminated(element, terminated);
-              }
-            });
+      if (childContext == null || stateBehavior.canBeTerminated(childContext)) {
+        // if we are able to terminate we try to trigger boundary events
+        eventSubscriptionBehavior
+            .findEventTrigger(subProcessContext)
+            .filter(
+                eventTrigger ->
+                    element.getBoundaryEvents().stream()
+                        .anyMatch(b -> b.getId().equals(eventTrigger.getElementId())))
+            .ifPresentOrElse(
+                eventTrigger -> {
+                  final var terminated =
+                      stateTransitionBehavior.transitionToTerminated(subProcessContext);
+                  eventSubscriptionBehavior.activateTriggeredEvent(
+                      subProcessContext.getFlowScopeKey(), terminated, eventTrigger);
+                },
+                () -> {
+                  final var terminated =
+                      stateTransitionBehavior.transitionToTerminated(subProcessContext);
+                  stateTransitionBehavior.onElementTerminated(element, terminated);
+                });
+      }
+
+    } else {
+      // if the flow scope is not terminating we allow
+      // * interrupting event sub processes
+      // * non interrupting boundary events
+      eventSubscriptionBehavior
+          .findEventTrigger(subProcessContext)
+          .ifPresent(
+              eventTrigger ->
+                  eventSubscriptionBehavior.activateTriggeredEvent(
+                      subProcessContext.getElementInstanceKey(), subProcessContext, eventTrigger));
+    }
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -131,7 +131,10 @@ public final class SubProcessProcessor
                   final var terminated =
                       stateTransitionBehavior.transitionToTerminated(subProcessContext);
                   eventSubscriptionBehavior.activateTriggeredEvent(
-                      subProcessContext.getFlowScopeKey(), terminated, eventTrigger);
+                      subProcessContext.getElementInstanceKey(),
+                      subProcessContext.getFlowScopeKey(),
+                      eventTrigger,
+                      terminated);
                 },
                 () -> {
                   final var terminated =
@@ -149,7 +152,10 @@ public final class SubProcessProcessor
           .ifPresent(
               eventTrigger ->
                   eventSubscriptionBehavior.activateTriggeredEvent(
-                      subProcessContext.getElementInstanceKey(), subProcessContext, eventTrigger));
+                      subProcessContext.getElementInstanceKey(),
+                      subProcessContext.getElementInstanceKey(),
+                      eventTrigger,
+                      subProcessContext));
     }
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
@@ -64,7 +64,7 @@ public final class EventBasedGatewayProcessor
     // - according to the BPMN specification, the sequence flow to this event is not taken
     final var completed = stateTransitionBehavior.transitionToCompleted(context);
     eventSubscriptionBehavior.activateTriggeredEvent(
-        completed.getFlowScopeKey(), completed, eventTrigger);
+        context.getElementInstanceKey(), completed.getFlowScopeKey(), eventTrigger, completed);
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
@@ -74,7 +74,10 @@ public final class ReceiveTaskProcessor implements BpmnElementProcessor<Executab
             eventTrigger -> {
               final var terminated = stateTransitionBehavior.transitionToTerminated(context);
               eventSubscriptionBehavior.activateTriggeredEvent(
-                  terminated.getFlowScopeKey(), terminated, eventTrigger);
+                  context.getElementInstanceKey(),
+                  terminated.getFlowScopeKey(),
+                  eventTrigger,
+                  terminated);
             },
             () -> {
               final var terminated = stateTransitionBehavior.transitionToTerminated(context);

--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/task/ServiceTaskProcessor.java
@@ -99,7 +99,10 @@ public final class ServiceTaskProcessor implements BpmnElementProcessor<Executab
             eventTrigger -> {
               final var terminated = stateTransitionBehavior.transitionToTerminated(context);
               eventSubscriptionBehavior.activateTriggeredEvent(
-                  terminated.getFlowScopeKey(), terminated, eventTrigger);
+                  context.getElementInstanceKey(),
+                  terminated.getFlowScopeKey(),
+                  eventTrigger,
+                  terminated);
             },
             () -> {
               final var terminated = stateTransitionBehavior.transitionToTerminated(context);

--- a/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
@@ -67,7 +67,8 @@ public final class EventHandle {
   }
 
   /**
-   * Triggers a process by updating the state with a new {@link ProcessEventIntent#TRIGGERED} event.
+   * Triggers a process by updating the state with a new {@link ProcessEventIntent#TRIGGERING}
+   * event.
    *
    * <p>NOTE: this method assumes that the caller already verified that the target can accept new
    * events!
@@ -90,7 +91,7 @@ public final class EventHandle {
         .setProcessDefinitionKey(eventScope.getValue().getProcessDefinitionKey())
         .setProcessInstanceKey(eventScope.getValue().getProcessInstanceKey());
     stateWriter.appendFollowUpEvent(
-        newElementInstanceKey, ProcessEventIntent.TRIGGERED, processEventRecord);
+        newElementInstanceKey, ProcessEventIntent.TRIGGERING, processEventRecord);
   }
 
   public void activateElement(

--- a/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
@@ -79,7 +79,7 @@ public final class EventHandle {
    * @param variables the variables/payload of the event (can be empty)
    * @return the key of the process event
    */
-  public long triggeringProcessEvent(
+  private long triggeringProcessEvent(
       final long processDefinitionKey,
       final long processInstanceKey,
       final long eventScopeKey,

--- a/engine/src/main/java/io/zeebe/engine/processing/timer/TriggerTimerProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/timer/TriggerTimerProcessor.java
@@ -37,6 +37,8 @@ import io.zeebe.protocol.record.intent.TimerIntent;
 import io.zeebe.util.Either;
 import io.zeebe.util.buffer.BufferUtil;
 import java.util.function.Consumer;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRecord> {
 
@@ -44,6 +46,7 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
       "Expected to trigger timer with key '%d', but no such timer was found";
   private static final String NO_ACTIVE_TIMER_MESSAGE =
       "Expected to trigger a timer with key '%d', but the timer is not active anymore";
+  private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
 
   private final CatchEventBehavior catchEventBehavior;
   private final ProcessState processState;
@@ -108,7 +111,8 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
 
       stateWriter.appendFollowUpEvent(record.getKey(), TimerIntent.TRIGGERED, timer);
       final long processInstanceKey = keyGenerator.nextKey();
-      eventHandle.activateProcessInstanceForStartEvent(processDefinitionKey, processInstanceKey);
+      eventHandle.activateProcessInstanceForStartEvent(
+          processDefinitionKey, processInstanceKey, timer.getTargetElementIdBuffer(), NO_VARIABLES);
     } else {
       final var elementInstance = elementInstanceState.getInstance(elementInstanceKey);
       if (!eventHandle.canTriggerElement(elementInstance)) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -76,13 +76,7 @@ public final class EventAppliers implements EventApplier {
   private void registerTimeEventAppliers(final MutableZeebeState state) {
     register(TimerIntent.CREATED, new TimerCreatedApplier(state.getTimerState()));
     register(TimerIntent.CANCELED, new TimerCancelledApplier(state.getTimerState()));
-    register(
-        TimerIntent.TRIGGERED,
-        new TimerTriggeredApplier(
-            state.getEventScopeInstanceState(),
-            state.getTimerState(),
-            state.getElementInstanceState(),
-            state.getProcessState()));
+    register(TimerIntent.TRIGGERED, new TimerTriggeredApplier(state.getTimerState()));
   }
 
   private void registerDeploymentAppliers(final MutableZeebeState state) {
@@ -214,11 +208,7 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessMessageSubscriptionIntent.CORRELATED,
         new ProcessMessageSubscriptionCorrelatedApplier(
-            subscriptionState,
-            state.getEventScopeInstanceState(),
-            state.getVariableState(),
-            state.getElementInstanceState(),
-            state.getProcessState()));
+            subscriptionState, state.getVariableState()));
     register(
         ProcessMessageSubscriptionIntent.DELETING,
         new ProcessMessageSubscriptionDeletingApplier(subscriptionState));

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -224,6 +224,9 @@ public final class EventAppliers implements EventApplier {
             state.getEventScopeInstanceState(),
             state.getElementInstanceState(),
             state.getProcessState()));
+    register(
+        ProcessEventIntent.TRIGGERED,
+        new ProcessEventTriggeredApplier(state.getEventScopeInstanceState()));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/EventAppliers.java
@@ -229,8 +229,8 @@ public final class EventAppliers implements EventApplier {
 
   private void registerProcessEventAppliers(final MutableZeebeState state) {
     register(
-        ProcessEventIntent.TRIGGERED,
-        new ProcessEventTriggeredApplier(
+        ProcessEventIntent.TRIGGERING,
+        new ProcessEventTriggeringApplier(
             state.getEventScopeInstanceState(),
             state.getElementInstanceState(),
             state.getProcessState()));

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessEventTriggeredApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessEventTriggeredApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.engine.state.appliers;
+
+import io.zeebe.engine.state.TypedEventApplier;
+import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
+import io.zeebe.protocol.record.intent.ProcessEventIntent;
+
+final class ProcessEventTriggeredApplier
+    implements TypedEventApplier<ProcessEventIntent, ProcessEventRecord> {
+  private final MutableEventScopeInstanceState eventScopeState;
+
+  public ProcessEventTriggeredApplier(final MutableEventScopeInstanceState eventScopeState) {
+    this.eventScopeState = eventScopeState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessEventRecord value) {
+    final var scopeKey = value.getScopeKey();
+    eventScopeState.deleteTrigger(scopeKey, key);
+  }
+}

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessEventTriggeringApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessEventTriggeringApplier.java
@@ -17,13 +17,13 @@ import io.zeebe.protocol.record.intent.ProcessEventIntent;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
-final class ProcessEventTriggeredApplier
+final class ProcessEventTriggeringApplier
     implements TypedEventApplier<ProcessEventIntent, ProcessEventRecord> {
   private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
   private final MutableEventScopeInstanceState eventScopeState;
   private final EventSubProcessInterruptionMarker eventSubProcessInterruptionMarker;
 
-  public ProcessEventTriggeredApplier(
+  public ProcessEventTriggeringApplier(
       final MutableEventScopeInstanceState eventScopeState,
       final MutableElementInstanceState elementInstanceState,
       final MutableProcessState processState) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionCorrelatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionCorrelatedApplier.java
@@ -8,10 +8,7 @@
 package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
-import io.zeebe.engine.state.mutable.MutableElementInstanceState;
-import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
-import io.zeebe.engine.state.mutable.MutableProcessState;
 import io.zeebe.engine.state.mutable.MutableVariableState;
 import io.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
@@ -21,23 +18,13 @@ public final class ProcessMessageSubscriptionCorrelatedApplier
         ProcessMessageSubscriptionIntent, ProcessMessageSubscriptionRecord> {
 
   private final MutableProcessMessageSubscriptionState subscriptionState;
-  private final MutableEventScopeInstanceState eventScopeInstanceState;
   private final MutableVariableState variableState;
-  private final MutableElementInstanceState elementInstanceState;
-  private final EventSubProcessInterruptionMarker eventSubProcessInterruptionMarker;
 
   public ProcessMessageSubscriptionCorrelatedApplier(
       final MutableProcessMessageSubscriptionState subscriptionState,
-      final MutableEventScopeInstanceState eventScopeInstanceState,
-      final MutableVariableState variableState,
-      final MutableElementInstanceState elementInstanceState,
-      final MutableProcessState processState) {
+      final MutableVariableState variableState) {
     this.subscriptionState = subscriptionState;
-    this.eventScopeInstanceState = eventScopeInstanceState;
     this.variableState = variableState;
-    this.elementInstanceState = elementInstanceState;
-    eventSubProcessInterruptionMarker =
-        new EventSubProcessInterruptionMarker(processState, elementInstanceState);
   }
 
   @Override
@@ -47,20 +34,8 @@ public final class ProcessMessageSubscriptionCorrelatedApplier
     }
 
     final var eventScopeKey = value.getElementInstanceKey();
-    // use the element instance key as the unique key of the event
-    final var eventKey = value.getElementInstanceKey();
-    eventScopeInstanceState.triggerEvent(
-        eventScopeKey, eventKey, value.getElementIdBuffer(), value.getVariablesBuffer());
-
     if (value.getVariablesBuffer().capacity() > 0) {
       variableState.setTemporaryVariables(eventScopeKey, value.getVariablesBuffer());
     }
-
-    final var targetElementId = value.getElementIdBuffer();
-    final var elementInstanceKey = value.getElementInstanceKey();
-    final var instance = elementInstanceState.getInstance(elementInstanceKey);
-
-    eventSubProcessInterruptionMarker.markInstanceIfInterrupted(
-        elementInstanceKey, instance.getValue().getProcessDefinitionKey(), targetElementId);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/TimerTriggeredApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/TimerTriggeredApplier.java
@@ -9,50 +9,22 @@ package io.zeebe.engine.state.appliers;
 
 import io.zeebe.engine.state.TypedEventApplier;
 import io.zeebe.engine.state.instance.TimerInstance;
-import io.zeebe.engine.state.mutable.MutableElementInstanceState;
-import io.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
-import io.zeebe.engine.state.mutable.MutableProcessState;
 import io.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.zeebe.protocol.record.intent.TimerIntent;
-import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
 
 final class TimerTriggeredApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
 
-  private static final UnsafeBuffer NO_VARIABLES = new UnsafeBuffer();
-  private final MutableEventScopeInstanceState eventScopeInstanceState;
   private final MutableTimerInstanceState timerInstanceState;
-  private final EventSubProcessInterruptionMarker eventSubProcessInterruptionMarker;
 
-  public TimerTriggeredApplier(
-      final MutableEventScopeInstanceState eventScopeInstanceState,
-      final MutableTimerInstanceState timerInstanceState,
-      final MutableElementInstanceState elementInstanceState,
-      final MutableProcessState processState) {
-    this.eventScopeInstanceState = eventScopeInstanceState;
+  public TimerTriggeredApplier(final MutableTimerInstanceState timerInstanceState) {
     this.timerInstanceState = timerInstanceState;
-    eventSubProcessInterruptionMarker =
-        new EventSubProcessInterruptionMarker(processState, elementInstanceState);
   }
 
   @Override
   public void applyState(final long key, final TimerRecord value) {
     final long elementInstanceKey = value.getElementInstanceKey();
     final TimerInstance timerInstance = timerInstanceState.get(elementInstanceKey, key);
-    final long processDefinitionKey = value.getProcessDefinitionKey();
-    final DirectBuffer targetElementId = value.getTargetElementIdBuffer();
-    final long eventScopeKey =
-        isRootStartEvent(elementInstanceKey) ? processDefinitionKey : elementInstanceKey;
-
     timerInstanceState.remove(timerInstance);
-    eventScopeInstanceState.triggerEvent(eventScopeKey, key, targetElementId, NO_VARIABLES);
-
-    eventSubProcessInterruptionMarker.markInstanceIfInterrupted(
-        elementInstanceKey, processDefinitionKey, targetElementId);
-  }
-
-  private boolean isRootStartEvent(final long elementInstanceKey) {
-    return elementInstanceKey < 0;
   }
 }

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
@@ -22,6 +22,7 @@ import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.IncidentIntent;
 import io.zeebe.protocol.record.intent.JobIntent;
+import io.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.zeebe.protocol.record.intent.TimerIntent;
 import io.zeebe.protocol.record.value.BpmnElementType;
@@ -251,6 +252,7 @@ public final class BoundaryEventTest {
         .extracting(Record::getValueType, Record::getIntent)
         .endsWith(
             tuple(ValueType.TIMER, TimerIntent.TRIGGERED),
+            tuple(ValueType.PROCESS_EVENT, ProcessEventIntent.TRIGGERING),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.TERMINATE_ELEMENT),

--- a/engine/src/test/java/io/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/bpmn/boundary/BoundaryEventTest.java
@@ -260,6 +260,7 @@ public final class BoundaryEventTest {
             tuple(ValueType.JOB, JobIntent.CANCEL),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(ValueType.PROCESS_EVENT, ProcessEventIntent.TRIGGERED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.COMPLETE_ELEMENT),

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/ProcessEventIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/ProcessEventIntent.java
@@ -16,7 +16,8 @@
 package io.zeebe.protocol.record.intent;
 
 public enum ProcessEventIntent implements ProcessInstanceRelatedIntent {
-  TRIGGERING((short) 0);
+  TRIGGERING((short) 0),
+  TRIGGERED((short) 1);
 
   private final short value;
 
@@ -29,12 +30,12 @@ public enum ProcessEventIntent implements ProcessInstanceRelatedIntent {
     return value;
   }
 
-  // suppress as it's simpler to have a short switch for extension later
-  @SuppressWarnings({"SwitchStatementWithTooFewBranches", "java:S1301"})
   public static Intent from(final short value) {
     switch (value) {
       case 0:
         return TRIGGERING;
+      case 1:
+        return TRIGGERED;
       default:
         return Intent.UNKNOWN;
     }

--- a/protocol/src/main/java/io/zeebe/protocol/record/intent/ProcessEventIntent.java
+++ b/protocol/src/main/java/io/zeebe/protocol/record/intent/ProcessEventIntent.java
@@ -16,7 +16,7 @@
 package io.zeebe.protocol.record.intent;
 
 public enum ProcessEventIntent implements ProcessInstanceRelatedIntent {
-  TRIGGERED((short) 0);
+  TRIGGERING((short) 0);
 
   private final short value;
 
@@ -34,7 +34,7 @@ public enum ProcessEventIntent implements ProcessInstanceRelatedIntent {
   public static Intent from(final short value) {
     switch (value) {
       case 0:
-        return TRIGGERED;
+        return TRIGGERING;
       default:
         return Intent.UNKNOWN;
     }


### PR DESCRIPTION
## Description

Reworks how we handle (create and delete) event triggers. We now create EventTrigger via the ProcessEvent.Triggering event and delete it on ProcessEvent.Triggered. Previous the EventTriggers have only be deleted, if the flowScope completes/terminates. Not deleting the EventTrigger could cause multiple activation of non-interrupting boundary events and event sub processes, which is obviously wrong.

In detail:

* Renames the old ProcessEventIntent.TRIGGERED to TRIGGERING, to align it with our current style (and make more clear that this is the initial state, where the trigger is created)
* Writes for all events the ProcessEvent (TRIGGERING intent), to create the corresponding EventTrigger
   * This allows to create the event trigger under a unique (newly) generate key and not overwrite the previous event triggers
   * Furthermore this allows to easily delete them
* Writes on activating the catch event the corresponding ProcessEvent (TRIGGERED) to remove the related EventTrigger
   * This is done for all type of events
   * This fixes our problems with multiple activation of the same event trigger
   * Added tests which caused the related bugs 
 * Fixes a bug where the EventSubProcess was already activated on the first notification of child terminated

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6850 
closes #6846 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
