### PR TITLE
Update commit message guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,36 +139,50 @@ To work on an issue, follow the following steps:
 
 ## Commit Message Guidelines
 
-Commit messages use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format with scope.
+Commit messages use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format.
 
+```
+<header>
+<BLANK LINE>
+<body>
+<BLANK LINE> (optional - mandatory with footer)
+<footer> (optional)
+```
+
+Zeebe uses a bot which will check your commit messages when a pull request is
+submitted. Please make sure to address any hints from the bot.
+
+### Commit message header
 Examples:
 
 * `docs(reference): add start event to bpmn symbol support matrix`
-* `fix(broker): reduce latency in backpressure`
+* `perf(broker): reduce latency in backpressure`
 * `feat(clients/go): allow more than 9000 jobs in a single call`
 
-The commit message should match the following pattern:
+The commit header should match the following pattern:
 ```
 %{type}(%{scope}): %{description}
 ```
 
-- `type` and `scope` should be chosen as follows
-    - `feat`: For user facing features or improvements. `scope` should be either
-      `broker`, `clients/java` or `clients/go`.
-    - `fix`: For user facing bug fixes. `scope` should be either
-      `broker`, `clients/java` or `clients/go`.
-    - `chore`: For code changes which are not user facing, `scope` should be
-      the folder name of the component which contains the main part of the
-      change, e.g. `broker` or `exporters`.
-    - `docs`:  For changes on the documentation. `scope` should be the sub folder
-      name in the `docs/src/` directory which contains the main change, e.g.
-      `introduction` or `reference`.
-- `description`: short description of the change to a max length of the whole
-  subject line of 120 characters
+The commit header should be kept short, preferably under 72 chars but we allow a max of 120 chars.
 
+- `type` should be one of:
+   - `build`: Changes that affect the build system (e.g. Maven, Docker, etc)
+   - `ci`: Changes to our CI configuration files and scripts (e.g. Jenkins, Bors, etc)
+   - `deps`: A change to the external dependencies (was already used by Dependabot)
+   - `docs`:  A change to the documentation
+   - `feat`: A new feature (both internal or user-facing)
+   - `fix`: A bug fix (both internal or user-facing)
+   - `perf`: A code change that improves performance
+   - `refactor`: A code change that does not change the behavior
+   - `style`: A change to align the code with our style guide
+   - `test`: Adding missing tests or correcting existing tests
+- `scope` (optional): name of the changed component (e.g. `engine`, `journal`, `README`)
+- `description`: short description of the change in present tense
 
-Zeebe uses a bot which will check your commit messages when a pull request is
-submitted. Please make sure to address any hints from the bot.
+### Commit message body
+
+Should describe the motivation for the change.
 
 ## Contributor License Agreement
 


### PR DESCRIPTION
## Description

The commit types were used to generate changelogs in the past. However,
that is no longer the case. The team wants to use commit types that help
to write better commit messages and better describe the intent of
the changes. This PR changes the allowed commit message guideline to 
better fit the current needs of the team.

Main changes are:
- drop the `chore` type. It was overused and did not describe the intent
- change `fix` and `feat` to allow smaller changes to match
- add a set of new types from [Angular](https://github.com/angular/angular/blob/master/CONTRIBUTING.md) to have more options to choose from
- add more types (`deps` and `style`), to match our needs
- scope is now optional and has a broader definition (name of component) to better fit our needs

It also describes the structure (header, body, footer) in a bit more detail.

These changes help to support https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews

## Related issues

Team meeting discussion

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
