### PR TITLE
Fix processing panels

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/metrics/StreamProcessorMetrics.java
+++ b/engine/src/main/java/io/zeebe/engine/metrics/StreamProcessorMetrics.java
@@ -95,13 +95,12 @@ public final class StreamProcessorMetrics {
    * We write various type of records. The positions are always increasing and incremented by 1 for
    * one record.
    */
-  public void recordsWritten(final long lastWrittenPosition) {
-    final var previousWritten =
-        STREAM_PROCESSOR_EVENTS.labels(LABEL_WRITTEN, partitionIdLabel).get();
-    final var diff = lastWrittenPosition - previousWritten;
-    if (diff > 0) {
-      STREAM_PROCESSOR_EVENTS.labels(LABEL_WRITTEN, partitionIdLabel).inc(diff);
+  public void recordsWritten(final long amount) {
+    if (amount < 1) {
+      return;
     }
+
+    STREAM_PROCESSOR_EVENTS.labels(LABEL_WRITTEN, partitionIdLabel).inc(amount);
   }
 
   /** We skip events on processing. */

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -398,8 +398,12 @@ public final class ProcessingStateMachine {
             LOG.error(ERROR_MESSAGE_WRITE_EVENT_ABORTED, currentEvent, metadata, t);
             onError(t, this::writeEvent);
           } else {
+            // We write various type of records. The positions are always increasing and
+            // incremented by 1 for one record (even in a batch), so we can count the amount
+            // of written events via the lastWritten and now written position.
+            final var amount = writtenEventPosition - lastWrittenEventPosition;
+            metrics.recordsWritten(amount);
             updateState();
-            metrics.recordsWritten(writtenEventPosition);
           }
         });
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/ProcessingStateMachine.java
@@ -253,7 +253,7 @@ public final class ProcessingStateMachine {
 
       processInTransaction(typedEvent);
 
-      metrics.eventProcessed();
+      metrics.commandsProcessed();
 
       writeEvent();
     } catch (final RecoverableException recoverableException) {
@@ -399,7 +399,7 @@ public final class ProcessingStateMachine {
             onError(t, this::writeEvent);
           } else {
             updateState();
-            metrics.eventWritten();
+            metrics.recordsWritten(writtenEventPosition);
           }
         });
   }

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -89,7 +89,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1619420916893,
+  "iteration": 1619420916904,
   "links": [],
   "panels": [
     {
@@ -1160,16 +1160,23 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}}-{{partition}}-{{processor}}-{{action}}",
+              "legendFormat": "{{pod}}-{{partition}}-{{processor}}-processed",
               "refId": "A"
             },
             {
               "expr": "sum(rate(zeebe_exporter_events_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[1m])) by (pod, partition, exporter)",
               "format": "time_series",
               "hide": false,
+              "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{pod}}-{{partition}}-{{exporter}}",
+              "legendFormat": "{{pod}}-{{partition}}-exported",
               "refId": "B"
+            },
+            {
+              "expr": "sum(rate(zeebe_stream_processor_records_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\", action=~\"written\"}[1m])) by (pod, partition, processor)",
+              "interval": "",
+              "legendFormat": "{{pod}}-{{partition}}-{{processor}}-written",
+              "refId": "C"
             }
           ],
           "thresholds": [],

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -89,7 +89,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1610701555265,
+  "iteration": 1619420916893,
   "links": [],
   "panels": [
     {
@@ -150,7 +150,7 @@
           "pluginVersion": "7.0.3",
           "targets": [
             {
-              "expr": "sum(rate(zeebe_stream_processor_events_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\", action=~\"processed\"}[1m])) by (pod, partition, processor, action)",
+              "expr": "sum(rate(zeebe_stream_processor_records_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\", action=~\"processed|skipped\"}[1m])) by (pod, partition, processor)",
               "format": "time_series",
               "instant": true,
               "interval": "",
@@ -214,6 +214,7 @@
               "expr": "sum(rate(zeebe_exporter_events_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[1m])) by (pod, partition, exporter)",
               "format": "time_series",
               "hide": false,
+              "instant": true,
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{pod}}-{{partition}}",
@@ -1155,8 +1156,9 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(zeebe_stream_processor_events_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\", action=~\"written|processed\"}[1m])) by (pod, partition, processor, action)",
+              "expr": "sum(rate(zeebe_stream_processor_records_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\", action=~\"skipped|processed\"}[1m])) by (pod, partition, processor)",
               "format": "time_series",
+              "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{pod}}-{{partition}}-{{processor}}-{{action}}",
               "refId": "A"
@@ -1164,6 +1166,7 @@
             {
               "expr": "sum(rate(zeebe_exporter_events_total{namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[1m])) by (pod, partition, exporter)",
               "format": "time_series",
+              "hide": false,
               "intervalFactor": 1,
               "legendFormat": "{{pod}}-{{partition}}-{{exporter}}",
               "refId": "B"
@@ -1176,7 +1179,7 @@
           "title": "Processing per Partition",
           "tooltip": {
             "shared": true,
-            "sort": 0,
+            "sort": 2,
             "value_type": "individual"
           },
           "type": "graph",
@@ -2015,47 +2018,51 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "description": "Shows how many positions are not updated by exporters per partition. Means what is the difference between last committed exporter position and committed log position.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1000
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
           "gridPos": {
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 2
+            "y": 59
           },
           "id": 192,
           "options": {
-            "fieldOptions": {
+            "orientation": "auto",
+            "reduceOptions": {
               "calcs": [
                 "last"
               ],
-              "defaults": {
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "red",
-                      "value": 1000
-                    }
-                  ]
-                }
-              },
-              "overrides": [],
+              "fields": "",
               "values": false
             },
-            "orientation": "auto",
             "showThresholdLabels": false,
             "showThresholdMarkers": true
           },
-          "pluginVersion": "6.7.1",
+          "pluginVersion": "7.0.3",
           "targets": [
             {
               "expr": "zeebe_exporter_last_exported_position{namespace=~\"$namespace\", partition=~\"$partition\"} - zeebe_exporter_last_updated_exported_position{namespace=~\"$namespace\", partition=~\"$partition\"}",
               "format": "time_series",
-              "instant": false,
+              "instant": true,
               "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{exporter}} {{partition}}",
@@ -2071,12 +2078,18 @@
           "columns": [],
           "datasource": "${DS_PROMETHEUS}",
           "description": "Shows the position, which was appended last by the leader per partition.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fontSize": "80%",
           "gridPos": {
             "h": 4,
             "w": 4,
             "x": 12,
-            "y": 2
+            "y": 59
           },
           "id": 196,
           "pageSize": null,
@@ -2149,12 +2162,18 @@
           "columns": [],
           "datasource": "${DS_PROMETHEUS}",
           "description": "Shows the last committed log position.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fontSize": "80%",
           "gridPos": {
             "h": 4,
             "w": 4,
             "x": 16,
-            "y": 2
+            "y": 59
           },
           "id": 200,
           "pageSize": null,
@@ -2227,12 +2246,18 @@
           "columns": [],
           "datasource": "${DS_PROMETHEUS}",
           "description": "Shows the last processed position by the stream processor per partition.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fontSize": "80%",
           "gridPos": {
             "h": 4,
             "w": 4,
             "x": 20,
-            "y": 2
+            "y": 59
           },
           "id": 198,
           "pageSize": null,
@@ -2310,42 +2335,46 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "description": "Shows how many records are not exported yet.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1000
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
           "gridPos": {
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 6
+            "y": 63
           },
           "id": 194,
           "options": {
-            "fieldOptions": {
+            "orientation": "auto",
+            "reduceOptions": {
               "calcs": [
                 "mean"
               ],
-              "defaults": {
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "red",
-                      "value": 1000
-                    }
-                  ]
-                }
-              },
-              "overrides": [],
+              "fields": "",
               "values": false
             },
-            "orientation": "auto",
             "showThresholdLabels": false,
             "showThresholdMarkers": true
           },
-          "pluginVersion": "6.7.1",
+          "pluginVersion": "7.0.3",
           "targets": [
             {
               "expr": "sum (zeebe_log_appender_last_committed_position{namespace=~\"$namespace\", partition=~\"$partition\"}) by (partition) - sum (zeebe_exporter_last_exported_position{namespace=~\"$namespace\", partition=~\"$partition\", exporter=\"elasticsearch\"}) by (partition)",
@@ -2364,42 +2393,46 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "description": "Shows how many records the stream processor has not processed yet.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1000
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
           "gridPos": {
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 6
+            "y": 63
           },
           "id": 189,
           "options": {
-            "fieldOptions": {
+            "orientation": "auto",
+            "reduceOptions": {
               "calcs": [
                 "last"
               ],
-              "defaults": {
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "red",
-                      "value": 1000
-                    }
-                  ]
-                }
-              },
-              "overrides": [],
+              "fields": "",
               "values": false
             },
-            "orientation": "auto",
             "showThresholdLabels": false,
             "showThresholdMarkers": true
           },
-          "pluginVersion": "6.7.1",
+          "pluginVersion": "7.0.3",
           "targets": [
             {
               "expr": "zeebe_log_appender_last_committed_position{namespace=~\"$namespace\", partition=~\"$partition\"} - zeebe_stream_processor_last_processed_position{namespace=~\"$namespace\", partition=~\"$partition\"}",
@@ -2420,12 +2453,18 @@
           "columns": [],
           "datasource": "${DS_PROMETHEUS}",
           "description": "Shows the last exported position which was committed by the given exporter per partition.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fontSize": "80%",
           "gridPos": {
             "h": 6,
             "w": 7,
             "x": 12,
-            "y": 6
+            "y": 63
           },
           "id": 199,
           "pageSize": null,
@@ -2498,12 +2537,18 @@
           "columns": [],
           "datasource": "${DS_PROMETHEUS}",
           "description": "Shows the last exported position per partition.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fontSize": "80%",
           "gridPos": {
             "h": 6,
             "w": 5,
             "x": 19,
-            "y": 6
+            "y": 63
           },
           "id": 201,
           "pageSize": null,
@@ -10006,5 +10051,5 @@
   "timezone": "",
   "title": "Zeebe",
   "uid": "I4lo7_EZk",
-  "version": 4
+  "version": 7
 }


### PR DESCRIPTION
## Description

Previous the panel for records processed per second wasn't showing correct values, it only showed the processed commands

![old-gen-proc](https://user-images.githubusercontent.com/2758593/116065723-97a68300-a687-11eb-8c5c-3f86dc08b468.png)

Now it also includes the skipped events, which is then in total the processed records.

![new-gen-proc](https://user-images.githubusercontent.com/2758593/116065717-96755600-a687-11eb-9a60-27e8d434740a.png)

Furthermore some panels have shown multiple bars or gauges, since they used a range queries.

![old-gen-export](https://user-images.githubusercontent.com/2758593/116065721-970dec80-a687-11eb-8f9e-9ab97b0f2b47.png)

[This is not fixed with instant queries. ](https://grafana.com/docs/grafana/next/datasources/prometheus/)

![new-gen-export](https://user-images.githubusercontent.com/2758593/116065713-95dcbf80-a687-11eb-9654-e04019278c8b.png)

The processing graph is now also fixed:

![old-gen-processing](https://user-images.githubusercontent.com/2758593/116065724-97a68300-a687-11eb-8586-f0f47ac02f36.png)

![new-gen-processing](https://user-images.githubusercontent.com/2758593/116066263-24514100-a688-11eb-928c-7bfb35e364a7.png)


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda-cloud/zeebe/issues/6721

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
