### PR TITLE
refactor(journal): cleanup unused maxEntrySize config

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionGroup.java
@@ -422,27 +422,6 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
     }
 
     /**
-     * Sets the maximum Raft log entry size.
-     *
-     * @param maxEntrySize the maximum Raft log entry size
-     * @return the Raft partition group builder
-     */
-    public Builder withMaxEntrySize(final int maxEntrySize) {
-      return withMaxEntrySize(new MemorySize(maxEntrySize));
-    }
-
-    /**
-     * Sets the maximum Raft log entry size.
-     *
-     * @param maxEntrySize the maximum Raft log entry size
-     * @return the Raft partition group builder
-     */
-    public Builder withMaxEntrySize(final MemorySize maxEntrySize) {
-      config.getStorageConfig().setMaxEntrySize(maxEntrySize);
-      return this;
-    }
-
-    /**
      * Set the minimum free disk space (in bytes) to leave when allocating a new segment
      *
      * @param freeDiskSpace free disk space in bytes

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftStorageConfig.java
@@ -25,13 +25,11 @@ public class RaftStorageConfig {
 
   private static final String DATA_PREFIX = ".data";
   private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
-  private static final int DEFAULT_MAX_ENTRY_SIZE = 1024 * 1024;
   private static final boolean DEFAULT_FLUSH_EXPLICITLY = true;
   private static final long DEFAULT_FREE_DISK_SPACE = 1024L * 1024 * 1024;
   private static final int DEFAULT_JOURNAL_INDEX_DENSITY = 100;
 
   private String directory;
-  private int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
   private long segmentSize = DEFAULT_MAX_SEGMENT_SIZE;
   private boolean flushExplicitly = DEFAULT_FLUSH_EXPLICITLY;
   private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
@@ -50,26 +48,6 @@ public class RaftStorageConfig {
     return directory != null
         ? directory
         : System.getProperty("atomix.data", DATA_PREFIX) + "/" + groupName;
-  }
-
-  /**
-   * Returns the maximum entry size.
-   *
-   * @return the maximum entry size
-   */
-  public MemorySize getMaxEntrySize() {
-    return MemorySize.from(maxEntrySize);
-  }
-
-  /**
-   * Sets the maximum entry size.
-   *
-   * @param maxEntrySize the maximum entry size
-   * @return the Raft storage configuration
-   */
-  public RaftStorageConfig setMaxEntrySize(final MemorySize maxEntrySize) {
-    this.maxEntrySize = (int) maxEntrySize.bytes();
-    return this;
   }
 
   /**

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -283,7 +283,6 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
         .withPrefix(partition.name())
         .withDirectory(partition.dataDirectory())
         .withMaxSegmentSize((int) storageConfig.getSegmentSize().bytes())
-        .withMaxEntrySize((int) storageConfig.getMaxEntrySize().bytes())
         .withFlushExplicitly(storageConfig.shouldFlushExplicitly())
         .withFreeDiskSpace(storageConfig.getFreeDiskSpace())
         .withSnapshotStore(persistedSnapshotStore)

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -53,7 +53,6 @@ public final class RaftStorage {
   private final String prefix;
   private final File directory;
   private final int maxSegmentSize;
-  private final int maxEntrySize;
   private final long freeDiskSpace;
   private final boolean flushExplicitly;
   private final ReceivableSnapshotStore persistedSnapshotStore;
@@ -63,7 +62,6 @@ public final class RaftStorage {
       final String prefix,
       final File directory,
       final int maxSegmentSize,
-      final int maxEntrySize,
       final long freeDiskSpace,
       final boolean flushExplicitly,
       final ReceivableSnapshotStore persistedSnapshotStore,
@@ -71,7 +69,6 @@ public final class RaftStorage {
     this.prefix = prefix;
     this.directory = directory;
     this.maxSegmentSize = maxSegmentSize;
-    this.maxEntrySize = maxEntrySize;
     this.freeDiskSpace = freeDiskSpace;
     this.flushExplicitly = flushExplicitly;
     this.persistedSnapshotStore = persistedSnapshotStore;
@@ -225,7 +222,6 @@ public final class RaftStorage {
         .withName(prefix)
         .withDirectory(directory)
         .withMaxSegmentSize(maxSegmentSize)
-        .withMaxEntrySize(maxEntrySize)
         .withFreeDiskSpace(freeDiskSpace)
         .withFlushExplicitly(flushExplicitly)
         .withJournalIndexDensity(journalIndexDensity)
@@ -282,7 +278,6 @@ public final class RaftStorage {
     private static final String DEFAULT_DIRECTORY =
         System.getProperty("atomix.data", System.getProperty("user.dir"));
     private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
-    private static final int DEFAULT_MAX_ENTRY_SIZE = 1024 * 1024;
     private static final long DEFAULT_FREE_DISK_SPACE = 1024L * 1024 * 1024;
     private static final boolean DEFAULT_FLUSH_EXPLICITLY = true;
     private static final int DEFAULT_JOURNAL_INDEX_DENSITY = 100;
@@ -290,7 +285,6 @@ public final class RaftStorage {
     private String prefix = DEFAULT_PREFIX;
     private File directory = new File(DEFAULT_DIRECTORY);
     private int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
-    private int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
     private long freeDiskSpace = DEFAULT_FREE_DISK_SPACE;
     private boolean flushExplicitly = DEFAULT_FLUSH_EXPLICITLY;
     private ReceivableSnapshotStore persistedSnapshotStore;
@@ -360,19 +354,6 @@ public final class RaftStorage {
     }
 
     /**
-     * Sets the maximum entry size in bytes, returning the builder for method chaining.
-     *
-     * @param maxEntrySize the maximum entry size in bytes
-     * @return the storage builder
-     * @throws IllegalArgumentException if the {@code maxEntrySize} is not positive
-     */
-    public Builder withMaxEntrySize(final int maxEntrySize) {
-      checkArgument(maxEntrySize > 0, "maxEntrySize must be positive");
-      this.maxEntrySize = maxEntrySize;
-      return this;
-    }
-
-    /**
      * Sets the percentage of free disk space that must be preserved before log compaction is
      * forced.
      *
@@ -424,7 +405,6 @@ public final class RaftStorage {
           prefix,
           directory,
           maxSegmentSize,
-          maxEntrySize,
           freeDiskSpace,
           flushExplicitly,
           persistedSnapshotStore,

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogBuilder.java
@@ -85,18 +85,6 @@ public class RaftLogBuilder implements io.atomix.utils.Builder<RaftLog> {
   }
 
   /**
-   * Sets the maximum entry size in bytes, returning the builder for method chaining.
-   *
-   * @param maxEntrySize the maximum entry size in bytes
-   * @return the storage builder
-   * @throws IllegalArgumentException if the {@code maxEntrySize} is not positive
-   */
-  public RaftLogBuilder withMaxEntrySize(final int maxEntrySize) {
-    journalBuilder.withMaxEntrySize(maxEntrySize);
-    return this;
-  }
-
-  /**
    * Sets the minimum free disk space to leave when allocating a new segment
    *
    * @param freeDiskSpace free disk space in bytes

--- a/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
@@ -119,7 +119,6 @@ public class ZeebeTestNode {
         .withPartitionSize(members.size())
         .withFlushExplicitly(true)
         .withSegmentSize(1024L)
-        .withMaxEntrySize(512)
         .withSnapshotStoreFactory(
             (path, partition) -> new TestSnapshotStore(new AtomicReference<>()));
   }

--- a/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
+++ b/broker/src/main/java/io/zeebe/broker/clustering/atomix/AtomixFactory.java
@@ -116,9 +116,7 @@ public final class AtomixFactory {
             .withFreeDiskSpace(dataCfg.getFreeDiskSpaceReplicationWatermark())
             .withJournalIndexDensity(dataCfg.getLogIndexDensity());
 
-    // by default, the Atomix max entry size is 1 MB
     final int maxMessageSize = (int) networkCfg.getMaxMessageSizeInBytes();
-    partitionGroupBuilder.withMaxEntrySize(maxMessageSize);
 
     final var segmentSize = dataCfg.getLogSegmentSizeInBytes();
     if (segmentSize < maxMessageSize) {

--- a/journal/src/main/java/io/zeebe/journal/file/JournalSegment.java
+++ b/journal/src/main/java/io/zeebe/journal/file/JournalSegment.java
@@ -49,7 +49,6 @@ class JournalSegment implements AutoCloseable {
   public JournalSegment(
       final JournalSegmentFile file,
       final JournalSegmentDescriptor descriptor,
-      final int maxEntrySize,
       final long maxWrittenIndex,
       final JournalIndex journalIndex) {
     this.file = file;
@@ -59,7 +58,7 @@ class JournalSegment implements AutoCloseable {
         IoUtil.mapExistingFile(
             file.file(), MapMode.READ_WRITE, file.name(), 0, descriptor.maxSegmentSize());
     buffer.order(ENDIANNESS);
-    writer = createWriter(maxEntrySize, maxWrittenIndex);
+    writer = createWriter(maxWrittenIndex);
   }
 
   /**
@@ -146,9 +145,8 @@ class JournalSegment implements AutoCloseable {
         buffer.asReadOnlyBuffer().position(0).order(ENDIANNESS), this, index);
   }
 
-  private MappedJournalSegmentWriter createWriter(
-      final int maxEntrySize, final long lastWrittenIndex) {
-    return new MappedJournalSegmentWriter(buffer, this, maxEntrySize, index, lastWrittenIndex);
+  private MappedJournalSegmentWriter createWriter(final long lastWrittenIndex) {
+    return new MappedJournalSegmentWriter(buffer, this, index, lastWrittenIndex);
   }
 
   /**

--- a/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
+++ b/journal/src/main/java/io/zeebe/journal/file/MappedJournalSegmentWriter.java
@@ -43,7 +43,6 @@ class MappedJournalSegmentWriter {
   private JournalRecord lastEntry;
   private boolean isOpen = true;
   private final JournalRecordReaderUtil recordUtil;
-  private final int maxEntrySize;
   private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
   private final JournalRecordSerializer serializer = new SBESerializer();
   private final MutableDirectBuffer writeBuffer = new UnsafeBuffer();
@@ -52,12 +51,10 @@ class MappedJournalSegmentWriter {
   MappedJournalSegmentWriter(
       final MappedByteBuffer buffer,
       final JournalSegment segment,
-      final int maxEntrySize,
       final JournalIndex index,
       final long lastWrittenIndex) {
     this.segment = segment;
     descriptorLength = segment.descriptor().length();
-    this.maxEntrySize = maxEntrySize;
     recordUtil = new JournalRecordReaderUtil(serializer);
     this.index = index;
     firstIndex = segment.index();

--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournal.java
@@ -55,7 +55,6 @@ public class SegmentedJournal implements Journal {
   private final String name;
   private final File directory;
   private final int maxSegmentSize;
-  private final int maxEntrySize;
   private final NavigableMap<Long, JournalSegment> segments = new ConcurrentSkipListMap<>();
   private final Collection<SegmentedJournalReader> readers = Sets.newConcurrentHashSet();
   private volatile JournalSegment currentSegment;
@@ -70,14 +69,12 @@ public class SegmentedJournal implements Journal {
       final String name,
       final File directory,
       final int maxSegmentSize,
-      final int maxEntrySize,
       final long minFreeSpace,
       final JournalIndex journalIndex,
       final long lastWrittenIndex) {
     this.name = checkNotNull(name, "name cannot be null");
     this.directory = checkNotNull(directory, "directory cannot be null");
     this.maxSegmentSize = maxSegmentSize;
-    this.maxEntrySize = maxEntrySize;
     journalMetrics = new JournalMetrics(name);
     minFreeDiskSpace = minFreeSpace;
     this.journalIndex = journalIndex;
@@ -458,8 +455,7 @@ public class SegmentedJournal implements Journal {
    */
   protected JournalSegment newSegment(
       final JournalSegmentFile segmentFile, final JournalSegmentDescriptor descriptor) {
-    return new JournalSegment(
-        segmentFile, descriptor, maxEntrySize, lastWrittenIndex, journalIndex);
+    return new JournalSegment(segmentFile, descriptor, lastWrittenIndex, journalIndex);
   }
 
   /** Loads a segment. */

--- a/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalBuilder.java
+++ b/journal/src/main/java/io/zeebe/journal/file/SegmentedJournalBuilder.java
@@ -27,14 +27,12 @@ public class SegmentedJournalBuilder {
   private static final String DEFAULT_NAME = "journal";
   private static final String DEFAULT_DIRECTORY = System.getProperty("user.dir");
   private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
-  private static final int DEFAULT_MAX_ENTRY_SIZE = 1024 * 1024;
   private static final long DEFAULT_MIN_FREE_DISK_SPACE = 1024L * 1024 * 1024;
   private static final int DEFAULT_JOURNAL_INDEX_DENSITY = 100;
 
   protected String name = DEFAULT_NAME;
   protected File directory = new File(DEFAULT_DIRECTORY);
   protected int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
-  protected int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
 
   private long freeDiskSpace = DEFAULT_MIN_FREE_DISK_SPACE;
   private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
@@ -102,19 +100,6 @@ public class SegmentedJournalBuilder {
   }
 
   /**
-   * Sets the maximum entry size in bytes, returning the builder for method chaining.
-   *
-   * @param maxEntrySize the maximum entry size in bytes
-   * @return the storage builder
-   * @throws IllegalArgumentException if the {@code maxEntrySize} is not positive
-   */
-  public SegmentedJournalBuilder withMaxEntrySize(final int maxEntrySize) {
-    checkArgument(maxEntrySize > 0, "maxEntrySize must be positive");
-    this.maxEntrySize = maxEntrySize;
-    return this;
-  }
-
-  /**
    * Sets the minimum free disk space to leave when allocating a new segment
    *
    * @param freeDiskSpace free disk space in bytes
@@ -146,12 +131,6 @@ public class SegmentedJournalBuilder {
   public SegmentedJournal build() {
     final JournalIndex journalIndex = new SparseJournalIndex(journalIndexDensity);
     return new SegmentedJournal(
-        name,
-        directory,
-        maxSegmentSize,
-        maxEntrySize,
-        freeDiskSpace,
-        journalIndex,
-        lastWrittenIndex);
+        name, directory, maxSegmentSize, freeDiskSpace, journalIndex, lastWrittenIndex);
   }
 }

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -49,7 +49,6 @@ class SegmentedJournalReaderTest {
             .withDirectory(directory.resolve("data").toFile())
             .withMaxSegmentSize(
                 entrySize * ENTRIES_PER_SEGMENT + JournalSegmentDescriptor.getEncodingLength())
-            .withMaxEntrySize(entrySize)
             .withJournalIndexDensity(5)
             .build();
     reader = journal.openReader();

--- a/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
+++ b/journal/src/test/java/io/zeebe/journal/file/SegmentedJournalTest.java
@@ -370,7 +370,6 @@ class SegmentedJournalTest {
         .withDirectory(directory.resolve("data").toFile())
         .withMaxSegmentSize(
             (int) (entrySize * entriesPerSegment) + JournalSegmentDescriptor.getEncodingLength())
-        .withMaxEntrySize(entrySize)
         .withJournalIndexDensity(journalIndexDensity)
         .build();
   }

--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -68,8 +68,7 @@ public final class LogStorageAppenderTest {
 
   @Before
   public void setUp() {
-    logStorageRule.open(
-        b -> b.withMaxSegmentSize(MAX_FRAGMENT_SIZE * 100).withMaxEntrySize(MAX_FRAGMENT_SIZE));
+    logStorageRule.open(b -> b.withMaxSegmentSize(MAX_FRAGMENT_SIZE * 100));
     logStorage = spy(logStorageRule.get());
 
     dispatcher =

--- a/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStreamReaderTest.java
+++ b/logstreams/src/test/java/io/zeebe/logstreams/impl/log/LogStreamReaderTest.java
@@ -38,7 +38,7 @@ public final class LogStreamReaderTest {
       LogStreamRule.startByDefault(
           temporaryFolder,
           builder -> builder.withMaxFragmentSize(LOG_SEGMENT_SIZE),
-          builder -> builder.withMaxEntrySize(LOG_SEGMENT_SIZE));
+          builder -> builder);
   private final LogStreamWriterRule writer = new LogStreamWriterRule(logStreamRule);
   private final LogStreamReaderRule readerRule = new LogStreamReaderRule(logStreamRule);
 


### PR DESCRIPTION
## Description

Remove unused maxEntrySize config parameter from journal and atomix.

## Related issues

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
