### PR TITLE
Clean up util

### DIFF
--- a/util/src/main/java/io/zeebe/util/logging/stackdriver/StackdriverLogEntry.java
+++ b/util/src/main/java/io/zeebe/util/logging/stackdriver/StackdriverLogEntry.java
@@ -52,14 +52,6 @@ public final class StackdriverLogEntry {
   @JsonProperty("timestampNanos")
   private Long timestampNanos;
 
-  @Deprecated(since = "0.24.0", forRemoval = true)
-  @JsonProperty("logger")
-  private String logger;
-
-  @Deprecated(since = "0.24.0", forRemoval = true)
-  @JsonProperty("thread")
-  private String thread;
-
   StackdriverLogEntry() {}
 
   public static StackdriverLogEntryBuilder builder() {
@@ -136,29 +128,5 @@ public final class StackdriverLogEntry {
 
   public void setTimestampNanos(final long timestampNanos) {
     this.timestampNanos = timestampNanos;
-  }
-
-  /** @deprecated deprecated in favor of the context map property {@code loggerName} */
-  @Deprecated(since = "0.24.0", forRemoval = true)
-  public String getLogger() {
-    return logger;
-  }
-
-  /** @deprecated deprecated in favor of the context map property {@code loggerName} */
-  @Deprecated(since = "0.24.0", forRemoval = true)
-  public void setLogger(final String logger) {
-    this.logger = logger;
-  }
-
-  /** @deprecated deprecated in favor of the context map property {@code threadName} */
-  @Deprecated(since = "0.24.0", forRemoval = true)
-  public String getThread() {
-    return thread;
-  }
-
-  /** @deprecated deprecated in favor of the context map property {@code threadName} */
-  @Deprecated(since = "0.24.0", forRemoval = true)
-  public void setThread(final String thread) {
-    this.thread = thread;
   }
 }

--- a/util/src/main/java/io/zeebe/util/logging/stackdriver/StackdriverLogEntryBuilder.java
+++ b/util/src/main/java/io/zeebe/util/logging/stackdriver/StackdriverLogEntryBuilder.java
@@ -29,12 +29,6 @@ public final class StackdriverLogEntryBuilder {
   private String exception;
   private Instant time;
 
-  @Deprecated(since = "0.24.0", forRemoval = true)
-  private String logger;
-
-  @Deprecated(since = "0.24.0", forRemoval = true)
-  private String thread;
-
   StackdriverLogEntryBuilder() {
     service = new ServiceContext();
     context = new HashMap<>();
@@ -118,12 +112,10 @@ public final class StackdriverLogEntryBuilder {
   }
 
   public StackdriverLogEntryBuilder withLogger(final String logger) {
-    this.logger = logger;
     return withContextEntry("loggerName", logger);
   }
 
   public StackdriverLogEntryBuilder withThreadName(final String threadName) {
-    thread = threadName;
     return withContextEntry("threadName", threadName);
   }
 
@@ -163,8 +155,6 @@ public final class StackdriverLogEntryBuilder {
     stackdriverLogEntry.setContext(context);
     stackdriverLogEntry.setType(type);
     stackdriverLogEntry.setException(exception);
-    stackdriverLogEntry.setLogger(logger);
-    stackdriverLogEntry.setThread(thread);
 
     return stackdriverLogEntry;
   }

--- a/util/src/test/java/io/zeebe/util/logging/StackdriverLayoutTest.java
+++ b/util/src/test/java/io/zeebe/util/logging/StackdriverLayoutTest.java
@@ -311,7 +311,6 @@ public final class StackdriverLayoutTest {
     final var jsonMap = readLoggedEvent();
     softly
         .assertThat(jsonMap)
-        .containsEntry("thread", currentThread.getName())
         .hasEntrySatisfying(
             "context",
             context ->
@@ -337,7 +336,6 @@ public final class StackdriverLayoutTest {
     final var jsonMap = readLoggedEvent();
     softly
         .assertThat(jsonMap)
-        .containsEntry("logger", logger.getName())
         .hasEntrySatisfying(
             "context",
             context ->
@@ -345,23 +343,6 @@ public final class StackdriverLayoutTest {
                     .assertThat(context)
                     .asInstanceOf(InstanceOfAssertFactories.MAP)
                     .containsEntry("loggerName", logger.getName()));
-  }
-
-  @Deprecated(since = "0.24.0", forRemoval = true)
-  @Test
-  public void shouldBeBackwardsCompatibleWithStackdriverJSONLayout() throws IOException {
-    // when
-    logger.error("Should appear as JSON formatted output");
-
-    // then
-    final var jsonMap = readLoggedEvent();
-    softly
-        .assertThat(jsonMap)
-        .containsKeys(
-            "logger", "message", "severity", "thread", "timestampNanos", "timestampSeconds")
-        .containsEntry("message", "Should appear as JSON formatted output")
-        .containsEntry("severity", Severity.ERROR.name())
-        .containsEntry("logger", logger.getName());
   }
 
   @Test


### PR DESCRIPTION
## Description

Removes logger and thread name, since they have been deprecated for a
while

Old output with duplicated fields:
![old](https://user-images.githubusercontent.com/2758593/116088613-5079bb80-a6a2-11eb-944e-535730204258.png)

New output:
![new](https://user-images.githubusercontent.com/2758593/116088609-5079bb80-a6a2-11eb-8034-62f008d97f98.png)

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #6863 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
