### PR TITLE
Remove directories from DataCfg

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -7,12 +7,9 @@
  */
 package io.zeebe.broker.system.configuration;
 
-import static io.zeebe.util.StringUtil.LIST_SANITIZER;
-
 import io.zeebe.broker.Loggers;
 import java.io.File;
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.springframework.util.unit.DataSize;
@@ -29,13 +26,6 @@ public final class DataCfg implements ConfigurationEntry {
   private static final double DEFAULT_DISK_USAGE_COMMAND_WATERMARK = 0.97;
   private static final Duration DEFAULT_DISK_USAGE_MONITORING_DELAY = Duration.ofSeconds(1);
   private static final double DISABLED_DISK_USAGE_WATERMARK = 1.0;
-
-  /**
-   * @deprecated this field is deprecated in favour of {@code directory}, and will be removed in
-   *     0.27.0
-   */
-  @Deprecated(since = "0.26.0")
-  private List<String> directories;
 
   private String directory = DEFAULT_DIRECTORY;
 
@@ -54,42 +44,12 @@ public final class DataCfg implements ConfigurationEntry {
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     directory = ConfigurationUtil.toAbsolutePath(directory, brokerBase);
 
-    // fallback to directories if it's still specified
-    if (directories != null) {
-      directories = LIST_SANITIZER.apply(directories);
-      if (!directories.isEmpty()) {
-        directories.replaceAll(d -> ConfigurationUtil.toAbsolutePath(d, brokerBase));
-        directory = directories.get(0);
-      }
-    }
-
     if (!diskUsageMonitoringEnabled) {
       LOG.info(
           "Disk usage watermarks are disabled, setting all watermarks to {}",
           DISABLED_DISK_USAGE_WATERMARK);
       diskUsageReplicationWatermark = DISABLED_DISK_USAGE_WATERMARK;
       diskUsageCommandWatermark = DISABLED_DISK_USAGE_WATERMARK;
-    }
-  }
-
-  /**
-   * @deprecated this method is deprecated in favour of {@link #getDirectory()}, and will be removed
-   *     in 0.27.0
-   */
-  @Deprecated(since = "0.26.0")
-  public List<String> getDirectories() {
-    return directories;
-  }
-
-  /**
-   * @deprecated this method is deprecated in favour of {@link #setDirectory(String)}}, and will be
-   *     removed in 0.27.0
-   */
-  @Deprecated(since = "0.26.0")
-  public void setDirectories(final List<String> directories) {
-    this.directories = LIST_SANITIZER.apply(directories);
-    if (!this.directories.isEmpty()) {
-      directory = directories.get(0);
     }
   }
 

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -68,9 +68,6 @@ public final class BrokerCfgTest {
       "zeebe.broker.experimental.disableExplicitRaftFlush";
   private static final String ZEEBE_BROKER_DATA_DIRECTORY = "zeebe.broker.data.directory";
 
-  @Deprecated(since = "0.26.0")
-  private static final String ZEEBE_BROKER_DATA_DIRECTORIES = "zeebe.broker.data.directories";
-
   private static final String ZEEBE_BROKER_NETWORK_HOST = "zeebe.broker.network.host";
   private static final String ZEEBE_BROKER_NETWORK_ADVERTISED_HOST =
       "zeebe.broker.network.advertisedHost";
@@ -375,17 +372,6 @@ public final class BrokerCfgTest {
     // given
     final String expectedDataDirectory = Paths.get(BROKER_BASE, "foo").toString();
     environment.put(ZEEBE_BROKER_DATA_DIRECTORY, "foo");
-
-    // then
-    assertWithDefaultConfigurations(
-        config -> assertThat(config.getData().getDirectory()).isEqualTo(expectedDataDirectory));
-  }
-
-  @Test
-  public void shouldOverrideDirectoryWithFirstDirectories() {
-    // given
-    final String expectedDataDirectory = Paths.get(BROKER_BASE, "foo").toString();
-    environment.put(ZEEBE_BROKER_DATA_DIRECTORIES, "foo,bar");
 
     // then
     assertWithDefaultConfigurations(

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/DataCfgTest.java
@@ -9,27 +9,9 @@ package io.zeebe.broker.system.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
-import java.util.List;
 import org.junit.Test;
 
 public class DataCfgTest {
-
-  @Test
-  public void shouldSanitizeDirectories() {
-    // given
-    final DataCfg sutDataCfg = new DataCfg();
-    final List<String> input = Arrays.asList("", "foo ", null, "   ", "bar");
-    final List<String> expected = Arrays.asList("foo", "bar");
-
-    // when
-    sutDataCfg.setDirectories(input);
-
-    // then
-    final List<String> actual = sutDataCfg.getDirectories();
-
-    assertThat(actual).isEqualTo(expected);
-  }
 
   @Test
   public void shouldSetWatermarksTo1IfDisabled() {


### PR DESCRIPTION
## Description

Multiple directories are no longer supported and deprecated since 0.26.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #6863 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
