### PR TITLE
Reduce redundancy in ReceivedSnapshotTest and related implementation tests

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
@@ -21,6 +21,7 @@ import io.zeebe.snapshots.ReceivableSnapshotStore;
 import io.zeebe.snapshots.ReceivedSnapshot;
 import io.zeebe.util.sched.future.ActorFuture;
 import io.zeebe.util.sched.future.CompletableActorFuture;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -77,6 +78,11 @@ public class TestSnapshotStore implements ReceivableSnapshotStore {
   public ActorFuture<Void> delete() {
     currentPersistedSnapshot.set(null);
     receivedSnapshots.clear();
+    return null;
+  }
+
+  @Override
+  public Path getPath() {
     return null;
   }
 

--- a/atomix/core/src/test/java/io/atomix/core/NoopSnapshotStore.java
+++ b/atomix/core/src/test/java/io/atomix/core/NoopSnapshotStore.java
@@ -21,6 +21,7 @@ import io.zeebe.snapshots.PersistedSnapshotListener;
 import io.zeebe.snapshots.ReceivableSnapshotStore;
 import io.zeebe.snapshots.ReceivedSnapshot;
 import io.zeebe.util.sched.future.ActorFuture;
+import java.nio.file.Path;
 import java.util.Optional;
 
 class NoopSnapshotStore implements ReceivableSnapshotStore {
@@ -57,6 +58,11 @@ class NoopSnapshotStore implements ReceivableSnapshotStore {
 
   @Override
   public ActorFuture<Void> delete() {
+    return null;
+  }
+
+  @Override
+  public Path getPath() {
     return null;
   }
 

--- a/broker/src/test/java/io/zeebe/broker/logstreams/NoopSnapshotStore.java
+++ b/broker/src/test/java/io/zeebe/broker/logstreams/NoopSnapshotStore.java
@@ -108,5 +108,10 @@ public class NoopSnapshotStore implements PersistedSnapshotStore {
   }
 
   @Override
+  public Path getPath() {
+    return null;
+  }
+
+  @Override
   public void close() {}
 }

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
@@ -88,7 +88,6 @@ public final class AsyncSnapshotingTest {
 
     snapshotController.openDb();
     autoCloseableRule.manage(snapshotController);
-    autoCloseableRule.manage(persistedSnapshotStore);
     snapshotController = spy(snapshotController);
 
     logStream = mock(LogStream.class);

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
@@ -85,9 +85,7 @@ public final class FailingSnapshotChunkReplicationTest {
     receiverStore.addSnapshotListener(receiverSnapshotController);
 
     autoCloseableRule.manage(replicatorSnapshotController);
-    autoCloseableRule.manage(senderStore);
     autoCloseableRule.manage(receiverSnapshotController);
-    autoCloseableRule.manage(receiverStore);
     replicatorSnapshotController.openDb();
   }
 

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
@@ -96,8 +96,6 @@ public final class ReplicateStateControllerTest {
 
     autoCloseableRule.manage(replicatorSnapshotController);
     autoCloseableRule.manage(receiverSnapshotController);
-    autoCloseableRule.manage(senderStore);
-    autoCloseableRule.manage(receiverStore);
 
     final RocksDBWrapper wrapper = new RocksDBWrapper();
     wrapper.wrap(replicatorSnapshotController.openDb());

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -70,7 +70,6 @@ public final class StateControllerImplTest {
             db -> exporterPosition.get());
 
     autoCloseableRule.manage(snapshotController);
-    autoCloseableRule.manage(store);
   }
 
   @Test

--- a/snapshot/src/main/java/io/zeebe/snapshots/PersistableSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/PersistableSnapshot.java
@@ -8,6 +8,7 @@
 package io.zeebe.snapshots;
 
 import io.zeebe.util.sched.future.ActorFuture;
+import java.nio.file.Path;
 
 /** A volatile snapshot which can be persisted. */
 public interface PersistableSnapshot {
@@ -28,4 +29,11 @@ public interface PersistableSnapshot {
 
   /** @return the snapshotId of the snapshot */
   SnapshotId snapshotId();
+
+  /**
+   * Returns the pending snapshot's path.
+   *
+   * @return the path of the pending snapshot
+   */
+  Path getPath();
 }

--- a/snapshot/src/main/java/io/zeebe/snapshots/PersistedSnapshotListener.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/PersistedSnapshotListener.java
@@ -11,6 +11,7 @@ package io.zeebe.snapshots;
  * Represents a listener which can be added to the {@link PersistedSnapshotStore} to be notified
  * when a new {@link PersistedSnapshot} is persisted at this store.
  */
+@FunctionalInterface
 public interface PersistedSnapshotListener {
 
   /**

--- a/snapshot/src/main/java/io/zeebe/snapshots/PersistedSnapshotStore.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/PersistedSnapshotStore.java
@@ -9,6 +9,7 @@ package io.zeebe.snapshots;
 
 import io.zeebe.util.CloseableSilently;
 import io.zeebe.util.sched.future.ActorFuture;
+import java.nio.file.Path;
 import java.util.Optional;
 
 /**
@@ -75,4 +76,6 @@ public interface PersistedSnapshotStore extends CloseableSilently {
    * @return
    */
   ActorFuture<Void> delete();
+
+  Path getPath();
 }

--- a/snapshot/src/main/java/io/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -202,6 +202,11 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
     return metadata;
   }
 
+  @Override
+  public Path getPath() {
+    return directory;
+  }
+
   private void abortInternal() {
     try {
       LOGGER.debug("DELETE dir {}", directory);

--- a/snapshot/src/main/java/io/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -243,7 +243,7 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
           new IllegalStateException(
               String.format(
                   "Expected '%d' chunk files for this snapshot, but found '%d'. Files are: %s.",
-                  expectedSnapshotChecksum, files.length, Arrays.toString(files))));
+                  expectedTotalCount, files.length, Arrays.toString(files))));
       return;
     }
 
@@ -262,7 +262,8 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
   private boolean verifyChecksums(final CompletableActorFuture<PersistedSnapshot> future) {
 
     try {
-      if (SnapshotChecksum.verify(directory)) {
+      final long writtenChecksum = SnapshotChecksum.read(directory);
+      if (writtenChecksum == expectedSnapshotChecksum) {
         return true;
       } else {
         future.completeExceptionally(

--- a/snapshot/src/main/java/io/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -137,6 +137,11 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
     return metadata;
   }
 
+  @Override
+  public Path getPath() {
+    return directory;
+  }
+
   private void abortInternal() {
     try {
       isValid = false;
@@ -148,10 +153,6 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
     } finally {
       snapshotStore.removePendingSnapshot(this);
     }
-  }
-
-  private Path getPath() {
-    return directory;
   }
 
   @Override

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/ReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/ReceivedSnapshotTest.java
@@ -9,42 +9,50 @@ package io.zeebe.snapshots.impl;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.zeebe.snapshots.ConstructableSnapshotStore;
+import io.zeebe.snapshots.PersistedSnapshot;
 import io.zeebe.snapshots.ReceivableSnapshotStore;
+import io.zeebe.snapshots.ReceivedSnapshot;
+import io.zeebe.snapshots.SnapshotChunk;
 import io.zeebe.util.FileUtil;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class ReceivedSnapshotTest {
+  private static final Map<String, String> SNAPSHOT_FILE_CONTENTS =
+      Map.of(
+          "file1", "file1 contents",
+          "file2", "file2 contents");
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
-  @Rule public ActorSchedulerRule senderScheduler = new ActorSchedulerRule();
-  @Rule public ActorSchedulerRule receiverScheduler = new ActorSchedulerRule();
+  @Rule public ActorSchedulerRule scheduler = new ActorSchedulerRule();
 
   private ConstructableSnapshotStore senderSnapshotStore;
   private ReceivableSnapshotStore receiverSnapshotStore;
 
   @Before
-  public void before() throws Exception {
+  public void beforeEach() throws Exception {
     final int partitionId = 1;
 
-    final var senderFactory = new FileBasedSnapshotStoreFactory(senderScheduler.get(), 1);
+    final var senderFactory = new FileBasedSnapshotStoreFactory(scheduler.get(), 1);
     senderFactory.createReceivableSnapshotStore(
         temporaryFolder.newFolder("sender").toPath(), partitionId);
     senderSnapshotStore = senderFactory.getConstructableSnapshotStore(partitionId);
     receiverSnapshotStore =
-        new FileBasedSnapshotStoreFactory(receiverScheduler.get(), 2)
+        new FileBasedSnapshotStoreFactory(scheduler.get(), 2)
             .createReceivableSnapshotStore(
                 temporaryFolder.newFolder("received").toPath(), partitionId);
   }
@@ -70,166 +78,161 @@ public class ReceivedSnapshotTest {
   }
 
   @Test
-  public void shouldPersistReceivedSnapshotChunks() throws Exception {
+  public void shouldNotCommitUntilPersisted() throws IOException {
     // given
-    final var index = 1L;
-    final var term = 0L;
-
-    final var transientSnapshot =
-        senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    transientSnapshot.take(
-        p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));
-    final var persistedSnapshot = transientSnapshot.persist().join();
+    final var persistedSnapshot = takePersistedSnapshot();
 
     // when
-    final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
-    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
-      while (snapshotChunkReader.hasNext()) {
-        receivedSnapshot.apply(snapshotChunkReader.next());
-      }
-    }
+    final var receivedSnapshot = receiveSnapshot(persistedSnapshot);
+
+    // then
+    assertThat(receivedSnapshot.getPath()).as("there exists a pending snapshot").isDirectory();
+    assertThat(receiverSnapshotStore.getLatestSnapshot())
+        .as("the pending snapshot was not committed")
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldPurgePendingOnPersist() throws IOException {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+
+    // when
+    final var receivedSnapshot = receiveSnapshot(persistedSnapshot);
     final var receivedPersistedSnapshot = receivedSnapshot.persist().join();
 
     // then
-    // path is different
-    assertThat(receivedPersistedSnapshot).isNotEqualTo(persistedSnapshot);
+    assertThat(receivedSnapshot.getPath())
+        .as("the pending snapshot was removed after persist")
+        .doesNotExist();
+    assertThat(receivedPersistedSnapshot.getPath())
+        .as("there exists a persisted received snapshot")
+        .exists();
+  }
 
-    assertThat(receivedPersistedSnapshot.getPath()).isNotEqualTo(persistedSnapshot.getPath());
-    assertThat(receivedPersistedSnapshot.getIndex()).isEqualTo(persistedSnapshot.getIndex());
-    assertThat(receivedPersistedSnapshot.getTerm()).isEqualTo(persistedSnapshot.getTerm());
-    assertThat(receivedPersistedSnapshot.getCompactionBound())
-        .isEqualTo(persistedSnapshot.getCompactionBound());
-    assertThat(receivedPersistedSnapshot.getId()).isEqualTo(persistedSnapshot.getId());
+  @Test
+  public void shouldReceiveSnapshot() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+
+    // when
+    final var receivedSnapshot = receiveSnapshot(persistedSnapshot).persist().join();
+
+    // then
+    assertThat(receiverSnapshotStore.getLatestSnapshot())
+        .as("the received snapshot was committed and is the latest snapshot")
+        .hasValue(receivedSnapshot);
+    assertThat(SnapshotChecksum.calculate(receivedSnapshot.getPath()))
+        .as("the received snapshot has the same checksum as the sent snapshot")
+        .isEqualTo(SnapshotChecksum.calculate(persistedSnapshot.getPath()));
+    assertThat(receivedSnapshot.getId())
+        .as("the received snapshot has the same ID as the sent snapshot")
+        .isEqualTo(persistedSnapshot.getId());
+  }
+
+  @Test
+  public void shouldDeletePendingSnapshotDirOnAbort() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+    final var receivedSnapshot = receiveSnapshot(persistedSnapshot);
+
+    // when
+    receivedSnapshot.abort().join();
+
+    // then
+    assertThat(receivedSnapshot.getPath())
+        .as("the pending snapshot does not exist anymore after purging")
+        .doesNotExist();
+  }
+
+  @Test
+  public void shouldNotDeletePersistedSnapshotOnPurgePendingOnStore() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+    final var receivedSnapshot = receiveSnapshot(persistedSnapshot).persist().join();
+    final var expectedChecksum = SnapshotChecksum.calculate(receivedSnapshot.getPath());
+
+    // when
+    receiverSnapshotStore.purgePendingSnapshots().join();
+
+    // then
+    assertThat(receivedSnapshot.getPath()).as("the received snapshot still exists").exists();
+    assertThat(receivedSnapshot)
+        .as("the previous snapshot should still be the latest snapshot")
+        .isEqualTo(receiverSnapshotStore.getLatestSnapshot().orElseThrow());
+    assertThat(SnapshotChecksum.calculate(receivedSnapshot.getPath()))
+        .as("the received snapshot still has the same checksum")
+        .isEqualTo(expectedChecksum);
   }
 
   @Test
   public void shouldReturnTrueOnConsumingChunk() throws Exception {
     // given
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    transientSnapshot.take(
-        p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));
-    final var persistedSnapshot = transientSnapshot.persist().join();
+    final var persistedSnapshot = takePersistedSnapshot();
 
     // when
+    final boolean chunkApplied;
     final var receivedSnapshot =
         receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
 
     try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
-      final var success = receivedSnapshot.apply(snapshotChunkReader.next()).join();
-
-      // then
-      assertThat(success).isTrue();
+      chunkApplied = receivedSnapshot.apply(snapshotChunkReader.next()).join();
     }
+
+    // then
+    assertThat(chunkApplied).as("the chunk should be successfully applied").isTrue();
   }
 
   @Test
-  public void shouldReturnTrueOnConsumingChunkTwice() throws Exception {
+  public void shouldPersistEvenIfSameChunkIsConsumedMultipleTimes() throws Exception {
     // given
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    transientSnapshot.take(
-        p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));
-    final var persistedSnapshot = transientSnapshot.persist().join();
+    final var persistedSnapshot = takePersistedSnapshot();
 
     // when
+    final boolean chunkApplied;
     final var receivedSnapshot =
         receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
 
     try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
-      receivedSnapshot.apply(snapshotChunkReader.next()).join();
-    }
+      final SnapshotChunk chunk = snapshotChunkReader.next();
+      receivedSnapshot.apply(chunk).join();
+      chunkApplied = receivedSnapshot.apply(chunk).join();
 
-    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
-      final var success = receivedSnapshot.apply(snapshotChunkReader.next()).join();
-      assertThat(success).isTrue();
-    }
-  }
-
-  @Test
-  public void shouldReturnTrueWhenSnapshotAlreadyExist() throws Exception {
-    // given
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    transientSnapshot.take(
-        p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));
-    final var persistedSnapshot = transientSnapshot.persist().join();
-    final var firstReceivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
-    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
       while (snapshotChunkReader.hasNext()) {
-        final var success = firstReceivedSnapshot.apply(snapshotChunkReader.next()).join();
-        assertThat(success).isTrue();
+        receivedSnapshot.apply(snapshotChunkReader.next()).join();
       }
     }
 
-    // when - same snapshot received again
-    final var secondReceivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
-    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
-      while (snapshotChunkReader.hasNext()) {
-        final var success = secondReceivedSnapshot.apply(snapshotChunkReader.next()).join();
+    final var receivedPersistedSnapshot = receivedSnapshot.persist().join();
 
-        // then
-        assertThat(success).isTrue();
-      }
-    }
+    // then
+    assertThat(chunkApplied).as("the chunk was successfully applied twice in a row").isTrue();
+    assertThat(receivedPersistedSnapshot)
+        .as("the snapshot was persisted even if one chunk was applied more than once")
+        .isEqualTo(receiverSnapshotStore.getLatestSnapshot().orElseThrow());
   }
 
   @Test
   public void shouldReturnAlreadyExistingSnapshotOnPersist() throws Exception {
     // given
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    transientSnapshot.take(
-        p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));
-    final var persistedSnapshot = transientSnapshot.persist().join();
-    final var firstReceivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
-    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
-      while (snapshotChunkReader.hasNext()) {
-        firstReceivedSnapshot.apply(snapshotChunkReader.next());
-      }
-    }
-    final var alreadyPeristedSnapshot = firstReceivedSnapshot.persist().join();
+    final var persistedSnapshot = takePersistedSnapshot();
+    final var firstReceivedSnapshot = receiveSnapshot(persistedSnapshot);
+    final var firstPersistedSnapshot = firstReceivedSnapshot.persist().join();
 
     // when - receives same snapshot again
-    final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
-    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
-      while (snapshotChunkReader.hasNext()) {
-        final var success = receivedSnapshot.apply(snapshotChunkReader.next()).join();
-        assertThat(success).isTrue();
-      }
-    }
-    final var persistedReceivedSnapshot = receivedSnapshot.persist().join();
+    final var secondReceivedSnapshot = receiveSnapshot(persistedSnapshot);
+    final var secondPersistedSnapshot = secondReceivedSnapshot.persist().join();
 
     // then
-    assertThat(persistedReceivedSnapshot)
-        .isEqualTo(alreadyPeristedSnapshot)
-        .isSameAs(alreadyPeristedSnapshot);
+    assertThat(secondPersistedSnapshot)
+        .isEqualTo(firstPersistedSnapshot)
+        .isSameAs(firstPersistedSnapshot);
   }
 
   @Test
   public void shouldThrowExceptionOnPersistWhenNoChunkApplied() {
     // given
-    final var index = 1L;
-    final var term = 0L;
-
-    final var transientSnapshot =
-        senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    transientSnapshot.take(
-        p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));
-    final var persistedSnapshot = transientSnapshot.persist().join();
+    final var persistedSnapshot = takePersistedSnapshot();
     final var receivedSnapshot =
         receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
 
@@ -239,35 +242,290 @@ public class ReceivedSnapshotTest {
   }
 
   @Test
+  public void shouldBeAbleToAbortAfterPersistFails() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+    final var receivedSnapshot =
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
+      receivedSnapshot.apply(snapshotChunkReader.next()).join();
+    }
+
+    // when
+    assertThatThrownBy(() -> receivedSnapshot.persist().join())
+        .as("the received snapshot is partial and should not be persisted")
+        .hasCauseInstanceOf(IllegalStateException.class);
+    receivedSnapshot.abort().join();
+
+    // then
+    assertThat(receivedSnapshot.getPath())
+        .as("the corrupted pending snapshot was deleted on abort")
+        .doesNotExist();
+  }
+
+  @Test
   public void shouldNotThrowExceptionOnAbortWhenNoChunkApplied() {
     // given
-    final var index = 1L;
-    final var term = 0L;
-
-    final var transientSnapshot =
-        senderSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    transientSnapshot.take(
-        p -> takeSnapshot(p, List.of("file3", "file1", "file2"), List.of("content", "this", "is")));
-    final var persistedSnapshot = transientSnapshot.persist().join();
+    final var persistedSnapshot = takePersistedSnapshot();
     final var receivedSnapshot =
         receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
 
     // when - then
-    receivedSnapshot.abort();
+    assertThatCode(receivedSnapshot::abort).doesNotThrowAnyException();
   }
 
-  private boolean takeSnapshot(
-      final Path path, final List<String> fileNames, final List<String> fileContents) {
-    assertThat(fileNames).hasSameSizeAs(fileContents);
+  @Test
+  public void shouldReceiveConcurrentlyWithoutOverwritingEachOther() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
 
+    // when
+    final ReceivedSnapshot firstReceivedSnapshot = receiveSnapshot(persistedSnapshot);
+    final ReceivedSnapshot secondReceivedSnapshot = receiveSnapshot(persistedSnapshot);
+
+    // then
+    assertThat(firstReceivedSnapshot.getPath())
+        .as("the first received snapshot is stored somewhere else than the second")
+        .exists()
+        .isNotEqualTo(secondReceivedSnapshot.getPath());
+    assertThat(secondReceivedSnapshot.getPath()).as("the second received snapshot exists").exists();
+  }
+
+  @Test
+  public void shouldReceiveConcurrentlyAndPersist() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+
+    // when
+    final ReceivedSnapshot firstReceivedSnapshot = receiveSnapshot(persistedSnapshot);
+    final ReceivedSnapshot secondReceivedSnapshot = receiveSnapshot(persistedSnapshot);
+    final PersistedSnapshot receivedPersistedSnapshot = firstReceivedSnapshot.persist().join();
+
+    // then
+    assertThat(firstReceivedSnapshot.getPath())
+        .as("the first received snapshot was removed on persist of concurrent receive")
+        .doesNotExist();
+    assertThat(secondReceivedSnapshot.getPath())
+        .as("the second received snapshot was not removed as it's not considered older")
+        .exists();
+    assertThat(SnapshotChecksum.calculate(receivedPersistedSnapshot.getPath()))
+        .as("the received, persisted snapshot have the same checksum as the persisted one")
+        .isEqualTo(SnapshotChecksum.calculate(persistedSnapshot.getPath()));
+  }
+
+  @Test
+  public void shouldDoNothingOnPersistOfAlreadyCommittedSnapshot() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+    final var receivedSnapshot = receiveSnapshot(persistedSnapshot);
+    final var otherReceivedSnapshot = receiveSnapshot(persistedSnapshot);
+
+    // when
+    final var otherReceivedPersisted = otherReceivedSnapshot.persist().join();
+    final var receivedPersisted = receivedSnapshot.persist().join();
+
+    // then
+    assertThat(receivedPersisted)
+        .as("the last persisted snapshot is the same as the first one as they have the same ID")
+        .isEqualTo(otherReceivedPersisted);
+    assertThat(receivedSnapshot.getPath())
+        .as("the received snapshot was removed on persist of the other snapshot")
+        .doesNotExist();
+    assertThat(SnapshotChecksum.calculate(receivedPersisted.getPath()))
+        .as("the received, persisted snapshot have the same checksum as the persisted one")
+        .isEqualTo(SnapshotChecksum.calculate(persistedSnapshot.getPath()));
+  }
+
+  @Test
+  public void shouldReturnFalseOnConsumingChunkWithInvalidSnapshotChecksum() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+
+    // when
+    final boolean chunkApplied;
+    final var receivedSnapshot =
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+
+    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
+      receivedSnapshot.apply(snapshotChunkReader.next()).join();
+
+      final var originalChunk = snapshotChunkReader.next();
+      final SnapshotChunk corruptedChunk =
+          SnapshotChunkWrapper.withSnapshotChecksum(originalChunk, 0xCAFEL);
+      chunkApplied = receivedSnapshot.apply(corruptedChunk).join();
+    }
+
+    // then
+    assertThat(chunkApplied)
+        .as("the snapshot chunk should not be applied as it had a different snapshot checksum")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldReturnFalseOnConsumingChunkWithInvalidChunkChecksum() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+
+    // when
+    final boolean chunkApplied;
+    final var receivedSnapshot =
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
+      final SnapshotChunk originalChunk = snapshotChunkReader.next();
+      final SnapshotChunk corruptedChunk =
+          SnapshotChunkWrapper.withChecksum(originalChunk, 0xCAFEL);
+      chunkApplied = receivedSnapshot.apply(corruptedChunk).join();
+    }
+
+    // then
+    assertThat(chunkApplied)
+        .as("the chunk should not be applied as its content checksum is not 0xCAFEL")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldNotPersistWhenSnapshotChecksumIsWrong() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+
+    // when
+    final var receivedSnapshot =
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
+      while (snapshotChunkReader.hasNext()) {
+        final var originalChunk = snapshotChunkReader.next();
+        final var corruptedChunk =
+            SnapshotChunkWrapper.withSnapshotChecksum(originalChunk, 0xDEADBEEFL);
+        receivedSnapshot.apply(corruptedChunk).join();
+      }
+    }
+
+    // then
+    assertThatThrownBy(() -> receivedSnapshot.persist().join())
+        .as(
+            "the snapshot should not be persisted since the computed checksum is not the reported one")
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Snapshot is corrupted");
+  }
+
+  @Test
+  public void shouldNotPersistWhenSnapshotIsPartial() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+
+    // when
+    final var receivedSnapshot =
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
+      final var firstChunk = snapshotChunkReader.next();
+      receivedSnapshot.apply(firstChunk).join();
+    }
+
+    // then
+    assertThatThrownBy(() -> receivedSnapshot.persist().join())
+        .as("the snapshot should be persisted as it's corrupted due to a missing chunk")
+        .hasCauseInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void shouldReturnFalseOnConsumingChunkWithNotEqualTotalCount() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+
+    // when
+    final boolean chunkApplied;
+    final var receivedSnapshot =
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
+      final var firstChunk = snapshotChunkReader.next();
+      receivedSnapshot.apply(firstChunk).join();
+
+      final var corruptedChunk =
+          SnapshotChunkWrapper.withTotalCount(snapshotChunkReader.next(), 55);
+      chunkApplied = receivedSnapshot.apply(corruptedChunk).join();
+    }
+
+    // then
+    assertThat(chunkApplied)
+        .as("the second chunk should not be applied as it reports a different chunk count")
+        .isFalse();
+  }
+
+  @Test
+  public void shouldNotPersistWhenTotalCountIsWrong() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+
+    // when
+    final var receivedSnapshot =
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
+      while (snapshotChunkReader.hasNext()) {
+        final var corruptedChunk =
+            SnapshotChunkWrapper.withTotalCount(snapshotChunkReader.next(), 1);
+        receivedSnapshot.apply(corruptedChunk).join();
+      }
+    }
+    final var persisted = receivedSnapshot.persist();
+
+    // then
+    assertThatThrownBy(persisted::join)
+        .as(
+            "the snapshot should not be persisted as it's corrupted due to missing chunks,"
+                + " even if the total count was present")
+        .hasCauseInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void shouldReturnFalseOnConsumingChunkWithNotEqualSnapshotId() throws Exception {
+    // given
+    final var persistedSnapshot = takePersistedSnapshot();
+
+    // when
+    final boolean chunkApplied;
+    final var receivedSnapshot =
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
+      final var originalChunk = snapshotChunkReader.next();
+      final SnapshotChunk corruptedChunk = SnapshotChunkWrapper.withSnapshotId(originalChunk, "id");
+      chunkApplied = receivedSnapshot.apply(corruptedChunk).join();
+    }
+
+    // then
+    assertThat(chunkApplied)
+        .as("the chunk should not be applied since it has a different snapshot ID than expected")
+        .isFalse();
+  }
+
+  private ReceivedSnapshot receiveSnapshot(final PersistedSnapshot persistedSnapshot)
+      throws IOException {
+    final var receivedSnapshot =
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+
+    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
+      while (snapshotChunkReader.hasNext()) {
+        receivedSnapshot.apply(snapshotChunkReader.next()).join();
+      }
+    }
+
+    return receivedSnapshot;
+  }
+
+  private PersistedSnapshot takePersistedSnapshot() {
+    final var transientSnapshot =
+        senderSnapshotStore.newTransientSnapshot(1L, 0L, 1, 0).orElseThrow();
+    transientSnapshot.take(this::writeSnapshot).join();
+    return transientSnapshot.persist().join();
+  }
+
+  private boolean writeSnapshot(final Path path) {
     try {
       FileUtil.ensureDirectoryExists(path);
 
-      for (int i = 0; i < fileNames.size(); i++) {
-        final var fileName = fileNames.get(i);
-        final var fileContent = fileContents.get(i);
-        Files.write(
-            path.resolve(fileName), fileContent.getBytes(), CREATE_NEW, StandardOpenOption.WRITE);
+      for (final var entry : SNAPSHOT_FILE_CONTENTS.entrySet()) {
+        final var fileName = path.resolve(entry.getKey());
+        final var fileContent = entry.getValue().getBytes(StandardCharsets.UTF_8);
+        Files.write(fileName, fileContent, CREATE_NEW, StandardOpenOption.WRITE);
       }
     } catch (final IOException e) {
       throw new UncheckedIOException(e);

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/SnapshotChunkWrapper.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/SnapshotChunkWrapper.java
@@ -12,42 +12,54 @@ import io.zeebe.snapshots.SnapshotChunk;
 public final class SnapshotChunkWrapper implements SnapshotChunk {
 
   private final SnapshotChunk wrappedChunk;
-  private final String snapshotId;
-  private final Integer totalCount;
-  private final Long checksum;
-  private final Long snapshotChecksum;
 
-  private SnapshotChunkWrapper(
-      final SnapshotChunk wrappedChunk,
-      final String snapshotId,
-      final Integer totalCount,
-      final Long checksum,
-      final Long snapshotChecksum) {
+  private String snapshotId;
+  private Integer totalCount;
+  private Long checksum;
+  private Long snapshotChecksum;
+  private byte[] contents;
+
+  private SnapshotChunkWrapper(final SnapshotChunk wrappedChunk) {
     this.wrappedChunk = wrappedChunk;
-    this.snapshotId = snapshotId;
-    this.totalCount = totalCount;
-    this.checksum = checksum;
-    this.snapshotChecksum = snapshotChecksum;
   }
 
-  public static SnapshotChunk withDifferentSnapshotId(
+  public static SnapshotChunk withSnapshotId(
       final SnapshotChunk wrappedChunk, final String snapshotId) {
-    return new SnapshotChunkWrapper(wrappedChunk, snapshotId, null, null, null);
+    final var wrapper = new SnapshotChunkWrapper(wrappedChunk);
+    wrapper.snapshotId = snapshotId;
+
+    return wrapper;
   }
 
-  public static SnapshotChunk withDifferentTotalCount(
+  public static SnapshotChunk withTotalCount(
       final SnapshotChunk wrappedChunk, final Integer totalCount) {
-    return new SnapshotChunkWrapper(wrappedChunk, null, totalCount, null, null);
+    final var wrapper = new SnapshotChunkWrapper(wrappedChunk);
+    wrapper.totalCount = totalCount;
+
+    return wrapper;
   }
 
-  public static SnapshotChunk withDifferentChecksum(
-      final SnapshotChunk wrappedChunk, final Long checksum) {
-    return new SnapshotChunkWrapper(wrappedChunk, null, null, checksum, null);
+  public static SnapshotChunk withChecksum(final SnapshotChunk wrappedChunk, final Long checksum) {
+    final var wrapper = new SnapshotChunkWrapper(wrappedChunk);
+    wrapper.checksum = checksum;
+
+    return wrapper;
   }
 
-  public static SnapshotChunk withDifferentSnapshotChecksum(
+  public static SnapshotChunk withSnapshotChecksum(
       final SnapshotChunk wrappedChunk, final Long snapshotChecksum) {
-    return new SnapshotChunkWrapper(wrappedChunk, null, null, null, snapshotChecksum);
+    final var wrapper = new SnapshotChunkWrapper(wrappedChunk);
+    wrapper.snapshotChecksum = snapshotChecksum;
+
+    return wrapper;
+  }
+
+  public static SnapshotChunk withContents(
+      final SnapshotChunk wrappedChunk, final byte[] contents) {
+    final var wrapper = new SnapshotChunkWrapper(wrappedChunk);
+    wrapper.contents = contents;
+
+    return wrapper;
   }
 
   @Override
@@ -81,7 +93,10 @@ public final class SnapshotChunkWrapper implements SnapshotChunk {
 
   @Override
   public byte[] getContent() {
-    return wrappedChunk.getContent();
+    if (contents == null) {
+      return wrappedChunk.getContent();
+    }
+    return contents;
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR introduces some changes to reduce redundancy in the `ReceivedSnapshot` tests and equivalent implementation tests.

The `PersistedSnapshotStore`, `PersistedSnapshot`, and `ReceivedSnapshot`, now all expose a `getPath` method. This is to simplify testing, but also as we don't foresee not persisting snapshots on disk in the near-to-mid future. Persistence is now coupled to disk, but that's a trade off we can make to simplify things.

Secondly, the `FileBasedSnapshotStore` now uses the actor lifecycle properly. This was done to allow opening/closing the store, which ended up not being used, but I kept the change as I think it makes sense - we should avoid initialization in the constructor such as I/O operations which can fail, and we should perform close operations when the actor is closed. Happy to split it to another PR if you'd like.

One small change, the 4th commit - to simplify testing persisting with a corrupted snapshot, it's simpler to compare the written snapshot to the expected total snapshot. This isn't exactly correct behavior now, but with #6666, we will move the checksum file to a sibling file, and as such we will go back to using the expected checksum as given in the request, so I think it's fine to make this change (partially) now.

Finally, I tried to untangle the implementation tests from the interface tests, but it's possible I missed some. If it makes it easier, I'm happy to split the last commit off in a separate PR. I kept it in because most of the other commits are changes which would otherwise be done in a vaccum (for now), so I wanted to keep it all together for context.

## Related issues

<!-- Which issues are closed by this PR or are related -->

related to #6666

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
