### PR TITLE
Remove deprecated processing methods

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
@@ -52,49 +52,6 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
   default void onActivate(final T element, final BpmnElementContext context) {}
 
   /**
-   * The element is entered (initial step). Perform every action to initialize the element.
-   *
-   * <p>Possible actions:
-   *
-   * <ul>
-   *   <li>apply input mappings
-   *   <li>open event subscriptions
-   * </ul>
-   *
-   * Next step: activated.
-   *
-   * @param element the instance of the BPMN element that is executed
-   * @param context process instance-related data of the element that is executed
-   * @deprecated will be replaced by onActivate
-   */
-  @Deprecated // todo (#6202): remove method
-  default void onActivating(final T element, final BpmnElementContext context) {
-    throw new UnsupportedOperationException("This method is replaced by onActivate");
-  }
-
-  /**
-   * The element is initialized. If the element is a wait-state (i.e. it is waiting for an event or
-   * an external trigger) then it is waiting in this step to continue. Otherwise, it continues
-   * directly to the next step.
-   *
-   * <p>Possible actions:
-   *
-   * <ul>
-   *   <li>initialize child elements - if the element is a container (e.g. a sub-process)
-   * </ul>
-   *
-   * Next step: completing - if not a wait-state.
-   *
-   * @param element the instance of the BPMN element that is executed
-   * @param context process instance-related data of the element that is executed
-   * @deprecated will be replaced by onActivate
-   */
-  @Deprecated // todo (#6202): remove method
-  default void onActivated(final T element, final BpmnElementContext context) {
-    throw new UnsupportedOperationException("This method is replaced by onActivate");
-  }
-
-  /**
    * The element is going to be left. Perform every action to leave the element and continue with
    * the next element.
    *
@@ -114,49 +71,6 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @param context process instance-related data of the element that is executed
    */
   default void onComplete(final T element, final BpmnElementContext context) {}
-
-  /**
-   * The element is going to be left. Perform every action to leave the element.
-   *
-   * <p>Possible actions:
-   *
-   * <ul>
-   *   <li>apply output mappings
-   *   <li>close event subscriptions
-   * </ul>
-   *
-   * <p>Next step: completed.
-   *
-   * @param element the instance of the BPMN element that is executed
-   * @param context process instance-related data of the element that is executed
-   * @deprecated will be replaced by onComplete
-   */
-  @Deprecated // todo (#6202): remove method
-  default void onCompleting(final T element, final BpmnElementContext context) {
-    throw new UnsupportedOperationException("This method is replaced by onComplete");
-  }
-
-  /**
-   * The element is left (final step). Continue with the next element.
-   *
-   * <p>Possible actions:
-   *
-   * <ul>
-   *   <li>take outgoing sequence flows - if any
-   *   <li>continue with parent element - if no outgoing sequence flows
-   *   <li>clean up the state
-   * </ul>
-   *
-   * Next step: none.
-   *
-   * @param element the instance of the BPMN element that is executed
-   * @param context process instance-related data of the element that is executed
-   * @deprecated will be replaced by onComplete
-   */
-  @Deprecated // todo (#6202): remove method
-  default void onCompleted(final T element, final BpmnElementContext context) {
-    throw new UnsupportedOperationException("This method is replaced by onComplete");
-  }
 
   /**
    * The element is going to be terminated. Perform every action to terminate the element and
@@ -179,49 +93,4 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @param context process instance-related data of the element that is executed
    */
   default void onTerminate(final T element, final BpmnElementContext context) {}
-
-  /**
-   * The element is going to be terminated. Perform every action to terminate the element.
-   *
-   * <p>Possible actions:
-   *
-   * <ul>
-   *   <li>close event subscriptions
-   * </ul>
-   *
-   * <p>Next step: terminated.
-   *
-   * @param element the instance of the BPMN element that is executed
-   * @param context process instance-related data of the element that is executed
-   * @deprecated will be replaced by onTerminate
-   */
-  @Deprecated // todo (#6202): remove method
-  default void onTerminating(final T element, final BpmnElementContext context) {
-    throw new UnsupportedOperationException("This method is replaced by onTerminate");
-  }
-
-  /**
-   * The element is terminated (final step). Continue with the element that caused the termination
-   * (e.g. the triggered boundary event).
-   *
-   * <p>Possible actions:
-   *
-   * <ul>
-   *   <li>resolve incidents
-   *   <li>activate the triggered boundary event - if any
-   *   <li>activate the triggered event sub-process - if any
-   *   <li>continue with parent element
-   *   <li>clean up the state
-   * </ul>
-   *
-   * Next step: none.
-   *
-   * @param element the instance of the BPMN element that is executed
-   * @param context process instance-related data of the element that is executed
-   * @deprecated will be replaced by onTerminate
-   */
-  @Deprecated // todo (#6202): remove method
-  default void onTerminated(final T element, final BpmnElementContext context) {
-    throw new UnsupportedOperationException("This method is replaced by onTerminate");
-  }
 }


### PR DESCRIPTION
## Description
Since all elements are migrated to event sourcing we now only process
commands, no longer events, which makes the other methods for processing bpmn elements in certain state obsolete.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #6863 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
