### PR TITLE
Update ElasticsearchClient and index templates for ES 7.12

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -2,12 +2,13 @@
   "index_patterns": [
     "zeebe-record_deployment_*"
   ],
-  "order": 20,
-  "aliases": {
-    "zeebe-record-deployment": {}
-  },
-  "mappings": {
-    "_doc": {
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "aliases": {
+      "zeebe-record-deployment": {}
+    },
+    "mappings": {
       "properties": {
         "value": {
           "dynamic": "strict",

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -5,6 +5,11 @@
   "priority": 20,
   "version": 1,
   "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
     "aliases": {
       "zeebe-record-deployment": {}
     },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-error-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-error-template.json
@@ -5,6 +5,11 @@
   "priority": 20,
   "version": 1,
   "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
     "aliases": {
       "zeebe-record-error": {}
     },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-error-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-error-template.json
@@ -2,12 +2,13 @@
   "index_patterns": [
     "zeebe-record_error_*"
   ],
-  "order": 20,
-  "aliases": {
-    "zeebe-record-error": {}
-  },
-  "mappings": {
-    "_doc": {
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "aliases": {
+      "zeebe-record-error": {}
+    },
+    "mappings": {
       "properties": {
         "value": {
           "dynamic": "strict",

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
@@ -5,6 +5,11 @@
   "priority": 20,
   "version": 1,
   "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
     "aliases": {
       "zeebe-record-incident": {}
     },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
@@ -2,12 +2,13 @@
   "index_patterns": [
     "zeebe-record_incident_*"
   ],
-  "order": 20,
-  "aliases": {
-    "zeebe-record-incident": {}
-  },
-  "mappings": {
-    "_doc": {
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "aliases": {
+      "zeebe-record-incident": {}
+    },
+    "mappings": {
       "properties": {
         "value": {
           "dynamic": "strict",

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -5,6 +5,11 @@
   "priority": 20,
   "version": 1,
   "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
     "aliases": {
       "zeebe-record-job-batch": {}
     },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -2,12 +2,13 @@
   "index_patterns": [
     "zeebe-record_job-batch_*"
   ],
-  "order": 20,
-  "aliases": {
-    "zeebe-record-job-batch": {}
-  },
-  "mappings": {
-    "_doc": {
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "aliases": {
+      "zeebe-record-job-batch": {}
+    },
+    "mappings": {
       "properties": {
         "value": {
           "dynamic": "strict",

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -2,15 +2,16 @@
   "index_patterns": [
     "zeebe-record_job_*"
   ],
-  "order": 20,
-  "settings": {
-    "number_of_shards": 3
-  },
-  "aliases": {
-    "zeebe-record-job": {}
-  },
-  "mappings": {
-    "_doc": {
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 3
+    },
+    "aliases": {
+      "zeebe-record-job": {}
+    },
+    "mappings": {
       "properties": {
         "value": {
           "dynamic": "strict",

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -6,7 +6,9 @@
   "version": 1,
   "template": {
     "settings": {
-      "number_of_shards": 3
+      "number_of_shards": 3,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
     },
     "aliases": {
       "zeebe-record-job": {}

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -2,12 +2,13 @@
   "index_patterns": [
     "zeebe-record_message-subscription_*"
   ],
-  "order": 20,
-  "aliases": {
-    "zeebe-record-message-subscription": {}
-  },
-  "mappings": {
-    "_doc": {
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "aliases": {
+      "zeebe-record-message-subscription": {}
+    },
+    "mappings": {
       "properties": {
         "value": {
           "dynamic": "strict",

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -5,6 +5,11 @@
   "priority": 20,
   "version": 1,
   "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
     "aliases": {
       "zeebe-record-message-subscription": {}
     },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
@@ -2,12 +2,13 @@
   "index_patterns": [
     "zeebe-record_message_*"
   ],
-  "order": 20,
-  "aliases": {
-    "zeebe-record-message": {}
-  },
-  "mappings": {
-    "_doc": {
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "aliases": {
+      "zeebe-record-message": {}
+    },
+    "mappings": {
       "properties": {
         "value": {
           "dynamic": "strict",

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
@@ -5,6 +5,11 @@
   "priority": 20,
   "version": 1,
   "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
     "aliases": {
       "zeebe-record-message": {}
     },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
@@ -2,12 +2,13 @@
   "index_patterns": [
     "zeebe-record_process-instance-creation_*"
   ],
-  "order": 20,
-  "aliases": {
-    "zeebe-record-process-instance-creation": {}
-  },
-  "mappings": {
-    "_doc": {
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "aliases": {
+      "zeebe-record-process-instance-creation": {}
+    },
+    "mappings": {
       "properties": {
         "value": {
           "dynamic": "strict",

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
@@ -5,6 +5,11 @@
   "priority": 20,
   "version": 1,
   "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
     "aliases": {
       "zeebe-record-process-instance-creation": {}
     },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -6,7 +6,9 @@
   "version": 1,
   "template": {
     "settings": {
-      "number_of_shards": 3
+      "number_of_shards": 3,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
     },
     "aliases": {
       "zeebe-record-process-instance": {}

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -2,15 +2,16 @@
   "index_patterns": [
     "zeebe-record_process-instance_*"
   ],
-  "order": 20,
-  "settings": {
-    "number_of_shards": 3
-  },
-  "aliases": {
-    "zeebe-record-process-instance": {}
-  },
-  "mappings": {
-    "_doc": {
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 3
+    },
+    "aliases": {
+      "zeebe-record-process-instance": {}
+    },
+    "mappings": {
       "properties": {
         "value": {
           "dynamic": "strict",

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
@@ -2,12 +2,13 @@
   "index_patterns": [
     "zeebe-record_process-message-subscription_*"
   ],
-  "order": 20,
-  "aliases": {
-    "zeebe-record-process-message-subscription": {}
-  },
-  "mappings": {
-    "_doc": {
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "aliases": {
+      "zeebe-record-process-message-subscription": {}
+    },
+    "mappings": {
       "properties": {
         "value": {
           "dynamic": "strict",

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
@@ -5,6 +5,11 @@
   "priority": 20,
   "version": 1,
   "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
     "aliases": {
       "zeebe-record-process-message-subscription": {}
     },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -2,17 +2,18 @@
   "index_patterns": [
     "zeebe-record_*"
   ],
-  "order": 10,
-  "settings": {
-    "number_of_shards": 1,
-    "number_of_replicas": 0,
-    "index.queries.cache.enabled": false
-  },
-  "aliases": {
-    "zeebe-record": {}
-  },
-  "mappings": {
-    "_doc": {
+  "priority": 10,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record": {}
+    },
+    "mappings": {
       "dynamic": "strict",
       "properties": {
         "position": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-document-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-document-template.json
@@ -5,6 +5,11 @@
   "priority": 20,
   "version": 1,
   "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
     "aliases": {
       "zeebe-record-variable-document": {}
     },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-document-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-document-template.json
@@ -2,12 +2,13 @@
   "index_patterns": [
     "zeebe-record_variable-document_*"
   ],
-  "order": 20,
-  "aliases": {
-    "zeebe-record-variable-document": {}
-  },
-  "mappings": {
-    "_doc": {
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "aliases": {
+      "zeebe-record-variable-document": {}
+    },
+    "mappings": {
       "properties": {
         "value": {
           "dynamic": "strict",

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
@@ -2,12 +2,13 @@
   "index_patterns": [
     "zeebe-record_variable_*"
   ],
-  "order": 20,
-  "aliases": {
-    "zeebe-record-variable": {}
-  },
-  "mappings": {
-    "_doc": {
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "aliases": {
+      "zeebe-record-variable": {}
+    },
+    "mappings": {
       "properties": {
         "value": {
           "dynamic": "strict",

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
@@ -5,6 +5,11 @@
   "priority": 20,
   "version": 1,
   "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
     "aliases": {
       "zeebe-record-variable": {}
     },


### PR DESCRIPTION
## Description

This PR migrates the index templates from the legacy API to the current API. This notably changes the index template format, as well as the endpoint where they are PUT. Adds a first version to the template.

Removes deprecated type fields from bulk operations and the indexes themselves as well.

See https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html#_typeless_apis_in_7_0 regarding the removal of types and introduction of typeless APIs, and https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-template.html about the new index template APIs (as opposed to the legacy ones at https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html)

## Related issues

closes #6868

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
