### PR TITLE
Remove deprecated code from engine

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/TypedStreamWriterProxy.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/bpmn/behavior/TypedStreamWriterProxy.java
@@ -9,11 +9,9 @@ package io.zeebe.engine.processing.bpmn.behavior;
 
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
-import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.Intent;
-import java.util.function.UnaryOperator;
 
 public final class TypedStreamWriterProxy implements TypedStreamWriter {
 
@@ -32,15 +30,6 @@ public final class TypedStreamWriterProxy implements TypedStreamWriter {
   }
 
   @Override
-  public void appendRejection(
-      final TypedRecord<? extends RecordValue> command,
-      final RejectionType type,
-      final String reason,
-      final UnaryOperator<RecordMetadata> modifier) {
-    writer.appendRejection(command, type, reason, modifier);
-  }
-
-  @Override
   public void configureSourceContext(final long sourceRecordPosition) {
     writer.configureSourceContext(sourceRecordPosition);
   }
@@ -51,15 +40,6 @@ public final class TypedStreamWriterProxy implements TypedStreamWriter {
   }
 
   @Override
-  public void appendFollowUpEvent(
-      final long key,
-      final Intent intent,
-      final RecordValue value,
-      final UnaryOperator<RecordMetadata> modifier) {
-    writer.appendFollowUpEvent(key, intent, value, modifier);
-  }
-
-  @Override
   public void appendNewCommand(final Intent intent, final RecordValue value) {
     writer.appendNewCommand(intent, value);
   }
@@ -67,15 +47,6 @@ public final class TypedStreamWriterProxy implements TypedStreamWriter {
   @Override
   public void appendFollowUpCommand(final long key, final Intent intent, final RecordValue value) {
     writer.appendFollowUpCommand(key, intent, value);
-  }
-
-  @Override
-  public void appendFollowUpCommand(
-      final long key,
-      final Intent intent,
-      final RecordValue value,
-      final UnaryOperator<RecordMetadata> modifier) {
-    writer.appendFollowUpCommand(key, intent, value, modifier);
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -11,8 +11,6 @@ import io.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
-import io.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
-import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.immutable.ElementInstanceState;
 import io.zeebe.engine.state.immutable.JobState;
 import io.zeebe.engine.state.immutable.ZeebeState;
@@ -27,14 +25,12 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
   private final JobState jobState;
   private final ElementInstanceState elementInstanceState;
   private final DefaultJobCommandPreconditionGuard<JobRecord> defaultProcessor;
-  private final TypedEventWriter eventWriter;
 
-  public JobCompleteProcessor(final ZeebeState state, final Writers writers) {
+  public JobCompleteProcessor(final ZeebeState state) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
     defaultProcessor =
         new DefaultJobCommandPreconditionGuard<>("complete", jobState, this::acceptCommand);
-    eventWriter = writers.events();
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobEventProcessors.java
@@ -32,7 +32,7 @@ public final class JobEventProcessors {
     final var keyGenerator = zeebeState.getKeyGenerator();
 
     typedRecordProcessors
-        .onCommand(ValueType.JOB, JobIntent.COMPLETE, new JobCompleteProcessor(zeebeState, writers))
+        .onCommand(ValueType.JOB, JobIntent.COMPLETE, new JobCompleteProcessor(zeebeState))
         .onCommand(
             ValueType.JOB,
             JobIntent.FAIL,

--- a/engine/src/main/java/io/zeebe/engine/processing/job/JobTimeoutTrigger.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/job/JobTimeoutTrigger.java
@@ -13,7 +13,6 @@ import io.zeebe.engine.processing.streamprocessor.ReadonlyProcessingContext;
 import io.zeebe.engine.processing.streamprocessor.StreamProcessorLifecycleAware;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.zeebe.engine.state.immutable.JobState;
-import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.JobIntent;
 import io.zeebe.util.sched.ScheduledTimer;
 import java.time.Duration;
@@ -77,8 +76,7 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
     state.forEachTimedOutEntry(
         now,
         (key, record) -> {
-          writer.appendFollowUpCommand(
-              key, JobIntent.TIME_OUT, record, (m) -> m.valueType(ValueType.JOB));
+          writer.appendFollowUpCommand(key, JobIntent.TIME_OUT, record);
 
           final boolean flushed = writer.flush() >= 0;
           if (!flushed) {

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/EventApplyingStateWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/EventApplyingStateWriter.java
@@ -8,10 +8,8 @@
 package io.zeebe.engine.processing.streamprocessor.writers;
 
 import io.zeebe.engine.state.EventApplier;
-import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.intent.Intent;
-import java.util.function.UnaryOperator;
 
 /**
  * A state writer that uses the event applier, to alter the state for each written event.
@@ -22,8 +20,6 @@ import java.util.function.UnaryOperator;
  * <p>Note that it does not change the state itself, but delegates this to the {@link EventApplier}.
  */
 public final class EventApplyingStateWriter implements StateWriter {
-
-  private static final UnaryOperator<RecordMetadata> NO_MODIFIER = UnaryOperator.identity();
 
   private final TypedEventWriter eventWriter;
   private final EventApplier eventApplier;
@@ -36,16 +32,7 @@ public final class EventApplyingStateWriter implements StateWriter {
 
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
-    appendFollowUpEvent(key, intent, value, NO_MODIFIER);
-  }
-
-  @Override
-  public void appendFollowUpEvent(
-      final long key,
-      final Intent intent,
-      final RecordValue value,
-      final UnaryOperator<RecordMetadata> modifier) {
-    eventWriter.appendFollowUpEvent(key, intent, value, modifier);
+    eventWriter.appendFollowUpEvent(key, intent, value);
     eventApplier.applyState(key, intent, value);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/NoopTypedStreamWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/NoopTypedStreamWriter.java
@@ -8,11 +8,9 @@
 package io.zeebe.engine.processing.streamprocessor.writers;
 
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
-import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.Intent;
-import java.util.function.UnaryOperator;
 
 public final class NoopTypedStreamWriter implements TypedStreamWriter {
 
@@ -21,15 +19,6 @@ public final class NoopTypedStreamWriter implements TypedStreamWriter {
       final TypedRecord<? extends RecordValue> command,
       final RejectionType type,
       final String reason) {
-    // no op implementation
-  }
-
-  @Override
-  public void appendRejection(
-      final TypedRecord<? extends RecordValue> command,
-      final RejectionType type,
-      final String reason,
-      final UnaryOperator<RecordMetadata> modifier) {
     // no op implementation
   }
 
@@ -44,30 +33,12 @@ public final class NoopTypedStreamWriter implements TypedStreamWriter {
   }
 
   @Override
-  public void appendFollowUpEvent(
-      final long key,
-      final Intent intent,
-      final RecordValue value,
-      final UnaryOperator<RecordMetadata> modifier) {
-    // no op implementation
-  }
-
-  @Override
   public void appendNewCommand(final Intent intent, final RecordValue value) {
     // no op implementation
   }
 
   @Override
   public void appendFollowUpCommand(final long key, final Intent intent, final RecordValue value) {
-    // no op implementation
-  }
-
-  @Override
-  public void appendFollowUpCommand(
-      final long key,
-      final Intent intent,
-      final RecordValue value,
-      final UnaryOperator<RecordMetadata> modifier) {
     // no op implementation
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/ReprocessingStreamWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/ReprocessingStreamWriter.java
@@ -8,14 +8,12 @@
 package io.zeebe.engine.processing.streamprocessor.writers;
 
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
-import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.RecordType;
 import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.RejectionType;
 import io.zeebe.protocol.record.intent.Intent;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.UnaryOperator;
 
 public final class ReprocessingStreamWriter implements TypedStreamWriter {
 
@@ -39,39 +37,12 @@ public final class ReprocessingStreamWriter implements TypedStreamWriter {
   }
 
   @Override
-  public void appendRejection(
-      final TypedRecord<? extends RecordValue> command,
-      final RejectionType type,
-      final String reason,
-      final UnaryOperator<RecordMetadata> modifier) {
-
-    final var record =
-        new ReprocessingRecord(
-            command.getKey(),
-            sourceRecordPosition,
-            command.getIntent(),
-            RecordType.COMMAND_REJECTION);
-    records.add(record);
-  }
-
-  @Override
   public void configureSourceContext(final long sourceRecordPosition) {
     this.sourceRecordPosition = sourceRecordPosition;
   }
 
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
-
-    final var record = new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.EVENT);
-    records.add(record);
-  }
-
-  @Override
-  public void appendFollowUpEvent(
-      final long key,
-      final Intent intent,
-      final RecordValue value,
-      final UnaryOperator<RecordMetadata> modifier) {
 
     final var record = new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.EVENT);
     records.add(record);
@@ -87,18 +58,6 @@ public final class ReprocessingStreamWriter implements TypedStreamWriter {
 
   @Override
   public void appendFollowUpCommand(final long key, final Intent intent, final RecordValue value) {
-
-    final var record =
-        new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.COMMAND);
-    records.add(record);
-  }
-
-  @Override
-  public void appendFollowUpCommand(
-      final long key,
-      final Intent intent,
-      final RecordValue value,
-      final UnaryOperator<RecordMetadata> modifier) {
 
     final var record =
         new ReprocessingRecord(key, sourceRecordPosition, intent, RecordType.COMMAND);

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedCommandWriter.java
@@ -7,10 +7,8 @@
  */
 package io.zeebe.engine.processing.streamprocessor.writers;
 
-import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.intent.Intent;
-import java.util.function.UnaryOperator;
 
 /** Things that any actor can write to a partition. */
 public interface TypedCommandWriter {
@@ -18,14 +16,6 @@ public interface TypedCommandWriter {
   void appendNewCommand(Intent intent, RecordValue value);
 
   void appendFollowUpCommand(long key, Intent intent, RecordValue value);
-
-  /**
-   * @deprecated The modifier parameter is used, but at the time of writing unnecessarily by {@link
-   *     io.zeebe.engine.processing.job.JobTimeoutTrigger}
-   */
-  @Deprecated
-  void appendFollowUpCommand(
-      long key, Intent intent, RecordValue value, UnaryOperator<RecordMetadata> modifier);
 
   void reset();
 

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedEventWriter.java
@@ -7,17 +7,10 @@
  */
 package io.zeebe.engine.processing.streamprocessor.writers;
 
-import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.intent.Intent;
-import java.util.function.UnaryOperator;
 
 public interface TypedEventWriter {
 
   void appendFollowUpEvent(long key, Intent intent, RecordValue value);
-
-  /** @deprecated The modifier parameter is not used at the time of writing */
-  @Deprecated
-  void appendFollowUpEvent(
-      long key, Intent intent, RecordValue value, UnaryOperator<RecordMetadata> modifier);
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedRejectionWriter.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/TypedRejectionWriter.java
@@ -8,21 +8,11 @@
 package io.zeebe.engine.processing.streamprocessor.writers;
 
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
-import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.RejectionType;
-import java.util.function.UnaryOperator;
 
 public interface TypedRejectionWriter {
 
   void appendRejection(
       TypedRecord<? extends RecordValue> command, RejectionType type, String reason);
-
-  /** @deprecated The modifier parameter is not used at the time of writing */
-  @Deprecated
-  void appendRejection(
-      TypedRecord<? extends RecordValue> command,
-      RejectionType type,
-      String reason,
-      UnaryOperator<RecordMetadata> modifier);
 }

--- a/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/Writers.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/streamprocessor/writers/Writers.java
@@ -44,10 +44,4 @@ public final class Writers {
   public TypedResponseWriter response() {
     return response;
   }
-
-  // todo (#6202): remove after migrations finished
-  @Deprecated
-  public TypedEventWriter events() {
-    return stream;
-  }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/deployment/PersistedProcess.java
+++ b/engine/src/main/java/io/zeebe/engine/state/deployment/PersistedProcess.java
@@ -13,7 +13,6 @@ import io.zeebe.msgpack.property.BinaryProperty;
 import io.zeebe.msgpack.property.IntegerProperty;
 import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.StringProperty;
-import io.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
 import io.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import org.agrona.DirectBuffer;
 
@@ -30,19 +29,6 @@ public final class PersistedProcess extends UnpackedObject implements DbValue {
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(resourceNameProp)
         .declareProperty(resourceProp);
-  }
-
-  @Deprecated
-  public void wrap(
-      final DeploymentResource resource,
-      final ProcessRecord processRecord,
-      final long processDefinitionKey) {
-    bpmnProcessIdProp.setValue(processRecord.getBpmnProcessIdBuffer());
-    resourceNameProp.setValue(resource.getResourceNameBuffer());
-    resourceProp.setValue(resource.getResourceBuffer());
-
-    versionProp.setValue(processRecord.getVersion());
-    keyProp.setValue(processDefinitionKey);
   }
 
   public void wrap(final ProcessRecord processRecord, final long processDefinitionKey) {

--- a/engine/src/test/java/io/zeebe/engine/processing/job/JobTimeoutTriggerTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/job/JobTimeoutTriggerTest.java
@@ -75,11 +75,11 @@ public final class JobTimeoutTriggerTest {
 
     inOrder
         .verify(typedStreamWriter)
-        .appendFollowUpCommand(eq(0L), eq(JobIntent.TIME_OUT), any(JobRecord.class), any());
+        .appendFollowUpCommand(eq(0L), eq(JobIntent.TIME_OUT), any(JobRecord.class));
     inOrder.verify(typedStreamWriter).flush();
     inOrder
         .verify(typedStreamWriter)
-        .appendFollowUpCommand(eq(1L), eq(JobIntent.TIME_OUT), any(JobRecord.class), any());
+        .appendFollowUpCommand(eq(1L), eq(JobIntent.TIME_OUT), any(JobRecord.class));
     inOrder.verify(typedStreamWriter).flush();
     inOrder.verify(typedStreamWriter).reset();
     inOrder.verifyNoMoreInteractions();

--- a/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/streamprocessor/StreamProcessorHealthTest.java
@@ -19,7 +19,6 @@ import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.state.mutable.MutableZeebeState;
 import io.zeebe.engine.util.StreamProcessorRule;
-import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.RejectionType;
@@ -31,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -236,28 +234,10 @@ public class StreamProcessorHealthTest {
         final String reason) {}
 
     @Override
-    public void appendRejection(
-        final TypedRecord<? extends RecordValue> command,
-        final RejectionType type,
-        final String reason,
-        final UnaryOperator<RecordMetadata> modifier) {}
-
-    @Override
     public void configureSourceContext(final long sourceRecordPosition) {}
 
     @Override
     public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
-      if (shouldFailErrorHandlingInTransaction.get()) {
-        throw new RuntimeException("Expected failure on append followup event");
-      }
-    }
-
-    @Override
-    public void appendFollowUpEvent(
-        final long key,
-        final Intent intent,
-        final RecordValue value,
-        final UnaryOperator<RecordMetadata> modifier) {
       if (shouldFailErrorHandlingInTransaction.get()) {
         throw new RuntimeException("Expected failure on append followup event");
       }
@@ -269,13 +249,6 @@ public class StreamProcessorHealthTest {
     @Override
     public void appendFollowUpCommand(
         final long key, final Intent intent, final RecordValue value) {}
-
-    @Override
-    public void appendFollowUpCommand(
-        final long key,
-        final Intent intent,
-        final RecordValue value,
-        final UnaryOperator<RecordMetadata> modifier) {}
 
     @Override
     public void reset() {}

--- a/engine/src/test/java/io/zeebe/engine/util/RecordingTypedEventWriter.java
+++ b/engine/src/test/java/io/zeebe/engine/util/RecordingTypedEventWriter.java
@@ -8,12 +8,10 @@
 package io.zeebe.engine.util;
 
 import io.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
-import io.zeebe.protocol.impl.record.RecordMetadata;
 import io.zeebe.protocol.record.RecordValue;
 import io.zeebe.protocol.record.intent.Intent;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.function.UnaryOperator;
 
 /**
  * An event writer which simply records follow up events in a thread-safe way. Can be passed to a
@@ -31,15 +29,6 @@ public final class RecordingTypedEventWriter implements TypedEventWriter {
   @Override
   public void appendFollowUpEvent(final long key, final Intent intent, final RecordValue value) {
     events.add(new RecordedEvent<>(key, intent, value));
-  }
-
-  @Override
-  public void appendFollowUpEvent(
-      final long key,
-      final Intent intent,
-      final RecordValue value,
-      final UnaryOperator<RecordMetadata> modifier) {
-    appendFollowUpEvent(key, intent, value);
   }
 
   public static final class RecordedEvent<T extends RecordValue> {


### PR DESCRIPTION
## Description

Remove deprecated code from the engine, like:

 * append with modifier from writers
 * wrap method
 * EventWritter from Writers

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related #6863 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
