### PR TITLE
refactor(broker): handle corruption at exporter

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -79,7 +79,11 @@ import org.slf4j.Logger;
  *                                 |informs
  *                                 |upwards   +-----+
  *                                 |----------| Log |
- *                                            +-----+
+ *                                 |          +-----+
+ *                                 |informs
+ *                                 |upwards   +------------------+
+ *                                 |----------| ExporterDirector |
+ *                                            +------------------+
  *
  * https://textik.com/#cb084adedb02d970
  */

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/ZeebePartition.java
@@ -273,7 +273,7 @@ public final class ZeebePartition extends Actor
 
   @Override
   public void onUnrecoverableFailure() {
-    actor.run(() -> handleUnrecoverableFailure());
+    actor.run(this::handleUnrecoverableFailure);
   }
 
   private void onInstallFailure(final long term, final Throwable error) {
@@ -295,11 +295,10 @@ public final class ZeebePartition extends Actor
         .forEach(l -> l.onBecomingInactive(context.getPartitionId(), term));
 
     if (context.getRaftPartition().getRole() == Role.LEADER) {
-      LOG.info("Unexpected failures occurred when installing leader services, stepping down");
+      LOG.info("Unexpected failure occurred, stepping down");
       context.getRaftPartition().stepDown();
     } else {
-      LOG.info(
-          "Unexpected failures occurred when installing follower services, transitioning to inactive");
+      LOG.info("Unexpected failure occurred, transitioning to inactive");
       context.getRaftPartition().goInactive();
     }
   }

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
@@ -15,6 +15,7 @@ import io.zeebe.util.sched.Actor;
 import io.zeebe.util.sched.future.ActorFuture;
 
 public class ExporterDirectorPartitionStep implements PartitionStep {
+
   private static final int EXPORTER_PROCESSOR_ID = 1003;
 
   @Override
@@ -31,6 +32,8 @@ public class ExporterDirectorPartitionStep implements PartitionStep {
 
     final ExporterDirector director = new ExporterDirector(exporterCtx, !context.shouldExport());
     context.setExporterDirector(director);
+    context.getComponentHealthMonitor().registerComponent(director.getName(), director);
+
     final var startFuture = director.startAsync(context.getScheduler());
     startFuture.onComplete(
         (nothing, error) -> {

--- a/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/broker/src/test/java/io/zeebe/broker/exporter/stream/ExporterRule.java
@@ -83,6 +83,10 @@ public final class ExporterRule implements TestRule {
     director.startAsync(actorSchedulerRule.get()).join();
   }
 
+  public ExporterDirector getDirector() {
+    return director;
+  }
+
   public ControlledActorClock getClock() {
     return clock;
   }

--- a/util/src/main/java/io/zeebe/util/health/FailureListener.java
+++ b/util/src/main/java/io/zeebe/util/health/FailureListener.java
@@ -21,7 +21,7 @@ public interface FailureListener {
   void onRecovered();
 
   /**
-   * Invoked when the health status becomes dead and the system can't becomes healthy again without
+   * Invoked when the health status becomes dead and the system can't become healthy again without
    * external intervention.
    */
   void onUnrecoverableFailure();

--- a/util/src/main/java/io/zeebe/util/sched/Actor.java
+++ b/util/src/main/java/io/zeebe/util/sched/Actor.java
@@ -80,8 +80,6 @@ public abstract class Actor implements CloseableSilently, AsyncClosable {
 
   /**
    * Invoked when a task throws an exception when the actor phase is not 'STARTING' and 'CLOSING'.
-   *
-   * @param failure
    */
   protected void handleFailure(final Exception failure) {
     Loggers.ACTOR_LOGGER.error(


### PR DESCRIPTION
## Description

Handles corruption in the exporter by propagating the unrecoverable failure status to the zeebe partition. There's already a test to cover that this results in going inactive.
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6697 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
