### PR TITLE
Reduce redundancy of tests for TransientSnapshotTest

### DIFF
--- a/snapshot/pom.xml
+++ b/snapshot/pom.xml
@@ -19,18 +19,22 @@
       <groupId>io.zeebe</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
+
     <dependency>
       <artifactId>simpleclient</artifactId>
       <groupId>io.prometheus</groupId>
     </dependency>
+
     <dependency>
       <artifactId>zeebe-protocol</artifactId>
       <groupId>io.zeebe</groupId>
     </dependency>
+
     <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -41,11 +45,7 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -130,7 +130,7 @@ public class FileBasedReceivedSnapshotTest {
     // then
     assertThat(receiverSnapshotsDir)
         .as("there is only the latest snapshot in the receiver's snapshot directory")
-        .isDirectoryContaining(p -> p.equals(secondReceivedPersistedSnapshot.getPath()));
+        .isDirectoryNotContaining(p -> !p.equals(secondReceivedPersistedSnapshot.getPath()));
   }
 
   @Test
@@ -148,7 +148,8 @@ public class FileBasedReceivedSnapshotTest {
     assertThat(receiverPendingDir)
         .as(
             "the latest pending snapshot should not be deleted because it is newer than the persisted one")
-        .isDirectoryContaining(p -> p.equals(receivedSnapshot.getPath()));
+        .isDirectoryContaining(p -> p.equals(receivedSnapshot.getPath()))
+        .isDirectoryNotContaining(p -> !p.equals(receivedSnapshot.getPath()));
   }
 
   @Test
@@ -207,7 +208,8 @@ public class FileBasedReceivedSnapshotTest {
 
     assertThat(receivedSnapshot.getPath())
         .as("the received snapshot should contain only the first chunk")
-        .isDirectoryContaining(p -> p.getFileName().toString().equals(firstChunk.getChunkName()));
+        .isDirectoryNotContaining(
+            p -> !p.getFileName().toString().equals(firstChunk.getChunkName()));
   }
 
   @Test
@@ -230,7 +232,8 @@ public class FileBasedReceivedSnapshotTest {
     // then
     assertThat(receivedSnapshot.getPath())
         .as("the received snapshot should contain only the first chunk")
-        .isDirectoryContaining(p -> p.getFileName().toString().equals(firstChunk.getChunkName()));
+        .isDirectoryNotContaining(
+            p -> !p.getFileName().toString().equals(firstChunk.getChunkName()));
   }
 
   @Test
@@ -254,7 +257,8 @@ public class FileBasedReceivedSnapshotTest {
     // then
     assertThat(receivedSnapshot.getPath())
         .as("the received snapshot should contain only the first chunk")
-        .isDirectoryContaining(p -> p.getFileName().toString().equals(firstChunk.getChunkName()));
+        .isDirectoryNotContaining(
+            p -> !p.getFileName().toString().equals(firstChunk.getChunkName()));
   }
 
   @Test
@@ -278,7 +282,8 @@ public class FileBasedReceivedSnapshotTest {
     // then
     assertThat(receivedSnapshot.getPath())
         .as("the received snapshot should contain only the first chunk")
-        .isDirectoryContaining(p -> p.getFileName().toString().equals(firstChunk.getChunkName()));
+        .isDirectoryNotContaining(
+            p -> !p.getFileName().toString().equals(firstChunk.getChunkName()));
   }
 
   private ReceivedSnapshot receiveSnapshot(final PersistedSnapshot persistedSnapshot)

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -19,7 +19,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.List;
 import java.util.Map;
 import org.agrona.IoUtil;
 import org.junit.Before;
@@ -121,24 +120,6 @@ public class FileBasedTransientSnapshotTest {
   }
 
   @Test
-  public void shouldPurgePendingSnapshots() {
-    // given
-    final var transientSnapshots =
-        List.of(
-            snapshotStore.newTransientSnapshot(1L, 2L, 1L, 0L).orElseThrow(),
-            snapshotStore.newTransientSnapshot(2L, 2L, 1L, 0L).orElseThrow());
-    transientSnapshots.forEach(s -> s.take(this::writeSnapshot).join());
-
-    // when
-    snapshotStore.purgePendingSnapshots().join();
-
-    // then
-    assertThat(pendingDir)
-        .as("there are no more transient snapshots after purge")
-        .isEmptyDirectory();
-  }
-
-  @Test
   public void shouldNotDeletePersistedSnapshotOnPurge() {
     // given
     final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
@@ -159,7 +140,7 @@ public class FileBasedTransientSnapshotTest {
   }
 
   @Test
-  public void shouldDeleteTransientDirectoryOnPersist() {
+  public void shouldDeleteOlderTransientDirectoryOnPersist() {
     // given
     final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
     transientSnapshot.take(this::writeSnapshot).join();

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/PersistedSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/PersistedSnapshotTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.snapshots.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.snapshots.ConstructableSnapshotStore;
+import io.zeebe.util.FileUtil;
+import io.zeebe.util.sched.testing.ActorSchedulerRule;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public final class PersistedSnapshotTest {
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Rule public ActorSchedulerRule scheduler = new ActorSchedulerRule();
+
+  private ConstructableSnapshotStore snapshotStore;
+
+  @Before
+  public void beforeEach() {
+    final int partitionId = 1;
+    final File root = temporaryFolder.getRoot();
+    final FileBasedSnapshotStoreFactory factory =
+        new FileBasedSnapshotStoreFactory(scheduler.get(), 1);
+
+    factory.createReceivableSnapshotStore(root.toPath(), partitionId);
+    snapshotStore = factory.getConstructableSnapshotStore(partitionId);
+  }
+
+  @Test
+  public void shouldDeleteSnapshot() {
+    // given
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+    transientSnapshot.take(this::writeSnapshot);
+    final var persistedSnapshot = transientSnapshot.persist().join();
+
+    // when
+    persistedSnapshot.delete();
+
+    // then
+    assertThat(persistedSnapshot.getPath()).doesNotExist();
+  }
+
+  private boolean writeSnapshot(final Path path) {
+    try {
+      FileUtil.ensureDirectoryExists(path);
+      Files.writeString(path.resolve("file"), "contents");
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return true;
+  }
+}

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/TransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/TransientSnapshotTest.java
@@ -9,15 +9,13 @@ package io.zeebe.snapshots.impl;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import io.zeebe.snapshots.ConstructableSnapshotStore;
+import io.zeebe.snapshots.PersistedSnapshot;
 import io.zeebe.snapshots.PersistedSnapshotListener;
 import io.zeebe.util.FileUtil;
+import io.zeebe.util.sched.future.ActorFuture;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.File;
 import java.io.IOException;
@@ -25,383 +23,353 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.concurrent.CompletableFuture;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class TransientSnapshotTest {
+  private static final Map<String, String> SNAPSHOT_FILE_CONTENTS =
+      Map.of(
+          "file1", "file1 contents",
+          "file2", "file2 contents");
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   @Rule public ActorSchedulerRule scheduler = new ActorSchedulerRule();
 
-  private ConstructableSnapshotStore persistedSnapshotStore;
-  private Path lastTransientSnapshotPath;
+  private ConstructableSnapshotStore snapshotStore;
 
   @Before
-  public void before() {
-    final FileBasedSnapshotStoreFactory factory =
-        new FileBasedSnapshotStoreFactory(scheduler.get(), 1);
+  public void beforeEach() {
     final int partitionId = 1;
     final File root = temporaryFolder.getRoot();
+    final FileBasedSnapshotStoreFactory factory =
+        new FileBasedSnapshotStoreFactory(scheduler.get(), 1);
 
     factory.createReceivableSnapshotStore(root.toPath(), partitionId);
-    persistedSnapshotStore = factory.getConstructableSnapshotStore(partitionId);
+    snapshotStore = factory.getConstructableSnapshotStore(partitionId);
   }
 
   @Test
-  public void shouldTransientPathContainsMetadata() {
-    // given
-    final var index = 1L;
-    final var term = 2L;
-    final var transientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 3, 4).orElseThrow();
-    final CompletableFuture<Path> transientPath = new CompletableFuture<>();
-
+  public void shouldHaveCorrectSnapshotId() {
     // when
-    transientSnapshot.take(
-        p -> {
-          transientPath.complete(p);
-          return true;
-        });
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+    final var snapshotId = transientSnapshot.snapshotId();
 
     // then
-    final var path = transientPath.join();
-    final var metadata =
-        FileBasedSnapshotMetadata.ofFileName(path.getFileName().toString()).orElseThrow();
-    assertThat(metadata.getIndex()).isEqualTo(1);
-    assertThat(metadata.getTerm()).isEqualTo(2);
-    assertThat(metadata.getProcessedPosition()).isEqualTo(3);
-    assertThat(metadata.getExportedPosition()).isEqualTo(4);
+    assertThat(snapshotId.getIndex()).as("the ID has the right index").isEqualTo(1L);
+    assertThat(snapshotId.getTerm()).as("the ID has the right term").isEqualTo(2L);
+    assertThat(snapshotId.getProcessedPosition())
+        .as("the ID has the right processed position")
+        .isEqualTo(3L);
+    assertThat(snapshotId.getExportedPosition())
+        .as("the ID has the right exported position")
+        .isEqualTo(4L);
   }
 
   @Test
-  public void shouldReturnTrueOnSuccessTake() {
+  public void shouldAbortSuccessfullyEvenIfNothingWasWritten() {
     // given
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
 
     // when
-    final var success =
-        transientSnapshot
-            .take(
-                p -> {
-                  try {
-                    FileUtil.ensureDirectoryExists(p);
-                    Files.createFile(p.resolve("file"));
-                    return true;
-                  } catch (final IOException e) {
-                    throw new UncheckedIOException(e);
-                  }
-                })
-            .join();
+    final ActorFuture<Void> didAbort = transientSnapshot.abort();
 
     // then
-    assertThat(success).isTrue();
+    assertThat(didAbort)
+        .as("the transient snapshot was aborted successfully")
+        .succeedsWithin(Duration.ofSeconds(5));
+  }
+
+  @Test
+  public void shouldNotCommitUntilPersisted() {
+    // given
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+
+    // when
+    transientSnapshot.take(this::writeSnapshot).join();
+
+    // then
+    assertThat(snapshotStore.getLatestSnapshot())
+        .as("there should be no persisted snapshot")
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldTakeTransientSnapshot() {
+    // given
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
+
+    // when
+    final var didWriteSnapshot = transientSnapshot.take(this::writeSnapshot).join();
+
+    // then
+    assertThat(didWriteSnapshot).as("the transient snapshot was successfully written").isTrue();
   }
 
   @Test
   public void shouldReturnFalseOnFailureTake() {
     // given
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
 
     // when
-    final var success = transientSnapshot.take(p -> false).join();
+    final var didTakeSnapshot = transientSnapshot.take(p -> false).join();
 
     // then
-    assertThat(success).isFalse();
+    assertThat(didTakeSnapshot)
+        .as("failed to take snapshot since the callback returned false")
+        .isFalse();
   }
 
   @Test
   public void shouldCompleteExceptionallyOnExceptionInTake() {
     // given
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
 
     // when
-    final var success =
+    final var didTakeSnapshot =
         transientSnapshot.take(
             p -> {
               throw new RuntimeException("EXPECTED");
             });
 
     // then
-    assertThatThrownBy(success::join)
+    assertThatThrownBy(didTakeSnapshot::join)
+        .as("did not take snapshot due to exception thrown in callback")
         .hasCauseInstanceOf(RuntimeException.class)
         .hasMessageContaining("EXPECTED");
   }
 
   @Test
-  public void shouldFailToPersistWhenTakeDoesnotWrite() {
-    // given
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    transientSnapshot.take(p -> true).join();
-
-    // when - then
-    assertThatThrownBy(() -> transientSnapshot.persist().join())
-        .hasCauseInstanceOf(IllegalStateException.class);
-  }
-
-  @Test
   public void shouldBeAbleToAbortNotStartedSnapshot() {
     // given
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 2L, 3L, 4L).orElseThrow();
 
-    // when - then
-    assertThatCode(transientSnapshot::abort).doesNotThrowAnyException();
+    // when
+    final ActorFuture<Void> didAbort = transientSnapshot.abort();
+
+    // then
+    assertThat(didAbort)
+        .as("did abort even if nothing was written")
+        .succeedsWithin(Duration.ofSeconds(5));
   }
 
   @Test
-  public void shouldPersistTransientSnapshot() {
+  public void shouldPersistSnapshotWithCorrectId() {
     // given
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    transientSnapshot.take(this::takeSnapshot);
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    transientSnapshot.take(this::writeSnapshot).join();
 
     // when
     final var persistedSnapshot = transientSnapshot.persist().join();
 
     // then
-    assertThat(persistedSnapshot.getIndex()).isEqualTo(1L);
-    assertThat(persistedSnapshot.getTerm()).isZero();
-
-    final var snapshotPath = persistedSnapshot.getPath();
-    assertThat(snapshotPath).exists().isNotEqualTo(lastTransientSnapshotPath);
-    assertThat(lastTransientSnapshotPath).doesNotExist();
-
-    final var committedSnapshotDir = snapshotPath.toFile();
-    assertThat(committedSnapshotDir).hasName(persistedSnapshot.getId());
-    assertThat(committedSnapshotDir.listFiles())
-        .extracting(File::getName)
-        .containsExactlyInAnyOrder("file1.txt", "CHECKSUM");
+    assertThat(persistedSnapshot.getId())
+        .as("the persisted snapshot as the same ID as the transient snapshot")
+        .isEqualTo(transientSnapshot.snapshotId().getSnapshotIdAsString());
   }
 
   @Test
-  public void shouldDeleteSnapshot() {
+  public void shouldPersistSnapshot() {
     // given
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    transientSnapshot.take(this::takeSnapshot);
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    transientSnapshot.take(this::writeSnapshot);
+
+    // when
     final var persistedSnapshot = transientSnapshot.persist().join();
 
-    // when
-    persistedSnapshot.delete();
-
     // then
-    final var snapshotPath = persistedSnapshot.getPath();
-    assertThat(snapshotPath).doesNotExist();
-    assertThat(lastTransientSnapshotPath).doesNotExist();
+    // TODO(npepinpe): compare checksums once the property is added to the PersistedSnapshot
+    // interface
+    assertThat(persistedSnapshot)
+        .as("the persisted snapshot should be the latest snapshot")
+        .isEqualTo(snapshotStore.getLatestSnapshot().orElseThrow());
   }
 
   @Test
-  public void shouldNewSnapshotShouldBeLargerThenOlder() {
+  public void shouldReplacePreviousSnapshotOnPersist() {
     // given
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    transientSnapshot.take(this::takeSnapshot);
-    final var previousSnapshot = transientSnapshot.persist().join();
+    final var oldSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    oldSnapshot.take(this::writeSnapshot);
+    oldSnapshot.persist().join();
 
     // when
-    final var newTransientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index + 1, term, 1, 0).orElseThrow();
-    newTransientSnapshot.take(this::takeSnapshot);
-    final var persistedSnapshot = newTransientSnapshot.persist().join();
-
-    // then
-    assertThat(previousSnapshot.getId()).isLessThan(persistedSnapshot.getId());
-  }
-
-  @Test
-  public void shouldReplacePersistedTransientSnapshot() {
-    // given
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    transientSnapshot.take(this::takeSnapshot);
-    final var previousSnapshot = transientSnapshot.persist().join();
-
-    // when
-    final var newTransientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index + 1, term, 1, 0).orElseThrow();
-    newTransientSnapshot.take(this::takeSnapshot);
-    final var persistedSnapshot = newTransientSnapshot.persist().join();
-
-    // then
-    assertThat(previousSnapshot.getPath()).doesNotExist();
-
-    final var snapshotPath = persistedSnapshot.getPath();
-    assertThat(snapshotPath).exists().isNotEqualTo(lastTransientSnapshotPath);
-
-    final var committedSnapshotDir = snapshotPath.toFile();
-    assertThat(committedSnapshotDir).hasName(persistedSnapshot.getId());
-    assertThat(committedSnapshotDir.listFiles())
-        .extracting(File::getName)
-        .containsExactlyInAnyOrder("file1.txt", "CHECKSUM");
-  }
-
-  @Test
-  public void shouldRemovePendingSnapshotOnCommittingSnapshot() {
-    // given
-    final var index = 1L;
-    final var term = 0L;
-    final var oldTransientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    oldTransientSnapshot.take(this::takeSnapshot).join();
-    final var oldTransientSnapshotPath = lastTransientSnapshotPath;
-
-    // when
-    final var newSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index + 1, term, 1, 0).orElseThrow();
-    newSnapshot.take(this::takeSnapshot).join();
+    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).orElseThrow();
+    newSnapshot.take(this::writeSnapshot);
     final var persistedSnapshot = newSnapshot.persist().join();
 
     // then
-    assertThat(lastTransientSnapshotPath).doesNotExist();
-    assertThat(oldTransientSnapshotPath).doesNotExist();
-    assertThat(persistedSnapshot.getPath()).exists();
+    assertThat(snapshotStore.getLatestSnapshot())
+        .as("the latest snapshot is the last persisted snapshot")
+        .hasValue(persistedSnapshot);
   }
 
   @Test
-  public void shouldNotRemovePendingSnapshotOnCommittingSnapshotWhenHigher() {
+  public void shouldNotPersistSnapshotIfIdIsLessThanTheLatestSnapshot() {
     // given
-    final var index = 1L;
-    final var term = 0L;
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(2L, 2L, 3L, 4L).orElseThrow();
+    transientSnapshot.take(this::writeSnapshot);
+    final var previousSnapshot = transientSnapshot.persist().join();
+
+    // when
     final var newTransientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index + 1, term, 1, 0).orElseThrow();
-    newTransientSnapshot.take(this::takeSnapshot).join();
-    final var oldTransientSnapshotPath = lastTransientSnapshotPath;
-
-    // when
-    final var oldSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    oldSnapshot.take(this::takeSnapshot).join();
-    final var persistedSnapshot = oldSnapshot.persist().join();
+        snapshotStore.newTransientSnapshot(1L, 2L, 4L, 5L).orElseThrow();
+    newTransientSnapshot.take(this::writeSnapshot);
+    final var didPersist = newTransientSnapshot.persist();
 
     // then
-    assertThat(lastTransientSnapshotPath).doesNotExist();
-    assertThat(oldTransientSnapshotPath).exists();
-    assertThat(persistedSnapshot.getPath()).exists();
+    assertThat(didPersist)
+        .as(
+            "did not persist snapshot %s with ID less than %s and returns the previous snapshot",
+            previousSnapshot.getId(), newTransientSnapshot.snapshotId().getSnapshotIdAsString())
+        .succeedsWithin(Duration.ofSeconds(5))
+        .isEqualTo(previousSnapshot);
   }
 
   @Test
-  public void shouldCleanUpPendingDirOnFailingTakeSnapshot() {
+  public void shouldRemoveTransientSnapshotOnPersist() {
     // given
-    final var index = 1L;
-    final var term = 0L;
-    final var oldTransientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    transientSnapshot.take(this::writeSnapshot);
 
     // when
-    oldTransientSnapshot
-        .take(
-            path -> {
-              try {
-                FileUtil.ensureDirectoryExists(path);
-                lastTransientSnapshotPath = path;
-              } catch (final IOException e) {
-                throw new UncheckedIOException(e);
-              }
-              return false;
-            })
-        .join();
+    final var newSnapshot = snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).orElseThrow();
+    newSnapshot.take(this::writeSnapshot);
+    newSnapshot.persist().join();
 
     // then
-    assertThat(lastTransientSnapshotPath).doesNotExist();
+    assertThat(newSnapshot.getPath()).as("the transient snapshot was removed").doesNotExist();
   }
 
   @Test
-  public void shouldCleanUpPendingDirOnException() {
-    // given
-    final var index = 1L;
-    final var term = 0L;
-    final var oldTransientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
+  public void shouldNotRemoveTransientSnapshotWithGreaterIdOnPersist() {
+    final var newerTransientSnapshot =
+        snapshotStore.newTransientSnapshot(2L, 0L, 1L, 0L).orElseThrow();
+    newerTransientSnapshot.take(this::writeSnapshot);
 
     // when
-    final var takenFuture =
-        oldTransientSnapshot.take(
+    final var newSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    newSnapshot.take(this::writeSnapshot);
+    newSnapshot.persist().join();
+    final var persistedSnapshot = newerTransientSnapshot.persist().join();
+
+    // then
+    assertThat(persistedSnapshot)
+        .as("the first transient snapshot with greater ID was persisted after the second one")
+        .isEqualTo(snapshotStore.getLatestSnapshot().orElseThrow());
+  }
+
+  @Test
+  public void shouldNotPersistOnTakeFailure() {
+    // given
+    final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+
+    // when
+    snapshot.take(path -> false).join();
+
+    // then
+    assertThat(snapshot.persist())
+        .as("did not persist snapshot as it failed to be taken")
+        .failsWithin(Duration.ofSeconds(5));
+  }
+
+  @Test
+  public void shouldNotPersistOnTakeException() {
+    // given
+    final var snapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+
+    // when
+    final var didTakeSnapshot =
+        snapshot.take(
             path -> {
-              try {
-                FileUtil.ensureDirectoryExists(path);
-                lastTransientSnapshotPath = path;
-                throw new RuntimeException("EXPECTED");
-              } catch (final IOException e) {
-                throw new UncheckedIOException(e);
-              }
+              throw new RuntimeException("expected");
             });
-    assertThatThrownBy(takenFuture::join).isNotNull();
 
     // then
-    assertThat(lastTransientSnapshotPath).doesNotExist();
+    assertThatThrownBy(didTakeSnapshot::join).hasCauseInstanceOf(RuntimeException.class);
+    assertThat(snapshot.persist())
+        .as("did not persist snapshot as it failed to be taken")
+        .failsWithin(Duration.ofSeconds(5));
   }
 
   @Test
   public void shouldNotifyListenersOnNewSnapshot() {
     // given
-    final var listener = mock(PersistedSnapshotListener.class);
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    persistedSnapshotStore.addSnapshotListener(listener);
-    transientSnapshot.take(this::takeSnapshot);
+    final AtomicReference<PersistedSnapshot> snapshotRef = new AtomicReference<>();
+    final PersistedSnapshotListener listener = snapshotRef::set;
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    snapshotStore.addSnapshotListener(listener);
+    transientSnapshot.take(this::writeSnapshot).join();
 
     // when
     final var persistedSnapshot = transientSnapshot.persist().join();
 
     // then
-    verify(listener, times(1)).onNewSnapshot(persistedSnapshot);
+    assertThat(snapshotRef).hasValue(persistedSnapshot);
   }
 
   @Test
-  public void shouldNotNotifyListenersOnNewSnapshotWhenDeregistered() {
+  public void shouldNotNotifyListenersOnNewSnapshotWhenRemoved() {
     // given
-    final var listener = mock(PersistedSnapshotListener.class);
-    final var index = 1L;
-    final var term = 0L;
-    final var transientSnapshot =
-        persistedSnapshotStore.newTransientSnapshot(index, term, 1, 0).orElseThrow();
-    persistedSnapshotStore.addSnapshotListener(listener);
-    persistedSnapshotStore.removeSnapshotListener(listener);
-    transientSnapshot.take(this::takeSnapshot);
+    final AtomicReference<PersistedSnapshot> snapshotRef = new AtomicReference<>();
+    final PersistedSnapshotListener listener = snapshotRef::set;
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 1L, 0L).orElseThrow();
+    snapshotStore.addSnapshotListener(listener);
+    snapshotStore.removeSnapshotListener(listener);
+    transientSnapshot.take(this::writeSnapshot).join();
 
     // when
-    final var persistedSnapshot = transientSnapshot.persist().join();
+    transientSnapshot.persist().join();
 
     // then
-    verify(listener, times(0)).onNewSnapshot(persistedSnapshot);
+    assertThat(snapshotRef)
+        .as("the listener was not called and did not record any new snapshot")
+        .hasValue(null);
   }
 
-  private boolean takeSnapshot(final Path path) {
-    lastTransientSnapshotPath = path;
+  @Test
+  public void shouldNotTakeSnapshotIfIdAlreadyExists() {
+    // given
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).orElseThrow();
+    transientSnapshot.take(this::writeSnapshot).join();
+
+    // when
+    transientSnapshot.persist().join();
+    final var secondTransientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L);
+
+    // then
+    assertThat(secondTransientSnapshot)
+        .as("should have no value since there already exists a transient snapshot with the same ID")
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldNotPersistDeletedTransientSnapshot() {
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(1L, 0L, 2L, 3L).orElseThrow();
+    transientSnapshot.take(this::writeSnapshot).join();
+
+    // when
+    snapshotStore.purgePendingSnapshots().join();
+    final var persisted = transientSnapshot.persist();
+
+    // then
+    assertThatThrownBy(persisted::join)
+        .as("did not persist a deleted transient snapshot")
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Snapshot is not valid");
+  }
+
+  private boolean writeSnapshot(final Path path) {
     try {
       FileUtil.ensureDirectoryExists(path);
-      Files.write(
-          path.resolve("file1.txt"),
-          "This is the content".getBytes(),
-          CREATE_NEW,
-          StandardOpenOption.WRITE);
+
+      for (final var entry : SNAPSHOT_FILE_CONTENTS.entrySet()) {
+        final var fileName = path.resolve(entry.getKey());
+        Files.writeString(fileName, entry.getValue(), CREATE_NEW, StandardOpenOption.WRITE);
+      }
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }


### PR DESCRIPTION
## Description

This PR refactors the `TransientSnapshotTest` and equivalent implementation tests. It untangles which tests is an interface/implementation test, and ensures tests are asserting only what the test case should, and not re-asserting the same things over and over in every test case. This should help reduce the amount of boilerplate required when doing more changes in the future.

## Related issues

related to #6666

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
