### PR TITLE
Process-message and message-start-event-subscription events have a key

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
@@ -181,7 +181,7 @@ public final class EngineProcessors {
     // on other partitions DISTRIBUTE command is received and processed
     final DeploymentDistributeProcessor deploymentDistributeProcessor =
         new DeploymentDistributeProcessor(
-            zeebeState.getProcessState(), deploymentResponder, partitionId, writers);
+            zeebeState.getProcessState(), deploymentResponder, partitionId, writers, keyGenerator);
     typedRecordProcessors.onCommand(
         ValueType.DEPLOYMENT, DeploymentIntent.DISTRIBUTE, deploymentDistributeProcessor);
 

--- a/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/EngineProcessors.java
@@ -181,7 +181,12 @@ public final class EngineProcessors {
     // on other partitions DISTRIBUTE command is received and processed
     final DeploymentDistributeProcessor deploymentDistributeProcessor =
         new DeploymentDistributeProcessor(
-            zeebeState.getProcessState(), deploymentResponder, partitionId, writers, keyGenerator);
+            zeebeState.getProcessState(),
+            zeebeState.getMessageStartEventSubscriptionState(),
+            deploymentResponder,
+            partitionId,
+            writers,
+            keyGenerator);
     typedRecordProcessors.onCommand(
         ValueType.DEPLOYMENT, DeploymentIntent.DISTRIBUTE, deploymentDistributeProcessor);
 

--- a/engine/src/main/java/io/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -251,9 +251,8 @@ public final class CatchEventBehavior {
     final long processInstanceKey = subscription.getRecord().getProcessInstanceKey();
     final long elementInstanceKey = subscription.getRecord().getElementInstanceKey();
 
-    // TODO (npepinpe): the subscription should have a key (#2805)
     stateWriter.appendFollowUpEvent(
-        -1L, ProcessMessageSubscriptionIntent.DELETING, subscription.getRecord());
+        subscription.getKey(), ProcessMessageSubscriptionIntent.DELETING, subscription.getRecord());
     sideEffects.add(
         () ->
             sendCloseMessageSubscriptionCommand(

--- a/engine/src/main/java/io/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -220,8 +220,9 @@ public final class CatchEventBehavior {
     subscription.setElementId(catchEvent.getId());
     subscription.setInterrupting(catchEvent.isInterrupting());
 
-    // TODO (saig0): the subscription should have a key (#2805)
-    stateWriter.appendFollowUpEvent(-1L, ProcessMessageSubscriptionIntent.CREATING, subscription);
+    final var subscriptionKey = keyGenerator.nextKey();
+    stateWriter.appendFollowUpEvent(
+        subscriptionKey, ProcessMessageSubscriptionIntent.CREATING, subscription);
 
     sideEffects.add(
         () ->

--- a/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/common/EventHandle.java
@@ -152,32 +152,31 @@ public final class EventHandle {
   }
 
   public void triggerMessageStartEvent(
-      final long processDefinitionKey,
-      final DirectBuffer startEventElementId,
+      final long subscriptionKey,
+      final MessageStartEventSubscriptionRecord subscription,
       final long messageKey,
       final MessageRecord message) {
 
     final var newProcessInstanceKey = keyGenerator.nextKey();
-    final var bpmnProcessId = processState.getProcessByKey(processDefinitionKey).getBpmnProcessId();
-
     startEventSubscriptionRecord
-        .setProcessDefinitionKey(processDefinitionKey)
-        .setBpmnProcessId(bpmnProcessId)
-        .setStartEventId(startEventElementId)
+        .setProcessDefinitionKey(subscription.getProcessDefinitionKey())
+        .setBpmnProcessId(subscription.getBpmnProcessIdBuffer())
+        .setStartEventId(subscription.getStartEventIdBuffer())
         .setProcessInstanceKey(newProcessInstanceKey)
         .setCorrelationKey(message.getCorrelationKeyBuffer())
         .setMessageKey(messageKey)
         .setMessageName(message.getNameBuffer())
         .setVariables(message.getVariablesBuffer());
 
-    // TODO (saig0): the subscription should have a key (#2805)
     stateWriter.appendFollowUpEvent(
-        -1L, MessageStartEventSubscriptionIntent.CORRELATED, startEventSubscriptionRecord);
+        subscriptionKey,
+        MessageStartEventSubscriptionIntent.CORRELATED,
+        startEventSubscriptionRecord);
 
     activateProcessInstanceForStartEvent(
-        processDefinitionKey,
+        subscription.getProcessDefinitionKey(),
         newProcessInstanceKey,
-        startEventElementId,
+        startEventSubscriptionRecord.getStartEventIdBuffer(),
         message.getVariablesBuffer());
   }
 

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -74,7 +74,8 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
     this.catchEventBehavior = catchEventBehavior;
     this.expressionProcessor = expressionProcessor;
     messageStartEventSubscriptionManager =
-        new MessageStartEventSubscriptionManager(processState, keyGenerator);
+        new MessageStartEventSubscriptionManager(
+            processState, zeebeState.getMessageStartEventSubscriptionState(), keyGenerator);
     deploymentDistributionBehavior =
         new DeploymentDistributionBehavior(writers, partitionsCount, deploymentDistributor, actor);
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -73,7 +73,8 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
         new DeploymentTransformer(stateWriter, zeebeState, expressionProcessor, keyGenerator);
     this.catchEventBehavior = catchEventBehavior;
     this.expressionProcessor = expressionProcessor;
-    messageStartEventSubscriptionManager = new MessageStartEventSubscriptionManager(processState);
+    messageStartEventSubscriptionManager =
+        new MessageStartEventSubscriptionManager(processState, keyGenerator);
     deploymentDistributionBehavior =
         new DeploymentDistributionBehavior(writers, partitionsCount, deploymentDistributor, actor);
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
@@ -16,6 +16,7 @@ import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.zeebe.engine.state.KeyGenerator;
 import io.zeebe.engine.state.immutable.ProcessState;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.record.intent.DeploymentIntent;
@@ -32,8 +33,10 @@ public final class DeploymentDistributeProcessor implements TypedRecordProcessor
       final ProcessState processState,
       final DeploymentResponder deploymentResponder,
       final int partitionId,
-      final Writers writers) {
-    messageStartEventSubscriptionManager = new MessageStartEventSubscriptionManager(processState);
+      final Writers writers,
+      final KeyGenerator keyGenerator) {
+    messageStartEventSubscriptionManager =
+        new MessageStartEventSubscriptionManager(processState, keyGenerator);
     this.deploymentResponder = deploymentResponder;
     this.partitionId = partitionId;
     stateWriter = writers.state();

--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
@@ -17,6 +17,7 @@ import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.zeebe.engine.state.KeyGenerator;
+import io.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
 import io.zeebe.engine.state.immutable.ProcessState;
 import io.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.zeebe.protocol.record.intent.DeploymentIntent;
@@ -31,12 +32,14 @@ public final class DeploymentDistributeProcessor implements TypedRecordProcessor
 
   public DeploymentDistributeProcessor(
       final ProcessState processState,
+      final MessageStartEventSubscriptionState messageStartEventSubscriptionState,
       final DeploymentResponder deploymentResponder,
       final int partitionId,
       final Writers writers,
       final KeyGenerator keyGenerator) {
     messageStartEventSubscriptionManager =
-        new MessageStartEventSubscriptionManager(processState, keyGenerator);
+        new MessageStartEventSubscriptionManager(
+            processState, messageStartEventSubscriptionState, keyGenerator);
     this.deploymentResponder = deploymentResponder;
     this.partitionId = partitionId;
     stateWriter = writers.state();

--- a/engine/src/main/java/io/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -157,7 +157,8 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
     startEventSubscriptionState.visitSubscriptionsByMessageName(
         messageRecord.getNameBuffer(),
         subscription -> {
-          final var bpmnProcessIdBuffer = subscription.getBpmnProcessIdBuffer();
+          final var subscriptionRecord = subscription.getRecord();
+          final var bpmnProcessIdBuffer = subscriptionRecord.getBpmnProcessIdBuffer();
           final var correlationKeyBuffer = messageRecord.getCorrelationKeyBuffer();
 
           // create only one instance of a process per correlation key
@@ -167,11 +168,11 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
                   || !messageState.existActiveProcessInstance(
                       bpmnProcessIdBuffer, correlationKeyBuffer))) {
 
-            correlatingSubscriptions.add(subscription);
+            correlatingSubscriptions.add(subscriptionRecord);
 
             eventHandle.triggerMessageStartEvent(
-                subscription.getProcessDefinitionKey(),
-                subscription.getStartEventIdBuffer(),
+                subscriptionRecord.getProcessDefinitionKey(),
+                subscriptionRecord.getStartEventIdBuffer(),
                 messageKey,
                 messageRecord);
           }

--- a/engine/src/main/java/io/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -171,10 +171,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
             correlatingSubscriptions.add(subscriptionRecord);
 
             eventHandle.triggerMessageStartEvent(
-                subscriptionRecord.getProcessDefinitionKey(),
-                subscriptionRecord.getStartEventIdBuffer(),
-                messageKey,
-                messageRecord);
+                subscription.getKey(), subscriptionRecord, messageKey, messageRecord);
           }
         });
   }

--- a/engine/src/main/java/io/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -111,7 +111,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
             .setInterrupting(subscriptionRecord.isInterrupting());
 
         stateWriter.appendFollowUpEvent(
-            command.getKey(), ProcessMessageSubscriptionIntent.CORRELATED, record);
+            subscription.getKey(), ProcessMessageSubscriptionIntent.CORRELATED, record);
 
         final var catchEvent =
             getCatchEvent(elementInstance.getValue(), record.getElementIdBuffer());

--- a/engine/src/main/java/io/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
@@ -54,9 +54,10 @@ public final class ProcessMessageSubscriptionCreateProcessor
             subscriptionRecord.getElementInstanceKey(), subscriptionRecord.getMessageNameBuffer());
 
     if (subscription != null && subscription.isOpening()) {
-      // TODO (saig0): the subscription should have a key (#2805)
       stateWriter.appendFollowUpEvent(
-          command.getKey(), ProcessMessageSubscriptionIntent.CREATED, subscription.getRecord());
+          subscription.getKey(),
+          ProcessMessageSubscriptionIntent.CREATED,
+          subscription.getRecord());
 
     } else {
       rejectCommand(command, subscription);

--- a/engine/src/main/java/io/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
@@ -44,19 +44,19 @@ public final class ProcessMessageSubscriptionDeleteProcessor
       final TypedResponseWriter responseWriter,
       final TypedStreamWriter streamWriter) {
 
-    final ProcessMessageSubscriptionRecord subscription = command.getValue();
+    final ProcessMessageSubscriptionRecord subscriptionRecord = command.getValue();
 
-    final var exists =
-        subscriptionState.existSubscriptionForElementInstance(
-            subscription.getElementInstanceKey(), subscription.getMessageNameBuffer());
+    final var subscription =
+        subscriptionState.getSubscription(
+            command.getValue().getElementInstanceKey(), subscriptionRecord.getMessageNameBuffer());
 
-    if (exists) {
-      stateWriter.appendFollowUpEvent(
-          command.getKey(), ProcessMessageSubscriptionIntent.DELETED, subscription);
-
-    } else {
+    if (subscription == null) {
       rejectCommand(command);
+      return;
     }
+
+    stateWriter.appendFollowUpEvent(
+        subscription.getKey(), ProcessMessageSubscriptionIntent.DELETED, subscription.getRecord());
   }
 
   private void rejectCommand(final TypedRecord<ProcessMessageSubscriptionRecord> command) {

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/MessageStartEventSubscriptionCreatedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/MessageStartEventSubscriptionCreatedApplier.java
@@ -35,7 +35,7 @@ public final class MessageStartEventSubscriptionCreatedApplier
   @Override
   public void applyState(final long key, final MessageStartEventSubscriptionRecord value) {
 
-    subscriptionState.put(value);
+    subscriptionState.put(key, value);
 
     eventScopeInstanceState.createIfNotExists(
         value.getProcessDefinitionKey(), NO_INTERRUPTING_ELEMENT_IDS);

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/MessageStartEventSubscriptionDeletedApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/MessageStartEventSubscriptionDeletedApplier.java
@@ -31,7 +31,7 @@ public final class MessageStartEventSubscriptionDeletedApplier
   public void applyState(final long key, final MessageStartEventSubscriptionRecord value) {
     final var processDefinitionKey = value.getProcessDefinitionKey();
 
-    subscriptionState.removeSubscriptionsOfProcess(processDefinitionKey);
+    subscriptionState.remove(processDefinitionKey, value.getMessageNameBuffer());
 
     eventScopeInstanceState.deleteInstance(processDefinitionKey);
   }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionCreatingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionCreatingApplier.java
@@ -35,6 +35,6 @@ public final class ProcessMessageSubscriptionCreatingApplier
       return;
     }
 
-    subscriptionState.put(value, sentTime);
+    subscriptionState.put(key, value, sentTime);
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionDeletingApplier.java
+++ b/engine/src/main/java/io/zeebe/engine/state/appliers/ProcessMessageSubscriptionDeletingApplier.java
@@ -26,7 +26,6 @@ final class ProcessMessageSubscriptionDeletingApplier
   @Override
   public void applyState(final long key, final ProcessMessageSubscriptionRecord value) {
     // TODO (npepinpe): the send time for the retry should be deterministic (#6364)
-    // TODO (npepinpe): the subscription should have a key (#2805)
     state.updateToClosingState(value, ActorClock.currentTimeMillis());
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/immutable/MessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/immutable/MessageStartEventSubscriptionState.java
@@ -7,8 +7,8 @@
  */
 package io.zeebe.engine.state.immutable;
 
+import io.zeebe.engine.state.message.MessageStartEventSubscription;
 import io.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
-import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 
 public interface MessageStartEventSubscriptionState {
@@ -16,5 +16,19 @@ public interface MessageStartEventSubscriptionState {
   boolean exists(MessageStartEventSubscriptionRecord subscription);
 
   void visitSubscriptionsByMessageName(
-      DirectBuffer messageName, Consumer<MessageStartEventSubscriptionRecord> visitor);
+      DirectBuffer messageName, MessageStartEventSubscriptionVisitor visitor);
+
+  /**
+   * Visit all subscriptions with the given process definition key.
+   *
+   * @param processDefinitionKey the key of the process definition the subscription belongs to
+   * @param visitor the function that is called for each subscription
+   */
+  void visitSubscriptionsByProcessDefinition(
+      long processDefinitionKey, MessageStartEventSubscriptionVisitor visitor);
+
+  @FunctionalInterface
+  interface MessageStartEventSubscriptionVisitor {
+    void visit(MessageStartEventSubscription subscription);
+  }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
@@ -70,6 +70,7 @@ public final class DbMessageStartEventSubscriptionState
         processDefinitionKeyAndMessageName, DbNil.INSTANCE);
   }
 
+  // TODO (saig0): replace with remove(key)
   @Override
   public void removeSubscriptionsOfProcess(final long processDefinitionKey) {
     this.processDefinitionKey.wrapLong(processDefinitionKey);
@@ -80,6 +81,15 @@ public final class DbMessageStartEventSubscriptionState
           subscriptionsColumnFamily.delete(messageNameAndProcessDefinitionKey);
           subscriptionsOfProcessDefinitionKeyColumnFamily.delete(key);
         });
+  }
+
+  @Override
+  public void remove(final long processDefinitionKey, final DirectBuffer messageName) {
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    this.messageName.wrapBuffer(messageName);
+
+    subscriptionsColumnFamily.delete(messageNameAndProcessDefinitionKey);
+    subscriptionsOfProcessDefinitionKeyColumnFamily.delete(processDefinitionKeyAndMessageName);
   }
 
   @Override

--- a/engine/src/main/java/io/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
@@ -60,8 +60,8 @@ public final class DbMessageStartEventSubscriptionState
   }
 
   @Override
-  public void put(final MessageStartEventSubscriptionRecord subscription) {
-    messageStartEventSubscription.setRecord(subscription);
+  public void put(final long key, final MessageStartEventSubscriptionRecord subscription) {
+    messageStartEventSubscription.setKey(key).setRecord(subscription);
 
     messageName.wrapBuffer(subscription.getMessageNameBuffer());
     processDefinitionKey.wrapLong(subscription.getProcessDefinitionKey());

--- a/engine/src/main/java/io/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/DbMessageStartEventSubscriptionState.java
@@ -70,19 +70,6 @@ public final class DbMessageStartEventSubscriptionState
         processDefinitionKeyAndMessageName, DbNil.INSTANCE);
   }
 
-  // TODO (saig0): replace with remove(key)
-  @Override
-  public void removeSubscriptionsOfProcess(final long processDefinitionKey) {
-    this.processDefinitionKey.wrapLong(processDefinitionKey);
-
-    subscriptionsOfProcessDefinitionKeyColumnFamily.whileEqualPrefix(
-        this.processDefinitionKey,
-        (key, value) -> {
-          subscriptionsColumnFamily.delete(messageNameAndProcessDefinitionKey);
-          subscriptionsOfProcessDefinitionKeyColumnFamily.delete(key);
-        });
-  }
-
   @Override
   public void remove(final long processDefinitionKey, final DirectBuffer messageName) {
     this.processDefinitionKey.wrapLong(processDefinitionKey);

--- a/engine/src/main/java/io/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
@@ -65,11 +65,12 @@ public final class DbProcessMessageSubscriptionState
   }
 
   @Override
-  public void put(final ProcessMessageSubscriptionRecord record, final long commandSentTime) {
+  public void put(
+      final long key, final ProcessMessageSubscriptionRecord record, final long commandSentTime) {
     wrapSubscriptionKeys(record.getElementInstanceKey(), record.getMessageNameBuffer());
 
     processMessageSubscription.reset();
-    processMessageSubscription.setRecord(record).setCommandSentTime(commandSentTime);
+    processMessageSubscription.setKey(key).setRecord(record).setCommandSentTime(commandSentTime);
 
     subscriptionColumnFamily.put(elementKeyAndMessageName, processMessageSubscription);
 

--- a/engine/src/main/java/io/zeebe/engine/state/message/MessageStartEventSubscription.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/MessageStartEventSubscription.java
@@ -13,22 +13,22 @@ import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.ObjectProperty;
 import io.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 
-public class SubscriptionValue extends UnpackedObject implements DbValue {
+public class MessageStartEventSubscription extends UnpackedObject implements DbValue {
 
   private final ObjectProperty<MessageStartEventSubscriptionRecord> recordProp =
       new ObjectProperty<>(
           "messageStartEventSubscriptionRecord", new MessageStartEventSubscriptionRecord());
   private final LongProperty keyProp = new LongProperty("key");
 
-  public SubscriptionValue() {
+  public MessageStartEventSubscription() {
     declareProperty(recordProp).declareProperty(keyProp);
   }
 
-  public void set(final MessageStartEventSubscriptionRecord record) {
+  public void setRecord(final MessageStartEventSubscriptionRecord record) {
     recordProp.getValue().wrap(record);
   }
 
-  public MessageStartEventSubscriptionRecord get() {
+  public MessageStartEventSubscriptionRecord getRecord() {
     return recordProp.getValue();
   }
 
@@ -36,7 +36,7 @@ public class SubscriptionValue extends UnpackedObject implements DbValue {
     return keyProp.getValue();
   }
 
-  public SubscriptionValue setKey(final long key) {
+  public MessageStartEventSubscription setKey(final long key) {
     keyProp.setValue(key);
     return this;
   }

--- a/engine/src/main/java/io/zeebe/engine/state/message/MessageSubscription.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/MessageSubscription.java
@@ -18,7 +18,7 @@ public final class MessageSubscription extends UnpackedObject implements DbValue
   private final ObjectProperty<MessageSubscriptionRecord> recordProp =
       new ObjectProperty<>("record", new MessageSubscriptionRecord());
 
-  private final LongProperty keyProp = new LongProperty("key", -1L);
+  private final LongProperty keyProp = new LongProperty("key");
 
   private final LongProperty commandSentTimeProp = new LongProperty("commandSentTime", 0);
 

--- a/engine/src/main/java/io/zeebe/engine/state/message/ProcessMessageSubscription.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/ProcessMessageSubscription.java
@@ -22,9 +22,13 @@ public final class ProcessMessageSubscription extends UnpackedObject implements 
   private final LongProperty commandSentTimeProp = new LongProperty("commandSentTime", 0);
   private final EnumProperty<State> stateProp =
       new EnumProperty<>("state", State.class, State.STATE_OPENING);
+  private final LongProperty keyProp = new LongProperty("key");
 
   public ProcessMessageSubscription() {
-    declareProperty(recordProp).declareProperty(commandSentTimeProp).declareProperty(stateProp);
+    declareProperty(recordProp)
+        .declareProperty(commandSentTimeProp)
+        .declareProperty(stateProp)
+        .declareProperty(keyProp);
   }
 
   public ProcessMessageSubscriptionRecord getRecord() {
@@ -60,6 +64,15 @@ public final class ProcessMessageSubscription extends UnpackedObject implements 
 
   public ProcessMessageSubscription setClosing() {
     stateProp.setValue(State.STATE_CLOSING);
+    return this;
+  }
+
+  public long getKey() {
+    return keyProp.getValue();
+  }
+
+  public ProcessMessageSubscription setKey(final long key) {
+    keyProp.setValue(key);
     return this;
   }
 

--- a/engine/src/main/java/io/zeebe/engine/state/message/SubscriptionValue.java
+++ b/engine/src/main/java/io/zeebe/engine/state/message/SubscriptionValue.java
@@ -9,16 +9,19 @@ package io.zeebe.engine.state.message;
 
 import io.zeebe.db.DbValue;
 import io.zeebe.msgpack.UnpackedObject;
+import io.zeebe.msgpack.property.LongProperty;
 import io.zeebe.msgpack.property.ObjectProperty;
 import io.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 
 public class SubscriptionValue extends UnpackedObject implements DbValue {
+
   private final ObjectProperty<MessageStartEventSubscriptionRecord> recordProp =
       new ObjectProperty<>(
           "messageStartEventSubscriptionRecord", new MessageStartEventSubscriptionRecord());
+  private final LongProperty keyProp = new LongProperty("key");
 
   public SubscriptionValue() {
-    declareProperty(recordProp);
+    declareProperty(recordProp).declareProperty(keyProp);
   }
 
   public void set(final MessageStartEventSubscriptionRecord record) {
@@ -27,5 +30,14 @@ public class SubscriptionValue extends UnpackedObject implements DbValue {
 
   public MessageStartEventSubscriptionRecord get() {
     return recordProp.getValue();
+  }
+
+  public long getKey() {
+    return keyProp.getValue();
+  }
+
+  public SubscriptionValue setKey(final long key) {
+    keyProp.setValue(key);
+    return this;
   }
 }

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableMessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableMessageStartEventSubscriptionState.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.state.mutable;
 
 import io.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
 import io.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
+import org.agrona.DirectBuffer;
 
 public interface MutableMessageStartEventSubscriptionState
     extends MessageStartEventSubscriptionState {
@@ -16,4 +17,6 @@ public interface MutableMessageStartEventSubscriptionState
   void put(final long key, MessageStartEventSubscriptionRecord subscription);
 
   void removeSubscriptionsOfProcess(long processDefinitionKey);
+
+  void remove(long processDefinitionKey, DirectBuffer messageName);
 }

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableMessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableMessageStartEventSubscriptionState.java
@@ -16,7 +16,5 @@ public interface MutableMessageStartEventSubscriptionState
 
   void put(final long key, MessageStartEventSubscriptionRecord subscription);
 
-  void removeSubscriptionsOfProcess(long processDefinitionKey);
-
   void remove(long processDefinitionKey, DirectBuffer messageName);
 }

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableMessageStartEventSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableMessageStartEventSubscriptionState.java
@@ -13,7 +13,7 @@ import io.zeebe.protocol.impl.record.value.message.MessageStartEventSubscription
 public interface MutableMessageStartEventSubscriptionState
     extends MessageStartEventSubscriptionState {
 
-  void put(MessageStartEventSubscriptionRecord subscription);
+  void put(final long key, MessageStartEventSubscriptionRecord subscription);
 
   void removeSubscriptionsOfProcess(long processDefinitionKey);
 }

--- a/engine/src/main/java/io/zeebe/engine/state/mutable/MutableProcessMessageSubscriptionState.java
+++ b/engine/src/main/java/io/zeebe/engine/state/mutable/MutableProcessMessageSubscriptionState.java
@@ -14,7 +14,7 @@ import org.agrona.DirectBuffer;
 
 public interface MutableProcessMessageSubscriptionState extends ProcessMessageSubscriptionState {
 
-  void put(ProcessMessageSubscriptionRecord record, final long commandSentTime);
+  void put(final long key, ProcessMessageSubscriptionRecord record, final long commandSentTime);
 
   void updateToOpenedState(ProcessMessageSubscriptionRecord record);
 

--- a/engine/src/test/java/io/zeebe/engine/state/message/MessageStartEventSubscriptionStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/message/MessageStartEventSubscriptionStateTest.java
@@ -142,36 +142,36 @@ public final class MessageStartEventSubscriptionStateTest {
         createSubscription("message1", "startEvent1", 1);
     state.put(1L, subscription1);
 
-    // more subscriptions for same process
     final MessageStartEventSubscriptionRecord subscription2 =
-        createSubscription("message2", "startEvent2", 1);
+        createSubscription("message2", "startEvent2", 2);
     state.put(2L, subscription2);
 
-    final MessageStartEventSubscriptionRecord subscription3 =
-        createSubscription("message3", "startEvent3", 1);
-    state.put(3L, subscription3);
-
-    state.removeSubscriptionsOfProcess(1);
+    state.remove(1L, wrapString("message1"));
+    state.remove(2L, wrapString("message2"));
 
     assertThat(state.exists(subscription1)).isFalse();
     assertThat(state.exists(subscription2)).isFalse();
-    assertThat(state.exists(subscription3)).isFalse();
   }
 
   @Test
-  public void shouldNotRemoveOtherKeys() {
+  public void shouldNotRemoveOtherSubscriptions() {
     final MessageStartEventSubscriptionRecord subscription1 =
         createSubscription("message1", "startEvent1", 1);
     state.put(1L, subscription1);
 
     final MessageStartEventSubscriptionRecord subscription2 =
-        createSubscription("message1", "startEvent1", 4);
+        createSubscription("message2", "startEvent2", 1);
     state.put(2L, subscription2);
 
-    state.removeSubscriptionsOfProcess(1);
+    final MessageStartEventSubscriptionRecord subscription3 =
+        createSubscription("message1", "startEvent1", 2);
+    state.put(3L, subscription3);
+
+    state.remove(1L, wrapString("message1"));
 
     assertThat(state.exists(subscription1)).isFalse();
     assertThat(state.exists(subscription2)).isTrue();
+    assertThat(state.exists(subscription3)).isTrue();
   }
 
   @Test

--- a/engine/src/test/java/io/zeebe/engine/state/message/ProcessMessageSubscriptionStateTest.java
+++ b/engine/src/test/java/io/zeebe/engine/state/message/ProcessMessageSubscriptionStateTest.java
@@ -38,7 +38,7 @@ public final class ProcessMessageSubscriptionStateTest {
   public void shouldNotExist() {
     // given
     final ProcessMessageSubscriptionRecord record = subscriptionRecordWithElementInstanceKey(1);
-    state.put(record, 1_000L);
+    state.put(1L, record, 1_000L);
 
     // when
     final boolean exist =
@@ -52,7 +52,7 @@ public final class ProcessMessageSubscriptionStateTest {
   public void shouldExistSubscription() {
     // given
     final ProcessMessageSubscriptionRecord record = subscriptionRecordWithElementInstanceKey(1);
-    state.put(record, 1_000L);
+    state.put(1L, record, 1_000L);
 
     // when
     final boolean exist =
@@ -63,13 +63,30 @@ public final class ProcessMessageSubscriptionStateTest {
   }
 
   @Test
+  public void shouldGetSubscription() {
+    // given
+    final ProcessMessageSubscriptionRecord record = subscriptionRecordWithElementInstanceKey(1);
+    state.put(1L, record, 1_000L);
+
+    // when
+    final var subscription =
+        state.getSubscription(record.getElementInstanceKey(), record.getMessageNameBuffer());
+
+    // then
+    assertThat(subscription).isNotNull();
+    assertThat(subscription.getKey()).isEqualTo(1L);
+    assertThat(subscription.getRecord()).isEqualTo(record);
+    assertThat(subscription.getCommandSentTime()).isEqualTo(1_000L);
+  }
+
+  @Test
   public void shouldNoVisitSubscriptionBeforeTime() {
     // given
     final ProcessMessageSubscriptionRecord record1 = subscriptionRecordWithElementInstanceKey(1L);
-    state.put(record1, 1_000L);
+    state.put(1L, record1, 1_000L);
 
     final ProcessMessageSubscriptionRecord record2 = subscriptionRecordWithElementInstanceKey(2L);
-    state.put(record2, 3_000L);
+    state.put(2L, record2, 3_000L);
 
     // then
     final List<Long> keys = new ArrayList<>();
@@ -82,10 +99,10 @@ public final class ProcessMessageSubscriptionStateTest {
   public void shouldVisitSubscriptionBeforeTime() {
     // given
     final ProcessMessageSubscriptionRecord record1 = subscriptionRecordWithElementInstanceKey(1L);
-    state.put(record1, 1_000L);
+    state.put(1L, record1, 1_000L);
 
     final ProcessMessageSubscriptionRecord record2 = subscriptionRecordWithElementInstanceKey(2L);
-    state.put(record2, 3_000L);
+    state.put(2L, record2, 3_000L);
 
     // then
     final List<Long> keys = new ArrayList<>();
@@ -98,10 +115,10 @@ public final class ProcessMessageSubscriptionStateTest {
   public void shouldFindSubscriptionBeforeTimeInOrder() {
     // given
     final ProcessMessageSubscriptionRecord record1 = subscriptionRecordWithElementInstanceKey(1L);
-    state.put(record1, 1_000L);
+    state.put(1L, record1, 1_000L);
 
     final ProcessMessageSubscriptionRecord record2 = subscriptionRecordWithElementInstanceKey(2L);
-    state.put(record2, 2_000L);
+    state.put(2L, record2, 2_000L);
 
     // then
     final List<Long> keys = new ArrayList<>();
@@ -114,10 +131,10 @@ public final class ProcessMessageSubscriptionStateTest {
   public void shouldNotVisitSubscriptionIfOpened() {
     // given
     final ProcessMessageSubscriptionRecord record1 = subscriptionRecordWithElementInstanceKey(1L);
-    state.put(record1, 1_000L);
+    state.put(1L, record1, 1_000L);
 
     final ProcessMessageSubscriptionRecord record2 = subscriptionRecordWithElementInstanceKey(2L);
-    state.put(record2, 2_000L);
+    state.put(2L, record2, 2_000L);
     state.updateToOpenedState(record2.setSubscriptionPartitionId(3));
 
     // then
@@ -133,7 +150,7 @@ public final class ProcessMessageSubscriptionStateTest {
     final ProcessMessageSubscriptionRecord record = subscriptionRecordWithElementInstanceKey(1L);
 
     // when
-    state.put(record, 1_000L);
+    state.put(1L, record, 1_000L);
 
     // then
     final List<Long> keys = new ArrayList<>();
@@ -156,7 +173,7 @@ public final class ProcessMessageSubscriptionStateTest {
   public void shouldUpdateOpenState() {
     // given
     final ProcessMessageSubscriptionRecord record = subscriptionRecordWithElementInstanceKey(1L);
-    state.put(record, 1_000L);
+    state.put(1L, record, 1_000L);
     final ProcessMessageSubscription subscription =
         state.getSubscription(record.getElementInstanceKey(), record.getMessageNameBuffer());
 
@@ -184,7 +201,7 @@ public final class ProcessMessageSubscriptionStateTest {
   public void shouldUpdateCloseState() {
     // given
     final ProcessMessageSubscriptionRecord record = subscriptionRecordWithElementInstanceKey(1L);
-    state.put(record, 1_000L);
+    state.put(1L, record, 1_000L);
     state.updateToOpenedState(record.setSubscriptionPartitionId(3));
     final ProcessMessageSubscription subscription =
         state.getSubscription(record.getElementInstanceKey(), record.getMessageNameBuffer());
@@ -210,7 +227,7 @@ public final class ProcessMessageSubscriptionStateTest {
   public void shouldRemoveSubscription() {
     // given
     final ProcessMessageSubscriptionRecord record = subscriptionRecordWithElementInstanceKey(1L);
-    state.put(record, 1_000L);
+    state.put(1L, record, 1_000L);
 
     // when
     state.remove(1L, record.getMessageNameBuffer());
@@ -230,7 +247,7 @@ public final class ProcessMessageSubscriptionStateTest {
   public void shouldNotFailOnRemoveSubscriptionTwice() {
     // given
     final ProcessMessageSubscriptionRecord record = subscriptionRecordWithElementInstanceKey(1L);
-    state.put(record, 1_000L);
+    state.put(1L, record, 1_000L);
 
     // when
     state.remove(1L, record.getMessageNameBuffer());
@@ -244,8 +261,8 @@ public final class ProcessMessageSubscriptionStateTest {
   @Test
   public void shouldNotRemoveSubscriptionOnDifferentKey() {
     // given
-    state.put(subscriptionRecord("messageName", "correlationKey", 1L), 1_000L);
-    state.put(subscriptionRecord("messageName", "correlationKey", 2L), 1_000L);
+    state.put(1L, subscriptionRecord("messageName", "correlationKey", 1L), 1_000L);
+    state.put(2L, subscriptionRecord("messageName", "correlationKey", 2L), 1_000L);
 
     // when
     state.remove(2L, wrapString("messageName"));
@@ -257,9 +274,9 @@ public final class ProcessMessageSubscriptionStateTest {
   @Test
   public void shouldVisitAllSubscriptionsInTheState() {
     // given
-    state.put(subscriptionRecord("message1", "correlationKey", 1L), 1_000L);
-    state.put(subscriptionRecord("message2", "correlationKey", 1L), 1_000L);
-    state.put(subscriptionRecord("message3", "correlationKey", 2L), 1_000L);
+    state.put(1L, subscriptionRecord("message1", "correlationKey", 1L), 1_000L);
+    state.put(2L, subscriptionRecord("message2", "correlationKey", 1L), 1_000L);
+    state.put(3L, subscriptionRecord("message3", "correlationKey", 2L), 1_000L);
 
     // when
     final List<Tuple<Long, DirectBuffer>> visited = new ArrayList<>();


### PR DESCRIPTION
## Description

* currently, all events of type process-message and message-start-event have no key set (i.e. it is always `-1`)
* in order to improve the visibility of the lifecycle of a subscription, generate a new key when creating it
* use this key to write all follow-up events of this subscription
* write additional events when a message start event subscription is deleted if the previous process contains more than one message start event
  * previously, the processor wrote just one deleted event for all subscriptions
  * changed the behavior to write one event per subscription  

## Related issues

closes #2805 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
