### PR TITLE
feat(snapshots): include chunkids in snapshot checksum

### DIFF
--- a/snapshot/src/main/java/io/zeebe/snapshots/impl/SnapshotChunkUtil.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/impl/SnapshotChunkUtil.java
@@ -12,15 +12,20 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.CRC32C;
+import java.util.zip.Checksum;
 
 final class SnapshotChunkUtil {
 
   private SnapshotChunkUtil() {}
 
   static long createChecksum(final byte[] content) {
-    final CRC32C crc32 = new CRC32C();
-    crc32.update(content);
-    return crc32.getValue();
+    final Checksum checksum = newChecksum();
+    checksum.update(content);
+    return checksum.getValue();
+  }
+
+  static Checksum newChecksum() {
+    return new CRC32C();
   }
 
   static SnapshotChunk createSnapshotChunkFromFile(

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/SnapshotChecksumTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/SnapshotChecksumTest.java
@@ -31,7 +31,7 @@ public class SnapshotChecksumTest {
     multipleFileSnapshot = temporaryFolder.newFolder().toPath();
     corruptedSnapshot = temporaryFolder.newFolder().toPath();
 
-    Files.createFile(singleFileSnapshot.resolve("singleFile.txt"));
+    Files.createFile(singleFileSnapshot.resolve("file1.txt"));
     Files.createFile(multipleFileSnapshot.resolve("file1.txt"));
     Files.createFile(multipleFileSnapshot.resolve("file2.txt"));
     Files.createFile(multipleFileSnapshot.resolve("file3.txt"));
@@ -51,6 +51,19 @@ public class SnapshotChecksumTest {
 
     // then
     assertThat(actual).isEqualTo(expectedChecksum);
+  }
+
+  @Test
+  public void shouldGenerateDifferentChecksumWhenFileNameIsDifferent() throws Exception {
+    // given
+    final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot);
+
+    // when
+    Files.move(singleFileSnapshot.resolve("file1.txt"), singleFileSnapshot.resolve("renamed"));
+    final var actual = SnapshotChecksum.calculate(singleFileSnapshot);
+
+    // then
+    assertThat(actual).isNotEqualTo(expectedChecksum);
   }
 
   @Test


### PR DESCRIPTION
## Description

* Include chunkid when calculating checksum of a snapshot and snapshot chunks
* Update how the checksum is calculated. Instead of adding the checksums together, use the same checksum object and update it with new contents.

## Related issues

Related #6666

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
