### PR TITLE
refactor(snapshots): read file in chunks to calculate checksum

### DIFF
--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/SnapshotChecksumTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/SnapshotChecksumTest.java
@@ -10,8 +10,13 @@ package io.zeebe.snapshots.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.zip.CRC32C;
+import java.util.zip.Checksum;
+import org.agrona.IoUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,14 +36,23 @@ public class SnapshotChecksumTest {
     multipleFileSnapshot = temporaryFolder.newFolder().toPath();
     corruptedSnapshot = temporaryFolder.newFolder().toPath();
 
-    Files.createFile(singleFileSnapshot.resolve("file1.txt"));
-    Files.createFile(multipleFileSnapshot.resolve("file1.txt"));
-    Files.createFile(multipleFileSnapshot.resolve("file2.txt"));
-    Files.createFile(multipleFileSnapshot.resolve("file3.txt"));
+    createChunk(singleFileSnapshot, "file1.txt");
 
-    Files.createFile(corruptedSnapshot.resolve("file1.txt"));
-    Files.createFile(corruptedSnapshot.resolve("file2.txt"));
-    Files.createFile(corruptedSnapshot.resolve("file3.txt"));
+    createChunk(multipleFileSnapshot, "file1.txt");
+    createChunk(multipleFileSnapshot, "file2.txt");
+    createChunk(multipleFileSnapshot, "file3.txt");
+
+    createChunk(corruptedSnapshot, "file1.txt");
+    createChunk(corruptedSnapshot, "file2.txt");
+    createChunk(corruptedSnapshot, "file3.txt");
+  }
+
+  private void createChunk(final Path snapshot, final String chunkName) throws IOException {
+    Files.writeString(
+        snapshot.resolve(chunkName),
+        chunkName,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.WRITE);
   }
 
   @Test
@@ -127,5 +141,25 @@ public class SnapshotChecksumTest {
 
     // then
     assertThat(SnapshotChecksum.verify(corruptedSnapshot)).isFalse();
+  }
+
+  @Test
+  public void shouldCalculateSameChecksumOfLargeFile() throws IOException {
+    // given
+    final var largeSnapshot = temporaryFolder.newFolder().toPath();
+    final Path file = largeSnapshot.resolve("file");
+    final String largeData = "a".repeat(4 * IoUtil.BLOCK_SIZE + 100);
+    Files.writeString(file, largeData, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+
+    final Checksum checksum = new CRC32C();
+    checksum.update("file".getBytes(StandardCharsets.UTF_8));
+    checksum.update(Files.readAllBytes(file));
+    final var expected = checksum.getValue();
+
+    // when
+    final var actual = SnapshotChecksum.calculate(largeSnapshot);
+
+    // then
+    assertThat(actual).isEqualTo(expected);
   }
 }


### PR DESCRIPTION
## Description

Reading the whole file to memory to calculate checksum is memory intensive. Instead read the files in chunks and update the checksum on the go.

## Related issues

Relates #6666

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
