### PR TITLE
Deploy command times out for processes with a timer start event

### DIFF
--- a/engine/src/main/java/io/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -21,6 +21,8 @@ import io.zeebe.engine.processing.deployment.transform.DeploymentTransformer;
 import io.zeebe.engine.processing.streamprocessor.TypedRecord;
 import io.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectProducer;
+import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffectQueue;
+import io.zeebe.engine.processing.streamprocessor.sideeffect.SideEffects;
 import io.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.zeebe.engine.processing.streamprocessor.writers.TypedStreamWriter;
@@ -45,6 +47,8 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
 
   private static final String COULD_NOT_CREATE_TIMER_MESSAGE =
       "Expected to create timer for start event, but encountered the following error: %s";
+
+  private final SideEffectQueue sideEffects = new SideEffectQueue();
 
   private final DeploymentTransformer deploymentTransformer;
   private final ProcessState processState;
@@ -84,6 +88,11 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
       final TypedResponseWriter responseWriter,
       final TypedStreamWriter streamWriter,
       final Consumer<SideEffectProducer> sideEffect) {
+
+    // need to add multiple side-effects for sending a response and scheduling timers
+    sideEffects.add(responseWriter);
+    sideEffect.accept(sideEffects);
+
     final DeploymentRecord deploymentEvent = command.getValue();
 
     final boolean accepted = deploymentTransformer.transform(deploymentEvent);
@@ -91,7 +100,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
       final long key = keyGenerator.nextKey();
 
       try {
-        createTimerIfTimerStartEvent(command, streamWriter, sideEffect);
+        createTimerIfTimerStartEvent(command, streamWriter, sideEffects);
       } catch (final RuntimeException e) {
         final String reason = String.format(COULD_NOT_CREATE_TIMER_MESSAGE, e.getMessage());
         responseWriter.writeRejectionOnCommand(command, RejectionType.PROCESSING_ERROR, reason);
@@ -100,6 +109,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
       }
 
       responseWriter.writeEventOnCommand(key, DeploymentIntent.CREATED, deploymentEvent, command);
+
       stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, deploymentEvent);
 
       deploymentDistributionBehavior.distributeDeployment(deploymentEvent, key);
@@ -121,7 +131,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
   private void createTimerIfTimerStartEvent(
       final TypedRecord<DeploymentRecord> record,
       final TypedStreamWriter streamWriter,
-      final Consumer<SideEffectProducer> sideEffects) {
+      final SideEffects sideEffects) {
     for (final ProcessRecord processRecord : record.getValue().processes()) {
       final List<ExecutableStartEvent> startEvents =
           processState.getProcessByKey(processRecord.getKey()).getProcess().getStartEvents();
@@ -147,7 +157,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
               startEvent.getId(),
               timerOrError.get(),
               streamWriter,
-              sideEffects::accept);
+              sideEffects);
         }
       }
     }

--- a/engine/src/test/java/io/zeebe/engine/processing/deployment/model/validation/SuccessfulDeploymentTest.java
+++ b/engine/src/test/java/io/zeebe/engine/processing/deployment/model/validation/SuccessfulDeploymentTest.java
@@ -8,13 +8,31 @@
 package io.zeebe.engine.processing.deployment.model.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.verify;
 
 import io.zeebe.engine.util.EngineRule;
+import io.zeebe.engine.util.client.DeploymentClient;
+import io.zeebe.model.bpmn.Bpmn;
+import io.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.protocol.record.Record;
+import io.zeebe.protocol.record.RecordType;
+import io.zeebe.protocol.record.ValueType;
 import io.zeebe.protocol.record.intent.DeploymentIntent;
+import io.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Function;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public final class SuccessfulDeploymentTest {
 
   @Rule public final EngineRule engine = EngineRule.singlePartition();
@@ -23,17 +41,70 @@ public final class SuccessfulDeploymentTest {
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
 
+  @Parameter(0)
+  public String description;
+
+  @Parameter(1)
+  public Function<DeploymentClient, Record<DeploymentRecordValue>> performDeployment;
+
+  @Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[] {"orphan error definition", deploy("/processes/orphan-error-definition.bpmn")},
+        new Object[] {
+          "none start event",
+          deploy(Bpmn.createExecutableProcess("process").startEvent().endEvent().done())
+        },
+        new Object[] {
+          "timer start event",
+          deploy(
+              Bpmn.createExecutableProcess("process")
+                  .startEvent()
+                  .timerWithCycle("R/PT10S")
+                  .endEvent()
+                  .done())
+        },
+        new Object[] {
+          "message start event",
+          deploy(
+              Bpmn.createExecutableProcess("process")
+                  .startEvent()
+                  .message("start")
+                  .endEvent()
+                  .done())
+        });
+  }
+
   @Test
-  public void shouldDeployProcessWithOrphanErrorDefinition() {
+  public void shouldWriteDeploymentCreatedEvent() {
     // when
-    final var deployment =
-        engine
-            .deployment()
-            .withXmlClasspathResource("/processes/orphan-error-definition.bpmn")
-            .deploy();
+    final var deployment = performDeployment.apply(engine.deployment());
 
     // then
     assertThat(deployment.getIntent()).isEqualTo(DeploymentIntent.CREATED);
     assertThat(deployment.getValue().getDeployedProcesses()).hasSize(1);
+  }
+
+  @Test
+  public void shouldSendResponse() {
+    // when
+    final var deployment = performDeployment.apply(engine.deployment());
+
+    // then
+    verify(engine.getCommandResponseWriter()).recordType(RecordType.EVENT);
+    verify(engine.getCommandResponseWriter()).valueType(ValueType.DEPLOYMENT);
+    verify(engine.getCommandResponseWriter()).intent(DeploymentIntent.CREATED);
+    verify(engine.getCommandResponseWriter()).key(deployment.getKey());
+    verify(engine.getCommandResponseWriter()).tryWriteResponse(anyInt(), anyLong());
+  }
+
+  private static Function<DeploymentClient, Record<DeploymentRecordValue>> deploy(
+      final String resource) {
+    return deploymentClient -> deploymentClient.withXmlClasspathResource(resource).deploy();
+  }
+
+  private static Function<DeploymentClient, Record<DeploymentRecordValue>> deploy(
+      final BpmnModelInstance process) {
+    return deploymentClient -> deploymentClient.withXmlResource(process).deploy();
   }
 }


### PR DESCRIPTION
## Description

* send a response of the deploy command if a process contains a timer start event
* avoid missing the response by adding it explicitly as a side-effect
  * by default, the response is written as a side-effect
  * if the side-effects are overridden by `sideEffects::accept` (as it was on calling `catchEventBehavior.subscribeToTimerEvent()`) then no response is sent implicitly 
  * created follow-up issue to make it harder to fall into this trap: #6919

## Related issues

closes #6911 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
