### PR TITLE
Persist snapshot checksum as sibling marker file

### DIFF
--- a/broker/src/test/java/io/zeebe/broker/logstreams/NoopSnapshotStore.java
+++ b/broker/src/test/java/io/zeebe/broker/logstreams/NoopSnapshotStore.java
@@ -66,6 +66,11 @@ public class NoopSnapshotStore implements PersistedSnapshotStore {
                   }
 
                   @Override
+                  public long getChecksum() {
+                    return 0;
+                  }
+
+                  @Override
                   public void close() {}
                 }));
   }

--- a/snapshot/pom.xml
+++ b/snapshot/pom.xml
@@ -51,5 +51,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/snapshot/src/main/java/io/zeebe/snapshots/PersistedSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/PersistedSnapshot.java
@@ -64,4 +64,11 @@ public interface PersistedSnapshot extends CloseableSilently {
 
   /** @return the identifier of the snapshot */
   String getId();
+
+  /**
+   * Returns the checksum of the snapshot, which can be used to verify integrity.
+   *
+   * @return the checksum of the snapshot
+   */
+  long getChecksum();
 }

--- a/snapshot/src/main/java/io/zeebe/snapshots/impl/FileBasedSnapshot.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/impl/FileBasedSnapshot.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,10 +23,18 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedSnapshot.class);
 
   private final Path directory;
+  private final Path checksumFile;
+  private final long checksum;
   private final FileBasedSnapshotMetadata metadata;
 
-  FileBasedSnapshot(final Path directory, final FileBasedSnapshotMetadata metadata) {
+  FileBasedSnapshot(
+      final Path directory,
+      final Path checksumFile,
+      final long checksum,
+      final FileBasedSnapshotMetadata metadata) {
     this.directory = directory;
+    this.checksumFile = checksumFile;
+    this.checksum = checksum;
     this.metadata = metadata;
   }
 
@@ -37,6 +44,10 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
 
   public Path getDirectory() {
     return directory;
+  }
+
+  public Path getChecksumFile() {
+    return checksumFile;
   }
 
   @Override
@@ -57,7 +68,7 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   @Override
   public SnapshotChunkReader newChunkReader() {
     try {
-      return new FileBasedSnapshotChunkReader(directory, SnapshotChecksum.read(directory));
+      return new FileBasedSnapshotChunkReader(directory, checksum);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -65,14 +76,17 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
 
   @Override
   public void delete() {
-    if (!Files.exists(directory)) {
-      return;
+    // the checksum, as a mark file, should be deleted first
+    try {
+      Files.deleteIfExists(checksumFile);
+    } catch (final IOException e) {
+      LOGGER.warn("Failed to delete snapshot checksum file {}", checksumFile, e);
     }
 
     try {
-      FileUtil.deleteFolder(directory);
+      FileUtil.deleteFolderIfExists(directory);
     } catch (final IOException e) {
-      LOGGER.warn("Failed to delete snapshot {}", this, e);
+      LOGGER.warn("Failed to delete snapshot {}", directory, e);
     }
   }
 
@@ -92,13 +106,22 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   }
 
   @Override
+  public long getChecksum() {
+    return checksum;
+  }
+
+  @Override
   public void close() {
     // nothing to be done
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getDirectory(), getMetadata());
+    int result = getDirectory().hashCode();
+    result = 31 * result + checksumFile.hashCode();
+    result = 31 * result + (int) (getChecksum() ^ (getChecksum() >>> 32));
+    result = 31 * result + getMetadata().hashCode();
+    return result;
   }
 
   @Override
@@ -106,17 +129,35 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
     if (this == o) {
       return true;
     }
-
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
 
     final FileBasedSnapshot that = (FileBasedSnapshot) o;
-    return getDirectory().equals(that.getDirectory()) && getMetadata().equals(that.getMetadata());
+
+    if (getChecksum() != that.getChecksum()) {
+      return false;
+    }
+    if (!getDirectory().equals(that.getDirectory())) {
+      return false;
+    }
+    if (!checksumFile.equals(that.checksumFile)) {
+      return false;
+    }
+    return getMetadata().equals(that.getMetadata());
   }
 
   @Override
   public String toString() {
-    return "FileBasedSnapshot{" + "directory=" + directory + ", metadata=" + metadata + '}';
+    return "FileBasedSnapshot{"
+        + "directory="
+        + directory
+        + ", checksumFile="
+        + checksumFile
+        + ", checksum="
+        + checksum
+        + ", metadata="
+        + metadata
+        + '}';
   }
 }

--- a/snapshot/src/main/java/io/zeebe/snapshots/impl/FileBasedSnapshotMetadata.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/impl/FileBasedSnapshotMetadata.java
@@ -34,6 +34,9 @@ public final class FileBasedSnapshotMetadata implements SnapshotId {
     this.exporterPosition = exporterPosition;
   }
 
+  // TODO(npepinpe): using Either here would improve readability and observability, as validation
+  //  can have better error messages, and the return type better expresses what we attempt to do,
+  //  i.e. either it failed (with an error) or it succeeded
   public static Optional<FileBasedSnapshotMetadata> ofPath(final Path path) {
     return ofFileName(path.getFileName().toString());
   }

--- a/snapshot/src/main/java/io/zeebe/snapshots/impl/FileBasedSnapshotMetadata.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/impl/FileBasedSnapshotMetadata.java
@@ -55,7 +55,10 @@ public final class FileBasedSnapshotMetadata implements SnapshotId {
       } catch (final NumberFormatException e) {
         LOGGER.warn("Failed to parse part of snapshot metadata", e);
       }
+    } else {
+      LOGGER.warn("Expected snapshot file format to be %d-%d-%d-%d, but was {}", name);
     }
+
     return metadata;
   }
 

--- a/snapshot/src/main/java/io/zeebe/snapshots/impl/InvalidSnapshotChecksum.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/impl/InvalidSnapshotChecksum.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.snapshots.impl;
+
+import io.zeebe.util.exception.UnrecoverableException;
+import java.nio.file.Path;
+
+@SuppressWarnings("unused")
+public final class InvalidSnapshotChecksum extends UnrecoverableException {
+  private static final String MESSAGE_FORMAT =
+      "Expected snapshot %s to have checksum %d, but was %d";
+  private final transient Path snapshotPath;
+  private final long expectedChecksum;
+  private final long actualChecksum;
+
+  public InvalidSnapshotChecksum(
+      final Path snapshotPath, final long expectedChecksum, final long actualChecksum) {
+    super(String.format(MESSAGE_FORMAT, snapshotPath, expectedChecksum, actualChecksum));
+
+    this.snapshotPath = snapshotPath;
+    this.expectedChecksum = expectedChecksum;
+    this.actualChecksum = actualChecksum;
+  }
+
+  public InvalidSnapshotChecksum(
+      final Throwable cause,
+      final Path snapshotPath,
+      final long expectedChecksum,
+      final long actualChecksum) {
+    super(String.format(MESSAGE_FORMAT, snapshotPath, expectedChecksum, actualChecksum), cause);
+
+    this.snapshotPath = snapshotPath;
+    this.expectedChecksum = expectedChecksum;
+    this.actualChecksum = actualChecksum;
+  }
+
+  public Path getSnapshotPath() {
+    return snapshotPath;
+  }
+
+  public long getExpectedChecksum() {
+    return expectedChecksum;
+  }
+
+  public long getActualChecksum() {
+    return actualChecksum;
+  }
+}

--- a/snapshot/src/main/java/io/zeebe/snapshots/impl/SnapshotChecksum.java
+++ b/snapshot/src/main/java/io/zeebe/snapshots/impl/SnapshotChecksum.java
@@ -22,73 +22,47 @@ import org.agrona.IoUtil;
 
 final class SnapshotChecksum {
 
-  private static final String CHECKSUM_FILE_NAME = "CHECKSUM";
-
   private SnapshotChecksum() {
     throw new IllegalStateException("Utility class");
   }
 
-  public static boolean hasChecksum(final Path snapshotDirectory) {
-    final var file = snapshotDirectory.resolve(CHECKSUM_FILE_NAME).toFile();
-    return file.exists();
-  }
-
-  public static long read(final Path snapshotDirectory) throws IOException {
-    final var file = snapshotDirectory.resolve(CHECKSUM_FILE_NAME).toFile();
-    if (!file.exists()) {
-      throw new IllegalStateException(
-          String.format(
-              "Expected to find a checksum file named %s, but no such file exists.",
-              CHECKSUM_FILE_NAME));
-    }
-    try (final RandomAccessFile checksumFile = new RandomAccessFile(file, "r")) {
+  public static long read(final Path checksumPath) throws IOException {
+    try (final RandomAccessFile checksumFile = new RandomAccessFile(checksumPath.toFile(), "r")) {
       return checksumFile.readLong();
     }
   }
 
   public static long calculate(final Path snapshotDirectory) throws IOException {
     try (final var fileStream = Files.list(snapshotDirectory).sorted()) {
-      return createCombinedChecksum(
-          fileStream
-              .filter(path -> !path.endsWith(CHECKSUM_FILE_NAME))
-              .collect(Collectors.toList()));
+      return createCombinedChecksum(fileStream.collect(Collectors.toList()));
     }
   }
 
-  public static void persist(final Path snapshotDirectory, final long checksum) throws IOException {
-    final var file = snapshotDirectory.resolve(CHECKSUM_FILE_NAME).toFile();
-    // If checksum file already exists, don't overwrite it
-    if (file.createNewFile()) {
-      try (final RandomAccessFile checksumFile = new RandomAccessFile(file, "rw")) {
-        checksumFile.writeLong(checksum);
-      }
+  public static void persist(final Path checksumPath, final long checksum) throws IOException {
+    try (final RandomAccessFile checksumFile = new RandomAccessFile(checksumPath.toFile(), "rwd")) {
+      checksumFile.writeLong(checksum);
     }
-  }
-
-  public static boolean verify(final Path snapshotDirectory) throws IOException {
-    final var expectedChecksum = read(snapshotDirectory);
-    final var actualChecksum = calculate(snapshotDirectory);
-    return expectedChecksum == actualChecksum;
   }
 
   /** computes a checksum for the files, in the order they're presented */
   private static long createCombinedChecksum(final List<Path> paths) throws IOException {
     final Checksum checksum = SnapshotChunkUtil.newChecksum();
+    final ByteBuffer readBuffer = ByteBuffer.allocate(IoUtil.BLOCK_SIZE);
 
-    final ByteBuffer buff = ByteBuffer.allocate(IoUtil.BLOCK_SIZE);
     for (final var path : paths) {
       final byte[] chunkId = path.getFileName().toString().getBytes(StandardCharsets.UTF_8);
       checksum.update(chunkId);
 
       try (final FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
-        buff.clear();
-        while (channel.read(buff) > 0) {
-          buff.flip();
-          checksum.update(buff);
-          buff.clear();
+        readBuffer.clear();
+        while (channel.read(readBuffer) > 0) {
+          readBuffer.flip();
+          checksum.update(readBuffer);
+          readBuffer.clear();
         }
       }
     }
+
     return checksum.getValue();
   }
 }

--- a/snapshot/src/test/java/io/zeebe/snapshots/PersistedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/PersistedSnapshotStoreTest.java
@@ -5,11 +5,11 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.zeebe.snapshots.impl;
+package io.zeebe.snapshots;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.zeebe.snapshots.ReceivableSnapshotStore;
+import io.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import org.junit.Before;
 import org.junit.Rule;

--- a/snapshot/src/test/java/io/zeebe/snapshots/PersistedSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/PersistedSnapshotTest.java
@@ -5,11 +5,11 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.zeebe.snapshots.impl;
+package io.zeebe.snapshots;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.zeebe.snapshots.ConstructableSnapshotStore;
+import io.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
 import io.zeebe.util.FileUtil;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.File;

--- a/snapshot/src/test/java/io/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -5,18 +5,15 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.zeebe.snapshots.impl;
+package io.zeebe.snapshots;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.zeebe.snapshots.ConstructableSnapshotStore;
-import io.zeebe.snapshots.PersistedSnapshot;
-import io.zeebe.snapshots.ReceivableSnapshotStore;
-import io.zeebe.snapshots.ReceivedSnapshot;
-import io.zeebe.snapshots.SnapshotChunk;
+import io.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
+import io.zeebe.snapshots.impl.InvalidSnapshotChecksum;
 import io.zeebe.util.FileUtil;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.IOException;

--- a/snapshot/src/test/java/io/zeebe/snapshots/SnapshotChunkReaderTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/SnapshotChunkReaderTest.java
@@ -5,15 +5,14 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.zeebe.snapshots.impl;
+package io.zeebe.snapshots;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.zeebe.protocol.Protocol;
-import io.zeebe.snapshots.PersistedSnapshot;
-import io.zeebe.snapshots.SnapshotChunk;
+import io.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
 import io.zeebe.util.FileUtil;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.IOException;
@@ -70,12 +69,10 @@ public class SnapshotChunkReaderTest {
 
         // then
         assertThat(asByteBuffer(chunk.getChunkName())).isNotNull().isEqualTo(nextId);
-
         assertThat(chunk.getSnapshotId()).isEqualTo(persistedSnapshot.getId());
         assertThat(chunk.getTotalCount()).isEqualTo(EXPECTED_CHUNK_COUNT);
         assertThat(chunk.getSnapshotChecksum()).isEqualTo(expectedSnapshotChecksum);
-        assertThat(chunk.getChecksum())
-            .isEqualTo(SnapshotChunkUtil.createChecksum(chunk.getContent()));
+        assertThat(chunk.getChecksum()).as("the chunk has a checksum").isNotNegative();
       }
     }
   }

--- a/snapshot/src/test/java/io/zeebe/snapshots/SnapshotChunkWrapper.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/SnapshotChunkWrapper.java
@@ -5,9 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.zeebe.snapshots.impl;
-
-import io.zeebe.snapshots.SnapshotChunk;
+package io.zeebe.snapshots;
 
 public final class SnapshotChunkWrapper implements SnapshotChunk {
 

--- a/snapshot/src/test/java/io/zeebe/snapshots/TransientSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/TransientSnapshotTest.java
@@ -5,15 +5,13 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.zeebe.snapshots.impl;
+package io.zeebe.snapshots;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.zeebe.snapshots.ConstructableSnapshotStore;
-import io.zeebe.snapshots.PersistedSnapshot;
-import io.zeebe.snapshots.PersistedSnapshotListener;
+import io.zeebe.snapshots.impl.FileBasedSnapshotStoreFactory;
 import io.zeebe.util.FileUtil;
 import io.zeebe.util.sched.future.ActorFuture;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -14,6 +14,7 @@ import io.zeebe.snapshots.PersistedSnapshot;
 import io.zeebe.snapshots.PersistedSnapshotListener;
 import io.zeebe.snapshots.ReceivedSnapshot;
 import io.zeebe.snapshots.SnapshotChunk;
+import io.zeebe.snapshots.SnapshotChunkWrapper;
 import io.zeebe.test.util.asserts.DirectoryAssert;
 import io.zeebe.util.FileUtil;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -14,6 +14,7 @@ import io.zeebe.snapshots.PersistedSnapshot;
 import io.zeebe.snapshots.PersistedSnapshotListener;
 import io.zeebe.snapshots.ReceivedSnapshot;
 import io.zeebe.snapshots.SnapshotChunk;
+import io.zeebe.test.util.asserts.DirectoryAssert;
 import io.zeebe.util.FileUtil;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.IOException;
@@ -125,12 +126,15 @@ public class FileBasedReceivedSnapshotTest {
     // when
     final PersistedSnapshot secondPersistedSnapshot = takePersistedSnapshot(2L);
     final var secondReceivedPersistedSnapshot =
-        receiveSnapshot(secondPersistedSnapshot).persist().join();
+        (FileBasedSnapshot) receiveSnapshot(secondPersistedSnapshot).persist().join();
 
     // then
     assertThat(receiverSnapshotsDir)
+        .asInstanceOf(DirectoryAssert.factory())
         .as("there is only the latest snapshot in the receiver's snapshot directory")
-        .isDirectoryNotContaining(p -> !p.equals(secondReceivedPersistedSnapshot.getPath()));
+        .isDirectoryContainingExactly(
+            secondReceivedPersistedSnapshot.getPath(),
+            secondReceivedPersistedSnapshot.getChecksumFile());
   }
 
   @Test
@@ -146,10 +150,10 @@ public class FileBasedReceivedSnapshotTest {
 
     // then
     assertThat(receiverPendingDir)
+        .asInstanceOf(DirectoryAssert.factory())
         .as(
             "the latest pending snapshot should not be deleted because it is newer than the persisted one")
-        .isDirectoryContaining(p -> p.equals(receivedSnapshot.getPath()))
-        .isDirectoryNotContaining(p -> !p.equals(receivedSnapshot.getPath()));
+        .isDirectoryContainingExactly(receivedSnapshot.getPath());
   }
 
   @Test
@@ -207,9 +211,10 @@ public class FileBasedReceivedSnapshotTest {
     }
 
     assertThat(receivedSnapshot.getPath())
+        .asInstanceOf(DirectoryAssert.factory())
         .as("the received snapshot should contain only the first chunk")
-        .isDirectoryNotContaining(
-            p -> !p.getFileName().toString().equals(firstChunk.getChunkName()));
+        .isDirectoryContainingExactly(
+            receivedSnapshot.getPath().resolve(firstChunk.getChunkName()));
   }
 
   @Test
@@ -231,9 +236,10 @@ public class FileBasedReceivedSnapshotTest {
 
     // then
     assertThat(receivedSnapshot.getPath())
+        .asInstanceOf(DirectoryAssert.factory())
         .as("the received snapshot should contain only the first chunk")
-        .isDirectoryNotContaining(
-            p -> !p.getFileName().toString().equals(firstChunk.getChunkName()));
+        .isDirectoryContainingExactly(
+            receivedSnapshot.getPath().resolve(firstChunk.getChunkName()));
   }
 
   @Test
@@ -256,9 +262,10 @@ public class FileBasedReceivedSnapshotTest {
 
     // then
     assertThat(receivedSnapshot.getPath())
+        .asInstanceOf(DirectoryAssert.factory())
         .as("the received snapshot should contain only the first chunk")
-        .isDirectoryNotContaining(
-            p -> !p.getFileName().toString().equals(firstChunk.getChunkName()));
+        .isDirectoryContainingExactly(
+            receivedSnapshot.getPath().resolve(firstChunk.getChunkName()));
   }
 
   @Test
@@ -281,9 +288,10 @@ public class FileBasedReceivedSnapshotTest {
 
     // then
     assertThat(receivedSnapshot.getPath())
+        .asInstanceOf(DirectoryAssert.factory())
         .as("the received snapshot should contain only the first chunk")
-        .isDirectoryNotContaining(
-            p -> !p.getFileName().toString().equals(firstChunk.getChunkName()));
+        .isDirectoryContainingExactly(
+            receivedSnapshot.getPath().resolve(firstChunk.getChunkName()));
   }
 
   private ReceivedSnapshot receiveSnapshot(final PersistedSnapshot persistedSnapshot)

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -9,20 +9,18 @@ package io.zeebe.snapshots.impl;
 
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
-import io.zeebe.snapshots.PersistedSnapshot;
 import io.zeebe.snapshots.TransientSnapshot;
+import io.zeebe.test.util.asserts.DirectoryAssert;
 import io.zeebe.util.FileUtil;
 import io.zeebe.util.sched.testing.ActorSchedulerRule;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
-import java.util.List;
 import org.agrona.IoUtil;
 import org.junit.Before;
 import org.junit.Rule;
@@ -45,8 +43,8 @@ public class FileBasedSnapshotStoreTest {
   @Before
   public void before() throws IOException {
     final var root = temporaryFolder.newFolder("snapshots").toPath();
-    snapshotsDir = root.resolve(PENDING_DIRECTORY);
-    pendingSnapshotsDir = root.resolve(SNAPSHOT_DIRECTORY);
+    snapshotsDir = root.resolve(SNAPSHOT_DIRECTORY);
+    pendingSnapshotsDir = root.resolve(PENDING_DIRECTORY);
     snapshotStore = createStore(snapshotsDir, pendingSnapshotsDir);
   }
 
@@ -79,46 +77,38 @@ public class FileBasedSnapshotStoreTest {
   @Test
   public void shouldLoadLatestSnapshotWhenMoreThanOneExistsAndDeleteOlder() {
     // given
-    final List<FileBasedSnapshotMetadata> snapshots = new ArrayList<>();
-    snapshots.add(new FileBasedSnapshotMetadata(1, 1, 1, 1));
-    snapshots.add(new FileBasedSnapshotMetadata(10, 1, 10, 10));
-    snapshots.add(new FileBasedSnapshotMetadata(2, 1, 2, 2));
-
-    // We can't use FileBasedSnapshotStore to create multiple snapshot as it always delete the
-    // previous snapshot during normal execution. However, due to errors or crashes during
-    // persisting a snapshot, it might end up with more than one snapshot directory on disk.
-    snapshots.forEach(
-        snapshotId -> {
-          try {
-            final var snapshot = snapshotsDir.resolve(snapshotId.getSnapshotIdAsString()).toFile();
-            assertThat(snapshot.mkdir()).isTrue();
-            createSnapshotDir(snapshot.toPath());
-            final var checksum = SnapshotChecksum.calculate(snapshot.toPath());
-            SnapshotChecksum.persist(snapshot.toPath(), checksum);
-          } catch (final IOException e) {
-            fail("Failed to create directory", e);
-          }
-        });
+    final FileBasedSnapshotStore otherStore = createStore(snapshotsDir, pendingSnapshotsDir);
+    final var olderSnapshot = takeTransientSnapshot(1L, otherStore).persist().join();
+    final var newerSnapshot =
+        (FileBasedSnapshot) takeTransientSnapshot(2L, snapshotStore).persist().join();
 
     // when
+    assertThat(snapshotsDir)
+        .asInstanceOf(DirectoryAssert.factory())
+        .as("ensure both the older and newer snapshots exist")
+        .isDirectoryContainingAllOf(olderSnapshot.getPath(), newerSnapshot.getPath());
     snapshotStore.close();
     snapshotStore = createStore(snapshotsDir, pendingSnapshotsDir);
 
     // then
-    assertThat(snapshotStore.getCurrentSnapshotIndex()).isEqualTo(10L);
-    final var latestSnapshotPath =
-        snapshotStore.getLatestSnapshot().map(PersistedSnapshot::getPath).orElseThrow();
+    assertThat(snapshotStore.getLatestSnapshot()).hasValue(newerSnapshot);
     assertThat(snapshotsDir)
-        .as("The older snapshots should have been deleted")
-        .isDirectoryNotContaining(p -> !p.equals(latestSnapshotPath));
+        .asInstanceOf(DirectoryAssert.factory())
+        .as("the older snapshots should have been deleted")
+        .isDirectoryContainingExactly(newerSnapshot.getPath(), newerSnapshot.getChecksumFile());
   }
 
   @Test
   public void shouldNotLoadCorruptedSnapshot() throws Exception {
     // given
-    final var persistedSnapshot = takeTransientSnapshot().persist().join();
-
-    corruptSnapshot(persistedSnapshot);
+    final var persistedSnapshot = (FileBasedSnapshot) takeTransientSnapshot().persist().join();
+    try (final var channel =
+        FileChannel.open(
+            persistedSnapshot.getChecksumFile(),
+            StandardOpenOption.WRITE,
+            StandardOpenOption.DSYNC)) {
+      channel.write(ByteBuffer.allocate(Long.BYTES).putLong(0, 0xCAFEL));
+    }
 
     // when
     snapshotStore.close();
@@ -140,14 +130,6 @@ public class FileBasedSnapshotStoreTest {
     assertThat(pendingSnapshotsDir).isEmptyDirectory();
   }
 
-  private void corruptSnapshot(final PersistedSnapshot persistedSnapshot) throws IOException {
-    final var corruptedFile =
-        persistedSnapshot.getPath().resolve(SNAPSHOT_CONTENT_FILE_NAME).toFile();
-    try (final RandomAccessFile file = new RandomAccessFile(corruptedFile, "rw")) {
-      file.writeLong(12346L);
-    }
-  }
-
   private boolean createSnapshotDir(final Path path) {
     try {
       FileUtil.ensureDirectoryExists(path);
@@ -163,7 +145,12 @@ public class FileBasedSnapshotStoreTest {
   }
 
   private TransientSnapshot takeTransientSnapshot() {
-    final var transientSnapshot = snapshotStore.newTransientSnapshot(1, 1, 1, 0).orElseThrow();
+    return takeTransientSnapshot(1L, snapshotStore);
+  }
+
+  private TransientSnapshot takeTransientSnapshot(
+      final long index, final FileBasedSnapshotStore store) {
+    final var transientSnapshot = store.newTransientSnapshot(index, 1, 1, 0).orElseThrow();
     transientSnapshot.take(this::createSnapshotDir);
     return transientSnapshot;
   }

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedSnapshotTest.java
@@ -1,0 +1,2 @@
+package io.zeebe.snapshots.impl;public class FileBasedSnapshotTest {
+}

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedSnapshotTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/FileBasedSnapshotTest.java
@@ -1,2 +1,69 @@
-package io.zeebe.snapshots.impl;public class FileBasedSnapshotTest {
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.snapshots.impl;
+
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public final class FileBasedSnapshotTest {
+  private static final Map<String, String> SNAPSHOT_FILE_CONTENTS =
+      Map.of(
+          "file1", "file1 contents",
+          "file2", "file2 contents");
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private Path snapshotDir;
+
+  @Before
+  public void beforeEach() throws Exception {
+    snapshotDir = temporaryFolder.newFolder("store", "snapshots").toPath();
+  }
+
+  @Test
+  public void shouldDeleteSnapshot() throws IOException {
+    // given
+    final var snapshotPath = snapshotDir.resolve("snapshot");
+    final Path checksumPath = snapshotDir.resolve("checksum");
+    final var snapshot = createSnapshot(snapshotPath, checksumPath);
+
+    // when
+    snapshot.delete();
+
+    // then
+    assertThat(snapshotPath).doesNotExist();
+    assertThat(checksumPath).doesNotExist();
+  }
+
+  private FileBasedSnapshot createSnapshot(final Path snapshotPath, final Path checksumPath)
+      throws IOException {
+    final var metadata = new FileBasedSnapshotMetadata(1L, 1L, 1L, 1L);
+
+    FileUtil.ensureDirectoryExists(snapshotPath);
+    for (final var entry : SNAPSHOT_FILE_CONTENTS.entrySet()) {
+      final var fileName = snapshotPath.resolve(entry.getKey());
+      final var fileContent = entry.getValue().getBytes(StandardCharsets.UTF_8);
+      Files.write(fileName, fileContent, CREATE_NEW, StandardOpenOption.WRITE);
+    }
+    SnapshotChecksum.persist(checksumPath, SnapshotChecksum.calculate(snapshotPath));
+
+    return new FileBasedSnapshot(snapshotPath, checksumPath, 1L, metadata);
+  }
 }

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/SnapshotChecksumTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/SnapshotChecksumTest.java
@@ -108,23 +108,11 @@ public class SnapshotChecksumTest {
   public void shouldPersistChecksum() throws Exception {
     // given
     final var expectedChecksum = SnapshotChecksum.calculate(multipleFileSnapshot);
-    SnapshotChecksum.persist(multipleFileSnapshot, expectedChecksum);
+    final var checksumPath = multipleFileSnapshot.resolveSibling("checksum");
+    SnapshotChecksum.persist(checksumPath, expectedChecksum);
 
     // when
-    final var actual = SnapshotChecksum.read(multipleFileSnapshot);
-
-    // then
-    assertThat(actual).isEqualTo(expectedChecksum);
-  }
-
-  @Test
-  public void shouldGenerateTheSameWithPersistedChecksum() throws Exception {
-    // given
-    final var expectedChecksum = SnapshotChecksum.calculate(multipleFileSnapshot);
-    SnapshotChecksum.persist(multipleFileSnapshot, expectedChecksum);
-
-    // when
-    final var actual = SnapshotChecksum.calculate(multipleFileSnapshot);
+    final var actual = SnapshotChecksum.read(checksumPath);
 
     // then
     assertThat(actual).isEqualTo(expectedChecksum);
@@ -134,13 +122,15 @@ public class SnapshotChecksumTest {
   public void shouldDetectCorruptedSnapshot() throws IOException {
     // given
     final var expectedChecksum = SnapshotChecksum.calculate(corruptedSnapshot);
-    SnapshotChecksum.persist(corruptedSnapshot, expectedChecksum);
+    final var checksumPath = corruptedSnapshot.resolveSibling("checksum");
+    SnapshotChecksum.persist(checksumPath, expectedChecksum);
 
     // when
     Files.delete(corruptedSnapshot.resolve("file1.txt"));
+    final var actualChecksum = SnapshotChecksum.calculate(corruptedSnapshot);
 
     // then
-    assertThat(SnapshotChecksum.verify(corruptedSnapshot)).isFalse();
+    assertThat(actualChecksum).isNotEqualTo(expectedChecksum);
   }
 
   @Test

--- a/snapshot/src/test/java/io/zeebe/snapshots/impl/SnapshotChunkReaderTest.java
+++ b/snapshot/src/test/java/io/zeebe/snapshots/impl/SnapshotChunkReaderTest.java
@@ -35,7 +35,7 @@ public class SnapshotChunkReaderTest {
 
   private static final Map<String, String> SNAPSHOT_CHUNK =
       Map.of("file3", "content", "file1", "this", "file2", "is");
-  private static final int EXPECTED_CHUNK_COUNT = 4;
+  private static final int EXPECTED_CHUNK_COUNT = 3;
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   @Rule public ActorSchedulerRule scheduler = new ActorSchedulerRule();
   private PersistedSnapshot persistedSnapshot;
@@ -57,9 +57,9 @@ public class SnapshotChunkReaderTest {
   }
 
   @Test
-  public void shouldReadSnapshotChunks() throws IOException {
+  public void shouldReadSnapshotChunks() {
     // given
-    final var expectedSnapshotChecksum = SnapshotChecksum.calculate(persistedSnapshot.getPath());
+    final var expectedSnapshotChecksum = persistedSnapshot.getChecksum();
 
     try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
       for (int i = 0; i < EXPECTED_CHUNK_COUNT; i++) {
@@ -94,14 +94,9 @@ public class SnapshotChunkReaderTest {
 
     // then
     assertThat(snapshotChunkIds)
-        .containsExactly(
-            asByteBuffer("CHECKSUM"),
-            asByteBuffer("file1"),
-            asByteBuffer("file2"),
-            asByteBuffer("file3"));
+        .containsExactly(asByteBuffer("file1"), asByteBuffer("file2"), asByteBuffer("file3"));
 
     assertThat(snapshotChunks)
-        .filteredOn(chunk -> !chunk.getChunkName().equals("CHECKSUM"))
         .extracting(SnapshotChunk::getContent)
         .extracting(String::new)
         .containsExactly("this", "is", "content");

--- a/test-util/src/main/java/io/zeebe/test/util/asserts/DirectoryAssert.java
+++ b/test-util/src/main/java/io/zeebe/test/util/asserts/DirectoryAssert.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.zeebe.test.util.asserts;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.assertj.core.api.AbstractPathAssert;
+import org.assertj.core.api.InstanceOfAssertFactory;
+
+/**
+ * An extension of {@link AbstractPathAssert} to add some functionality specifically for
+ * directories.
+ *
+ * <p>You can easily extend an existing {@link AbstractPathAssert} by using the factory method, as:
+ *
+ * <p>{@code
+ * assertThat(myPath).asInstanceOf(DirectoryAssert.factory().isDirectoryContainingExactly(...) }
+ */
+@SuppressWarnings({"UnusedReturnValue", "unused", "java:S5803"})
+public final class DirectoryAssert extends AbstractPathAssert<DirectoryAssert> {
+
+  public DirectoryAssert(final Path actual) {
+    super(actual, DirectoryAssert.class);
+  }
+
+  public static DirectoryAssert assertThat(final Path actual) {
+    return new DirectoryAssert(actual);
+  }
+
+  /**
+   * A convenience method to extend existing {@link AbstractPathAssert} by using {@link
+   * #asInstanceOf(InstanceOfAssertFactory)}.
+   *
+   * @return a factory for this assertion class
+   */
+  public static InstanceOfAssertFactory<Path, DirectoryAssert> factory() {
+    return new InstanceOfAssertFactory<>(Path.class, DirectoryAssert::assertThat);
+  }
+
+  /**
+   * Asserts that {@link #actual} contains exactly only the paths in the given collection.
+   *
+   * <p>NOTE: this is not traversing {@link #actual} recursively, and will only look at the direct
+   * descendants.
+   *
+   * <p>NOTE: while you can use this to assert the directory is empty, it's better to use {@link
+   * #isEmptyDirectory()}.
+   *
+   * @param collection the paths to check for
+   * @throws AssertionError if {@link #actual} is not a directory
+   * @throws AssertionError if {@link #actual} contains paths not specified in {@code collection}
+   * @throws AssertionError if there is at least one path from {@code collection} not contained in
+   *     {@link #actual}
+   * @return this assert for chaining
+   */
+  public DirectoryAssert isDirectoryContainingExactly(final Collection<? extends Path> collection) {
+    paths.assertIsDirectory(info, actual);
+
+    final Set<Path> containedPaths = new HashSet<>();
+    final Set<Path> expectedPaths = new HashSet<>(collection);
+
+    try (final Stream<Path> files = Files.list(actual)) {
+      files.forEach(containedPaths::add);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    final Set<Path> missingPaths = new HashSet<>(expectedPaths);
+    final Set<Path> extraPaths = new HashSet<>(containedPaths);
+    missingPaths.removeAll(containedPaths);
+    extraPaths.removeAll(expectedPaths);
+
+    if (!missingPaths.isEmpty() || !extraPaths.isEmpty()) {
+      throw failure(
+          "%nPath %s should contain exactly the following %n%s%nBut found %n%s%nMissing paths: %n%s%nUnexpected paths: %n%s",
+          actual, expectedPaths, containedPaths, missingPaths, extraPaths);
+    }
+
+    return myself;
+  }
+
+  /** @see #isDirectoryContainingExactly(Collection) */
+  public DirectoryAssert isDirectoryContainingExactly(final Path... paths) {
+    return isDirectoryContainingExactly(Arrays.asList(paths));
+  }
+
+  /**
+   * Asserts that {@link #actual} contains all of the paths in the given collection, but may contain
+   * extra, unspecified paths. Use {@link #isDirectoryContainingExactly(Collection)} if you need an
+   * exact comparison.
+   *
+   * <p>NOTE: this is not traversing {@link #actual} recursively, and will only look at the direct
+   * descendants.
+   *
+   * @param collection the paths to check for
+   * @throws AssertionError if {@link #actual} is not a directory
+   * @throws AssertionError if there is at least one path from {@code collection} not contained in
+   *     {@link #actual}
+   * @return this assert for chaining
+   */
+  public DirectoryAssert isDirectoryContainingAllOf(final Collection<? extends Path> collection) {
+    paths.assertIsDirectory(info, actual);
+
+    final Set<Path> containedPaths = new HashSet<>();
+    final Set<Path> expectedPaths = new HashSet<>(collection);
+
+    try (final Stream<Path> files = Files.list(actual)) {
+      files.forEach(containedPaths::add);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    final Set<Path> missingPaths = new HashSet<>(expectedPaths);
+    missingPaths.removeAll(containedPaths);
+
+    if (!missingPaths.isEmpty()) {
+      throw failure(
+          "%nPath %s should contain exactly the following %n%s%nBut found %n%s%nMissing paths: %n%s",
+          actual, expectedPaths, containedPaths, missingPaths);
+    }
+
+    return myself;
+  }
+
+  /** @see #isDirectoryContainingAllOf(Collection) */
+  public DirectoryAssert isDirectoryContainingAllOf(final Path... paths) {
+    return isDirectoryContainingAllOf(Arrays.asList(paths));
+  }
+}

--- a/util/src/main/java/io/zeebe/util/exception/UnrecoverableException.java
+++ b/util/src/main/java/io/zeebe/util/exception/UnrecoverableException.java
@@ -12,4 +12,8 @@ public class UnrecoverableException extends RuntimeException {
   public UnrecoverableException(final String message) {
     super(message);
   }
+
+  public UnrecoverableException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
 }


### PR DESCRIPTION
## Description

This PR modifies how we persist snapshot checksum. The checksum file will is not contained in the snapshot directory anymore, but lives next to it. It has the same file name, but with a `.checksum` extension. The contents of the file were not changed and are still just the CRC32C checksum of the directory (note: this was changed in a separate PR).

Validation of the checksum on persisting is done after the snapshot has been moved to its final location. Then, if the checksum matches the expected checksum, the store will persist it as a sibling `.checksum` file. This file acts as a marker file - on start up, any snapshot which does not have this file is considered to have only been partially written and is immediately deleted. This means that for transient/constructed snapshots, we are calculating it twice - once before moving, and once after. This is somewhat safer, but it's also possibly expensive, and should be challenged/discussed.

The PR also comes with some new utilities - one is `FileUtil#deleteFolderIfExists`, which is inspired from the standard library's `Files#deleteIfExists`, and will ignore `NoSuchFileException` both when deleting contained files and the folder itself. For cases such as when we rollback a snapshot, this can be useful since we don't care too much about it. For cases where it would be important to know we did not delete it, we should use the normal `FileUtil#deleteFolder`.

The PR also adds `DirectoryAssert` which provides some convenience methods to assert that a directory contains exactly the expected paths.

## Related issues

closes #6666

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
