### PR TITLE
Do not trigger job timeouts

### DIFF
--- a/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ServiceTaskBlockBuilder.java
+++ b/test-util/src/main/java/io/zeebe/test/util/bpmn/random/blocks/ServiceTaskBlockBuilder.java
@@ -121,7 +121,9 @@ public class ServiceTaskBlockBuilder implements BlockBuilder {
   private ExecutionPathSegment buildStepsForFailedExecutions(final Random random) {
     final ExecutionPathSegment result = new ExecutionPathSegment();
 
-    if (random.nextBoolean()) {
+    // If we already have a timer boundary event we should not timeout the job,
+    // otherwise this makes the test too fragile (flaky).
+    if (!hasBoundaryTimerEvent && random.nextBoolean()) {
       result.appendDirectSuccessor(new StepActivateAndTimeoutJob(jobType));
     }
 


### PR DESCRIPTION
## Description

In our randomized property based tests we randomly decide, whether we
want to fail, complete or timeout an job. Timer
boundary events on service tasks and testing timeouts can make tests flaky, since
we adjust the clock which is consumed by both. It is not deterministic
which happens.

In order to fix that we add with this commit a condition that we not
trigger job timeouts if we already have timer boundary event.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6910 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
