### PR TITLE
fix(elastisearch-exporter): use component template for common mappings

### DIFF
--- a/exporters/elasticsearch-exporter/docker-compose.yml
+++ b/exporters/elasticsearch-exporter/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.12.0
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.12.1
         ports:
             - "9200:9200"
             - "9300:9300"
@@ -12,7 +12,7 @@ services:
             - ES_JAVA_OPTS=-Xmx750m -Xms750m
 
     kibana:
-        image: docker.elastic.co/kibana/kibana:7.12.0
+        image: docker.elastic.co/kibana/kibana:7.12.1
         ports:
             - "5601:5601"
         links:

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -130,7 +130,7 @@ public class ElasticsearchExporter implements Exporter {
     final IndexConfiguration index = configuration.index;
 
     if (index.createTemplate) {
-      createRootIndexTemplate();
+      createComponentTemplate();
 
       if (index.deployment) {
         createValueIndexTemplate(ValueType.DEPLOYMENT);
@@ -176,11 +176,11 @@ public class ElasticsearchExporter implements Exporter {
     indexTemplatesCreated = true;
   }
 
-  private void createRootIndexTemplate() {
+  private void createComponentTemplate() {
     final String templateName = configuration.index.prefix;
     final String aliasName = configuration.index.prefix;
     final String filename = ZEEBE_RECORD_TEMPLATE_JSON;
-    if (!client.putIndexTemplate(templateName, aliasName, filename)) {
+    if (!client.putComponentTemplate(templateName, aliasName, filename)) {
       log.warn("Put index template {} from file {} was not acknowledged", templateName, filename);
     }
   }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -2,6 +2,7 @@
   "index_patterns": [
     "zeebe-record_deployment_*"
   ],
+  "composed_of": ["zeebe-record"],
   "priority": 20,
   "version": 1,
   "template": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-error-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-error-template.json
@@ -2,6 +2,7 @@
   "index_patterns": [
     "zeebe-record_error_*"
   ],
+  "composed_of": ["zeebe-record"],
   "priority": 20,
   "version": 1,
   "template": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
@@ -2,6 +2,7 @@
   "index_patterns": [
     "zeebe-record_incident_*"
   ],
+  "composed_of": ["zeebe-record"],
   "priority": 20,
   "version": 1,
   "template": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -2,6 +2,7 @@
   "index_patterns": [
     "zeebe-record_job-batch_*"
   ],
+  "composed_of": ["zeebe-record"],
   "priority": 20,
   "version": 1,
   "template": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -2,6 +2,7 @@
   "index_patterns": [
     "zeebe-record_job_*"
   ],
+  "composed_of": ["zeebe-record"],
   "priority": 20,
   "version": 1,
   "template": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -2,6 +2,7 @@
   "index_patterns": [
     "zeebe-record_message-subscription_*"
   ],
+  "composed_of": ["zeebe-record"],
   "priority": 20,
   "version": 1,
   "template": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
@@ -2,6 +2,7 @@
   "index_patterns": [
     "zeebe-record_message_*"
   ],
+  "composed_of": ["zeebe-record"],
   "priority": 20,
   "version": 1,
   "template": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-creation-template.json
@@ -2,6 +2,7 @@
   "index_patterns": [
     "zeebe-record_process-instance-creation_*"
   ],
+  "composed_of": ["zeebe-record"],
   "priority": 20,
   "version": 1,
   "template": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -2,6 +2,7 @@
   "index_patterns": [
     "zeebe-record_process-instance_*"
   ],
+  "composed_of": ["zeebe-record"],
   "priority": 20,
   "version": 1,
   "template": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-message-subscription-template.json
@@ -2,6 +2,7 @@
   "index_patterns": [
     "zeebe-record_process-message-subscription_*"
   ],
+  "composed_of": ["zeebe-record"],
   "priority": 20,
   "version": 1,
   "template": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json
@@ -2,6 +2,7 @@
   "index_patterns": [
     "zeebe-record_process_*"
   ],
+  "composed_of": ["zeebe-record"],
   "priority": 20,
   "version": 1,
   "template": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -1,17 +1,10 @@
 {
-  "index_patterns": [
-    "zeebe-record_*"
-  ],
-  "priority": 10,
   "version": 1,
   "template": {
     "settings": {
       "number_of_shards": 1,
       "number_of_replicas": 0,
       "index.queries.cache.enabled": false
-    },
-    "aliases": {
-      "zeebe-record": {}
     },
     "mappings": {
       "dynamic": "strict",

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-document-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-document-template.json
@@ -2,6 +2,7 @@
   "index_patterns": [
     "zeebe-record_variable-document_*"
   ],
+  "composed_of": ["zeebe-record"],
   "priority": 20,
   "version": 1,
   "template": {

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-variable-template.json
@@ -2,6 +2,7 @@
   "index_patterns": [
     "zeebe-record_variable_*"
   ],
+  "composed_of": ["zeebe-record"],
   "priority": 20,
   "version": 1,
   "template": {

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -81,7 +81,7 @@ public class ElasticsearchExporterTest {
     testHarness.export();
 
     // then
-    verify(esClient).putIndexTemplate("foo-bar", "foo-bar", ZEEBE_RECORD_TEMPLATE_JSON);
+    verify(esClient).putComponentTemplate("foo-bar", "foo-bar", ZEEBE_RECORD_TEMPLATE_JSON);
 
     verify(esClient).putIndexTemplate(ValueType.DEPLOYMENT);
     verify(esClient).putIndexTemplate(ValueType.PROCESS);


### PR DESCRIPTION
## Description

Migrate root index template with common mappings and settings to component template used by all record templates.


<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
