### PR TITLE
fix(project): auto update Go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     open-pull-requests-limit: 5
   # Enable version updates for the go client
   - package-ecosystem: "gomod"
-    directory: "/"
+    directory: "clients/go"
     schedule:
       interval: "daily"
     commit-message:
@@ -20,4 +20,6 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "github.com/docker/*"
     

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ],
-
-  "ignoreDeps": ["github.com/docker/engine", "github.com/docker/docker", "github.com/docker/distribution", "github.com/docker/go-connections", "github.com/docker/go-units"],
-
-  "postUpdateOptions": ["gomodTidy"]
-}


### PR DESCRIPTION
## Description

Re-enables automatic version updates for Go dependencies. Previously these were done by the renovate bot which we had in the zeebe.io/zeebe repository. This configuration should accomplish the same using dependabot.

## Related issues

closes #6940 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
