### PR TITLE
Fix some slow tests

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ServiceTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ServiceTaskTest.java
@@ -214,7 +214,7 @@ public final class ServiceTaskTest {
     final long processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("foo", 10).create();
     assertThat(
-            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(2))
+            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(1))
         .extracting(Record::getIntent)
         .containsExactly(IncidentIntent.CREATED);
 
@@ -234,7 +234,7 @@ public final class ServiceTaskTest {
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
 
     assertThat(
-            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(3))
+            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(2))
         .extracting(Record::getIntent)
         .containsExactly(IncidentIntent.CREATED, IncidentIntent.RESOLVED);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTest.java
@@ -287,7 +287,7 @@ public final class UserTaskTest {
     final long processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("foo", 10).create();
     assertThat(
-            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(2))
+            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(1))
         .extracting(Record::getIntent)
         .containsExactly(IncidentIntent.CREATED);
 
@@ -307,7 +307,7 @@ public final class UserTaskTest {
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
 
     assertThat(
-            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(3))
+            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(2))
         .extracting(Record::getIntent)
         .containsExactly(IncidentIntent.CREATED, IncidentIntent.RESOLVED);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayTest.java
@@ -341,7 +341,7 @@ public final class ExclusiveGatewayTest {
     final long processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId(processId).withVariable("foo", 10).create();
     assertThat(
-            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(2))
+            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(1))
         .extracting(Record::getIntent)
         .containsExactly(IncidentIntent.CREATED);
 
@@ -361,7 +361,7 @@ public final class ExclusiveGatewayTest {
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
 
     assertThat(
-            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(3))
+            RecordingExporter.incidentRecords().withProcessInstanceKey(processInstanceKey).limit(2))
         .extracting(Record::getIntent)
         .containsExactly(IncidentIntent.CREATED, IncidentIntent.RESOLVED);
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionDeploymentRecoveryTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionDeploymentRecoveryTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import java.util.stream.Collectors;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,14 +52,13 @@ public class MultiPartitionDeploymentRecoveryTest {
     ENGINE.start();
 
     // then
-    final var list =
+
+    final var fullyDistributedDeployment =
         RecordingExporter.deploymentRecords()
             .withRecordKey(deployment.getKey())
             .withIntent(DeploymentIntent.FULLY_DISTRIBUTED)
-            .collect(Collectors.toList());
-    assertThat(list).hasSize(1);
+            .getFirst();
 
-    final var fullyDistributedDeployment = list.get(0);
     assertThat(fullyDistributedDeployment.getKey()).isNotNegative();
     assertThat(fullyDistributedDeployment.getPartitionId()).isEqualTo(PARTITION_ID);
     assertThat(fullyDistributedDeployment.getRecordType()).isEqualTo(RecordType.EVENT);


### PR DESCRIPTION
## Description

 * Instead of collecting all record and waiting for the timeout we get the
first element.
 * On several incident tests we haven't used the correct limits, which
caused long execution times of the tests (reduced the execution time for each test from 20 s to 1)
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda-cloud/zeebe/issues/6892

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
