### PR TITLE
feat(broker,gateway): Fix the start process to enable readiness probes.

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.concurrent.CountDownLatch;
 import org.apache.logging.log4j.LogManager;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +35,6 @@ public class StandaloneBroker implements CommandLineRunner {
   @Autowired Environment springEnvironment;
   @Autowired SpringBrokerBridge springBrokerBridge;
 
-  private final CountDownLatch waiting_latch = new CountDownLatch(1);
   private String tempFolder;
 
   public static void main(final String[] args) throws Exception {
@@ -71,7 +69,6 @@ public class StandaloneBroker implements CommandLineRunner {
                 }
               }
             });
-    waiting_latch.await();
   }
 
   private Broker createBrokerInBaseDirectory() {

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -5,8 +5,13 @@ management.endpoints.web.exposure.include=health,prometheus,loggers,partitions
 #Metrics related configurations
 management.endpoint.prometheus.enabled=true
 management.metrics.export.prometheus.enabled=true
+management.health.livenessState.enabled=true
+management.health.readinessState.enabled=true
+management.endpoint.health.probes.enabled=true
 management.endpoint.health.group.startup.include=gatewayStarted
 management.endpoint.health.group.startup.show-details=never
+management.endpoint.health.group.readiness.include=gatewayStarted
+management.endpoint.health.group.readiness.show-details=never
 management.endpoint.health.group.liveness.include=gatewayStarted,livenessGatewayResponsive,livenessGatewayClusterAwareness,livenessGatewayPartitionLeaderAwareness,livenessDiskSpace,livenessMemory
 management.endpoint.health.group.liveness.show-details=never
 #Allow runtime configuration of log levels

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -185,9 +185,8 @@ public final class Gateway {
     return LongPollingActivateJobsHandler.newBuilder().setBrokerClient(brokerClient).build();
   }
 
-  public void listenAndServe() throws InterruptedException, IOException {
+  public void listenAndServe() throws IOException {
     start();
-    server.awaitTermination();
   }
 
   public void stop() {


### PR DESCRIPTION
## Description

So, the `READINESS_STATE` was not published because:
1. It should be published there: `org.springframework.boot.context.event.EventPublishingRunListener#running`
2. But, a broker is `org.springframework.boot.CommandLineRunner` with an infinitive latch
3. In the `org.springframework.boot.SpringApplication#run(java.lang.String...)` we have this order:
3.1. App started
3.2. Calling `org.springframework.boot.SpringApplicationRunListeners#started`
3.3. In one listener this means that the app is in `LivenessState.CORRECT` state (org.springframework.boot.context.event.EventPublishingRunListener#started)
3.4. So, liveness became ok.
3.5. App running (i.e. `org.springframework.boot.CommandLineRunner` is executed)
3.6. Calling `org.springframework.boot.SpringApplicationRunListeners#running`
3.7. In one listener this means that the app is in `org.springframework.boot.availability.ReadinessState#ACCEPTING_TRAFFIC` state
3.8. So, readiness became ok.

I decided to remove sync calls and add some shutdown hooks instead of them.

Because of the current implementation, we are stuck in the 3.5 and don't go down the list.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6413

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
