### PR TITLE
Don't override variables when completing sub process

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -208,7 +208,10 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessMessageSubscriptionIntent.CORRELATED,
         new ProcessMessageSubscriptionCorrelatedApplier(
-            subscriptionState, state.getVariableState()));
+            subscriptionState,
+            state.getVariableState(),
+            state.getElementInstanceState(),
+            state.getProcessState()));
     register(
         ProcessMessageSubscriptionIntent.DELETING,
         new ProcessMessageSubscriptionDeletingApplier(subscriptionState));

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessMessageSubscriptionCorrelatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessMessageSubscriptionCorrelatedApplier.java
@@ -7,7 +7,10 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
@@ -19,23 +22,65 @@ public final class ProcessMessageSubscriptionCorrelatedApplier
 
   private final MutableProcessMessageSubscriptionState subscriptionState;
   private final MutableVariableState variableState;
+  private final ElementInstanceState elementInstanceState;
+  private final ProcessState processState;
 
   public ProcessMessageSubscriptionCorrelatedApplier(
       final MutableProcessMessageSubscriptionState subscriptionState,
-      final MutableVariableState variableState) {
+      final MutableVariableState variableState,
+      final ElementInstanceState elementInstanceState,
+      final ProcessState processState) {
     this.subscriptionState = subscriptionState;
     this.variableState = variableState;
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
   }
 
   @Override
   public void applyState(final long key, final ProcessMessageSubscriptionRecord value) {
+    final var eventScopeKey = value.getElementInstanceKey();
     if (value.isInterrupting()) {
-      subscriptionState.remove(value.getElementInstanceKey(), value.getMessageNameBuffer());
+      subscriptionState.remove(eventScopeKey, value.getMessageNameBuffer());
+    }
+
+    if (shouldCreateTemporaryVariables(value)) {
+      variableState.setTemporaryVariables(eventScopeKey, value.getVariablesBuffer());
+    }
+  }
+
+  // temporary variables are being replaced with local variables and variables on the event trigger
+  // try to reduce the number of cases this method returns true
+  private boolean shouldCreateTemporaryVariables(final ProcessMessageSubscriptionRecord value) {
+    if (value.getVariablesBuffer().capacity() <= 0) {
+      return false;
     }
 
     final var eventScopeKey = value.getElementInstanceKey();
-    if (value.getVariablesBuffer().capacity() > 0) {
-      variableState.setTemporaryVariables(eventScopeKey, value.getVariablesBuffer());
+    final var eventScopeInstance = elementInstanceState.getInstance(eventScopeKey);
+    if (eventScopeInstance == null) {
+      // unexpected...
+      return false;
+    }
+
+    // the event element is the specific element that the message was correlated to
+    // i.e. the boundary event, the intermediary event, the start event, etc
+    final ExecutableFlowElement eventElement =
+        processState.getFlowElement(
+            eventScopeInstance.getValue().getProcessDefinitionKey(),
+            value.getElementIdBuffer(),
+            ExecutableFlowElement.class);
+    if (eventElement == null) {
+      // unexpected...
+      return false;
+    }
+
+    switch (eventElement.getElementType()) {
+      case INTERMEDIATE_CATCH_EVENT:
+      case RECEIVE_TASK:
+      case START_EVENT:
+        return true;
+      default:
+        return false;
     }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/VariableClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/VariableClient.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.util.client;
 
 import io.camunda.zeebe.engine.util.StreamProcessorRule;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
@@ -62,6 +63,10 @@ public final class VariableClient {
   public VariableClient withDocument(final DirectBuffer variables) {
     variableDocumentRecord.setVariables(variables);
     return this;
+  }
+
+  public VariableClient withDocument(final String variables) {
+    return withDocument(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(variables)));
   }
 
   public VariableClient withUpdateSemantic(final VariableDocumentUpdateSemantic semantic) {

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -489,15 +489,15 @@ public class CompactRecordLogger {
   private String summarizeVariable(final Record<?> record) {
     final var value = (VariableRecordValue) record.getValue();
 
-    return new StringBuilder()
-        .append(value.getName())
-        .append("->")
-        .append(value.getValue())
-        .append(" in <process ")
-        .append("[")
-        .append(shortenKey(value.getProcessInstanceKey()))
-        .append("]>")
-        .toString();
+    final var builder = new StringBuilder();
+    builder
+        .append(String.format("%s->%s", value.getName(), value.getValue()))
+        .append(String.format(" in <process [%s]", shortenKey(value.getProcessInstanceKey())));
+    if (value.getProcessInstanceKey() != value.getScopeKey()) {
+      // only add if they're different, no need to state things twice
+      builder.append(String.format(" at [%s]", shortenKey(value.getScopeKey())));
+    }
+    return builder.append(">").toString();
   }
 
   private StringBuilder summarizeRejection(final Record<?> record) {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

fix(engine): use local vars for msg correlation

Variables could be overridden when a subprocess is completed,
specifically when non-interrupting events have happened on that
subprocess that placed temporary variables on it.

The biggest problem here is/was that the temporary variables are not
cleaned up until the element is completed. On completing the element,
the output mappings are applied and these then use all temporary
variables that still exist on it.

We can avoid this by reducing our temporary variables usage (something
we anyways want to do).

Message correlations with variables already create the variables
locally, so temporary variables are no longer needed for boundary
events.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6926 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
