### PR TITLE
Rename distro archive folder to camunda-cloud-zeebe

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -144,6 +144,7 @@
 
   </dependencies>
   <build>
+    <finalName>camunda-cloud-zeebe-${project.version}</finalName>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -159,7 +160,7 @@
           <repositoryLayout>flat</repositoryLayout>
           <useWildcardClassPath>true</useWildcardClassPath>
           <repositoryName>lib</repositoryName>
-          <assembleDirectory>${project.build.directory}/zeebe-broker</assembleDirectory>
+          <assembleDirectory>${project.build.directory}/camunda-cloud-zeebe</assembleDirectory>
           <platforms>
             <platform>windows</platform>
             <platform>unix</platform>
@@ -198,10 +199,10 @@
             </goals>
             <configuration>
               <target>
-                <copy file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl" tofile="${project.build.directory}/zeebe-broker/bin/zbctl" failonerror="${zbctl.force}" />
-                <copy file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.exe" tofile="${project.build.directory}/zeebe-broker/bin/zbctl.exe" failonerror="${zbctl.force}" />
-                <copy file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.darwin" tofile="${project.build.directory}/zeebe-broker/bin/zbctl.darwin" failonerror="${zbctl.force}" />
-                <chmod dir="${project.build.directory}/zeebe-broker/bin" perm="ugo+rx" includes="zbctl*" failonerror="${zbctl.force}" />
+                <copy file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl" failonerror="${zbctl.force}" />
+                <copy file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.exe" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl.exe" failonerror="${zbctl.force}" />
+                <copy file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.darwin" tofile="${project.build.directory}/camunda-cloud-zeebe/bin/zbctl.darwin" failonerror="${zbctl.force}" />
+                <chmod dir="${project.build.directory}/camunda-cloud-zeebe/bin" perm="ugo+rx" includes="zbctl*" failonerror="${zbctl.force}" />
               </target>
             </configuration>
           </execution>

--- a/dist/src/main/assembly.xml
+++ b/dist/src/main/assembly.xml
@@ -5,7 +5,7 @@
   <id>distro</id>
 
   <includeBaseDirectory>true</includeBaseDirectory>
-  <baseDirectory>zeebe-broker-${project.version}/</baseDirectory>
+  <baseDirectory>camunda-cloud-zeebe-${project.version}/</baseDirectory>
 
   <formats>
     <format>zip</format>
@@ -14,7 +14,7 @@
 
   <fileSets>
     <fileSet>
-      <directory>${project.build.directory}/zeebe-broker</directory>
+      <directory>${project.build.directory}/camunda-cloud-zeebe</directory>
       <outputDirectory>/</outputDirectory>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
## Description

- Rename folder inside distro archive from `zeebe-broker` to `camunda-cloud-zeebe`
- Align with archive name and Operate/Tasklist
- zeebe-broker is misleading as the bin folder also contains the gateway and the zbctl to run

## Related issues

related #6913

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
