### PR TITLE
Remove timer start event event scope

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -75,7 +75,10 @@ public final class EventAppliers implements EventApplier {
 
   private void registerTimeEventAppliers(final MutableZeebeState state) {
     register(TimerIntent.CREATED, new TimerCreatedApplier(state.getTimerState()));
-    register(TimerIntent.CANCELED, new TimerCancelledApplier(state.getTimerState()));
+    register(
+        TimerIntent.CANCELED,
+        new TimerCancelledApplier(
+            state.getTimerState(), state.getProcessState(), state.getEventScopeInstanceState()));
     register(TimerIntent.TRIGGERED, new TimerTriggeredApplier(state.getTimerState()));
   }
 
@@ -226,7 +229,8 @@ public final class EventAppliers implements EventApplier {
             state.getProcessState()));
     register(
         ProcessEventIntent.TRIGGERED,
-        new ProcessEventTriggeredApplier(state.getEventScopeInstanceState()));
+        new ProcessEventTriggeredApplier(
+            state.getEventScopeInstanceState(), state.getProcessState()));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessCreatedApplier.java
@@ -27,16 +27,6 @@ public class ProcessCreatedApplier implements TypedEventApplier<ProcessIntent, P
 
   @Override
   public void applyState(final long processDefinitionKey, final ProcessRecord value) {
-
-    final var earlierProcessVersion =
-        processState.getLatestProcessVersionByProcessId(value.getBpmnProcessIdBuffer());
-    final var earlierProcessHasTimerStartEvent =
-        earlierProcessVersion != null && earlierProcessVersion.getProcess().hasTimerStartEvent();
-    if (earlierProcessHasTimerStartEvent) {
-      // we need to clean up the event scope for the previous timer start event
-      eventScopeInstanceState.deleteInstance(earlierProcessVersion.getKey());
-    }
-
     processState.putProcess(processDefinitionKey, value);
 
     final var currentProcessHasTimerStartEvent =

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessEventTriggeredApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessEventTriggeredApplier.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
@@ -15,14 +17,28 @@ import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 final class ProcessEventTriggeredApplier
     implements TypedEventApplier<ProcessEventIntent, ProcessEventRecord> {
   private final MutableEventScopeInstanceState eventScopeState;
+  private final ProcessState processState;
 
-  public ProcessEventTriggeredApplier(final MutableEventScopeInstanceState eventScopeState) {
+  public ProcessEventTriggeredApplier(
+      final MutableEventScopeInstanceState eventScopeState, final ProcessState processState) {
     this.eventScopeState = eventScopeState;
+    this.processState = processState;
   }
 
   @Override
   public void applyState(final long key, final ProcessEventRecord value) {
     final var scopeKey = value.getScopeKey();
     eventScopeState.deleteTrigger(scopeKey, key);
+
+    if (scopeKey == value.getProcessDefinitionKey()) {
+      final var process = processState.getProcessByKey(value.getProcessDefinitionKey());
+      process.getProcess().getStartEvents().stream()
+          .filter(ExecutableCatchEventElement::isTimer)
+          .filter(
+              executableStartEvent ->
+                  executableStartEvent.getId().equals(value.getTargetElementIdBuffer()))
+          .findAny()
+          .ifPresent(executableStartEvent -> eventScopeState.deleteInstance(process.getKey()));
+    }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerCancelledApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerCancelledApplier.java
@@ -7,8 +7,11 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
@@ -16,14 +19,31 @@ import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 final class TimerCancelledApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
 
   private final MutableTimerInstanceState timerInstanceState;
+  private final MutableProcessState processState;
+  private final MutableEventScopeInstanceState eventScopeInstanceState;
 
-  TimerCancelledApplier(final MutableTimerInstanceState timerInstanceState) {
+  TimerCancelledApplier(
+      final MutableTimerInstanceState timerInstanceState,
+      final MutableProcessState processState,
+      final MutableEventScopeInstanceState eventScopeInstanceState) {
     this.timerInstanceState = timerInstanceState;
+    this.processState = processState;
+    this.eventScopeInstanceState = eventScopeInstanceState;
   }
 
   @Override
   public void applyState(final long key, final TimerRecord value) {
     final TimerInstance timerInstance = timerInstanceState.get(value.getElementInstanceKey(), key);
     timerInstanceState.remove(timerInstance);
+
+    final var process = processState.getProcessByKey(value.getProcessDefinitionKey());
+    process.getProcess().getStartEvents().stream()
+        .filter(ExecutableCatchEventElement::isTimer)
+        .filter(
+            executableStartEvent ->
+                executableStartEvent.getId().equals(value.getTargetElementIdBuffer()))
+        .findAny()
+        .ifPresent(
+            executableStartEvent -> eventScopeInstanceState.deleteInstance(process.getKey()));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -73,6 +73,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.awaitility.Awaitility;
 import org.junit.rules.ExternalResource;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -368,6 +369,13 @@ public final class EngineRule extends ExternalResource {
                                   MsgPackConverter.convertToJson(value.getDirectBuffer())));
                   return entries;
                 }));
+  }
+
+  public void awaitProcessingOf(final Record<?> record) {
+    final var recordPosition = record.getPosition();
+
+    Awaitility.await("await the record to be processed")
+        .until(() -> getLastProcessedPosition() >= recordPosition);
   }
 
   private static final class VersatileBlob implements DbKey, DbValue {


### PR DESCRIPTION
## Description

* Add multiple tests for clean state
  * On deploying new version of a process without timer 
  * On deploying first version with a timer and then without
  * after triggering a non recurring timer start event
* Fix removing event scope for timer start events
   *  on canceling timer 
   * on process event triggered
 * Fix flaky test and introduce helper to await processing of a record on engine rule

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6955 
closes #6975 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
