### PR TITLE
fix(clients/go): fix JSON comparisons in zbctl tests

### DIFF
--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -187,43 +186,44 @@ func (s *integrationTestSuite) TestCommonCommands() {
 				t.Fatal(err)
 			}
 
+			var comparer cmp.Option
 			if test.jsonOutput {
-				assertEqJSON(t, test, goldenOut, cmdOut)
+				comparer = jsonComparer()
 			} else {
-				assertEqText(t, test, goldenOut, cmdOut)
+				comparer = textComparer()
 			}
+
+			assertEq(t, test, comparer, goldenOut, cmdOut)
 		})
 	}
 }
 
-func assertEqText(t *testing.T, test testCase, golden, cmdOut []byte) {
+func assertEq(t *testing.T, test testCase, comparer cmp.Option, golden, cmdOut []byte) {
 	wantLines := strings.Split(string(golden), "\n")
 	gotLines := strings.Split(string(cmdOut), "\n")
 
-	if diff := cmp.Diff(wantLines, gotLines, cmp.Comparer(composeComparer(cmpIgnoreNums, cmpIgnoreVersion))); diff != "" {
+	if diff := cmp.Diff(wantLines, gotLines, comparer); diff != "" {
 		t.Fatalf("%s: diff (-want +got):\n%s", test.name, diff)
 	}
 }
 
-func assertEqJSON(t *testing.T, test testCase, golden, cmdOut []byte) {
-	want := string(golden)
-	got := string(cmdOut)
-
-	// remove versions
-	ignorePattern := regexp.MustCompile(semVer)
-	want = ignorePattern.ReplaceAllString(want, "")
-	got = ignorePattern.ReplaceAllString(got, "")
-
-	// remove numbers
-	ignorePattern = regexp.MustCompile(`\d`)
-	want = ignorePattern.ReplaceAllString(want, "1")
-	got = ignorePattern.ReplaceAllString(got, "1")
-
-	require.JSONEqf(t, want, got, "expected JSON output from '%s' to match golden file '%s'", strings.Join(test.cmd, " "), test.goldenFile)
+func jsonComparer() cmp.Option {
+	return composeComparer(func(x string) string {
+		// ignore whitespace
+		pattern := regexp.MustCompile(`\s+`)
+		x = pattern.ReplaceAllString(x, "")
+		return x
+	}, cmpIgnoreVersion, cmpIgnoreNums)
 }
 
-func composeComparer(cmpFuncs ...func(x, y string) bool) func(x, y string) bool {
-	return func(x, y string) bool {
+func textComparer() cmp.Option {
+	return composeComparer(func(x string) string { return x }, cmpIgnoreVersion, cmpIgnoreNums)
+}
+
+func composeComparer(transf func(string) string, cmpFuncs ...func(x, y string) bool) cmp.Option {
+	return cmp.Comparer(func(x, y string) bool {
+		x, y = transf(x), transf(y)
+
 		for _, cmpFunc := range cmpFuncs {
 			if cmpFunc(x, y) {
 				return true
@@ -231,7 +231,7 @@ func composeComparer(cmpFuncs ...func(x, y string) bool) func(x, y string) bool 
 		}
 
 		return false
-	}
+	})
 }
 
 func cmpIgnoreVersion(x, y string) bool {
@@ -243,7 +243,7 @@ func cmpIgnoreVersion(x, y string) bool {
 }
 
 func cmpIgnoreNums(x, y string) bool {
-	numbersRegex := regexp.MustCompile(`\d`)
+	numbersRegex := regexp.MustCompile(`\d+`)
 	newX := numbersRegex.ReplaceAllString(x, "")
 	newY := numbersRegex.ReplaceAllString(y, "")
 

--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -169,7 +169,7 @@ func (s *integrationTestSuite) TestCommonCommands() {
 		s.T().Run(test.name, func(t *testing.T) {
 			for _, cmd := range test.setupCmds {
 				if _, err := s.runCommand(cmd); err != nil {
-					t.Fatal(fmt.Errorf("failed while executing set up command '%s': %w", cmd, err))
+					t.Fatalf("failed while executing set up command '%s': %v", strings.Join(cmd, " "), err)
 				}
 			}
 
@@ -180,7 +180,7 @@ func (s *integrationTestSuite) TestCommonCommands() {
 
 			cmdOut, err := s.runCommand(test.cmd, test.envVars...)
 			if errors.Is(err, context.DeadlineExceeded) {
-				t.Fatal(fmt.Errorf("timed out while executing command '%s': %w", strings.Join(test.cmd, " "), err))
+				t.Fatalf("timed out while executing command '%s': %v", strings.Join(test.cmd, " "), err)
 			}
 
 			goldenOut, err := ioutil.ReadFile(test.goldenFile)
@@ -191,12 +191,12 @@ func (s *integrationTestSuite) TestCommonCommands() {
 			if test.jsonOutput {
 				cmdOut, err = reformatJSON(cmdOut)
 				if err != nil {
-					t.Fatalf("failed to reformat JSON: %s", err.Error())
+					t.Fatalf("failed to reformat JSON: %v", err)
 				}
 
 				goldenOut, err = reformatJSON(goldenOut)
 				if err != nil {
-					t.Fatalf("failed to reformat JSON: %s", err.Error())
+					t.Fatalf("failed to reformat JSON: %v", err)
 				}
 			}
 

--- a/clients/go/cmd/zbctl/testdata/topology_json.golden
+++ b/clients/go/cmd/zbctl/testdata/topology_json.golden
@@ -6,7 +6,7 @@
       "port":  26501,
       "partitions":  [
         {
-          "partitionId":  1,
+          "partitionId":  12,
           "role":  "LEADER",
           "health":  "HEALTHY"
         }

--- a/clients/go/cmd/zbctl/testdata/topology_json.golden
+++ b/clients/go/cmd/zbctl/testdata/topology_json.golden
@@ -1,7 +1,4 @@
-{
-  "brokers":  [
-    {
-      "nodeId":  0,
+{  "brokers":  [    {      "nodeId":  0,
       "host":  "172.17.0.3",
       "port":  26501,
       "partitions":  [


### PR DESCRIPTION
## Description

Fixes a couple of issues in the JSON comparisons:
* in case of failures, the generated diffs had incorrect numbers
* correctly ignores numbers (previously numbers were only considered equal if
they had the same number of digits)
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6967 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
