### PR TITLE
Fixes wrong source record position due incomplete writer reset

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTrigger.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTrigger.java
@@ -76,13 +76,10 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
     state.forEachTimedOutEntry(
         now,
         (key, record) -> {
+          writer.reset();
           writer.appendFollowUpCommand(key, JobIntent.TIME_OUT, record);
 
-          final boolean flushed = writer.flush() >= 0;
-          if (!flushed) {
-            writer.reset();
-          }
-          return flushed;
+          return writer.flush() >= 0;
         });
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriterImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedStreamWriterImpl.java
@@ -96,6 +96,8 @@ public class TypedStreamWriterImpl implements TypedStreamWriter {
 
   @Override
   public void reset() {
+    sourceRecordPosition = -1;
+    metadata.reset();
     batchWriter.reset();
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTriggerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTriggerTest.java
@@ -73,15 +73,16 @@ public final class JobTimeoutTriggerTest {
     // then
     final InOrder inOrder = Mockito.inOrder(typedStreamWriter);
 
+    inOrder.verify(typedStreamWriter).reset();
     inOrder
         .verify(typedStreamWriter)
         .appendFollowUpCommand(eq(0L), eq(JobIntent.TIME_OUT), any(JobRecord.class));
     inOrder.verify(typedStreamWriter).flush();
+    inOrder.verify(typedStreamWriter).reset();
     inOrder
         .verify(typedStreamWriter)
         .appendFollowUpCommand(eq(1L), eq(JobIntent.TIME_OUT), any(JobRecord.class));
     inOrder.verify(typedStreamWriter).flush();
-    inOrder.verify(typedStreamWriter).reset();
     inOrder.verifyNoMoreInteractions();
   }
 }


### PR DESCRIPTION
## Description

This PR fixes resetting the `TypedRecordWriterImpl` - previously, reset would reset the wrapped log writer, but neither the in-memory metadata nor the source record position, which caused some records written outside of the stream processor to have the wrong source record position.

The reset method now resets its whole state, and also the job time outs also reset the writer every time, not just when the flush failed.

I added regression tests for processors which use the `TypedRecordWriterImpl` outside of the `StreamProcessor`/`ProcessingStateMachine`.

## Related issues

closes #5420 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
