### PR TITLE
Remove Event scope when Timer is canceled

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -75,7 +75,10 @@ public final class EventAppliers implements EventApplier {
 
   private void registerTimeEventAppliers(final MutableZeebeState state) {
     register(TimerIntent.CREATED, new TimerCreatedApplier(state.getTimerState()));
-    register(TimerIntent.CANCELED, new TimerCancelledApplier(state.getTimerState()));
+    register(
+        TimerIntent.CANCELED,
+        new TimerCancelledApplier(
+            state.getTimerState(), state.getProcessState(), state.getEventScopeInstanceState()));
     register(TimerIntent.TRIGGERED, new TimerTriggeredApplier(state.getTimerState()));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerCancelledApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerCancelledApplier.java
@@ -7,8 +7,11 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
@@ -16,14 +19,31 @@ import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 final class TimerCancelledApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
 
   private final MutableTimerInstanceState timerInstanceState;
+  private final MutableProcessState processState;
+  private final MutableEventScopeInstanceState eventScopeInstanceState;
 
-  TimerCancelledApplier(final MutableTimerInstanceState timerInstanceState) {
+  TimerCancelledApplier(
+      final MutableTimerInstanceState timerInstanceState,
+      final MutableProcessState processState,
+      final MutableEventScopeInstanceState eventScopeInstanceState) {
     this.timerInstanceState = timerInstanceState;
+    this.processState = processState;
+    this.eventScopeInstanceState = eventScopeInstanceState;
   }
 
   @Override
   public void applyState(final long key, final TimerRecord value) {
     final TimerInstance timerInstance = timerInstanceState.get(value.getElementInstanceKey(), key);
     timerInstanceState.remove(timerInstance);
+
+    final var process = processState.getProcessByKey(value.getProcessDefinitionKey());
+    process.getProcess().getStartEvents().stream()
+        .filter(ExecutableCatchEventElement::isTimer)
+        .filter(
+            executableStartEvent ->
+                executableStartEvent.getId().equals(value.getTargetElementIdBuffer()))
+        .findAny()
+        .ifPresent(
+            executableStartEvent -> eventScopeInstanceState.deleteInstance(process.getKey()));
   }
 }


### PR DESCRIPTION
## Description

Reopening https://github.com/camunda-cloud/zeebe/pull/6969 with only concentrating on Timer cancelation if the timer is either recurring or has not yet triggered. Timers which have already been triggered need to be handled separately https://github.com/camunda-cloud/zeebe/issues/6976


### Details 
Remove the event scope when we cancel the Timer. We can't do it on newest ProcessEvent.CREATED,
otherwise we have problems on triggering the timer and deploying a new version concurrently.
This can cause problems since the event scope doesn't exist anymore on activating the process instance.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6955 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
