### PR TITLE
[Backport 1.0.0] Not retrigger Timer start events

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -135,11 +135,13 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
       final TypedStreamWriter streamWriter,
       final SideEffects sideEffects) {
     for (final ProcessMetadata processMetadata : record.getValue().processesMetadata()) {
-      final List<ExecutableStartEvent> startEvents =
-          processState.getProcessByKey(processMetadata.getKey()).getProcess().getStartEvents();
+      if (!processMetadata.isDuplicate()) {
+        final List<ExecutableStartEvent> startEvents =
+            processState.getProcessByKey(processMetadata.getKey()).getProcess().getStartEvents();
 
-      unsubscribeFromPreviousTimers(streamWriter, processMetadata);
-      subscribeToTimerStartEventIfExists(streamWriter, sideEffects, processMetadata, startEvents);
+        unsubscribeFromPreviousTimers(streamWriter, processMetadata);
+        subscribeToTimerStartEventIfExists(streamWriter, sideEffects, processMetadata, startEvents);
+      }
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -182,7 +182,10 @@ public final class DeploymentTransformer {
         final var isDuplicate =
             isDuplicateOfLatest(deploymentResource, resourceDigest, lastProcess, lastDigest);
         if (isDuplicate) {
-          processMetadata.setVersion(lastProcess.getVersion()).setKey(lastProcess.getKey());
+          processMetadata
+              .setVersion(lastProcess.getVersion())
+              .setKey(lastProcess.getKey())
+              .markAsDuplicate();
         } else {
           final var key = keyGenerator.nextKey();
           processMetadata.setKey(key).setVersion(processState.getProcessVersion(bpmnProcessId) + 1);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.protocol.impl.record.value.processinstance.Proces
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -32,12 +33,16 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
   private final BinaryProperty checksumProp = new BinaryProperty("checksum");
 
+  // should be set to true if the process was already deployed - property should not be exported
+  private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
+
   public ProcessMetadata() {
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
         .declareProperty(resourceNameProp)
-        .declareProperty(checksumProp);
+        .declareProperty(checksumProp)
+        .declareProperty(isDuplicateProp);
   }
 
   @Override
@@ -135,5 +140,15 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
       final DirectBuffer bpmnProcessId, final int offset, final int length) {
     bpmnProcessIdProp.setValue(bpmnProcessId, offset, length);
     return this;
+  }
+
+  public ProcessMetadata markAsDuplicate() {
+    isDuplicateProp.setValue(true);
+    return this;
+  }
+
+  @JsonIgnore
+  public boolean isDuplicate() {
+    return isDuplicateProp.getValue();
   }
 }


### PR DESCRIPTION
## Description

Backports https://github.com/camunda-cloud/zeebe/pull/6961 

> introduce new property on the ProcessMetadata to mark a process as duplicate during deployment
Is useful to handle duplicates differently
Makes it possible to not recalculate whether a process is a duplicate
Do not recreate timer subscription on duplicate process

No fruits (commits) where harmed by these cherry picks :cherries: . 
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6515
backports https://github.com/camunda-cloud/zeebe/pull/6961 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
