### PR TITLE
[Backport 1.0.0] Disable deployment exporting via elastic exporter

### DIFF
--- a/broker/src/test/resources/system/elasticexporter.yaml
+++ b/broker/src/test/resources/system/elasticexporter.yaml
@@ -29,7 +29,8 @@ zeebe:
         #     event: true
         #     rejection: false
         #
-        #     deployment: true
+        #     deployment: false
+        #     process: true
         #     error: true
         #     incident: true
         #     job: true

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -472,7 +472,7 @@
         #     event: true
         #     rejection: false
         #
-        #     deployment: true
+        #     deployment: false
         #     process: true
         #     error: true
         #     incident: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -431,7 +431,7 @@
         #     event: true
         #     rejection: false
         #
-        #     deployment: true
+        #     deployment: false
         #     process: true
         #     error: true
         #     incident: true

--- a/exporters/elasticsearch-exporter/README.md
+++ b/exporters/elasticsearch-exporter/README.md
@@ -1,19 +1,20 @@
 # Zeebe Elasticsearch Exporter
 
 The Zeebe Elasticsearch Exporter acts as a bridge between
-[Zeebe](https://zeebe.io/) and [Elasticsearch](https://www.elastic.co/products/elasticsearch),
-by exporting records written to Zeebe streams as documents into several indices.
+[Zeebe](https://zeebe.io/) and [Elasticsearch](https://www.elastic.co/products/elasticsearch), by
+exporting records written to Zeebe streams as documents into several indices.
 
 ## Concept
 
-The exporter operates on the idea that it should perform as little as possible on the Zeebe side
-of things. In other words, you can think of the indexes into which the records are exported as a staging data
-warehouse: any enrichment or transformation on the exported data should be performed by your own ETL jobs.
+The exporter operates on the idea that it should perform as little as possible on the Zeebe side of
+things. In other words, you can think of the indexes into which the records are exported as a
+staging data warehouse: any enrichment or transformation on the exported data should be performed by
+your own ETL jobs.
 
 To simplify things, when configured to do so, the exporter will automatically create an index per
-record value type (see the value type in the Zeebe protocol). Each of these indexes has a corresponding
-pre-defined mapping to facilitate data ingestion for your own ETL jobs. You can find those as templates
-in this module's resources folder.
+record value type (see the value type in the Zeebe protocol). Each of these indexes has a
+corresponding pre-defined mapping to facilitate data ingestion for your own ETL jobs. You can find
+those as templates in this module's resources folder.
 
 > **Note:** the indexes are created as required, and will not be created twice if they already exist. However,
 > once disabled, they will not be deleted, that is up to the administrator. Similarly, data is never deleted by
@@ -25,141 +26,149 @@ in this module's resources folder.
 
 You can configure the Elasticsearch Exporter with the following arguments:
 
-* `url` (`string`): a valid URLs as comma-separated string (e.g. `http://localhost:9200,http://localhost:9201`)
+* `url` (`string`): a valid URLs as comma-separated string (
+  e.g. `http://localhost:9200,http://localhost:9201`)
 
 All other options fall under a two categories, both expressed as nested maps: `bulk` and `index`.
 
 ### Bulk
 
-To avoid doing too many expensive requests to the Elasticsearch cluster, the exporter
-performs batch updates by default. The size of the batch, along with how often
-it should be flushed (regardless of size) can be controlled by configuration.
+To avoid doing too many expensive requests to the Elasticsearch cluster, the exporter performs batch
+updates by default. The size of the batch, along with how often it should be flushed (regardless of
+size) can be controlled by configuration.
 
 For example:
 
 ```yaml
 ...
-  exporters:
-    elasticsearch:
-      args:
-        delay: 5
-        size: 1000
-        memoryLimit: 10485760
+exporters:
+  elasticsearch:
+    args:
+      delay: 5
+      size: 1000
+      memoryLimit: 10485760
 ```
 
-With the above example, the exporter would aggregate records and flush them to Elasticsearch
-either:
-  1. when it has aggregated 1000 records
-  2. when the batch memory size exceeds 10 MB
-  3. 5 seconds have elapsed since the last flush (regardless of how many records were aggregated)
+With the above example, the exporter would aggregate records and flush them to Elasticsearch either:
+
+1. when it has aggregated 1000 records
+2. when the batch memory size exceeds 10 MB
+3. 5 seconds have elapsed since the last flush (regardless of how many records were aggregated)
 
 More specifically, each option configures the following:
 
-* `delay` (`integer`): a specific delay, in seconds, before we force flush the current batch. This ensures
-that even when we have low traffic of records we still export every once in a while.
+* `delay` (`integer`): a specific delay, in seconds, before we force flush the current batch. This
+  ensures that even when we have low traffic of records we still export every once in a while.
 * `size` (`integer`): how many records a batch should have before we export.
 * `memoryLimit` (`integer`): the size of the bulk, in bytes, before we export.
 
 ### Index
 
-In most cases, you will not be interested in exporting every single record produced by a
-Zeebe cluster, but rather only a subset of them. This can also be configured to limit the
-kinds of records being exported (e.g. only events, no commands), and the value type of these
-records (e.g. only job and process values).
+In most cases, you will not be interested in exporting every single record produced by a Zeebe
+cluster, but rather only a subset of them. This can also be configured to limit the kinds of records
+being exported (e.g. only events, no commands), and the value type of these records (e.g. only job
+and process values).
 
 For example:
 
 ```yaml
 ...
-  exporters:
-    elasticsearch:
-      args:
-        index:
-          prefix: zeebe-record
-          createTemplate: true
+exporters:
+  elasticsearch:
+    args:
+      index:
+        prefix: zeebe-record
+        createTemplate: true
 
-          command: false
-          event: true
-          rejection: false
+        command: false
+        event: true
+        rejection: false
 
-          deployment: false
-          incident: true
-          job: false
-          jobBatch: false
-          message: false
-          messageSubscription: false
-          processInstance: false
-          processMessageSubscription: false
+        deployment: false
+        incident: true
+        job: false
+        jobBatch: false
+        message: false
+        messageSubscription: false
+        processInstance: false
+        processMessageSubscription: false
 ```
 
 The given example would only export incident events, and nothing else.
 
 More specifically, each option configures the following:
 
-* `prefix` (`string`): this prefix will be appended to every index created by the exporter; must not contain `_` (underscore).
+* `prefix` (`string`): this prefix will be appended to every index created by the exporter; must not
+  contain `_` (underscore).
 * `createTemplate` (`boolean`): if true, missing indexes will be created as needed.
 * `command` (`boolean`): if true, command records will be exported; if false, ignored.
 * `event` (`boolean`): if true, event records will be exported; if false, ignored.
 * `rejection` (`boolean`): if true, rejection records will be exported; if false, ignored.
-* `deployment` (`boolean`): if true, records related to deployments will be exported; if false, ignored.
+* `deployment` (`boolean`): if true, records related to deployments will be exported; if false,
+  ignored.
 * `incident` (`boolean`): if true, records related to incidents will be exported; if false, ignored.
 * `job` (`boolean`): if true, records related to jobs will be exported; if false, ignored.
-* `jobBatch` (`boolean`): if true, records related to job batches will be exported; if false, ignored.
+* `jobBatch` (`boolean`): if true, records related to job batches will be exported; if false,
+  ignored.
 * `message` (`boolean`): if true, records related to messages will be exported; if false, ignored.
-* `messageSubscription` (`boolean`): if true, records related to message subscriptions will be exported; if false, ignored.
-* `processInstance` (`boolean`): if true, records related to process instances will be exported; if false, ignored.
-* `processMessageSubscription` (`boolean`): if true, records related to process message subscriptions will be exported; if false, ignored.
+* `messageSubscription` (`boolean`): if true, records related to message subscriptions will be
+  exported; if false, ignored.
+* `processInstance` (`boolean`): if true, records related to process instances will be exported; if
+  false, ignored.
+* `processMessageSubscription` (`boolean`): if true, records related to process message
+  subscriptions will be exported; if false, ignored.
 
 Here is a complete, default configuration example:
 
 ```yaml
 ...
-  exporters:
-    elasticsearch:
-      # Elasticsearch Exporter ----------
-      # An example configuration for the elasticsearch exporter:
-      #
-      # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_..."
-      #
+exporters:
+  elasticsearch:
+    # Elasticsearch Exporter ----------
+    # An example configuration for the elasticsearch exporter:
+    #
+    # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_..."
+    #
 
-      className: io.camunda.zeebe.exporter.ElasticsearchExporter
+    className: io.camunda.zeebe.exporter.ElasticsearchExporter
 
-      args:
-        # A comma separated list of URLs pointing to the Elasticsearch instances you wish to export to.
-        # For example, if you want to connect to multiple nodes for redundancy:
-        # url: http://localhost:9200,http://localhost:9201
-        url: http://localhost:9200
+    args:
+      # A comma separated list of URLs pointing to the Elasticsearch instances you wish to export to.
+      # For example, if you want to connect to multiple nodes for redundancy:
+      # url: http://localhost:9200,http://localhost:9201
+      url: http://localhost:9200
 
-        bulk:
-          delay: 5
-          size: 1000
-          memoryLimit: 10485760
+      bulk:
+        delay: 5
+        size: 1000
+        memoryLimit: 10485760
 
-        authentication:
-          username: elastic
-          password: changeme
+      authentication:
+        username: elastic
+        password: changeme
 
-        index:
-          prefix: zeebe-record
-          createTemplate: true
+      index:
+        prefix: zeebe-record
+        createTemplate: true
 
-          command: false
-          event: true
-          rejection: false
+        command: false
+        event: true
+        rejection: false
 
-          deployment: true
-          error: true
-          incident: true
-          job: true
-          jobBatch: false
-          message: false
-          messageSubscription: false
-          variable: true
-          variableDocument: true
-          processInstance: true
-          processInstanceCreation: false
-          processMessageSubscription: false
+        deployment: false
+        process: true
+        error: true
+        incident: true
+        job: true
+        jobBatch: false
+        message: false
+        messageSubscription: false
+        variable: true
+        variableDocument: true
+        processInstance: true
+        processInstanceCreation: false
+        processMessageSubscription: false
 
-          ignoreVariablesAbove: 32677
+        ignoreVariablesAbove: 32677
 
 ```

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -107,7 +107,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean rejection = false;
 
     // value types to export
-    public boolean deployment = true;
+    public boolean deployment = false;
     public boolean process = true;
     public boolean error = true;
     public boolean incident = true;

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/AbstractElasticsearchExporterIntegrationTestCase.java
@@ -144,7 +144,8 @@ public abstract class AbstractElasticsearchExporterIntegrationTestCase {
     configuration.index.command = true;
     configuration.index.event = true;
     configuration.index.rejection = true;
-    configuration.index.deployment = true;
+    configuration.index.deployment = false;
+    configuration.index.process = true;
     configuration.index.error = true;
     configuration.index.incident = true;
     configuration.index.job = true;


### PR DESCRIPTION
## Description

Backports https://github.com/camunda-cloud/zeebe/pull/6942:

> Deployments are no longer consumed by operate, so we can disable it by
default. They have been replaced by the consumption of ProcessRecord's
<!-- Please explain the changes you made here. -->

I had to resolve some conflicts on the README update.

## Related issues

<!-- Which issues are closed by this PR or are related -->
backports https://github.com/camunda-cloud/zeebe/pull/6942

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
