### PR TITLE
Add new rocksdb configurations

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/DataCfg.java
@@ -51,7 +51,7 @@ public final class DataCfg implements ConfigurationEntry {
   private double diskUsageReplicationWatermark = DEFAULT_DISK_USAGE_REPLICATION_WATERMARK;
   private double diskUsageCommandWatermark = DEFAULT_DISK_USAGE_COMMAND_WATERMARK;
   private Duration diskUsageMonitoringInterval = DEFAULT_DISK_USAGE_MONITORING_DELAY;
-  private RocksdbCfg rocksdb = new RocksdbCfg();
+  private RocksdbColumnFamilyCfg rocksdb = new RocksdbColumnFamilyCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -187,11 +187,11 @@ public final class DataCfg implements ConfigurationEntry {
     this.diskUsageMonitoringInterval = diskUsageMonitoringInterval;
   }
 
-  public RocksdbCfg getRocksdb() {
+  public RocksdbColumnFamilyCfg getRocksdb() {
     return rocksdb;
   }
 
-  public void setRocksdb(final RocksdbCfg rocksdb) {
+  public void setRocksdb(final RocksdbColumnFamilyCfg rocksdb) {
     this.rocksdb = rocksdb;
   }
 

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -26,6 +26,7 @@ public class ExperimentalCfg {
   private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;
   private boolean disableExplicitRaftFlush = DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH;
   private boolean detectReprocessingInconsistency = DEFAULT_DETECT_REPROCESSING_INCONSISTENCY;
+  private RocksdbCfg rocksdb = new RocksdbCfg();
 
   public int getMaxAppendsPerFollower() {
     return maxAppendsPerFollower;
@@ -63,6 +64,14 @@ public class ExperimentalCfg {
     this.detectReprocessingInconsistency = detectReprocessingInconsistency;
   }
 
+  public RocksdbCfg getRocksdb() {
+    return rocksdb;
+  }
+
+  public void setRocksdb(final RocksdbCfg rocksdb) {
+    this.rocksdb = rocksdb;
+  }
+
   @Override
   public String toString() {
     return "ExperimentalCfg{"
@@ -74,6 +83,8 @@ public class ExperimentalCfg {
         + disableExplicitRaftFlush
         + ", detectReprocessingInconsistency="
         + detectReprocessingInconsistency
+        + ", rocksdb="
+        + rocksdb
         + '}';
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.configuration;
+
+import io.zeebe.db.impl.rocksdb.RocksDbConfiguration;
+import java.util.Properties;
+
+public final class RocksdbCfg implements ConfigurationEntry {
+
+  private boolean enableStatistics = RocksDbConfiguration.DEFAULT_STATISTICS_ENABLED;
+  private int maxOpenFiles = RocksDbConfiguration.DEFAULT_MAX_OPEN_FILES;
+  private int ioRateBytesPerSecond = RocksDbConfiguration.DEFAULT_IO_RATE_BYTES_PER_SECOND;
+  private boolean disableWal = RocksDbConfiguration.DEFAULT_WAL_DISABLED;
+
+  @Override
+  public void init(final BrokerCfg globalConfig, final String brokerBase) {}
+
+  public boolean isEnableStatistics() {
+    return enableStatistics;
+  }
+
+  public void setEnableStatistics(final boolean enableStatistics) {
+    this.enableStatistics = enableStatistics;
+  }
+
+  public int getMaxOpenFiles() {
+    return maxOpenFiles;
+  }
+
+  public void setMaxOpenFiles(final int maxOpenFiles) {
+    this.maxOpenFiles = maxOpenFiles;
+  }
+
+  public int getIoRateBytesPerSecond() {
+    return ioRateBytesPerSecond;
+  }
+
+  public void setIoRateBytesPerSecond(final int ioRateBytesPerSecond) {
+    this.ioRateBytesPerSecond = ioRateBytesPerSecond;
+  }
+
+  public boolean isDisableWal() {
+    return disableWal;
+  }
+
+  public void setDisableWal(final boolean disableWal) {
+    this.disableWal = disableWal;
+  }
+
+  public RocksDbConfiguration createRocksDbConfiguration(
+      final Properties rocksdbColumnFamilyOptions) {
+    return new RocksDbConfiguration()
+        .setMaxOpenFiles(maxOpenFiles)
+        .setStatisticsEnabled(enableStatistics)
+        .setIoRateBytesPerSecond(ioRateBytesPerSecond)
+        .setWalDisabled(disableWal)
+        .setColumnFamilyOptions(rocksdbColumnFamilyOptions);
+  }
+
+  @Override
+  public String toString() {
+    return "RocksdbCfg{"
+        + "enableStatistics="
+        + enableStatistics
+        + ", maxOpenFiles="
+        + maxOpenFiles
+        + ", ioRateBytesPerSecond="
+        + ioRateBytesPerSecond
+        + ", disableWal="
+        + disableWal
+        + '}';
+  }
+}

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -7,6 +7,7 @@
  */
 package io.zeebe.broker.system.configuration;
 
+import io.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Properties;
@@ -42,6 +43,10 @@ public final class RocksdbCfg implements ConfigurationEntry {
 
   public void setColumnFamilyOptions(final Properties columnFamilyOptions) {
     this.columnFamilyOptions = columnFamilyOptions;
+  }
+
+  public RocksDbConfiguration createRocksDbConfiguration() {
+    return new RocksDbConfiguration().setColumnFamilyOptions(columnFamilyOptions);
   }
 
   private static final class RocksDBColumnFamilyOption {

--- a/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbColumnFamilyCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbColumnFamilyCfg.java
@@ -7,13 +7,12 @@
  */
 package io.zeebe.broker.system.configuration;
 
-import io.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
-public final class RocksdbCfg implements ConfigurationEntry {
+public final class RocksdbColumnFamilyCfg implements ConfigurationEntry {
 
   private Properties columnFamilyOptions;
 
@@ -43,10 +42,6 @@ public final class RocksdbCfg implements ConfigurationEntry {
 
   public void setColumnFamilyOptions(final Properties columnFamilyOptions) {
     this.columnFamilyOptions = columnFamilyOptions;
-  }
-
-  public RocksDbConfiguration createRocksDbConfiguration() {
-    return new RocksDbConfiguration().setColumnFamilyOptions(columnFamilyOptions);
   }
 
   private static final class RocksDBColumnFamilyOption {

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
@@ -28,7 +28,7 @@ public class StateControllerPartitionStep implements PartitionStep {
     final var stateController =
         new StateControllerImpl(
             context.getPartitionId(),
-            DefaultZeebeDbFactory.defaultFactory(databaseCfg.getColumnFamilyOptions()),
+            DefaultZeebeDbFactory.defaultFactory(databaseCfg.createRocksDbConfiguration()),
             context
                 .getSnapshotStoreSupplier()
                 .getConstructableSnapshotStore(context.getRaftPartition().name()),

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
@@ -25,11 +25,13 @@ public class StateControllerPartitionStep implements PartitionStep {
         context.getRaftPartition().dataDirectory().toPath().resolve("runtime");
     final var rocksdbColumnFamilyOptions =
         context.getBrokerCfg().getData().getRocksdb().getColumnFamilyOptions();
+    final var rocksDbConfig = context.getBrokerCfg().getExperimental().getRocksdb();
 
     final var stateController =
         new StateControllerImpl(
             context.getPartitionId(),
-            DefaultZeebeDbFactory.defaultFactory(rocksdbColumnFamilyOptions),
+            DefaultZeebeDbFactory.defaultFactory(
+                rocksDbConfig.createRocksDbConfiguration(rocksdbColumnFamilyOptions)),
             context
                 .getSnapshotStoreSupplier()
                 .getConstructableSnapshotStore(context.getRaftPartition().name()),

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
@@ -23,12 +23,13 @@ public class StateControllerPartitionStep implements PartitionStep {
   public ActorFuture<Void> open(final PartitionContext context) {
     final var runtimeDirectory =
         context.getRaftPartition().dataDirectory().toPath().resolve("runtime");
-    final var databaseCfg = context.getBrokerCfg().getData().getRocksdb();
+    final var rocksdbColumnFamilyOptions =
+        context.getBrokerCfg().getData().getRocksdb().getColumnFamilyOptions();
 
     final var stateController =
         new StateControllerImpl(
             context.getPartitionId(),
-            DefaultZeebeDbFactory.defaultFactory(databaseCfg.createRocksDbConfiguration()),
+            DefaultZeebeDbFactory.defaultFactory(rocksdbColumnFamilyOptions),
             context
                 .getSnapshotStoreSupplier()
                 .getConstructableSnapshotStore(context.getRaftPartition().name()),

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/RocksDbColumnFamilyCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/RocksDbColumnFamilyCfgTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.broker.system.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public final class RocksDbColumnFamilyCfgTest {
+
+  public final Map<String, String> environment = new HashMap<>();
+
+  @Test
+  public void shouldSetColumnFamilyOptionsConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getData().getRocksdb();
+
+    // then
+    final var columnFamilyOptions = rocksdb.getColumnFamilyOptions();
+    assertThat(columnFamilyOptions)
+        .containsEntry("compaction_pri", "kOldestSmallestSeqFirst")
+        .containsEntry("write_buffer_size", "67108864");
+  }
+
+  @Test
+  public void shouldSetColumnFamilyOptionsConfigFromEnvironmentVariables() {
+    // given
+    environment.put("zeebe.broker.data.rocksdb.columnFamilyOptions.arena.block.size", "16777216");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getData().getRocksdb();
+
+    // then keys should contain underscores
+    final var columnFamilyOptions = rocksdb.getColumnFamilyOptions();
+    assertThat(columnFamilyOptions).containsEntry("arena_block_size", "16777216");
+  }
+}

--- a/broker/src/test/java/io/zeebe/broker/system/configuration/RocksdbCfgTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/configuration/RocksdbCfgTest.java
@@ -9,8 +9,10 @@ package io.zeebe.broker.system.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import org.junit.Test;
 
 public final class RocksdbCfgTest {
@@ -18,28 +20,151 @@ public final class RocksdbCfgTest {
   public final Map<String, String> environment = new HashMap<>();
 
   @Test
-  public void shouldSetColumnFamilyOptionsConfig() {
+  public void shouldDisableStatisticsPerDefault() {
     // when
-    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
-    final var rocksdb = cfg.getData().getRocksdb();
+    final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
 
     // then
-    final var columnFamilyOptions = rocksdb.getColumnFamilyOptions();
-    assertThat(columnFamilyOptions).containsEntry("compaction_pri", "kOldestSmallestSeqFirst");
-    assertThat(columnFamilyOptions).containsEntry("write_buffer_size", "67108864");
+    assertThat(rocksdb.isEnableStatistics()).isFalse();
   }
 
   @Test
-  public void shouldSetColumnFamilyOptionsConfigFromEnvironmentVariables() {
+  public void shouldUseDefaultMaxOpenFiles() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getMaxOpenFiles()).isEqualTo(RocksDbConfiguration.DEFAULT_MAX_OPEN_FILES);
+  }
+
+  @Test
+  public void shouldCreateRocksDbConfigurationFromDefault() {
     // given
-    environment.put("zeebe.broker.data.rocksdb.columnFamilyOptions.arena.block.size", "16777216");
+    final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+    final Properties columnFamilyOptions = cfg.getData().getRocksdb().getColumnFamilyOptions();
+
+    // when
+    final var rocksDbConfiguration = rocksdb.createRocksDbConfiguration(columnFamilyOptions);
+
+    // then
+    assertThat(rocksDbConfiguration.getColumnFamilyOptions()).isEmpty();
+    assertThat(rocksDbConfiguration.isStatisticsEnabled()).isFalse();
+    assertThat(rocksDbConfiguration.getMaxOpenFiles())
+        .isEqualTo(RocksDbConfiguration.DEFAULT_MAX_OPEN_FILES);
+    assertThat(rocksDbConfiguration.getIoRateBytesPerSecond()).isZero();
+    assertThat(rocksDbConfiguration.isWalDisabled()).isFalse();
+  }
+
+  @Test
+  public void shouldCreateRocksDbConfigurationFromConfig() {
+    // given
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+    final Properties columnFamilyOptions = cfg.getData().getRocksdb().getColumnFamilyOptions();
+
+    // when
+    final var rocksDbConfiguration = rocksdb.createRocksDbConfiguration(columnFamilyOptions);
+
+    // then
+    assertThat(rocksDbConfiguration.getColumnFamilyOptions())
+        .containsEntry("compaction_pri", "kOldestSmallestSeqFirst")
+        .containsEntry("write_buffer_size", "67108864");
+    assertThat(rocksDbConfiguration.isStatisticsEnabled()).isTrue();
+    assertThat(rocksDbConfiguration.getMaxOpenFiles()).isEqualTo(3);
+  }
+
+  @Test
+  public void shouldEnableStatisticsViaConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.isEnableStatistics()).isTrue();
+  }
+
+  @Test
+  public void shouldSetMaxOpenFilesViaConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getMaxOpenFiles()).isEqualTo(3);
+  }
+
+  @Test
+  public void shouldEnableStatisticsViaEnvironmentVariables() {
+    // given
+    environment.put("zeebe.broker.experimental.rocksdb.enableStatistics", "true");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
-    final var rocksdb = cfg.getData().getRocksdb();
+    final var rocksdb = cfg.getExperimental().getRocksdb();
 
-    // then keys should contain underscores
-    final var columnFamilyOptions = rocksdb.getColumnFamilyOptions();
-    assertThat(columnFamilyOptions).containsEntry("arena_block_size", "16777216");
+    // then
+    assertThat(rocksdb.isEnableStatistics()).isTrue();
+  }
+
+  @Test
+  public void shouldSetMaxOpenFilesViaEnvironmentVariables() {
+    // given
+    environment.put("zeebe.broker.experimental.rocksdb.maxOpenFiles", "5");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getMaxOpenFiles()).isEqualTo(5);
+  }
+
+  @Test
+  public void shouldSetIoRateBytesPerSecondViaConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getIoRateBytesPerSecond()).isEqualTo(4096);
+  }
+
+  @Test
+  public void shouldSetIoRateBytesPerSecondViaEnvironmentVariables() {
+    // given
+    environment.put("zeebe.broker.experimental.rocksdb.ioRateBytesPerSecond", "4096");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.getIoRateBytesPerSecond()).isEqualTo(4096);
+  }
+
+  @Test
+  public void shouldSetIsDisableWalPerSecondViaConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.isDisableWal()).isTrue();
+  }
+
+  @Test
+  public void shouldSetIsDisableWalViaEnvironmentVariables() {
+    // given
+    environment.put("zeebe.broker.experimental.rocksdb.disableWal", "true");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("rocksdb-cfg", environment);
+    final var rocksdb = cfg.getExperimental().getRocksdb();
+
+    // then
+    assertThat(rocksdb.isDisableWal()).isTrue();
   }
 }

--- a/broker/src/test/resources/system/rocksdb-cfg.yaml
+++ b/broker/src/test/resources/system/rocksdb-cfg.yaml
@@ -5,3 +5,9 @@ zeebe:
         columnFamilyOptions:
           compaction_pri: "kOldestSmallestSeqFirst"
           write_buffer_size: 67108864
+    experimental:
+      rocksdb:
+        enableStatistics: true
+        maxOpenFiles: 3
+        ioRateBytesPerSecond: 4096
+        disableWal: true

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -507,7 +507,7 @@
         #     workflowInstanceSubscription: false
         #
         #     ignoreVariablesAbove: 32677
-    # experimental
+    # experimental:
       # Be aware that all configuration's which are part of the experimental section
       # are subject to change and can be dropped at any time.
       # It might be that also some of them are actually dangerous so be aware when you change one of these!
@@ -524,3 +524,28 @@
       # failed and the partition becomes unhealthy, no further progress will made on that specific partition.
       # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_DETECT_REPROCESSING_INCONSISTENCY
       # detectReprocessingInconsistency = false;
+
+      # Exposed additional rocksdb configuration parameters. Note that rocksdb column family is configured via `broker.data.rocksdb.columnfamilyoptions`
+      # rocksdb:
+        # Defines how many files are kept open by RocksDB, per default it is unlimited (-1). We override
+        # the default because when there are snapshots with too many files, keeping all files opened has
+        # a performance as well as memory impact.
+        # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_ROCKSDB_MAXOPENFILES
+        # maxOpenFiles = 2048
+
+
+        # Enables metrics collection in rocksdb. The metrics will be dumped to rocksdb log periodically.
+        # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_ROCKSDB_ENABLESTATISTICS
+        # enableStatistics = false
+
+        # Allows limiting the rate of I/O writes by RocksDB. This affects all writes performed by
+        # RocksDB, including flushing, compaction, WAL, etc. It can be useful to configure to prevent
+        # write spikes from affecting reads, thereby achieving a more predictable performance.
+        # Setting to 0 or less will disable any rate limiting.
+        # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_ROCKSDB_IORATEBYTESPERSECOND
+        # ioRateBytesPerSecond = 0
+
+        # If true, writes to RocksDB will not first go to the write ahead log, and the write to RocksDB may got lost after a crash.
+        # This is ok because Zeebe has its own way to recover after crash. This flag may have a performance impact.
+        # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_ROCKSDB_DISABLEWAL
+        # disableWal = false;

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -467,3 +467,45 @@
         #     workflowInstanceSubscription: false
         #
         #     ignoreVariablesAbove: 32677
+    # experimental:
+      # Be aware that all configuration's which are part of the experimental section
+      # are subject to change and can be dropped at any time.
+      # It might be that also some of them are actually dangerous so be aware when you change one of these!
+
+      # Sets the maximum of appends which are send per follower.
+      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_MAX_APPENDS_PER_FOLLOWER
+      # maxAppendsPerFollower = 2
+
+      # Sets the maximum batch size, which is send per append request to a follower.
+      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_MAX_APPEND_BATCH_SIZE
+      # maxAppendBatchSize = 32KB;
+
+      # Enables the detection of an inconsistency during reprocessing. If a inconsistency is detect the StreamProcessor is
+      # failed and the partition becomes unhealthy, no further progress will made on that specific partition.
+      # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_DETECT_REPROCESSING_INCONSISTENCY
+      # detectReprocessingInconsistency = false;
+
+      # Exposed additional rocksdb configuration parameters. Note that rocksdb column family is configured via `broker.data.rocksdb.columnfamilyoptions`
+      # rocksdb:
+        # Defines how many files are kept open by RocksDB, per default it is unlimited (-1). We override
+        # the default because when there are snapshots with too many files, keeping all files opened has
+        # a performance as well as memory impact.
+        # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_ROCKSDB_MAXOPENFILES
+        # maxOpenFiles = 2048
+
+
+        # Enables metrics collection in rocksdb. The metrics will be dumped to rocksdb log periodically.
+        # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_ROCKSDB_ENABLESTATISTICS
+        # enableStatistics = false
+
+        # Allows limiting the rate of I/O writes by RocksDB. This affects all writes performed by
+        # RocksDB, including flushing, compaction, WAL, etc. It can be useful to configure to prevent
+        # write spikes from affecting reads, thereby achieving a more predictable performance.
+        # Setting to 0 or less will disable any rate limiting.
+        # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_ROCKSDB_IORATEBYTESPERSECOND
+        # ioRateBytesPerSecond = 0
+
+        # If true, writes to RocksDB will not first go to the write ahead log, and the write to RocksDB may got lost after a crash.
+        # This is ok because Zeebe has its own way to recover after crash. This flag may have a performance impact.
+        # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_ROCKSDB_DISABLEWAL
+        # disableWal = false;

--- a/engine/src/main/java/io/zeebe/engine/state/DefaultZeebeDbFactory.java
+++ b/engine/src/main/java/io/zeebe/engine/state/DefaultZeebeDbFactory.java
@@ -39,7 +39,7 @@ public final class DefaultZeebeDbFactory {
    * @param userProvidedColumnFamilyOptions additional column family options
    * @return the created zeebe database factory
    */
-  public static ZeebeDbFactory<ZbColumnFamilies> defaultFactory(
+  private static ZeebeDbFactory<ZbColumnFamilies> defaultFactory(
       final Properties userProvidedColumnFamilyOptions) {
     return defaultFactory(
         ZbColumnFamilies.class,

--- a/engine/src/main/java/io/zeebe/engine/state/DefaultZeebeDbFactory.java
+++ b/engine/src/main/java/io/zeebe/engine/state/DefaultZeebeDbFactory.java
@@ -9,6 +9,7 @@ package io.zeebe.engine.state;
 
 import io.zeebe.db.ZeebeDb;
 import io.zeebe.db.ZeebeDbFactory;
+import io.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDBMetricExporter;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import java.util.Properties;
@@ -40,7 +41,9 @@ public final class DefaultZeebeDbFactory {
    */
   public static ZeebeDbFactory<ZbColumnFamilies> defaultFactory(
       final Properties userProvidedColumnFamilyOptions) {
-    return defaultFactory(ZbColumnFamilies.class, userProvidedColumnFamilyOptions);
+    return defaultFactory(
+        ZbColumnFamilies.class,
+        new RocksDbConfiguration().setColumnFamilyOptions(userProvidedColumnFamilyOptions));
   }
 
   /**
@@ -53,7 +56,20 @@ public final class DefaultZeebeDbFactory {
   public static <ColumnFamilyNames extends Enum<ColumnFamilyNames>>
       ZeebeDbFactory<ColumnFamilyNames> defaultFactory(
           final Class<ColumnFamilyNames> columnFamilyNamesClass) {
-    return defaultFactory(columnFamilyNamesClass, new Properties());
+    return defaultFactory(
+        columnFamilyNamesClass,
+        new RocksDbConfiguration().setColumnFamilyOptions(new Properties()));
+  }
+
+  /**
+   * Returns the default zeebe database factory which is used in the broker.
+   *
+   * @return the created zeebe database factory
+   */
+  public static ZeebeDbFactory<ZbColumnFamilies> defaultFactory(
+      final RocksDbConfiguration rocksDbConfiguration) {
+    // one place to replace the zeebe database implementation
+    return defaultFactory(ZbColumnFamilies.class, rocksDbConfiguration);
   }
 
   /**
@@ -61,14 +77,14 @@ public final class DefaultZeebeDbFactory {
    *
    * @param <ColumnFamilyNames> the type of the enum
    * @param columnFamilyNamesClass the enum class, which contains the column family names
-   * @param userProvidedColumnFamilyOptions additional column family options
+   * @param rocksDbConfiguration additional rocksdb configuration
    * @return the created zeebe database factory
    */
   public static <ColumnFamilyNames extends Enum<ColumnFamilyNames>>
       ZeebeDbFactory<ColumnFamilyNames> defaultFactory(
           final Class<ColumnFamilyNames> columnFamilyNamesClass,
-          final Properties userProvidedColumnFamilyOptions) {
+          final RocksDbConfiguration rocksDbConfiguration) {
     // one place to replace the zeebe database implementation
-    return ZeebeRocksDbFactory.newFactory(columnFamilyNamesClass, userProvidedColumnFamilyOptions);
+    return ZeebeRocksDbFactory.newFactory(columnFamilyNamesClass, rocksDbConfiguration);
   }
 }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -10,8 +10,34 @@ package io.zeebe.db.impl.rocksdb;
 import java.util.Properties;
 
 public final class RocksDbConfiguration {
+  public static final int DEFAULT_MAX_OPEN_FILES = 2048;
+  public static final boolean DEFAULT_STATISTICS_ENABLED = false;
+  public static final boolean DEFAULT_WAL_DISABLED = false;
+  public static final int DEFAULT_IO_RATE_BYTES_PER_SECOND = 0;
 
   private Properties columnFamilyOptions = new Properties();
+  private boolean statisticsEnabled = DEFAULT_STATISTICS_ENABLED;
+  private boolean walDisabled = DEFAULT_WAL_DISABLED;
+
+  /**
+   * Defines how many files are kept open by RocksDB, per default it is unlimited (-1). We override
+   * the default because when there are snapshots with too many files, keeping all files opened has
+   * a performance as well as memory impact.
+   *
+   * <p>https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide#general-options
+   */
+  private int maxOpenFiles = DEFAULT_MAX_OPEN_FILES;
+
+  /**
+   * Allows limiting the rate of I/O writes by RocksDB. This affects all writes performed by
+   * RocksDB, including flushing, compaction, WAL, etc. It can be useful to configure to prevent
+   * write spikes from affecting reads, thereby achieving a more predictable performance.
+   *
+   * <p>Setting to 0 (the default) or less will disable any rate limiting.
+   *
+   * <p>https://github.com/facebook/rocksdb/wiki/Rate-Limiter
+   */
+  private int ioRateBytesPerSecond = DEFAULT_IO_RATE_BYTES_PER_SECOND;
 
   public Properties getColumnFamilyOptions() {
     return columnFamilyOptions;
@@ -19,6 +45,42 @@ public final class RocksDbConfiguration {
 
   public RocksDbConfiguration setColumnFamilyOptions(final Properties columnFamilyOptions) {
     this.columnFamilyOptions = columnFamilyOptions;
+    return this;
+  }
+
+  public boolean isStatisticsEnabled() {
+    return statisticsEnabled;
+  }
+
+  public RocksDbConfiguration setStatisticsEnabled(final boolean statisticsEnabled) {
+    this.statisticsEnabled = statisticsEnabled;
+    return this;
+  }
+
+  public int getMaxOpenFiles() {
+    return maxOpenFiles;
+  }
+
+  public RocksDbConfiguration setMaxOpenFiles(final int maxOpenFiles) {
+    this.maxOpenFiles = maxOpenFiles;
+    return this;
+  }
+
+  public int getIoRateBytesPerSecond() {
+    return ioRateBytesPerSecond;
+  }
+
+  public RocksDbConfiguration setIoRateBytesPerSecond(final int ioRateBytesPerSecond) {
+    this.ioRateBytesPerSecond = ioRateBytesPerSecond;
+    return this;
+  }
+
+  public boolean isWalDisabled() {
+    return walDisabled;
+  }
+
+  public RocksDbConfiguration setWalDisabled(final boolean walDisabled) {
+    this.walDisabled = walDisabled;
     return this;
   }
 }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/RocksDbConfiguration.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.0. You may not use this file
+ * except in compliance with the Zeebe Community License 1.0.
+ */
+package io.zeebe.db.impl.rocksdb;
+
+import java.util.Properties;
+
+public final class RocksDbConfiguration {
+
+  private Properties columnFamilyOptions = new Properties();
+
+  public Properties getColumnFamilyOptions() {
+    return columnFamilyOptions;
+  }
+
+  public RocksDbConfiguration setColumnFamilyOptions(final Properties columnFamilyOptions) {
+    this.columnFamilyOptions = columnFamilyOptions;
+    return this;
+  }
+}

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -93,7 +93,8 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
               dbDirectory.getAbsolutePath(),
               columnFamilyDescriptors,
               closeables,
-              columnFamilyTypeClass);
+              columnFamilyTypeClass,
+              rocksDbConfiguration);
 
     } catch (final RocksDBException e) {
       throw new RuntimeException("Unexpected error occurred trying to open the database", e);

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -10,18 +10,27 @@ package io.zeebe.db.impl.rocksdb;
 import io.zeebe.db.ZeebeDbFactory;
 import io.zeebe.db.impl.rocksdb.transaction.ZeebeTransactionDb;
 import java.io.File;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.stream.Collectors;
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.BloomFilter;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompactionPriority;
+import org.rocksdb.CompactionStyle;
+import org.rocksdb.CompressionType;
 import org.rocksdb.DBOptions;
+import org.rocksdb.RateLimiter;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
+import org.rocksdb.Statistics;
+import org.rocksdb.StatsLevel;
+import org.rocksdb.TableFormatConfig;
 
 public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamilyType>>
     implements ZeebeDbFactory<ColumnFamilyType> {
@@ -70,12 +79,12 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
       final List<AutoCloseable> closeables = new ArrayList<>();
 
       // column family options have to be closed as last
-      final ColumnFamilyOptions columnFamilyOptions = createColumnFamilyOptions();
+      final ColumnFamilyOptions columnFamilyOptions = createColumnFamilyOptions(closeables);
       closeables.add(columnFamilyOptions);
 
       final List<ColumnFamilyDescriptor> columnFamilyDescriptors =
           createFamilyDescriptors(columnFamilyNames, columnFamilyOptions);
-      final DBOptions dbOptions = createDefaultDbOptions();
+      final DBOptions dbOptions = createDefaultDbOptions(closeables);
       closeables.add(dbOptions);
 
       db =
@@ -107,7 +116,7 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
   }
 
   /** @return Options which are used on all column families */
-  public ColumnFamilyOptions createColumnFamilyOptions() {
+  public ColumnFamilyOptions createColumnFamilyOptions(final List<AutoCloseable> closeables) {
     final var userProvidedColumnFamilyOptions = rocksDbConfiguration.getColumnFamilyOptions();
     final var hasUserOptions = !userProvidedColumnFamilyOptions.isEmpty();
 
@@ -115,12 +124,51 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
       return createFromUserOptions(userProvidedColumnFamilyOptions);
     }
 
-    return createDefaultColumnFamilyOptions();
+    return createDefaultColumnFamilyOptions(closeables);
   }
 
-  private ColumnFamilyOptions createDefaultColumnFamilyOptions() {
+  private ColumnFamilyOptions createDefaultColumnFamilyOptions(
+      final List<AutoCloseable> closeables) {
     final var columnFamilyOptions = new ColumnFamilyOptions();
-    return columnFamilyOptions.setCompactionPriority(CompactionPriority.OldestSmallestSeqFirst);
+    final var tableConfig = createTableFormatConfig(closeables);
+
+    final int level0CompactionTrigger = 4;
+    columnFamilyOptions
+        // compaction
+        .setLevelCompactionDynamicLevelBytes(true)
+        .setCompactionPriority(CompactionPriority.OldestSmallestSeqFirst)
+        .setCompactionStyle(CompactionStyle.LEVEL)
+        .setLevel0FileNumCompactionTrigger(level0CompactionTrigger)
+        .setLevel0SlowdownWritesTrigger(level0CompactionTrigger + (level0CompactionTrigger / 2))
+        .setLevel0StopWritesTrigger(level0CompactionTrigger * 2)
+        // configure 4 levels: L1 = 32mb, L2 = 320mb, L3 = 3.2Gb, L4 >= 3.2Gb
+        // level 1 and 2 are uncompressed, level 3 and above are compressed using a CPU-cheap
+        // compression algo. compressed blocks are stored in the OS page cache, and uncompressed in
+        // the LRUCache created above. note L0 is always uncompressed
+        .setNumLevels(4)
+        .setMaxBytesForLevelBase(32 * 1024 * 1024L)
+        .setMaxBytesForLevelMultiplier(10)
+        .setCompressionPerLevel(
+            List.of(
+                CompressionType.NO_COMPRESSION,
+                CompressionType.NO_COMPRESSION,
+                CompressionType.LZ4_COMPRESSION,
+                CompressionType.LZ4_COMPRESSION))
+        // Target file size for compaction.
+        // Defines the desired SST file size for different levels (but not guaranteed, it is usually
+        // lower)
+        // L0 is what gets merged and flushed, e.g. 3 memtables to X, and target file size and
+        // multiplier is for L1 and other levels.
+        // L1 => 8Mb, L2 => 16Mb, L3 => 32Mb
+        // As levels get bigger, we want to have a good balance between the number of files and the
+        // individual file sizes
+        // https://github.com/facebook/rocksdb/blob/fd0d35d390e212b617e90d7567102d3e5fd1c706/include/rocksdb/advanced_options.h#L417-L429
+        .setTargetFileSizeBase(8 * 1024 * 1024L)
+        .setTargetFileSizeMultiplier(2)
+        // misc
+        .setTableFormatConfig(tableConfig);
+
+    return columnFamilyOptions;
   }
 
   private ColumnFamilyOptions createFromUserOptions(
@@ -139,11 +187,70 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
     return columnFamilyOptions;
   }
 
-  private DBOptions createDefaultDbOptions() {
-    return new DBOptions()
-        .setCreateMissingColumnFamilies(true)
-        .setErrorIfExists(false)
-        .setCreateIfMissing(true)
-        .setParanoidChecks(true);
+  private DBOptions createDefaultDbOptions(final List<AutoCloseable> closeables) {
+    final var dbOptions =
+        new DBOptions()
+            .setCreateMissingColumnFamilies(true)
+            .setErrorIfExists(false)
+            .setCreateIfMissing(true)
+            .setParanoidChecks(true)
+            // disabling mmap helps improve performance/memory usage when a DB is highly
+            // fragmented with many small files
+            .setAllowMmapReads(false)
+            .setAllowMmapWrites(false)
+            .setMaxOpenFiles(rocksDbConfiguration.getMaxOpenFiles())
+            // do not hog processing if the DB is highly fragmented by opening many threads to
+            // open all files
+            .setMaxFileOpeningThreads(1)
+            // 1 flush, 1 compaction
+            .setMaxBackgroundJobs(2)
+            // may not be necessary when WAL is disabled, but nevertheless recommended to avoid
+            // many small SST files
+            .setAvoidFlushDuringRecovery(true)
+            .setAvoidFlushDuringShutdown(true)
+            // limit the size of the manifest (logs all operations), otherwise it will grow
+            // unbounded
+            .setMaxManifestFileSize(256 * 1024 * 1024L)
+            // keep 1 hour of logs - completely arbitrary. we should keep what we think would be
+            // a good balance between useful for performance and small for replication
+            .setLogFileTimeToRoll(Duration.ofMinutes(30).toSeconds())
+            .setKeepLogFileNum(2);
+
+    // limit I/O writes
+    if (rocksDbConfiguration.getIoRateBytesPerSecond() > 0) {
+      final RateLimiter rateLimiter =
+          new RateLimiter(rocksDbConfiguration.getIoRateBytesPerSecond());
+      dbOptions.setRateLimiter(rateLimiter);
+    }
+
+    if (rocksDbConfiguration.isStatisticsEnabled()) {
+      final var statistics = new Statistics();
+      closeables.add(statistics);
+      statistics.setStatsLevel(StatsLevel.ALL);
+      dbOptions
+          .setStatistics(statistics)
+          // speeds up opening the DB
+          .setSkipStatsUpdateOnDbOpen(true)
+          // can be disabled when not profiling
+          .setStatsDumpPeriodSec(20);
+    }
+
+    return dbOptions;
+  }
+
+  private TableFormatConfig createTableFormatConfig(final List<AutoCloseable> closeables) {
+    final var filter = new BloomFilter(10, false);
+    closeables.add(filter);
+    return new BlockBasedTableConfig()
+        // increasing block size means reducing memory usage, but increasing read iops
+        .setBlockSize(32 * 1024L)
+        // caching and pinning indexes and filters is important to keep reads/seeks fast when we
+        // have many memtables, and pinning them ensures they are never evicted from the block
+        // cache
+        .setFormatVersion(5)
+        .setFilterPolicy(filter)
+        .setCacheIndexAndFilterBlocks(true)
+        .setPinL0FilterAndIndexBlocksInCache(true)
+        .setCacheIndexAndFilterBlocksWithHighPriority(true);
   }
 }

--- a/zb-db/src/test/java/io/zeebe/db/impl/DefaultZeebeDbFactory.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/DefaultZeebeDbFactory.java
@@ -8,6 +8,7 @@
 package io.zeebe.db.impl;
 
 import io.zeebe.db.ZeebeDbFactory;
+import io.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import java.util.Properties;
 
@@ -23,6 +24,8 @@ public final class DefaultZeebeDbFactory {
       ZeebeDbFactory<ColumnFamilyType> getDefaultFactory(
           final Class<ColumnFamilyType> columnFamilyTypeClass,
           final Properties columnFamilyOptions) {
-    return ZeebeRocksDbFactory.newFactory(columnFamilyTypeClass, columnFamilyOptions);
+    return ZeebeRocksDbFactory.newFactory(
+        columnFamilyTypeClass,
+        new RocksDbConfiguration().setColumnFamilyOptions(columnFamilyOptions));
   }
 }

--- a/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -75,7 +75,9 @@ public final class ZeebeRocksDbFactoryTest {
             ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class);
     final var factoryWithCustomOptions =
         (ZeebeRocksDbFactory<DefaultColumnFamily>)
-            ZeebeRocksDbFactory.newFactory(DefaultColumnFamily.class, customProperties);
+            ZeebeRocksDbFactory.newFactory(
+                DefaultColumnFamily.class,
+                new RocksDbConfiguration().setColumnFamilyOptions(customProperties));
 
     // when
     final var defaults = factoryWithDefaults.createColumnFamilyOptions();

--- a/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zb-db/src/test/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -14,6 +14,7 @@ import io.zeebe.db.ZeebeDbFactory;
 import io.zeebe.db.impl.DefaultColumnFamily;
 import io.zeebe.util.ByteValue;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Properties;
 import org.junit.Rule;
 import org.junit.Test;
@@ -80,8 +81,8 @@ public final class ZeebeRocksDbFactoryTest {
                 new RocksDbConfiguration().setColumnFamilyOptions(customProperties));
 
     // when
-    final var defaults = factoryWithDefaults.createColumnFamilyOptions();
-    final var customOptions = factoryWithCustomOptions.createColumnFamilyOptions();
+    final var defaults = factoryWithDefaults.createColumnFamilyOptions(new ArrayList<>());
+    final var customOptions = factoryWithCustomOptions.createColumnFamilyOptions(new ArrayList<>());
 
     // then
     assertThat(defaults)


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6929 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
