### PR TITLE
[Backport 1.0.0] Fix flaky timer test

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -73,6 +73,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.awaitility.Awaitility;
 import org.junit.rules.ExternalResource;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -368,6 +369,13 @@ public final class EngineRule extends ExternalResource {
                                   MsgPackConverter.convertToJson(value.getDirectBuffer())));
                   return entries;
                 }));
+  }
+
+  public void awaitProcessingOf(final Record<?> record) {
+    final var recordPosition = record.getPosition();
+
+    Awaitility.await("await the record to be processed")
+        .until(() -> getLastProcessedPosition() >= recordPosition);
   }
 
   private static final class VersatileBlob implements DbKey, DbValue {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.util;
 
 import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
@@ -374,8 +375,16 @@ public final class EngineRule extends ExternalResource {
   public void awaitProcessingOf(final Record<?> record) {
     final var recordPosition = record.getPosition();
 
-    Awaitility.await("await the record to be processed")
-        .until(() -> getLastProcessedPosition() >= recordPosition);
+    Awaitility.await(
+            String.format(
+                "Await the %s.%s to be processed at position %d",
+                record.getValueType(), record.getIntent(), recordPosition))
+        .untilAsserted(
+            () ->
+                assertThat(getLastProcessedPosition())
+                    .describedAs(
+                        "Last process position should be greater or equal to " + recordPosition)
+                    .isGreaterThanOrEqualTo(recordPosition));
   }
 
   private static final class VersatileBlob implements DbKey, DbValue {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Backports https://github.com/camunda-cloud/zeebe/pull/6977

> - add helper to engine rule
> - fix flaky test

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6975
backports https://github.com/camunda-cloud/zeebe/pull/6977

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
