### PR TITLE
Remove ignoreVariablesAbove ES configuration option

### DIFF
--- a/benchmarks/setup/default/zeebe-values.yaml
+++ b/benchmarks/setup/default/zeebe-values.yaml
@@ -69,9 +69,6 @@ env:
       fieldRef:
         fieldPath: metadata.namespace
   # Avoid tons of noise when exporting larger payloads
-  - name: JAVA_OPTS
-    value: >-
-      -Dzeebe.broker.exporters.elasticsearch.args.index.ignoreVariablesAbove=32767
   - name: ZEEBE_BROKER_EXECUTION_METRICS_EXPORTER_ENABLED
     value: "true"
   - name: ATOMIX_LOG_LEVEL

--- a/broker/src/test/resources/system/elasticexporter.yaml
+++ b/broker/src/test/resources/system/elasticexporter.yaml
@@ -42,5 +42,3 @@ zeebe:
         #     processInstance: true
         #     processInstanceCreation: false
         #     processMessageSubscription: false
-        #
-        #     ignoreVariablesAbove: 32677

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -485,8 +485,6 @@
         #     processInstance: true
         #     processInstanceCreation: false
         #     processMessageSubscription: false
-        #
-        #     ignoreVariablesAbove: 32677
     # experimental
       # Be aware that all configuration's which are part of the experimental section
       # are subject to change and can be dropped at any time.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -444,8 +444,6 @@
         #     processInstance: true
         #     processInstanceCreation: false
         #     processMessageSubscription: false
-        #
-        #     ignoreVariablesAbove: 32677
 
 
     # experimental

--- a/exporters/elasticsearch-exporter/README.md
+++ b/exporters/elasticsearch-exporter/README.md
@@ -168,6 +168,4 @@ exporters:
         processInstance: true
         processInstanceCreation: false
         processMessageSubscription: false
-
-        ignoreVariablesAbove: 32677
 ```

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -121,9 +121,6 @@ public class ElasticsearchExporterConfiguration {
     public boolean processInstanceCreation = false;
     public boolean processMessageSubscription = false;
 
-    // size limits
-    public int ignoreVariablesAbove = 8191;
-
     @Override
     public String toString() {
       return "IndexConfiguration{"
@@ -162,8 +159,6 @@ public class ElasticsearchExporterConfiguration {
           + processInstanceCreation
           + ", processMessageSubscription="
           + processMessageSubscription
-          + ", ignoreVariablesAbove="
-          + ignoreVariablesAbove
           + '}';
     }
   }

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
@@ -9,9 +9,7 @@ package io.camunda.zeebe.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,13 +18,10 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,69 +41,6 @@ public class ElasticsearchClientTest extends AbstractElasticsearchExporterIntegr
     logSpy = spy(LoggerFactory.getLogger(ElasticsearchClientTest.class));
     bulkRequest = new ArrayList<>();
     client = new ElasticsearchClient(configuration, logSpy, bulkRequest);
-  }
-
-  @Test
-  public void shouldNotLogWarningWhenIndexingSmallVariableValue() {
-    // given
-    final String variableValue = "x".repeat(configuration.index.ignoreVariablesAbove);
-
-    final Record<VariableRecordValue> recordMock = mock(Record.class);
-    when(recordMock.getPartitionId()).thenReturn(1);
-    when(recordMock.getKey()).thenReturn(RECORD_KEY);
-    when(recordMock.getValueType()).thenReturn(ValueType.VARIABLE);
-    when(recordMock.toJson()).thenReturn("{}");
-
-    final VariableRecordValue value = mock(VariableRecordValue.class);
-    when(value.getValue()).thenReturn(variableValue);
-    when(recordMock.getValue()).thenReturn(value);
-
-    // when
-    client.index(recordMock);
-
-    // then
-    verify(logSpy, never()).warn(anyString(), ArgumentMatchers.<Object[]>any());
-  }
-
-  @Test
-  public void shouldLogWarnWhenIndexingLargeVariableValue() {
-    // given
-    final String variableName = "varName";
-    final String variableValue = "x".repeat(configuration.index.ignoreVariablesAbove + 1);
-    final long scopeKey = 1234L;
-    final long processInstanceKey = 5678L;
-
-    final Record<VariableRecordValue> recordMock = mock(Record.class);
-    when(recordMock.getPartitionId()).thenReturn(1);
-    when(recordMock.getKey()).thenReturn(RECORD_KEY);
-    when(recordMock.getValueType()).thenReturn(ValueType.VARIABLE);
-    when(recordMock.toJson()).thenReturn("{}");
-
-    final VariableRecordValue value = mock(VariableRecordValue.class);
-    when(value.getName()).thenReturn(variableName);
-    when(value.getValue()).thenReturn(variableValue);
-    when(value.getScopeKey()).thenReturn(scopeKey);
-    when(value.getProcessInstanceKey()).thenReturn(processInstanceKey);
-
-    when(recordMock.getValue()).thenReturn(value);
-
-    // when
-    client.index(recordMock);
-
-    // then
-    final ArgumentCaptor<Object[]> argumentCaptor = ArgumentCaptor.forClass(Object[].class);
-
-    verify(logSpy).warn(anyString(), argumentCaptor.capture());
-
-    // required to explicitly cast List<Objects[]> to List<Object>
-    final List<Object> args = new ArrayList<>(argumentCaptor.getAllValues());
-    assertThat(args)
-        .contains(
-            RECORD_KEY,
-            variableName,
-            variableValue.getBytes().length,
-            scopeKey,
-            processInstanceKey);
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR removes the `ignoreVariablesAbove` configuration option from the ES exporter. This option was previously used to control when to log a warning if a variable was too big. After discussion, it was considered a normal pitfall of using Elastic, and it should be documented, but doesn't warrant a warning in the logs.

## Related issues

closes #6286 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
