### PR TITLE
Create no event scopes for process start events

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TriggerTimerProcessor.java
@@ -104,11 +104,6 @@ public final class TriggerTimerProcessor implements TypedRecordProcessor<TimerRe
         processState.getFlowElement(
             processDefinitionKey, timer.getTargetElementIdBuffer(), ExecutableCatchEvent.class);
     if (isStartEvent(elementInstanceKey)) {
-      if (!eventScopeInstanceState.isAcceptingEvent(processDefinitionKey)) {
-        rejectNoActiveTimer(record);
-        return;
-      }
-
       stateWriter.appendFollowUpEvent(record.getKey(), TimerIntent.TRIGGERED, timer);
       final long processInstanceKey = keyGenerator.nextKey();
       eventHandle.activateProcessInstanceForStartEvent(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -175,7 +175,7 @@ public final class EventAppliers implements EventApplier {
     register(
         MessageStartEventSubscriptionIntent.CREATED,
         new MessageStartEventSubscriptionCreatedApplier(
-            state.getMessageStartEventSubscriptionState(), state.getEventScopeInstanceState()));
+            state.getMessageStartEventSubscriptionState()));
     register(
         MessageStartEventSubscriptionIntent.CORRELATED,
         new MessageStartEventSubscriptionCorrelatedApplier(
@@ -183,7 +183,7 @@ public final class EventAppliers implements EventApplier {
     register(
         MessageStartEventSubscriptionIntent.DELETED,
         new MessageStartEventSubscriptionDeletedApplier(
-            state.getMessageStartEventSubscriptionState(), state.getEventScopeInstanceState()));
+            state.getMessageStartEventSubscriptionState()));
   }
 
   private void registerIncidentEventAppliers(final MutableZeebeState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartEventSubscriptionCorrelatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartEventSubscriptionCorrelatedApplier.java
@@ -43,7 +43,7 @@ public final class MessageStartEventSubscriptionCorrelatedApplier
     }
 
     // write the event trigger for the start event
-    eventScopeInstanceState.triggerEvent(
+    eventScopeInstanceState.triggerStartEvent(
         value.getProcessDefinitionKey(),
         value.getMessageKey(),
         value.getStartEventIdBuffer(),

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartEventSubscriptionCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartEventSubscriptionCreatedApplier.java
@@ -8,36 +8,23 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptionState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
-import java.util.Collections;
-import java.util.List;
-import org.agrona.DirectBuffer;
 
 public final class MessageStartEventSubscriptionCreatedApplier
     implements TypedEventApplier<
         MessageStartEventSubscriptionIntent, MessageStartEventSubscriptionRecord> {
 
-  private static final List<DirectBuffer> NO_INTERRUPTING_ELEMENT_IDS = Collections.emptyList();
-
   private final MutableMessageStartEventSubscriptionState subscriptionState;
-  private final MutableEventScopeInstanceState eventScopeInstanceState;
 
   public MessageStartEventSubscriptionCreatedApplier(
-      final MutableMessageStartEventSubscriptionState subscriptionState,
-      final MutableEventScopeInstanceState eventScopeInstanceState) {
+      final MutableMessageStartEventSubscriptionState subscriptionState) {
     this.subscriptionState = subscriptionState;
-    this.eventScopeInstanceState = eventScopeInstanceState;
   }
 
   @Override
   public void applyState(final long key, final MessageStartEventSubscriptionRecord value) {
-
     subscriptionState.put(key, value);
-
-    eventScopeInstanceState.createIfNotExists(
-        value.getProcessDefinitionKey(), NO_INTERRUPTING_ELEMENT_IDS);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartEventSubscriptionDeletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartEventSubscriptionDeletedApplier.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageStartEventSubscriptionState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
@@ -18,21 +17,15 @@ public final class MessageStartEventSubscriptionDeletedApplier
         MessageStartEventSubscriptionIntent, MessageStartEventSubscriptionRecord> {
 
   private final MutableMessageStartEventSubscriptionState subscriptionState;
-  private final MutableEventScopeInstanceState eventScopeInstanceState;
 
   public MessageStartEventSubscriptionDeletedApplier(
-      final MutableMessageStartEventSubscriptionState subscriptionState,
-      final MutableEventScopeInstanceState eventScopeInstanceState) {
+      final MutableMessageStartEventSubscriptionState subscriptionState) {
     this.subscriptionState = subscriptionState;
-    this.eventScopeInstanceState = eventScopeInstanceState;
   }
 
   @Override
   public void applyState(final long key, final MessageStartEventSubscriptionRecord value) {
     final var processDefinitionKey = value.getProcessDefinitionKey();
-
     subscriptionState.remove(processDefinitionKey, value.getMessageNameBuffer());
-
-    eventScopeInstanceState.deleteInstance(processDefinitionKey);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessCreatedApplier.java
@@ -7,36 +7,22 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
-import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableZeebeState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
-import java.util.Collections;
 
 public class ProcessCreatedApplier implements TypedEventApplier<ProcessIntent, ProcessRecord> {
 
   private final MutableProcessState processState;
-  private final MutableEventScopeInstanceState eventScopeInstanceState;
 
   public ProcessCreatedApplier(final MutableZeebeState state) {
     processState = state.getProcessState();
-    eventScopeInstanceState = state.getEventScopeInstanceState();
   }
 
   @Override
   public void applyState(final long processDefinitionKey, final ProcessRecord value) {
     processState.putProcess(processDefinitionKey, value);
-
-    // timer start events
-    final var hasAtLeastOneTimer =
-        processState.getProcessByKey(processDefinitionKey).getProcess().getStartEvents().stream()
-            .anyMatch(ExecutableCatchEventElement::isTimer);
-
-    if (hasAtLeastOneTimer) {
-      eventScopeInstanceState.createIfNotExists(processDefinitionKey, Collections.emptyList());
-    }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessEventTriggeringApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessEventTriggeringApplier.java
@@ -43,7 +43,11 @@ final class ProcessEventTriggeringApplier
     final var targetElementIdBuffer = value.getTargetElementIdBuffer();
     final var scopeKey = value.getScopeKey();
 
-    eventScopeState.triggerEvent(scopeKey, key, targetElementIdBuffer, variables);
+    if (value.getProcessDefinitionKey() == scopeKey) {
+      eventScopeState.triggerStartEvent(scopeKey, key, targetElementIdBuffer, variables);
+    } else {
+      eventScopeState.triggerEvent(scopeKey, key, targetElementIdBuffer, variables);
+    }
     eventSubProcessInterruptionMarker.markInstanceIfInterrupted(
         scopeKey, value.getProcessDefinitionKey(), targetElementIdBuffer);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbEventScopeInstanceState.java
@@ -137,6 +137,15 @@ public final class DbEventScopeInstanceState implements MutableEventScopeInstanc
   }
 
   @Override
+  public void triggerStartEvent(
+      final long processDefinitionKey,
+      final long eventKey,
+      final DirectBuffer elementId,
+      final DirectBuffer variables) {
+    createTrigger(processDefinitionKey, eventKey, elementId, variables);
+  }
+
+  @Override
   public void deleteTrigger(final long eventScopeKey, final long eventKey) {
     eventTriggerScopeKey.wrapLong(eventScopeKey);
     eventTriggerEventKey.wrapLong(eventKey);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableEventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableEventScopeInstanceState.java
@@ -67,12 +67,13 @@ public interface MutableEventScopeInstanceState extends EventScopeInstanceState 
       long eventScopeKey, long eventKey, DirectBuffer elementId, DirectBuffer variables);
 
   /**
-   * Creates an eventTrigger for an start event as scope key the process definition key is used.
+   * Creates an event trigger for a process start event. Uses the process definition key as the
+   * scope key of the trigger.
    *
-   * @param processDefinitionKey the process definition key of the to be triggered start event, this
-   *     is used as scope key for the event trigger
+   * @param processDefinitionKey the key of the process definition a new instance should be created
+   *     of
    * @param eventKey the key of the event record (used for ordering)
-   * @param elementId the id of the element which should be triggered
+   * @param elementId the id of the start event which should be triggered
    * @param variables the variables of the occurred event, i.e. message variables
    */
   void triggerStartEvent(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableEventScopeInstanceState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableEventScopeInstanceState.java
@@ -67,6 +67,18 @@ public interface MutableEventScopeInstanceState extends EventScopeInstanceState 
       long eventScopeKey, long eventKey, DirectBuffer elementId, DirectBuffer variables);
 
   /**
+   * Creates an eventTrigger for an start event as scope key the process definition key is used.
+   *
+   * @param processDefinitionKey the process definition key of the to be triggered start event, this
+   *     is used as scope key for the event trigger
+   * @param eventKey the key of the event record (used for ordering)
+   * @param elementId the id of the element which should be triggered
+   * @param variables the variables of the occurred event, i.e. message variables
+   */
+  void triggerStartEvent(
+      long processDefinitionKey, long eventKey, DirectBuffer elementId, DirectBuffer variables);
+
+  /**
    * Deletes an event trigger by key and scope key. Does not fail if the trigger does not exist.
    *
    * @param eventScopeKey the key of the event scope


### PR DESCRIPTION
## Description

 * Add several test cases where previous the state was not cleaned up correctly
 * Fix the clean up issues with not creating event scopes for process start events, like timer and message start events

Replaces this PR https://github.com/camunda-cloud/zeebe/pull/6978 

### More details

Previous we had the issue that for non-none process start events, event scopes have been created, which were never been cleaned up. We tried several approaches to clean them up correctly, but we ran into multiple issues regarding concurrent triggering and deleting of these scopes. In order to resolve and avoid this issue we decided to not create event scopes for process start events, like timer and message start events.


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6955 
closes #6976 
closes https://github.com/camunda-cloud/zeebe/pull/6978

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
