### PR TITLE
Lower log level of IOException during snapshot replication to warning

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -43,6 +43,7 @@ import io.camunda.zeebe.journal.JournalException.InvalidIndex;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
 import io.camunda.zeebe.snapshots.ReceivedSnapshot;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -237,12 +238,21 @@ public class PassiveRole extends InactiveRole {
       }
     }
 
-    boolean snapshotChunkConsumptionFailed;
+    boolean snapshotChunkConsumptionFailed = true;
     try {
       snapshotChunkConsumptionFailed = !pendingSnapshot.apply(snapshotChunk).join();
+    } catch (final IOException e) {
+      log.warn(
+          "Failed to write pending snapshot chunk {}, rolling back snapshot {}",
+          snapshotChunk,
+          pendingSnapshot,
+          e);
     } catch (final Exception e) {
-      log.error("Failed to write pending snapshot chunk {}, rolling back", pendingSnapshot, e);
-      snapshotChunkConsumptionFailed = true;
+      log.error(
+          "Failed to write pending snapshot chunk {}, rolling back snapshot {}",
+          snapshotChunk,
+          pendingSnapshot,
+          e);
     }
 
     if (snapshotChunkConsumptionFailed) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -230,7 +230,11 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
         markSnapshotAsInvalid(context, snapshotChunk);
       }
     } catch (final IOException e) {
-      LOG.error("Unexpected error on writing the received snapshot chunk {}", snapshotChunk, e);
+      LOG.warn(
+          "Unexpected error on writing the received snapshot chunk {}, marking snapshot {} as invalid",
+          snapshotChunk,
+          snapshotId,
+          e);
       markSnapshotAsInvalid(context, snapshotChunk);
     }
   }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.snapshots.impl;
 
-import static java.nio.file.StandardOpenOption.CREATE_NEW;
-
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunk;
@@ -173,7 +171,11 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
 
   private boolean writeReceivedSnapshotChunk(
       final SnapshotChunk snapshotChunk, final Path snapshotFile) throws IOException {
-    Files.write(snapshotFile, snapshotChunk.getContent(), CREATE_NEW, StandardOpenOption.WRITE);
+    Files.write(
+        snapshotFile,
+        snapshotChunk.getContent(),
+        StandardOpenOption.CREATE_NEW,
+        StandardOpenOption.WRITE);
     LOGGER.trace("Wrote replicated snapshot chunk to file {}", snapshotFile);
     return SUCCESS;
   }


### PR DESCRIPTION
## Description

This PR lowers the log level of IOException occurring during snapshot replication on the follower side, both in the Atomix replication and in the push based replication. This aligns the logging to our guidelines, where most IOException may be recovered, but only repeated ones should be investigated by a human.

## Related issues

closes #6505

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
