### PR TITLE
[Backport 1.0] fix JSON comparisons in zbctl tests

### DIFF
--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -15,7 +15,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
@@ -169,44 +171,56 @@ func (s *integrationTestSuite) TestCommonCommands() {
 				t.Fatal(err)
 			}
 
-			var comparer cmp.Option
 			if test.jsonOutput {
-				comparer = jsonComparer()
-			} else {
-				comparer = textComparer()
+				cmdOut, err = reformatJSON(cmdOut)
+				if err != nil {
+					t.Fatalf("failed to reformat JSON: %s", err.Error())
+				}
+
+				goldenOut, err = reformatJSON(goldenOut)
+				if err != nil {
+					t.Fatalf("failed to reformat JSON: %s", err.Error())
+				}
 			}
 
-			assertEq(t, test, comparer, goldenOut, cmdOut)
+			assertEq(t, test, goldenOut, cmdOut)
 		})
 	}
 }
 
-func assertEq(t *testing.T, test testCase, comparer cmp.Option, golden, cmdOut []byte) {
+// reformatJSON formats the JSON files in the same way so that whitespace differences are ignored
+func reformatJSON(in []byte) ([]byte, error) {
+	buf := &bytes.Buffer{}
+
+	// must compact before calling json.Indent because event though that will remove leading whitespace, it won't remove
+	// trailing whitespace.
+	if err := json.Compact(buf, in); err != nil {
+		return nil, err
+	}
+
+	compacted := make([]byte, buf.Len())
+	copy(compacted, buf.Bytes())
+	buf.Reset()
+
+	if err := json.Indent(buf, compacted, "", "\t"); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func assertEq(t *testing.T, test testCase, golden, cmdOut []byte) {
 	wantLines := strings.Split(string(golden), "\n")
 	gotLines := strings.Split(string(cmdOut), "\n")
 
-	if diff := cmp.Diff(wantLines, gotLines, comparer); diff != "" {
+	opt := composeComparers(cmpIgnoreVersion, cmpIgnoreNums)
+	if diff := cmp.Diff(wantLines, gotLines, opt); diff != "" {
 		t.Fatalf("%s: diff (-want +got):\n%s", test.name, diff)
 	}
 }
 
-func jsonComparer() cmp.Option {
-	return composeComparer(func(x string) string {
-		// ignore whitespace
-		pattern := regexp.MustCompile(`\s+`)
-		x = pattern.ReplaceAllString(x, "")
-		return x
-	}, cmpIgnoreVersion, cmpIgnoreNums)
-}
-
-func textComparer() cmp.Option {
-	return composeComparer(func(x string) string { return x }, cmpIgnoreVersion, cmpIgnoreNums)
-}
-
-func composeComparer(transf func(string) string, cmpFuncs ...func(x, y string) bool) cmp.Option {
+func composeComparers(cmpFuncs ...func(x string, y string) bool) cmp.Option {
 	return cmp.Comparer(func(x, y string) bool {
-		x, y = transf(x), transf(y)
-
 		for _, cmpFunc := range cmpFuncs {
 			if cmpFunc(x, y) {
 				return true

--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -152,7 +152,7 @@ func (s *integrationTestSuite) TestCommonCommands() {
 		s.T().Run(test.name, func(t *testing.T) {
 			for _, cmd := range test.setupCmds {
 				if _, err := s.runCommand(cmd); err != nil {
-					t.Fatal(fmt.Errorf("failed while executing set up command '%s': %w", cmd, err))
+					t.Fatalf("failed while executing set up command '%s': %v", cmd, err)
 				}
 			}
 
@@ -163,7 +163,7 @@ func (s *integrationTestSuite) TestCommonCommands() {
 
 			cmdOut, err := s.runCommand(test.cmd, test.envVars...)
 			if errors.Is(err, context.DeadlineExceeded) {
-				t.Fatal(fmt.Errorf("timed out while executing command '%s': %w", test.cmd, err))
+				t.Fatalf("timed out while executing command '%s': %v", test.cmd, err)
 			}
 
 			goldenOut, err := ioutil.ReadFile(test.goldenFile)
@@ -174,12 +174,12 @@ func (s *integrationTestSuite) TestCommonCommands() {
 			if test.jsonOutput {
 				cmdOut, err = reformatJSON(cmdOut)
 				if err != nil {
-					t.Fatalf("failed to reformat JSON: %s", err.Error())
+					t.Fatalf("failed to reformat JSON: %v", err)
 				}
 
 				goldenOut, err = reformatJSON(goldenOut)
 				if err != nil {
-					t.Fatalf("failed to reformat JSON: %s", err.Error())
+					t.Fatalf("failed to reformat JSON: %v", err)
 				}
 			}
 

--- a/clients/go/cmd/zbctl/testdata/topology_json.golden
+++ b/clients/go/cmd/zbctl/testdata/topology_json.golden
@@ -6,7 +6,7 @@
       "port":  26501,
       "partitions":  [
         {
-          "partitionId":  1,
+          "partitionId":  12,
           "role":  "LEADER",
           "health":  "HEALTHY"
         }

--- a/clients/go/cmd/zbctl/testdata/topology_json.golden
+++ b/clients/go/cmd/zbctl/testdata/topology_json.golden
@@ -1,7 +1,4 @@
-{
-  "brokers":  [
-    {
-      "nodeId":  0,
+{  "brokers":  [    {      "nodeId":  0,
       "host":  "172.17.0.3",
       "port":  26501,
       "partitions":  [


### PR DESCRIPTION
## Description

Backports #6970
## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6967 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
