### PR TITLE
Remove closed components from health monitors

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -417,7 +417,10 @@ public final class Broker implements AutoCloseable {
                 owningPartition.id().id(), zeebePartition);
             diskSpaceUsageListeners.add(zeebePartition);
             partitions.add(zeebePartition);
-            return zeebePartition;
+            return () -> {
+              healthCheckService.removeMonitoredPartition(partitionId);
+              zeebePartition.close();
+            };
           });
     }
     return partitionStartProcess.start();

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -34,11 +34,12 @@ import io.camunda.zeebe.util.sched.SchedulingHints;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -62,7 +63,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable {
   private final String name;
   private final RetryStrategy exportingRetryStrategy;
   private final RetryStrategy recordWrapStrategy;
-  private final List<FailureListener> listeners = new ArrayList<>();
+  private final Set<FailureListener> listeners = new HashSet<>();
   private LogStreamReader logStreamReader;
   private EventFilter eventFilter;
   private ExportersState state;
@@ -368,13 +369,13 @@ public final class ExporterDirector extends Actor implements HealthMonitorable {
   }
 
   @Override
-  public void addFailureListener(final FailureListener listener) {
-    actor.run(() -> listeners.add(listener));
+  public HealthStatus getHealthStatus() {
+    return healthStatus;
   }
 
   @Override
-  public HealthStatus getHealthStatus() {
-    return healthStatus;
+  public void addFailureListener(final FailureListener listener) {
+    actor.run(() -> listeners.add(listener));
   }
 
   private static class RecordExporter {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -378,6 +378,11 @@ public final class ExporterDirector extends Actor implements HealthMonitorable {
     actor.run(() -> listeners.add(listener));
   }
 
+  @Override
+  public void removeFailureListener(final FailureListener failureListener) {
+    actor.run(() -> listeners.remove(failureListener));
+  }
+
   private static class RecordExporter {
 
     private final RecordValues recordValues = new RecordValues();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -191,6 +191,15 @@ public final class BrokerHealthCheckService extends Actor implements PartitionLi
     registerComponent(componentName, partition);
   }
 
+  public void removeMonitoredPartition(final int partitionId) {
+    final String componentName = String.format(PARTITION_COMPONENT_NAME_FORMAT, partitionId);
+    removeComponent(componentName);
+  }
+
+  private void removeComponent(final String componentName) {
+    actor.run(() -> healthMonitor.removeComponent(componentName));
+  }
+
   public boolean isBrokerHealthy() {
     return !actor.isClosed() && getBrokerHealth() == HealthStatus.HEALTHY;
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -319,6 +319,11 @@ public final class ZeebePartition extends Actor
   }
 
   @Override
+  public void removeFailureListener(final FailureListener failureListener) {
+    actor.run(() -> failureListeners.remove(failureListener));
+  }
+
+  @Override
   public void onDiskSpaceNotAvailable() {
     actor.call(
         () -> {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -192,6 +192,8 @@ public final class ZeebePartition extends Actor
 
   @Override
   protected void onActorClosing() {
+    context.getComponentHealthMonitor().removeComponent(zeebePartitionHealth.getName());
+
     transitionToInactive()
         .onComplete(
             (nothing, err) -> {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -192,8 +192,6 @@ public final class ZeebePartition extends Actor
 
   @Override
   protected void onActorClosing() {
-    context.getComponentHealthMonitor().removeComponent(zeebePartitionHealth.getName());
-
     transitionToInactive()
         .onComplete(
             (nothing, err) -> {
@@ -207,6 +205,12 @@ public final class ZeebePartition extends Actor
   }
 
   @Override
+  protected void onActorCloseRequested() {
+    LOG.debug("Closing ZeebePartition {}", context.getPartitionId());
+    context.getComponentHealthMonitor().removeComponent(zeebePartitionHealth.getName());
+  }
+
+  @Override
   public ActorFuture<Void> closeAsync() {
     if (closeFuture != null) {
       return closeFuture;
@@ -214,15 +218,11 @@ public final class ZeebePartition extends Actor
 
     closeFuture = new CompletableActorFuture<>();
 
-    actor.call(
+    actor.run(
         () ->
             // allows to await current transition to avoid concurrent modifications and
             // transitioning
-            currentTransitionFuture.onComplete(
-                (nothing, err) -> {
-                  LOG.debug("Closing Zeebe Partition {}.", context.getPartitionId());
-                  super.closeAsync();
-                }));
+            currentTransitionFuture.onComplete((nothing, err) -> super.closeAsync()));
 
     return closeFuture;
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthStatus;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Reflects the health of ZeebePartition. The health is updated by ZeebePartition when role
@@ -17,9 +19,9 @@ import io.camunda.zeebe.util.health.HealthStatus;
  */
 class ZeebePartitionHealth implements HealthMonitorable {
 
-  private HealthStatus healthStatus = HealthStatus.UNHEALTHY;
   private final String name;
-  private FailureListener failureListener;
+  private final Set<FailureListener> failureListeners = new HashSet<>();
+  private HealthStatus healthStatus = HealthStatus.UNHEALTHY;
   /*
   Multiple factors determine ZeebePartition's health :
   * - servicesInstalled: indicates if role transition was successful and all services are installed
@@ -40,7 +42,7 @@ class ZeebePartitionHealth implements HealthMonitorable {
 
   @Override
   public void addFailureListener(final FailureListener failureListener) {
-    this.failureListener = failureListener;
+    failureListeners.add(failureListener);
   }
 
   private void updateHealthStatus() {
@@ -56,13 +58,16 @@ class ZeebePartitionHealth implements HealthMonitorable {
       healthStatus = HealthStatus.UNHEALTHY;
     }
 
-    if (previousStatus != healthStatus && failureListener != null) {
+    if (previousStatus != healthStatus) {
       switch (healthStatus) {
         case HEALTHY:
-          failureListener.onRecovered();
+          failureListeners.forEach(FailureListener::onRecovered);
           break;
         case UNHEALTHY:
-          failureListener.onFailure();
+          failureListeners.forEach(FailureListener::onFailure);
+          break;
+        case DEAD:
+          failureListeners.forEach(FailureListener::onUnrecoverableFailure);
           break;
         default:
           break;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
@@ -45,6 +45,11 @@ class ZeebePartitionHealth implements HealthMonitorable {
     failureListeners.add(failureListener);
   }
 
+  @Override
+  public void removeFailureListener(final FailureListener failureListener) {
+    failureListeners.remove(failureListener);
+  }
+
   private void updateHealthStatus() {
     final var previousStatus = healthStatus;
     if (previousStatus == HealthStatus.DEAD) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -21,8 +21,8 @@ import io.camunda.zeebe.util.sched.SchedulingHints;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import org.slf4j.Logger;
 
 public final class AsyncSnapshotDirector extends Actor implements HealthMonitorable {
@@ -45,7 +45,7 @@ public final class AsyncSnapshotDirector extends Actor implements HealthMonitora
   private final String processorName;
   private final StreamProcessor streamProcessor;
   private final String actorName;
-  private final List<FailureListener> listeners = new ArrayList<>();
+  private final Set<FailureListener> listeners = new HashSet<>();
 
   private ActorCondition commitCondition;
   private Long lastWrittenEventPosition;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -141,6 +141,11 @@ public final class AsyncSnapshotDirector extends Actor implements HealthMonitora
     actor.run(() -> listeners.add(listener));
   }
 
+  @Override
+  public void removeFailureListener(final FailureListener failureListener) {
+    actor.run(() -> listeners.remove(failureListener));
+  }
+
   private void prepareTakingSnapshot() {
     if (takingSnapshot) {
       return;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -102,19 +102,6 @@ public final class AsyncSnapshotDirector extends Actor implements HealthMonitora
     return super.closeAsync();
   }
 
-  private void scheduleSnapshotOnRate() {
-    actor.runAtFixedRate(snapshotRate, this::prepareTakingSnapshot);
-    prepareTakingSnapshot();
-  }
-
-  private String getConditionNameForPosition() {
-    return getName() + "-wait-for-endPosition-committed";
-  }
-
-  public void forceSnapshot() {
-    actor.call(this::prepareTakingSnapshot);
-  }
-
   @Override
   protected void handleFailure(final Exception failure) {
     LOG.error(
@@ -131,14 +118,27 @@ public final class AsyncSnapshotDirector extends Actor implements HealthMonitora
     }
   }
 
-  @Override
-  public void addFailureListener(final FailureListener listener) {
-    actor.run(() -> listeners.add(listener));
+  private void scheduleSnapshotOnRate() {
+    actor.runAtFixedRate(snapshotRate, this::prepareTakingSnapshot);
+    prepareTakingSnapshot();
+  }
+
+  private String getConditionNameForPosition() {
+    return getName() + "-wait-for-endPosition-committed";
+  }
+
+  public void forceSnapshot() {
+    actor.call(this::prepareTakingSnapshot);
   }
 
   @Override
   public HealthStatus getHealthStatus() {
     return healthStatus;
+  }
+
+  @Override
+  public void addFailureListener(final FailureListener listener) {
+    actor.run(() -> listeners.add(listener));
   }
 
   private void prepareTakingSnapshot() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionStep.java
@@ -51,7 +51,9 @@ public class ExporterDirectorPartitionStep implements PartitionStep {
 
   @Override
   public ActorFuture<Void> close(final PartitionContext context) {
-    final ActorFuture<Void> future = context.getExporterDirector().closeAsync();
+    final var director = context.getExporterDirector();
+    context.getComponentHealthMonitor().removeComponent(director.getName());
+    final ActorFuture<Void> future = director.closeAsync();
     context.setExporterDirector(null);
     return future;
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionStep.java
@@ -33,7 +33,9 @@ public class SnapshotDirectorPartitionStep implements PartitionStep {
 
   @Override
   public ActorFuture<Void> close(final PartitionContext context) {
-    final ActorFuture<Void> future = context.getSnapshotDirector().closeAsync();
+    final var director = context.getSnapshotDirector();
+    context.getComponentHealthMonitor().removeComponent(director.getName());
+    final ActorFuture<Void> future = director.closeAsync();
     context.setSnapshotDirector(null);
     return future;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -363,6 +363,11 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
     actor.run(() -> failureListeners.add(failureListener));
   }
 
+  @Override
+  public void removeFailureListener(final FailureListener failureListener) {
+    actor.run(() -> failureListeners.remove(failureListener));
+  }
+
   public ActorFuture<Phase> getCurrentPhase() {
     return actor.call(() -> phase);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/StreamProcessor.java
@@ -29,7 +29,9 @@ import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -46,6 +48,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
   private final AtomicBoolean isOpened = new AtomicBoolean(false);
   private final List<StreamProcessorLifecycleAware> lifecycleAwareListeners;
   private final Function<MutableZeebeState, EventApplier> eventApplierFactory;
+  private final Set<FailureListener> failureListeners = new HashSet<>();
 
   // log stream
   private final LogStream logStream;
@@ -65,7 +68,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
 
   private CompletableActorFuture<Void> openFuture;
   private CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);
-  private FailureListener failureListener;
   private volatile long lastTickTime;
   private boolean shouldProcess = true;
   /** Recover future is completed after reprocessing is done. */
@@ -309,12 +311,10 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
       openFuture.completeExceptionally(throwable);
     }
 
-    if (failureListener != null) {
-      if (throwable instanceof UnrecoverableException) {
-        failureListener.onUnrecoverableFailure();
-      } else {
-        failureListener.onFailure();
-      }
+    if (throwable instanceof UnrecoverableException) {
+      failureListeners.forEach(FailureListener::onUnrecoverableFailure);
+    } else {
+      failureListeners.forEach(FailureListener::onFailure);
     }
   }
 
@@ -360,7 +360,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable {
 
   @Override
   public void addFailureListener(final FailureListener failureListener) {
-    actor.run(() -> this.failureListener = failureListener);
+    actor.run(() -> failureListeners.add(failureListener));
   }
 
   public ActorFuture<Phase> getCurrentPhase() {

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -31,7 +31,9 @@ import io.camunda.zeebe.util.sched.clock.ActorClock;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.LongConsumer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
@@ -52,7 +54,7 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
   private final Environment env;
   private final LoggedEventImpl positionReader = new LoggedEventImpl();
   private final AppenderMetrics appenderMetrics;
-  private FailureListener failureListener;
+  private final Set<FailureListener> failureListeners = new HashSet<>();
   private final ActorFuture<Void> closeFuture;
   private final LongConsumer commitPositionListener;
 
@@ -197,15 +199,13 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
 
   @Override
   public void addFailureListener(final FailureListener failureListener) {
-    actor.run(() -> this.failureListener = failureListener);
+    actor.run(() -> failureListeners.add(failureListener));
   }
 
   private void onFailure(final Throwable error) {
     LOG.error("Actor {} failed in phase {}.", name, actor.getLifecyclePhase(), error);
     actor.fail();
-    if (failureListener != null) {
-      failureListener.onFailure();
-    }
+    failureListeners.forEach(FailureListener::onFailure);
   }
 
   void runOnFailure(final Throwable error) {

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -202,6 +202,11 @@ public class LogStorageAppender extends Actor implements HealthMonitorable {
     actor.run(() -> failureListeners.add(failureListener));
   }
 
+  @Override
+  public void removeFailureListener(final FailureListener failureListener) {
+    actor.run(() -> failureListeners.remove(failureListener));
+  }
+
   private void onFailure(final Throwable error) {
     LOG.error("Actor {} failed in phase {}.", name, actor.getLifecyclePhase(), error);
     actor.fail();

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -349,6 +349,11 @@ public final class LogStreamImpl extends Actor implements LogStream, FailureList
   }
 
   @Override
+  public void removeFailureListener(final FailureListener failureListener) {
+    actor.run(() -> failureListeners.remove(failureListener));
+  }
+
+  @Override
   public void onFailure() {
     actor.run(
         () -> {

--- a/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
@@ -45,7 +45,8 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
   public void removeComponent(final String componentName) {
     actor.run(
         () -> {
-          monitoredComponents.remove(componentName);
+          final var monitoredComponent = monitoredComponents.remove(componentName);
+          monitoredComponent.component.removeFailureListener(monitoredComponent);
           componentHealth.remove(componentName);
         });
   }
@@ -166,19 +167,19 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
 
     private void onComponentFailure() {
       log.error("{} failed, marking it as unhealthy", componentName);
-      componentHealth.computeIfPresent(componentName, (k, v) -> HealthStatus.UNHEALTHY);
+      componentHealth.put(componentName, HealthStatus.UNHEALTHY);
       calculateHealth();
     }
 
     private void onComponentRecovered() {
       log.info("{} recovered, marking it as healthy", componentName);
-      componentHealth.computeIfPresent(componentName, (k, v) -> HealthStatus.HEALTHY);
+      componentHealth.put(componentName, HealthStatus.HEALTHY);
       calculateHealth();
     }
 
     private void onComponentDied() {
       log.error("{} failed, marking it as dead", componentName);
-      componentHealth.computeIfPresent(componentName, (k, v) -> HealthStatus.DEAD);
+      componentHealth.put(componentName, HealthStatus.DEAD);
       calculateHealth();
     }
   }

--- a/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitor.java
@@ -73,6 +73,11 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
     actor.run(() -> failureListeners.add(failureListener));
   }
 
+  @Override
+  public void removeFailureListener(final FailureListener failureListener) {
+    actor.run(() -> failureListeners.remove(failureListener));
+  }
+
   private void updateHealth() {
     componentHealth
         .keySet()

--- a/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitorable.java
+++ b/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitorable.java
@@ -25,4 +25,12 @@ public interface HealthMonitorable {
    *     status of this component occurs
    */
   void addFailureListener(FailureListener failureListener);
+
+  /**
+   * Removes a previously registered listener. Should do nothing if it was not previously
+   * registered.
+   *
+   * @param failureListener the failure listener to remove
+   */
+  void removeFailureListener(FailureListener failureListener);
 }

--- a/util/src/test/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitorTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitorTest.java
@@ -193,5 +193,10 @@ public class CriticalComponentsHealthMonitorTest {
     public void addFailureListener(final FailureListener failureListener) {
       failureListeners.add(failureListener);
     }
+
+    @Override
+    public void removeFailureListener(final FailureListener failureListener) {
+      failureListeners.remove(failureListener);
+    }
   }
 }

--- a/util/src/test/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitorTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/health/CriticalComponentsHealthMonitorTest.java
@@ -128,6 +128,7 @@ public class CriticalComponentsHealthMonitorTest {
 
     // when
     monitor.removeComponent("test");
+    waitUntilAllDone();
     component.setHealthStatus(HealthStatus.UNHEALTHY);
     waitUntilAllDone();
 


### PR DESCRIPTION
## Description

This PR introduces a new method `removeFailureListener` to the `HealthMonitorable` interface, and tries to ensure we always remove components/failure listeners from health monitors when the components are closed/discarded.

This also fixes the issue we had with ZeebePartition being marked as unhealthy when closing.

NOTE: there's still the issue of potential race condition, for example in ZeebePartition. See commit https://github.com/camunda-cloud/zeebe/commit/708a2897a47181e3231151570ae4dc0efca15dad for more. It's not ideal, and I'm happy to change this for something better :+1: 

## Related issues

closes #6938 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
