### PR TITLE
fix(benchmark): update helm chart reference

### DIFF
--- a/benchmarks/setup/default/Makefile
+++ b/benchmarks/setup/default/Makefile
@@ -5,7 +5,7 @@ all: zeebe starter timer simpleStarter worker
 
 .PHONY: zeebe
 zeebe:
-	-helm install --namespace $(namespace) $(namespace) zeebe/zeebe-cluster -f zeebe-values.yaml --skip-crds
+	-helm install --namespace $(namespace) $(namespace) zeebe/zeebe-cluster-helm -f zeebe-values.yaml --skip-crds
 	-kubectl apply -n $(namespace) -f curator-cronjob.yaml
 	-kubectl apply -n $(namespace) -f curator-configmap.yaml
 
@@ -13,11 +13,11 @@ zeebe:
 # To apply the templates use k apply -f zeebe-cluster/templates/
 .PHONY: zeebe-template
 zeebe-template:
-	-helm template $(namespace) zeebe/zeebe-cluster -f zeebe-values.yaml --skip-crds --output-dir .
+	-helm template $(namespace) zeebe/zeebe-cluster-helm -f zeebe-values.yaml --skip-crds --output-dir .
 
 .PHONY: update
 update:
-	-helm upgrade --namespace $(namespace) $(namespace) zeebe/zeebe-cluster -f zeebe-values.yaml
+	-helm upgrade --namespace $(namespace) $(namespace) zeebe/zeebe-cluster-helm -f zeebe-values.yaml
 
 .PHONY: starter
 starter:


### PR DESCRIPTION
## Description
Updates the helm chart reference. Without that, Zeebe pods won't start due to an invalid configuration of ElasticSearch exporter.

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [X] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
