### PR TITLE
Replace clirr with Revapi and enable backwards compatibility checks

### DIFF
--- a/bpmn-model/pom.xml
+++ b/bpmn-model/pom.xml
@@ -55,17 +55,14 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>clirr-maven-plugin</artifactId>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
         <configuration>
-          <ignored>
-            <ignored>
-              <!-- ignore new methods in the Zeebe element instance interfaces -->
-              <className>io/camunda/zeebe/model/bpmn/instance/zeebe/*</className>
-              <differenceType>7012</differenceType>
-              <method>*</method>
-            </ignored>
-          </ignored>
+          <analysisConfigurationFiles>
+            <configurationFile>
+              <path>revapi.json</path>
+            </configurationFile>
+          </analysisConfigurationFiles>
         </configuration>
       </plugin>
     </plugins>

--- a/bpmn-model/revapi.json
+++ b/bpmn-model/revapi.json
@@ -1,0 +1,18 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "justification": "Ignore new methods for Zeebe extensions, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.method.addedToInterface",
+          "new": {
+            "matcher": "java-package",
+            "match": "/io\\.camunda\\.zeebe\\.model\\.bpmn\\.instance\\.zeebe(\\..*)?/"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/build-tools/src/main/resources/revapi/revapi.json
+++ b/build-tools/src/main/resources/revapi/revapi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "extension": "revapi.semver.ignore",
+    "configuration": {
+      "enabled" : true,
+      "versionIncreaseAllows" : {
+        "major" : "breaking",
+        "minor" : "nonBreaking",
+        "patch" : "equivalent"
+      },
+      "passThroughDifferences": ["java.class.nonPublicPartOfAPI"]
+    }
+  }
+]

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -166,12 +166,14 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>clirr-maven-plugin</artifactId>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>io/camunda/zeebe/client/impl/**</exclude>
-          </excludes>
+          <analysisConfigurationFiles>
+            <configurationFile>
+              <path>revapi.json</path>
+            </configurationFile>
+          </analysisConfigurationFiles>
         </configuration>
       </plugin>
     </plugins>

--- a/clients/java/revapi.json
+++ b/clients/java/revapi.json
@@ -1,0 +1,16 @@
+[
+  {
+    "extension": "revapi.filter",
+    "configuration": {
+      "justification": "The implementation package is not meant to be used directly, and as such does not need to maintain any backwards compatibility guarantees.",
+      "elements": {
+        "exclude": [
+          {
+            "matcher": "java-package",
+            "match": "/io\\.camunda\\.zeebe\\.client\\.impl(\\..*)?/"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/exporter-api/pom.xml
+++ b/exporter-api/pom.xml
@@ -26,21 +26,19 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>clirr-maven-plugin</artifactId>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
         <configuration>
-          <ignored>
-            <ignored>
-              <!-- ignore new methods in the Zeebe element instance interfaces -->
-              <className>io/camunda/zeebe/exporter/api/context/Controller</className>
-              <differenceType>7012</differenceType>
-              <method>*</method>
-            </ignored>
-          </ignored>
+          <analysisConfigurationFiles>
+            <configurationFile>
+              <path>revapi.json</path>
+            </configurationFile>
+          </analysisConfigurationFiles>
         </configuration>
       </plugin>
     </plugins>
   </build>
+
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>

--- a/exporter-api/revapi.json
+++ b/exporter-api/revapi.json
@@ -1,0 +1,18 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "justification": "Ignore new methods on all types, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.method.addedToInterface",
+          "new": {
+            "matcher": "java-package",
+            "match": "/io\\.camunda\\.zeebe\\.exporter\\.api(\\..*)?/"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -134,7 +134,6 @@
     <extension.version.os-maven-plugin>1.7.0</extension.version.os-maven-plugin>
 
     <!-- version against which backwards compatibility is checked -->
-    <!-- TODO: may not be necessary to have this, though we will want it for the update tests -->
     <backwards.compat.version>1.0.0</backwards.compat.version>
     <ignored.changes.file>ignored-changes.json</ignored.changes.file>
   </properties>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -100,6 +100,7 @@
     <version.jmock>2.12.0</version.jmock>
     <version.json-smart>2.4.7</version.json-smart>
     <version.byte-buddy>1.11.1</version.byte-buddy>
+    <version.revapi>0.24.1</version.revapi>
 
     <!-- maven plugins -->
     <plugin.version.antrun>3.0.0</plugin.version.antrun>
@@ -124,17 +125,18 @@
     <plugin.version.dependency>3.1.2</plugin.version.dependency>
     <plugin.version.spotbugs>4.2.3</plugin.version.spotbugs>
     <plugin.version.sonar>3.9.0.2155</plugin.version.sonar>
-    <plugin.version.clirr>2.8</plugin.version.clirr>
     <plugin.version.maven-jar>3.2.0</plugin.version.maven-jar>
     <plugin.version.dependency-analyzer>1.11.1</plugin.version.dependency-analyzer>
     <plugin.version.jacoco>0.8.7</plugin.version.jacoco>
+    <plugin.version.revapi>0.14.2</plugin.version.revapi>
 
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.7.0</extension.version.os-maven-plugin>
 
     <!-- version against which backwards compatibility is checked -->
+    <!-- TODO: may not be necessary to have this, though we will want it for the update tests -->
     <backwards.compat.version>1.0.0</backwards.compat.version>
-    <ignored.changes.file>ignored-changes.xml</ignored.changes.file>
+    <ignored.changes.file>ignored-changes.json</ignored.changes.file>
   </properties>
 
   <dependencyManagement>
@@ -776,24 +778,55 @@
           </configuration>
         </plugin>
 
+        <!-- compatibility checks/guard -->
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>clirr-maven-plugin</artifactId>
-          <version>${plugin.version.clirr}</version>
-          <configuration>
-            <comparisonVersion>${backwards.compat.version}</comparisonVersion>
-            <ignoredDifferencesFile>${ignored.changes.file}</ignoredDifferencesFile>
-            <!-- TODO(menski): Enable again after 1.0 release -->
-            <skip>true</skip>
-          </configuration>
+          <groupId>org.revapi</groupId>
+          <artifactId>revapi-maven-plugin</artifactId>
+          <version>${plugin.version.revapi}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.revapi</groupId>
+              <artifactId>revapi-java</artifactId>
+              <version>${version.revapi}</version>
+            </dependency>
+            <dependency>
+              <groupId>io.camunda</groupId>
+              <artifactId>zeebe-build-tools</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+          </dependencies>
           <executions>
             <execution>
+              <phase>verify</phase>
+              <id>check</id>
               <goals>
                 <goal>check</goal>
               </goals>
-              <phase>verify</phase>
             </execution>
           </executions>
+          <configuration>
+            <!-- see the property's documentation as to why -->
+            <checkDependencies>true</checkDependencies>
+            <!-- expands maven properties in the configuration files -->
+            <expandProperties>true</expandProperties>
+            <!-- allows us to pre-defined ignored-changes, even when missing -->
+            <failOnMissingConfigurationFiles>false</failOnMissingConfigurationFiles>
+            <analysisConfigurationFiles combine.children="append">
+              <!-- uses the default configuration file packaged in build-tools -->
+              <configurationFile>
+                <resource>revapi/revapi.json</resource>
+              </configurationFile>
+              <!-- will pick up a project relative ignored-changes file -->
+              <configurationFile>
+                <path>${ignored.changes.file}</path>
+              </configurationFile>
+            </analysisConfigurationFiles>
+            <!--
+              unfortunately we cannot use the meta version LATEST since we want to run this on
+              different branches which need to compare to different versions
+              -->
+            <oldVersion>${backwards.compat.version}</oldVersion>
+          </configuration>
         </plugin>
 
         <plugin>

--- a/protocol/ignored-changes.json
+++ b/protocol/ignored-changes.json
@@ -1,0 +1,25 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "justification": "We added a new value, DEAD, which changed the ordinals; however, SBE enums do not/should not rely on ordinals, but rather on the defined value.",
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.field.enumConstantOrderChanged",
+          "classQualifiedName": "io.camunda.zeebe.protocol.record.PartitionHealthStatus",
+          "fieldName": "NULL_VAL",
+          "oldOrdinal": "3",
+          "newOrdinal": "4"
+        },
+        {
+          "code": "java.field.enumConstantOrderChanged",
+          "classQualifiedName": "io.camunda.zeebe.protocol.record.PartitionHealthStatus",
+          "fieldName": "SBE_UNKNOWN",
+          "oldOrdinal": "2",
+          "newOrdinal": "3"
+        }
+      ]
+    }
+  }
+]

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -52,6 +52,7 @@
         <filtering>true</filtering>
       </resource>
     </resources>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -66,6 +67,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
@@ -84,6 +86,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -112,26 +115,16 @@
           </dependency>
         </dependencies>
       </plugin>
+
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>clirr-maven-plugin</artifactId>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
         <configuration>
-          <ignored>
-            <ignored>
-              <!-- ignore new methods in the Record interface -->
-              <className>io/camunda/zeebe/protocol/record/Record</className>
-              <method>*</method>
-              <differenceType>7012</differenceType>
-            </ignored>
-            <ignored>
-              <!-- ignore new methods in the interface -->
-              <className>
-                io/zeebe/protocol/record/value/**/**
-              </className>
-              <method>*</method>
-              <differenceType>7012</differenceType>
-            </ignored>
-          </ignored>
+          <analysisConfigurationFiles>
+            <configurationFile>
+              <path>revapi.json</path>
+            </configurationFile>
+          </analysisConfigurationFiles>
         </configuration>
       </plugin>
     </plugins>

--- a/protocol/revapi.json
+++ b/protocol/revapi.json
@@ -1,0 +1,36 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "justification": "Ignore new methods on all types, as these are not meant to be implemented but simply consumed; as such, new methods are perfectly fine to add",
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.method.addedToInterface",
+          "new": {
+            "matcher": "java-package",
+            "match": "/io\\.camunda\\.zeebe\\.protocol\\.record(\\..*)?/"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "extension": "revapi.filter",
+    "configuration": {
+      "justification": "The generated encoders/decoders are not meant to be used directly, and as such does not need to maintain any backwards compatibility guarantees.",
+      "elements": {
+        "exclude": [
+          {
+            "matcher": "java",
+            "match": "type ^* implements org.agrona.sbe.CompositeEncoderFlyweight {}"
+          },
+          {
+            "matcher": "java",
+            "match": "type ^* implements org.agrona.sbe.CompositeDecoderFlyweight {}"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/test/ignored-changes.json
+++ b/test/ignored-changes.json
@@ -1,0 +1,57 @@
+[
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "justification": "Hide or remove previously exposed types which come from external modules which offer no backwards compatibility guarantees",
+      "ignore": true,
+      "differences": [
+        {
+          "code": "java.field.visibilityReduced",
+          "old": "field io.camunda.zeebe.test.EmbeddedBrokerRule.broker",
+          "new": "field io.camunda.zeebe.test.EmbeddedBrokerRule.broker",
+          "oldVisibility": "protected",
+          "newVisibility": "private"
+        },
+        {
+          "code": "java.field.visibilityReduced",
+          "old": "field io.camunda.zeebe.test.EmbeddedBrokerRule.brokerCfg",
+          "new": "field io.camunda.zeebe.test.EmbeddedBrokerRule.brokerCfg",
+          "oldVisibility": "protected",
+          "newVisibility": "private"
+        },
+        {
+          "code": "java.field.visibilityReduced",
+          "old": "field io.camunda.zeebe.test.EmbeddedBrokerRule.configurators",
+          "new": "field io.camunda.zeebe.test.EmbeddedBrokerRule.configurators",
+          "oldVisibility": "protected",
+          "newVisibility": "private"
+        },
+        {
+          "code": "java.field.visibilityReduced",
+          "old": "field io.camunda.zeebe.test.EmbeddedBrokerRule.controlledActorClock",
+          "new": "field io.camunda.zeebe.test.EmbeddedBrokerRule.controlledActorClock",
+          "oldVisibility": "protected",
+          "newVisibility": "private"
+        },
+        {
+          "code": "java.field.visibilityReduced",
+          "old": "field io.camunda.zeebe.test.EmbeddedBrokerRule.recordingExporterTestWatcher",
+          "new": "field io.camunda.zeebe.test.EmbeddedBrokerRule.recordingExporterTestWatcher",
+          "oldVisibility": "protected",
+          "newVisibility": "private"
+        },
+        {
+          "code": "java.field.visibilityReduced",
+          "old": "field io.camunda.zeebe.test.EmbeddedBrokerRule.springBrokerBridge",
+          "new": "field io.camunda.zeebe.test.EmbeddedBrokerRule.springBrokerBridge",
+          "oldVisibility": "protected",
+          "newVisibility": "private"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.broker.Broker io.camunda.zeebe.test.EmbeddedBrokerRule::getBroker()"
+        }
+      ]
+    }
+  }
+]

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -16,8 +16,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>clirr-maven-plugin</artifactId>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
+++ b/test/src/main/java/io/camunda/zeebe/test/EmbeddedBrokerRule.java
@@ -54,15 +54,15 @@ public class EmbeddedBrokerRule extends ExternalResource {
   protected static final Logger LOG = LoggerFactory.getLogger("io.camunda.zeebe.test");
   private static final String SNAPSHOTS_DIRECTORY = "snapshots";
   private static final String STATE_DIRECTORY = "state";
-  protected final RecordingExporterTestWatcher recordingExporterTestWatcher =
-      new RecordingExporterTestWatcher();
   protected final Supplier<InputStream> configSupplier;
-  protected final Consumer<BrokerCfg>[] configurators;
-  protected BrokerCfg brokerCfg;
-  protected Broker broker;
-  protected final ControlledActorClock controlledActorClock = new ControlledActorClock();
-  protected final SpringBrokerBridge springBrokerBridge = new SpringBrokerBridge();
   protected long startTime;
+  private final Consumer<BrokerCfg>[] configurators;
+  private final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+  private final BrokerCfg brokerCfg;
+  private Broker broker;
+  private final ControlledActorClock controlledActorClock = new ControlledActorClock();
+  private final SpringBrokerBridge springBrokerBridge = new SpringBrokerBridge();
   private final Duration timeout;
   private final File newTemporaryFolder;
   private String dataDirectory;
@@ -182,10 +182,6 @@ public class EmbeddedBrokerRule extends ExternalResource {
 
   public InetSocketAddress getGatewayAddress() {
     return brokerCfg.getGateway().getNetwork().toSocketAddress();
-  }
-
-  public Broker getBroker() {
-    return broker;
   }
 
   public ControlledActorClock getClock() {

--- a/test/src/main/java/io/camunda/zeebe/test/exporter/record/ExporterMappedObject.java
+++ b/test/src/main/java/io/camunda/zeebe/test/exporter/record/ExporterMappedObject.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.test.exporter.record;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.broker.exporter.ExporterObjectMapper;
 
-class ExporterMappedObject {
+public class ExporterMappedObject {
 
   protected static final ExporterObjectMapper OBJECT_MAPPER = new ExporterObjectMapper();
 


### PR DESCRIPTION
## Description

This PR re-enables backwards compatibility checks post 1.0 in preparation for future releases. To do so, it replaces clirr with [revapi](https://revapi.org).

The main motivations to replace clirr with revapi are the following:

- it's actively maintained (see https://github.com/revapi/revapi)
- it's extensively documented (though it's sometimes hard to navigate, it's all there, and much better than clirr)
- the output it provides is great - it tells you why it failed, where the failure comes from, and how to fix it and/or ignore it
- it has much more powerful matching/filtering features than clirr, which are much simpler to understand/parse than a code list
- it can warn you when you inadvertently expose non-public types via your API (thereby widening the surface of how much you support)

Additionally to the PR, I will also update/rewrite the relevant wiki page explaining how to deal with revapi/compatibility changes.

BREAKING CHANGE: the last commit introduces a breaking change, which are:

1. Make some protected fields private - these fields were exposing "internal" types, e.g. Broker, BrokerCfg, SpringBrokerBridge, types for which we don't want to maintain backwards compatibility guarantees.
2. Remove the `EmbeddedBrokerRule#getBroker()` method - again, exposing the internal `Broker` type.

The reason for this is outlined in the commit, but TL;DR, I want to avoid having to provide compatibility guarantees on types that users aren't meant to use/consume, such as the `Broker`, and by exposing them here, they may start relying on them in their test and expect the same guarantees that the test module offers.

As such, the breaking change is minimal, and serves to prevent future constraints and/or necessary breaking changes.

## Related issues

closes #6499

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
