### PR TITLE
Wrap ObjectMapper instead of extending it

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeObjectMapper.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 
-public final class ZeebeObjectMapper extends ObjectMapper implements JsonMapper {
+public final class ZeebeObjectMapper implements JsonMapper {
 
   private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE =
       new TypeReference<Map<String, Object>>() {};
@@ -33,49 +33,57 @@ public final class ZeebeObjectMapper extends ObjectMapper implements JsonMapper 
   private static final TypeReference<Map<String, String>> STRING_MAP_TYPE_REFERENCE =
       new TypeReference<Map<String, String>>() {};
 
+  private final ObjectMapper objectMapper;
+
   public ZeebeObjectMapper() {
-    configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    objectMapper = new ObjectMapper();
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   }
 
+  @Override
   public <T> T fromJson(final String json, final Class<T> typeClass) {
     try {
-      return readValue(json, typeClass);
+      return objectMapper.readValue(json, typeClass);
     } catch (final IOException e) {
       throw new InternalClientException(
           String.format("Failed to deserialize json '%s' to class '%s'", json, typeClass), e);
     }
   }
 
+  @Override
   public Map<String, Object> fromJsonAsMap(final String json) {
     try {
-      return readValue(json, MAP_TYPE_REFERENCE);
+      return objectMapper.readValue(json, MAP_TYPE_REFERENCE);
     } catch (final IOException e) {
       throw new InternalClientException(
           String.format("Failed to deserialize json '%s' to 'Map<String, Object>'", json), e);
     }
   }
 
+  @Override
   public Map<String, String> fromJsonAsStringMap(final String json) {
     try {
-      return readValue(json, STRING_MAP_TYPE_REFERENCE);
+      return objectMapper.readValue(json, STRING_MAP_TYPE_REFERENCE);
     } catch (final IOException e) {
       throw new InternalClientException(
           String.format("Failed to deserialize json '%s' to 'Map<String, String>'", json), e);
     }
   }
 
+  @Override
   public String toJson(final Object value) {
     try {
-      return writeValueAsString(value);
+      return objectMapper.writeValueAsString(value);
     } catch (final JsonProcessingException e) {
       throw new InternalClientException(
           String.format("Failed to serialize object '%s' to json", value), e);
     }
   }
 
+  @Override
   public String validateJson(final String propertyName, final String jsonInput) {
     try {
-      return readTree(jsonInput).toString();
+      return objectMapper.readTree(jsonInput).toString();
     } catch (final IOException e) {
       throw new InternalClientException(
           String.format(
@@ -84,9 +92,10 @@ public final class ZeebeObjectMapper extends ObjectMapper implements JsonMapper 
     }
   }
 
+  @Override
   public String validateJson(final String propertyName, final InputStream jsonInput) {
     try {
-      return readTree(jsonInput).toString();
+      return objectMapper.readTree(jsonInput).toString();
     } catch (final IOException e) {
       throw new InternalClientException(
           String.format("Failed to validate json input stream for property '%s'", propertyName), e);


### PR DESCRIPTION
## Description

We currently extend a library defined type, ObjectMapper,  in our client, instead of providing an adapter for our interface. Extending a class we have no control over for something like this is a bad idea, as you may inadvertently start using inherited features from the new class where you shouldn't (since it's not meant to be a drop in replacement of ObjectMapper). Instead, we now wrap an existing one and use it where we need, and only expose the methods we need to.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
