### PR TITLE
fix(gateway): fix NPE related to cluster state supplier

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -17,12 +17,14 @@ import io.atomix.utils.net.Address;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.BrokerClientImpl;
+import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.impl.configuration.MembershipCfg;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.sched.ActorScheduler;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.slf4j.Logger;
@@ -49,7 +51,10 @@ public class StandaloneGateway {
 
     springGatewayBridge.registerGatewayStatusSupplier(gateway::getStatus);
     springGatewayBridge.registerClusterStateSupplier(
-        () -> gateway.getBrokerClient().getTopologyManager().getTopology());
+        () ->
+            Optional.ofNullable(gateway.getBrokerClient())
+                .map(BrokerClient::getTopologyManager)
+                .map(BrokerTopologyManager::getTopology));
   }
 
   private AtomixCluster createAtomixCluster(final ClusterCfg clusterCfg) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridge.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridge.java
@@ -21,13 +21,14 @@ import org.springframework.stereotype.Component;
 public class SpringGatewayBridge {
 
   private Supplier<Status> gatewayStatusSupplier;
-  private Supplier<BrokerClusterState> clusterStateSupplier;
+  private Supplier<Optional<BrokerClusterState>> clusterStateSupplier;
 
-  public void registerGatewayStatusSupplier(Supplier<Status> gatewayStatusSupplier) {
+  public void registerGatewayStatusSupplier(final Supplier<Status> gatewayStatusSupplier) {
     this.gatewayStatusSupplier = gatewayStatusSupplier;
   }
 
-  public void registerClusterStateSupplier(Supplier<BrokerClusterState> clusterStateSupplier) {
+  public void registerClusterStateSupplier(
+      final Supplier<Optional<BrokerClusterState>> clusterStateSupplier) {
     this.clusterStateSupplier = clusterStateSupplier;
   }
 
@@ -40,10 +41,6 @@ public class SpringGatewayBridge {
   }
 
   public Optional<BrokerClusterState> getClusterState() {
-    if (clusterStateSupplier != null) {
-      return Optional.ofNullable(clusterStateSupplier.get());
-    } else {
-      return Optional.empty();
-    }
+    return Optional.ofNullable(clusterStateSupplier).flatMap(Supplier::get);
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridgeTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridgeTest.java
@@ -62,7 +62,7 @@ public class SpringGatewayBridgeTest {
     // given
     final BrokerClusterState mockClusterState = Mockito.mock(BrokerClusterState.class);
 
-    final Supplier<BrokerClusterState> testSupplier = () -> mockClusterState;
+    final Supplier<Optional<BrokerClusterState>> testSupplier = () -> Optional.of(mockClusterState);
     sutBrigde.registerClusterStateSupplier(testSupplier);
 
     // when

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,7 +49,9 @@ public class LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getBrokers()).thenReturn(List.of(1));
 
-    final Supplier<BrokerClusterState> stateSupplier = () -> mockClusterState;
+    final Supplier<Optional<BrokerClusterState>> stateSupplier =
+        () -> Optional.of(mockClusterState);
+
     final var healthIndicator =
         sutAutoConfig.gatewayClusterAwarenessHealthIndicator(helperGatewayBridge);
 

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import io.camunda.zeebe.gateway.impl.broker.cluster.BrokerClusterState;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +51,8 @@ public class LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTes
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
     when(mockClusterState.getLeaderForPartition(1)).thenReturn(42);
 
-    final Supplier<BrokerClusterState> stateSupplier = () -> mockClusterState;
+    final Supplier<Optional<BrokerClusterState>> stateSupplier =
+        () -> Optional.of(mockClusterState);
     final var healthIndicator =
         sutAutoConfig.gatewayPartitionLeaderAwarenessHealthIndicator(helperGatewayBridge);
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/gateway/GatewayHealthIndicatorsIntegrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/broker/it/gateway/GatewayHealthIndicatorsIntegrationTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.gateway.impl.probes.health.PartitionLeaderAwarenessHealt
 import io.camunda.zeebe.gateway.impl.probes.health.StartedHealthIndicator;
 import io.camunda.zeebe.util.health.MemoryHealthIndicator;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.junit.After;
 import org.junit.Test;
@@ -90,7 +91,8 @@ public class GatewayHealthIndicatorsIntegrationTest {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getBrokers()).thenReturn(List.of(1));
 
-    final Supplier<BrokerClusterState> stateSupplier = () -> mockClusterState;
+    final Supplier<Optional<BrokerClusterState>> stateSupplier =
+        () -> Optional.of(mockClusterState);
 
     // when
     final Health actualHealthBeforeRegisteringStatusSupplier =
@@ -118,7 +120,8 @@ public class GatewayHealthIndicatorsIntegrationTest {
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
     when(mockClusterState.getLeaderForPartition(1)).thenReturn(42);
 
-    final Supplier<BrokerClusterState> stateSupplier = () -> mockClusterState;
+    final Supplier<Optional<BrokerClusterState>> stateSupplier =
+        () -> Optional.of(mockClusterState);
 
     // when
     final Health actualHealthBeforeRegisteringStatusSupplier =


### PR DESCRIPTION
## Description

Fix NPE in cluster state supllier

## Related issues

closes #7018 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [X] I've reviewed my own code
* [X] I've written a clear changelist description
* [X] I've narrowly scoped my changes
* [X] I've separated structural from behavioural changes
-->

## Definition of Done

Code changes:
* [X] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [X] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
