### PR TITLE
Add on-comment trigger to backport action workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,14 +1,18 @@
-name: Backport labeled PRs after merge
+name: Backport labeled merged pull requests
 on:
   pull_request:
-    types: [closed]
+    types: [ closed ]
+  issue_comment:
+    types: [ created ]
 jobs:
   build:
     name: Create backport PRs
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/backport')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
+          # required to find all branches
           fetch-depth: 0
       - name: Create backport PRs
         uses: zeebe-io/backport-action@master


### PR DESCRIPTION
## Description

Adds a workflow configuration to trigger the backport action
when a user writes a `/backport` comment on a pull request.
The bot itself restricts that only merged pull requests can be
backported.

This allows to backport pull requests that have already been merged.
Just add the backport labels to the merged PR and write `/backport`.

> WARNING! The bot will try to backport to the branches of all backport labels. 
> Previously created backport pull requests are not taken into account. 
> New pull requests will be created for each label.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to https://github.com/zeebe-io/backport-action/issues/11

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
