### PR TITLE
[Backport 1.0] Improve failure handling at snapshot actor

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -83,6 +83,10 @@ import org.slf4j.Logger;
  *                                 |informs
  *                                 |upwards   +------------------+
  *                                 |----------| ExporterDirector |
+ *                                 |          +------------------+
+ *                                 |informs
+ *                                 |upwards   +------------------+
+ *                                 |----------| SnapshotDirector |
  *                                            +------------------+
  *
  * https://textik.com/#cb084adedb02d970

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionStep.java
@@ -18,7 +18,7 @@ public class SnapshotDirectorPartitionStep implements PartitionStep {
   @Override
   public ActorFuture<Void> open(final PartitionContext context) {
     final Duration snapshotPeriod = context.getBrokerCfg().getData().getSnapshotPeriod();
-    final AsyncSnapshotDirector snapshotDirector =
+    final AsyncSnapshotDirector director =
         new AsyncSnapshotDirector(
             context.getNodeId(),
             context.getStreamProcessor(),
@@ -26,8 +26,9 @@ public class SnapshotDirectorPartitionStep implements PartitionStep {
             context.getLogStream(),
             snapshotPeriod);
 
-    context.setSnapshotDirector(snapshotDirector);
-    return context.getScheduler().submitActor(snapshotDirector);
+    context.setSnapshotDirector(director);
+    context.getComponentHealthMonitor().registerComponent(director.getName(), director);
+    return context.getScheduler().submitActor(director);
   }
 
   @Override


### PR DESCRIPTION
## Description

Backports  https://github.com/camunda-cloud/zeebe/pull/6912

Improves the handling and reporting of uncaught exceptions at the snapshot director and incorporates it into the
system's health status.

## Related issues

closes #6698

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
