### PR TITLE
Handle partially written segment descriptors

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegmentDescriptor.java
@@ -69,7 +69,13 @@ public final class JournalSegmentDescriptor {
 
     if (headerDecoder.schemaId() != segmentDescriptorDecoder.sbeSchemaId()
         || headerDecoder.templateId() != segmentDescriptorDecoder.sbeTemplateId()) {
-      throw new CorruptedLogException("Cannot read segment descriptor. Header does not match.");
+      throw new CorruptedLogException(
+          String.format(
+              "Cannot read segment descriptor. Read schema and template ids ('%d' and '%d') don't match expected '%d' and %d'.",
+              headerDecoder.schemaId(),
+              headerDecoder.templateId(),
+              segmentDescriptorDecoder.sbeSchemaId(),
+              segmentDescriptorDecoder.sbeTemplateId()));
     }
 
     segmentDescriptorDecoder.wrap(

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -30,14 +30,16 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.locks.StampedLock;
 import org.agrona.DirectBuffer;
@@ -494,49 +496,83 @@ public class SegmentedJournal implements Journal {
   protected Collection<JournalSegment> loadSegments() {
     // Ensure log directories are created.
     directory.mkdirs();
+    final List<JournalSegment> segments = new ArrayList<>();
 
-    final TreeMap<Long, JournalSegment> segments = new TreeMap<>();
+    final List<File> files = getSortedLogSegments();
+    for (int i = 0; i < files.size(); i++) {
+      final File file = files.get(i);
 
-    // Iterate through all files in the log directory.
-    for (final File file : directory.listFiles(File::isFile)) {
-
-      // If the file looks like a segment file, attempt to load the segment.
-      if (JournalSegmentFile.isSegmentFile(name, file)) {
-        final JournalSegmentFile segmentFile = new JournalSegmentFile(file);
+      try {
         final JournalSegmentDescriptor descriptor = readDescriptor(file);
-
-        // Load the segment.
         final JournalSegment segment = loadSegment(descriptor.id());
 
-        // Add the segment to the segments list.
-        log.debug(
-            "Found segment: {} ({})", segment.descriptor().id(), segmentFile.file().getName());
-        segments.put(segment.index(), segment);
+        if (i > 0 && segments.get(i - 1).lastIndex() + 1 != segment.index()) {
+          throw new CorruptedLogException(
+              String.format(
+                  "Log segment %s is not aligned with previous segment %s.",
+                  segments.get(i - 1), segment));
+        }
+
+        log.debug("Found segment: {} ({})", descriptor.id(), file.getName());
+        segments.add(segment);
+      } catch (final CorruptedLogException e) {
+        if (handleSegmentCorruption(files, segments, i)) {
+          return segments;
+        }
+
+        throw e;
       }
     }
 
-    // Verify that all the segments in the log align with one another.
-    JournalSegment previousSegment = null;
-    boolean corrupted = false;
-    final Iterator<Entry<Long, JournalSegment>> iterator = segments.entrySet().iterator();
-    while (iterator.hasNext()) {
-      final JournalSegment segment = iterator.next().getValue();
-      if (previousSegment != null && previousSegment.lastIndex() != segment.index() - 1) {
-        log.warn(
-            "Journal is inconsistent. {} is not aligned with prior segment {}",
-            segment.file().file(),
-            previousSegment.file().file());
-        corrupted = true;
-      }
-      if (corrupted) {
-        segment.close();
-        segment.delete();
-        iterator.remove();
-      }
-      previousSegment = segment;
+    return segments;
+  }
+
+  /** Returns true if segments after corrupted segment were deleted; false, otherwise */
+  private boolean handleSegmentCorruption(
+      final List<File> files, final List<JournalSegment> segments, final int failedIndex) {
+    long lastSegmentIndex = 0;
+
+    if (!segments.isEmpty()) {
+      final JournalSegment previousSegment = segments.get(segments.size() - 1);
+      lastSegmentIndex = previousSegment.lastIndex();
     }
 
-    return segments.values();
+    if (lastWrittenIndex > lastSegmentIndex) {
+      return false;
+    }
+
+    log.debug(
+        "Found corrupted segment after last ack'ed index {}. Deleting it and subsequent segments",
+        lastWrittenIndex);
+
+    for (int i = failedIndex; i < files.size(); i++) {
+      final File file = files.get(i);
+      try {
+        Files.delete(file.toPath());
+      } catch (IOException e) {
+        log.warn("Failed to delete log segment {}", file.getName(), e);
+      }
+    }
+
+    return true;
+  }
+
+  /** Returns an array of valid log segments sorted by their id which may be empty but not null. */
+  private List<File> getSortedLogSegments() {
+    final File[] files =
+        directory.listFiles(file -> file.isFile() && JournalSegmentFile.isSegmentFile(name, file));
+
+    if (files == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Could not list files in directory '%s'. Either the path doesn't point to a directory or an I/O error occurred.",
+              directory));
+    }
+
+    Arrays.sort(
+        files, Comparator.comparingInt(f -> JournalSegmentFile.getSegmentIdFromPath(f.getName())));
+
+    return Arrays.asList(files);
   }
 
   private JournalSegmentDescriptor readDescriptor(final File file) {

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/JournalSegmentDescriptorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/JournalSegmentDescriptorTest.java
@@ -21,10 +21,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.ByteBuffer;
 import org.junit.jupiter.api.Test;
 
-public class JournalSegmentDescriptorTest {
+class JournalSegmentDescriptorTest {
 
   @Test
-  public void shouldWriteAndReadDescriptor() {
+  void shouldWriteAndReadDescriptor() {
     // given
     JournalSegmentDescriptor descriptor =
         JournalSegmentDescriptor.builder()

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/JournalSegmentDescriptorTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/JournalSegmentDescriptorTest.java
@@ -17,7 +17,9 @@
 package io.camunda.zeebe.journal.file;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.journal.file.record.CorruptedLogException;
 import java.nio.ByteBuffer;
 import org.junit.jupiter.api.Test;
 
@@ -44,5 +46,15 @@ class JournalSegmentDescriptorTest {
     assertThat(descriptorRead.index()).isEqualTo(100);
     assertThat(descriptorRead.maxSegmentSize()).isEqualTo(1024);
     assertThat(descriptorRead.length()).isEqualTo(JournalSegmentDescriptor.getEncodingLength());
+  }
+
+  @Test
+  void shouldValidateDescriptorHeader() {
+    // given
+    final ByteBuffer buffer = ByteBuffer.allocate(JournalSegmentDescriptor.getEncodingLength());
+
+    // when/then
+    assertThatThrownBy(() -> new JournalSegmentDescriptor(buffer))
+        .isInstanceOf(CorruptedLogException.class);
   }
 }

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/JournalTest.java
@@ -606,7 +606,7 @@ class JournalTest {
     assertThat(reader.next()).isEqualTo(lastRecord);
   }
 
-  private PersistedJournalRecord copyRecord(final JournalRecord record) {
+  static PersistedJournalRecord copyRecord(final JournalRecord record) {
     final DirectBuffer data = record.data();
     final byte[] buffer = new byte[data.capacity()];
     data.getBytes(0, buffer);

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/JournalTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/JournalTest.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -112,7 +113,7 @@ class JournalTest {
   }
 
   @Test
-  public void shouldReadMultipleRecord() {
+  void shouldReadMultipleRecord() {
     // given
     final var firstRecord = journal.append(1, data);
     final var secondRecord = journal.append(20, dataOther);
@@ -128,7 +129,7 @@ class JournalTest {
   }
 
   @Test
-  public void shouldAppendAndReadMultipleRecordsInOrder() {
+  void shouldAppendAndReadMultipleRecordsInOrder() {
     // when
     for (int i = 0; i < 10; i++) {
       final var recordAppended = journal.append(i + 10, data);
@@ -185,7 +186,7 @@ class JournalTest {
     // then
     assertThat(journal.isEmpty()).isTrue();
     assertThat(journal.getLastIndex()).isEqualTo(1);
-    final var record = journal.append(asqn++, data);
+    final var record = journal.append(asqn, data);
     assertThat(record.index()).isEqualTo(2);
   }
 
@@ -205,7 +206,7 @@ class JournalTest {
 
     // then
     assertThat(journal.getLastIndex()).isEqualTo(1);
-    final var record = journal.append(asqn++, data);
+    final var record = journal.append(asqn, data);
     assertThat(record.index()).isEqualTo(2);
 
     // then
@@ -541,7 +542,7 @@ class JournalTest {
   }
 
   @Test
-  public void shouldInvalidateAllEntries() throws Exception {
+  void shouldInvalidateAllEntries() throws Exception {
     // given
     data.wrap("000".getBytes(StandardCharsets.UTF_8));
     final var firstRecord = copyRecord(journal.append(data));
@@ -565,14 +566,13 @@ class JournalTest {
   }
 
   @Test
-  public void shouldDetectCorruptedEntry() throws Exception {
+  void shouldDetectCorruptedEntry() throws Exception {
     // given
     data.wrap("000".getBytes(StandardCharsets.UTF_8));
     journal.append(data);
     final var secondRecord = copyRecord(journal.append(data));
-    assertThat(directory.toFile().listFiles()).hasSize(1);
-    assertThat(directory.toFile().listFiles()[0].listFiles()).hasSize(1);
-    final File log = directory.toFile().listFiles()[0].listFiles()[0];
+    final File dataFile = Objects.requireNonNull(directory.toFile().listFiles())[0];
+    final File log = Objects.requireNonNull(dataFile.listFiles())[0];
 
     // when
     journal.close();
@@ -585,14 +585,13 @@ class JournalTest {
   }
 
   @Test
-  public void shouldDeletePartiallyWrittenEntry() throws Exception {
+  void shouldDeletePartiallyWrittenEntry() throws Exception {
     // given
     data.wrap("000".getBytes(StandardCharsets.UTF_8));
     final var firstRecord = copyRecord(journal.append(data));
     final var secondRecord = copyRecord(journal.append(data));
-    assertThat(directory.toFile().listFiles()).hasSize(1);
-    assertThat(directory.toFile().listFiles()[0].listFiles()).hasSize(1);
-    final File log = directory.toFile().listFiles()[0].listFiles()[0];
+    final File dataFile = Objects.requireNonNull(directory.toFile().listFiles())[0];
+    final File log = Objects.requireNonNull(dataFile.listFiles())[0];
 
     // when
     journal.close();

--- a/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
+++ b/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
@@ -23,10 +23,10 @@ import io.camunda.zeebe.journal.JournalRecord;
 import org.junit.jupiter.api.Test;
 
 /** Sparse journal index test. */
-public class SparseJournalIndexTest {
+class SparseJournalIndexTest {
 
   @Test
-  public void shouldNotFindIndexWhenNotReachedDensity() {
+  void shouldNotFindIndexWhenNotReachedDensity() {
     // given - every 5 index is added
     final JournalIndex index = new SparseJournalIndex(5);
 
@@ -42,7 +42,7 @@ public class SparseJournalIndexTest {
   }
 
   @Test
-  public void shouldFindIndexWhenReachedDensity() {
+  void shouldFindIndexWhenReachedDensity() {
     // given - every 5 index is added
     final JournalIndex index = new SparseJournalIndex(5);
 
@@ -60,7 +60,7 @@ public class SparseJournalIndexTest {
   }
 
   @Test
-  public void shouldFindLowerIndexWhenNotReachedDensity() {
+  void shouldFindLowerIndexWhenNotReachedDensity() {
     // given - every 5 index is added
     final JournalIndex index = new SparseJournalIndex(5);
     // index entries
@@ -82,7 +82,7 @@ public class SparseJournalIndexTest {
   }
 
   @Test
-  public void shouldFindNextIndexWhenReachedDensity() {
+  void shouldFindNextIndexWhenReachedDensity() {
     // given - every 5 index is added
     final JournalIndex index = new SparseJournalIndex(5);
     // index entries
@@ -106,7 +106,7 @@ public class SparseJournalIndexTest {
   }
 
   @Test
-  public void shouldTruncateIndex() {
+  void shouldTruncateIndex() {
     // given - every 5 index is added
     final JournalIndex index = new SparseJournalIndex(5);
     // index entries
@@ -134,7 +134,7 @@ public class SparseJournalIndexTest {
   }
 
   @Test
-  public void shouldTruncateCompleteIndex() {
+  void shouldTruncateCompleteIndex() {
     // given - every 5 index is added
     final JournalIndex index = new SparseJournalIndex(5);
     // index entries
@@ -165,7 +165,7 @@ public class SparseJournalIndexTest {
   }
 
   @Test
-  public void shouldNotCompactIndex() {
+  void shouldNotCompactIndex() {
     // given - every 5 index is added
     final JournalIndex index = new SparseJournalIndex(5);
     // index entries
@@ -190,7 +190,7 @@ public class SparseJournalIndexTest {
   }
 
   @Test
-  public void shouldCompactIndex() {
+  void shouldCompactIndex() {
     // given - every 5 index is added
     final JournalIndex index = new SparseJournalIndex(5);
     // index entries
@@ -217,7 +217,7 @@ public class SparseJournalIndexTest {
   }
 
   @Test
-  public void shouldFindAsqnWithInBound() {
+  void shouldFindAsqnWithInBound() {
     // given - every 2nd index is added
     final JournalIndex index = new SparseJournalIndex(2);
 


### PR DESCRIPTION
## Description

* Adds detection of corruption and partial writes when loading the segment/descriptors
* Handles partial writes by checking the metastore's last written index. If the segment doesn't contain acked entries, the subsequent segments are deleted and the journal is opened. If not then the corrupted is reported. 
* Adds adds additional checks that the descriptor is correctly read
* Test improvements (fixes code smells, improve log corrupter)

## Related issues

closes #6979

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
