### PR TITLE
fix(broker): use correct term and role when reacting to install failures 

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
+import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -62,6 +63,9 @@ public class PartitionContext {
   private ActorControl actor;
   private ScheduledTimer metricsTimer;
   private ExporterDirector exporterDirector;
+
+  private long currentTerm;
+  private Role currentRole;
 
   public PartitionContext(
       final int nodeId,
@@ -276,5 +280,21 @@ public class PartitionContext {
 
   public boolean resumeExporting() throws IOException {
     return partitionProcessingState.resumeExporting();
+  }
+
+  public long getCurrentTerm() {
+    return currentTerm;
+  }
+
+  public void setCurrentTerm(final long currentTerm) {
+    this.currentTerm = currentTerm;
+  }
+
+  public Role getCurrentRole() {
+    return currentRole;
+  }
+
+  public void setCurrentRole(final Role currentRole) {
+    this.currentRole = currentRole;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStep.java
@@ -16,20 +16,6 @@ import io.camunda.zeebe.util.sched.future.CompletableActorFuture;
  * will be closed in the reverse order.
  */
 public interface PartitionStep {
-
-  /**
-   * Performs some action required for the partition to function. This may include opening
-   * components (e.g., logstream), setting their values in {@link PartitionContext}, etc. The
-   * subsequent partition steps will only be opened after the returned future is completed.
-   *
-   * @param currentTerm the current term of the transition
-   * @param context the partition context
-   * @return future
-   */
-  default ActorFuture<Void> open(final long currentTerm, final PartitionContext context) {
-    return open(context);
-  }
-
   /**
    * Performs some action required for the partition to function. This may include opening
    * components (e.g., logstream), setting their values in {@link PartitionContext}, etc. The

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -115,7 +115,6 @@ public final class ZeebePartition extends Actor
             actor.runOnCompletion(
                 listenerFutures,
                 t -> {
-                  // Compare with the current term in case a new role transition happened
                   if (t != null) {
                     onInstallFailure(t);
                   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -40,7 +40,6 @@ public final class ZeebePartition extends Actor
   private final List<FailureListener> failureListeners;
   private final HealthMetrics healthMetrics;
   private final ZeebePartitionHealth zeebePartitionHealth;
-  private long term;
 
   private final PartitionContext context;
   private final PartitionTransition transition;
@@ -74,7 +73,6 @@ public final class ZeebePartition extends Actor
 
   private void onRoleChange(final Role newRole, final long newTerm) {
     ActorFuture<Void> nextTransitionFuture = null;
-    term = newTerm;
     switch (newRole) {
       case LEADER:
         if (raftRole != Role.LEADER) {
@@ -98,7 +96,7 @@ public final class ZeebePartition extends Actor
     if (nextTransitionFuture != null) {
       currentTransitionFuture = nextTransitionFuture;
     }
-    LOG.debug("Partition role transitioning from {} to {} in term {}", raftRole, newRole, term);
+    LOG.debug("Partition role transitioning from {} to {} in term {}", raftRole, newRole, newTerm);
     raftRole = newRole;
   }
 
@@ -118,14 +116,14 @@ public final class ZeebePartition extends Actor
                 listenerFutures,
                 t -> {
                   // Compare with the current term in case a new role transition happened
-                  if (t != null && term == newTerm) {
-                    onInstallFailure(newTerm, t);
+                  if (t != null) {
+                    onInstallFailure(t);
                   }
                 });
             onRecoveredInternal();
           } else {
             LOG.error("Failed to install leader partition {}", context.getPartitionId(), error);
-            onInstallFailure(newTerm, error);
+            onInstallFailure(error);
           }
         });
     return leaderTransitionFuture;
@@ -144,14 +142,14 @@ public final class ZeebePartition extends Actor
                 listenerFutures,
                 t -> {
                   // Compare with the current term in case a new role transition happened
-                  if (t != null && term == newTerm) {
-                    onInstallFailure(newTerm, t);
+                  if (t != null) {
+                    onInstallFailure(t);
                   }
                 });
             onRecoveredInternal();
           } else {
             LOG.error("Failed to install follower partition {}", context.getPartitionId(), error);
-            onInstallFailure(newTerm, error);
+            onInstallFailure(error);
           }
         });
     return followerTransitionFuture;
@@ -232,7 +230,7 @@ public final class ZeebePartition extends Actor
     LOG.warn("Uncaught exception in {}.", actorName, failure);
     // Most probably exception happened in the middle of installing leader or follower services
     // because this actor is not doing anything else
-    onInstallFailure(term, failure);
+    onInstallFailure(failure);
   }
 
   @Override
@@ -258,7 +256,7 @@ public final class ZeebePartition extends Actor
     actor.run(this::handleUnrecoverableFailure);
   }
 
-  private void onInstallFailure(final long term, final Throwable error) {
+  private void onInstallFailure(final Throwable error) {
     if (error instanceof UnrecoverableException) {
       LOG.error(
           "Failed to install partition {} with unrecoverable failure: ",
@@ -266,20 +264,23 @@ public final class ZeebePartition extends Actor
           error);
       handleUnrecoverableFailure();
     } else {
-      handleRecoverableFailure(term);
+      handleRecoverableFailure();
     }
   }
 
-  private void handleRecoverableFailure(final long term) {
+  private void handleRecoverableFailure() {
     zeebePartitionHealth.setServicesInstalled(false);
     context
         .getPartitionListeners()
-        .forEach(l -> l.onBecomingInactive(context.getPartitionId(), term));
+        .forEach(l -> l.onBecomingInactive(context.getPartitionId(), context.getCurrentTerm()));
 
-    if (context.getRaftPartition().getRole() == Role.LEADER) {
+    // If RaftPartition has already transition to a new role in a new term, we can ignore this
+    // failure. Services will be installed for the new role.
+    if (context.getCurrentRole() == Role.LEADER
+        && context.getCurrentTerm() == context.getRaftPartition().term()) {
       LOG.info("Unexpected failure occurred, stepping down");
       context.getRaftPartition().stepDown();
-    } else {
+    } else if (context.getCurrentRole() == Role.FOLLOWER) {
       LOG.info("Unexpected failure occurred, transitioning to inactive");
       context.getRaftPartition().goInactive();
     }
@@ -293,7 +294,7 @@ public final class ZeebePartition extends Actor
     failureListeners.forEach(FailureListener::onUnrecoverableFailure);
     context
         .getPartitionListeners()
-        .forEach(l -> l.onBecomingInactive(context.getPartitionId(), term));
+        .forEach(l -> l.onBecomingInactive(context.getPartitionId(), context.getCurrentTerm()));
   }
 
   private void onRecoveredInternal() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl;
 
+import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.partitions.PartitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStep;
@@ -42,17 +43,17 @@ public class PartitionTransitionImpl implements PartitionTransition {
 
   @Override
   public ActorFuture<Void> toFollower(final long currentTerm) {
-    return enqueueTransition(currentTerm, followerSteps);
+    return enqueueTransition(currentTerm, Role.FOLLOWER, followerSteps);
   }
 
   @Override
   public ActorFuture<Void> toLeader(final long currentTerm) {
-    return enqueueTransition(currentTerm, leaderSteps);
+    return enqueueTransition(currentTerm, Role.LEADER, leaderSteps);
   }
 
   @Override
   public ActorFuture<Void> toInactive() {
-    return enqueueTransition(INACTIVE_TERM, EMPTY_LIST);
+    return enqueueTransition(INACTIVE_TERM, Role.INACTIVE, EMPTY_LIST);
   }
 
   /**
@@ -60,22 +61,27 @@ public class PartitionTransitionImpl implements PartitionTransition {
    * order. Previous we had the issue that all transitions have subscribe to the current transition,
    * which lead to undefined behavior.
    *
+   * @param currentRole
    * @param partitionStepList the steps which should be installed on the transition
    */
   private ActorFuture<Void> enqueueTransition(
-      final long currentTerm, final List<PartitionStep> partitionStepList) {
+      final long currentTerm, final Role currentRole, final List<PartitionStep> partitionStepList) {
     final var nextTransitionFuture = new CompletableActorFuture<Void>();
     final var nextCurrentTransition = currentTransition;
     currentTransition = nextTransitionFuture;
     nextCurrentTransition.onComplete(
-        (nothing, err) -> transition(currentTerm, nextTransitionFuture, partitionStepList));
+        (nothing, err) ->
+            transition(currentTerm, currentRole, nextTransitionFuture, partitionStepList));
     return nextTransitionFuture;
   }
 
   private void transition(
       final long currentTerm,
+      final Role currentRole,
       final CompletableActorFuture<Void> future,
       final List<PartitionStep> steps) {
+    context.setCurrentRole(currentRole);
+    context.setCurrentTerm(currentTerm);
     closePartition()
         .onComplete(
             (nothing, err) -> {

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -125,10 +125,13 @@ public class ZeebePartitionTest {
               return CompletableActorFuture.completed(null);
             });
     when(raft.getRole()).thenReturn(Role.LEADER);
+    when(raft.term()).thenReturn(1L);
+    when(ctx.getCurrentRole()).thenReturn(Role.LEADER);
+    when(ctx.getCurrentTerm()).thenReturn(1L);
     when(raft.stepDown())
         .then(
             invocation -> {
-              partition.onNewRole(Role.FOLLOWER, 2);
+              partition.onNewRole(Role.FOLLOWER, 1);
               return CompletableFuture.completedFuture(null);
             });
 
@@ -142,7 +145,7 @@ public class ZeebePartitionTest {
     final InOrder order = inOrder(transition, raft);
     order.verify(transition).toLeader(1);
     order.verify(raft).stepDown();
-    order.verify(transition).toFollower(2);
+    order.verify(transition).toFollower(1);
   }
 
   @Test
@@ -160,6 +163,7 @@ public class ZeebePartitionTest {
               return CompletableActorFuture.completed(null);
             });
     when(raft.getRole()).thenReturn(Role.FOLLOWER);
+    when(ctx.getCurrentRole()).thenReturn(Role.FOLLOWER);
     when(raft.goInactive())
         .then(
             invocation -> {


### PR DESCRIPTION
## Description

The role transitions are enqueued in ZeebePartition actor. When there are more than one role transition happened one after the other in a short span, ZeebePartition doesn't know which installation has failed. Previously it was reading the term and role from the RaftPartition. However, since the role transitions are asynchronous the role and term on the RaftPartition might be already referring to a newer term and role.

To fix this, now PartitionContext keep track of current term and role which is updated when the corresponding install steps has started. On install failure, ZeebePartition can read the term and role from the context to determine how to react to the failure.

## Related issues

closes #6997 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
