### PR TITLE
Use child instance loop counter

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -114,13 +114,14 @@ public final class MultiInstanceBodyProcessor
       final BpmnElementContext flowScopeContext,
       final BpmnElementContext childContext) {
 
-    final var bodyInstance = stateBehavior.getElementInstance(flowScopeContext);
-    final var loopCounter = bodyInstance.getMultiInstanceLoopCounter();
+    // loop counter is already set on the inner instance on activating
+    final int loopCounter =
+        stateBehavior.getElementInstance(childContext).getMultiInstanceLoopCounter();
 
     return readInputCollectionVariable(multiInstanceBody, childContext)
         .flatMap(
             collection -> {
-              // the loop counter starts by 1
+              // the loop counter starts at 1
               final var index = loopCounter - 1;
               if (index < collection.size()) {
                 final var item = collection.get(index);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/MultiInstanceIncidentTest.java
@@ -8,14 +8,16 @@
 package io.camunda.zeebe.engine.processing.incident;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.client.IncidentClient.ResolveIncidentClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
@@ -25,6 +27,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -34,7 +37,8 @@ public final class MultiInstanceIncidentTest {
 
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
-  private static final String PROCESS_ID = "process";
+  private static final String MULTI_TASK_PROCESS = "multi-task-process";
+  private static final String MULTI_SUB_PROC_PROCESS = "multi-sub-process-process";
   private static final String ELEMENT_ID = "task";
   private static final String INPUT_COLLECTION = "items";
   private static final String INPUT_ELEMENT = "item";
@@ -46,33 +50,34 @@ public final class MultiInstanceIncidentTest {
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
   private String jobType;
 
-  private static BpmnModelInstance createProcess(final String jobType) {
-    return Bpmn.createExecutableProcess(PROCESS_ID)
-        .startEvent()
-        .serviceTask(
-            ELEMENT_ID,
-            t ->
-                t.zeebeJobType(jobType)
-                    .multiInstance(
-                        b ->
-                            b.zeebeInputCollectionExpression(INPUT_COLLECTION)
-                                .zeebeInputElement(INPUT_ELEMENT)
-                                .zeebeOutputElementExpression("sum(undefined_var)")
-                                .zeebeOutputCollection("results")))
-        .endEvent()
-        .done();
-  }
-
   @Before
   public void init() {
     jobType = helper.getJobType();
-    ENGINE.deployment().withXmlResource(createProcess(jobType)).deploy();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(MULTI_TASK_PROCESS)
+                .startEvent()
+                .serviceTask(
+                    ELEMENT_ID,
+                    t ->
+                        t.zeebeJobType(jobType)
+                            .multiInstance(
+                                b ->
+                                    b.zeebeInputCollectionExpression(INPUT_COLLECTION)
+                                        .zeebeInputElement(INPUT_ELEMENT)
+                                        .zeebeOutputElementExpression("sum(undefined_var)")
+                                        .zeebeOutputCollection("results")))
+                .endEvent()
+                .done())
+        .deploy();
   }
 
   @Test
   public void shouldCreateIncidentIfInputVariableNotFound() {
     // when
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(MULTI_TASK_PROCESS).create();
 
     // then
     final Record<IncidentRecordValue> incident =
@@ -104,7 +109,7 @@ public final class MultiInstanceIncidentTest {
     final long processInstanceKey =
         ENGINE
             .processInstance()
-            .ofBpmnProcessId(PROCESS_ID)
+            .ofBpmnProcessId(MULTI_TASK_PROCESS)
             .withVariable(INPUT_COLLECTION, "not-an-array-but-a-string")
             .create();
 
@@ -136,7 +141,7 @@ public final class MultiInstanceIncidentTest {
     final long processInstanceKey =
         ENGINE
             .processInstance()
-            .ofBpmnProcessId(PROCESS_ID)
+            .ofBpmnProcessId(MULTI_TASK_PROCESS)
             .withVariable(INPUT_COLLECTION, List.of(1, 2, 3))
             .create();
 
@@ -167,7 +172,8 @@ public final class MultiInstanceIncidentTest {
   @Test
   public void shouldResolveIncident() {
     // given
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(MULTI_TASK_PROCESS).create();
 
     final Record<IncidentRecordValue> incident =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
@@ -190,5 +196,65 @@ public final class MultiInstanceIncidentTest {
                 .limit(3))
         .extracting(Record::getIntent)
         .contains(ProcessInstanceIntent.ELEMENT_ACTIVATED);
+  }
+
+  @Test
+  public void shouldUseTheSameLoopVariablesWhenIncidentResolved() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(MULTI_SUB_PROC_PROCESS)
+                .startEvent()
+                .subProcess("sub-process")
+                .zeebeInputExpression("y", "y")
+                .multiInstance(
+                    b ->
+                        b.parallel()
+                            .zeebeInputCollectionExpression(INPUT_COLLECTION)
+                            .zeebeInputElement(INPUT_ELEMENT))
+                .embeddedSubProcess()
+                .startEvent("sub-process-start")
+                .endEvent("sub-process-end")
+                .moveToNode("sub-process")
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(MULTI_SUB_PROC_PROCESS)
+            .withVariables("{\"items\":[1,2,3]}")
+            .create();
+
+    // when
+    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .limit(3)
+        .map(Record::getKey)
+        .map(key -> ENGINE.incident().ofInstance(processInstanceKey).withKey(key))
+        .forEach(ResolveIncidentClient::resolve);
+
+    // then
+    final var variableNames = Set.of("item", "loopCounter");
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .filter(v -> variableNames.contains(v.getValue().getName()))
+                .limit(12))
+        .extracting(v -> tuple(v.getIntent(), v.getValue().getName(), v.getValue().getValue()))
+        .containsExactly(
+            tuple(VariableIntent.CREATED, "item", "1"),
+            tuple(VariableIntent.CREATED, "loopCounter", "1"),
+            tuple(VariableIntent.CREATED, "item", "2"),
+            tuple(VariableIntent.CREATED, "loopCounter", "2"),
+            tuple(VariableIntent.CREATED, "item", "3"),
+            tuple(VariableIntent.CREATED, "loopCounter", "3"),
+            tuple(VariableIntent.UPDATED, "item", "1"),
+            tuple(VariableIntent.UPDATED, "loopCounter", "1"),
+            tuple(VariableIntent.UPDATED, "item", "2"),
+            tuple(VariableIntent.UPDATED, "loopCounter", "2"),
+            tuple(VariableIntent.UPDATED, "item", "3"),
+            tuple(VariableIntent.UPDATED, "loopCounter", "3"));
   }
 }


### PR DESCRIPTION
## Description

After resolving an incident the failed command is processed again. If
that command is Element:Activate for a multi-instance marked element,
then the loop counter has already been incremented and would be
incremented again. 

To make sure we continue at the correct loop index, the loop counter
(which is used as index) can just be taken directly from the child instance.
The child instance already has the correct value set on activating.

## Related issues

closes #6933 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
