### PR TITLE
Detect segment descriptor corruption

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegmentDescriptor.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/JournalSegmentDescriptor.java
@@ -44,13 +44,18 @@ import org.agrona.concurrent.UnsafeBuffer;
  */
 public final class JournalSegmentDescriptor {
 
-  private static final byte VERSION = 1;
+  private static final byte CUR_VERSION = 2;
+  private static final byte NO_META_VERSION = 1;
   private static final int VERSION_LENGTH = Byte.BYTES;
 
-  private final long id;
-  private final long index;
-  private final int maxSegmentSize;
-  private final int encodedLength;
+  private long id;
+  private long index;
+  private int maxSegmentSize;
+  private int encodedLength;
+  private long checksum;
+
+  private final DescriptorMetadataEncoder metadataEncoder = new DescriptorMetadataEncoder();
+  private final DescriptorMetadataDecoder metadataDecoder = new DescriptorMetadataDecoder();
 
   private final SegmentDescriptorDecoder segmentDescriptorDecoder = new SegmentDescriptorDecoder();
   private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
@@ -58,37 +63,22 @@ public final class JournalSegmentDescriptor {
 
   private final SegmentDescriptorEncoder segmentDescriptorEncoder = new SegmentDescriptorEncoder();
   private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+  private final ChecksumGenerator checksumGen = new ChecksumGenerator();
 
   public JournalSegmentDescriptor(final ByteBuffer buffer) {
     directBuffer.wrap(buffer);
 
-    /* The first byte of the buffer contains the version at which the descriptor is written.
-     Currently we have only one version, so we can ignore it. We can use this version in future
-    when needed. Note that we can add fields to SBE schema of the descriptor without changing this version. */
-    headerDecoder.wrap(directBuffer, VERSION_LENGTH);
-
-    if (headerDecoder.schemaId() != segmentDescriptorDecoder.sbeSchemaId()
-        || headerDecoder.templateId() != segmentDescriptorDecoder.sbeTemplateId()) {
+    final byte version = directBuffer.getByte(0);
+    if (version == CUR_VERSION) {
+      readV2Descriptor(directBuffer);
+    } else if (version == NO_META_VERSION) {
+      readV1Descriptor(directBuffer);
+    } else {
       throw new CorruptedLogException(
           String.format(
-              "Cannot read segment descriptor. Read schema and template ids ('%d' and '%d') don't match expected '%d' and %d'.",
-              headerDecoder.schemaId(),
-              headerDecoder.templateId(),
-              segmentDescriptorDecoder.sbeSchemaId(),
-              segmentDescriptorDecoder.sbeTemplateId()));
+              "Expected version to be one [%d %d] but read %d instead.",
+              NO_META_VERSION, CUR_VERSION, version));
     }
-
-    segmentDescriptorDecoder.wrap(
-        directBuffer,
-        VERSION_LENGTH + headerDecoder.encodedLength(),
-        headerDecoder.blockLength(),
-        headerDecoder.version());
-
-    id = segmentDescriptorDecoder.id();
-    index = segmentDescriptorDecoder.index();
-    maxSegmentSize = segmentDescriptorDecoder.maxSegmentSize();
-    encodedLength =
-        VERSION_LENGTH + headerDecoder.encodedLength() + segmentDescriptorDecoder.encodedLength();
   }
 
   private JournalSegmentDescriptor(final long id, final long index, final int maxSegmentSize) {
@@ -96,6 +86,108 @@ public final class JournalSegmentDescriptor {
     this.index = index;
     this.maxSegmentSize = maxSegmentSize;
     encodedLength = getEncodingLength();
+  }
+
+  /** Validates the header's schema and template ids before loading the descriptor's fields. */
+  private void readV1Descriptor(final MutableDirectBuffer buffer) {
+    validateHeader(
+        buffer,
+        VERSION_LENGTH,
+        segmentDescriptorDecoder.sbeSchemaId(),
+        segmentDescriptorDecoder.sbeTemplateId());
+
+    readDescriptor(buffer, VERSION_LENGTH);
+  }
+
+  /**
+   * Validates the headers' schema and template ids, as well as the metadata's checksum, before
+   * loading the descriptor's fields.
+   */
+  private void readV2Descriptor(final MutableDirectBuffer buffer) {
+    // validate metadata header
+    validateHeader(
+        buffer, VERSION_LENGTH, metadataDecoder.sbeSchemaId(), metadataDecoder.sbeTemplateId());
+    final int descHeaderOffset = readChecksum(buffer, VERSION_LENGTH);
+
+    // validate descriptor header
+    validateHeader(
+        buffer,
+        descHeaderOffset,
+        segmentDescriptorDecoder.sbeSchemaId(),
+        segmentDescriptorDecoder.sbeTemplateId());
+    final int totalLength = readDescriptor(buffer, descHeaderOffset);
+
+    // length of the header + descriptor
+    final int descriptorLength = totalLength - descHeaderOffset;
+    validateChecksum(buffer, descHeaderOffset, descriptorLength);
+  }
+
+  private void validateChecksum(
+      final MutableDirectBuffer buffer, final int descHeaderOffset, final int descriptorLength) {
+    final ByteBuffer slice = ByteBuffer.allocate(descriptorLength);
+    buffer.getBytes(descHeaderOffset, slice, descriptorLength);
+    final long computedChecksum = checksumGen.compute(slice, 0, descriptorLength);
+
+    if (computedChecksum != checksum) {
+      throw new CorruptedLogException(
+          "Descriptor doesn't match checksum (possibly due to corruption).");
+    }
+  }
+
+  /**
+   * Loads the descriptor's fields.
+   *
+   * @param offset offset where the descriptor's header starts
+   * @return offset after reading the descriptor
+   */
+  private int readDescriptor(final MutableDirectBuffer buffer, final int offset) {
+    headerDecoder.wrap(buffer, offset);
+    segmentDescriptorDecoder.wrap(
+        directBuffer,
+        offset + headerDecoder.encodedLength(),
+        headerDecoder.blockLength(),
+        headerDecoder.version());
+
+    id = segmentDescriptorDecoder.id();
+    index = segmentDescriptorDecoder.index();
+    maxSegmentSize = segmentDescriptorDecoder.maxSegmentSize();
+    encodedLength =
+        offset + headerDecoder.encodedLength() + segmentDescriptorDecoder.encodedLength();
+
+    return encodedLength;
+  }
+
+  /**
+   * Loads the metadata's checksum field.
+   *
+   * @return offset after the metadata
+   */
+  private int readChecksum(final MutableDirectBuffer buffer, final int offset) {
+    headerDecoder.wrap(buffer, offset);
+    metadataDecoder.wrap(
+        buffer,
+        offset + headerDecoder.encodedLength(),
+        headerDecoder.blockLength(),
+        headerDecoder.version());
+
+    checksum = metadataDecoder.checksum();
+    return offset + headerDecoder.encodedLength() + metadataDecoder.encodedLength();
+  }
+
+  /** Validate that the header's schema and template ids match the expected ones. */
+  private void validateHeader(
+      final MutableDirectBuffer buffer,
+      final int offset,
+      final int schemaId,
+      final int templateId) {
+    headerDecoder.wrap(buffer, offset);
+
+    if (headerDecoder.schemaId() != schemaId || headerDecoder.templateId() != templateId) {
+      throw new CorruptedLogException(
+          String.format(
+              "Cannot read header. Read schema and template ids ('%d' and '%d') don't match expected '%d' and %d'.",
+              headerDecoder.schemaId(), headerDecoder.templateId(), schemaId, templateId));
+    }
   }
 
   /**
@@ -115,7 +207,8 @@ public final class JournalSegmentDescriptor {
    */
   public static int getEncodingLength() {
     return VERSION_LENGTH
-        + MessageHeaderEncoder.ENCODED_LENGTH
+        + MessageHeaderEncoder.ENCODED_LENGTH * 2
+        + DescriptorMetadataEncoder.BLOCK_LENGTH
         + SegmentDescriptorEncoder.BLOCK_LENGTH;
   }
 
@@ -167,20 +260,27 @@ public final class JournalSegmentDescriptor {
    */
   JournalSegmentDescriptor copyTo(final ByteBuffer buffer) {
     directBuffer.wrap(buffer);
-    directBuffer.putByte(0, VERSION);
+    directBuffer.putByte(0, CUR_VERSION);
 
-    headerEncoder
-        .wrap(directBuffer, VERSION_LENGTH)
-        .blockLength(segmentDescriptorEncoder.sbeBlockLength())
-        .templateId(segmentDescriptorEncoder.sbeTemplateId())
-        .schemaId(segmentDescriptorEncoder.sbeSchemaId())
-        .version(segmentDescriptorEncoder.sbeSchemaVersion());
-
+    // descriptor header
+    final int descHeaderOffset =
+        VERSION_LENGTH
+            + MessageHeaderEncoder.ENCODED_LENGTH
+            + DescriptorMetadataEncoder.BLOCK_LENGTH;
     segmentDescriptorEncoder
-        .wrap(directBuffer, VERSION_LENGTH + headerEncoder.encodedLength())
+        .wrapAndApplyHeader(directBuffer, descHeaderOffset, headerEncoder)
         .id(id)
         .index(index)
         .maxSegmentSize(maxSegmentSize);
+
+    final long checksum =
+        checksumGen.compute(
+            buffer,
+            descHeaderOffset,
+            headerEncoder.encodedLength() + segmentDescriptorEncoder.encodedLength());
+    metadataEncoder
+        .wrapAndApplyHeader(directBuffer, VERSION_LENGTH, headerEncoder)
+        .checksum(checksum);
 
     return this;
   }

--- a/journal/src/main/java/io/camunda/zeebe/journal/file/UnknownVersionException.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/UnknownVersionException.java
@@ -13,17 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.zeebe.journal.file.record;
+package io.camunda.zeebe.journal.file;
 
-import io.camunda.zeebe.util.exception.UnrecoverableException;
+public class UnknownVersionException extends RuntimeException {
 
-public final class CorruptedLogException extends UnrecoverableException {
-
-  public CorruptedLogException(final String message) {
+  public UnknownVersionException(final String message) {
     super(message);
-  }
-
-  public CorruptedLogException(final Throwable cause) {
-    super(cause);
   }
 }

--- a/journal/src/main/resources/journal-schema.xml
+++ b/journal/src/main/resources/journal-schema.xml
@@ -26,10 +26,13 @@
     <data name="data" id="3" type="blob"/>
   </sbe:message>
 
-
   <sbe:message name="SegmentDescriptor" id="3">
     <field name="id" id="1" type="int64"/>
     <field name="index" id="2" type="int64"/>
     <field name="maxSegmentSize" id="3" type="int32"/>
+  </sbe:message>
+
+  <sbe:message name="DescriptorMetadata" id="4" >
+    <field name="checksum" id="1" type="int64"/>
   </sbe:message>
 </sbe:messageSchema>

--- a/util/src/main/java/io/camunda/zeebe/util/exception/UnrecoverableException.java
+++ b/util/src/main/java/io/camunda/zeebe/util/exception/UnrecoverableException.java
@@ -16,4 +16,8 @@ public class UnrecoverableException extends RuntimeException {
   public UnrecoverableException(final String message, final Throwable cause) {
     super(message, cause);
   }
+
+  public UnrecoverableException(final Throwable cause) {
+    super(cause);
+  }
 }


### PR DESCRIPTION
## Description

Introduces checksums to detect descriptor corruption and improves validations when reading descriptors to take into account the different descriptor versions that can be written.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #7041

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
