### PR TITLE
Make the InterruptingEventSubprocessTest more robust

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/subprocess/InterruptingEventSubprocessTest.java
@@ -377,22 +377,20 @@ public class InterruptingEventSubprocessTest {
 
     // then
     assertThat(
-            RecordingExporter.records()
-                .limitToProcessInstance(processInstanceKey)
-                .messageSubscriptionRecords()
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.DELETED)
                 .withProcessInstanceKey(processInstanceKey)
-                .withMessageName("other-message"))
-        .extracting(Record::getIntent)
-        .contains(MessageSubscriptionIntent.DELETED);
+                .withMessageName("other-message")
+                .findFirst())
+        .describedAs("Expected the message subscription to be deleted")
+        .isPresent();
 
     assertThat(
-            RecordingExporter.records()
-                .limitToProcessInstance(processInstanceKey)
-                .timerRecords()
+            RecordingExporter.timerRecords(TimerIntent.CANCELED)
                 .withProcessInstanceKey(processInstanceKey)
-                .withHandlerNodeId("other-timer"))
-        .extracting(Record::getIntent)
-        .contains(TimerIntent.CANCELED);
+                .withHandlerNodeId("other-timer")
+                .findFirst())
+        .describedAs("Expected the timer to be canceled")
+        .isPresent();
   }
 
   private static void assertEventSubprocessLifecycle(final long processInstanceKey) {


### PR DESCRIPTION
## Description

* the message subscription is deleted asynchronously to the process execution
* it can happen that the subscription is deleted after the process instance is completed which is fine
* make the test case more robust by not limiting the stream to the end of the process instance

## Related issues

closes #6673 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
