### PR TITLE
Make 'Dead' status more observable

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/TopologyManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/topology/TopologyManagerImpl.java
@@ -276,6 +276,8 @@ public final class TopologyManagerImpl extends Actor
             localBroker.setPartitionHealthy(partitionId);
           } else if (status == HealthStatus.UNHEALTHY) {
             localBroker.setPartitionUnhealthy(partitionId);
+          } else if (status == HealthStatus.DEAD) {
+            localBroker.setPartitionDead(partitionId);
           }
           publishTopologyChanges();
         });

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetrics.java
@@ -10,11 +10,12 @@ package io.camunda.zeebe.broker.system.monitoring;
 import io.prometheus.client.Gauge;
 
 public class HealthMetrics {
+
   private static final Gauge HEALTH =
       Gauge.build()
           .namespace("zeebe")
           .name("health")
-          .help("Shows current health of the partition (1 = healthy, 0 = unhealthy)")
+          .help("Shows current health of the partition (1 = healthy, 0 = unhealthy, -1 = dead)")
           .labelNames("partition")
           .register();
   private final String partitionIdLabel;
@@ -29,5 +30,9 @@ public class HealthMetrics {
 
   public void setUnhealthy() {
     HEALTH.labels(partitionIdLabel).set(0);
+  }
+
+  public void setDead() {
+    HEALTH.labels(partitionIdLabel).set(-1);
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -297,7 +297,7 @@ public final class ZeebePartition extends Actor
   }
 
   private void handleUnrecoverableFailure() {
-    // TODO(#6664): set health metrics to dead
+    healthMetrics.setDead();
     zeebePartitionHealth.onUnrecoverableFailure();
     transitionToInactive();
     context.getRaftPartition().goInactive();

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -268,6 +268,7 @@ message Partition {
   enum PartitionBrokerHealth {
     HEALTHY = 0;
     UNHEALTHY = 1;
+    DEAD = 2;
   }
 
   // the unique ID of this partition

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -29,6 +29,10 @@
               {
                 "name": "UNHEALTHY",
                 "integer": 1
+              },
+              {
+                "name": "DEAD",
+                "integer": 2
               }
             ]
           }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -93,10 +93,24 @@ public final class EndpointManager {
               if (!setRole(brokerId, partitionId, topology, partitionBuilder)) {
                 return;
               }
-              if (topology.isPartitionHealthy(brokerId, partitionId)) {
-                partitionBuilder.setHealth(PartitionBrokerHealth.HEALTHY);
-              } else {
-                partitionBuilder.setHealth(PartitionBrokerHealth.UNHEALTHY);
+
+              final var status = topology.getPartitionHealth(brokerId, partitionId);
+              switch (status) {
+                case HEALTHY:
+                  partitionBuilder.setHealth(PartitionBrokerHealth.HEALTHY);
+                  break;
+
+                case UNHEALTHY:
+                  partitionBuilder.setHealth(PartitionBrokerHealth.UNHEALTHY);
+                  break;
+
+                case DEAD:
+                  partitionBuilder.setHealth(PartitionBrokerHealth.DEAD);
+                  break;
+
+                default:
+                  Loggers.GATEWAY_LOGGER.debug(
+                      "Unsupported partition broker health status '{}'", status.name());
               }
               brokerInfo.addPartitions(partitionBuilder);
             });

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClientImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/BrokerClientImpl.java
@@ -189,24 +189,6 @@ public final class BrokerClientImpl implements BrokerClient {
             .join();
   }
 
-  public <T> void sendRequestWithRetry(
-      final BrokerRequest<T> request,
-      final BrokerResponseConsumer<T> responseConsumer,
-      final Consumer<Throwable> throwableConsumer,
-      final Duration requestTimeout) {
-
-    requestManager
-        .sendRequestWithRetry(request, requestTimeout)
-        .whenComplete(
-            (response, error) -> {
-              if (error == null) {
-                responseConsumer.accept(response.getKey(), response.getResponse());
-              } else {
-                throwableConsumer.accept(error);
-              }
-            });
-  }
-
   private void doAndLogException(final Runnable r) {
     try {
       r.run();

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerClusterState.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerClusterState.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.impl.broker.cluster;
 
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.List;
 
 public interface BrokerClusterState {
@@ -43,5 +44,5 @@ public interface BrokerClusterState {
 
   String getBrokerVersion(int brokerId);
 
-  boolean isPartitionHealthy(int brokerId, int partition);
+  PartitionHealthStatus getPartitionHealth(int brokerId, int partition);
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/cluster/BrokerTopologyManagerImpl.java
@@ -139,9 +139,7 @@ public final class BrokerTopologyManagerImpl extends Actor
         inactivePartitionId -> newTopology.addPartitionInactive(inactivePartitionId, nodeId));
 
     distributedBrokerInfo.consumePartitionsHealth(
-        newTopology::addPartitionIfAbsent,
-        partition -> newTopology.setPartitionHealthy(nodeId, partition),
-        partition -> newTopology.setPartitionUnhealthy(nodeId, partition));
+        (partition, health) -> newTopology.setPartitionHealthStatus(nodeId, partition, health));
 
     final String clientAddress = distributedBrokerInfo.getCommandApiAddress();
     if (clientAddress != null) {

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/topology/TopologyTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/topology/TopologyTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Partition.PartitionBr
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Partition.PartitionBrokerRole;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyResponse;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -43,7 +44,7 @@ public final class TopologyTest extends GatewayTest {
   public void shouldUpdatePartitionHealthHealthy() {
     // given
     final var topology = (BrokerClusterStateImpl) brokerClient.getTopologyManager().getTopology();
-    topology.setPartitionHealthy(0, 1);
+    topology.setPartitionHealthStatus(0, 1, PartitionHealthStatus.HEALTHY);
 
     // when
     final var response = client.topology(TopologyRequest.newBuilder().build());
@@ -57,7 +58,7 @@ public final class TopologyTest extends GatewayTest {
   public void shouldUpdatePartitionHealth() {
     // given
     final var topology = (BrokerClusterStateImpl) brokerClient.getTopologyManager().getTopology();
-    topology.setPartitionUnhealthy(0, 1);
+    topology.setPartitionHealthStatus(0, 1, PartitionHealthStatus.UNHEALTHY);
 
     // when
     final var response = client.topology(TopologyRequest.newBuilder().build());
@@ -71,8 +72,8 @@ public final class TopologyTest extends GatewayTest {
   public void shouldUpdateMultiplePartitionHealths() {
     // given
     final var topology = (BrokerClusterStateImpl) brokerClient.getTopologyManager().getTopology();
-    topology.setPartitionUnhealthy(0, 1);
-    topology.setPartitionHealthy(0, 6);
+    topology.setPartitionHealthStatus(0, 1, PartitionHealthStatus.UNHEALTHY);
+    topology.setPartitionHealthStatus(0, 6, PartitionHealthStatus.HEALTHY);
 
     // when
     final var response = client.topology(TopologyRequest.newBuilder().build());

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.function.BiConsumer;
 import java.util.function.IntConsumer;
 import java.util.function.ObjLongConsumer;
 import org.agrona.DirectBuffer;
@@ -209,6 +210,11 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
 
   public BrokerInfo setPartitionHealthy(final Integer partitionId) {
     addPartitionHealth(partitionId, PartitionHealthStatus.HEALTHY);
+    return this;
+  }
+
+  public BrokerInfo setPartitionDead(final Integer partitionId) {
+    addPartitionHealth(partitionId, PartitionHealthStatus.DEAD);
     return this;
   }
 
@@ -452,23 +458,8 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   public BrokerInfo consumePartitionsHealth(
-      final IntConsumer partitionConsumer,
-      final IntConsumer partitionHealthyConsumer,
-      final IntConsumer partitionUnhealthyConsumer) {
-    partitionHealthStatuses.forEach(
-        (partition, health) -> {
-          partitionConsumer.accept(partition);
-          switch (health) {
-            case HEALTHY:
-              partitionHealthyConsumer.accept(partition);
-              break;
-            case UNHEALTHY:
-              partitionUnhealthyConsumer.accept(partition);
-              break;
-            default:
-              LOG.warn("Failed to decode broker info, found unknown health status: {}", health);
-          }
-        });
+      final BiConsumer<Integer, PartitionHealthStatus> partitionConsumer) {
+    partitionHealthStatuses.forEach(partitionConsumer);
     return this;
   }
 

--- a/protocol/src/main/resources/protocol.xml
+++ b/protocol/src/main/resources/protocol.xml
@@ -64,6 +64,7 @@
     <enum name="PartitionHealthStatus" encodingType="uint8">
       <validValue name="UNHEALTHY">0</validValue>
       <validValue name="HEALTHY">1</validValue>
+      <validValue name="DEAD">2</validValue>
     </enum>
 
     <composite name="Version" description="Version information">


### PR DESCRIPTION
## Description

Adds a 'dead' status to metrics and topology.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #6664 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
