### PR TITLE
Fixes deleting non existent folder

### DIFF
--- a/util/src/test/java/io/camunda/zeebe/util/FileUtilTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/FileUtilTest.java
@@ -8,11 +8,13 @@
 package io.camunda.zeebe.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -45,5 +47,17 @@ public final class FileUtilTest {
               FileUtil.deleteFolder(root.getAbsolutePath());
             })
         .isInstanceOf(NoSuchFileException.class);
+  }
+
+  // regression test
+  @Test
+  public void shouldNotThrowErrorIfFolderDoesNotExist() {
+    // given
+    final Path nonExistent = tempFolder.getRoot().toPath().resolve("something");
+
+    // when - then
+    assertThatCode(() -> FileUtil.deleteFolderIfExists(nonExistent))
+        .as("no error if folder does not exist")
+        .doesNotThrowAnyException();
   }
 }


### PR DESCRIPTION
## Description

This PR fixes calling deleteFolderIfExists where a NoSuchFileException would be thrown if the root folder did not exist.

At the same time, simplifies the implementation of both deleteFolder and deleteFolderIfExists to reuse the same code path with different deletion handlers.

## Related issues

related to #6231 
closes #7098

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
