### PR TITLE
Delete runtime folder when closing the state controller

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImpl.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.sched.future.ActorFuture;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
@@ -109,10 +108,7 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
 
   @Override
   public void recover() throws Exception {
-
-    if (Files.exists(runtimeDirectory)) {
-      FileUtil.deleteFolder(runtimeDirectory);
-    }
+    FileUtil.deleteFolderIfExists(runtimeDirectory);
 
     final var optLatestSnapshot = constructableSnapshotStore.getLatestSnapshot();
     if (optLatestSnapshot.isPresent()) {
@@ -156,9 +152,11 @@ public class StateControllerImpl implements StateController, PersistedSnapshotLi
   public void close() throws Exception {
     if (db != null) {
       db.close();
-      LOG.debug("Closed database from '{}'.", runtimeDirectory);
       db = null;
+      LOG.debug("Closed database from '{}'.", runtimeDirectory);
     }
+
+    FileUtil.deleteFolderIfExists(runtimeDirectory);
   }
 
   boolean isDbOpened() {


### PR DESCRIPTION
## Description

When closing the state, we may leave behind a copy of the database, which is only deleted the next time we open the state. This causes unnecessary data usage as that copy is anyway thrown away on the next open. With this fix, we now delete it always when opening and when closing.

## Related issues

closes #6231 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
