### PR TITLE
Enable force compaction on state to reduce the number of files

### DIFF
--- a/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
+++ b/broker/src/main/java/io/zeebe/broker/system/configuration/RocksdbCfg.java
@@ -12,10 +12,21 @@ import java.util.Properties;
 
 public final class RocksdbCfg implements ConfigurationEntry {
 
+  private static final boolean DEFAULT_ENABLE_MANUAL_COMPACTION = true;
+  private static final int DEFAULT_OUTPUTLEVEL_MANUAL_COMPACTION = 1;
+  private static final int DEFAULT_TRIGGER_FILECOUNT_MANUAL_COMPACTION = 1000;
+
   private boolean enableStatistics = RocksDbConfiguration.DEFAULT_STATISTICS_ENABLED;
   private int maxOpenFiles = RocksDbConfiguration.DEFAULT_MAX_OPEN_FILES;
   private int ioRateBytesPerSecond = RocksDbConfiguration.DEFAULT_IO_RATE_BYTES_PER_SECOND;
   private boolean disableWal = RocksDbConfiguration.DEFAULT_WAL_DISABLED;
+  private boolean enableManualCompactionOnRecovery = DEFAULT_ENABLE_MANUAL_COMPACTION;
+  // The level to which the files should be compacted. If a lower level is set and there are files
+  // in higher level, rocksdb may compact them to the higher level.
+  private int outputLevelManualCompaction = DEFAULT_OUTPUTLEVEL_MANUAL_COMPACTION;
+  // When manual compaction on recovery is enabled, the compaction is triggered only if the number
+  // of files cross the given threshold. This is done to prevent unnecessary compactions.
+  private int triggerFileCountManualCompaction = DEFAULT_TRIGGER_FILECOUNT_MANUAL_COMPACTION;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {}
@@ -52,6 +63,30 @@ public final class RocksdbCfg implements ConfigurationEntry {
     this.disableWal = disableWal;
   }
 
+  public boolean isEnableManualCompactionOnRecovery() {
+    return enableManualCompactionOnRecovery;
+  }
+
+  public void setEnableManualCompactionOnRecovery(final boolean enableManualCompactionOnRecovery) {
+    this.enableManualCompactionOnRecovery = enableManualCompactionOnRecovery;
+  }
+
+  public int getOutputLevelManualCompaction() {
+    return outputLevelManualCompaction;
+  }
+
+  public void setOutputLevelManualCompaction(final int outputLevelManualCompaction) {
+    this.outputLevelManualCompaction = outputLevelManualCompaction;
+  }
+
+  public int getTriggerFileCountManualCompaction() {
+    return triggerFileCountManualCompaction;
+  }
+
+  public void setTriggerFileCountManualCompaction(final int triggerFileCountManualCompaction) {
+    this.triggerFileCountManualCompaction = triggerFileCountManualCompaction;
+  }
+
   public RocksDbConfiguration createRocksDbConfiguration(
       final Properties rocksdbColumnFamilyOptions) {
     return new RocksDbConfiguration()
@@ -73,6 +108,12 @@ public final class RocksdbCfg implements ConfigurationEntry {
         + ioRateBytesPerSecond
         + ", disableWal="
         + disableWal
+        + ", enableManualCompactionOnRecovery="
+        + enableManualCompactionOnRecovery
+        + ", outputLevelManualCompaction="
+        + outputLevelManualCompaction
+        + ", triggerFileCountManualCompaction="
+        + triggerFileCountManualCompaction
         + '}';
   }
 }

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/StateController.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/StateController.java
@@ -24,8 +24,13 @@ public interface StateController extends AutoCloseable {
   /** Registers to consumes replicated snapshots. */
   void consumeReplicatedSnapshots();
 
-  /** Recovers the state from the latest snapshot. */
-  void recover() throws Exception;
+  /**
+   * Recovers the state from the latest snapshot.
+   *
+   * @param shouldForceCompactionAfterRecovery if true a manual compaction on the state is
+   *     triggered.
+   */
+  void recover(final boolean shouldForceCompactionAfterRecovery) throws Exception;
 
   /**
    * Opens the database from the latest snapshot.

--- a/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
+++ b/broker/src/main/java/io/zeebe/broker/system/partitions/impl/steps/StateControllerPartitionStep.java
@@ -42,7 +42,9 @@ public class StateControllerPartitionStep implements PartitionStep {
             context.getSnapshotReplication(),
             new AtomixRecordEntrySupplierImpl(
                 context.getZeebeIndexMapping(), context.getRaftLogReader()),
-            StatePositionSupplier::getHighestExportedPosition);
+            StatePositionSupplier::getHighestExportedPosition,
+            rocksDbConfig.getOutputLevelManualCompaction(),
+            rocksDbConfig.getTriggerFileCountManualCompaction());
 
     context.setSnapshotController(stateController);
     return CompletableActorFuture.completed(null);

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/AsyncSnapshotingTest.java
@@ -85,7 +85,9 @@ public final class AsyncSnapshotingTest {
                 Optional.of(
                     new Indexed(
                         l + 100, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0)),
-            db -> Long.MAX_VALUE);
+            db -> Long.MAX_VALUE,
+            1,
+            1000);
 
     snapshotController.openDb();
     autoCloseableRule.manage(snapshotController);

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/FailingSnapshotChunkReplicationTest.java
@@ -65,7 +65,9 @@ public final class FailingSnapshotChunkReplicationTest {
             l ->
                 Optional.of(
                     new Indexed(l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0)),
-            db -> Long.MAX_VALUE);
+            db -> Long.MAX_VALUE,
+            1,
+            1000);
     senderStore.addSnapshotListener(replicatorSnapshotController);
 
     receiverSnapshotController =
@@ -79,7 +81,9 @@ public final class FailingSnapshotChunkReplicationTest {
             l ->
                 Optional.ofNullable(
                     new Indexed(l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0)),
-            db -> Long.MAX_VALUE);
+            db -> Long.MAX_VALUE,
+            1,
+            1000);
     receiverStore.addSnapshotListener(receiverSnapshotController);
 
     autoCloseableRule.manage(replicatorSnapshotController);

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/ReplicateStateControllerTest.java
@@ -75,7 +75,9 @@ public final class ReplicateStateControllerTest {
             l ->
                 Optional.of(
                     new Indexed(l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0)),
-            db -> Long.MAX_VALUE);
+            db -> Long.MAX_VALUE,
+            1,
+            1000);
     senderStore.addSnapshotListener(replicatorSnapshotController);
 
     receiverSnapshotController =
@@ -89,7 +91,9 @@ public final class ReplicateStateControllerTest {
             l ->
                 Optional.of(
                     new Indexed(l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0)),
-            db -> Long.MAX_VALUE);
+            db -> Long.MAX_VALUE,
+            1,
+            1000);
     receiverStore.addSnapshotListener(receiverSnapshotController);
 
     autoCloseableRule.manage(replicatorSnapshotController);
@@ -163,7 +167,7 @@ public final class ReplicateStateControllerTest {
 
     // then
     final RocksDBWrapper wrapper = new RocksDBWrapper();
-    receiverSnapshotController.recover();
+    receiverSnapshotController.recover(false);
     assertThat(receiverSnapshotController.isDbOpened()).isTrue();
 
     wrapper.wrap(receiverSnapshotController.openDb());
@@ -193,7 +197,7 @@ public final class ReplicateStateControllerTest {
 
     // then
     final RocksDBWrapper wrapper = new RocksDBWrapper();
-    receiverSnapshotController.recover();
+    receiverSnapshotController.recover(false);
     assertThat(receiverSnapshotController.isDbOpened()).isTrue();
 
     wrapper.wrap(receiverSnapshotController.openDb());

--- a/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/broker/src/test/java/io/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -65,7 +65,9 @@ public final class StateControllerImplTest {
             l ->
                 Optional.ofNullable(
                     new Indexed(l, new ZeebeEntry(1, System.currentTimeMillis(), 1, 10, null), 0)),
-            db -> exporterPosition.get());
+            db -> exporterPosition.get(),
+            1,
+            1000);
 
     autoCloseableRule.manage(snapshotController);
     autoCloseableRule.manage(store);
@@ -217,7 +219,7 @@ public final class StateControllerImplTest {
     // given
 
     // when
-    snapshotController.recover();
+    snapshotController.recover(false);
 
     // then
     assertThat(snapshotController.isDbOpened()).isFalse();
@@ -234,7 +236,7 @@ public final class StateControllerImplTest {
     wrapper.wrap(snapshotController.openDb());
     wrapper.putInt(key, value);
     snapshotController.close();
-    snapshotController.recover();
+    snapshotController.recover(false);
     assertThat(snapshotController.isDbOpened()).isFalse();
     wrapper.wrap(snapshotController.openDb());
 
@@ -260,7 +262,7 @@ public final class StateControllerImplTest {
     snapshotController.close();
 
     // when
-    snapshotController.recover();
+    snapshotController.recover(false);
     wrapper.wrap(snapshotController.openDb());
 
     // then
@@ -280,7 +282,7 @@ public final class StateControllerImplTest {
     corruptLatestSnapshot();
 
     // when/then
-    assertThatThrownBy(() -> snapshotController.recover())
+    assertThatThrownBy(() -> snapshotController.recover(false))
         .isInstanceOf(RuntimeException.class)
         .hasMessage("Failed to recover from snapshots");
   }

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -549,3 +549,19 @@
         # This is ok because Zeebe has its own way to recover after crash. This flag may have a performance impact.
         # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_ROCKSDB_DISABLEWAL
         # disableWal = false;
+
+        # If true, triggers a manual compaction on the state when the state is recovered from a snapshot.
+        # That happens during startup or when a leader change happens. This is useful when the state has thousands of file.
+        # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_ROCKSDB_ENABLEMANUALCOMPACTIONONRECOVERY
+        # enableManualCompactionOnRecovery = true;
+
+        # The level to which the files should be compacted during manual compaction. If a lower level is set and there are files
+        # in higher level, rocksdb may compact them to the higher level. This setting is used only when enableManualCompactionOnRecovery is true.
+        # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_ROCKSDB_OUTPUTLEVELMANUALCOMPACTION
+        # outputLevelManualCompaction = 1;
+
+        # When manual compaction on recovery is enabled, the compaction happend only if the number of files in the state
+        # is more than the given triggerFileCountManualCompaction. This is useful to prevent unnecessary compaction.
+        # This setting is used only when enableManualCompactionOnRecovery is true.
+        # This setting can also be overridden using the environment variable ZEEBE_EXPERIMENTAL_ROCKSDB_TRIGGERFILECOUNTMANUALCOMPACTION
+        # triggerFileCountManualCompaction = 1000;

--- a/zb-db/src/main/java/io/zeebe/db/ZeebeDb.java
+++ b/zb-db/src/main/java/io/zeebe/db/ZeebeDb.java
@@ -9,6 +9,7 @@ package io.zeebe.db;
 
 import java.io.File;
 import java.util.Optional;
+import org.rocksdb.RocksDBException;
 
 /**
  * The zeebe database, to store key value pairs in different column families. The column families
@@ -64,4 +65,19 @@ public interface ZeebeDb<ColumnFamilyType extends Enum<ColumnFamilyType>> extend
    * @return {@code true} if the column is empty, otherwise {@code false}
    */
   boolean isEmpty(ColumnFamilyType column, DbContext context);
+
+  /**
+   * Run a manual compaction on the state. It is recommended to disable auto compaction before
+   * calling this method and re-enable it after by calling {@link ZeebeDb#enableAutoCompaction()}
+   *
+   * @param outputLevelManualCompaction the level to which the files should be compacted
+   */
+  void compactFiles(final int outputLevelManualCompaction);
+
+  /**
+   * Enable auto compaction
+   *
+   * @throws RocksDBException when it cannot change the compaction configuration
+   */
+  void enableAutoCompaction() throws RocksDBException;
 }

--- a/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zb-db/src/main/java/io/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -136,6 +136,10 @@ public final class ZeebeRocksDbFactory<ColumnFamilyType extends Enum<ColumnFamil
     final int level0CompactionTrigger = 4;
     columnFamilyOptions
         // compaction
+        // temporary disable auto compaction so that it doesn't interfere with the forced manual
+        // compaction during recovery.
+        // Auto compaction should be explicitly re-enabled after manual compaction is completed.
+        .setDisableAutoCompactions(true)
         .setLevelCompactionDynamicLevelBytes(true)
         .setCompactionPriority(CompactionPriority.OldestSmallestSeqFirst)
         .setCompactionStyle(CompactionStyle.LEVEL)


### PR DESCRIPTION
## Description

* Force compact the state on recovery using rocksdb's manual compaction api
* Enable a feature flag to turn it on/off
 
Forced manual compaction is necessary in some cases where rocksdb is not compacting the state even though auto-compaction is enabled resulting in thousands of file in the state. Using manual compaction of rocksdb, we can compact files from each columnfamily into a target outputlevel.

Since this forced compaction is only necessary in some cases we also expose a feature flag to turn it on/off. To prevent unnecessary compaction, we trigger the compaction only if the number of files is above a threshold.

In our tests we found that if we set a lower level as output level, and if there files in higher level, then rocksdb compact them to the higher level. This is acceptable for our case. Hence as default we set the output level to 1.

## Related issues

closes #7086 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
