### PR TITLE
Combine Elasticsearch errors with exception

### DIFF
--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
@@ -10,8 +10,6 @@ package io.camunda.zeebe.exporter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.protocol.record.Record;
@@ -22,14 +20,12 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ElasticsearchClientTest extends AbstractElasticsearchExporterIntegrationTestCase {
 
   private static final long RECORD_KEY = 1234L;
   private ElasticsearchExporterConfiguration configuration;
-  private Logger logSpy;
   private ElasticsearchClient client;
   private ArrayList<String> bulkRequest;
 
@@ -38,9 +34,10 @@ public class ElasticsearchClientTest extends AbstractElasticsearchExporterIntegr
     elastic.start();
 
     configuration = getDefaultConfiguration();
-    logSpy = spy(LoggerFactory.getLogger(ElasticsearchClientTest.class));
     bulkRequest = new ArrayList<>();
-    client = new ElasticsearchClient(configuration, logSpy, bulkRequest);
+    client =
+        new ElasticsearchClient(
+            configuration, LoggerFactory.getLogger(ElasticsearchClientTest.class), bulkRequest);
   }
 
   @Test
@@ -69,14 +66,7 @@ public class ElasticsearchClientTest extends AbstractElasticsearchExporterIntegr
     // when/then
     assertThatThrownBy(client::flush)
         .isInstanceOf(ElasticsearchExporterException.class)
-        .hasMessage("Failed to flush all items of the bulk");
-
-    verify(logSpy)
-        .warn(
-            "Failed to flush {} item(s) of bulk request [type: {}, reason: {}]",
-            bulkSize,
-            "mapper_parsing_exception",
-            "failed to parse");
+        .hasMessageContaining("Failed to flush bulk request:");
   }
 
   @Test

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
@@ -66,7 +66,8 @@ public class ElasticsearchClientTest extends AbstractElasticsearchExporterIntegr
     // when/then
     assertThatThrownBy(client::flush)
         .isInstanceOf(ElasticsearchExporterException.class)
-        .hasMessageContaining("Failed to flush bulk request:");
+        .hasMessageContaining(
+            "Failed to flush 10 item(s) of bulk request [type: mapper_parsing_exception, reason: failed to parse]");
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR combines the Elastic application-level errors with the exception thrown to avoid having to trawl the logs for the cause of the exception.

The exceptions now look like this:

> "Failed to flush bulk request: [Failed to flush 10 item(s) of bulk request [type: mapper_parsing_exception, reason: failed to parse], Failed to flush 2 item(s) of bulk request [type: document_missing_exception, reason: no document was present]]"

## Related issues

closes #5398 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda-cloud/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/zeebe-io/zeebe/compare/stable/0.24...develop?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/0.25`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark 

Documentation: 
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] New content is added to the [release announcement](https://drive.google.com/drive/u/0/folders/1DTIeswnEEq-NggJ25rm2BsDjcCQpDape)
